### PR TITLE
Fixed uneven settings dividers

### DIFF
--- a/app/screens/settings/settings_item.js
+++ b/app/screens/settings/settings_item.js
@@ -137,7 +137,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         divider: {
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
             height: 1,
-            marginLeft: 16
+            marginHorizontal: 16
         }
     });
 });


### PR DESCRIPTION
These margins match the ChannelInfo modal

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator, Nexus 5

#### Screenshots
<img width="388" alt="screen shot 2017-07-05 at 10 21 58 am" src="https://user-images.githubusercontent.com/3277310/27868872-1849c5ea-616c-11e7-9a9a-60a27ae16ef4.png">

