### PR TITLE
Fix unread channels

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -9,7 +9,6 @@ import {UserTypes} from 'mattermost-redux/action_types';
 import {
     fetchMyChannelsAndMembers,
     getChannelStats,
-    getMyChannelMembers,
     selectChannel,
     leaveChannel as serviceLeaveChannel
 } from 'mattermost-redux/actions/channels';
@@ -33,22 +32,7 @@ import {getPreferencesByCategory} from 'mattermost-redux/utils/preference_utils'
 
 export function loadChannelsIfNecessary(teamId) {
     return async (dispatch, getState) => {
-        const {channels} = getState().entities.channels;
-
-        let hasChannelsForTeam = false;
-        for (const channel of Object.values(channels)) {
-            if (channel.team_id === teamId) {
-                // If we have one channel, assume we have all of them
-                hasChannelsForTeam = true;
-                break;
-            }
-        }
-
-        if (hasChannelsForTeam) {
-            await getMyChannelMembers(teamId)(dispatch, getState);
-        } else {
-            await fetchMyChannelsAndMembers(teamId)(dispatch, getState);
-        }
+        await fetchMyChannelsAndMembers(teamId)(dispatch, getState);
     };
 }
 


### PR DESCRIPTION
#### Summary
Whenever we loaded the app or changed teams we were checking to see if we had loaded channels for the current Team, and if that was the case we were loading just the channel members and this won't have the latests total_msg_count for each channel.

Now will be loading channel and members for when loading the app or when changing teams