### PR TITLE
PLT-5610 Localize login error message to match what's displayed in webapp

### DIFF
--- a/app/scenes/login/login.js
+++ b/app/scenes/login/login.js
@@ -158,6 +158,43 @@ class Login extends Component {
         return '';
     }
 
+    getLoginErrorMessage = () => {
+        return (
+            this.getServerErrorForLogin() ||
+            this.props.checkMfaRequest.error ||
+            this.state.error
+        );
+    };
+
+    getServerErrorForLogin = () => {
+        const {error} = this.props.loginRequest;
+        if (!error) {
+            return null;
+        }
+        const errorId = error.server_error_id;
+        if (!errorId) {
+            return error.message;
+        }
+        if (
+            errorId === 'store.sql_user.get_for_login.app_error' ||
+            errorId === 'ent.ldap.do_login.user_not_registered.app_error'
+        ) {
+            return {
+                id: 'login.userNotFound',
+                defaultMessage: "We couldn't find an account matching your login credentials."
+            };
+        } else if (
+            errorId === 'api.user.check_user_password.invalid.app_error' ||
+            errorId === 'ent.ldap.do_login.invalid_password.app_error'
+        ) {
+            return {
+                id: 'login.invalidPassword',
+                defaultMessage: 'Your password is incorrect.'
+            };
+        }
+        return error.message;
+    }
+
     loginRef = (ref) => {
         this.loginId = ref;
     };
@@ -196,7 +233,7 @@ class Login extends Component {
                                 defaultMessage='All team communication in one place, searchable and accessible anywhere'
                             />
                         </View>
-                        <ErrorText error={this.props.loginRequest.error || this.props.checkMfaRequest.error || this.state.error}/>
+                        <ErrorText error={this.getLoginErrorMessage()}/>
                         <TextInput
                             ref={this.loginRef}
                             value={this.props.loginId}

--- a/service/client/client.js
+++ b/service/client/client.js
@@ -727,7 +727,12 @@ export default class Client {
             console.error(msg); // eslint-disable-line no-console
         }
 
-        throw {message: msg, status_code: data.status_code, url};
+        throw {
+            message: msg,
+            server_error_id: data.id,
+            status_code: data.status_code,
+            url
+        };
     };
 }
 


### PR DESCRIPTION
#### Summary
When a user attempted to login with an unrecognized email address or an incorrect password, we were displaying the error message that's returned from the server, but in the webapp we instead display a corresponding error message from `webapp/i18n.json`. Now we are displaying the same messages here.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5610

@thomchop 