### PR TITLE
Fix fetch offset for more dms

### DIFF
--- a/app/scenes/more_dms/more_dms.js
+++ b/app/scenes/more_dms/more_dms.js
@@ -127,7 +127,7 @@ class MoreDirectMessages extends PureComponent {
         let {page} = this.state;
         if (this.props.requestStatus.status !== RequestStatus.STARTED && this.state.next && !this.state.searching) {
             page = page + 1;
-            this.props.actions.getProfiles(page, Constants.PROFILE_CHUNK_SIZE).
+            this.props.actions.getProfiles(page * Constants.PROFILE_CHUNK_SIZE, Constants.PROFILE_CHUNK_SIZE).
             then((data) => {
                 if (Object.keys(data).length) {
                     this.setState({


### PR DESCRIPTION
This PR changes the way the profiles are fetched, before it was using the page number instead of the number of profiles as the offset