### PR TITLE
Update channel header/purpose when current channel

### DIFF
--- a/service/actions/channels.js
+++ b/service/actions/channels.js
@@ -537,6 +537,30 @@ export function removeChannelMember(teamId, channelId, userId) {
     };
 }
 
+export function updateChannelHeader(channelId, header) {
+    return async (dispatch, getState) => {
+        dispatch({
+            type: ChannelTypes.UPDATE_CHANNEL_HEADER,
+            data: {
+                channelId,
+                header
+            }
+        }, getState);
+    };
+}
+
+export function updateChannelPurpose(channelId, purpose) {
+    return async (dispatch, getState) => {
+        dispatch({
+            type: ChannelTypes.UPDATE_CHANNEL_PURPOSE,
+            data: {
+                channelId,
+                purpose
+            }
+        }, getState);
+    };
+}
+
 export default {
     selectChannel,
     createChannel,
@@ -553,5 +577,7 @@ export default {
     getMoreChannels,
     getChannelStats,
     addChannelMember,
-    removeChannelMember
+    removeChannelMember,
+    updateChannelHeader,
+    updateChannelPurpose
 };

--- a/service/actions/websocket.js
+++ b/service/actions/websocket.js
@@ -19,7 +19,9 @@ import {
     fetchMyChannelsAndMembers,
     getChannel,
     getChannelStats,
-    viewChannel
+    viewChannel,
+    updateChannelHeader,
+    updateChannelPurpose
 } from 'service/actions/channels';
 
 import {
@@ -159,6 +161,14 @@ function handleNewPostEvent(msg, dispatch, getState) {
     if (post.channel_id === channels.currentId) {
         if (isActive) {
             viewChannel(teamId, post.channel_id)(dispatch, getState);
+            switch (post.type) {
+            case Constants.POST_HEADER_CHANGE:
+                updateChannelHeader(post.channel_id, post.props.new_header)(dispatch, getState);
+                break;
+            case Constants.POST_PURPOSE_CHANGE:
+                updateChannelPurpose(post.channel_id, post.props.new_purpose)(dispatch, getState);
+                break;
+            }
         } else {
             getChannel(teamId, post.channel_id)(dispatch, getState);
         }

--- a/service/constants/channels.js
+++ b/service/constants/channels.js
@@ -70,7 +70,9 @@ const ChannelTypes = keyMirror({
     RECEIVED_CHANNEL_STATS: null,
     RECEIVED_CHANNEL_PROPS: null,
     RECEIVED_CHANNEL_DELETED: null,
-    RECEIVED_LAST_VIEWED: null
+    RECEIVED_LAST_VIEWED: null,
+    UPDATE_CHANNEL_HEADER: null,
+    UPDATE_CHANNEL_PURPOSE: null
 });
 
 export default ChannelTypes;

--- a/service/constants/constants.js
+++ b/service/constants/constants.js
@@ -28,7 +28,10 @@ const Constants = {
     CATEGORY_DISPLAY_SETTINGS: 'display_settings',
     CATEGORY_FAVORITE_CHANNEL: 'favorite_channel',
     DISPLAY_PREFER_NICKNAME: 'nickname_full_name',
-    DISPLAY_PREFER_FULL_NAME: 'full_name'
+    DISPLAY_PREFER_FULL_NAME: 'full_name',
+
+    POST_HEADER_CHANGE: 'system_header_change',
+    POST_PURPOSE_CHANGE: 'system_purpose_change'
 };
 
 export default Constants;

--- a/service/reducers/entities/channels.js
+++ b/service/reducers/entities/channels.js
@@ -46,6 +46,26 @@ function channels(state = {}, action) {
             }
         };
     }
+    case ChannelTypes.UPDATE_CHANNEL_HEADER: {
+        const {channelId, header} = action.data;
+        return {
+            ...state,
+            [channelId]: {
+                ...state[channelId],
+                header
+            }
+        };
+    }
+    case ChannelTypes.UPDATE_CHANNEL_PURPOSE: {
+        const {channelId, purpose} = action.data;
+        return {
+            ...state,
+            [channelId]: {
+                ...state[channelId],
+                purpose
+            }
+        };
+    }
     case UsersTypes.LOGOUT_SUCCESS:
         return {};
 

--- a/test/service/actions/channels.test.js
+++ b/test/service/actions/channels.test.js
@@ -395,4 +395,42 @@ describe('Actions.Channels', () => {
         assert.ok(notChannel.has(user.id));
         assert.ifError(channel.has(user.id));
     });
+
+    it('updateChannelHeader', async () => {
+        await Actions.getChannel(TestHelper.basicTeam.id, TestHelper.basicChannel.id)(store.dispatch, store.getState);
+
+        const channelRequest = store.getState().requests.channels.getChannel;
+        if (channelRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(channelRequest.error));
+        }
+
+        const header = 'this is an updated test header';
+        await Actions.updateChannelHeader(
+            TestHelper.basicChannel.id,
+            header
+        )(store.dispatch, store.getState);
+        const {channels} = store.getState().entities.channels;
+        const channel = channels[TestHelper.basicChannel.id];
+        assert.ok(channel);
+        assert.deepEqual(channel.header, header);
+    });
+
+    it('updateChannelPurpose', async () => {
+        await Actions.getChannel(TestHelper.basicTeam.id, TestHelper.basicChannel.id)(store.dispatch, store.getState);
+
+        const channelRequest = store.getState().requests.channels.getChannel;
+        if (channelRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(channelRequest.error));
+        }
+
+        const purpose = 'this is an updated test purpose';
+        await Actions.updateChannelPurpose(
+            TestHelper.basicChannel.id,
+            purpose
+        )(store.dispatch, store.getState);
+        const {channels} = store.getState().entities.channels;
+        const channel = channels[TestHelper.basicChannel.id];
+        assert.ok(channel);
+        assert.deepEqual(channel.purpose, purpose);
+    });
 });


### PR DESCRIPTION
When the channel header or purpose is added/edited on another client a post gets made but if you are viewing that same channel the header and purpose do not update on the store, this will handle that scenario