### PR TITLE
RN-196 Added a key to try to force ProfilePicture to rerender

### DIFF
--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -85,6 +85,7 @@ export default class ProfilePicture extends PureComponent {
         return (
             <View style={{width: this.props.size + STATUS_BUFFER, height: this.props.size + STATUS_BUFFER}}>
                 <Image
+                    key={pictureUrl}
                     style={{width: this.props.size, height: this.props.size, borderRadius: this.props.size / 2}}
                     source={{uri: pictureUrl}}
                     defaultSource={placeholder}


### PR DESCRIPTION
Hopefully this helps get the app to render the correct profile picture on a slow connection. I wasn't able to repro the bug described in the ticket, but this should prevent it from displaying an outdated picture if it reuses the component.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-196
