### PR TITLE
PLT-6145 RN: File upload overlay doesn't clear

### DIFF
--- a/app/components/file_upload_preview/file_upload_preview.js
+++ b/app/components/file_upload_preview/file_upload_preview.js
@@ -26,6 +26,7 @@ export default class FileUploadPreview extends PureComponent {
             handleRemoveFile: PropTypes.func.isRequired
         }).isRequired,
         channelId: PropTypes.string.isRequired,
+        channelIsLoading: PropTypes.bool,
         createPostRequestStatus: PropTypes.string.isRequired,
         fetchCache: PropTypes.object.isRequired,
         files: PropTypes.array.isRequired,
@@ -70,7 +71,7 @@ export default class FileUploadPreview extends PureComponent {
     }
 
     render() {
-        if (!this.props.files.length && this.props.uploadFileRequestStatus !== RequestStatus.STARTED) {
+        if (this.props.channelIsLoading || (!this.props.files.length && this.props.uploadFileRequestStatus !== RequestStatus.STARTED)) {
             return null;
         }
 

--- a/app/components/file_upload_preview/index.js
+++ b/app/components/file_upload_preview/index.js
@@ -13,6 +13,7 @@ import FileUploadPreview from './file_upload_preview';
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
+        channelIsLoading: state.views.channel.loading,
         createPostRequestStatus: state.requests.posts.createPost.status,
         fetchCache: state.views.fetchCache,
         uploadFileRequestStatus: state.requests.files.uploadFiles.status,

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -26,6 +26,7 @@ const MAX_CONTENT_HEIGHT = 100;
 
 export default class PostTextbox extends PureComponent {
     static propTypes = {
+        channelIsLoading: PropTypes.bool.isRequired,
         currentUserId: PropTypes.string.isRequired,
         typing: PropTypes.array.isRequired,
         teamId: PropTypes.string.isRequired,
@@ -238,10 +239,12 @@ export default class PostTextbox extends PureComponent {
     };
 
     render() {
-        const {theme} = this.props;
+        const {channelIsLoading, theme, value} = this.props;
 
         const style = getStyleSheet(theme);
         const textInputHeight = Math.min(this.state.contentHeight, MAX_CONTENT_HEIGHT);
+
+        const textValue = channelIsLoading ? '' : value;
 
         let placeholder;
         if (this.props.rootId) {
@@ -290,7 +293,7 @@ export default class PostTextbox extends PureComponent {
                         <View style={style.inputContainer}>
                             <TextInputWithLocalizedPlaceholder
                                 ref='input'
-                                value={this.props.value}
+                                value={textValue}
                                 onChangeText={this.handleTextChange}
                                 onSelectionChange={this.handleSelectionChange}
                                 onContentSizeChange={this.handleContentSizeChange}

--- a/app/components/post_textbox/post_textbox_container.js
+++ b/app/components/post_textbox/post_textbox_container.js
@@ -17,6 +17,7 @@ import PostTextbox from './post_textbox';
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
+        channelIsLoading: state.views.channel.loading,
         currentUserId: getCurrentUserId(state),
         typing: getUsersTyping(state),
         theme: getTheme(state),

--- a/app/scenes/image_preview/image_preview.js
+++ b/app/scenes/image_preview/image_preview.js
@@ -130,6 +130,12 @@ export default class ImagePreview extends PureComponent {
         }
     }
 
+    handleClose = () => {
+        if (this.state.showFileInfo) {
+            this.props.actions.goBack();
+        }
+    }
+
     handleImageTap = () => {
         /*if (!this.lastPress) {
             this.lastPress = Date.now();
@@ -268,7 +274,7 @@ export default class ImagePreview extends PureComponent {
                         <View style={style.header}>
                             <View style={style.headerControls}>
                                 <TouchableOpacity
-                                    onPress={this.props.actions.goBack}
+                                    onPress={this.handleClose}
                                     style={style.headerIcon}
                                 >
                                     <Icon

--- a/app/scenes/load_team/load_team.js
+++ b/app/scenes/load_team/load_team.js
@@ -26,7 +26,7 @@ export default class LoadTeam extends PureComponent {
 
     static navigationProps = {
         renderBackButton: () => null,
-        renderTitleComponent: () => <View style={{flex: 1, backgroundColor: 'blue'}}/>
+        renderTitleComponent: () => null
     }
 
     componentDidMount() {


### PR DESCRIPTION
#### Summary
This PR fixes the issue where the file upload modal would show during a channel switch. It also fixes an issue with being able to hit the close button on image previews when the button is hidden. 

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6145

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23

@jarredwitt 