### PR TITLE
PostList date separator to match webapp

### DIFF
--- a/app/components/post_list/date_header.js
+++ b/app/components/post_list/date_header.js
@@ -48,6 +48,10 @@ export default class DateHeader extends React.Component {
                     <FormattedDate
                         style={style.date}
                         value={this.props.date}
+                        weekday='short'
+                        day='2-digit'
+                        month='short'
+                        year='numeric'
                     />
                 </View>
                 <View style={style.line}/>

--- a/test/service/actions/websocket.test.js
+++ b/test/service/actions/websocket.test.js
@@ -258,29 +258,4 @@ describe('Actions.Websocket', () => {
 
         test();
     });
-
-    it('Websocket Handle Preferences Changed', (done) => {
-        async function test() {
-            const client = TestHelper.createClient();
-            const user = await client.createUserWithInvite(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-            await client.login(user.email, 'password1');
-            const dm = await client.createDirectChannel(TestHelper.basicTeam.id, TestHelper.basicUser.id);
-            const post = {...TestHelper.fakePost(), channel_id: dm.id};
-            await client.createPost(TestHelper.basicTeam.id, post);
-
-            setTimeout(() => {
-                const entities = store.getState().entities;
-                const preferences = entities.preferences.myPreferences;
-                assert.ok(preferences[`${Constants.CATEGORY_DIRECT_CHANNEL_SHOW}--${user.id}`]);
-                done();
-            }, 500);
-        }
-
-        test();
-    });
 });


### PR DESCRIPTION
#### Summary
This PR makes the date separator in the post list to match the one using in the web app

format `DDD, MMM DD, YYYY` 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
