### PR TITLE
Various Updates and fixes

### DIFF
--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -8,7 +8,8 @@ import {
     StyleSheet,
     Text,
     TouchableWithoutFeedback,
-    View
+    View,
+    ViewPropTypes
 } from 'react-native';
 
 export default class Badge extends PureComponent {
@@ -21,7 +22,7 @@ export default class Badge extends PureComponent {
     static propTypes = {
         count: PropTypes.number.isRequired,
         extraPaddingHorizontal: PropTypes.number,
-        style: View.propTypes.style,
+        style: ViewPropTypes.style,
         countStyle: Text.propTypes.style,
         minHeight: PropTypes.number,
         minWidth: PropTypes.number,

--- a/app/components/channel_drawer_list/unread_indicator.js
+++ b/app/components/channel_drawer_list/unread_indicator.js
@@ -3,23 +3,16 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, Text, View} from 'react-native';
-
-const Styles = StyleSheet.create({
-    container: {
-        justifyContent: 'center',
-        alignItems: 'center',
-        flexDirection: 'row',
-        position: 'absolute',
-        borderRadius: 15,
-        marginHorizontal: 15,
-        height: 25
-    }
-});
+import {
+    StyleSheet,
+    Text,
+    View,
+    ViewPropTypes
+} from 'react-native';
 
 export default class UnreadIndicator extends PureComponent {
     static propTypes = {
-        style: View.propTypes.style,
+        style: ViewPropTypes.style,
         textStyle: Text.propTypes.style,
         text: PropTypes.node.isRequired
     };
@@ -34,3 +27,15 @@ export default class UnreadIndicator extends PureComponent {
         );
     }
 }
+
+const Styles = StyleSheet.create({
+    container: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'row',
+        position: 'absolute',
+        borderRadius: 15,
+        marginHorizontal: 15,
+        height: 25
+    }
+});

--- a/app/components/loading.js
+++ b/app/components/loading.js
@@ -4,25 +4,18 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 
-import {ActivityIndicator, StyleSheet, View} from 'react-native';
-
-const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center'
-    },
-
-    loading: {
-        marginLeft: 3
-    }
-});
+import {
+    ActivityIndicator,
+    StyleSheet,
+    View,
+    ViewPropTypes
+} from 'react-native';
 
 export default class Loading extends PureComponent {
     static propTypes = {
         size: PropTypes.string,
         color: PropTypes.string,
-        style: View.propTypes.style
+        style: ViewPropTypes.style
     };
 
     static defaultProps = {
@@ -44,3 +37,15 @@ export default class Loading extends PureComponent {
         );
     }
 }
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+
+    loading: {
+        marginLeft: 3
+    }
+});

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -11,7 +11,8 @@ import {
     Text,
     TouchableHighlight,
     TouchableOpacity,
-    View
+    View,
+    ViewPropTypes
 } from 'react-native';
 import {injectIntl, intlShape} from 'react-intl';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -45,7 +46,7 @@ class Post extends PureComponent {
         commentCount: PropTypes.number.isRequired,
         currentUserId: PropTypes.string.isRequired,
         intl: intlShape.isRequired,
-        style: View.propTypes.style,
+        style: ViewPropTypes.style,
         post: PropTypes.object.isRequired,
         user: PropTypes.object,
         displayName: PropTypes.string,

--- a/app/components/post_list/date_header.js
+++ b/app/components/post_list/date_header.js
@@ -3,34 +3,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, View} from 'react-native';
+import {
+    StyleSheet,
+    View,
+    ViewPropTypes
+} from 'react-native';
 
 import FormattedDate from 'app/components/formatted_date';
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
-
-const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
-        container: {
-            alignItems: 'center',
-            flexDirection: 'row',
-            height: 28
-        },
-        dateContainer: {
-            marginHorizontal: 15
-        },
-        line: {
-            flex: 1,
-            height: StyleSheet.hairlineWidth,
-            backgroundColor: theme.centerChannelColor,
-            opacity: 0.2
-        },
-        date: {
-            color: theme.centerChannelColor,
-            fontSize: 14,
-            fontWeight: '600'
-        }
-    });
-});
 
 function DateHeader(props) {
     const style = getStyleSheet(props.theme);
@@ -56,7 +36,31 @@ function DateHeader(props) {
 DateHeader.propTypes = {
     date: PropTypes.object.isRequired,
     theme: PropTypes.object.isRequired,
-    style: View.propTypes.style
+    style: ViewPropTypes.style
 };
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return StyleSheet.create({
+        container: {
+            alignItems: 'center',
+            flexDirection: 'row',
+            height: 28
+        },
+        dateContainer: {
+            marginHorizontal: 15
+        },
+        line: {
+            flex: 1,
+            height: StyleSheet.hairlineWidth,
+            backgroundColor: theme.centerChannelColor,
+            opacity: 0.2
+        },
+        date: {
+            color: theme.centerChannelColor,
+            fontSize: 14,
+            fontWeight: '600'
+        }
+    });
+});
 
 export default DateHeader;

