### PR TITLE
RN-136 Post list pull to refresh

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -331,3 +331,10 @@ export function setChannelLoading(loading = true) {
         loading
     };
 }
+
+export function setChannelRefreshing(refreshing = true) {
+    return {
+        type: ViewTypes.SET_CHANNEL_REFRESHING,
+        refreshing
+    };
+}

--- a/app/components/post_list/index.js
+++ b/app/components/post_list/index.js
@@ -1,18 +1,32 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
+import {loadPostsIfNecessary, setChannelRefreshing} from 'app/actions/views/channel';
 import {getTheme} from 'app/selectors/preferences';
 
 import PostList from './post_list';
 
 function mapStateToProps(state, ownProps) {
+    const {loading, refreshing} = state.views.channel;
+
     return {
         ...ownProps,
-        channelIsLoading: state.views.channel.loading,
+        channelIsLoading: loading,
+        refreshing,
         theme: getTheme(state)
     };
 }
 
-export default connect(mapStateToProps)(PostList);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            loadPostsIfNecessary,
+            setChannelRefreshing
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PostList);

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -5,9 +5,9 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     ListView,
-    StyleSheet,
     View
 } from 'react-native';
+import InvertibleScrollView from 'react-native-invertible-scroll-view';
 
 import {General, Posts} from 'mattermost-redux/constants';
 import {addDatesToPostList} from 'mattermost-redux/utils/post_utils';
@@ -90,7 +90,7 @@ export default class PostList extends Component {
             }
 
             return (
-                <View style={style.row}>
+                <View>
                     <ChannelIntro/>
                 </View>
             );
@@ -107,7 +107,6 @@ export default class PostList extends Component {
             return (
                 <NewMessagesDivider
                     theme={this.props.theme}
-                    style={style.row}
                 />
             );
         }
@@ -116,7 +115,6 @@ export default class PostList extends Component {
                 <LoadMorePosts
                     loading={this.props.isLoadingMore}
                     theme={this.props.theme}
-                    style={style.row}
                 />
             );
         }
