### PR TITLE
Re-factor post_list with VirtualizedList

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -17,7 +17,7 @@ import {getFilesForPost} from 'mattermost-redux/actions/files';
 import {savePreferences, deletePreferences} from 'mattermost-redux/actions/preferences';
 import {getTeamMembersByIds} from 'mattermost-redux/actions/teams';
 import {getProfilesInChannel} from 'mattermost-redux/actions/users';
-import {General, Posts, Preferences} from 'mattermost-redux/constants';
+import {General, Preferences} from 'mattermost-redux/constants';
 import {
     getChannelByName,
     getDirectChannelName,
@@ -29,8 +29,6 @@ import {
 } from 'mattermost-redux/utils/channel_utils';
 import {getLastCreateAt} from 'mattermost-redux/utils/post_utils';
 import {getPreferencesByCategory} from 'mattermost-redux/utils/preference_utils';
-
-const POST_INCREASE_AMOUNT = Posts.POST_CHUNK_SIZE / 2;
 
 export function loadChannelsIfNecessary(teamId) {
     return async (dispatch, getState) => {
@@ -146,7 +144,7 @@ export function loadPostsIfNecessary(channelId) {
         const postsIds = postsInChannel[channelId];
 
         // Get the first page of posts if it appears we haven't gotten it yet, like the webapp
-        if (!postsIds || postsIds.length < POST_INCREASE_AMOUNT) {
+        if (!postsIds || postsIds.length < ViewTypes.POST_VISIBILITY_CHUNK_SIZE) {
             return getPosts(channelId)(dispatch, getState);
         }
 
@@ -381,13 +379,13 @@ export function increasePostVisibility(channelId, focusedPostId) {
             }
         ]));
 
-        const page = Math.floor(currentPostVisibility / POST_INCREASE_AMOUNT);
+        const page = Math.floor(currentPostVisibility / ViewTypes.POST_VISIBILITY_CHUNK_SIZE);
 
         let posts;
         if (focusedPostId) {
-            posts = await getPostsBefore(channelId, focusedPostId, page, POST_INCREASE_AMOUNT)(dispatch, getState);
+            posts = await getPostsBefore(channelId, focusedPostId, page, ViewTypes.POST_VISIBILITY_CHUNK_SIZE)(dispatch, getState);
         } else {
-            posts = await getPosts(channelId, page, POST_INCREASE_AMOUNT)(dispatch, getState);
+            posts = await getPosts(channelId, page, ViewTypes.POST_VISIBILITY_CHUNK_SIZE)(dispatch, getState);
         }
 
         if (posts) {
@@ -396,7 +394,7 @@ export function increasePostVisibility(channelId, focusedPostId) {
             dispatch({
                 type: ViewTypes.INCREASE_POST_VISIBILITY,
                 data: channelId,
-                amount: POST_INCREASE_AMOUNT
+                amount: ViewTypes.POST_VISIBILITY_CHUNK_SIZE
             });
         }
 
@@ -406,6 +404,6 @@ export function increasePostVisibility(channelId, focusedPostId) {
             channelId
         });
 
-        return posts && posts.order.length >= POST_INCREASE_AMOUNT;
+        return posts && posts.order.length >= ViewTypes.POST_VISIBILITY_CHUNK_SIZE;
     };
 }

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -146,7 +146,7 @@ export function loadPostsIfNecessary(channelId) {
         const postsIds = postsInChannel[channelId];
 
         // Get the first page of posts if it appears we haven't gotten it yet, like the webapp
-        if (!postsIds || postsIds.length < Posts.POST_CHUNK_SIZE / 2) {
+        if (!postsIds || postsIds.length < POST_INCREASE_AMOUNT) {
             return getPosts(channelId)(dispatch, getState);
         }
 

--- a/app/components/channel_drawer/channel_drawer.js
+++ b/app/components/channel_drawer/channel_drawer.js
@@ -86,13 +86,17 @@ export default class ChannelDrawer extends PureComponent {
 
     handleDrawerClose = () => {
         this.resetDrawer();
-        setTimeout(() => {
+
+        if (this.closeLeftHandle) {
             InteractionManager.clearInteractionHandle(this.closeLeftHandle);
-        });
+            this.closeLeftHandle = null;
+        }
     };
 
     handleDrawerCloseStart = () => {
-        this.closeLeftHandle = InteractionManager.createInteractionHandle();
+        if (!this.closeLeftHandle) {
+            this.closeLeftHandle = InteractionManager.createInteractionHandle();
+        }
     };
 
     handleDrawerOpen = () => {
@@ -100,13 +104,17 @@ export default class ChannelDrawer extends PureComponent {
         if (this.state.openDrawerOffset === DRAWER_INITIAL_OFFSET) {
             Keyboard.dismiss();
         }
-        setTimeout(() => {
+
+        if (this.openLeftHandle) {
             InteractionManager.clearInteractionHandle(this.openLeftHandle);
-        });
+            this.openLeftHandle = null;
+        }
     };
 
     handleDrawerOpenStart = () => {
-        this.openLeftHandle = InteractionManager.createInteractionHandle();
+        if (!this.openLeftHandle) {
+            this.openLeftHandle = InteractionManager.createInteractionHandle();
+        }
     };
 
     handleDrawerTween = (ratio) => {

--- a/app/components/inverted_flat_list/index.js
+++ b/app/components/inverted_flat_list/index.js
@@ -21,6 +21,12 @@ export default class InvertibleFlatList extends PureComponent {
         inverted: true
     };
 
+    constructor(props) {
+        super(props);
+
+        this.inversionDirection = props.horizontal ? styles.horizontal : styles.vertical;
+    }
+
     getMetrics = () => {
         return this.flatListRef.getMetrics();
     };
@@ -105,7 +111,6 @@ export default class InvertibleFlatList extends PureComponent {
             );
         }
 
-        this.inversionDirection = this.props.horizontal ? styles.horizontal : styles.vertical;
         return (
             <View style={[styles.container, this.inversionDirection]}>
                 <VirtualList

--- a/app/components/inverted_flat_list/index.js
+++ b/app/components/inverted_flat_list/index.js
@@ -50,6 +50,29 @@ export default class InvertibleFlatList extends PureComponent {
         );
     };
 
+    renderScrollComponent = (props) => {
+        const {theme} = this.props;
+
+        if (props.onRefresh) {
+            return (
+                <ScrollView
+                    {...props}
+                    refreshControl={
+                        <RefreshControl
+                            refreshing={props.refreshing}
+                            onRefresh={props.onRefresh}
+                            tintColor={theme.centerChannelColor}
+                            colors={[theme.centerChannelColor]}
+                            style={this.inversionDirection}
+                        />
+                    }
+                />
+            );
+        }
+
+        return <ScrollView {...props}/>;
+    };
+
     scrollToEnd = (params) => {
         this.flatListRef.scrollToEnd(params);
     };
@@ -83,7 +106,6 @@ export default class InvertibleFlatList extends PureComponent {
         }
 
         this.inversionDirection = this.props.horizontal ? styles.horizontal : styles.vertical;
-        const {theme} = this.props;
         return (
             <View style={[styles.container, this.inversionDirection]}>
                 <VirtualList
@@ -91,26 +113,7 @@ export default class InvertibleFlatList extends PureComponent {
                     {...forwardedProps}
                     ListFooterComponent={this.renderFooter}
                     renderItem={this.renderItem}
-                    renderScrollComponent={(props) => {
-                        if (props.onRefresh) {
-                            return (
-                                <ScrollView
-                                    {...props}
-                                    refreshControl={
-                                        <RefreshControl
-                                            refreshing={props.refreshing}
-                                            onRefresh={props.onRefresh}
-                                            tintColor={theme.centerChannelColor}
-                                            colors={[theme.centerChannelColor]}
-                                            style={this.inversionDirection}
-                                        />
-                                    }
-                                />
-                            );
-                        }
-
-                        return <ScrollView {...props}/>;
-                    }}
+                    renderScrollComponent={this.renderScrollComponent}
                 />
             </View>
         );

--- a/app/components/inverted_flat_list/index.js
+++ b/app/components/inverted_flat_list/index.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {FlatList, RefreshControl, ScrollView, StyleSheet, View} from 'react-native';
+
+import VirtualList from './virtual_list';
+
+export default class InvertibleFlatList extends PureComponent {
+    static propTypes = {
+        horizontal: PropTypes.bool,
+        inverted: PropTypes.bool,
+        ListFooterComponent: PropTypes.func,
+        renderItem: PropTypes.func.isRequired,
+        theme: PropTypes.object.isRequired
+    };
+
+    static defaultProps = {
+        horizontal: false,
+        inverted: true
+    };
+
+    getMetrics = () => {
+        return this.flatListRef.getMetrics();
+    };
+
+    recordInteraction = () => {
+        this.flatListRef.recordInteraction();
+    };
+
+    renderFooter = () => {
+        const {ListFooterComponent: footer} = this.props;
+        if (!footer) {
+            return null;
+        }
+
+        return (
+            <View style={[styles.container, this.inversionDirection]}>
+                {footer()}
+            </View>
+        );
+    };
+
+    renderItem = (info) => {
+        return (
+            <View style={[styles.container, this.inversionDirection]}>
+                {this.props.renderItem(info)}
+            </View>
+        );
+    };
+
+    scrollToEnd = (params) => {
+        this.flatListRef.scrollToEnd(params);
+    };
+
+    scrollToIndex = (params) => {
+        this.flatListRef.scrollToIndex(params);
+    };
+
+    scrollToItem = (params) => {
+        this.flatListRef.scrollToItem(params);
+    };
+
+    scrollToOffset = (params) => {
+        this.flatListRef.scrollToOffset(params);
+    };
+
+    setFlatListRef = (flatListRef) => {
+        this.flatListRef = flatListRef;
+    };
+
+    render() {
+        const {inverted, ...forwardedProps} = this.props;
+
+        // If not inverted, render as an ordinary FlatList
+        if (!inverted) {
+            return (
+                <FlatList
+                    {...forwardedProps}
+                />
+            );
+        }
+
+        this.inversionDirection = this.props.horizontal ? styles.horizontal : styles.vertical;
+        const {theme} = this.props;
+        return (
+            <View style={[styles.container, this.inversionDirection]}>
+                <VirtualList
+                    ref={this.setFlatListRef}
+                    {...forwardedProps}
+                    ListFooterComponent={this.renderFooter}
+                    renderItem={this.renderItem}
+                    renderScrollComponent={(props) => {
+                        if (props.onRefresh) {
+                            return (
+                                <ScrollView
+                                    {...props}
+                                    refreshControl={
+                                        <RefreshControl
+                                            refreshing={props.refreshing}
+                                            onRefresh={props.onRefresh}
+                                            tintColor={theme.centerChannelColor}
+                                            colors={[theme.centerChannelColor]}
+                                            style={this.inversionDirection}
+                                        />
+                                    }
+                                />
+                            );
+                        }
+
+                        return <ScrollView {...props}/>;
+                    }}
+                />
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1
+    },
+    vertical: {
+        transform: [{scaleY: -1}]
+    },
+    horizontal: {
+        transform: [{scaleX: -1}]
+    }
+});
+

--- a/app/components/inverted_flat_list/virtual_list.js
+++ b/app/components/inverted_flat_list/virtual_list.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {VirtualizedList} from 'react-native';
+
+/* eslint-disable */
+
+export default class Virtualized extends VirtualizedList {
+    _onScroll = (e) => {
+        if (this.props.onScroll) {
+            this.props.onScroll(e);
+        }
+        const timestamp = e.timeStamp;
+        const visibleLength = this._selectLength(e.nativeEvent.layoutMeasurement);
+        const contentLength = this._selectLength(e.nativeEvent.contentSize);
+        const offset = this._selectOffset(e.nativeEvent.contentOffset);
+        const dt = Math.max(1, timestamp - this._scrollMetrics.timestamp);
+        const dOffset = offset - this._scrollMetrics.offset;
+        const velocity = dOffset / dt;
+        this._scrollMetrics = {contentLength, dt, offset, timestamp, velocity, visibleLength};
+        const {data, getItemCount, onEndReached, onEndReachedThreshold, windowSize} = this.props;
+        this._updateViewableItems(data);
+        if (!data) {
+            return;
+        }
+        const distanceFromEnd = contentLength - visibleLength - offset;
+        const itemCount = getItemCount(data);
+        if (this.state.last === itemCount - 1 &&
+            distanceFromEnd <= onEndReachedThreshold &&
+            (this._hasDataChangedSinceEndReached ||
+            this._scrollMetrics.contentLength !== this._sentEndForContentLength)) {
+            // Only call onEndReached once for a given dataset + content length.
+            this._hasDataChangedSinceEndReached = false;
+            this._sentEndForContentLength = this._scrollMetrics.contentLength;
+            onEndReached({distanceFromEnd});
+        }
+        const {first, last} = this.state;
+        if ((first > 0 && velocity < 0) || (last < itemCount - 1 && velocity > 0)) {
+            const distanceToContentEdge = Math.min(
+                Math.abs(this._getFrameMetricsApprox(first).offset - offset),
+                Math.abs(this._getFrameMetricsApprox(last).offset - (offset + visibleLength)),
+            );
+            const hiPri = distanceToContentEdge < (windowSize * visibleLength / 4);
+            if (hiPri) {
+                // Don't worry about interactions when scrolling quickly; focus on filling content as fast
+                // as possible.
+                this._updateCellsToRenderBatcher.dispose({abort: true});
+                this._updateCellsToRender();
+                return;
+            }
+        }
+        this._updateCellsToRenderBatcher.schedule();
+    };
+}

--- a/app/components/post_list/index.js
+++ b/app/components/post_list/index.js
@@ -4,10 +4,8 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {setChannelRefreshing} from 'app/actions/views/channel';
+import {refreshChannel} from 'app/actions/views/channel';
 import {getTheme} from 'app/selectors/preferences';
-
-import {getPosts} from 'mattermost-redux/actions/posts';
 
 import PostList from './post_list';
 
@@ -25,8 +23,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getPosts,
-            setChannelRefreshing
+            refreshChannel
         }, dispatch)
     };
 }

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -1,16 +1,14 @@
-// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    ListView,
-    RefreshControl,
     View
 } from 'react-native';
