### PR TITLE
Fix gradle to build without Mattermost keys as dev

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,10 +100,12 @@ android {
     }
     signingConfigs {
         release {
-            storeFile file(MATTERMOST_RELEASE_STORE_FILE)
-            storePassword MATTERMOST_RELEASE_PASSWORD
-            keyAlias MATTERMOST_RELEASE_KEY_ALIAS
-            keyPassword MATTERMOST_RELEASE_PASSWORD
+            if (project.hasProperty('MATTERMOST_RELEASE_STORE_FILE')) {
+                storeFile file(MATTERMOST_RELEASE_STORE_FILE)
+                storePassword MATTERMOST_RELEASE_PASSWORD
+                keyAlias MATTERMOST_RELEASE_KEY_ALIAS
+                keyPassword MATTERMOST_RELEASE_PASSWORD
+            }
         }
     }
     splits {
@@ -119,6 +121,10 @@ android {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release
+        }
+        debug {
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
     // applicationVariants are e.g. debug, release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -198,7 +198,7 @@ platform :android do
 
   desc 'Build Release file'
   lane :dev do
-    build_android({release: true})
+    build_android({release: false})
   end
 
   desc 'Submit a new Beta Build to Google Play'


### PR DESCRIPTION
This will allow any dev to build the apk in debug mode without complaining that the ENV does not have the keystore registered