### PR TITLE
PLT-5486 Removed channel_viewed websocket event

### DIFF
--- a/app/components/channel_list/channel_list.js
+++ b/app/components/channel_list/channel_list.js
@@ -78,6 +78,7 @@ class ChannelList extends Component {
         onSelectChannel: PropTypes.func.isRequired,
         actions: PropTypes.shape({
             viewChannel: PropTypes.func.isRequired,
+            markChannelAsRead: PropTypes.func.isRequired,
             closeDMChannel: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired,
             markFavorite: PropTypes.func.isRequired,
@@ -162,7 +163,8 @@ class ChannelList extends Component {
         } = this.props;
 
         this.props.onSelectChannel(channel.id);
-        this.props.actions.viewChannel(currentTeam.id, channel.id, currentChannel.id);
+        this.props.actions.viewChannel(currentTeam.id, channel.id);
+        this.props.actions.markChannelAsRead(channel.id, currentChannel.id);
     };
 
     handleClose = (channel) => {
@@ -297,7 +299,7 @@ class ChannelList extends Component {
             mentions = member.mention_count;
             unreadCount = channel.total_msg_count - member.msg_count;
 
-            if (member.notify_props && member.notify_props.mark_unread === 'mention') {
+            if (member.notify_props && member.notify_props.mark_unread === Constants.MENTION) {
                 unreadCount = 0;
             }
         }

--- a/app/components/channel_list/channel_list_container.js
+++ b/app/components/channel_list/channel_list_container.js
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import {showDirectMessagesModal, showOptionsModal, closeModal} from 'app/actions/navigation';
 import {closeDMChannel, leaveChannel, markFavorite, unmarkFavorite} from 'app/actions/views/channel';
 
-import {viewChannel} from 'service/actions/channels';
+import {viewChannel, markChannelAsRead} from 'service/actions/channels';
 import ChannelList from './channel_list';
 
 function mapStateToProps(state, ownProps) {
@@ -20,6 +20,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             viewChannel,
+            markChannelAsRead,
             closeDMChannel,
             leaveChannel,
             markFavorite,

--- a/app/scenes/channel_drawer/channel_drawer_container.js
+++ b/app/scenes/channel_drawer/channel_drawer_container.js
@@ -5,9 +5,8 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {closeDrawers} from 'app/actions/navigation';
-import {closeDMChannel, handleSelectChannel, leaveChannel, markFavorite, unmarkFavorite} from 'app/actions/views/channel';
+import {handleSelectChannel} from 'app/actions/views/channel';
 
-import {viewChannel} from 'service/actions/channels';
 import {getChannelsByCategory, getCurrentChannel} from 'service/selectors/entities/channels';
 import {getTheme} from 'service/selectors/entities/preferences';
 import {getCurrentTeam} from 'service/selectors/entities/teams';
@@ -27,12 +26,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            viewChannel,
-            closeDMChannel,
             closeDrawers,
-            leaveChannel,
-            markFavorite,
-            unmarkFavorite,
             handleSelectChannel
         }, dispatch)
     };

--- a/service/actions/general.js
+++ b/service/actions/general.js
@@ -4,6 +4,7 @@
 import Client from 'service/client';
 import {bindClientFunc} from './helpers.js';
 import {GeneralTypes} from 'service/constants';
+import {getMyChannelMembers} from './channels';
 
 export function getPing() {
     return bindClientFunc(
@@ -46,6 +47,13 @@ export function logClientError(message, level = 'ERROR') {
 export function setAppState(state) {
     return async (dispatch, getState) => {
         dispatch({type: GeneralTypes.RECEIVED_APP_STATE, data: state}, getState);
+
+        if (state) {
+            const teamId = getState().entities.teams.currentId;
+            if (teamId) {
+                getMyChannelMembers(teamId)(dispatch, getState);
+            }
+        }
     };
 }
 

--- a/service/constants/constants.js
+++ b/service/constants/constants.js
@@ -7,6 +7,8 @@ const Constants = {
     CHANNELS_CHUNK_SIZE: 50,
     SEARCH_TIMEOUT_MILLISECONDS: 100,
 
+    MENTION: 'mention',
+
     OFFLINE: 'offline',
     AWAY: 'away',
     ONLINE: 'online',

--- a/service/constants/websocket.js
+++ b/service/constants/websocket.js
@@ -6,7 +6,6 @@ const WebsocketEvents = {
     POST_EDITED: 'post_edited',
     POST_DELETED: 'post_deleted',
     CHANNEL_DELETED: 'channel_deleted',
-    CHANNEL_VIEWED: 'channel_viewed',
     DIRECT_ADDED: 'direct_added',
     LEAVE_TEAM: 'leave_team',
     USER_ADDED: 'user_added',

--- a/test/service/actions/channels.test.js
+++ b/test/service/actions/channels.test.js
@@ -264,12 +264,11 @@ describe('Actions.Channels', () => {
             TestHelper.fakeChannel(TestHelper.basicTeam.id)
         );
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
-        let members = store.getState().entities.channels.myMembers;
-        let member = members[TestHelper.basicChannel.id];
-        let otherMember = members[userChannel.id];
+        const members = store.getState().entities.channels.myMembers;
+        const member = members[TestHelper.basicChannel.id];
+        const otherMember = members[userChannel.id];
         assert.ok(member);
         assert.ok(otherMember);
-        const lastViewed = member.last_viewed_at;
 
         await Actions.viewChannel(
             TestHelper.basicTeam.id,
@@ -281,12 +280,6 @@ describe('Actions.Channels', () => {
         if (updateRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(updateRequest.error));
         }
-
-        members = store.getState().entities.channels.myMembers;
-        member = members[TestHelper.basicChannel.id];
-        otherMember = members[userChannel.id];
-        assert.ok(member.last_viewed_at > lastViewed);
-        assert.ok(otherMember.last_viewed_at > lastViewed);
     });
 
     it('getMoreChannels', async () => {

--- a/test/service/actions/websocket.test.js
+++ b/test/service/actions/websocket.test.js
@@ -210,27 +210,6 @@ describe('Actions.Websocket', () => {
         });
     });
 
-    it('Websocket Handle Channel Viewed', (done) => {
-        async function test() {
-            await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
-
-            await Client.viewChannel(
-                TestHelper.basicTeam.id,
-                TestHelper.basicChannel.id
-            );
-
-            setTimeout(() => {
-                const state = store.getState();
-                const entities = state.entities;
-                const {channels} = entities.channels;
-                assert.ok(channels[TestHelper.basicChannel.id]);
-                done();
-            }, 1500);
-        }
-
-        test();
-    });
-
     it('Websocket Handle Channel Deleted', (done) => {
         async function test() {
             await ChannelActions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
@@ -255,30 +234,29 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle Direct Channel', (done) => {
-        // TODO: Uncomment once fixed on platform
-        // const test = async () => {
-        //     const client = TestHelper.createClient();
-        //     const user = await client.createUserWithInvite(
-        //         TestHelper.fakeUser(),
-        //         null,
-        //         null,
-        //         TestHelper.basicTeam.invite_id
-        //     );
-        //
-        //     await client.login(user.email, 'password1');
-        //     await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
-        //
-        //     store.subscribe(() => {
-        //         const entities = store.getState().entities;
-        //         const {channels} = entities.channels;
-        //         assert.ok(Object.keys(channels).length);
-        //         done();
-        //     });
-        //
-        //     await client.createDirectChannel(TestHelper.basicTeam.id, TestHelper.basicUser.id);
-        // };
-        // test();
-        done();
+        async function test() {
+            const client = TestHelper.createClient();
+            const user = await client.createUserWithInvite(
+                TestHelper.fakeUser(),
+                null,
+                null,
+                TestHelper.basicTeam.invite_id
+            );
+
+            await client.login(user.email, 'password1');
+            await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
+
+            setTimeout(() => {
+                const entities = store.getState().entities;
+                const {channels} = entities.channels;
+                assert.ok(Object.keys(channels).length);
+                done();
+            }, 500);
+
+            await client.createDirectChannel(TestHelper.basicTeam.id, TestHelper.basicUser.id);
+        }
+
+        test();
     });
 
     it('Websocket Handle Preferences Changed', (done) => {


### PR DESCRIPTION
#### Summary
This PR get's rid of the `CHANNEL_VIEWED` WebSocket event and handles marking and unmarking the unread channels client side to match the webapp in to be performance compliant.

Additionally enabled the test for the `DIRECT_ADDED` WebSocket event as it was fixed on `platform`

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5486

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
