### PR TITLE
PLT-5494 Added at mention detection

### DIFF
--- a/app/components/at_mention/at_mention.js
+++ b/app/components/at_mention/at_mention.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PropTypes, PureComponent} from 'react';
+import {Text} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+
+export default class AtMention extends PureComponent {
+    static propTypes = {
+        mentionName: PropTypes.string.isRequired,
+        mentionStyle: CustomPropTypes.Style,
+        textStyle: CustomPropTypes.Style,
+        usersByUsername: PropTypes.object.isRequired
+    };
+
+    getUsernameFromMentionName = () => {
+        let mentionName = this.props.mentionName;
+
+        while (mentionName.length > 0) {
+            if (this.props.usersByUsername[mentionName]) {
+                return this.props.usersByUsername[mentionName].username;
+            }
+
+            // Repeatedly trim off trailing punctuation in case this is at the end of a sentence
+            if ((/[._-]$/).test(mentionName)) {
+                mentionName = mentionName.substring(0, mentionName.length - 1);
+            } else {
+                break;
+            }
+        }
+
+        // Just assume this is a mention for a user that we don't have
+        return mentionName;
+    }
+
+    render() {
+        const username = this.getUsernameFromMentionName();
+        const suffix = this.props.mentionName.substring(username.length);
+
+        return (
+            <Text style={this.props.textStyle}>
+                <Text style={this.props.mentionStyle}>
+                    {'@' + username}
+                </Text>
+                {suffix}
+            </Text>
+        );
+    }
+}

--- a/app/components/at_mention/at_mention_container.js
+++ b/app/components/at_mention/at_mention_container.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
+
+import AtMention from './at_mention';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        usersByUsername: getUsersByUsername(state),
+        ...ownProps
+    };
+}
+
+export default connect(mapStateToProps)(AtMention);

--- a/app/components/at_mention/index.js
+++ b/app/components/at_mention/index.js
@@ -1,0 +1,5 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import AtMention from './at_mention_container';
+export default AtMention;

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -10,6 +10,7 @@ import {
     View
 } from 'react-native';
 
+import AtMention from 'app/components/at_mention';
 import CustomPropTypes from 'app/constants/custom_prop_types';
 import {concatStyles} from 'app/utils/theme';
 
@@ -49,6 +50,7 @@ export default class Markdown extends PureComponent {
                 code: this.renderCodeSpan,
                 link: MarkdownLink,
                 image: this.renderImage,
+                atMention: this.renderAtMention,
 
                 paragraph: this.renderParagraph,
                 heading: this.renderHeading,
@@ -92,6 +94,16 @@ export default class Markdown extends PureComponent {
                 {src}
                 {')'}
             </Text>
+        );
+    }
+
+    renderAtMention = ({context, mentionName}) => {
+        return (
+            <AtMention
+                mentionStyle={this.props.textStyles.mention}
+                textStyle={this.computeTextStyle(this.props.baseTextStyle, context)}
+                mentionName={mentionName}
+            />
         );
     }
 

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -564,6 +564,9 @@ const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
             height: StyleSheet.hairlineWidth,
             flex: 1,
             marginVertical: 10
+        },
+        mention: {
+            color: theme.linkColor
         }
     });
 });

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "commonmark": "hmhealey/commonmark.js#00189db64c261926de98db16ca14d5b1bcba4d8e",
-    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#2e8ea6ac67b683b44782f403b69a06bb0e5c63e6",
+    "commonmark": "hmhealey/commonmark.js#46784f1461fa34e148940534c1763af6d344ab0f",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#7479202c42ab1b722359adadaa13f738edf5f88a",
     "deep-equal": "1.0.1",
     "harmony-reflect": "1.5.1",
     "intl": "1.2.5",


### PR DESCRIPTION
Right now, this works as at mentions on the webapp do where we trim punctuation off of the mention to see if we find a username, but if we run out of punctuation, we just assume that user exists and we haven't seen them yet. This'll need some changes when I have the at mentions stored with their ID.

Clicking on the at mentions also doesn't do anything right now since it's blocked on adding search (or whatever we decide to have them do)

Changes made for this PR (since this is on top of the autolinking and markdown PRs):
https://github.com/mattermost/mattermost-mobile/commit/77a43e8a5cdada0b0862fed84472518a1228268c (Code to render at mentions)
https://github.com/hmhealey/commonmark.js/pull/2 (Code to find at mentions in the text)
https://github.com/hmhealey/commonmark-react-renderer/pull/1 (Code to make renderer actually do something for at mentions)
https://github.com/mattermost/mattermost-redux/pull/12

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5494

#### Checklist
- Has UI changes
- Added unit tests (see commonmark.js PR)

#### Device Information
This PR was tested on: iOS Simulator (iPhone 6, iOS 10.1)

#### Screenshots
<img width="365" alt="screen shot 2017-03-20 at 10 57 18 am" src="https://cloud.githubusercontent.com/assets/3277310/24105679/081ea708-0d5c-11e7-8c43-12a6fd1d3fd6.png">

