### PR TITLE
Several Fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [ "react-native" ],
   "plugins": [
     ["module-resolver", {
-      "root": ["."],
+      "root": ["./src", "."],
       "alias": {
         "assets": "./dist/assets"
       }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,12 +26,16 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+    >
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:windowSoftInputMode="adjustResize"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:launchMode="singleInstance"
+        android:taskAffinity=""
+      >
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/java/com/mattermost/MainActivity.java
+++ b/android/app/src/main/java/com/mattermost/MainActivity.java
@@ -34,4 +34,17 @@ public class MainActivity extends ReactActivity {
         intent.putExtra("newConfig", newConfig);
         this.sendBroadcast(intent);
     }
+
+    /**
+     * When the back button is pressed and the app is closed it will
+     * be sent to the background instead of exiting fixing the newIntent
+     * problem where the splash screen wasn't being removed
+     */
+    @Override
+    public void invokeDefaultOnBackPressed() {
+        Intent setIntent = new Intent(Intent.ACTION_MAIN);
+        setIntent.addCategory(Intent.CATEGORY_HOME);
+        setIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(setIntent);
+    }
 }

--- a/app/components/channel_intro/channel_intro.js
+++ b/app/components/channel_intro/channel_intro.js
@@ -8,7 +8,7 @@ import {
     View
 } from 'react-native';
 import {getFullName} from 'mattermost-redux/utils/user_utils';
-import {Constants} from 'mattermost-redux/constants';
+import {General} from 'mattermost-redux/constants';
 import {injectIntl, intlShape} from 'react-intl';
 
 import ProfilePicture from 'app/components/profile_picture';
@@ -55,7 +55,7 @@ class ChannelIntro extends PureComponent {
                 />
             </View>
         ));
-    }
+    };
 
     buildNames = () => {
         const {currentChannelMembers, theme} = this.props;
@@ -64,7 +64,7 @@ class ChannelIntro extends PureComponent {
         const names = currentChannelMembers.map((member) => this.getDisplayName(member));
 
         return <Text style={style.displayName}>{names.join(', ')}</Text>;
-    }
+    };
 
     buildDMContent = () => {
         const {currentChannelMembers, intl, theme} = this.props;
@@ -81,7 +81,7 @@ class ChannelIntro extends PureComponent {
                 })}
             </Text>
         );
-    }
+    };
 
     buildGMContent = () => {
         const {intl, theme} = this.props;
@@ -95,7 +95,7 @@ class ChannelIntro extends PureComponent {
                 })}
             </Text>
         );
