### PR TITLE
Fix "libary" --> "library" typo

### DIFF
--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -321,7 +321,7 @@ class PostTextbox extends PureComponent {
                 action: this.attachVideoFromLibraryAndroid,
                 text: {
                     id: 'mobile.file_upload.video',
-                    defaultMessage: 'Video Libary'
+                    defaultMessage: 'Video Library'
                 },
                 icon: 'file-video-o'
             });

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1723,7 +1723,7 @@
   "mobile.file_upload.camera": "Take Photo or Video",
   "mobile.file_upload.library": "Photo Library",
   "mobile.file_upload.more": "More",
-  "mobile.file_upload.video": "Video Libary",
+  "mobile.file_upload.video": "Video Library",
   "mobile.help.title": "Help",
   "mobile.intro_messages.DM": "This is the start of your direct message history with {teammate}. Direct messages and files shared here are not shown to people outside this area.",
   "mobile.intro_messages.default_message": "This is the first channel teammates see when they sign up - use it for posting updates everyone needs to know.",


### PR DESCRIPTION
Fix "libary" --> "library" typo

Credit to @wget who noticed it while doing translations.