### PR TITLE
Ensure build uses the right dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ check-style: .yarninstall
 clean:
 	@echo Cleaning app
 
-	npm cache clean
+	yarn cache clean
 	rm -rf node_modules
 	rm -f .yarninstall
 	rm -rf dist
@@ -126,7 +126,7 @@ do-build-ios:
 	@cd fastlane && bundle exec fastlane ios $(ios_target)
 
 
-build-ios: | check-ios-target pre-run check-style start-packager do-build-ios stop-packager
+build-ios: | check-ios-target clean pre-run check-style start-packager do-build-ios stop-packager
 
 check-android-target:
 ifneq ($(android_target), $(filter $(android_target), dev alpha release))
@@ -144,7 +144,7 @@ do-build-android:
 	@echo "Building android $(android_target) app"
 	@cd fastlane && bundle exec fastlane android $(android_target)
 
-build-android: | check-android-target pre-run check-style start-packager prepare-android-build do-build-android stop-packager
+build-android: | check-android-target clean pre-run check-style start-packager prepare-android-build do-build-android stop-packager
 
 alpha:
 	@:


### PR DESCRIPTION
#### Summary
Modified makefile to use `yarn cache clean` on `make clean` and call `clean` before making a build to ensure it uses the right dependencies