### PR TITLE
RN-170 Remove the box for the offline indicator

### DIFF
--- a/app/components/offline_indicator/offline_indicator.js
+++ b/app/components/offline_indicator/offline_indicator.js
@@ -158,7 +158,7 @@ export default class OfflineIndicator extends PureComponent {
             i18nId = 'mobile.offlineIndicator.connecting';
             defaultMessage = 'Connecting...';
             action = (
-                <View style={[styles.actionContainer, styles.actionButton]}>
+                <View style={styles.actionContainer}>
                     <ActivityIndicator
                         color='#FFFFFF'
                         size='small'


### PR DESCRIPTION
#### Summary
The offline indicator that appears when no WS connection is present now when saying connecting.. it wont show the box surrounding the loading indicator

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-170

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
