### PR TITLE
Replace dismissAllModals for dismissModal

### DIFF
--- a/app/screens/create_channel/create_channel.js
+++ b/app/screens/create_channel/create_channel.js
@@ -131,7 +131,7 @@ class CreateChannel extends PureComponent {
         if (goBack) {
             this.props.navigator.pop({animated: true});
         } else {
-            this.props.navigator.dismissAllModals({
+            this.props.navigator.dismissModal({
                 animationType: 'slide-down'
             });
         }

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -51,7 +51,7 @@ export default class SelectTeam extends PureComponent {
             handleTeamChange(team);
             EventEmitter.emit('close_channel_drawer');
             InteractionManager.runAfterInteractions(() => {
-                this.props.navigator.dismissAllModals({
+                this.props.navigator.dismissModal({
                     animationType: 'slide-down'
                 });
             });


### PR DESCRIPTION
#### Summary
By using `dissmissModal` instead of `dismissAllModals` we make sure the navigator doesn't break (see https://github.com/wix/react-native-navigation/issues/418)