### PR TITLE
RN-147 Properly handle Account Notifications when Email Batching is enabled

### DIFF
--- a/app/screens/account_notifications/account_notifications.js
+++ b/app/screens/account_notifications/account_notifications.js
@@ -120,7 +120,9 @@ class AccountNotifications extends PureComponent {
         let interval;
         if (this.props.config.EnableEmailBatching === 'true') {
             const emailPreferences = getPreferencesByCategory(this.props.myPreferences, Preferences.CATEGORY_NOTIFICATIONS);
-            interval = emailPreferences.get(Preferences.EMAIL_INTERVAL).value;
+            if (emailPreferences.size) {
+                interval = emailPreferences.get(Preferences.EMAIL_INTERVAL).value;
+            }
         }
 
         const comments = notifyProps.comments || 'never';


### PR DESCRIPTION
#### Summary
Fixes a bug that cause the app to crash when Email batching was enabled and the Account notifications screen was loaded

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-147
