### PR TITLE
PLT-5717 Initial markdown support

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -84,8 +84,10 @@ export default class Markdown extends PureComponent {
 
     renderParagraph = ({children}) => {
         return (
-            <View style={[style.block, this.props.blockStyles.paragraph]}>
-                {children}
+            <View style={style.block}>
+                <Text>
+                    {children}
+                </Text>
             </View>
         );
     }
@@ -93,7 +95,9 @@ export default class Markdown extends PureComponent {
     renderHeading = ({children, level}) => {
         return (
             <View style={[style.block, this.props.blockStyles[`heading${level}`]]}>
-                {children}
+                <Text>
+                    {children}
+                </Text>
             </View>
         );
     }
@@ -115,7 +119,6 @@ export default class Markdown extends PureComponent {
     renderBlockQuote = ({children, ...otherProps}) => {
         return (
             <MarkdownBlockQuote
-                blockStyle={style.block}
                 bulletStyle={this.props.baseTextStyle}
                 {...otherProps}
             >
@@ -124,11 +127,12 @@ export default class Markdown extends PureComponent {
         );
     }
 
-    renderList = ({children, type, start}) => {
+    renderList = ({children, type, start, tight}) => {
         return (
             <MarkdownList
                 ordered={type !== 'bullet'}
                 startAt={start}
+                tight={tight}
             >
                 {children}
             </MarkdownList>
@@ -138,7 +142,6 @@ export default class Markdown extends PureComponent {
     renderListItem = ({children, ...otherProps}) => {
         return (
             <MarkdownListItem
-                blockStyle={style.block}
                 bulletStyle={this.props.baseTextStyle}
                 {...otherProps}
             >
@@ -156,8 +159,7 @@ export default class Markdown extends PureComponent {
     }
 
     renderSoftBreak = () => {
-        // Render a large, empty view and have it shrink to fill the remaining space to force a line break
-        return <View style={style.softBreak}/>;
+        return <Text>{'\n'}</Text>;
     }
 
     renderHtml = () => {
@@ -176,9 +178,5 @@ const style = StyleSheet.create({
         alignItems: 'flex-start',
         flexDirection: 'row',
         flexWrap: 'wrap'
-    },
-    softBreak: {
-        flexBasis: 1000000,
-        flexShrink: 1
     }
 });

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -1,0 +1,184 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Parser} from 'commonmark';
+import Renderer from 'commonmark-react-renderer';
+import React, {PropTypes, PureComponent} from 'react';
+import {
+    StyleSheet,
+    Text,
+    View
+} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+import {concatStyles} from 'app/utils/theme';
+
+import MarkdownBlockQuote from './markdown_block_quote';
+import MarkdownCodeBlock from './markdown_code_block';
+import MarkdownImage from './markdown_image';
+import MarkdownLink from './markdown_link';
+import MarkdownList from './markdown_list';
+import MarkdownListItem from './markdown_list_item';
+
+export default class Markdown extends PureComponent {
+    static propTypes = {
+        baseTextStyle: CustomPropTypes.Style,
+        textStyles: PropTypes.object,
+        blockStyles: PropTypes.object,
+        value: PropTypes.string.isRequired
+    };
+
+    static defaultProps = {
+        textStyles: {},
+        blockStyles: {}
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.parser = new Parser();
+        this.renderer = this.createRenderer();
+    }
+
+    createRenderer = () => {
+        return new Renderer({
+            renderers: {
+                text: this.renderText,
+
+                emph: Renderer.forwardChildren,
+                strong: Renderer.forwardChildren,
+                code: this.renderCodeSpan,
+                link: MarkdownLink,
+                image: MarkdownImage,
+
+                paragraph: this.renderParagraph,
+                heading: this.renderHeading,
+                codeBlock: this.renderCodeBlock,
+                blockQuote: this.renderBlockQuote,
+
+                list: this.renderList,
+                item: this.renderListItem,
+
+                hardBreak: this.renderHardBreak,
+                thematicBreak: this.renderThematicBreak,
+                softBreak: this.renderSoftBreak,
+
+                htmlBlock: this.renderHtml,
+                htmlInline: this.renderHtml
+            }
+        });
+    }
+
+    computeTextStyle = (baseStyle, context) => {
+        return concatStyles(baseStyle, context.map((type) => this.props.textStyles[type]));
+    }
+
+    renderText = ({literal, context}) => {
+        // Construct the text style based off of the parents of this node since RN's inheritance is limited
+        return <Text style={this.computeTextStyle(this.props.baseTextStyle, context)}>{literal}</Text>;
+    }
+
+    renderCodeSpan = ({literal, context}) => {
+        return <Text style={this.computeTextStyle(this.props.textStyles.code, context)}>{literal}</Text>;
+    }
+
+    renderParagraph = ({children}) => {
+        return (
+            <View style={[style.block, this.props.blockStyles.paragraph]}>
+                {children}
+            </View>
+        );
+    }
+
+    renderHeading = ({children, level}) => {
+        return (
+            <View style={[style.block, this.props.blockStyles[`heading${level}`]]}>
+                {children}
+            </View>
+        );
+    }
+
+    renderCodeBlock = (props) => {
+        // These sometimes include a trailing newline
+        const contents = props.literal.replace(/\n$/, '');
+
+        return (
+            <MarkdownCodeBlock
+                blockStyle={this.props.blockStyles.codeBlock}
+                textStyle={concatStyles(this.props.baseTextStyle, this.props.textStyles.codeBlock)}
+            >
+                {contents}
+            </MarkdownCodeBlock>
+        );
+    }
+
+    renderBlockQuote = ({children, ...otherProps}) => {
+        return (
+            <MarkdownBlockQuote
+                blockStyle={style.block}
+                bulletStyle={this.props.baseTextStyle}
+                {...otherProps}
+            >
+                {children}
+            </MarkdownBlockQuote>
+        );
+    }
+
+    renderList = ({children, type, start}) => {
+        return (
+            <MarkdownList
+                ordered={type !== 'bullet'}
+                startAt={start}
+            >
+                {children}
+            </MarkdownList>
+        );
+    }
+
+    renderListItem = ({children, ...otherProps}) => {
+        return (
+            <MarkdownListItem
+                blockStyle={style.block}
+                bulletStyle={this.props.baseTextStyle}
+                {...otherProps}
+            >
+                {children}
+            </MarkdownListItem>
+        );
+    }
+
+    renderHardBreak = () => {
+        return <View/>;
+    }
+
+    renderThematicBreak = () => {
+        return <View style={this.props.blockStyles.horizontalRule}/>;
+    }
+
+    renderSoftBreak = () => {
+        // Render a large, empty view and have it shrink to fill the remaining space to force a line break
+        return <View style={style.softBreak}/>;
+    }
+
+    renderHtml = () => {
+        return null;
+    }
+
+    render() {
+        const ast = this.parser.parse(this.props.value);
+
+        return <View>{this.renderer.render(ast)}</View>;
+    }
+}
+
+const style = StyleSheet.create({
+    block: {
+        alignItems: 'flex-start',
+        flexDirection: 'row',
+        flexWrap: 'wrap'
+    },
+    softBreak: {
+        flexBasis: 1000000,
+        flexShrink: 1
+    }
+});

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -15,7 +15,6 @@ import {concatStyles} from 'app/utils/theme';
 
 import MarkdownBlockQuote from './markdown_block_quote';
 import MarkdownCodeBlock from './markdown_code_block';
-import MarkdownImage from './markdown_image';
 import MarkdownLink from './markdown_link';
 import MarkdownList from './markdown_list';
 import MarkdownListItem from './markdown_list_item';
@@ -49,7 +48,7 @@ export default class Markdown extends PureComponent {
                 strong: Renderer.forwardChildren,
                 code: this.renderCodeSpan,
                 link: MarkdownLink,
-                image: MarkdownImage,
+                image: this.renderImage,
 
                 paragraph: this.renderParagraph,
                 heading: this.renderHeading,
@@ -74,13 +73,26 @@ export default class Markdown extends PureComponent {
         return concatStyles(baseStyle, context.map((type) => this.props.textStyles[type]));
     }
 
-    renderText = ({literal, context}) => {
+    renderText = ({context, literal}) => {
         // Construct the text style based off of the parents of this node since RN's inheritance is limited
         return <Text style={this.computeTextStyle(this.props.baseTextStyle, context)}>{literal}</Text>;
     }
 
-    renderCodeSpan = ({literal, context}) => {
+    renderCodeSpan = ({context, literal}) => {
         return <Text style={this.computeTextStyle(this.props.textStyles.code, context)}>{literal}</Text>;
+    }
+
+    renderImage = ({children, context, src}) => {
+        // TODO This will be properly implemented for PLT-5736
+        return (
+            <Text style={this.computeTextStyle(this.props.baseTextStyle, context)}>
+                {'!['}
+                {children}
+                {']('}
+                {src}
+                {')'}
+            </Text>
+        );
     }
 
     renderParagraph = ({children}) => {
@@ -128,7 +140,7 @@ export default class Markdown extends PureComponent {
         );
     }
 
-    renderList = ({children, type, start, tight}) => {
+    renderList = ({children, start, tight, type}) => {
         return (
             <MarkdownList
                 ordered={type !== 'bullet'}

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -65,7 +65,8 @@ export default class Markdown extends PureComponent {
 
                 htmlBlock: this.renderHtml,
                 htmlInline: this.renderHtml
-            }
+            },
+            renderParagraphsInLists: true
         });
     }
 

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -79,7 +79,7 @@ export default class Markdown extends PureComponent {
     }
 
     renderCodeSpan = ({context, literal}) => {
-        return <Text style={this.computeTextStyle(this.props.textStyles.code, context)}>{literal}</Text>;
+        return <Text style={this.computeTextStyle([this.props.baseTextStyle, this.props.textStyles.code], context)}>{literal}</Text>;
     }
 
     renderImage = ({children, context, src}) => {

--- a/app/components/markdown/markdown_block_quote.js
+++ b/app/components/markdown/markdown_block_quote.js
@@ -3,6 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import {
+    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -17,22 +18,24 @@ export default class MarkdownBlockQuote extends PureComponent {
     };
 
     render() {
-        // Inject the text style in case the children of this node are plain text which wouldn't
-        // get the text style from anywhere else
-        // const children = React.Children.map(this.props.children, (child) => {
-        //     return React.cloneElement(child, {
-        //         style: this.props.textStyle
-        //     });
-        // });
-        const children = this.props.children;
-
         return (
-            <View style={this.props.blockStyle}>
-                <Text style={this.props.bulletStyle}>
-                    {'> '}
-                </Text>
-                <View>{children}</View>
+            <View style={style.container}>
+                <View>
+                    <Text style={this.props.bulletStyle}>
+                        {'> '}
+                    </Text>
+                </View>
+                <View>
+                    {this.props.children}
+                </View>
             </View>
         );
     }
 }
+
+const style = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'flex-start'
+    }
+});

--- a/app/components/markdown/markdown_block_quote.js
+++ b/app/components/markdown/markdown_block_quote.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import {
+    Text,
+    View
+} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+
+export default class MarkdownBlockQuote extends PureComponent {
+    static propTypes = {
+        blockStyle: CustomPropTypes.Style,
+        bulletStyle: CustomPropTypes.Style,
+        children: CustomPropTypes.Children.isRequired
+    };
+
+    render() {
+        // Inject the text style in case the children of this node are plain text which wouldn't
+        // get the text style from anywhere else
+        // const children = React.Children.map(this.props.children, (child) => {
+        //     return React.cloneElement(child, {
+        //         style: this.props.textStyle
+        //     });
+        // });
+        const children = this.props.children;
+
+        return (
+            <View style={this.props.blockStyle}>
+                <Text style={this.props.bulletStyle}>
+                    {'> '}
+                </Text>
+                <View>{children}</View>
+            </View>
+        );
+    }
+}

--- a/app/components/markdown/markdown_code_block.js
+++ b/app/components/markdown/markdown_code_block.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import {ScrollView, Text} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+
+export default class MarkdownCodeBlock extends PureComponent {
+    static propTypes = {
+        children: CustomPropTypes.Children,
+        blockStyle: CustomPropTypes.Style,
+        textStyle: CustomPropTypes.Style
+    };
+
+    render() {
+        return (
+            <ScrollView
+                style={this.props.blockStyle}
+                horizontal={true}
+            >
+                <Text style={this.props.textStyle}>
+                    {this.props.children}
+                </Text>
+            </ScrollView>
+        );
+    }
+}

--- a/app/components/markdown/markdown_image.js
+++ b/app/components/markdown/markdown_image.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PropTypes, PureComponent} from 'react';
+import {Image} from 'react-native';
+
+export default class MarkdownLink extends PureComponent {
+    static propTypes = {
+        src: PropTypes.string.isRequired
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            width: 10000,
+            maxWidth: 10000,
+            height: 0
+        };
+    }
+
+    componentWillMount() {
+        Image.getSize(this.props.src, this.handleSizeReceived, this.handleSizeFailed);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (this.props.src !== nextProps.src) {
+            Image.getSize(nextProps.src, this.handleSizeReceived, this.handleSizeFailed);
+        }
+    }
+
+    handleSizeReceived = (width, height) => {
+        this.setState({
+            width,
+            height
+        });
+    };
+
+    handleSizeFailed = () => {
+        this.setState({
+            width: 0,
+            height: 0
+        });
+    }
+
+    handleLayout = (event) => {
+        this.setState({
+            maxWidth: event.nativeEvent.layout.width
+        });
+    }
+
+    render() {
+        let {width, maxWidth, height} = this.state; // eslint-disable-line prefer-const
+
+        if (width > maxWidth) {
+            height = height * (maxWidth / width);
+            width = maxWidth;
+        }
+
+        // React Native complains if we try to pass resizeMode into a StyleSheet
+        return (
+            <Image
+                source={{uri: this.props.src}}
+                onLayout={this.handleLayout}
+                style={{width, height, flexShrink: 1, resizeMode: 'cover'}}
+            />
+        );
+    }
+}

--- a/app/components/markdown/markdown_link.js
+++ b/app/components/markdown/markdown_link.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import React, {PropTypes, PureComponent} from 'react';
-import {Linking, TouchableHighlight, View} from 'react-native';
+import {Linking, Text} from 'react-native';
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
 
@@ -23,12 +23,6 @@ export default class MarkdownLink extends PureComponent {
     };
 
     render() {
-        return (
-            <TouchableHighlight onPress={this.handlePress}>
-                <View style={{flexWrap: 'wrap', flexDirection: 'row'}}>
-                    {this.props.children}
-                </View>
-            </TouchableHighlight>
-        );
+        return <Text onPress={this.handlePress}>{this.props.children}</Text>;
     }
 }

--- a/app/components/markdown/markdown_link.js
+++ b/app/components/markdown/markdown_link.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PropTypes, PureComponent} from 'react';
+import {Linking, TouchableHighlight, View} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+
+export default class MarkdownLink extends PureComponent {
+    static propTypes = {
+        children: CustomPropTypes.Children.isRequired,
+        href: PropTypes.string.isRequired
+    };
+
+    handlePress = () => {
+        const url = this.props.href;
+
+        Linking.canOpenURL(url).then((supported) => {
+            if (supported) {
+                Linking.openURL(url);
+            }
+        });
+    };
+
+    render() {
+        return (
+            <TouchableHighlight onPress={this.handlePress}>
+                <View style={{flexWrap: 'wrap', flexDirection: 'row'}}>
+                    {this.props.children}
+                </View>
+            </TouchableHighlight>
+        );
+    }
+}

--- a/app/components/markdown/markdown_list.js
+++ b/app/components/markdown/markdown_list.js
@@ -6,10 +6,10 @@ import {View} from 'react-native';
 
 export default class MarkdownList extends PureComponent {
     static propTypes = {
-        containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
         children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf([PropTypes.node])]).isRequired,
         ordered: PropTypes.bool.isRequired,
-        startAt: PropTypes.number
+        startAt: PropTypes.number,
+        tight: PropTypes.bool
     };
 
     render() {
@@ -17,12 +17,13 @@ export default class MarkdownList extends PureComponent {
             return React.cloneElement(child, {
                 ordered: this.props.ordered,
                 startAt: this.props.startAt,
-                index: i
+                index: i,
+                tight: this.props.tight
             });
         });
 
         return (
-            <View style={this.props.containerStyle}>
+            <View>
                 {children}
             </View>
         );

--- a/app/components/markdown/markdown_list.js
+++ b/app/components/markdown/markdown_list.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PropTypes, PureComponent} from 'react';
+import {View} from 'react-native';
+
+export default class MarkdownList extends PureComponent {
+    static propTypes = {
+        containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+        children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf([PropTypes.node])]).isRequired,
+        ordered: PropTypes.bool.isRequired,
+        startAt: PropTypes.number
+    };
+
+    render() {
+        const children = React.Children.map(this.props.children, (child, i) => {
+            return React.cloneElement(child, {
+                ordered: this.props.ordered,
+                startAt: this.props.startAt,
+                index: i
+            });
+        });
+
+        return (
+            <View style={this.props.containerStyle}>
+                {children}
+            </View>
+        );
+    }
+}

--- a/app/components/markdown/markdown_list_item.js
+++ b/app/components/markdown/markdown_list_item.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PropTypes, PureComponent} from 'react';
+import {
+    Text,
+    View
+} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+
+export default class MarkdownListItem extends PureComponent {
+    static propTypes = {
+        children: CustomPropTypes.Children.isRequired,
+        ordered: PropTypes.bool.isRequired,
+        startAt: PropTypes.number,
+        index: PropTypes.number.isRequired,
+        blockStyle: CustomPropTypes.Style,
+        bulletStyle: CustomPropTypes.Style
+    };
+
+    static defaultProps = {
+        startAt: 1
+    };
+
+    render() {
+        let bullet;
+        if (this.props.ordered) {
+            bullet = (this.props.startAt + this.props.index) + '. ';
+        } else {
+            bullet = '• ';
+        }
+
+        return (
+            <View style={this.props.blockStyle}>
+                <Text style={this.props.bulletStyle}>
+                    {bullet}
+                </Text>
+                <View style={{flex: 1}}>{this.props.children}</View>
+            </View>
+        );
+    }
+}

