### PR TITLE
Convert entity collection stores to objects instead of arrays

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -8,7 +8,7 @@ import {ChannelsTypes as types} from 'constants';
 export function selectChannel(channel) {
     return {
         type: types.SELECT_CHANNEL,
-        channel_id: channel.id
+        channelId: channel.id
     };
 }
 

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -9,7 +9,7 @@ export function selectTeam(team) {
     Client.setTeamId(team.id);
     return {
         type: types.SELECT_TEAM,
-        team_id: team.id
+        teamId: team.id
     };
 }
 

--- a/src/components/channels_list.js
+++ b/src/components/channels_list.js
@@ -7,11 +7,10 @@ import {connect} from 'react-redux';
 
 import {ListView, StyleSheet, View, Text} from 'react-native';
 const {DataSource} = ListView;
-import {Actions as Routes} from 'react-native-router-flux'; // eslint-disable-line no-unused-vars
+import {Actions as Routes} from 'react-native-router-flux';
+import _ from 'lodash';
 
 import * as channelActions from 'actions/channels';
-
-// import _ from 'lodash';
 import ErrorText from 'components/error_text';
 
 const styles = StyleSheet.create({
@@ -49,10 +48,11 @@ class ChannelsList extends Component {
     }
 
     render() {
+        const channels = _.values(this.props.channels.data);
         return (
             <View style={styles.container}>
                 <ListView
-                    dataSource={this.ds.cloneWithRows(this.props.channels.data)}
+                    dataSource={this.ds.cloneWithRows(channels)}
                     enableEmptySections={true}
                     renderRow={(channel) => (
                         <Text onPress={() => this.props.actions.selectChannel(channel)}>

--- a/src/components/posts_list.js
+++ b/src/components/posts_list.js
@@ -6,6 +6,7 @@ import React, {Component, PropTypes} from 'react';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {StyleSheet, Text, View} from 'react-native';
+import _ from 'lodash';
 
 import * as postActions from 'actions/posts';
 import ErrorText from 'components/error_text';
@@ -38,15 +39,14 @@ class PostsList extends Component {
     }
 
     render() {
+        const posts = _.values(this.props.posts.data);
         return (
             <View style={styles.container}>
-                {this.props.posts.data.map((post) => {
-                    return (
-                        <Text key={post.id}>
-                            {`${post.user_id} - ${post.message}`}
-                        </Text>
-                    );
-                })}
+                {posts.map((post) => (
+                    <Text key={post.id}>
+                        {`${post.user_id} - ${post.message}`}
+                    </Text>
+                ))}
                 <ErrorText error={this.props.posts.error}/>
             </View>
         );

--- a/src/reducers/channels.js
+++ b/src/reducers/channels.js
@@ -1,11 +1,17 @@
+import _ from 'lodash';
 import {ChannelsTypes as types} from 'constants';
 
 const initState = {
     status: 'not fetched',
     error: null,
-    data: [],
+    data: {},
     currentChannelId: null
 };
+
+// TODO: this can be extracted into a util
+function zipById(channels) {
+    return _.zipObject(_.map(channels, 'id'), channels);
+}
 
 export default function reduceChannels(state = initState, action) {
     switch (action.type) {
@@ -23,7 +29,7 @@ export default function reduceChannels(state = initState, action) {
     case types.FETCH_CHANNELS_SUCCESS:
         return {...state,
             status: 'fetched',
-            data: action.data.channels
+            data: zipById(action.data.channels)
         };
     case types.FETCH_CHANNELS_FAILURE:
         return {...state,

--- a/src/reducers/channels.js
+++ b/src/reducers/channels.js
@@ -12,7 +12,7 @@ export default function reduceChannels(state = initState, action) {
 
     case types.SELECT_CHANNEL:
         return {...state,
-            currentChannelId: action.channel_id
+            currentChannelId: action.channelId
         };
 
     case types.FETCH_CHANNELS_REQUEST:

--- a/src/reducers/posts.js
+++ b/src/reducers/posts.js
@@ -1,10 +1,9 @@
-import _ from 'lodash';
 import {PostsTypes as types} from 'constants';
 
 const initState = {
     status: 'not fetched',
     error: null,
-    data: []
+    data: {}
 };
 
 export default function reducePosts(state = initState, action) {
@@ -18,7 +17,7 @@ export default function reducePosts(state = initState, action) {
     case types.FETCH_POSTS_SUCCESS:
         return {...state,
             status: 'fetched',
-            data: _.values(action.data.posts)
+            data: action.data.posts
         };
     case types.FETCH_POSTS_FAILURE:
         return {...state,

--- a/src/reducers/teams.js
+++ b/src/reducers/teams.js
@@ -13,7 +13,7 @@ export default function reduceTeams(state = initState, action) {
 
     case types.SELECT_TEAM:
         return {...state,
-            currentTeamId: action.team_id
+            currentTeamId: action.teamId
         };
 
     case types.FETCH_TEAMS_REQUEST:

--- a/src/reducers/teams.js
+++ b/src/reducers/teams.js
@@ -1,10 +1,9 @@
-import _ from 'lodash';
 import {TeamsTypes as types} from 'constants';
 
 const initState = {
     status: 'not fetched',
     error: null,
-    data: [],
+    data: {},
     currentTeamId: null
 };
 
@@ -24,7 +23,7 @@ export default function reduceTeams(state = initState, action) {
     case types.FETCH_TEAMS_SUCCESS:
         return {...state,
             status: 'fetched',
-            data: _.values(action.data)
+            data: action.data
         };
     case types.FETCH_TEAMS_FAILURE:
         return {...state,


### PR DESCRIPTION
Until we are ready to handle request status in a separate store, I don't think it makes sense to singularize these collection stores (so `state.entities.teams.data` would become `state.entities.team.teams`), because inside of the components it would be confusing to see `state.team.status`. This is a step towards the intended store.