### PR TITLE
RN-199 Leave Channel isn't hidden for last member of private channel

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -287,9 +287,9 @@ class ChannelInfo extends PureComponent {
                             textId={canManageUsers ? 'channel_header.manageMembers' : 'channel_header.viewMembers'}
                             theme={theme}
                         />
-                        <View style={style.separator}/>
                         {canManageUsers &&
                             <View>
+                                <View style={style.separator}/>
                                 <ChannelInfoRow
                                     action={() => preventDoubleTap(this.goToChannelAddMembers)}
                                     defaultMessage='Add Members'
@@ -297,17 +297,20 @@ class ChannelInfo extends PureComponent {
                                     textId='channel_header.addMembers'
                                     theme={theme}
                                 />
-                                <View style={style.separator}/>
                             </View>
                         }
-                        <ChannelInfoRow
-                            action={() => preventDoubleTap(this.handleDeleteOrLeave, this, 'leave')}
-                            defaultMessage='Leave Channel'
-                            icon='sign-out'
-                            textId='navbar.leave'
-                            shouldRender={this.renderLeaveOrDeleteChannelRow()}
-                            theme={theme}
-                        />
+                        {this.renderLeaveOrDeleteChannelRow() && currentChannelMemberCount > 1 &&
+                            <View>
+                                <View style={style.separator}/>
+                                <ChannelInfoRow
+                                    action={() => preventDoubleTap(this.handleDeleteOrLeave, this, 'leave')}
+                                    defaultMessage='Leave Channel'
+                                    icon='sign-out'
+                                    textId='navbar.leave'
+                                    theme={theme}
+                                />
+                            </View>
+                        }
                     </View>
                     {this.renderLeaveOrDeleteChannelRow() && canDeleteChannel &&
                         <View style={style.footer}>


### PR DESCRIPTION
#### Summary
Fixes the issue where leave channel was being shown to the last member of a private channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-199

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23