### PR TITLE
Move Android lane from beta to alpha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ do-build-ios:
 build-ios: | check-ios-target pre-run check-style start-packager do-build-ios stop-packager
 
 check-android-target:
-ifneq ($(android_target), $(filter $(android_target), dev beta release))
+ifneq ($(android_target), $(filter $(android_target), dev alpha release))
 	@echo "Try running make build-android TARGET\nWhere TARGET is one of dev, beta or release"
 	@exit 1
 endif
@@ -145,6 +145,9 @@ do-build-android:
 	@cd fastlane && bundle exec fastlane android $(android_target)
 
 build-android: | check-android-target pre-run check-style start-packager prepare-android-build do-build-android stop-packager
+
+alpha:
+	@:
 
 dev:
 	@:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -202,7 +202,7 @@ platform :android do
   end
 
   desc 'Submit a new Beta Build to Google Play'
-  lane :beta do
+  lane :alpha do
     build_android({
         release: true,
         increment_build: true,
@@ -211,7 +211,7 @@ platform :android do
           })
 
     supply(
-        track: 'beta',
+        track: 'alpha',
         apk: "#{lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]}",
     )
 


### PR DESCRIPTION
#### Summary
To have internal builds for Android this changes the lane to be published from Beta to Alpha so we can then promote the correct builds to beta and have external testers.