### PR TITLE
Fixed uneven vertical margin on iOS search box

### DIFF
--- a/app/components/search_bar/search_box.js
+++ b/app/components/search_bar/search_box.js
@@ -462,7 +462,10 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         justifyContent: 'flex-start',
         alignItems: 'center',
-        padding: 5
+        paddingBottom: 5,
+        paddingLeft: 5,
+        paddingRight: 5,
+        paddingTop: 4
     },
     input: {
         height: containerHeight - 10,


### PR DESCRIPTION
Not sure where that extra margin is coming from

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator, Nexus 5

#### Screenshots
<img width="387" alt="screen shot 2017-07-05 at 10 21 42 am" src="https://user-images.githubusercontent.com/3277310/27868839-f8455c78-616b-11e7-98a3-4a2dfb633b57.png">

