### PR TITLE
Android Version Bump to 21


### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,7 +91,7 @@ android {
         applicationId "com.mattermost.react.native"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 20
+        versionCode 21
         versionName "1.0"
         multiDexEnabled true
         ndk {

--- a/app/scenes/login/login.js
+++ b/app/scenes/login/login.js
@@ -6,6 +6,7 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     Image,
     Keyboard,
+    KeyboardAvoidingView,
     Platform,
     Text,
     TextInput,
@@ -16,7 +17,6 @@ import Button from 'react-native-button';
 
 import ErrorText from 'app/components/error_text';
 import FormattedText from 'app/components/formatted_text';
-import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import {GlobalStyles} from 'app/styles';
 
 import logo from 'assets/images/logo.png';
@@ -227,7 +227,7 @@ class Login extends Component {
 
     render() {
         return (
-            <KeyboardLayout
+            <KeyboardAvoidingView
                 behavior='padding'
                 style={{flex: 1}}
                 keyboardVerticalOffset={65}
@@ -286,7 +286,7 @@ class Login extends Component {
                         </Button>
                     </View>
                 </TouchableWithoutFeedback>
-            </KeyboardLayout>
+            </KeyboardAvoidingView>
         );
     }
 }

--- a/app/scenes/mfa/mfa.js
+++ b/app/scenes/mfa/mfa.js
@@ -5,6 +5,7 @@ import React, {Component} from 'react';
 import {
     Image,
     Keyboard,
+    KeyboardAvoidingView,
     Platform,
     TouchableWithoutFeedback,
     View
@@ -13,7 +14,6 @@ import Button from 'react-native-button';
 
 import ErrorText from 'app/components/error_text';
 import FormattedText from 'app/components/formatted_text';
-import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import TextInputWithLocalizedPlaceholder from 'app/components/text_input_with_localized_placeholder';
 import {GlobalStyles} from 'app/styles';
 
@@ -97,7 +97,7 @@ export default class Mfa extends Component {
 
     render() {
         return (
-            <KeyboardLayout
+            <KeyboardAvoidingView
                 behavior='padding'
                 style={{flex: 1}}
                 keyboardVerticalOffset={0}
@@ -141,7 +141,7 @@ export default class Mfa extends Component {
                         </Button>
                     </View>
                 </TouchableWithoutFeedback>
-            </KeyboardLayout>
+            </KeyboardAvoidingView>
         );
     }
 }

--- a/app/scenes/select_server/select_server.js
+++ b/app/scenes/select_server/select_server.js
@@ -5,6 +5,7 @@ import React, {PropTypes, PureComponent} from 'react';
 import {
     Image,
     Keyboard,
+    KeyboardAvoidingView,
     Platform,
     StatusBar,
     TouchableWithoutFeedback,
@@ -20,7 +21,7 @@ import EventEmitter from 'mattermost-redux/utils/event_emitter';
 import {SplashScreenTypes} from 'app/constants';
 import ErrorText from 'app/components/error_text';
 import FormattedText from 'app/components/formatted_text';
-import KeyboardLayout from 'app/components/layout/keyboard_layout';
+
 import TextInputWithLocalizedPlaceholder from 'app/components/text_input_with_localized_placeholder';
 import {GlobalStyles} from 'app/styles';
 import {isValidUrl, stripTrailingSlashes} from 'app/utils/url';
@@ -121,7 +122,7 @@ export default class SelectServer extends PureComponent {
         const error = pingRequest.error || configRequest.error || licenseRequest.error;
 
         return (
-            <KeyboardLayout
+            <KeyboardAvoidingView
                 behavior='padding'
                 style={{flex: 1}}
                 keyboardVerticalOffset={0}
@@ -165,7 +166,7 @@ export default class SelectServer extends PureComponent {
                         <ErrorText error={this.state.error || error}/>
                     </View>
                 </TouchableWithoutFeedback>
-            </KeyboardLayout>
+            </KeyboardAvoidingView>
         );
     }
 }


### PR DESCRIPTION
In this PR I changed to `KeyboardAvoidingView` in select_server, login and mfa because is the only way to make it work on Android because we moved those views to be a Modal instead of a regular view, the way we had it before wasn't working at all in this views.