### PR TITLE
RN-124 Improved text flow in markdown paragraphs and headers

### DIFF
--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -111,7 +111,9 @@ export default class Markdown extends PureComponent {
     renderParagraph = ({children}) => {
         return (
             <View style={style.block}>
-                {children}
+                <Text>
+                    {children}
+                </Text>
             </View>
         );
     }
@@ -119,7 +121,9 @@ export default class Markdown extends PureComponent {
     renderHeading = ({children, level}) => {
         return (
             <View style={[style.block, this.props.blockStyles[`heading${level}`]]}>
-                {children}
+                <Text>
+                    {children}
+                </Text>
             </View>
         );
     }


### PR DESCRIPTION
I thought I might not be able to do this due to eventual emoji support requiring `<Image/>` tags within the paragraphs, but despite documentation saying that won't work properly on Android, that will still work when we add parser support for them.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-124

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator, Nexus 5

![image](https://cloud.githubusercontent.com/assets/3277310/26512264/cf3e81d0-4233-11e7-928e-0684e5076502.png)

