### PR TITLE
Fix first load to include the right DM's and GM's

### DIFF
--- a/app/components/channel_drawer_list/channel_drawer_list_container.js
+++ b/app/components/channel_drawer_list/channel_drawer_list_container.js
@@ -21,7 +21,7 @@ import {
 } from 'app/actions/views/channel';
 
 import {Constants} from 'mattermost-redux/constants';
-import {getCurrentUserRoles} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, getCurrentUserRoles} from 'mattermost-redux/selectors/entities/users';
 import {showCreateOption} from 'mattermost-redux/utils/channel_utils';
 import {isAdmin, isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
@@ -29,7 +29,7 @@ import ChannelDrawerList from './channel_drawer_list';
 
 function mapStateToProps(state, ownProps) {
     const {config, license} = state.entities.general;
-    const roles = getCurrentUserRoles(state);
+    const roles = getCurrentUserId(state) ? getCurrentUserRoles(state) : '';
 
     return {
         canCreatePrivateChannels: showCreateOption(config, license, Constants.PRIVATE_CHANNEL, isAdmin(roles), isSystemAdmin(roles)),

--- a/app/components/post/post_container.js
+++ b/app/components/post/post_container.js
@@ -23,6 +23,7 @@ function makeMapStateToProps() {
         const user = getUser(state, ownProps.post.user_id);
         const myPreferences = getMyPreferences(state);
         const {config, license} = state.entities.general;
+        const roles = getCurrentUserId(state) ? getCurrentUserRoles(state) : '';
 
         return {
             ...ownProps,
@@ -34,7 +35,7 @@ function makeMapStateToProps() {
             displayName: displayUsername(user, myPreferences),
             isFlagged: isPostFlagged(ownProps.post.id, myPreferences),
             license,
-            roles: getCurrentUserRoles(state),
+            roles,
             theme: getTheme(state),
             user
         };


### PR DESCRIPTION
#### Summary
The app was loading really slow cause it was fetching every DM and GM that was used since the beginning of time, this will load just the DM's and GM's that need to be loaded.