### PR TITLE
Fix localization + setting the token for APIv3

### DIFF
--- a/app/actions/views/login.js
+++ b/app/actions/views/login.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 import {GeneralTypes} from 'mattermost-redux/action_types';
-import {Client4} from 'mattermost-redux/client';
+import {Client, Client4} from 'mattermost-redux/client';
 
 import {ViewTypes} from 'app/constants';
 
@@ -25,13 +25,18 @@ export function handlePasswordChanged(password) {
 
 export function handleSuccessfulLogin() {
     return async (dispatch, getState) => {
+        const token = Client4.getToken();
+        const url = Client4.getUrl();
         dispatch({
             type: GeneralTypes.RECEIVED_APP_CREDENTIALS,
             data: {
-                url: Client4.getUrl(),
-                token: Client4.getToken()
+                url,
+                token
             }
         }, getState);
+
+        Client.setToken(token);
+        Client.setUrl(url);
 
         return true;
     };

--- a/app/components/root/index.js
+++ b/app/components/root/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import DeviceInfo from 'react-native-device-info';
 
+import {Client, Client4} from 'mattermost-redux/client';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUrl} from 'mattermost-redux/selectors/entities/general';
 
@@ -20,6 +21,9 @@ function mapStateToProps(state, ownProps) {
     if (currentUserId && users.profiles[currentUserId]) {
         locale = users.profiles[currentUserId].locale;
     }
+
+    Client.setLocale(locale);
+    Client4.setLocale(locale);
 
     return {
         ...ownProps,

--- a/app/i18n/index.js
+++ b/app/i18n/index.js
@@ -48,20 +48,18 @@ const TRANSLATIONS = {
     'zh-TW': zhTW
 };
 
-addLocaleData([
-    deLocaleData,
-    enLocaleData,
-    esLocaleData,
-    frLocaleData,
-    jaLocaleData,
-    koLocaleData,
-    nlLocaleData,
-    plLocaleData,
-    ptLocaleData,
-    trLocaleData,
-    ruLocaleData,
-    zhLocaleData
-]);
+addLocaleData(deLocaleData);
+addLocaleData(enLocaleData);
+addLocaleData(esLocaleData);
+addLocaleData(frLocaleData);
+addLocaleData(jaLocaleData);
+addLocaleData(koLocaleData);
+addLocaleData(nlLocaleData);
+addLocaleData(plLocaleData);
+addLocaleData(ptLocaleData);
+addLocaleData(trLocaleData);
+addLocaleData(ruLocaleData);
+addLocaleData(zhLocaleData);
 
 export function getTranslations(locale) {
     return TRANSLATIONS[locale] || TRANSLATIONS[DEFAULT_LOCALE];

--- a/app/styles/index.js
+++ b/app/styles/index.js
@@ -90,7 +90,7 @@ export const GlobalStyles = StyleSheet.create({
         marginTop: 15,
         marginBottom: 15,
         fontSize: 12,
-        textAlign: 'center'
+        textAlign: 'left'
     },
 
     switchUp: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,7 +3645,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/b21461562fefc6abe2e31373045059652d814ad1"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/caf81fd083fb4f883c787e4ca11bf17e5898e031"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
This PR fixes localization and adds the `Accept-Language` header using the users locale or the device locale when the user hasn't logged in.

Make sure we set the correct `token` for APIv3 for those actions that still need v3 endpoints.

Changed the global style for the error message so it aligns the text to the left and not centered.
