### PR TITLE
Posts are now seen as pending until submitted successfully

### DIFF
--- a/app/actions/views/file_upload.js
+++ b/app/actions/views/file_upload.js
@@ -19,19 +19,22 @@ export function handleUploadFiles(files, rootId) {
 
         files.forEach((file) => {
             const mimeType = lookupMimeType(file.fileName);
+            const extension = file.fileName.split('.').pop().replace('.', '');
             const clientId = generateId();
 
             clientIds.push({
                 clientId,
                 localPath: file.uri,
                 name: file.fileName,
-                type: mimeType
+                type: mimeType,
+                extension
             });
 
             const fileData = {
                 uri: file.uri,
                 name: file.fileName,
-                type: mimeType
+                type: mimeType,
+                extension
             };
 
             formData.append('files', fileData);

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -37,7 +37,7 @@ import webhookIcon from 'assets/images/icons/webhook.jpg';
 import {Posts} from 'mattermost-redux/constants';
 import DelayedAction from 'mattermost-redux/utils/delayed_action';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
-import {canDeletePost, canEditPost, isPostEphemeral, isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {canDeletePost, canEditPost, isPostEphemeral, isPostPendingOrFailed, isSystemMessage} from 'mattermost-redux/utils/post_utils';
 import {isAdmin, isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
 const BOT_NAME = 'BOT';
@@ -216,7 +216,7 @@ class Post extends PureComponent {
     handlePress = () => {
         const {post, onPress, tooltipVisible} = this.props;
         if (!tooltipVisible) {
-            if (onPress && post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !post.failed) {
+            if (onPress && post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostPendingOrFailed(post)) {
                 preventDoubleTap(onPress, null, post);
             } else if (isPostEphemeral(post)) {
                 preventDoubleTap(this.onRemovePost, this, post);
@@ -349,7 +349,7 @@ class Post extends PureComponent {
         const actions = [];
 
         // we should check for the user roles and permissions
-        if (!post.failed) {
+        if (!isPostPendingOrFailed(post)) {
             if (isFlagged) {
                 actions.push({
                     text: formatMessage({id: 'post_info.mobile.unflag', defaultMessage: 'Unflag'}),
@@ -384,7 +384,7 @@ class Post extends PureComponent {
         } else if (this.props.post.message.length) {
             message = (
                 <View style={{flexDirection: 'row'}}>
-                    <View style={[{flex: 1}, (post.failed && style.failedPost)]}>
+                    <View style={[{flex: 1}, (isPostPendingOrFailed(post) && style.pendingPost)]}>
                         <Markdown
                             baseTextStyle={messageStyle}
                             textStyles={textStyles}
@@ -594,11 +594,11 @@ class Post extends PureComponent {
         if (this.props.commentedOnPost) {
             contents = (
                 <View style={[style.container, this.props.style, selected]}>
-                    <View style={[style.profilePictureContainer, (post.failed && style.failedPost)]}>
+                    <View style={[style.profilePictureContainer, (isPostPendingOrFailed(post) && style.pendingPost)]}>
                         {profilePicture}
                     </View>
                     <View style={style.rightColumn}>
-                        <View style={[style.postInfoContainer, (post.failed && style.failedPost)]}>
+                        <View style={[style.postInfoContainer, (isPostPendingOrFailed(post) && style.pendingPost)]}>
                             {displayName}
                             <Text style={style.time}>
                                 <FormattedTime value={this.props.post.create_at}/>
@@ -614,13 +614,13 @@ class Post extends PureComponent {
         } else {
             contents = (
                 <View style={[style.container, this.props.style, selected]}>
-                    <View style={[style.profilePictureContainer, (post.failed && style.failedPost)]}>
+                    <View style={[style.profilePictureContainer, (isPostPendingOrFailed(post) && style.pendingPost)]}>
                         {profilePicture}
                     </View>
                     <View style={style.messageContainerWithReplyBar}>
                         {this.renderReplyBar(style)}
                         <View style={[style.rightColumn, (this.props.isLastReply && style.rightColumnPadding)]}>
-                            <View style={[style.postInfoContainer, (post.failed && style.failedPost)]}>
+                            <View style={[style.postInfoContainer, (isPostPendingOrFailed(post) && style.pendingPost)]}>
                                 <View style={{flexDirection: 'row', flex: 1}}>
                                     {displayName}
                                     <Text style={style.time}>
@@ -659,7 +659,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             backgroundColor: theme.centerChannelBg,
             flexDirection: 'row'
         },
-        failedPost: {
+        pendingPost: {
             opacity: 0.5
         },
         rightColumn: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,7 +3645,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/a31265e306e862ba75b30c3d396847d21319b524"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/fe5182358d2e2f0897b4fd5c80cba96e85061d96"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
This PR reduces the opacity of a post until it either fails or is submitted successfully. 

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-52

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23

#### Screenshots
![optimistic_post](https://user-images.githubusercontent.com/5090577/27301595-602646ba-54f9-11e7-94d6-9bb0e299bcf8.gif)