### PR TITLE
RN-168 Attachment selector closes without attachment

### DIFF
--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -222,10 +222,6 @@ class PostTextbox extends PureComponent {
     };
 
     attachFileFromCamera = () => {
-        this.props.navigator.dismissModal({
-            animationType: 'none'
-        });
-
         const options = {
             quality: 0.7,
             noData: true,
@@ -245,10 +241,6 @@ class PostTextbox extends PureComponent {
     };
 
     attachFileFromLibrary = () => {
-        this.props.navigator.dismissModal({
-            animationType: 'none'
-        });
-
         const options = {
             quality: 0.7,
             noData: true
@@ -268,10 +260,6 @@ class PostTextbox extends PureComponent {
     };
 
     attachVideoFromLibraryAndroid = () => {
-        this.props.navigator.dismissModal({
-            animationType: 'none'
-        });
-
         const options = {
             quality: 0.7,
             mediaType: 'video',
@@ -291,18 +279,33 @@ class PostTextbox extends PureComponent {
         this.props.actions.handleUploadFiles(images, this.props.rootId);
     };
 
+    handleFileAttachmentOption = (action) => {
+        this.props.navigator.dismissModal({
+            animationType: 'none'
+        });
+
+        // Have to wait to launch the library attachment action.
+        // If we call the action after dismissModal with no delay then the
+        // Wix navigator will dismiss the library attachment modal as well.
+        setTimeout(() => {
+            if (typeof action === 'function') {
+                action();
+            }
+        }, 100);
+    }
+
     showFileAttachmentOptions = () => {
         this.blur();
         const options = {
             items: [{
-                action: this.attachFileFromCamera,
+                action: () => this.handleFileAttachmentOption(this.attachFileFromCamera),
                 text: {
                     id: 'mobile.file_upload.camera',
                     defaultMessage: 'Take Photo or Video'
                 },
                 icon: 'camera'
             }, {
-                action: this.attachFileFromLibrary,
+                action: () => this.handleFileAttachmentOption(this.attachFileFromLibrary),
                 text: {
                     id: 'mobile.file_upload.library',
                     defaultMessage: 'Photo Library'
@@ -313,7 +316,7 @@ class PostTextbox extends PureComponent {
 
         if (Platform.OS === 'android') {
             options.items.push({
-                action: this.attachVideoFromLibraryAndroid,
+                action: () => this.handleFileAttachmentOption(this.attachVideoFromLibraryAndroid),
                 text: {
                     id: 'mobile.file_upload.video',
                     defaultMessage: 'Video Library'


### PR DESCRIPTION
#### Summary
Fixes an issue where the attachment selector would fail to open.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-168

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23