### PR TITLE
PLT-5511 Ability to flag and unflag posts

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -38,6 +38,7 @@ class Post extends PureComponent {
         displayName: PropTypes.string,
         renderReplies: PropTypes.bool,
         isFirstReply: PropTypes.bool,
+        isFlagged: PropTypes.bool,
         isLastReply: PropTypes.bool,
         commentedOnDisplayName: PropTypes.string,
         commentedOnPost: PropTypes.object,
@@ -46,7 +47,9 @@ class Post extends PureComponent {
         onPress: PropTypes.func,
         actions: PropTypes.shape({
             deletePost: PropTypes.func.isRequired,
-            goToUserProfile: PropTypes.func.isRequired
+            flagPost: PropTypes.func.isRequired,
+            goToUserProfile: PropTypes.func.isRequired,
+            unflagPost: PropTypes.func.isRequired
         }).isRequired
     };
 
@@ -167,14 +170,23 @@ class Post extends PureComponent {
 
     renderMessage = (style, messageStyle, replyBar = false) => {
         const {formatMessage} = this.props.intl;
-        const {currentUserId, post, roles, theme} = this.props;
+        const {currentUserId, isFlagged, post, roles, theme} = this.props;
+        const {flagPost, unflagPost} = this.props.actions;
         const actions = [];
 
         // we should check for the user roles and permissions
-        // actions.push({text: 'Flag', onPress: () => console.log('flag pressed')}); //eslint-disable-line no-console
-        // if (post.user_id === currentUserId) {
-        //     actions.push({text: 'Edit', onPress: () => console.log('edit pressed')}); //eslint-disable-line no-console
-        // }
+        if (isFlagged) {
+            actions.push({
+                text: formatMessage({id: 'post_info.mobile.unflag', defaultMessage: 'Unflag'}),
+                onPress: () => unflagPost(post.id)
+            });
+        } else {
+            actions.push({
+                text: formatMessage({id: 'post_info.mobile.flag', defaultMessage: 'Flag'}),
+                onPress: () => flagPost(post.id)
+            });
+        }
+
         if (post.user_id === currentUserId || isAdmin(roles)) {
             actions.push({text: formatMessage({id: 'post_info.del', defaultMessage: 'Delete'}), onPress: () => this.handlePostDelete()});
         }

--- a/app/components/post/post_container.js
+++ b/app/components/post/post_container.js
@@ -7,10 +7,11 @@ import {bindActionCreators} from 'redux';
 import {goToUserProfile} from 'app/actions/navigation';
 import {getTheme} from 'app/selectors/preferences';
 
-import {deletePost} from 'mattermost-redux/actions/posts';
+import {deletePost, flagPost, unflagPost} from 'mattermost-redux/actions/posts';
 import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getCurrentUserRoles, getUser} from 'mattermost-redux/selectors/entities/users';
+import {isPostFlagged} from 'mattermost-redux/utils/post_utils';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import Post from './post';
@@ -25,6 +26,7 @@ function mapStateToProps(state, ownProps) {
         currentTeamId: getCurrentTeamId(state),
         currentUserId: getCurrentUserId(state),
         displayName: displayUsername(user, myPreferences),
+        isFlagged: isPostFlagged(ownProps.post.id, myPreferences),
         roles: getCurrentUserRoles(state),
         theme: getTheme(state),
         user,
@@ -36,7 +38,9 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             deletePost,
-            goToUserProfile
+            flagPost,
+            goToUserProfile,
+            unflagPost
         }, dispatch)
     };
 }


### PR DESCRIPTION
#### Summary
This PR depends on [PLT-5498 Add ability to delete a message](https://github.com/mattermost/mattermost-mobile/pull/357) and adds another set of options to flag an unflag posts

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5511

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (https://github.com/mattermost/mattermost-redux/pull/7)
- [x] Has UI changes

#### Device Information
This PR was tested on: IOS 10.2.1 iPhone 6s, Android 6.0.1 Samsung J5
