### PR TITLE
Add "Unreads" section to channel drawer

### DIFF
--- a/app/components/channel_drawer/index.js
+++ b/app/components/channel_drawer/index.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 
 import {handleSelectChannel, setChannelLoading} from 'app/actions/views/channel';
 
-import {getChannelsByCategory, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannelsWithUnreadSection, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getTheme} from 'app/selectors/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
@@ -19,7 +19,7 @@ function mapStateToProps(state, ownProps) {
         ...ownProps,
         currentTeam: getCurrentTeam(state),
         currentChannel: getCurrentChannel(state),
-        channels: getChannelsByCategory(state),
+        channels: getChannelsWithUnreadSection(state),
         channelMembers: state.entities.channels.myMembers,
         theme: getTheme(state)
     };

--- a/app/components/channel_drawer_list/channel_drawer_list.js
+++ b/app/components/channel_drawer_list/channel_drawer_list.js
@@ -201,11 +201,19 @@ class ChannelDrawerList extends Component {
         const styles = getStyleSheet(theme);
 
         const {
+            unreadChannels,
             favoriteChannels,
             publicChannels,
             privateChannels,
             directAndGroupChannels
         } = props.channels;
+
+        if (unreadChannels.length) {
+            data.push(
+                this.renderTitle(styles, 'mobile.channel_list.unreads', 'UNREADS', null, unreadChannels.length > 0),
+                ...unreadChannels
+            );
+        }
 
         if (favoriteChannels.length) {
             data.push(

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1695,6 +1695,7 @@
   "mobile.channel_list.openGM": "Open Group Message",
   "mobile.channel_list.privateChannel": "Private Channel",
   "mobile.channel_list.publicChannel": "Public Channel",
+  "mobile.channel_list.unreads": "UNREADS",
   "mobile.components.channels_list_view.yourChannels": "Your channels:",
   "mobile.components.error_list.dismiss_all": "Dismiss All",
   "mobile.components.select_server_view.continue": "Continue",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3526,7 +3526,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/17b85854e5fda76d4e91b1e28d1e26b4ad57394d"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/dd0d59b2b29aea9c9e6407b72c8eb6e6e0ba091f"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
Whenever you get a new message or a mention now the channels appear under an **UNREADS** Section in the channel drawer at the very top when channels with mentions appear first and then unread channels

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-117

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 
* IOS 10.3.1 iPhone 6
* Android 6.0.1 Samsung J5

#### Screenshots
IOS
![image](https://cloud.githubusercontent.com/assets/6757047/26414513/680fd12e-407d-11e7-91c7-074d6ee5241f.png)

Android
![image](https://cloud.githubusercontent.com/assets/6757047/26414555/8930450a-407d-11e7-9568-f3b5cc09c73a.png)

