### PR TITLE
PLT-5545 Fix Unread above/below indicator size to fit on screen

### DIFF
--- a/app/components/channel_list/channel_list.js
+++ b/app/components/channel_list/channel_list.js
@@ -115,7 +115,7 @@ class ChannelList extends Component {
         this.setState({
             dataSource: this.state.dataSource.cloneWithRows(this.buildData(nextProps))
         });
-        const container = this.refs.scrollContainer;
+        const container = this.scrollContainer;
         if (container && container._visibleRows && container._visibleRows.s1) { //eslint-disable-line no-underscore-dangle
             this.updateUnreadIndicators(container._visibleRows);  //eslint-disable-line no-underscore-dangle
         }
@@ -165,6 +165,11 @@ class ChannelList extends Component {
         this.props.onSelectChannel(channel.id);
         this.props.actions.viewChannel(currentTeam.id, channel.id);
         this.props.actions.markChannelAsRead(channel.id, currentChannel.id);
+    };
+
+    onLayout = (event) => {
+        const {width} = event.nativeEvent.layout;
+        this.width = width;
     };
 
     handleClose = (channel) => {
@@ -303,6 +308,7 @@ class ChannelList extends Component {
                 unreadCount = 0;
             }
         }
+
         return {
             mentions,
             unreadCount
@@ -469,7 +475,7 @@ class ChannelList extends Component {
         if (this.state.showAbove) {
             above = (
                 <UnreadIndicator
-                    style={{top: 55, backgroundColor: theme.mentionBj}}
+                    style={{top: 55, backgroundColor: theme.mentionBj, width: (this.width - 40)}}
                     text={(
                         <FormattedText
                             style={[Styles.indicatorText, {color: theme.mentionColor}]}
@@ -484,7 +490,7 @@ class ChannelList extends Component {
         if (this.state.showBelow) {
             below = (
                 <UnreadIndicator
-                    style={{bottom: 15, backgroundColor: theme.mentionBj}}
+                    style={{bottom: 15, backgroundColor: theme.mentionBj, width: (this.width - 40)}}
                     text={(
                         <FormattedText
                             style={[Styles.indicatorText, {color: theme.mentionColor}]}
@@ -497,7 +503,10 @@ class ChannelList extends Component {
         }
 
         return (
-            <View style={[Styles.container, {backgroundColor: theme.sidebarBg}]}>
+            <View
+                style={[Styles.container, {backgroundColor: theme.sidebarBg}]}
+                onLayout={this.onLayout}
+            >
                 <View style={[Styles.headerContainer, {backgroundColor: theme.sidebarHeaderBg}]}>
                     <Text
                         ellipsizeMode='tail'

--- a/app/components/channel_list/unread_indicator.js
+++ b/app/components/channel_list/unread_indicator.js
@@ -13,7 +13,6 @@ const Styles = StyleSheet.create({
         position: 'absolute',
         borderRadius: 15,
         marginHorizontal: 15,
-        flex: 1,
         height: 25
     }
 });

--- a/app/components/channel_list/unread_indicator.js
+++ b/app/components/channel_list/unread_indicator.js
@@ -12,8 +12,8 @@ const Styles = StyleSheet.create({
         flexDirection: 'row',
         position: 'absolute',
         borderRadius: 15,
-        marginLeft: 25,
-        width: 250,
+        marginHorizontal: 15,
+        flex: 1,
         height: 25
     }
 });


### PR DESCRIPTION
#### Summary
The unread indicators had a fixed width of 250 causing it not to show properly on smaller screen sizes, this PR makes the indicators width dynamic

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5545

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
