### PR TITLE
RN-185 ensure leaving channels and teams

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -5,7 +5,8 @@ import {ViewTypes} from 'app/constants';
 import {
     handleSelectChannel,
     loadChannelsIfNecessary,
-    loadProfilesAndTeamMembersForDMSidebar
+    loadProfilesAndTeamMembersForDMSidebar,
+    setChannelDisplayName
 } from 'app/actions/views/channel';
 import {handleTeamChange, selectFirstAvailableTeam} from 'app/actions/views/select_team';
 
@@ -37,6 +38,7 @@ export function goToNotification(notification) {
         const state = getState();
         const {data} = notification;
         const {currentTeamId, teams} = state.entities.teams;
+        const {currentChannelId} = state.entities.channels;
         const channelId = data.channel_id;
 
         // if the notification does not have a team id is because its from a DM or GM
@@ -53,9 +55,10 @@ export function goToNotification(notification) {
         viewChannel(channelId)(dispatch, getState);
         loadProfilesAndTeamMembersForDMSidebar(teamId)(dispatch, getState);
 
-        // when the notification is tapped go to the channel view before selecting the channel to prevent
-        // weird behavior
-        handleSelectChannel(channelId)(dispatch, getState);
+        if (channelId !== currentChannelId) {
+            dispatch(setChannelDisplayName(''));
+            handleSelectChannel(channelId)(dispatch, getState);
+        }
         markChannelAsRead(teamId, channelId)(dispatch, getState).then(() => true).catch(() => true);
     };
 }

--- a/app/screens/load_team/load_team.js
+++ b/app/screens/load_team/load_team.js
@@ -30,12 +30,14 @@ export default class LoadTeam extends PureComponent {
         if (notification) {
             clearNotification();
             goToNotification(notification);
-            this.goToChannelView();
-        } else if (currentTeam) {
-            this.onSelectTeam(currentTeam);
-        } else if (!currentTeam) {
-            this.selectFirstTeam(teams, myMembers);
+            return this.goToChannelView();
         }
+
+        if (currentTeam && myMembers[currentTeam.id]) {
+            return this.onSelectTeam(currentTeam);
+        }
+
+        return this.selectFirstTeam(teams, myMembers);
     }
 
     componentWillReceiveProps(nextProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,7 +3645,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/488faa22c03e1c187c714a5db7f0a42b69d50ae8"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/909f75d50678998a1fcb9d3b35d1fae9e918147f"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
When leaving channels and teams from another device now we make sure that they are left in RN whenever the app is re-opened or the WebSocket reconnects

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-185
