### PR TITLE
Fix channel selection when switching teams

### DIFF
--- a/app/components/channel_drawer/channel_drawer.js
+++ b/app/components/channel_drawer/channel_drawer.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import {Platform, BackAndroid} from 'react-native';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import deepEqual from 'deep-equal';
 
 import Drawer from 'react-native-drawer';
 import ChannelList from './channel_list';
@@ -27,7 +27,6 @@ export default class ChannelDrawer extends React.Component {
     constructor(props) {
         super(props);
 
-        this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
         this.handleBackButton = this.handleBackButton.bind(this);
     }
 
@@ -41,6 +40,9 @@ export default class ChannelDrawer extends React.Component {
         if (Platform.OS === 'android') {
             BackAndroid.removeEventListener('hardwareBackPress', this.handleBackButton);
         }
+    }
+    shouldComponentUpdate(nextProps) {
+        return !deepEqual(this.props, nextProps, {strict: true});
     }
 
     componentWillReceiveProps(nextProps) {

--- a/app/components/channel_drawer/channel_list.js
+++ b/app/components/channel_drawer/channel_list.js
@@ -73,21 +73,13 @@ export default class ChannelList extends React.Component {
         };
     }
 
-    shouldComponentUpdate(nextProps) {
-        return !deepEqual(this.props, nextProps, {strict: true});
+    shouldComponentUpdate(nextProps, nextState) {
+        return !deepEqual(this.props, nextProps, {strict: true}) || !deepEqual(this.state, nextState, {strict: true});
     }
 
     componentWillReceiveProps(nextProps) {
-        let dataSource;
-        if (this.props.currentChannel.id === nextProps.currentChannel.id) {
-            dataSource = this.state.dataSource.cloneWithRows(this.buildData(nextProps));
-        } else {
-            dataSource = new ListView.DataSource({
-                rowHasChanged: (a, b) => a !== b
-            }).cloneWithRows(this.buildData(nextProps));
-        }
         this.setState({
-            dataSource
+            dataSource: this.state.dataSource.cloneWithRows(this.buildData(nextProps))
         });
         const container = this.refs.scrollContainer;
         if (container && container._visibleRows && container._visibleRows.s1) { //eslint-disable-line no-underscore-dangle
@@ -194,7 +186,7 @@ export default class ChannelList extends React.Component {
                 hasUnread={unread}
                 mentions={mentions}
                 onSelectChannel={this.onSelectChannel}
-                isActive={channel.id === this.props.currentChannel.id}
+                isActive={channel.isCurrent}
                 theme={this.props.theme}
             />
         );

--- a/app/components/channel_drawer/channel_list.js
+++ b/app/components/channel_drawer/channel_list.js
@@ -9,6 +9,7 @@ import LineDivider from 'app/components/line_divider';
 import ChannelItem from './channel_item';
 import FormattedText from 'app/components/formatted_text';
 import UnreadIndicator from './unread_indicator';
+import deepEqual from 'deep-equal';
 
 const Styles = StyleSheet.create({
     container: {
@@ -72,9 +73,21 @@ export default class ChannelList extends React.Component {
         };
     }
 
+    shouldComponentUpdate(nextProps) {
+        return !deepEqual(this.props, nextProps, {strict: true});
+    }
+
     componentWillReceiveProps(nextProps) {
+        let dataSource;
+        if (this.props.currentChannel.id === nextProps.currentChannel.id) {
+            dataSource = this.state.dataSource.cloneWithRows(this.buildData(nextProps));
+        } else {
+            dataSource = new ListView.DataSource({
+                rowHasChanged: (a, b) => a !== b
+            }).cloneWithRows(this.buildData(nextProps));
+        }
         this.setState({
-            dataSource: this.state.dataSource.cloneWithRows(this.buildData(nextProps))
+            dataSource
         });
         const container = this.refs.scrollContainer;
         if (container && container._visibleRows && container._visibleRows.s1) { //eslint-disable-line no-underscore-dangle

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "deep-equal": "1.0.1",
     "intl": "1.2.5",
     "isomorphic-fetch": "2.2.1",
     "react": "15.4.1",

--- a/service/reducers/entities/teams.js
+++ b/service/reducers/entities/teams.js
@@ -75,16 +75,20 @@ function membersInTeam(state = {}, action) {
     }
     case TeamsTypes.RECEIVED_MEMBERS_IN_TEAM: {
         const data = action.data;
-        const teamId = data[0].team_id;
-        const members = new Set(state[teamId]);
-        for (const member of data) {
-            members.add(member.user_id);
+        if (data.length) {
+            const teamId = data[0].team_id;
+            const members = new Set(state[teamId]);
+            for (const member of data) {
+                members.add(member.user_id);
+            }
+
+            return {
+                ...state,
+                [teamId]: members
+            };
         }
 
-        return {
-            ...state,
-            [teamId]: members
-        };
+        return state;
     }
     case TeamsTypes.REMOVE_MEMBER_FROM_TEAM: {
         const data = action.data;

--- a/service/selectors/entities/channels.js
+++ b/service/selectors/entities/channels.js
@@ -38,11 +38,18 @@ export const getChannelsOnCurrentTeam = createSelector(
 );
 
 export const getChannelsByCategory = createSelector(
+    getCurrentChannelId,
     getChannelsOnCurrentTeam,
     (state) => state.entities.users,
     (state) => state.entities.preferences.myPreferences,
     (state) => state.entities.teams,
-    (channels, usersState, myPreferences, teamsState) => {
-        return buildDisplayableChannelList(usersState, teamsState, channels, myPreferences);
+    (currentChannelId, channels, usersState, myPreferences, teamsState) => {
+        const allChannels = channels.map((c) => {
+            const channel = {...c};
+            channel.isCurrent = c.id === currentChannelId;
+            return channel;
+        });
+
+        return buildDisplayableChannelList(usersState, teamsState, allChannels, myPreferences);
     }
 );

--- a/service/utils/channel_utils.js
+++ b/service/utils/channel_utils.js
@@ -147,7 +147,7 @@ function completeDirectChannelInfo(usersState, myPreferences, channel) {
         return channel;
     }
 
-    const dmChannelClone = JSON.parse(JSON.stringify(channel));
+    const dmChannelClone = {...channel};
     const teammateId = getUserIdFromChannelName(usersState.currentId, channel);
 
     return Object.assign(dmChannelClone, {


### PR DESCRIPTION
Fix channel selection when switching teams by instantiating a new DataSource if the currentChannel changes, if we don't do that then the rendering of the channels will happen before getting the new currentChannel and will fail to select the current ones.

Also added `deepEqual` to be able to compare the objects and prevent the component to be rendered multiple times without the need to, there are a few components that implement PureComponent which only checks for shallow equality and should compare more deeply, maybe we should take another look at those.

Also fixed another bug when the data return for teamMembers was an empty array.

Finally changed the way we were cloning an object in the channel utils 