### PR TITLE
Ui improvements

### DIFF
--- a/app/components/channel_drawer/channels_list/index.js
+++ b/app/components/channel_drawer/channels_list/index.js
@@ -265,6 +265,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         headerContainer: {
             alignItems: 'center',
+            paddingLeft: 10,
             backgroundColor: theme.sidebarHeaderBg,
             flexDirection: 'row',
             borderBottomWidth: 1,
@@ -337,7 +338,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flexDirection: 'row',
             height: 32,
             justifyContent: 'center',
-            marginLeft: 16,
+            marginLeft: 6,
             marginRight: 10,
             paddingHorizontal: 6
         },

--- a/app/components/channel_drawer/channels_list/list/list.js
+++ b/app/components/channel_drawer/channels_list/list/list.js
@@ -330,7 +330,7 @@ class List extends Component {
                         </Text>
                         {action && this.renderSectionAction(styles, action)}
                     </View>
-                    {bottomDivider && this.renderDivider(styles, 16)}
+                    {bottomDivider && this.renderDivider(styles, 0)}
                 </View>
             )
         };

--- a/app/components/channel_drawer/teams_list/teams_list.js
+++ b/app/components/channel_drawer/teams_list/teams_list.js
@@ -235,7 +235,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             alignItems: 'center',
             backgroundColor: theme.sidebarHeaderBg,
             flexDirection: 'row',
-            paddingLeft: 16,
             borderBottomWidth: 1,
             borderBottomColor: changeOpacity(theme.sidebarHeaderTextColor, 0.10),
             ...Platform.select({
@@ -251,7 +250,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.sidebarHeaderTextColor,
             flex: 1,
             fontSize: 17,
-            fontWeight: 'normal'
+            textAlign: 'center',
+            fontWeight: '600'
         },
         moreActionContainer: {
             alignItems: 'center',

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -528,13 +528,22 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         sendButton: {
             backgroundColor: theme.buttonBg,
             borderRadius: 18,
-            marginBottom: 3,
             marginRight: 5,
             height: 28,
             width: 28,
             alignItems: 'center',
             justifyContent: 'center',
-            paddingLeft: 2
+            paddingLeft: 2,
+            ...Platform.select({
+                ios: {
+                    marginBottom: 3
+                },
+                android: {
+                    height: 29,
+                    marginBottom: 4,
+                    width: 29
+                }
+            })
         },
         typing: {
             paddingLeft: 10,


### PR DESCRIPTION
#### Summary
RN-171 - Extending border bottom on sidebar title
RN-164 - Teams title center and bold
RN-103 - Updating position for sendButton
RN-231 - Increasing left margin when only one team

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-171
https://mattermost.atlassian.net/browse/RN-164
https://mattermost.atlassian.net/browse/RN-103
https://mattermost.atlassian.net/browse/RN-231

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
- IOS simulator (6s)
- Moto x (First generation)

#### Screenshots
![screen shot 2017-06-23 at 2 17 30 pm](https://user-images.githubusercontent.com/11034289/27478553-91bfe112-5829-11e7-96f7-bf0b3bf76433.png)
![screen shot 2017-06-23 at 2 17 19 pm](https://user-images.githubusercontent.com/11034289/27478556-933274ce-5829-11e7-98ea-c24fca7814b1.png)
![screen shot 2017-06-23 at 2 17 17 pm](https://user-images.githubusercontent.com/11034289/27478561-95a84f1c-5829-11e7-8e6e-e115750c63b1.png)
![screenshot_2017-06-23-14-32-33](https://user-images.githubusercontent.com/11034289/27478573-a5a582e0-5829-11e7-802e-dafe68283132.png)
![screenshot_2017-06-23-15-41-26](https://user-images.githubusercontent.com/11034289/27478775-9015e41e-582a-11e7-8e6f-a353366d7dbf.png)


