### PR TITLE
PLT-6129 There's no cutout in the profile picture for the offline ind…

### DIFF
--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -65,6 +65,20 @@ export default class ProfilePicture extends React.PureComponent {
                     size={this.props.statusIconSize}
                 />
             );
+        } else {
+            statusIcon = (
+                <View
+                    style={[style.offlineIcon, {
+                        borderRadius: this.props.statusSize / 2,
+                        height: this.props.statusSize - this.props.statusBorderWidth,
+                        width: this.props.statusSize - this.props.statusBorderWidth,
+                        borderWidth: Platform.select({
+                            ios: this.props.statusBorderWidth,
+                            android: this.props.statusBorderWidth / 2
+                        })
+                    }]}
+                />
+            );
         }
 
         return (
@@ -82,9 +96,9 @@ export default class ProfilePicture extends React.PureComponent {
                                 width: this.props.statusSize,
                                 height: this.props.statusSize,
                                 borderWidth: this.props.statusBorderWidth,
-                                borderRadius: this.props.statusSize / 2
-                            },
-                            (this.props.status === 'offline' && style.offline)
+                                borderRadius: this.props.statusSize / 2,
+                                borderColor: this.props.theme.centerChannelBg
+                            }
                         ]}
                     >
                         <View
@@ -116,8 +130,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             right: 0,
             overflow: 'hidden',
             alignItems: 'center',
-            justifyContent: 'center',
-            borderColor: theme.centerChannelBg
+            justifyContent: 'center'
         },
         statusContainer: {
             alignItems: 'center',
@@ -134,7 +147,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             backgroundColor: theme.awayIndicator
         },
         offline: {
-            backgroundColor: theme.centerChannelBg,
+            backgroundColor: theme.centerChannelBg
+        },
+        offlineIcon: {
             borderColor: '#bababa'
         }
     });


### PR DESCRIPTION
#### Summary
This PR updates to the offline status icon design to be the same as the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6129

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23

#### Screenshots
![region capture 1](https://cloud.githubusercontent.com/assets/5090577/24522069/fd91e2be-1553-11e7-8014-268840bfc49d.png)
![region capture 2](https://cloud.githubusercontent.com/assets/5090577/24522070/fd949acc-1553-11e7-8f87-0378aa1c77d6.png)

@jarredwitt 