### PR TITLE
Various Bug Fixes

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -126,7 +126,7 @@ export function loadProfilesAndTeamMembersForDMSidebar(teamId) {
 
         let membersToLoad = members;
         if (membersInTeam[teamId]) {
-            membersToLoad = members.filter((m) => !membersInTeam[teamId].has(m));
+            membersToLoad = members.filter((m) => !membersInTeam[teamId].hasOwnProperty(m));
         }
 
         if (membersToLoad.length) {

--- a/app/actions/views/channel_add_members.js
+++ b/app/actions/views/channel_add_members.js
@@ -3,10 +3,10 @@
 
 import {addChannelMember} from 'mattermost-redux/actions/channels';
 
-export function handleAddChannelMembers(teamId, channelId, members) {
+export function handleAddChannelMembers(channelId, members) {
     return async (dispatch, getState) => {
         try {
-            const requests = members.map((m) => dispatch(addChannelMember(teamId, channelId, m, getState)));
+            const requests = members.map((m) => dispatch(addChannelMember(channelId, m, getState)));
 
             await Promise.all(requests);
         } catch (error) {

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -21,7 +21,7 @@ const LOAD_MORE_POSTS = 'load-more-posts';
 
 export default class PostList extends Component {
     static propTypes = {
-        channel: PropTypes.object.isRequired,
+        channel: PropTypes.object,
         channelIsLoading: PropTypes.bool.isRequired,
         posts: PropTypes.array.isRequired,
         theme: PropTypes.object.isRequired,
@@ -76,18 +76,22 @@ export default class PostList extends Component {
     renderChannelIntro = () => {
         const {channel, channelIsLoading, posts} = this.props;
 
-        const firstPostHasRendered = channel.total_msg_count ? posts.length > 0 : true;
-        const messageCount = channel.total_msg_count - posts.length;
-        if (channelIsLoading || !firstPostHasRendered || messageCount > Posts.POST_CHUNK_SIZE) {
-            return null;
+        if (channel) {
+            const firstPostHasRendered = channel.total_msg_count ? posts.length > 0 : true;
+            const messageCount = channel.total_msg_count - posts.length;
+            if (channelIsLoading || !firstPostHasRendered || messageCount > Posts.POST_CHUNK_SIZE) {
+                return null;
+            }
+
+            return (
+                <View style={style.row}>
+                    <ChannelIntro/>
+                </View>
+            );
         }
 
-        return (
-            <View style={style.row}>
-                <ChannelIntro/>
-            </View>
-        );
-    }
+        return null;
+    };
 
     renderRow = (row) => {
         if (row instanceof Date) {

--- a/app/scenes/channel_add_members/channel_add_members.js
+++ b/app/scenes/channel_add_members/channel_add_members.js
@@ -20,7 +20,7 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import {General, RequestStatus} from 'mattermost-redux/constants';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
-import {filterProfiles} from 'mattermost-redux/utils/user_utils';
+import {filterProfilesMatchingTerm} from 'mattermost-redux/utils/user_utils';
 
 class ChannelAddMembers extends PureComponent {
     static propTypes = {
@@ -112,7 +112,7 @@ class ChannelAddMembers extends PureComponent {
             this.setState({profiles, showNoResults: true});
         } else if (this.state.searching &&
             nextProps.searchRequestStatus === RequestStatus.SUCCESS) {
-            const results = filterProfiles(nextProps.membersNotInChannel, this.state.term);
+            const results = filterProfilesMatchingTerm(nextProps.membersNotInChannel, this.state.term);
             this.setState({profiles: results, showNoResults: true});
         }
 

--- a/app/scenes/channel_add_members/channel_add_members.js
+++ b/app/scenes/channel_add_members/channel_add_members.js
@@ -15,7 +15,7 @@ import {
 import ActionButton from 'app/components/action_button';
 import MemberList from 'app/components/custom_list';
 import SearchBar from 'app/components/search_bar';
-import {createMembersSections, loadingText, renderMemberRow} from 'app/utils/member_list';
+import {createMembersSections, loadingText, markSelectedProfiles, renderMemberRow} from 'app/utils/member_list';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import {General, RequestStatus} from 'mattermost-redux/constants';
@@ -108,11 +108,17 @@ class ChannelAddMembers extends PureComponent {
         if (loadMoreRequestStatus === RequestStatus.STARTED &&
             nextProps.loadMoreRequestStatus === RequestStatus.SUCCESS) {
             const {page} = this.state;
-            const profiles = nextProps.membersNotInChannel.splice(0, (page + 1) * General.PROFILE_CHUNK_SIZE);
+            const profiles = markSelectedProfiles(
+                nextProps.membersNotInChannel.splice(0, (page + 1) * General.PROFILE_CHUNK_SIZE),
+                this.state.selectedMembers
+            );
             this.setState({profiles, showNoResults: true});
         } else if (this.state.searching &&
             nextProps.searchRequestStatus === RequestStatus.SUCCESS) {
-            const results = filterProfilesMatchingTerm(nextProps.membersNotInChannel, this.state.term);
+            const results = markSelectedProfiles(
+                filterProfilesMatchingTerm(nextProps.membersNotInChannel, this.state.term),
+                this.state.selectedMembers
+            );
             this.setState({profiles: results, showNoResults: true});
         }
 
@@ -138,7 +144,7 @@ class ChannelAddMembers extends PureComponent {
 
     handleAddMembersPress = () => {
         const {selectedMembers} = this.state;
-        const {actions, currentTeam, currentChannel} = this.props;
+        const {actions, currentChannel} = this.props;
         const membersToAdd = Object.keys(selectedMembers).filter((m) => selectedMembers[m]);
 
         if (!membersToAdd.length) {
@@ -146,7 +152,7 @@ class ChannelAddMembers extends PureComponent {
             return;
         }
 
-        actions.handleAddChannelMembers(currentTeam.id, currentChannel.id, membersToAdd);
+        actions.handleAddChannelMembers(currentChannel.id, membersToAdd);
     };
 
     handleAndroidKeyboard = () => {
@@ -181,6 +187,7 @@ class ChannelAddMembers extends PureComponent {
             this.emitCanAddMembers(false);
         }
         this.setState({
+            profiles: markSelectedProfiles(this.state.profiles, selectedMembers),
             selectedMembers
         });
     };
@@ -223,7 +230,7 @@ class ChannelAddMembers extends PureComponent {
             searching: false,
             term: null,
             page: 0,
-            profiles: this.props.membersNotInChannel
+            profiles: markSelectedProfiles(this.props.membersNotInChannel, this.state.selectedMembers)
         });
     };
 

--- a/app/scenes/channel_members/channel_members.js
+++ b/app/scenes/channel_members/channel_members.js
@@ -20,7 +20,7 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import {General, RequestStatus} from 'mattermost-redux/constants';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
-import {displayUsername, filterProfiles} from 'mattermost-redux/utils/user_utils';
+import {displayUsername, filterProfilesMatchingTerm} from 'mattermost-redux/utils/user_utils';
 
 import ChannelMembersTitle from './channel_members_title';
 import RemoveMemberButton from './remove_member_button';
@@ -106,7 +106,7 @@ class ChannelMembers extends PureComponent {
             this.setState({profiles, showNoResults: true});
         } else if (this.state.searching &&
             nextProps.searchRequestStatus === RequestStatus.SUCCESS) {
-            const results = filterProfiles(nextProps.currentChannelMembers, this.state.term);
+            const results = filterProfilesMatchingTerm(nextProps.currentChannelMembers, this.state.term);
             this.setState({profiles: results, showNoResults: true});
         }
 

--- a/app/scenes/channel_members/channel_members.js
+++ b/app/scenes/channel_members/channel_members.js
@@ -14,7 +14,7 @@ import {injectIntl, intlShape} from 'react-intl';
 
 import MemberList from 'app/components/custom_list';
 import SearchBar from 'app/components/search_bar';
-import {createMembersSections, loadingText} from 'app/utils/member_list';
+import {createMembersSections, loadingText, markSelectedProfiles} from 'app/utils/member_list';
 import MemberListRow from 'app/components/custom_list/member_list_row';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
@@ -102,11 +102,17 @@ class ChannelMembers extends PureComponent {
         if (requestStatus === RequestStatus.STARTED &&
             nextProps.requestStatus === RequestStatus.SUCCESS) {
             const {page} = this.state;
-            const profiles = nextProps.currentChannelMembers.splice(0, (page + 1) * General.PROFILE_CHUNK_SIZE);
+            const profiles = markSelectedProfiles(
+                nextProps.currentChannelMembers.splice(0, (page + 1) * General.PROFILE_CHUNK_SIZE),
+                this.state.selectedMembers
+            );
             this.setState({profiles, showNoResults: true});
         } else if (this.state.searching &&
             nextProps.searchRequestStatus === RequestStatus.SUCCESS) {
-            const results = filterProfilesMatchingTerm(nextProps.currentChannelMembers, this.state.term);
+            const results = markSelectedProfiles(
+                filterProfilesMatchingTerm(nextProps.currentChannelMembers, this.state.term),
+                this.state.selectedMembers
+            );
             this.setState({profiles: results, showNoResults: true});
         }
 
@@ -203,6 +209,7 @@ class ChannelMembers extends PureComponent {
             this.emitCanRemoveMembers(false);
         }
         this.setState({
+            profiles: markSelectedProfiles(this.state.profiles, selectedMembers),
             selectedMembers
         });
     };
@@ -244,7 +251,7 @@ class ChannelMembers extends PureComponent {
             searching: false,
             term: null,
             page: 0,
-            profiles: this.props.currentChannelMembers
+            profiles: markSelectedProfiles(this.props.currentChannelMembers, this.state.selectedMembers)
         });
     };
 

--- a/app/scenes/edit_post/edit_post.js
+++ b/app/scenes/edit_post/edit_post.js
@@ -21,7 +21,6 @@ import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 export default class EditPost extends PureComponent {
     static propTypes = {
-        currentTeamId: PropTypes.string.isRequired,
         editPostRequest: PropTypes.object.isRequired,
         post: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
@@ -71,7 +70,7 @@ export default class EditPost extends PureComponent {
     onEditPost = async () => {
         const {message} = this.state;
         const post = Object.assign({}, this.props.post, {message});
-        await this.props.actions.editPost(this.props.currentTeamId, post);
+        await this.props.actions.editPost(post);
     };
 
     onPostChangeText = (message) => {

--- a/app/scenes/edit_post/index.js
+++ b/app/scenes/edit_post/index.js
@@ -9,7 +9,6 @@ import {closeModal} from 'app/actions/navigation';
 import {getTheme} from 'app/selectors/preferences';
 
 import {editPost} from 'mattermost-redux/actions/posts';
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import EditPost from './edit_post';
 
@@ -18,7 +17,6 @@ function mapStateToProps(state, ownProps) {
 
     return {
         ...ownProps,
-        currentTeamId: getCurrentTeamId(state),
         editPostRequest,
         post: ownProps.post,
         theme: getTheme(state)

--- a/app/scenes/more_dms/more_dms.js
+++ b/app/scenes/more_dms/more_dms.js
@@ -20,7 +20,7 @@ import {createMembersSections, loadingText, renderMemberRow} from 'app/utils/mem
 import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
 
 import {General, RequestStatus} from 'mattermost-redux/constants';
-import {filterProfiles} from 'mattermost-redux/utils/user_utils';
+import {filterProfilesMatchingTerm} from 'mattermost-redux/utils/user_utils';
 
 class MoreDirectMessages extends PureComponent {
     static propTypes = {
@@ -86,7 +86,7 @@ class MoreDirectMessages extends PureComponent {
             this.setState({profiles, showNoResults: true});
         } else if (this.state.searching &&
             nextProps.searchRequest.status === RequestStatus.SUCCESS) {
-            const results = filterProfiles(nextProps.profiles, this.state.term);
+            const results = filterProfilesMatchingTerm(nextProps.profiles, this.state.term);
             this.setState({profiles: results, showNoResults: true});
         }
     }

--- a/app/utils/member_list.js
+++ b/app/utils/member_list.js
@@ -48,3 +48,11 @@ export function renderMemberRow(user, sectionId, rowId, preferences, theme, sele
         />
     );
 }
+
+export function markSelectedProfiles(profiles, selectedProfiles) {
+    return profiles.map((p) => {
+        const profile = {...p};
+        profile.selected = selectedProfiles[p.id];
+        return profile;
+    });
+}


### PR DESCRIPTION
#### Summary
* Fix edit post that was passing the wrong arguments to the action
* filterProfiles was renamed in `mattermost-redux` to filterProfilesMatchingTerm
* Fix a bug when opening a thread to not compute or show the channel intro message
* Fix membersToLoad in channel action
* Fix channel lists for `add members` and `manage members` where you weren't able to select users if the search function was used.

#### Device Information
This PR was tested on: 
* IOS 10.3.1 iPhone 6s
* Android 6.0.1 Samsung J5
* Android 7.1.1 (Simulator Nexus 7)