-import InvertibleScrollView from 'react-native-invertible-scroll-view';
+import FlatList from 'app/components/inverted_flat_list';
 
-import {General, Posts} from 'mattermost-redux/constants';
+import {General} from 'mattermost-redux/constants';
 import {addDatesToPostList} from 'mattermost-redux/utils/post_utils';
 
 import ChannelIntro from 'app/components/channel_intro';
@@ -21,72 +19,56 @@ import NewMessagesDivider from './new_messages_divider';
 
 const LOAD_MORE_POSTS = 'load-more-posts';
 
-export default class PostList extends Component {
+export default class PostList extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            getPosts: PropTypes.func.isRequired,
-            setChannelRefreshing: PropTypes.func.isRequired
+            refreshChannel: PropTypes.func.isRequired
         }).isRequired,
         channel: PropTypes.object,
         channelIsLoading: PropTypes.bool.isRequired,
-        posts: PropTypes.array.isRequired,
-        theme: PropTypes.object.isRequired,
+        currentUserId: PropTypes.string,
+        indicateNewMessages: PropTypes.bool,
+        isLoadingMore: PropTypes.bool,
+        lastViewedAt: PropTypes.number,
         loadMore: PropTypes.func,
         navigator: PropTypes.object,
-        isLoadingMore: PropTypes.bool,
-        showLoadMore: PropTypes.bool,
         onPostPress: PropTypes.func,
