### PR TITLE
Move periodic status check to channel scene

### DIFF
--- a/app/components/root/root.js
+++ b/app/components/root/root.js
@@ -14,8 +14,6 @@ export default class Root extends React.Component {
         locale: React.PropTypes.string.isRequired,
         actions: React.PropTypes.shape({
             loadConfigAndLicense: React.PropTypes.func.isRequired,
-            startPeriodicStatusUpdates: React.PropTypes.func.isRequired,
-            stopPeriodicStatusUpdates: React.PropTypes.func.isRequired,
             setAppState: React.PropTypes.func.isRequired
         }).isRequired
     };
@@ -31,13 +29,11 @@ export default class Root extends React.Component {
     componentDidMount() {
         AppState.addEventListener('change', this.handleAppStateChange);
         EventEmitter.on(Constants.CONFIG_CHANGED, this.handleConfigChanged);
-        this.props.actions.startPeriodicStatusUpdates();
     }
 
     componentWillUnmount() {
         AppState.removeEventListener('change', this.handleAppStateChange);
         EventEmitter.off(Constants.CONFIG_CHANGED, this.handleConfigChanged);
-        this.props.actions.stopPeriodicStatusUpdates();
     }
 
     handleAppStateChange(appState) {

--- a/app/components/root/root_container.js
+++ b/app/components/root/root_container.js
@@ -8,7 +8,6 @@ import Config from 'assets/config.json';
 
 import {loadConfigAndLicense} from 'app/actions/views/root';
 import {setAppState} from 'service/actions/general';
-import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'service/actions/users';
 
 import Root from './root';
 
@@ -31,8 +30,6 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             loadConfigAndLicense,
-            startPeriodicStatusUpdates,
-            stopPeriodicStatusUpdates,
             setAppState
         }, dispatch)
     };

--- a/app/scenes/channel/channel.js
+++ b/app/scenes/channel/channel.js
@@ -30,7 +30,9 @@ export default class Channel extends React.PureComponent {
             handlePostDraftChanged: React.PropTypes.func.isRequired,
             goToChannelInfo: React.PropTypes.func.isRequired,
             initWebSocket: React.PropTypes.func.isRequired,
-            closeWebSocket: React.PropTypes.func.isRequired
+            closeWebSocket: React.PropTypes.func.isRequired,
+            startPeriodicStatusUpdates: React.PropTypes.func.isRequired,
+            stopPeriodicStatusUpdates: React.PropTypes.func.isRequired
         }).isRequired,
         currentTeam: React.PropTypes.object,
         currentChannel: React.PropTypes.object,
@@ -63,6 +65,10 @@ export default class Channel extends React.PureComponent {
         this.loadChannels(teamId);
     }
 
+    componentDidMount() {
+        this.props.actions.startPeriodicStatusUpdates();
+    }
+
     componentWillReceiveProps(nextProps) {
         if (nextProps.currentTeam && this.props.currentTeam.id !== nextProps.currentTeam.id) {
             const teamId = nextProps.currentTeam.id;
@@ -72,6 +78,7 @@ export default class Channel extends React.PureComponent {
 
     componentWillUnmount() {
         this.props.actions.closeWebSocket();
+        this.props.actions.stopPeriodicStatusUpdates();
         this.props.unsubscribeFromHeaderEvent('open_channel_drawer');
         EventEmitter.off('leave_team', this.handleLeaveTeam);
     }

--- a/app/scenes/channel/channel_container.js
+++ b/app/scenes/channel/channel_container.js
@@ -16,6 +16,7 @@ import {
     selectInitialChannel,
     handlePostDraftChanged
 } from 'app/actions/views/channel';
+import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'service/actions/users';
 import {selectFirstAvailableTeam} from 'app/actions/views/select_team';
 
 import {getCurrentChannel} from 'service/selectors/entities/channels';
@@ -51,7 +52,9 @@ function mapDispatchToProps(dispatch) {
             handlePostDraftChanged,
             goToChannelInfo,
             initWebSocket,
-            closeWebSocket
+            closeWebSocket,
+            startPeriodicStatusUpdates,
+            stopPeriodicStatusUpdates
         }, dispatch)
     };
 }


### PR DESCRIPTION
#### Summary
This PR moves the logic for getting profile statuses from the root component to the channel scene
