### PR TITLE
PLT-5500 Added URL autolinking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "commonmark": "0.27.0",
+    "commonmark": "hmhealey/commonmark.js#00189db64c261926de98db16ca14d5b1bcba4d8e",
     "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#2e8ea6ac67b683b44782f403b69a06bb0e5c63e6",
     "deep-equal": "1.0.1",
     "harmony-reflect": "1.5.1",


### PR DESCRIPTION
This supports all links that either start with a protocol or www. It's based off the changes I made to marked in the webapp, but it also handles surrounding asterisks and underscores better (since the previous regex messes up italics and bold when used with commonmark).

This PR doesn't make any changes to mattermost-mobile (outside of those for PLT-5717). The actual changes made are here: https://github.com/hmhealey/commonmark.js/pull/1

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5500

#### Checklist
- Added or updated unit tests (required for all new features) (in commonmark.js repo)
- Has UI changes

#### Device Information
This PR was tested on: iOS simulator

#### Screenshots
![image](https://cloud.githubusercontent.com/assets/3277310/24050500/5fb0435e-0b05-11e7-9e7a-2e89d6912d5a.png)

