### PR TITLE
[RN-47] Remove download icon from file thumbnails

### DIFF
--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -13,8 +13,6 @@ import {
     StyleSheet
 } from 'react-native';
 
-import Icon from 'react-native-vector-icons/FontAwesome';
-
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 import * as Utils from 'mattermost-redux/utils/file_utils.js';
 
@@ -44,11 +42,6 @@ export default class FileAttachment extends PureComponent {
                     {file.name.trim()}
                 </Text>
                 <View style={style.fileDownloadContainer}>
-                    <Icon
-                        name='download'
-                        size={16}
-                        style={style.downloadIcon}
-                    />
                     <Text style={style.fileInfo}>
                         {`${file.extension.toUpperCase()} ${Utils.getFormattedFileSize(file)}`}
                     </Text>


### PR DESCRIPTION
#### Summary
Remove download icon from file thumbnails

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/RN-47
Github: https://github.com/mattermost/mattermost-mobile/issues/423

#### Device Information
This PR was tested on: Emulator android 6 nexus 5

