### PR TITLE
Use the new API for view channel

### DIFF
--- a/service/actions/websocket.js
+++ b/service/actions/websocket.js
@@ -19,7 +19,7 @@ import {
     fetchMyChannelsAndMembers,
     getChannel,
     getChannelStats,
-    updateLastViewedAt
+    viewChannel
 } from 'service/actions/channels';
 
 import {
@@ -158,7 +158,7 @@ function handleNewPostEvent(msg, dispatch, getState) {
 
     if (post.channel_id === channels.currentId) {
         if (isActive) {
-            updateLastViewedAt(teamId, post.channel_id)(dispatch, getState);
+            viewChannel(teamId, post.channel_id)(dispatch, getState);
         } else {
             getChannel(teamId, post.channel_id)(dispatch, getState);
         }
@@ -208,7 +208,7 @@ function handlePostEdited(msg, dispatch, getState) {
 
     if (msg.broadcast.channel_id === channels.currentId && isActive) {
         // FIXME: Update post should include team_id in the message cause its not always the current team
-        // updateLastViewedAt(msg.data.team_id, data.channel_id)(dispatch, getState);
+        // viewChannel(msg.data.team_id, data.channel_id)(dispatch, getState);
     }
 }
 

--- a/service/client/client.js
+++ b/service/client/client.js
@@ -486,10 +486,15 @@ export default class Client {
         );
     };
 
-    updateLastViewedAt = async (teamId, channelId, active) => {
+    viewChannel = async (teamId, channelId, prevChannelId = '') => {
+        const data = {
+            channel_id: channelId,
+            prev_channel_id: prevChannelId
+        };
+
         return this.doFetch(
-            `${this.getChannelNeededRoute(teamId, channelId)}/update_last_viewed_at`,
-            {method: 'post', body: JSON.stringify({active})}
+            `${this.getChannelsRoute(teamId)}/view`,
+            {method: 'post', body: JSON.stringify(data)}
         );
     };
 

--- a/service/reducers/entities/channels.js
+++ b/service/reducers/entities/channels.js
@@ -72,6 +72,8 @@ function myMembers(state = {}, action) {
     case ChannelTypes.RECEIVED_LAST_VIEWED: {
         const member = {...state[action.data.channel_id]};
         member.last_viewed_at = action.data.last_viewed_at;
+        member.mention_count = 0;
+        member.msg_count = 0;
 
         return {
             ...state,

--- a/test/service/actions/channels.test.js
+++ b/test/service/actions/channels.test.js
@@ -257,16 +257,23 @@ describe('Actions.Channels', () => {
         assert.ifError(myMembers[secondChannel.id]);
     });
 
-    it('updateLastViewedAt', async () => {
+    it('viewChannel', async () => {
+        const userChannel = await Client.createChannel(
+            TestHelper.fakeChannel(TestHelper.basicTeam.id)
+        );
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
         let members = store.getState().entities.channels.myMembers;
         let member = members[TestHelper.basicChannel.id];
+        let otherMember = members[userChannel.id];
         assert.ok(member);
+        assert.ok(otherMember);
         const lastViewed = member.last_viewed_at;
 
-        await Actions.updateLastViewedAt(
+        await Actions.viewChannel(
             TestHelper.basicTeam.id,
-            TestHelper.basicChannel.id, true)(store.dispatch, store.getState);
+            TestHelper.basicChannel.id,
+            userChannel.id
+        )(store.dispatch, store.getState);
 
         const updateRequest = store.getState().requests.channels.updateLastViewedAt;
         if (updateRequest.status === RequestStatus.FAILURE) {
@@ -275,7 +282,9 @@ describe('Actions.Channels', () => {
 
         members = store.getState().entities.channels.myMembers;
         member = members[TestHelper.basicChannel.id];
+        otherMember = members[userChannel.id];
         assert.ok(member.last_viewed_at > lastViewed);
+        assert.ok(otherMember.last_viewed_at > lastViewed);
     });
 
     it('getMoreChannels', async () => {

--- a/test/service/actions/websocket.test.js
+++ b/test/service/actions/websocket.test.js
@@ -208,10 +208,9 @@ describe('Actions.Websocket', () => {
         async function test() {
             await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
 
-            await Client.updateLastViewedAt(
+            await Client.viewChannel(
                 TestHelper.basicTeam.id,
-                TestHelper.basicChannel.id,
-                false
+                TestHelper.basicChannel.id
             );
 
             setTimeout(() => {


### PR DESCRIPTION
This gets rid of the `lastViewedAt` and uses the new `viewChannel` api