### PR TITLE
GH-671 Fixed entire link being made lower case

### DIFF
--- a/app/components/markdown/markdown_link.js
+++ b/app/components/markdown/markdown_link.js
@@ -19,7 +19,14 @@ export default class MarkdownLink extends PureComponent {
     }
 
     handlePress = () => {
-        const url = this.props.href.toLowerCase();
+        // Android doesn't like the protocol being upper case
+        let url = this.props.href;
+
+        const index = url.indexOf(':');
+        if (index !== -1) {
+            const protocol = url.substring(0, index);
+            url = protocol.toLowerCase() + url.substring(index);
+        }
 
         Linking.canOpenURL(url).then((supported) => {
             if (supported) {


### PR DESCRIPTION
We'll just make the HTTP protocol lower case to satisfy Android instead of making the whole thing lower case

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/issues/671

#### Device Information
This PR was tested on: iOS Simulator
