### PR TITLE
Added deep freeze of stores in dev mode

### DIFF
--- a/service/actions/posts.js
+++ b/service/actions/posts.js
@@ -43,7 +43,7 @@ export function deletePost(teamId, post) {
         dispatch(batchActions([
             {
                 type: PostsTypes.POST_DELETED,
-                data: post
+                data: {...post}
             },
             {
                 type: PostsTypes.DELETE_POST_SUCCESS
@@ -56,7 +56,7 @@ export function removePost(post) {
     return async (dispatch, getState) => {
         dispatch({
             type: PostsTypes.REMOVE_POST,
-            data: post
+            data: {...post}
         }, getState);
     };
 }
@@ -77,7 +77,7 @@ export function getPost(teamId, channelId, postId) {
         dispatch(batchActions([
             {
                 type: PostsTypes.RECEIVED_POSTS,
-                data: post,
+                data: {...post},
                 channelId
             },
             {

--- a/service/reducers/entities/posts.js
+++ b/service/reducers/entities/posts.js
@@ -111,11 +111,14 @@ function deletePost(state, action) {
     if (postInfo.posts[post.id]) {
         const combinedPosts = makePostListNonNull(postInfo);
 
-        combinedPosts.posts[post.id] = {
-            ...post,
-            state: Constants.POST_DELETED,
-            file_ids: [],
-            has_reactions: false
+        combinedPosts.posts = {
+            ...combinedPosts.posts,
+            [post.id]: {
+                ...post,
+                state: Constants.POST_DELETED,
+                file_ids: [],
+                has_reactions: false
+            }
         };
 
         return {
@@ -143,6 +146,11 @@ function removePost(state, action) {
 
     if (postInfo.posts[post.id]) {
         const combinedPosts = makePostListNonNull(postInfo);
+
+        combinedPosts.order = combinedPosts.order.slice(0);
+        combinedPosts.posts = {...combinedPosts.posts};
+
+        // Remove the post
         Reflect.deleteProperty(combinedPosts.posts, post.id);
 
         const index = combinedPosts.order.indexOf(post.id);
@@ -150,11 +158,8 @@ function removePost(state, action) {
             combinedPosts.order.splice(index, 1);
         }
 
-        for (const pid in combinedPosts.posts) {
-            if (!combinedPosts.posts.hasOwnProperty(pid)) {
-                continue;
-            }
-
+        // Remove any children of the post
+        for (const pid of Object.keys(combinedPosts.posts)) {
             if (combinedPosts.posts[pid].root_id === post.id) {
                 Reflect.deleteProperty(combinedPosts.posts, pid);
                 const commentIndex = combinedPosts.order.indexOf(pid);

--- a/service/utils/deepFreezeAndThrowOnMutation.js
+++ b/service/utils/deepFreezeAndThrowOnMutation.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/**
+ * If your application is accepting different values for the same field over
+ * time and is doing a diff on them, you can either (1) create a copy or
+ * (2) ensure that those values are not mutated behind two passes.
+ * This function helps you with (2) by freezing the object and throwing if
+ * the user subsequently modifies the value.
+ *
+ * There are two caveats with this function:
+ *   - If the call site is not in strict mode, it will only throw when
+ *     mutating existing fields, adding a new one
+ *     will unfortunately fail silently :(
+ *   - If the object is already frozen or sealed, it will not continue the
+ *     deep traversal and will leave leaf nodes unfrozen.
+ *
+ * Freezing the object and adding the throw mechanism is expensive and will
+ * only be used in DEV.
+ */
+export default function deepFreezeAndThrowOnMutation(object) {
+    if (typeof object !== 'object' || object === null || Object.isFrozen(object) || Object.isSealed(object)) {
+        return;
+    }
+
+    for (const key in object) {
+        if (object.hasOwnProperty(key)) {
+            object.__defineGetter__(key, identity.bind(null, object[key])); // eslint-disable-line no-underscore-dangle
+            object.__defineSetter__(key, throwOnImmutableMutation.bind(null, key)); // eslint-disable-line no-underscore-dangle
+        }
+    }
+
+    Object.freeze(object);
+    Object.seal(object);
+
+    for (const key in object) {
+        if (object.hasOwnProperty(key)) {
+            deepFreezeAndThrowOnMutation(object[key]);
+        }
+    }
+}
+
+function throwOnImmutableMutation(key, value) {
+    throw Error(
+        'You attempted to set the key `' + key + '` with the value `' +
+        JSON.stringify(value) + '` on an object that is meant to be immutable ' +
+        'and has been frozen.'
+    );
+}
+
+function identity(value) {
+    return value;
+}


### PR DESCRIPTION
This will catch and prevent most cases where we mutate the store. It unfortunately fails silently in a few cases (like `Reflect.deleteProperty`), but it'll at least fail if we do anything sketchy