### PR TITLE
Updated yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,7 +3645,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/aa2841b7b75fd08c9819ac14a9d27d4f6baa959a"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/26b897a943a2095bdc793f28c10415441859ad6f"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
To include the fixes pointed out by Jarred where getTeammateNameDisplaySetting could return a preference object