### PR TITLE
RN-78: Can't reply to a post with only files

### DIFF
--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -8,6 +8,7 @@ import React, {
 
 import {
     Text,
+    TouchableOpacity,
     View,
     StyleSheet
 } from 'react-native';
@@ -25,6 +26,8 @@ export default class FileAttachment extends PureComponent {
         addFileToFetchCache: PropTypes.func.isRequired,
         fetchCache: PropTypes.object.isRequired,
         file: PropTypes.object.isRequired,
+        onInfoPress: PropTypes.func.isRequired,
+        onPreviewPress: PropTypes.func.isRequired,
         theme: PropTypes.object.isRequired
     };
 
@@ -33,7 +36,7 @@ export default class FileAttachment extends PureComponent {
         const style = getStyleSheet(theme);
 
         return (
-            <View style={style.fileInfoContainer}>
+            <View>
                 <Text
                     numberOfLines={4}
                     style={style.fileName}
@@ -52,6 +55,10 @@ export default class FileAttachment extends PureComponent {
                 </View>
             </View>
         );
+    }
+
+    handlePreviewPress = () => {
+        this.props.onPreviewPress(this.props.file);
     }
 
     render() {
@@ -79,8 +86,15 @@ export default class FileAttachment extends PureComponent {
 
         return (
             <View style={style.fileWrapper}>
-                {fileAttachmentComponent}
-                {this.renderFileInfo()}
+                <TouchableOpacity onPress={this.handlePreviewPress}>
+                    {fileAttachmentComponent}
+                </TouchableOpacity>
+                <TouchableOpacity
+                    onPress={this.props.onInfoPress}
+                    style={style.fileInfoContainer}
+                >
+                    {this.renderFileInfo()}
+                </TouchableOpacity>
             </View>
         );
     }

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -21,6 +21,7 @@ export default class FileAttachmentList extends Component {
         files: PropTypes.array.isRequired,
         hideOptionsContext: PropTypes.func.isRequired,
         onLongPress: PropTypes.func,
+        onPress: PropTypes.func,
         post: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
         toggleSelected: PropTypes.func.isRequired
@@ -31,9 +32,14 @@ export default class FileAttachmentList extends Component {
         this.props.actions.loadFilesForPostIfNecessary(post);
     }
 
-    handleOnPress = (file) => {
+    handleInfoPress = () => {
         this.props.hideOptionsContext();
-        this.props.actions.goToImagePreviewModal(this.props.post, file.id);
+        this.props.onPress();
+    }
+
+    handlePreviewPress = (file) => {
+        this.props.hideOptionsContext();
+        preventDoubleTap(this.props.actions.goToImagePreviewModal, this, this.props.post, file.id);
     };
 
     render() {
@@ -41,7 +47,6 @@ export default class FileAttachmentList extends Component {
             <TouchableOpacity
                 key={file.id}
                 onLongPress={this.props.onLongPress}
-                onPress={() => preventDoubleTap(this.handleOnPress, this, file)}
                 onPressIn={() => this.props.toggleSelected(true)}
                 onPressOut={() => this.props.toggleSelected(false)}
             >
@@ -49,6 +54,8 @@ export default class FileAttachmentList extends Component {
                     addFileToFetchCache={this.props.actions.addFileToFetchCache}
                     fetchCache={this.props.fetchCache}
                     file={file}
+                    onInfoPress={this.handleInfoPress}
+                    onPreviewPress={this.handlePreviewPress}
                     theme={this.props.theme}
                 />
             </TouchableOpacity>

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -212,6 +212,7 @@ class Post extends PureComponent {
                 <FileAttachmentList
                     hideOptionsContext={this.hideOptionsContext}
                     onLongPress={this.showOptionsContext}
+                    onPress={this.handlePress}
                     post={post}
                     toggleSelected={this.toggleSelected}
                 />

--- a/app/scenes/image_preview/image_preview.js
+++ b/app/scenes/image_preview/image_preview.js
@@ -60,7 +60,7 @@ export default class ImagePreview extends PureComponent {
         const currentFile = props.files.findIndex((file) => file.id === props.fileId);
         this.state = {
             currentFile,
-            deviceHeight,
+            deviceHeight: deviceHeight - STATUSBAR_HEIGHT,
             deviceWidth,
             drag: new Animated.ValueXY(),
             footerOpacity: new Animated.Value(1),


### PR DESCRIPTION
#### Summary
This PR fixes an issue where posts with only file attachments could not be replied to.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-78

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23

@jarredwitt 