### PR TITLE
PLT-5644 Center align login header text and topbar title text

### DIFF
--- a/app/scenes/navigationSceneConnect.js
+++ b/app/scenes/navigationSceneConnect.js
@@ -43,7 +43,7 @@ const defaults = {
                     <FormattedText
                         id={title.id}
                         defaultMessage={title.defaultMessage}
-                        style={{color: theme.sidebarHeaderTextColor, fontSize: 15, fontWeight: 'bold'}}
+                        style={{textAlign: 'center', color: theme.sidebarHeaderTextColor, fontSize: 15, fontWeight: 'bold'}}
                     />
                 </View>
             );

--- a/app/styles/index.js
+++ b/app/styles/index.js
@@ -22,6 +22,7 @@ export const GlobalStyles = StyleSheet.create({
         height: 50
     },
     header: {
+        textAlign: 'center',
         marginTop: 15,
         marginBottom: 15,
         fontSize: 32,


### PR DESCRIPTION
#### Summary
In PLT-5609 (#290) we wrapped the header text in the logic scenes (select server, login, & MFA)  in a `View`. This made the text left-aligned because we had been centering the text with flex instead of `textAlign`. Now the text is centered again. Everywhere we are using `GlobalStyles.header` should've been center-aligned anyway.
Also the title text in the topbar was not being properly centered, but it was only apparent when the scene title wrapped onto a second line, like in the MFA scene. Now it is centered too.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5644

#### Checklist
- [x] Has UI changes

@thomchop 