### PR TITLE
PLT-5997 show the above unread indicator 15px below the header

### DIFF
--- a/app/components/channel_drawer_list/channel_drawer_list.js
+++ b/app/components/channel_drawer_list/channel_drawer_list.js
@@ -467,7 +467,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         above: {
             backgroundColor: theme.mentionBj,
-            top: 55
+            top: 79
         },
         below: {
             backgroundColor: theme.mentionBj,


### PR DESCRIPTION
Known issue: The unread indicators above/below won't show up in android.

This is because of a React Native bug with the ListViews
