### PR TITLE
Channel info favorite

### DIFF
--- a/app/scenes/channel_info/channel_info.js
+++ b/app/scenes/channel_info/channel_info.js
@@ -41,12 +41,21 @@ export default class ChannelInfo extends PureComponent {
         theme: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             getChannelStats: PropTypes.func.isRequired,
-            goToChannelMembers: PropTypes.func.isRequired
+            goToChannelMembers: PropTypes.func.isRequired,
+            markFavorite: PropTypes.func.isRequired,
+            unmarkFavorite: PropTypes.func.isRequired
         })
     }
 
     componentDidMount() {
         this.props.actions.getChannelStats(this.props.currentChannel.team_id, this.props.currentChannel.id);
+    }
+
+    handleFavorite() {
+        const {isFavorite, actions, currentChannel} = this.props;
+        const {markFavorite, unmarkFavorite} = actions;
+        const toggleFavorite = isFavorite ? unmarkFavorite : markFavorite;
+        toggleFavorite(currentChannel.id);
     }
 
     render() {
@@ -72,7 +81,7 @@ export default class ChannelInfo extends PureComponent {
                         purpose={currentChannel.purpose}
                     />
                     <ChannelInfoRow
-                        action={() => true}
+                        action={() => this.handleFavorite()}
                         defaultMessage='Favorite'
                         detail={isFavorite}
                         icon='star-o'

--- a/app/scenes/channel_info/channel_info.js
+++ b/app/scenes/channel_info/channel_info.js
@@ -51,7 +51,7 @@ export default class ChannelInfo extends PureComponent {
         this.props.actions.getChannelStats(this.props.currentChannel.team_id, this.props.currentChannel.id);
     }
 
-    handleFavorite() {
+    handleFavorite = () => {
         const {isFavorite, actions, currentChannel} = this.props;
         const {markFavorite, unmarkFavorite} = actions;
         const toggleFavorite = isFavorite ? unmarkFavorite : markFavorite;
@@ -81,7 +81,7 @@ export default class ChannelInfo extends PureComponent {
                         purpose={currentChannel.purpose}
                     />
                     <ChannelInfoRow
-                        action={() => this.handleFavorite()}
+                        action={this.handleFavorite}
                         defaultMessage='Favorite'
                         detail={isFavorite}
                         icon='star-o'

--- a/app/scenes/channel_info/channel_info.js
+++ b/app/scenes/channel_info/channel_info.js
@@ -47,6 +47,21 @@ export default class ChannelInfo extends PureComponent {
         })
     }
 
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isFavorite: this.props.isFavorite
+        };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const isFavorite = nextProps.isFavorite;
+        if (isFavorite !== this.state.isFavorite) {
+            this.setState({isFavorite});
+        }
+    }
+
     componentDidMount() {
         this.props.actions.getChannelStats(this.props.currentChannel.team_id, this.props.currentChannel.id);
     }
@@ -55,6 +70,7 @@ export default class ChannelInfo extends PureComponent {
         const {isFavorite, actions, currentChannel} = this.props;
         const {markFavorite, unmarkFavorite} = actions;
         const toggleFavorite = isFavorite ? unmarkFavorite : markFavorite;
+        this.setState({isFavorite: !isFavorite});
         toggleFavorite(currentChannel.id);
     }
 
@@ -63,7 +79,6 @@ export default class ChannelInfo extends PureComponent {
             currentChannel,
             currentChannelCreatorName,
             currentChannelMemberCount,
-            isFavorite,
             theme
         } = this.props;
 
@@ -83,7 +98,7 @@ export default class ChannelInfo extends PureComponent {
                     <ChannelInfoRow
                         action={this.handleFavorite}
                         defaultMessage='Favorite'
-                        detail={isFavorite}
+                        detail={this.state.isFavorite}
                         icon='star-o'
                         textId='mobile.routes.channelInfo.favorite'
                         togglable={true}

--- a/app/scenes/channel_info/channel_info_container.js
+++ b/app/scenes/channel_info/channel_info_container.js
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 
 import {goToChannelMembers} from 'app/actions/navigation';
 import {getChannelStats} from 'service/actions/channels';
+import {markFavorite, unmarkFavorite} from 'app/actions/views/channel';
 import {getCurrentChannel, getCurrentChannelStats, getChannelsByCategory} from 'service/selectors/entities/channels';
 import {getTheme} from 'service/selectors/entities/preferences';
 import {getUser} from 'service/selectors/entities/users';
@@ -34,7 +35,9 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getChannelStats,
-            goToChannelMembers
+            goToChannelMembers,
+            markFavorite,
+            unmarkFavorite
         }, dispatch)
     };
 }

--- a/app/scenes/channel_info/channel_info_row.js
+++ b/app/scenes/channel_info/channel_info_row.js
@@ -63,7 +63,7 @@ function channelInfoRow(props) {
             <Text style={style.detail}>{detail}</Text>
             {togglable ?
                 <Switch
-                    action={action}
+                    onValueChange={action}
                     value={detail}
                 /> :
                 <Icon


### PR DESCRIPTION
#### Summary
This pull request enables a user to toggle favoriting a channel from the channel_info view.

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/issues/197

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers
- [X] Has UI changes
- [ ] Includes text changes and localization file updates