### PR TITLE
Fix hamburger unread indicator

### DIFF
--- a/app/screens/channel/channel_drawer_button.js
+++ b/app/screens/channel/channel_drawer_button.js
@@ -18,7 +18,7 @@ import Badge from 'app/components/badge';
 import {getTheme} from 'app/selectors/preferences';
 import {preventDoubleTap} from 'app/utils/tap';
 
-import {getUnreads} from 'mattermost-redux/selectors/entities/channels';
+import {getUnreadsInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 class ChannelDrawerButton extends PureComponent {
@@ -159,7 +159,7 @@ function mapStateToProps(state) {
     return {
         applicationInitializing: state.views.root.appInitializing,
         theme: getTheme(state),
-        ...getUnreads(state)
+        ...getUnreadsInCurrentTeam(state)
     };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3526,7 +3526,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/b09177a214a90292b9b450e381f16edbdbcb7daa"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/95a1a719b9b0b692f27ed93235751647777cbddd"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
Fix the unread indicator in the hamburger button to show only those that belong to the current team