### PR TITLE
Fix build in release mode

### DIFF
--- a/service/store/configureStore.prod.js
+++ b/service/store/configureStore.prod.js
@@ -7,8 +7,9 @@ import serviceReducer from 'service/reducers';
 import thunk from 'redux-thunk';
 
 export default function configureServiceStore(preloadedState, appReducer) {
+    const baseReducer = combineReducers(Object.assign({}, serviceReducer, appReducer));
     return createStore(
-        enableBatching(combineReducers({serviceReducer, appReducer})),
+        enableBatching(baseReducer),
         preloadedState,
         applyMiddleware(thunk)
     );


### PR DESCRIPTION
#### Summary
So thanks to @jarredwitt now we can build in release mode without the need to hack the Makefile by having to always build in dev mode.

It seems that somehow the `combineReducers` in the production store was making the reducers not to be called after a dispatch, Jarred hunt it down and by doing an Object.assign fixes the issue.