-    }
+    };
 
     buildOpenChannelContent = () => {
         const {currentChannel, currentChannelMembers, currentUser, intl, theme} = this.props;
@@ -164,7 +164,7 @@ class ChannelIntro extends PureComponent {
                 </Text>
             </View>
         );
-    }
+    };
 
     buildPrivateChannelContent = () => {
         const {currentChannel, currentChannelMembers, currentUser, intl, theme} = this.props;
@@ -211,7 +211,7 @@ class ChannelIntro extends PureComponent {
                 </Text>
             </View>
         );
-    }
+    };
 
     buildTownSquareContent = () => {
         const {currentChannel, intl, theme} = this.props;
@@ -243,32 +243,32 @@ class ChannelIntro extends PureComponent {
                 </Text>
             </View>
         );
-    }
+    };
 
     buildContent = () => {
         const {currentChannel} = this.props;
 
         switch (currentChannel.type) {
         default:
-        case Constants.DM_CHANNEL:
+        case General.DM_CHANNEL:
             return this.buildDMContent();
 
-        case Constants.GM_CHANNEL:
+        case General.GM_CHANNEL:
             return this.buildGMContent();
 
-        case Constants.OPEN_CHANNEL: {
-            if (currentChannel.name === Constants.DEFAULT_CHANNEL) {
+        case General.OPEN_CHANNEL: {
+            if (currentChannel.name === General.DEFAULT_CHANNEL) {
                 return this.buildTownSquareContent();
             }
 
             return this.buildOpenChannelContent();
         }
 
-        case Constants.PRIVATE_CHANNEL:
+        case General.PRIVATE_CHANNEL:
             return this.buildPrivateChannelContent();
 
         }
-    }
+    };
 
     render() {
         const {theme} = this.props;

--- a/app/components/channel_intro/index.js
+++ b/app/components/channel_intro/index.js
@@ -3,7 +3,7 @@
 
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
-import {Constants} from 'mattermost-redux/constants';
+import {General} from 'mattermost-redux/constants';
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUser, getProfilesInCurrentChannel} from 'mattermost-redux/selectors/entities/users';
 
@@ -16,12 +16,12 @@ function mapStateToProps(state) {
     const currentUser = getCurrentUser(state);
 
     let currentChannelMembers = [];
-    if (currentChannel.type === Constants.DM_CHANNEL) {
+    if (currentChannel.type === General.DM_CHANNEL) {
         const otherChannelMember = currentChannel.name.split('__').find((m) => m.id !== currentUser.id);
         currentChannelMembers.push(state.entities.users.profiles[otherChannelMember]);
     }
 
-    if (currentChannel.type === Constants.GM_CHANNEL) {
+    if (currentChannel.type === General.GM_CHANNEL) {
         currentChannelMembers = getProfilesInCurrentChannel(state);
     }
 

--- a/app/components/channel_intro/index.js
+++ b/app/components/channel_intro/index.js
@@ -17,7 +17,7 @@ function mapStateToProps(state) {
 
     let currentChannelMembers = [];
     if (currentChannel.type === General.DM_CHANNEL) {
-        const otherChannelMember = currentChannel.name.split('__').find((m) => m.id !== currentUser.id);
+        const otherChannelMember = currentChannel.name.split('__').find((m) => m !== currentUser.id);
         currentChannelMembers.push(state.entities.users.profiles[otherChannelMember]);
     }
 

--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -13,7 +13,7 @@ import {
     StyleSheet
 } from 'react-native';
 
-import {Client4} from 'mattermost-redux/client';
+import {Client} from 'mattermost-redux/client';
 
 import imageIcon from 'assets/images/icons/image.png';
 
@@ -24,8 +24,6 @@ const IMAGE_SIZE = {
     Preview: 'preview',
     Thumbnail: 'thumbnail'
 };
-
-const IMAGE_HEADERS = Client4.getOptions().headers;
 
 export default class FileAttachmentImage extends PureComponent {
     static propTypes = {
@@ -105,12 +103,12 @@ export default class FileAttachmentImage extends PureComponent {
 
         switch (imageSize) {
         case IMAGE_SIZE.Fullsize:
-            return Client4.getFileUrl(file.id, this.state.timestamp);
+            return Client.getFileUrl(file.id, this.state.timestamp);
         case IMAGE_SIZE.Preview:
-            return Client4.getFilePreviewUrl(file.id, this.state.timestamp);
+            return Client.getFilePreviewUrl(file.id, this.state.timestamp);
         case IMAGE_SIZE.Thumbnail:
         default:
-            return Client4.getFileThumbnailUrl(file.id, this.state.timestamp);
+            return Client.getFileThumbnailUrl(file.id, this.state.timestamp);
         }
     };
 
@@ -133,7 +131,7 @@ export default class FileAttachmentImage extends PureComponent {
         if (this.state.retry === 4) {
             source = imageIcon;
         } else if (file.id) {
-            source = {uri: this.handleGetImageURL(), headers: IMAGE_HEADERS};
+            source = {uri: this.handleGetImageURL()};
         }
 
         const isInFetchCache = fetchCache[source.uri];

--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -9,7 +9,7 @@ import {makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import placeholder from 'assets/images/profile.jpg';
 
-import {Client4} from 'mattermost-redux/client';
+import {Client} from 'mattermost-redux/client';
 
 const statusToIcon = {
     online: 'check',
@@ -20,8 +20,6 @@ const STATUS_BUFFER = Platform.select({
     ios: 3,
     android: 2
 });
-
-const IMAGE_HEADERS = Client4.getOptions().headers;
 
 export default class ProfilePicture extends React.PureComponent {
     static propTypes = {
@@ -55,7 +53,7 @@ export default class ProfilePicture extends React.PureComponent {
 
         let pictureUrl;
         if (this.props.user) {
-            pictureUrl = Client4.getProfilePictureUrl(this.props.user.id, this.props.user.last_picture_update);
+            pictureUrl = Client.getProfilePictureUrl(this.props.user.id, this.props.user.last_picture_update);
         }
 
         let statusIcon;
@@ -87,7 +85,7 @@ export default class ProfilePicture extends React.PureComponent {
             <View style={{width: this.props.size + STATUS_BUFFER, height: this.props.size + STATUS_BUFFER}}>
                 <Image
                     style={{width: this.props.size, height: this.props.size, borderRadius: this.props.size / 2}}
-                    source={{uri: pictureUrl, headers: IMAGE_HEADERS}}
+                    source={{uri: pictureUrl}}
                     defaultSource={placeholder}
                 />
                 {this.props.status &&

--- a/app/scenes/login/login.js
+++ b/app/scenes/login/login.js
@@ -123,7 +123,7 @@ class Login extends Component {
         }
         if (this.props.config.EnableMultifactorAuthentication === 'true') {
             this.props.actions.checkMfa(this.props.loginId).then((result) => {
-                if (result.mfa_required === 'true') {
+                if (result) {
                     this.props.actions.goToMfa();
                 } else {
                     this.signIn();

--- a/app/scenes/root/root.js
+++ b/app/scenes/root/root.js
@@ -5,7 +5,7 @@ import React, {PropTypes, PureComponent} from 'react';
 import Orientation from 'react-native-orientation';
 import SplashScreen from 'react-native-smart-splash-screen';
 
-import {Client4} from 'mattermost-redux/client';
+import {Client, Client4} from 'mattermost-redux/client';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import Loading from 'app/components/loading';
@@ -63,6 +63,7 @@ export default class Root extends PureComponent {
             if (loginRequest.status === RequestStatus.NOT_STARTED) {
                 Client4.setToken(credentials.token);
                 Client4.setUrl(stripTrailingSlashes(credentials.url));
+                Client.setUrl(stripTrailingSlashes(credentials.url));
 
                 loadMe().then(goToLoadTeam).catch(goToLoadTeam);
             } else {

--- a/app/scenes/select_server/select_server.js
+++ b/app/scenes/select_server/select_server.js
@@ -16,7 +16,7 @@ import {
 import Button from 'react-native-button';
 
 import {RequestStatus} from 'mattermost-redux/constants';
-import {Client4} from 'mattermost-redux/client';
+import {Client, Client4} from 'mattermost-redux/client';
 
 import ErrorText from 'app/components/error_text';
 import FormattedText from 'app/components/formatted_text';
@@ -84,6 +84,7 @@ export default class SelectServer extends PureComponent {
 
         if (isValidUrl(url)) {
             Client4.setUrl(stripTrailingSlashes(url));
+            Client.setUrl(stripTrailingSlashes(url));
             await this.props.actions.getPing();
         } else {
             error = {


### PR DESCRIPTION
#### Summary
This PR fixes the following:
* Use APIv3 to get the image files cause the android Image component does not yet support headers (this has been added in RN 0.43) we could move it to APIv4 once we upgrade.
* Channel intro was using constants from the `release-3.7` branch
* Make babel to use `./src` as root for building `mattermost-redux`
* Fix android back button to not exit the app and then when opening the app again it was creating a newIntent and the root component did not mount
* Fix how we check for MFA required

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (https://github.com/mattermost/mattermost-redux/pull/76)

#### Device Information
This PR was tested on: 
* IOS 10.3.1 iPhone 6s
* Android 7.1.1 Nexus 7
* Android 6.0.1 Samsung J5
