### PR TITLE
RN-35 handle clear push notifications

### DIFF
--- a/android/app/src/main/java/com/mattermost/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/CustomPushNotification.java
@@ -9,6 +9,8 @@ import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.os.Build;
 import android.app.Notification;
+import android.app.NotificationManager;
+import java.util.LinkedHashMap;
 
 import com.wix.reactnativenotifications.core.notification.PushNotification;
 import com.wix.reactnativenotifications.core.AppLaunchHelper;
@@ -16,10 +18,41 @@ import com.wix.reactnativenotifications.core.AppLifecycleFacade;
 import com.wix.reactnativenotifications.core.JsIOHelper;
 import com.wix.reactnativenotifications.helpers.ApplicationBadgeHelper;
 
+import static com.wix.reactnativenotifications.Defs.NOTIFICATION_RECEIVED_EVENT_NAME;
+
 public class CustomPushNotification extends PushNotification {
+
+    public static final int MESSAGE_NOTIFICATION_ID = 435345;
+    public static final String GROUP_KEY_MESSAGES = "mm_group_key_messages";
+    private static LinkedHashMap<String,Integer> channelIdToNotificationCount = new LinkedHashMap<String,Integer>();
 
     public CustomPushNotification(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
+    }
+
+    @Override
+    public void onReceived() throws InvalidNotificationException {
+        Bundle data = mNotificationProps.asBundle();
+        final String channelId = data.getString("channel_id");
+        final String type = data.getString("type");
+        int notificationId = MESSAGE_NOTIFICATION_ID;
+        if (channelId != null) {
+            notificationId = channelId.hashCode();
+            Object objCount = channelIdToNotificationCount.get(channelId);
+            Integer count = 1;
+            if (objCount != null) {
+                count = (Integer)objCount + 1;
+            }
+            channelIdToNotificationCount.put(channelId, count);
+        }
+
+        if ("clear".equals(type)) {
+            cancelNotification(data, notificationId);
+        } else {
+            super.postNotification(notificationId);
+        }
+
+        notifyReceivedToJS();
     }
 
     @Override
@@ -42,30 +75,17 @@ public class CustomPushNotification extends PushNotification {
             ApplicationInfo appInfo = mContext.getApplicationInfo();
             title = mContext.getPackageManager().getApplicationLabel(appInfo).toString();
         }
-        notification.setContentTitle(title);
+
+        int notificationId = bundle.getString("channel_id").hashCode();
         String channelId = bundle.getString("channel_id");
-        if (channelId != null) {
-            notification.setGroup(channelId).setGroupSummary(true);
-        }
-        notification.setContentText(bundle.getString("message"));
-
-        String largeIcon = bundle.getString("largeIcon");
-
+        String message = bundle.getString("message");
         String subText = bundle.getString("subText");
-
-        if (subText != null) {
-            notification.setSubText(subText);
-        }
-
         String numberString = bundle.getString("badge");
-        if (numberString != null) {
-            ApplicationBadgeHelper.instance.setApplicationIconBadgeNumber(mContext.getApplicationContext(), Integer.parseInt(numberString));
-        }
+        String smallIcon = bundle.getString("smallIcon");
+        String largeIcon = bundle.getString("largeIcon");
 
         int smallIconResId;
         int largeIconResId;
-
-        String smallIcon = bundle.getString("smallIcon");
 
         if (smallIcon != null) {
             smallIconResId = res.getIdentifier(smallIcon, "mipmap", packageName);
@@ -87,17 +107,55 @@ public class CustomPushNotification extends PushNotification {
             largeIconResId = res.getIdentifier("ic_launcher", "mipmap", packageName);
         }
 
-        Bitmap largeIconBitmap = BitmapFactory.decodeResource(res, largeIconResId);
+        if (numberString != null) {
+            ApplicationBadgeHelper.instance.setApplicationIconBadgeNumber(mContext.getApplicationContext(), Integer.parseInt(numberString));
+        }
 
+        int numMessages = 0;
+        Object objCount = channelIdToNotificationCount.get(channelId);
+        if (objCount != null) {
+            numMessages = (Integer)objCount;
+        }
+
+        notification
+                .setContentTitle(title)
+                .setContentText(message)
+                .setGroup(GROUP_KEY_MESSAGES)
+                .setGroupSummary(true)
+                .setSmallIcon(smallIconResId)
+                .setVisibility(Notification.VISIBILITY_PRIVATE)
+                .setPriority(Notification.PRIORITY_HIGH);
+
+        if (numMessages > 1) {
+            notification.setNumber(numMessages);
+        }
+
+        Bitmap largeIconBitmap = BitmapFactory.decodeResource(res, largeIconResId);
         if (largeIconResId != 0 && (largeIcon != null || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)) {
             notification.setLargeIcon(largeIconBitmap);
         }
 
-        notification.setSmallIcon(smallIconResId);
-        notification
-                .setVisibility(Notification.VISIBILITY_PRIVATE)
-                .setPriority(Notification.PRIORITY_HIGH);
+        if (subText != null) {
+            notification.setSubText(subText);
+        }
 
         return notification;
+    }
+
+    private void notifyReceivedToJS() {
+        mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
+    }
+
+    private void cancelNotification(Bundle data, int notificationId) {
+        final String channelId = data.getString("channel_id");
+
+        String numberString = data.getString("badge");
+        if (numberString != null) {
+            ApplicationBadgeHelper.instance.setApplicationIconBadgeNumber(mContext.getApplicationContext(), Integer.parseInt(numberString));
+        }
+
+        channelIdToNotificationCount.remove(channelId);
+        final NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.cancel(notificationId);
     }
 }

--- a/app/push_notifications/push_notifications.android.js
+++ b/app/push_notifications/push_notifications.android.js
@@ -10,17 +10,15 @@ class PushNotification {
         this.onNotification = null;
 
         NotificationsAndroid.setNotificationReceivedListener((notification) => {
-            const data = notification.getData();
-
             if (notification) {
+                const data = notification.getData();
                 this.handleNotification(data, false);
             }
         });
 
         NotificationsAndroid.setNotificationOpenedListener((notification) => {
-            const data = notification.getData();
-
             if (notification) {
+                const data = notification.getData();
                 this.handleNotification(data, true);
             }
         });


### PR DESCRIPTION
#### Summary
Android: Push notifications will be one per channel, when receiving more than one push notification per channel the text on the push notification gets updated and it displays at the far right the amount of notifications per channel, on Android 7 it should group the notifications belonging to Mattermost.
When a channel is read in another **NON-mobile** device it will **clear the notifications from the notification center** for that channel and will subtract the amount of mentions in that channel from the badge in the app icon and if the app is in the foreground it will mark the channel as read.

IOS: Push notifications will be one per notification, when receiving more than one push notification per channel each notification will be shown individually on the notification center. When a channel is read in another **NON-mobile** device the notifications in the **notification center will remain there** but it will subtract the amount of mentions in that channel from the badge in the app icon and if the app is in the foreground it will mark the channel as read. In case the badge count drops to `0` then `all` the notifications in the **notification center will be cleared**

Note: This needs the latest push proxy running

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-35

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Include changes in push proxy server

#### Device Information
This PR was tested on: 
* IOS 10.3.1 iPhone 6s
* Android 6.0.1 Samsung J5
