### PR TITLE
Remove the onRequest parameter from Client calls

### DIFF
--- a/src/actions/helpers.js
+++ b/src/actions/helpers.js
@@ -32,9 +32,7 @@ export function emptyError() {
 
 export function bindClientFunc(clientFunc, request, success, failure, ...args) {
     return (dispatch, getState) => {
-        function onRequest() {
-            return dispatch(requestData(request), getState);
-        }
+        dispatch(requestData(request), getState);
 
         function onSuccess(data) {
             return dispatch(requestSuccess(success, data), getState);
@@ -44,6 +42,6 @@ export function bindClientFunc(clientFunc, request, success, failure, ...args) {
             return dispatch(requestFailure(failure, err), getState);
         }
 
-        return dispatch(() => clientFunc(...args, onRequest, onSuccess, onFailure), getState);
+        return dispatch(() => clientFunc(...args, onSuccess, onFailure), getState);
     };
 }

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -125,27 +125,25 @@ export default class Client {
 
     // General routes
 
-    getClientConfig = (onRequest, onSuccess, onFailure) => {
+    getClientConfig = (onSuccess, onFailure) => {
         return this.doFetch(
             `${this.getGeneralRoute()}/client_props`,
             {method: 'get'},
-            onRequest,
             onSuccess,
             onFailure
         );
     }
 
-    getPing = (onRequest, onSuccess, onFailure) => {
+    getPing = (onSuccess, onFailure) => {
         return this.doFetch(
             `${this.getGeneralRoute()}/ping`,
             {method: 'get'},
-            onRequest,
             onSuccess,
             onFailure
         );
     }
 
-    logClientError = (message, level, onRequest, onSuccess, onFailure) => {
+    logClientError = (message, level, onSuccess, onFailure) => {
         const body = {
             message,
             level: level || 'ERROR'
@@ -154,7 +152,6 @@ export default class Client {
         return this.doFetch(
             `${this.getGeneralRoute()}/log_client`,
             {method: 'post', body},
-            onRequest,
             onSuccess,
             onFailure
         );
@@ -162,17 +159,16 @@ export default class Client {
 
     // User routes
 
-    createUser = (user, onRequest, onSuccess, onFailure) => {
+    createUser = (user, onSuccess, onFailure) => {
         return this.doFetch(
             `${this.getUsersRoute()}/create`,
             {method: 'post', body: JSON.stringify(user)},
-            onRequest,
             onSuccess,
             onFailure
         );
     }
 
-    login = (loginId, password, token, onRequest, onSuccess, onFailure) => {
+    login = (loginId, password, token, onSuccess, onFailure) => {
         const body = {
             login_id: loginId,
             password,
@@ -182,7 +178,6 @@ export default class Client {
         return this.doFetch(
             `${this.getUsersRoute()}/login`,
             {method: 'post', body: JSON.stringify(body)},
-            onRequest,
             (data, response) => {
                 if (response.headers.has(HEADER_TOKEN)) {
                     this.token = response.headers.get(HEADER_TOKEN);
@@ -194,11 +189,10 @@ export default class Client {
         );
     }
 
-    getInitialLoad = (onRequest, onSuccess, onFailure) => {
+    getInitialLoad = (onSuccess, onFailure) => {
         return this.doFetch(
             `${this.getUsersRoute()}/initial_load`,
             {method: 'get'},
-            onRequest,
             onSuccess,
             onFailure
         );
@@ -206,11 +200,10 @@ export default class Client {
 
     // Team routes
 
-    createTeam = (team, onRequest, onSuccess, onFailure) => {
+    createTeam = (team, onSuccess, onFailure) => {
         return this.doFetch(
             `${this.getTeamsRoute()}/create`,
             {method: 'post', body: JSON.stringify(team)},
-            onRequest,
             onSuccess,
             onFailure
         );
@@ -218,11 +211,10 @@ export default class Client {
 
     // Channel routes
 
-    createChannel = (channel, onRequest, onSuccess, onFailure) => {
+    createChannel = (channel, onSuccess, onFailure) => {
         return this.doFetch(
             `${this.getChannelsRoute()}/create`,
             {method: 'post', body: JSON.stringify(channel)},
-            onRequest,
             onSuccess,
             onFailure
         );
@@ -230,20 +222,16 @@ export default class Client {
 
     // Post routes
 
-    createPost = (post, onRequest, onSuccess, onFailure) => {
+    createPost = (post, onSuccess, onFailure) => {
         return this.doFetch(
             `${this.getPostsRoute(post.channel_id)}/create`,
             {method: 'post', body: JSON.stringify(post)},
-            onRequest,
             onSuccess,
             onFailure
         );
     }
 
-    doFetch = async (url, options, onRequest, onSuccess, onFailure) => {
-        if (onRequest) {
-            onRequest();
-        }
+    doFetch = async (url, options, onSuccess, onFailure) => {
         try {
             const response = await fetch(url, this.getOptions(options));
             const data = await response.json();

--- a/test/client/client.test.js
+++ b/test/client/client.test.js
@@ -1,25 +1,16 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import assert from 'assert';
-
 import TestHelper from 'test_helper.js';
 
 describe('Client', () => {
     it('doFetch', (done) => {
         const client = TestHelper.createClient();
 
-        let onRequestCalled = false;
-
         client.doFetch(
             `${client.getGeneralRoute()}/ping`,
             {},
             () => {
-                onRequestCalled = true;
-            },
-            () => {
-                assert.ok(onRequestCalled, 'onSuccess called before onRequest');
-
                 done();
             },
             (err) => {

--- a/test/client/client_channel.test.js
+++ b/test/client/client_channel.test.js
@@ -12,7 +12,6 @@ describe('Client.Channel', () => {
 
             client.createChannel(
                 channel,
-                null,
                 (data) => {
                     assert.ok(data.id, 'id is empty');
                     assert.equal(data.name, channel.name, 'name doesn\'t match');

--- a/test/client/client_general.test.js
+++ b/test/client/client_general.test.js
@@ -9,7 +9,6 @@ describe('Client.General', () => {
     it('getClientConfig', (done) => {
         TestHelper.initBasic(({client}) => {
             client.getClientConfig(
-                null,
                 (data) => {
                     assert.ok(data.Version);
                     assert.ok(data.BuildNumber);
@@ -28,7 +27,6 @@ describe('Client.General', () => {
     it('getPing', (done) => {
         TestHelper.initBasic(({client}) => {
             client.getPing(
-                null,
                 () => {
                     done();
                 },
@@ -44,7 +42,6 @@ describe('Client.General', () => {
             client.setUrl('https://example.com/fake/url');
 
             client.getPing(
-                null,
                 () => {
                     done(new Error('ping should\'ve failed'));
                 },
@@ -60,7 +57,6 @@ describe('Client.General', () => {
             client.logClientError(
                 'this is a test',
                 'ERROR',
-                null,
                 (data) => {
                     TestHelper.assertStatusOkay(data);
 

--- a/test/client/client_post.test.js
+++ b/test/client/client_post.test.js
@@ -12,7 +12,6 @@ describe('Client.Post', () => {
 
             client.createPost(
                 post,
-                null,
                 (data) => {
                     assert.ok(data.id, 'id is empty');
 

--- a/test/client/client_team.test.js
+++ b/test/client/client_team.test.js
@@ -12,7 +12,6 @@ describe('Client.Team', () => {
 
         client.createTeam(
             team,
-            null,
             (data) => {
                 assert.equal(data.id.length > 0, true);
                 assert.equal(data.name, team.name);

--- a/test/client/client_user.test.js
+++ b/test/client/client_user.test.js
@@ -12,7 +12,6 @@ describe('Client.User', () => {
 
         client.createUser(
             user,
-            null,
             (data) => {
                 assert.ok(data.id, 'id is empty');
                 assert.equal(data.email, user.email, 'email addresses aren\'t equal');
@@ -31,13 +30,11 @@ describe('Client.User', () => {
 
         client.createUser(
             user,
-            null,
             () => {
                 client.login(
                     user.email,
                     user.password,
                     '',
-                    null,
                     (data) => {
                         assert.ok(data.id, 'id is empty');
                         assert.equal(data.email, user.email, 'email addresses aren\'t equal');
@@ -59,7 +56,6 @@ describe('Client.User', () => {
     it('getInitialLoad', (done) => {
         TestHelper.initBasic(({client, user}) => {
             client.getInitialLoad(
-                null,
                 (data) => {
                     assert.ok(data.user.id.length, 'id is empty');
                     assert.equal(data.user.id, user.id, 'user ids don\'t match');

--- a/test/sanity.test.js
+++ b/test/sanity.test.js
@@ -9,15 +9,16 @@ describe('Sanity test', () => {
         Promise.resolve(true).then(() => {
             done();
         }).catch((err) => {
-            done.fail(err);
+            done(err);
         });
     });
 
     it('fetch', (done) => {
         fetch('http://example.com').then(() => {
             done();
-        }).catch((err) => {
-            done.fail(err);
+        }).catch(() => {
+            // No internet connection, but fetch still returned at least
+            done();
         });
     });
 });

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -98,7 +98,6 @@ class TestHelper {
 
         client.createUser(
             this.fakeUser(),
-            null,
             (user) => {
                 this.basicUser = user;
 
@@ -106,11 +105,9 @@ class TestHelper {
                     user.email,
                     PASSWORD,
                     '',
-                    null,
                     () => {
                         client.createTeam(
                             this.fakeTeam(),
-                            null,
                             (team) => {
                                 this.basicTeam = team;
 
@@ -118,13 +115,11 @@ class TestHelper {
 
                                 client.createChannel(
                                     this.fakeChannel(this.basicTeam.id),
-                                    null,
                                     (channel) => {
                                         this.basicChannel = channel;
 
                                         client.createPost(
                                             this.fakePost(this.basicChannel.id),
-                                            null,
                                             (post) => {
                                                 this.basicPost = post;
 


### PR DESCRIPTION
This isn't needed for the Javascript client, and it'll keep the interface more like the existing client used by the webapp.