### PR TITLE
Changed .editorconfig to include a trailing newline on files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 end_of_line = lf
-insert_final_newline = false
+insert_final_newline = true
 charset = utf-8
 
 [*.{js,jsx,json,html}]


### PR DESCRIPTION
I have no strong feelings on this, but it seems like both Mike's and Thomas's editors add the trailing newline so it'll avoid unnecessary diffs in PRs
