### PR TITLE
PLT-5963 RN: Message over 4000 characters

### DIFF
--- a/app/scenes/channel_members/channel_members.js
+++ b/app/scenes/channel_members/channel_members.js
@@ -169,7 +169,7 @@ class ChannelMembers extends PureComponent {
     };
 
     loadMoreMembers = () => {
-        if (this.props.requestStatus !== 'started' && this.props.currentChannelMembers.length < this.props.currentChannelMemberCount) {
+        if (this.props.requestStatus !== 'started' && this.props.currentChannelMembers.length < this.props.currentChannelMemberCount - 1) {
             this.props.actions.getProfilesInChannel(this.props.currentTeam.id, this.props.currentChannel.id, this.props.currentChannelMembers.length);
         }
     };

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1687,6 +1687,8 @@
   "mobile.loading_members": "Loading Members...",
   "mobile.loading_posts": "Loading Messages...",
   "mobile.login_options.choose_title": "Choose your login method",
+  "mobile.message_length.title": "Message Length",
+  "mobile.message_length.message": "Your current message is too long. Current character count: {max}/{count}",
   "mobile.post.cancel": "Cancel",
   "mobile.post.delete_question": "Are you sure you want to delete this post?",
   "mobile.post.delete_title": "Delete Post",


### PR DESCRIPTION
#### Summary
Fixes an issue where messages longer than 4000 characters were allowed to be sent. Also fixes a loading message bug in channel_members.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5963

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23

@jarredwitt 