### PR TITLE
PLT-6171 Get Push Notifications after the app was killed

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="com.google.android.c2dm.permission.SEND" />
 
     <uses-sdk
         android:minSdkVersion="16"


### PR DESCRIPTION
#### Summary
This should make the app get push notifications on Android even after the app was killed in the Active Apps Screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6171

#### Device Information
This PR was tested on: Android 6.0.1