### PR TITLE
Android Leaving/Deleting channel redirects to info page of Town Square

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import {injectIntl, intlShape} from 'react-intl';
 import {
     Alert,
+    Platform,
     ScrollView,
     StyleSheet,
     View
@@ -67,7 +68,11 @@ class ChannelInfo extends PureComponent {
 
     close = () => {
         EventEmitter.emit(General.DEFAULT_CHANNEL, '');
-        this.props.navigator.pop({animated: true});
+        if (Platform.OS === 'android') {
+            this.props.navigator.dismissModal({animated: true});
+        } else {
+            this.props.navigator.pop({animated: true});
+        }
     };
 
     goToChannelAddMembers = () => {


### PR DESCRIPTION
#### Summary
Fixes the issue where leaving or deleting a channel on Android would navigate back to the channel info screen of the default channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-259

#### Device Information
This PR was tested on: 
Galaxy s7 - Android 6.0 API 23