--- a/app/components/post_list/load_more_posts.js
+++ b/app/components/post_list/load_more_posts.js
@@ -4,9 +4,10 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    View,
     StyleSheet,
-    TouchableOpacity
+    TouchableOpacity,
+    View,
+    ViewPropTypes
 } from 'react-native';
 
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
@@ -18,7 +19,7 @@ export default class LoadMorePosts extends PureComponent {
         loading: PropTypes.bool.isRequired,
         loadMore: PropTypes.func,
         theme: PropTypes.object.isRequired,
-        style: View.propTypes.style
+        style: ViewPropTypes.style
     };
 
     loadMore = () => {

--- a/app/components/post_list/new_messages_divider.js
+++ b/app/components/post_list/new_messages_divider.js
@@ -2,9 +2,33 @@
 // See License.txt for license information.
 
 import React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {
+    StyleSheet,
+    View,
+    ViewPropTypes
+} from 'react-native';
 
 import FormattedText from 'app/components/formatted_text';
+
+function NewMessagesDivider(props) {
+    return (
+        <View style={[style.container, props.style]}>
+            <View style={style.line}/>
+            <View style={style.textContainer}>
+                <FormattedText
+                    id='post_list.newMsg'
+                    defaultMessage='New Messages'
+                    style={style.text}
+                />
+            </View>
+            <View style={style.line}/>
+        </View>
+    );
+}
+
+NewMessagesDivider.propTypes = {
+    style: ViewPropTypes.style
+};
 
 const style = StyleSheet.create({
     container: {
@@ -26,25 +50,5 @@ const style = StyleSheet.create({
         color: '#ffaf53'
     }
 });
-
-function NewMessagesDivider(props) {
-    return (
-        <View style={[style.container, props.style]}>
-            <View style={style.line}/>
-            <View style={style.textContainer}>
-                <FormattedText
-                    id='post_list.newMsg'
-                    defaultMessage='New Messages'
-                    style={style.text}
-                />
-            </View>
-            <View style={style.line}/>
-        </View>
-    );
-}
-
-NewMessagesDivider.propTypes = {
-    style: View.propTypes.style
-};
 
 export default NewMessagesDivider;

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -59,9 +59,14 @@ export default class PostList extends Component {
 
     componentWillReceiveProps(nextProps) {
         if (nextProps.posts !== this.props.posts) {
-            this.props.actions.setChannelRefreshing(false);
             const posts = this.getPostsWithDates(nextProps);
-            this.setState({posts});
+            this.setState({posts}, () => {
+                if (nextProps.refreshing) {
+                    this.props.actions.setChannelRefreshing(false);
+                }
+            });
+        } else if (nextProps.refreshing) {
+            this.props.actions.setChannelRefreshing(false);
         }
     }
 

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -174,7 +174,7 @@ class Channel extends PureComponent {
             );
         }
 
-        const channelDraft = this.props.drafts[currentChannel.id];
+        const channelDraft = this.props.drafts[currentChannel.id] || {};
         const style = getStyleFromTheme(theme);
 
         return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3526,7 +3526,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/95a1a719b9b0b692f27ed93235751647777cbddd"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/dad1a74263edb36271bf422cef977a06ac56815c"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
This PR updates `mattermost-redux` that has a fix for Android WebSocket connection, also updates `View.propTypes` to `ViewPropTypes` to get rid of the deprecated warning, make sure we use an empty object if the draft for the channel is undefined and finally fixes an issue where we had a never ending loop when setting the `refreshing` prop as false