### PR TITLE
RN-187 Fixed right margin for block quotes

### DIFF
--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -202,7 +202,7 @@ export default class Markdown extends React.PureComponent {
     renderBlockQuote = ({children, ...otherProps}) => {
         return (
             <MarkdownBlockQuote
-                blockStyle={this.props.blockStyles.quoteBlock}
+                iconStyle={this.props.blockStyles.quoteBlockIcon}
                 {...otherProps}
             >
                 {children}

--- a/app/components/markdown/markdown_block_quote.js
+++ b/app/components/markdown/markdown_block_quote.js
@@ -12,7 +12,7 @@ import CustomPropTypes from 'app/constants/custom_prop_types';
 
 export default class MarkdownBlockQuote extends PureComponent {
     static propTypes = {
-        blockStyle: CustomPropTypes.Style,
+        iconStyle: CustomPropTypes.Style,
         children: CustomPropTypes.Children.isRequired
     };
 
@@ -22,11 +22,11 @@ export default class MarkdownBlockQuote extends PureComponent {
                 <View>
                     <Icon
                         name='quote-left'
-                        style={this.props.blockStyle}
+                        style={this.props.iconStyle}
                         size={14}
                     />
                 </View>
-                <View>
+                <View style={style.childContainer}>
                     {this.props.children}
                 </View>
             </View>
@@ -36,7 +36,10 @@ export default class MarkdownBlockQuote extends PureComponent {
 
 const style = StyleSheet.create({
     container: {
-        flexDirection: 'row',
-        alignItems: 'flex-start'
+        alignItems: 'flex-start',
+        flexDirection: 'row'
+    },
+    childContainer: {
+        flex: 1
     }
 });

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -83,7 +83,7 @@ export const getMarkdownBlockStyles = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             marginVertical: 10
         },
-        quoteBlock: {
+        quoteBlockIcon: {
             color: changeOpacity(theme.centerChannelColor, 0.5),
             padding: 5
         }


### PR DESCRIPTION
Adding `flex: 1` to things is the RN version of adding `position: relative` all over the place in CSS

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-187

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator, Nexus 5 

#### Screenshots
(Colours for illustration purposes only)
<img width="369" alt="screen shot 2017-06-15 at 3 50 10 pm" src="https://user-images.githubusercontent.com/3277310/27198997-5e156334-51e2-11e7-90c7-ca95f88a7078.png">

