### PR TITLE
PLT-5711 Fix Tapping on the button to open the drawers not always work

### DIFF
--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -230,6 +230,12 @@ export function requestCloseModal() {
     };
 }
 
+export function renderDrawer() {
+    return async (dispatch, getState) => {
+        dispatch({type: NavigationTypes.NAVIGATION_RENDER_LEFT_DRAWER}, getState);
+    };
+}
+
 export function showOptionsModal(options) {
     return async (dispatch, getState) => {
         dispatch({

--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -2,7 +2,13 @@
 // See License.txt for license information.
 
 import React, {PropTypes, PureComponent} from 'react';
-import {View, Text, TouchableWithoutFeedback, StyleSheet} from 'react-native';
+import {
+    PanResponder,
+    StyleSheet,
+    Text,
+    TouchableWithoutFeedback,
+    View
+} from 'react-native';
 
 export default class Badge extends PureComponent {
     static defaultProps = {
@@ -22,6 +28,14 @@ export default class Badge extends PureComponent {
         onPress: PropTypes.func
     };
 
+    componentWillMount() {
+        this.panResponder = PanResponder.create({
+            onStartShouldSetPanResponder: () => true,
+            onMoveShouldSetPanResponder: () => true,
+            onStartShouldSetResponderCapture: () => false
+        });
+    }
+
     renderText = () => {
         const {count} = this.props;
         let text = count.toString();
@@ -39,7 +53,10 @@ export default class Badge extends PureComponent {
 
     render() {
         return (
-            <View style={[styles.badge, this.props.style]}>
+            <View
+                {...this.panResponder.panHandlers}
+                style={[styles.badge, this.props.style]}
+            >
                 <TouchableWithoutFeedback onPress={this.props.onPress}>
                     <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
                         {this.renderText()}

--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -14,8 +14,7 @@ export default class Badge extends PureComponent {
     static defaultProps = {
         extraPaddingHorizontal: 10,
         minHeight: 0,
-        minWidth: 0,
-        onPress: () => true
+        minWidth: 0
     };
 
     static propTypes = {
@@ -32,19 +31,31 @@ export default class Badge extends PureComponent {
         this.panResponder = PanResponder.create({
             onStartShouldSetPanResponder: () => true,
             onMoveShouldSetPanResponder: () => true,
-            onStartShouldSetResponderCapture: () => false
+            onStartShouldSetResponderCapture: () => true,
+            onMoveShouldSetResponderCapture: () => true,
+            onResponderMove: () => false
         });
     }
+
+    handlePress = () => {
+        if (this.props.onPress) {
+            this.props.onPress();
+        }
+    };
 
     renderText = () => {
         const {count} = this.props;
         let text = count.toString();
+        const extra = {};
         if (count < 0) {
             text = '•';
+
+            //the extra margin is to align to the center?
+            extra.marginBottom = 1;
         }
         return (
             <Text
-                style={[styles.text, this.props.countStyle]}
+                style={[styles.text, this.props.countStyle, extra]}
             >
                 {text}
             </Text>
@@ -53,16 +64,18 @@ export default class Badge extends PureComponent {
 
     render() {
         return (
-            <View
+            <TouchableWithoutFeedback
                 {...this.panResponder.panHandlers}
-                style={[styles.badge, this.props.style]}
+                onPress={this.handlePress}
             >
-                <TouchableWithoutFeedback onPress={this.props.onPress}>
+                <View
+                    style={[styles.badge, this.props.style]}
+                >
                     <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
                         {this.renderText()}
                     </View>
-                </TouchableWithoutFeedback>
-            </View>
+                </View>
+            </TouchableWithoutFeedback>
         );
     }
 }

--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -71,7 +71,7 @@ export default class Badge extends PureComponent {
                 <View
                     style={[styles.badge, this.props.style]}
                 >
-                    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
+                    <View style={styles.wrapper}>
                         {this.renderText()}
                     </View>
                 </View>
@@ -90,6 +90,11 @@ const styles = StyleSheet.create({
         borderRadius: 20,
         position: 'absolute',
         right: 30
+    },
+    wrapper: {
+        alignItems: 'center',
+        flex: 1,
+        justifyContent: 'center'
     },
     text: {
         fontSize: 14,

--- a/app/constants/navigation.js
+++ b/app/constants/navigation.js
@@ -8,6 +8,7 @@ const NavigationTypes = keyMirror({
     NAVIGATION_POP: null,
     NAVIGATION_POP_TO_INDEX: null,
     NAVIGATION_OPEN_LEFT_DRAWER: null,
+    NAVIGATION_RENDER_LEFT_DRAWER: null,
     NAVIGATION_OPEN_RIGHT_DRAWER: null,
     NAVIGATION_CLOSE_DRAWERS: null,
     NAVIGATION_JUMP: null,

--- a/app/initial_state.js
+++ b/app/initial_state.js
@@ -272,7 +272,8 @@ const state = {
         leftDrawerOpen: false,
         leftDrawerRoute: Routes.ChannelDrawer,
         rightDrawerOpen: false,
-        rightDrawerRoute: null
+        rightDrawerRoute: null,
+        shouldRenderDrawer: false
     },
     views: {
         channel: {

--- a/app/navigation/router.js
+++ b/app/navigation/router.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import React from 'react';
+import React, {Component, PropTypes} from 'react';
 import {
     Dimensions,
     Easing,
@@ -12,7 +12,7 @@ import {
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {closeDrawers, goBack} from 'app/actions/navigation';
+import {closeDrawers, goBack, openChannelDrawer} from 'app/actions/navigation';
 import Drawer from 'app/components/drawer';
 import FormattedText from 'app/components/formatted_text';
 import {RouteTransitions} from 'app/navigation/routes';
@@ -27,13 +27,14 @@ const navigationPanResponder = NavigationExperimental.Card.CardStackPanResponder
 
 const {width: deviceWidth, height: deviceHeight} = Dimensions.get('window');
 
-class Router extends React.Component {
+class Router extends Component {
     static propTypes = {
-        navigation: React.PropTypes.object,
-        theme: React.PropTypes.object,
-        actions: React.PropTypes.shape({
-            closeDrawers: React.PropTypes.func.isRequired,
-            goBack: React.PropTypes.func.isRequired
+        navigation: PropTypes.object,
+        theme: PropTypes.object,
+        actions: PropTypes.shape({
+            closeDrawers: PropTypes.func.isRequired,
+            goBack: PropTypes.func.isRequired,
+            openChannelDrawer: PropTypes.func.isRequired
         }).isRequired
     };
 
@@ -213,6 +214,10 @@ class Router extends React.Component {
             mainOverlay: {
                 backgroundColor: '#000',
                 opacity
+            },
+            drawerOverlay: {
+                backgroundColor: '#000',
+                opacity: (1 - ratio) / 2
             }
         };
     };
@@ -234,6 +239,7 @@ class Router extends React.Component {
     };
 
     handleLeftDrawerOpenStart = () => {
+        this.props.actions.openChannelDrawer();
         this.openLeftHandle = InteractionManager.createInteractionHandle();
     };
 
@@ -245,6 +251,7 @@ class Router extends React.Component {
             leftDrawerRoute,
             modal,
             rightDrawerRoute,
+            shouldRenderDrawer,
             routes
         } = this.props.navigation;
 
@@ -252,7 +259,7 @@ class Router extends React.Component {
         const modalNavigationProps = this.extractNavigationProps(modal.routes[0]);
 
         let leftDrawerContent;
-        if (leftDrawerRoute) {
+        if (leftDrawerRoute && shouldRenderDrawer) {
             leftDrawerContent = this.renderRoute(leftDrawerRoute);
         }
 
@@ -272,15 +279,15 @@ class Router extends React.Component {
                     onOpen={this.handleLeftDrawerOpen}
                     onCloseStart={this.handleLeftDrawerCloseStart}
                     onClose={this.handleLeftDrawerClose}
-                    type='displace'
+                    type='static'
                     disabled={modalVisible}
                     content={leftDrawerContent}
                     tapToClose={true}
-                    openDrawerOffset={42}
+                    openDrawerOffset={40}
                     onRequestClose={this.props.actions.closeDrawers}
                     panOpenMask={0.2}
-                    panCloseMask={42}
-                    panThreshold={0.2}
+                    panCloseMask={40}
+                    panThreshold={0.25}
                     acceptPan={navigationProps.allowMenuSwipe}
                     negotiatePan={true}
                     useInteractionManager={false}
@@ -341,7 +348,8 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             closeDrawers,
-            goBack
+            goBack,
+            openChannelDrawer
         }, dispatch)
     };
 }

--- a/app/navigation/router.js
+++ b/app/navigation/router.js
@@ -285,6 +285,7 @@ class Router extends React.Component {
                     negotiatePan={true}
                     useInteractionManager={false}
                     tweenHandler={this.handleDrawerTween}
+                    elevation={-5}
                 >
                     <Drawer
                         open={false}
@@ -295,12 +296,12 @@ class Router extends React.Component {
                         tapToClose={true}
                         openDrawerOffset={50}
                         onRequestClose={this.props.actions.closeDrawers}
-                        panOpenMask={0.2}
+                        panOpenMask={0}
                         panCloseMask={50}
-                        panThreshold={0.2}
-                        acceptPan={navigationProps.allowMenuSwipe}
+                        panThreshold={0}
+                        acceptPan={false}
                         negotiatePan={false}
-                        useInteractionManager={true}
+                        useInteractionManager={false}
                         tweenHandler={this.handleDrawerTween}
                     >
                         <NavigationExperimental.Transitioner

--- a/app/reducers/navigation/index.js
+++ b/app/reducers/navigation/index.js
@@ -22,7 +22,8 @@ const initialState = {
     leftDrawerOpen: false,
     leftDrawerRoute: null,
     rightDrawerOpen: false,
-    rightDrawerRoute: null
+    rightDrawerRoute: null,
+    shouldRenderDrawer: false
 };
 
 export default function(state = initialState, action) {
@@ -206,6 +207,13 @@ export default function(state = initialState, action) {
         return {
             ...state,
             modal: modalState
+        };
+    }
+
+    case NavigationTypes.NAVIGATION_RENDER_LEFT_DRAWER: {
+        return {
+            ...state,
+            shouldRenderDrawer: true
         };
     }
 

--- a/app/scenes/channel/channel.js
+++ b/app/scenes/channel/channel.js
@@ -32,7 +32,8 @@ export default class Channel extends React.PureComponent {
             initWebSocket: React.PropTypes.func.isRequired,
             closeWebSocket: React.PropTypes.func.isRequired,
             startPeriodicStatusUpdates: React.PropTypes.func.isRequired,
-            stopPeriodicStatusUpdates: React.PropTypes.func.isRequired
+            stopPeriodicStatusUpdates: React.PropTypes.func.isRequired,
+            renderDrawer: React.PropTypes.func.isRequired
         }).isRequired,
         currentTeam: React.PropTypes.object,
         currentChannel: React.PropTypes.object,
@@ -65,6 +66,7 @@ export default class Channel extends React.PureComponent {
 
     componentDidMount() {
         this.props.actions.startPeriodicStatusUpdates();
+        this.props.actions.renderDrawer();
     }
 
     componentWillReceiveProps(nextProps) {

--- a/app/scenes/channel/channel_container.js
+++ b/app/scenes/channel/channel_container.js
@@ -7,7 +7,8 @@ import navigationSceneConnect from '../navigationSceneConnect';
 
 import {
     goToChannelInfo,
-    openChannelDrawer
+    openChannelDrawer,
+    renderDrawer
 } from 'app/actions/navigation';
 import {
     loadChannelsIfNecessary,
@@ -52,7 +53,8 @@ function mapDispatchToProps(dispatch) {
             initWebSocket,
             closeWebSocket,
             startPeriodicStatusUpdates,
-            stopPeriodicStatusUpdates
+            stopPeriodicStatusUpdates,
+            renderDrawer
         }, dispatch)
     };
 }

--- a/app/scenes/channel/channel_drawer_button.js
+++ b/app/scenes/channel/channel_drawer_button.js
@@ -4,6 +4,8 @@
 import React, {PropTypes, PureComponent} from 'react';
 import {connect} from 'react-redux';
 import {
+    PanResponder,
+    StyleSheet,
     TouchableOpacity,
     View
 } from 'react-native';
@@ -38,6 +40,15 @@ class ChannelDrawerButton extends PureComponent {
         };
     }
 
+    componentWillMount() {
+        this.panResponder = PanResponder.create({
+            onStartShouldSetPanResponder: () => true,
+            onMoveShouldSetPanResponder: () => true,
+            onStartShouldSetResponderCapture: () => true,
+            onMoveShouldSetResponderCapture: () => true
+        });
+    }
+
     componentDidMount() {
         EventEmitter.on('drawer_opacity', this.setOpacity);
     }
@@ -50,6 +61,10 @@ class ChannelDrawerButton extends PureComponent {
         this.setState({opacity: value > 0 ? 0.1 : 1});
     };
 
+    handlePress = () => {
+        this.props.emitter('open_channel_drawer');
+    };
+
     render() {
         let badge;
         let badgeCount = this.props.mentionCount;
@@ -59,53 +74,66 @@ class ChannelDrawerButton extends PureComponent {
         }
 
         if (badgeCount !== 0) {
-            const badgeStyle = {
-                backgroundColor: 'rgb(214, 73, 70)',
-                borderRadius: 10,
-                flexDirection: 'row',
-                height: 20,
-                left: 5,
-                padding: 3,
-                position: 'absolute',
-                right: 0,
-                top: 5,
-                width: 20
-            };
-
-            const mentionStyle = {
-                color: '#fff',
-                fontSize: 10
-            };
-
             badge = (
                 <Badge
-                    style={badgeStyle}
-                    countStyle={mentionStyle}
+                    style={style.badge}
+                    countStyle={style.mention}
                     count={badgeCount}
                     minHeight={5}
                     minWidth={5}
-                    onPress={() => this.props.emitter('open_channel_drawer')}
+                    onPress={this.handlePress}
                 />
             );
         }
 
         return (
-            <View style={{flexDirection: 'column', justifyContent: 'center', alignItems: 'center', flex: 1, opacity: this.state.opacity}}>
-                <TouchableOpacity
-                    onPress={() => this.props.emitter('open_channel_drawer')}
-                    style={{height: 25, width: 25, marginLeft: 10, marginRight: 10}}
-                >
+            <TouchableOpacity
+                {...this.panResponder.panHandlers}
+                onPress={this.handlePress}
+                style={style.container}
+            >
+                <View style={[style.wrapper, {opacity: this.state.opacity, zIndex: 30}]}>
                     <Icon
                         name='bars'
                         size={25}
                         color={this.props.theme.sidebarHeaderTextColor}
                     />
-                </TouchableOpacity>
-                {badge}
-            </View>
+                    {badge}
+                </View>
+            </TouchableOpacity>
         );
     }
 }
+
+const style = StyleSheet.create({
+    container: {
+        flex: 1
+    },
+    wrapper: {
+        alignItems: 'center',
+        flex: 1,
+        flexDirection: 'column',
+        justifyContent: 'center',
+        paddingHorizontal: 10,
+        zIndex: 30
+    },
+    badge: {
+        backgroundColor: 'rgb(214, 73, 70)',
+        borderRadius: 10,
+        flexDirection: 'row',
+        height: 20,
+        left: 5,
+        padding: 3,
+        position: 'absolute',
+        right: 0,
+        top: 5,
+        width: 20
+    },
+    mention: {
+        color: '#fff',
+        fontSize: 10
+    }
+});
 
 function mapStateToProps(state) {
     return {

--- a/app/scenes/channel/channel_drawer_button.js
+++ b/app/scenes/channel/channel_drawer_button.js
@@ -5,6 +5,7 @@ import React, {PropTypes, PureComponent} from 'react';
 import {connect} from 'react-redux';
 import {
     PanResponder,
+    Platform,
     StyleSheet,
     TouchableOpacity,
     View
@@ -45,7 +46,8 @@ class ChannelDrawerButton extends PureComponent {
             onStartShouldSetPanResponder: () => true,
             onMoveShouldSetPanResponder: () => true,
             onStartShouldSetResponderCapture: () => true,
-            onMoveShouldSetResponderCapture: () => true
+            onMoveShouldSetResponderCapture: () => true,
+            onResponderMove: () => false
         });
     }
 
@@ -126,7 +128,14 @@ const style = StyleSheet.create({
         padding: 3,
         position: 'absolute',
         right: 0,
-        top: 5,
+        ...Platform.select({
+            android: {
+                top: 10
+            },
+            ios: {
+                top: 5
+            }
+        }),
         width: 20
     },
     mention: {

--- a/test/app/reducers/navigation.test.js
+++ b/test/app/reducers/navigation.test.js
@@ -32,7 +32,8 @@ describe('Reducers.Navigation', () => {
             leftDrawerOpen: false,
             leftDrawerRoute: null,
             rightDrawerOpen: false,
-            rightDrawerRoute: null
+            rightDrawerRoute: null,
+            shouldRenderDrawer: false
         }, 'initial state');
     });
 
@@ -213,6 +214,20 @@ describe('Reducers.Navigation', () => {
             assert.equal(state.leftDrawerOpen, false);
             assert.equal(state.rightDrawerOpen, true);
             assert.deepEqual(state.rightDrawerRoute, {key: 'fake'});
+        });
+    });
+
+    it('NAVIGATION_RENDER_LEFT_DRAWER', () => {
+        let state = initialState();
+
+        it('render left drawer', () => {
+            state = reduceAndFreeze(state, {type: NavigationTypes.NAVIGATION_RENDER_LEFT_DRAWER});
+
+            assert.equal(state.index, 0);
+            assert.deepEqual(state.routes, [Routes.Root]);
+            assert.equal(state.leftDrawerOpen, false);
+            assert.equal(state.rightDrawerOpen, true);
+            assert.equal(state.shouldRenderDrawer, true);
         });
     });
 


### PR DESCRIPTION
#### Summary
This PR takes care of:
1. Tapping on the hamburger button should always open the drawer
2. Drawer transition to open from below the scene and with the change of the opacity
3. Hamburger badge dot button should be centered

#### Ticket Link
* https://mattermost.atlassian.net/browse/PLT-5711
* https://mattermost.atlassian.net/browse/PLT-5992
* https://mattermost.atlassian.net/browse/PLT-5996
* https://mattermost.atlassian.net/browse/PLT-6052

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: 
* IOS 10.2.1 iPhone 6s
* Android 6.0.1 Samsung J5

#### Screenshots
https://pre-release.mattermost.com/core/pl/fcaef7b1tigzpd81qjggu4ai9y
