### PR TITLE
Gitignore .npminstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ local.properties
 #
 node_modules/
 npm-debug.log
+.npminstall
 
 # BUCK
 buck-out/


### PR DESCRIPTION
`.npminstall` is a lockfile created by make. It's gitignored in the platform repo so we should gitignore it here.