### PR TITLE
Reset cache when starting the app with make run

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Follow the [React Native Getting Started Guide](https://facebook.github.io/react
     $ make run
     ```
 
+- Stop the packager server
+    ```bash
+    $ make stop
+    ```
 ## Linux:
 
 - General requiriments:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "check": "node_modules/.bin/eslint --ext \".js\" --ignore-pattern node_modules --quiet .",
     "run-ios": "node node_modules/react-native/local-cli/cli.js run-ios",
     "run-android": "node node_modules/react-native/local-cli/cli.js run-android",
-    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "start": "node node_modules/react-native/local-cli/cli.js start -- --reset-cache",
     "test": "NODE_ENV=test mocha --compilers js:babel-register --require babel-polyfill",
     "postinstall": "make post-install"
   }


### PR DESCRIPTION
#### Summary
When running the app with `$ make run`, `$ make run-ios` or `$ make run-android` will start the react-native packager with the `--reset-cache` flag and that will transform the whole javascript code the first time avoiding the behavior seen in #191.

To stop the react-native packager just run `$ make stop`

#### Ticket Link
#201 