### PR TITLE
Add join teams in settings screen

### DIFF
--- a/app/components/channel_drawer/channel_drawer.js
+++ b/app/components/channel_drawer/channel_drawer.js
@@ -22,6 +22,7 @@ const DRAWER_INITIAL_OFFSET = 40;
 export default class ChannelDrawer extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
+            getTeams: PropTypes.func.isRequired,
             handleSelectChannel: PropTypes.func.isRequired,
             viewChannel: PropTypes.func.isRequired,
             markChannelAsRead: PropTypes.func.isRequired,
@@ -49,6 +50,10 @@ export default class ChannelDrawer extends PureComponent {
     };
 
     swiperIndex = 1;
+
+    componentWillMount() {
+        this.props.actions.getTeams();
+    }
 
     componentDidMount() {
         EventEmitter.on('open_channel_drawer', this.openChannelDrawer);

--- a/app/components/channel_drawer/index.js
+++ b/app/components/channel_drawer/index.js
@@ -4,13 +4,13 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {handleSelectChannel, setChannelLoading} from 'app/actions/views/channel';
-
+import {viewChannel, markChannelAsRead} from 'mattermost-redux/actions/channels';
+import {getTeams} from 'mattermost-redux/actions/teams';
 import {getChannelsWithUnreadSection, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getTheme} from 'app/selectors/preferences';
 import {getCurrentTeam, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 
-import {viewChannel, markChannelAsRead} from 'mattermost-redux/actions/channels';
+import {handleSelectChannel, setChannelLoading} from 'app/actions/views/channel';
+import {getTheme} from 'app/selectors/preferences';
 
 import ChannelDrawer from './channel_drawer.js';
 
@@ -29,6 +29,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            getTeams,
             handleSelectChannel,
             viewChannel,
             markChannelAsRead,

--- a/app/components/channel_drawer_teams/channel_drawer_teams.js
+++ b/app/components/channel_drawer_teams/channel_drawer_teams.js
@@ -24,7 +24,6 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 class ChannelDrawerTeams extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            getTeams: PropTypes.func.isRequired,
             handleTeamChange: PropTypes.func.isRequired,
             markChannelAsRead: PropTypes.func.isRequired
         }).isRequired,
@@ -48,10 +47,6 @@ class ChannelDrawerTeams extends PureComponent {
         then((source) => {
             this.closeButton = source;
         });
-    }
-
-    componentWillMount() {
-        this.props.actions.getTeams();
     }
 
     selectTeam = (team) => {

--- a/app/components/channel_drawer_teams/index.js
+++ b/app/components/channel_drawer_teams/index.js
@@ -5,7 +5,6 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {markChannelAsRead} from 'mattermost-redux/actions/channels';
-import {getTeams} from 'mattermost-redux/actions/teams';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUrl} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId, getJoinableTeams, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
@@ -43,7 +42,6 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getTeams,
             handleTeamChange,
             markChannelAsRead
         }, dispatch)

--- a/app/screens/settings/index.js
+++ b/app/screens/settings/index.js
@@ -6,8 +6,11 @@ import {connect} from 'react-redux';
 
 import {clearErrors} from 'mattermost-redux/actions/errors';
 import {logout} from 'mattermost-redux/actions/users';
+import {getCurrentUrl} from 'mattermost-redux/selectors/entities/general';
+import {getJoinableTeams} from 'mattermost-redux/selectors/entities/teams';
 
 import {getTheme} from 'app/selectors/preferences';
+import {removeProtocol} from 'app/utils/url';
 
 import Settings from './settings';
 
@@ -20,7 +23,9 @@ function mapStateToProps(state, ownProps) {
         theme: getTheme(state),
         errors: state.errors,
         currentUserId: state.entities.users.currentUserId,
-        currentTeamId: state.entities.teams.currentTeamId
+        currentTeamId: state.entities.teams.currentTeamId,
+        currentUrl: removeProtocol(getCurrentUrl(state)),
+        joinableTeams: getJoinableTeams(state)
     };
 }
 

--- a/app/screens/settings/settings.js
+++ b/app/screens/settings/settings.js
@@ -27,8 +27,10 @@ class Settings extends PureComponent {
         config: PropTypes.object.isRequired,
         currentTeamId: PropTypes.string.isRequired,
         currentUserId: PropTypes.string.isRequired,
+        currentUrl: PropTypes.string.isRequired,
         errors: PropTypes.array.isRequired,
         intl: intlShape.isRequired,
+        joinableTeams: PropTypes.object.isRequired,
         navigator: PropTypes.object,
         theme: PropTypes.object
     };
@@ -88,6 +90,28 @@ class Settings extends PureComponent {
         });
     };
 
+    goToSelectTeam = () => {
+        const {currentUrl, intl, navigator, theme} = this.props;
+
+        navigator.push({
+            screen: 'SelectTeam',
+            title: intl.formatMessage({id: 'mobile.routes.selectTeam', defaultMessage: 'Select Team'}),
+            animationType: 'slide-up',
+            animated: true,
+            backButtonTitle: '',
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg
+            },
+            passProps: {
+                currentUrl,
+                theme
+            }
+        });
+    };
+
     handlePress = (action) => {
         preventDoubleTap(action, this);
     };
@@ -122,8 +146,9 @@ class Settings extends PureComponent {
     };
 
     render() {
-        const {config, theme} = this.props;
+        const {config, joinableTeams, theme} = this.props;
         const style = getStyleSheet(theme);
+        const showTeams = Object.keys(joinableTeams).length > 0;
 
         return (
             <View style={style.container}>
@@ -137,6 +162,17 @@ class Settings extends PureComponent {
                         separator={true}
                         theme={theme}
                     />
+                    {showTeams &&
+                        <SettingsItem
+                            defaultMessage='Open teams you can join'
+                            i18nId='mobile.select_team.join_open'
+                            iconName='group'
+                            iconType='material'
+                            onPress={() => preventDoubleTap(this.goToSelectTeam, this)}
+                            separator={true}
+                            theme={theme}
+                        />
+                    }
                     {config.HelpLink &&
                         <SettingsItem
                             defaultMessage='Help'


### PR DESCRIPTION
#### Summary
Join other open teams in the settings screen (useful when you are in only one team)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: 
* IOS 10.3.1 iPhone 6s
* Android 6.0.1 Samsung J5