### PR TITLE
RN-207 Fixed missing divider in ChannelInfo

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -273,9 +273,9 @@ class ChannelInfo extends PureComponent {
                             textId={canManageUsers ? 'channel_header.manageMembers' : 'channel_header.viewMembers'}
                             theme={theme}
                         />
-                        {canManageUsers && this.renderLeaveOrDeleteChannelRow() &&
+                        <View style={style.separator}/>
+                        {canManageUsers &&
                             <View>
-                                <View style={style.separator}/>
                                 <ChannelInfoRow
                                     action={() => preventDoubleTap(this.goToChannelAddMembers)}
                                     defaultMessage='Add Members'


### PR DESCRIPTION
The setting that determines `canManageUsers` is currently broken, but I'll be submitting a separate PR to fix that

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-207

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
<img width="368" alt="screen shot 2017-06-16 at 4 19 16 pm" src="https://user-images.githubusercontent.com/3277310/27243479-17e823d2-52b0-11e7-8a72-5d4470e15f3f.png">

