### PR TITLE
RN-156 Fix android channel drawer

### DIFF
--- a/app/components/channel_drawer/channel_drawer.js
+++ b/app/components/channel_drawer/channel_drawer.js
@@ -154,10 +154,7 @@ export default class ChannelDrawer extends PureComponent {
     };
 
     resetDrawer = () => {
-        const teamsCount = Object.keys(this.props.myTeamMembers).length;
-        if (this.swiperIndex === 0 && teamsCount > 1) {
-            this.refs.swiper.resetPage();
-        }
+        this.refs.swiper.resetPage();
     };
 
     renderContent = () => {

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -102,8 +102,7 @@ class Channel extends PureComponent {
 
     goToChannelInfo = () => {
         const {intl, navigator, theme} = this.props;
-
-        navigator.push({
+        const options = {
             screen: 'ChannelInfo',
             title: intl.formatMessage({id: 'mobile.routes.channelInfo', defaultMessage: 'Info'}),
             animated: true,
@@ -114,7 +113,13 @@ class Channel extends PureComponent {
                 navBarButtonColor: theme.sidebarHeaderTextColor,
                 screenBackgroundColor: theme.centerChannelBg
             }
-        });
+        };
+
+        if (Platform.OS === 'android') {
+            navigator.showModal(options);
+        } else {
+            navigator.push(options);
+        }
     };
 
     handleConnectionChange = (isConnected) => {

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -7,6 +7,7 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     Animated,
     Dimensions,
+    Platform,
     View
 } from 'react-native';
 
@@ -124,7 +125,7 @@ class ChannelPostList extends PureComponent {
             title = intl.formatMessage({id: 'mobile.routes.thread', defaultMessage: '{channelName} Thread'}, {channelName});
         }
 
-        navigator.push({
+        const options = {
             screen: 'Thread',
             title,
             animated: true,
@@ -139,7 +140,13 @@ class ChannelPostList extends PureComponent {
                 channelId,
                 rootId
             }
-        });
+        };
+
+        if (Platform.OS === 'android') {
+            navigator.showModal(options);
+        } else {
+            navigator.push(options);
+        }
     };
 
     render() {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-native-invertible-scroll-view": "1.0.0",
     "react-native-keyboard-aware-scroll-view": "0.2.8",
     "react-native-linear-gradient": "2.0.0",
-    "react-native-navigation": "1.1.72",
+    "react-native-navigation": "1.1.88",
     "react-native-notifications": "enahum/react-native-notifications.git",
     "react-native-orientation": "enahum/react-native-orientation.git",
     "react-native-search-bar": "enahum/react-native-search-bar.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,7 +3645,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/67a40ea6c89a5065b751f434094183956817b1d3"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/969e3ef432a077025ae13d3ad917bf5aaf054086"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"
@@ -4531,9 +4531,9 @@ react-native-mock@^0.2.7:
     react-timer-mixin "^0.13.3"
     warning "^2.1.0"
 
-react-native-navigation@1.1.72:
-  version "1.1.72"
-  resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-1.1.72.tgz#18e5067e74d5690b7bfddd100b06d5a7126ba2a8"
+react-native-navigation@1.1.88:
+  version "1.1.88"
+  resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-1.1.88.tgz#22239c8c722b13a8750a5b99debd45bded13c2f5"
   dependencies:
     lodash "4.x.x"
 


### PR DESCRIPTION
#### Summary
On Android there bug occurs because the wix-navigation does some weird stuff when pushing and pop-ing a screen causing the `ViewPagerAndroid` to stop responding, to fix it the screens that were being pushed on top of the channel screen are now opened as modals (only on Android) and that fixes the issue.

This also includes the update for `matterrmost-redux` that fixes RN-160

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-156
https://mattermost.atlassian.net/browse/RN-160

#### Device Information
This PR was tested on:
* IOS 10.3.1 iPhone 6s
* Android 6.0.1 Samsung J5