+        posts: PropTypes.array.isRequired,
         refreshing: PropTypes.bool,
         renderReplies: PropTypes.bool,
-        indicateNewMessages: PropTypes.bool,
-        currentUserId: PropTypes.string,
-        lastViewedAt: PropTypes.number
+        showLoadMore: PropTypes.bool,
+        theme: PropTypes.object.isRequired
     };
 
     static defaultProps = {
         channel: {}
     };
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            posts: this.getPostsWithDates(props),
-            dataSource: new ListView.DataSource({
-                rowHasChanged: (a, b) => a !== b
-            })
-        };
-    }
+    getPostsWithDates = () => {
+        const {posts, indicateNewMessages, currentUserId, lastViewedAt, showLoadMore} = this.props;
+        const list = addDatesToPostList(posts, {indicateNewMessages, currentUserId, lastViewedAt});
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.posts !== this.props.posts) {
-            const posts = this.getPostsWithDates(nextProps);
-            this.setState({posts}, () => {
-                if (nextProps.refreshing) {
-                    this.props.actions.setChannelRefreshing(false);
-                }
-            });
-        } else if (nextProps.refreshing) {
-            this.props.actions.setChannelRefreshing(false);
-        }
-    }
-
-    getPostsWithDates(props) {
-        const {posts, indicateNewMessages, currentUserId, lastViewedAt} = props;
-        return addDatesToPostList(posts, {indicateNewMessages, currentUserId, lastViewedAt});
-    }
-
-    getPostsWithLoadMore() {
-        const {showLoadMore} = this.props;
-        const {posts} = this.state;
         if (showLoadMore) {
-            return [...posts, LOAD_MORE_POSTS];
+            return [...list, LOAD_MORE_POSTS];
         }
-        return posts;
-    }
 
