### PR TITLE
PLT-5659 Server URL input box does not scroll when a long URL is entered

### DIFF
--- a/app/styles/index.js
+++ b/app/styles/index.js
@@ -107,7 +107,7 @@ export const GlobalStyles = StyleSheet.create({
         borderWidth: 1,
         marginTop: 5,
         marginBottom: 5,
-        padding: 15,
+        paddingLeft: 10,
         alignSelf: 'stretch',
         borderRadius: 3
     }


### PR DESCRIPTION
#### Summary
By removing the right padding on the TextInput component style we are not longer truncating the autoscroll of the component making possible to auto scroll to the right when the text is too long.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5659
