### PR TITLE
Made HTML in posts render as plain text

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -187,8 +187,18 @@ export default class Markdown extends PureComponent {
         return <Text>{'\n'}</Text>;
     }
 
-    renderHtml = () => {
-        return null;
+    renderHtml = (props) => {
+        let rendered = this.renderText(props);
+
+        if (props.isBlock) {
+            rendered = (
+                <View style={style.block}>
+                    {rendered}
+                </View>
+            );
+        }
+
+        return rendered;
     }
 
     render() {


### PR DESCRIPTION
This makes anything that CommonMark recognizes as HTML render as plain text instead of as `null` since RN doesn't support `null` nodes inside of `<Text>`. This also stops text recognized as HTML from being rendered as blank as it would've if the first error hadn't occurred.

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator (iPhone 6, iOS 10.1)