--- a/app/components/markdown/markdown_list_item.js
+++ b/app/components/markdown/markdown_list_item.js
@@ -3,6 +3,7 @@
 
 import React, {PropTypes, PureComponent} from 'react';
 import {
+    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -15,7 +16,7 @@ export default class MarkdownListItem extends PureComponent {
         ordered: PropTypes.bool.isRequired,
         startAt: PropTypes.number,
         index: PropTypes.number.isRequired,
-        blockStyle: CustomPropTypes.Style,
+        tight: PropTypes.bool,
         bulletStyle: CustomPropTypes.Style
     };
 
@@ -32,12 +33,23 @@ export default class MarkdownListItem extends PureComponent {
         }
 
         return (
-            <View style={this.props.blockStyle}>
-                <Text style={this.props.bulletStyle}>
-                    {bullet}
-                </Text>
-                <View style={{flex: 1}}>{this.props.children}</View>
+            <View style={style.container}>
+                <View>
+                    <Text style={this.props.bulletStyle}>
+                        {bullet}
+                    </Text>
+                </View>
+                <View>
+                    {this.props.children}
+                </View>
             </View>
         );
     }
 }
+
+const style = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'flex-start'
+    }
+});

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -3,8 +3,8 @@
 
 import React, {Component, PropTypes} from 'react';
 import {
-    Platform,
     Image,
+    Platform,
     StyleSheet,
     Text,
     TouchableHighlight,
@@ -15,9 +15,10 @@ import {
 import FormattedText from 'app/components/formatted_text';
 import FormattedTime from 'app/components/formatted_time';
 import MattermostIcon from 'app/components/mattermost_icon';
+import Markdown from 'app/components/markdown/markdown';
 import ProfilePicture from 'app/components/profile_picture';
 import FileAttachmentList from 'app/components/file_attachment_list/file_attachment_list_container';
-import {makeStyleSheetFromTheme} from 'app/utils/theme';
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils.js';
 
@@ -117,15 +118,25 @@ export default class Post extends Component {
     };
 
     renderMessage = (style, messageStyle, replyBar = false) => {
+        let contents;
+        if (this.props.post.message.length > 0) {
+            const theme = this.props.theme;
+
+            contents = (
+                <Markdown
+                    baseTextStyle={messageStyle}
+                    textStyles={getMarkdownTextStyles(theme)}
+                    blockStyles={getMarkdownBlockStyles(theme)}
+                    value={this.props.post.message}
+                />
+            );
+        }
+
         return (
             <TouchableHighlight onPress={this.handlePress}>
                 <View style={{flex: 1}}>
                     {replyBar && this.renderReplyBar(style)}
-                    {this.props.post.message.length > 0 &&
-                    <Text style={messageStyle}>
-                        {this.props.post.message}
-                    </Text>
-                    }
+                    {contents}
                     {this.renderFileAttachments()}
                 </View>
             </TouchableHighlight>
@@ -133,7 +144,9 @@ export default class Post extends Component {
     };
 
     render() {
-        const style = getStyleSheet(this.props.theme);
+        const theme = this.props.theme;
+        const style = getStyleSheet(theme);
+
         const PROFILE_PICTURE_SIZE = 32;
 
         let profilePicture;
@@ -178,6 +191,7 @@ export default class Post extends Component {
                     {this.props.post.props.override_username}
                 </Text>
             );
+
             messageStyle = [style.message, style.webhookMessage];
         } else {
             profilePicture = (
@@ -322,9 +336,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         message: {
             color: theme.centerChannelColor,
-            fontSize: 14,
-            lineHeight: 21,
-            marginBottom: 10
+            fontSize: 14
         },
         systemMessage: {
             opacity: 0.5
@@ -333,6 +345,77 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             fontSize: 16,
             fontWeight: '600'
+        }
+    });
+});
+
+const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
+    const codeFont = Platform.OS === 'ios' ? 'Courier New' : 'monospace';
+
+    return StyleSheet.create({
+        emph: {
+            fontStyle: 'italic'
+        },
+        strong: {
+            fontWeight: 'bold'
+        },
+        link: {
+            color: theme.linkColor
+        },
+        heading1: {
+            fontSize: 30,
+            lineHeight: 45
+        },
+        heading2: {
+            fontSize: 24,
+            lineHeight: 36
+        },
+        heading3: {
+            fontSize: 20,
+            lineHeight: 30
+        },
+        heading4: {
+            fontSize: 16,
+            lineHeight: 24
+        },
+        heading5: {
+            fontSize: 14,
+            lineHeight: 21
+        },
+        heading6: {
+            fontSize: 14,
+            lineHeight: 21,
+            opacity: 0.8
+        },
+        code: {
+            alignSelf: 'center',
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
+            fontFamily: codeFont,
+            paddingHorizontal: 4,
+            paddingVertical: 2
+        },
+        codeBlock: {
+            fontFamily: codeFont
+        },
+        horizontalRule: {
+            backgroundColor: theme.centerChannelColor,
+            height: StyleSheet.hairlineWidth,
+            flex: 1,
+            marginVertical: 10
+        }
+    });
+});
+
+const getMarkdownBlockStyles = makeStyleSheetFromTheme((theme) => {
+    return StyleSheet.create({
+        codeBlock: {
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
+            borderRadius: 4,
+            paddingHorizontal: 4,
+            paddingVertical: 2
+        },
+        horizontalRule: {
+            backgroundColor: theme.centerChannelColor
         }
     });
 });

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -192,7 +192,7 @@ export default class Post extends Component {
                 </Text>
             );
 