-    loadMore = () => {
-        const {loadMore} = this.props;
-        if (typeof loadMore === 'function') {
+        return list;
+    };
+
+    keyExtractor = (item) => {
+        if (item instanceof Date) {
+            return item.getTime();
+        }
+        if (item === General.START_OF_NEW_MESSAGES || item === LOAD_MORE_POSTS) {
+            return item;
+        }
+
+        return item.id;
+    };
+
+    loadMorePosts = () => {
+        const {loadMore, isLoadingMore} = this.props;
+        if (typeof loadMore === 'function' && !isLoadingMore) {
             loadMore();
         }
     };
@@ -95,18 +77,18 @@ export default class PostList extends Component {
         const {actions, channel} = this.props;
 
         if (Object.keys(channel).length) {
-            actions.setChannelRefreshing(true);
-            actions.getPosts(channel.id);
+            actions.refreshChannel(channel.id);
         }
     };
 
     renderChannelIntro = () => {
         const {channel, channelIsLoading, navigator, posts} = this.props;
 
+        // Check the webapp for atEnd, and replace it here
         if (channel.hasOwnProperty('id')) {
             const firstPostHasRendered = channel.total_msg_count ? posts.length > 0 : true;
             const messageCount = channel.total_msg_count - posts.length;
-            if (channelIsLoading || !firstPostHasRendered || messageCount > Posts.POST_CHUNK_SIZE) {
+            if (channelIsLoading || !firstPostHasRendered || messageCount > 0) {
                 return null;
             }
 
@@ -120,18 +102,27 @@ export default class PostList extends Component {
         return null;
     };
 
-    renderRow = (row) => {
-        if (row instanceof Date) {
-            return this.renderDateHeader(row);
+    renderDateHeader = (date) => {
+        return (
+            <DateHeader
+                theme={this.props.theme}
+                date={date}
+            />
+        );
+    };
+
+    renderItem = ({item}) => {
+        if (item instanceof Date) {
+            return this.renderDateHeader(item);
         }
-        if (row === General.START_OF_NEW_MESSAGES) {
+        if (item === General.START_OF_NEW_MESSAGES) {
             return (
                 <NewMessagesDivider
                     theme={this.props.theme}
                 />
             );
         }
-        if (row === LOAD_MORE_POSTS) {
+        if (item === LOAD_MORE_POSTS) {
             return (
                 <LoadMorePosts
                     loading={this.props.isLoadingMore}
@@ -140,16 +131,7 @@ export default class PostList extends Component {
             );
         }
 
-        return this.renderPost(row);
-    };
-
-    renderDateHeader = (date) => {
-        return (
-            <DateHeader
-                theme={this.props.theme}
-                date={date}
-            />
-        );
+        return this.renderPost(item);
     };
 
     renderPost = (post) => {
@@ -166,44 +148,29 @@ export default class PostList extends Component {
         );
     };
 
-    renderRefreshControl = () => {
-        const {theme, refreshing} = this.props;
-
-        return (
-            <RefreshControl
-                refreshing={refreshing}
-                onRefresh={this.onRefresh}
-                tintColor={theme.centerChannelColor}
-                colors={[theme.centerChannelColor]}
-            />
-        );
-    };
-
-    renderScrollComponent = (props) => {
-        return (
-            <InvertibleScrollView
-                {...props}
-                inverted={true}
-            />
-        );
-    };
-
     render() {
-        const {dataSource} = this.state;
+        const {channel, refreshing, theme} = this.props;
+
+        const refreshControl = {
+            refreshing
+        };
+
+        if (Object.keys(channel).length) {
+            refreshControl.onRefresh = this.onRefresh;
+        }
 
         return (
-            <ListView
-                renderScrollComponent={this.renderScrollComponent}
-                dataSource={dataSource.cloneWithRows(this.getPostsWithLoadMore())}
-                renderFooter={this.renderChannelIntro}
-                renderRow={this.renderRow}
-                onEndReached={this.loadMore}
-                enableEmptySections={true}
-                showsVerticalScrollIndicator={true}
-                initialListSize={30}
-                onEndReachedThreshold={200}
-                pageSize={10}
-                refreshControl={this.renderRefreshControl()}
+            <FlatList
+                data={this.getPostsWithDates()}
+                initialNumToRender={20}
+                inverted={true}
+                keyExtractor={this.keyExtractor}
+                ListFooterComponent={this.renderChannelIntro}
+                onEndReached={this.loadMorePosts}
+                onEndReachedThreshold={700}
+                {...refreshControl}
+                renderItem={this.renderItem}
+                theme={theme}
             />
         );
     }

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -42,7 +42,11 @@ const ViewTypes = keyMirror({
     SET_LAST_CHANNEL_FOR_TEAM: null,
 
     GITLAB: null,
-    SAML: null
+    SAML: null,
+
+    INCREASE_POST_VISIBILITY: null,
+    RECEIVED_FOCUSED_POST: null,
+    LOADING_POSTS: null
 });
 
 export default ViewTypes;

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {Posts} from 'mattermost-redux/constants';
 import keyMirror from 'mattermost-redux/utils/key_mirror';
 
 const ViewTypes = keyMirror({
@@ -49,4 +50,7 @@ const ViewTypes = keyMirror({
     LOADING_POSTS: null
 });
 
-export default ViewTypes;
+export default {
+    ...ViewTypes,
+    POST_VISIBILITY_CHUNK_SIZE: Posts.POST_CHUNK_SIZE / 2
+};

--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -2,7 +2,8 @@
 // See License.txt for license information.
 
 import {combineReducers} from 'redux';
-import {ChannelTypes, FileTypes} from 'mattermost-redux/action_types';
+import {ChannelTypes, FileTypes, PostTypes} from 'mattermost-redux/action_types';
+import {Posts} from 'mattermost-redux/constants';
 
 import {ViewTypes} from 'app/constants';
 
@@ -199,10 +200,54 @@ function tooltipVisible(state = false, action) {
     }
 }
 
+function postVisibility(state = {}, action) {
+    switch (action.type) {
+    case ChannelTypes.SELECT_CHANNEL: {
+        const nextState = {...state};
+        nextState[action.data] = Posts.POST_CHUNK_SIZE / 2;
+        return nextState;
+    }
+    case ViewTypes.INCREASE_POST_VISIBILITY: {
+        const nextState = {...state};
+        nextState[action.data] += action.amount;
+        return nextState;
+    }
+    case ViewTypes.RECEIVED_FOCUSED_POST: {
+        const nextState = {...state};
+        nextState[action.channelId] = Posts.POST_CHUNK_SIZE / 2;
+        return nextState;
+    }
+    case PostTypes.RECEIVED_POST: {
+        if (action.data && state[action.data.channel_id]) {
+            const nextState = {...state};
+            nextState[action.data.channel_id] += 1;
+            return nextState;
+        }
+        return state;
+    }
+    default:
+        return state;
+    }
+}
+
+function loadingPosts(state = {}, action) {
+    switch (action.type) {
+    case ViewTypes.LOADING_POSTS: {
+        const nextState = {...state};
+        nextState[action.channelId] = action.data;
+        return nextState;
+    }
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     displayName,
     drafts,
     loading,
     refreshing,
-    tooltipVisible
+    tooltipVisible,
+    postVisibility,
+    loadingPosts
 });

--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -3,7 +3,6 @@
 
 import {combineReducers} from 'redux';
 import {ChannelTypes, FileTypes, PostTypes} from 'mattermost-redux/action_types';
-import {Posts} from 'mattermost-redux/constants';
 
 import {ViewTypes} from 'app/constants';
 
@@ -204,7 +203,7 @@ function postVisibility(state = {}, action) {
     switch (action.type) {
     case ChannelTypes.SELECT_CHANNEL: {
         const nextState = {...state};
-        nextState[action.data] = Posts.POST_CHUNK_SIZE / 2;
+        nextState[action.data] = ViewTypes.POST_VISIBILITY_CHUNK_SIZE;
         return nextState;
     }
     case ViewTypes.INCREASE_POST_VISIBILITY: {
@@ -214,7 +213,7 @@ function postVisibility(state = {}, action) {
     }
     case ViewTypes.RECEIVED_FOCUSED_POST: {
         const nextState = {...state};
-        nextState[action.channelId] = Posts.POST_CHUNK_SIZE / 2;
+        nextState[action.channelId] = ViewTypes.POST_VISIBILITY_CHUNK_SIZE;
         return nextState;
     }
     case PostTypes.RECEIVED_POST: {

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -26,7 +26,7 @@ import {makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import ChannelDrawerButton from './channel_drawer_button';
 import ChannelTitle from './channel_title';
-import ChannelPostList from './channel_post_list/index';
+import ChannelPostList from './channel_post_list';
 
 class Channel extends PureComponent {
     static propTypes = {

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -136,6 +136,7 @@ class ChannelPostList extends PureComponent {
             channelIsRefreshing,
             loadingPosts,
             myMember,
+            navigator,
             networkOnline,
             posts,
             postVisibility,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-native-device-info": "0.10.2",
     "react-native-drawer": "2.3.0",
     "react-native-image-picker": "jp928/react-native-image-picker#6ee35b69f3dbd6c7c66f580fd4d9eabf398703d4",
-    "react-native-invertible-scroll-view": "1.0.0",
     "react-native-keyboard-aware-scroll-view": "0.2.8",
     "react-native-linear-gradient": "2.0.0",
     "react-native-navigation": "1.1.88",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4480,13 +4480,6 @@ react-native-image-picker@jp928/react-native-image-picker#6ee35b69f3dbd6c7c66f58
   version "0.26.2"
   resolved "https://codeload.github.com/jp928/react-native-image-picker/tar.gz/6ee35b69f3dbd6c7c66f580fd4d9eabf398703d4"
 
-react-native-invertible-scroll-view@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-invertible-scroll-view/-/react-native-invertible-scroll-view-1.0.0.tgz#60ceb384dc950c34eba3a5aeda39f97cdc7d4e23"
-  dependencies:
-    react-clone-referenced-element "^1.0.1"
-    react-native-scrollable-mixin "^1.0.1"
-
 react-native-keyboard-aware-scroll-view@0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.2.8.tgz#e9843c0d7467a2e6a2a737883bd9c2b7c7e38e35"
@@ -4547,10 +4540,6 @@ react-native-notifications@enahum/react-native-notifications.git:
 react-native-orientation@enahum/react-native-orientation.git:
   version "1.17.0"
   resolved "https://codeload.github.com/enahum/react-native-orientation/tar.gz/75ba7da814b99a949324846ce3a63fcbaeee9fdc"
-
-react-native-scrollable-mixin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
 
 react-native-search-bar@enahum/react-native-search-bar.git:
   version "2.16.0"


### PR DESCRIPTION
#### Summary
This PR is a refactor of the `channel_post_list` and the `post_list`.

* `channel_post_list` was simplified and now it uses the pagination instead of `getPostsBefore` that way we ensure that we are retrieving the correct posts in order from the server, it also adds a postVisibility control where we establish the amount of posts that are going to get rendered.
* `post_list` was refactor to use the `VirtualizedList` instead of the `ListView`. In order to make the `VirtualizedList` to work as an inverted list we needed to extend the list from RN and make some adjustments.

This PR also fixes the issue were if the channel drawer was open by sliding the `channel_loader` would not disappear from the screen, that was due to a race condition with the `InteractionManager`

On IOS the refresh control on `pull up to refresh` now shows as expected.

#### Ticket Link
No Ticket

#### Device Information
This PR was tested on: 
* IOS 10.3.2 iPhone 6 (Simulator)
* IOS 10.3.1 iPhone 6s
* Android 6.0.1 Samsung J5


@jarredwitt @hmhealey please try and carefully review as this touches a critical component of the app and if you can please test it locally