### PR TITLE
Fixed makefile for run-android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ios_target := $(filter-out build-ios,$(MAKECMDGOALS))
 android_target := $(filter-out build-android,$(MAKECMDGOALS))
 
 .npminstall: package.json
-	@if ! [ $(shell command -v npm) ]; then \
+	@if ! [ $(shell command -v npm 2> /dev/null) ]; then \
 		echo "npm is not installed"; \
 		exit 1; \
 	fi
@@ -58,15 +58,15 @@ run-android: | start prepare-android-build
 		echo "ANDROID_HOME is not set"; \
 		exit 1; \
 	fi
-	@if ! [ $(shell command -v adb) ]; then \
+	@if ! [ $(shell command -v adb 2> /dev/null) ]; then \
 		echo "adb is not installed"; \
 		exit 1; \
 	fi
-	@if ! [ $(shell adb get-state) == "device" ]; then \
-		echo "no android device or emulator is running"; \
-		exit 1; \
-	fi
-	@if ! [ $(shell command -v watchman) ]; then \
+    ifneq ($(shell adb get-state),device)
+		echo "no android device or emulator is running"
+		exit 1;
+    endif
+	@if ! [ $(shell command -v watchman 2> /dev/null) ]; then \
 		echo "watchman is not installed"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
#### Summary
Encountered build failure running ```make run-android``` in Ubuntu 16.04. See other info below:
 -  android emulator is running
 - versions: node 6.10.0 / npm 3.10.10 / watchman 4.7.0

Makefile failed to validate whether npm, adb and watchman are installed. In addition, it cannot determine whether adb emulator is running (```adb get-state``` to return```device```)

Actual log after running ```make run-android```: 
```
make: command: Command not found
npm is not installed
Makefile:10: recipe for target '.npminstall' failed
make: *** [.npminstall] Error 1
```

#### Ticket Link
None. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] updated Makefile

#### Device Information
This PR was tested on: [Android emulator only, OS version: Ubuntu 16.04] 