-            messageStyle = [style.message, style.webhookMessage];
+            messageStyle = style.message;
         } else {
             profilePicture = (
                 <TouchableOpacity onPress={this.viewUserProfile}>
@@ -336,15 +336,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         message: {
             color: theme.centerChannelColor,
-            fontSize: 14
+            fontSize: 14,
+            lineHeight: 21
         },
         systemMessage: {
             opacity: 0.5
-        },
-        webhookMessage: {
-            color: theme.centerChannelColor,
-            fontSize: 16,
-            fontWeight: '600'
         }
     });
 });

--- a/app/constants/custom_prop_types.js
+++ b/app/constants/custom_prop_types.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {PropTypes} from 'react';
+
+export const Children = PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf([PropTypes.node])]);
+
+export const Style = PropTypes.oneOfType([
+    PropTypes.object, // inline style
+    PropTypes.number, // style sheet entry
+    PropTypes.array
+]);
+
+export default {
+    Children,
+    Style
+};

--- a/app/utils/theme.js
+++ b/app/utils/theme.js
@@ -36,3 +36,7 @@ export function changeOpacity(oldColor, opacity) {
 
     return 'rgba(' + r + ',' + g + ',' + b + ',' + opacity + ')';
 }
+
+export function concatStyles(...styles) {
+    return [].concat(styles);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "commonmark": "0.27.0",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#f88c479a23bb418ca7d787be6763f0415e51f726",
     "deep-equal": "1.0.1",
     "harmony-reflect": "1.5.1",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "commonmark": "0.27.0",
-    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#55da1c569c497db7b58d2f4d8c5e6c2fbbf3f2ff",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#2e8ea6ac67b683b44782f403b69a06bb0e5c63e6",
     "deep-equal": "1.0.1",
     "harmony-reflect": "1.5.1",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "commonmark": "0.27.0",
-    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#f88c479a23bb418ca7d787be6763f0415e51f726",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#55da1c569c497db7b58d2f4d8c5e6c2fbbf3f2ff",
     "deep-equal": "1.0.1",
     "harmony-reflect": "1.5.1",
     "intl": "1.2.5",


### PR DESCRIPTION
What this includes:
- Bold/Italics
- Explicit links `[Google](http://google.ca)`
- Headings
- Code blocks (fenced and indented)
- Inline code
- Lists
- Horizontal ines

------

What this doesn't include (https://mattermost.atlassian.net/browse/PLT-5736):
- ~~Strikethrough text~~ (not part of commonmark spec, https://mattermost.atlassian.net/browse/PLT-5736)
- Tables (not part of commonmark spec, https://mattermost.atlassian.net/browse/PLT-5736)
- Images (ran into implementation difficulties, https://mattermost.atlassian.net/browse/PLT-5736)
- Emoji (https://mattermost.atlassian.net/browse/PLT-5537)
- Various mentions and hashtags

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5717

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: Nexus 5 (Android 6.0.1) and iPhone Emulator (iPhone 6, iOS 10.1 )

#### Screenshots
![image](https://cloud.githubusercontent.com/assets/3277310/23960406/4230b0e4-097e-11e7-8660-628361e1b4aa.png)

![image](https://cloud.githubusercontent.com/assets/3277310/23960360/33cca364-097e-11e7-9878-38720b119753.png)

