### PR TITLE
RN-121 Upload thumbnail

### DIFF
--- a/app/components/file_upload_preview/file_upload_preview.js
+++ b/app/components/file_upload_preview/file_upload_preview.js
@@ -15,6 +15,7 @@ import Icon from 'react-native-vector-icons/Ionicons';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import FileAttachmentImage from 'app/components/file_attachment_list/file_attachment_image';
+import FileAttachmentIcon from 'app/components/file_attachment_list/file_attachment_icon';
 import KeyboardLayout from 'app/components/layout/keyboard_layout';
 
 const {height: deviceHeight} = Dimensions.get('window');
@@ -33,6 +34,7 @@ export default class FileUploadPreview extends PureComponent {
         files: PropTypes.array.isRequired,
         inputHeight: PropTypes.number.isRequired,
         rootId: PropTypes.string,
+        theme: PropTypes.object.isRequired,
         uploadFileRequestStatus: PropTypes.string.isRequired
     };
 
@@ -46,17 +48,30 @@ export default class FileUploadPreview extends PureComponent {
 
     buildFilePreviews = () => {
         return this.props.files.map((file) => {
+            let filePreviewComponent;
+            if (file.loading | file.has_preview_image) {
+                filePreviewComponent = (
+                    <FileAttachmentImage
+                        addFileToFetchCache={this.props.actions.addFileToFetchCache}
+                        fetchCache={this.props.fetchCache}
+                        file={file}
+                    />
+                );
+            } else {
+                filePreviewComponent = (
+                    <FileAttachmentIcon
+                        file={file}
+                        theme={this.props.theme}
+                    />
+                );
+            }
             return (
                 <View
                     key={file.clientId}
                     style={style.preview}
                 >
                     <View style={style.previewShadow}>
-                        <FileAttachmentImage
-                            addFileToFetchCache={this.props.actions.addFileToFetchCache}
-                            fetchCache={this.props.fetchCache}
-                            file={file}
-                        />
+                        {filePreviewComponent}
                         {file.failed &&
                         <TouchableOpacity
                             style={style.failed}

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -255,6 +255,10 @@ class PostTextbox extends PureComponent {
             noData: true
         };
 
+        if (Platform.OS === 'ios') {
+            options.mediaType = 'mixed';
+        }
+
         ImagePicker.launchImageLibrary(options, (response) => {
             if (response.error) {
                 return;
@@ -263,6 +267,26 @@ class PostTextbox extends PureComponent {
             this.uploadFiles([response]);
         });
     };
+
+    attachVideoFromLibraryAndroid = () => {
+        this.props.navigator.dismissModal({
+            animationType: 'none'
+        });
+
+        const options = {
+            quality: 0.7,
+            mediaType: 'video',
+            noData: true
+        };
+
+        ImagePicker.launchImageLibrary(options, (response) => {
+            if (response.error) {
+                return;
+            }
+
+            this.uploadFiles([response]);
+        });
+    }
 
     uploadFiles = (images) => {
         this.props.actions.handleUploadFiles(images, this.props.rootId);
@@ -287,6 +311,17 @@ class PostTextbox extends PureComponent {
                 icon: 'photo'
             }]
         };
+
+        if (Platform.OS === 'android') {
+            options.items.push({
+                action: this.attachVideoFromLibraryAndroid,
+                text: {
+                    id: 'mobile.file_upload.video',
+                    defaultMessage: 'Video Libary'
+                },
+                icon: 'file-video-o'
+            });
+        }
 
         this.props.navigator.showModal({
             screen: 'OptionsModal',

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1709,6 +1709,7 @@
   "mobile.file_upload.camera": "Take Photo or Video",
   "mobile.file_upload.library": "Photo Library",
   "mobile.file_upload.more": "More",
+  "mobile.file_upload.video": "Video Libary",
   "mobile.help.title": "Help",
   "mobile.intro_messages.DM": "This is the start of your direct message history with {teammate}. Direct messages and files shared here are not shown to people outside this area.",
   "mobile.intro_messages.default_message": "This is the first channel teammates see when they sign up - use it for posting updates everyone needs to know.",


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the upload preview icon was different than the icon shown in the channel. It also adds the ability to upload videos from both Android and iOS.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-121

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23