### PR TITLE
[RN-48] "Help" menu option should open help link in a mobile browser

### DIFF
--- a/app/scenes/settings/settings.js
+++ b/app/scenes/settings/settings.js
@@ -14,6 +14,7 @@ import DeviceInfo from 'react-native-device-info';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+import {preventDoubleTap} from 'app/utils/tap';
 
 import SettingsItem from './settings_item';
 
@@ -101,8 +102,13 @@ export default class Settings extends PureComponent {
         this.props.actions.clearErrors();
     };
 
+    openHelp = () => {
+        const {config} = this.props;
+        Linking.openURL(config.HelpLink);
+    }
+
     render() {
-        const {actions, showTeamSelection, theme} = this.props;
+        const {actions, config, showTeamSelection, theme} = this.props;
         const {goToAccountSettings, goToSelectTeam, goToAbout} = actions;
         const style = getStyleSheet(theme);
 
@@ -125,6 +131,17 @@ export default class Settings extends PureComponent {
                             iconName='ios-people'
                             iconType='ion'
                             onPress={() => this.handlePress(goToSelectTeam)}
+                            separator={true}
+                            theme={theme}
+                        />
+                    }
+                    {config.HelpLink &&
+                        <SettingsItem
+                            defaultMessage='Help'
+                            i18nId='mobile.help.title'
+                            iconName='help'
+                            iconType='material'
+                            onPress={() => preventDoubleTap(this.openHelp, this)}
                             separator={true}
                             theme={theme}
                         />

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -16,6 +16,7 @@
   "about.teamEditiont1": "Enterprise Edition",
   "about.title": "About Mattermost",
   "about.version": "Version:",
+  "mobile.help.title": "Help",
   "access_history.title": "Access History",
   "activity_log.activeSessions": "Active Sessions",
   "activity_log.browser": "Browser: {browser}",


### PR DESCRIPTION
#### Summary
"Help" menu option should open help link in a mobile browser

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/RN-48
GitHub: https://github.com/mattermost/mattermost-mobile/issues/283

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: Emulator Android 6.0