### PR TITLE
RN-269 fix for huawei not rendering posts

### DIFF
--- a/app/components/inverted_flat_list/index.js
+++ b/app/components/inverted_flat_list/index.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {FlatList, RefreshControl, ScrollView, StyleSheet, View} from 'react-native';
+import {FlatList, Platform, RefreshControl, ScrollView, StyleSheet, View} from 'react-native';
 
 import VirtualList from './virtual_list';
 
@@ -129,11 +129,21 @@ const styles = StyleSheet.create({
     container: {
         flex: 1
     },
-    vertical: {
-        transform: [{scaleY: -1}]
-    },
-    horizontal: {
-        transform: [{scaleX: -1}]
-    }
+    vertical: Platform.select({
+        android: {
+            scaleY: -1
+        },
+        ios: {
+            transform: [{scaleY: -1}]
+        }
+    }),
+    horizontal: Platform.select({
+        android: {
+            scaleX: -1
+        },
+        ios: {
+            transform: [{scaleX: -1}]
+        }
+    })
 });
 


### PR DESCRIPTION
To be included in **dot release 1.0.1**

#### Summary
In some Android devices the style for transform does not work causing the list of post to render as blank, this PR will fix that issue by using the scaleY directly instead of a transform object.

Note: This will cause RN to display a deprecation warning in the yellowbox but it works as expected in all Android phones

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-269
