### PR TITLE
Fix push notification switch channel name

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -44,6 +44,8 @@ export function goToNotification(notification) {
         // if the notification does not have a team id is because its from a DM or GM
         let teamId = data.team_id || currentTeamId;
 
+        dispatch(setChannelDisplayName(''));
+
         if (teamId) {
             handleTeamChange(teams[teamId])(dispatch, getState);
             await loadChannelsIfNecessary(teamId)(dispatch, getState);
@@ -56,7 +58,6 @@ export function goToNotification(notification) {
         loadProfilesAndTeamMembersForDMSidebar(teamId)(dispatch, getState);
 
         if (channelId !== currentChannelId) {
-            dispatch(setChannelDisplayName(''));
             handleSelectChannel(channelId)(dispatch, getState);
         }
         markChannelAsRead(teamId, channelId)(dispatch, getState).then(() => true).catch(() => true);

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -68,7 +68,8 @@ export default class Mattermost {
                         // purge the store
                         store.dispatch({type: General.OFFLINE_STORE_PURGE});
                     }
-                }]
+                }],
+                {cancelable: false}
             );
         }
     };
@@ -103,7 +104,8 @@ export default class Mattermost {
                     [{
                         text: intl.formatMessage({id: 'mobile.server_upgrade.button', defaultMessage: 'OK'}),
                         onPress: this.handleVersionUpgrade
-                    }]
+                    }],
+                    {cancelable: false}
                 );
             } else {
                 setServerVersion('')(dispatch, getState);


### PR DESCRIPTION
#### Summary
Fixes the channel name not being updated when opening the app with a push notification.

Also prevents the exception alert from being dismissed on Android