### PR TITLE
Added Intl polyfill for platforms that don't support it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ clean:
 	rm -f .npminstall
 
 post-install:
-	# Hack to get react-intl and its dependencies to work with react-native
-	# Based off of https://github.com/este/este/blob/master/gulp/native-fix.js
+	@# Hack to get react-intl and its dependencies to work with react-native
+	@# Based off of https://github.com/este/este/blob/master/gulp/native-fix.js
 	sed -i'' -e 's|"./locale-data/index.js": false|"./locale-data/index.js": "./locale-data/index.js"|g' node_modules/react-intl/package.json
 	sed -i'' -e 's|"./lib/locales": false|"./lib/locales": "./lib/locales"|g' node_modules/intl-messageformat/package.json
 	sed -i'' -e 's|"./lib/locales": false|"./lib/locales": "./lib/locales"|g' node_modules/intl-relativeformat/package.json
-	# sed -i'' -e 's|"./locale-data/complete.js": false|"./locale-data/complete.js": "./locale-data/complete.js"|g' node_modules/intl/package.json
+	sed -i'' -e 's|"./locale-data/complete.js": false|"./locale-data/complete.js": "./locale-data/complete.js"|g' node_modules/intl/package.json

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "intl": "1.2.5",
     "isomorphic-fetch": "2.2.1",
     "lodash": "4.16.4",
     "react": "15.3.2",

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import 'intl';
+
 import en from 'i18n/en.json';
 import es from 'i18n/es.json';
 


### PR DESCRIPTION
@dmeza Do you mind pulling this branch and confirming that it works for you? I've only got an iOS environment set up and it has `Intl` predefined in it.