@@ -128,7 +126,6 @@ export default class PostList extends Component {
         return (
             <DateHeader
                 theme={this.props.theme}
-                style={style.row}
                 date={date}
             />
         );
@@ -137,7 +134,6 @@ export default class PostList extends Component {
     renderPost = (post) => {
         return (
             <Post
-                style={style.row}
                 post={post}
                 renderReplies={this.props.renderReplies}
                 isFirstReply={post.isFirstReply}
@@ -152,13 +148,20 @@ export default class PostList extends Component {
     render() {
         return (
             <ListView
-                style={style.container}
+                renderScrollComponent={(props) => {
+                    return (
+                        <InvertibleScrollView
+                            {...props}
+                            inverted={true}
+                        />
+                    );
+                }}
                 dataSource={this.state.dataSource.cloneWithRows(this.getPostsWithLoadMore())}
                 renderFooter={this.renderChannelIntro}
                 renderRow={this.renderRow}
                 onEndReached={this.loadMore}
                 enableEmptySections={true}
-                showsVerticalScrollIndicator={false}
+                showsVerticalScrollIndicator={true}
                 initialListSize={30}
                 onEndReachedThreshold={200}
                 pageSize={10}
@@ -166,12 +169,3 @@ export default class PostList extends Component {
         );
     }
 }
-
-const style = StyleSheet.create({
-    container: {
-        transform: [{rotate: '180deg'}]
-    },
-    row: {
-        transform: [{rotate: '180deg'}]
-    }
-});

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -34,6 +34,7 @@ const ViewTypes = keyMirror({
     ADD_FILE_TO_FETCH_CACHE: null,
 
     SET_CHANNEL_LOADER: null,
+    SET_CHANNEL_REFRESHING: null,
 
     SET_LAST_CHANNEL_FOR_TEAM: null,
 

--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -172,7 +172,17 @@ function loading(state = false, action) {
     }
 }
 
+function refreshing(state = false, action) {
+    switch (action.type) {
+    case ViewTypes.SET_CHANNEL_REFRESHING:
+        return action.refreshing;
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     drafts,
-    loading
+    loading,
+    refreshing
 });

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -29,6 +29,7 @@ class ChannelPostList extends PureComponent {
         applicationInitializing: PropTypes.bool.isRequired,
         channel: PropTypes.object.isRequired,
         channelIsLoading: PropTypes.bool,
+        channelIsRefreshing: PropTypes.bool,
         intl: intlShape.isRequired,
         myMember: PropTypes.object.isRequired,
         navigator: PropTypes.object,
@@ -147,6 +148,7 @@ class ChannelPostList extends PureComponent {
             applicationInitializing,
             channel,
             channelIsLoading,
+            channelIsRefreshing,
             navigator,
             posts,
             postsRequests,
@@ -162,7 +164,7 @@ class ChannelPostList extends PureComponent {
                     theme={theme}
                 />
             );
-        } else if (!applicationInitializing && !channelIsLoading && posts && (postsRequests.getPosts.status !== RequestStatus.STARTED || !this.state.didInitialPostsLoad)) {
+        } else if (!applicationInitializing && !channelIsLoading && posts && (postsRequests.getPosts.status !== RequestStatus.STARTED || channelIsRefreshing || !this.state.didInitialPostsLoad)) {
             component = (
                 <PostList
                     posts={posts}

--- a/app/screens/channel/channel_post_list/index.js
+++ b/app/screens/channel/channel_post_list/index.js
@@ -64,10 +64,12 @@ const getPostsInCurrentChannelWithReplyProps = createSelector(
 );
 
 function mapStateToProps(state, ownProps) {
+    const {loading, refreshing} = state.views.channel;
     return {
         ...ownProps,
         applicationInitializing: state.views.root.appInitializing,
-        channelIsLoading: state.views.channel.loading,
+        channelIsLoading: loading,
+        channelIsRefreshing: refreshing,
         myMember: getMyCurrentChannelMembership(state),
         postsRequests: state.requests.posts,
         posts: getPostsInCurrentChannelWithReplyProps(state),

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-native-device-info": "0.10.2",
     "react-native-drawer": "2.3.0",
     "react-native-image-picker": "jp928/react-native-image-picker#6ee35b69f3dbd6c7c66f580fd4d9eabf398703d4",
+    "react-native-invertible-scroll-view": "1.0.0",
     "react-native-keyboard-aware-scroll-view": "0.2.8",
     "react-native-linear-gradient": "2.0.0",
     "react-native-navigation": "1.1.72",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,6 +4307,13 @@ react-native-image-picker@jp928/react-native-image-picker#6ee35b69f3dbd6c7c66f58
   version "0.26.2"
   resolved "https://codeload.github.com/jp928/react-native-image-picker/tar.gz/6ee35b69f3dbd6c7c66f580fd4d9eabf398703d4"
 
+react-native-invertible-scroll-view@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-invertible-scroll-view/-/react-native-invertible-scroll-view-1.0.0.tgz#60ceb384dc950c34eba3a5aeda39f97cdc7d4e23"
+  dependencies:
+    react-clone-referenced-element "^1.0.1"
+    react-native-scrollable-mixin "^1.0.1"
+
 react-native-keyboard-aware-scroll-view@0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.2.8.tgz#e9843c0d7467a2e6a2a737883bd9c2b7c7e38e35"
@@ -4364,6 +4371,10 @@ react-native-orientation@enahum/react-native-orientation.git:
 react-native-push-notification@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-native-push-notification/-/react-native-push-notification-3.0.0.tgz#00282ea656443e89df6057f14b10500e7b89551f"
+
+react-native-scrollable-mixin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
 
 react-native-search-bar@enahum/react-native-search-bar.git:
   version "2.16.0"


### PR DESCRIPTION
#### Summary
This PR takes care of two things
1. Adds pull to refresh from the bottoms up in the post list to get the latest posts if necessary.
2. Modifies the post list to use an inverted ListView, that is able to show the scrollbar and removes the necessity of the hacky CSS to rotate the list and the rows in the list. (this should gain on performance)

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-136

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: 
* IOS 10.3.1 iPhone 6s
* Android 6.0.1 Samsung J5