### PR TITLE
RN-256 Image thumbnails are blurry

### DIFF
--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -46,7 +46,7 @@ export default class FileAttachmentImage extends PureComponent {
     static defaultProps = {
         fadeInOnLoad: false,
         imageHeight: 100,
-        imageSize: IMAGE_SIZE.Thumbnail,
+        imageSize: IMAGE_SIZE.Preview,
         imageWidth: 100,
         loading: false,
         loadingBackgroundColor: '#fff',
@@ -114,12 +114,24 @@ export default class FileAttachmentImage extends PureComponent {
         }
     };
 
+    calculateNeededWidth = (height, width, newHeight) => {
+        const ratio = width / height;
+
+        let newWidth = newHeight * ratio;
+        if (newWidth < newHeight) {
+            newWidth = newHeight;
+        }
+
+        return newWidth;
+    }
+
     render() {
         const {
             fetchCache,
             file,
             imageHeight,
             imageWidth,
+            imageSize,
             loadingBackgroundColor,
             resizeMethod,
             resizeMode,
@@ -147,11 +159,20 @@ export default class FileAttachmentImage extends PureComponent {
         };
         const opacity = isInFetchCache ? 1 : this.state.opacity;
 
+        let height = imageHeight;
+        let width = imageWidth;
+        let imageStyle = {height, width};
+        if (imageSize === IMAGE_SIZE.Preview) {
+            height = 100;
+            width = this.calculateNeededWidth(file.height, file.width, height);
+            imageStyle = {height, width, position: 'absolute', top: 0, left: 0};
+        }
+
         return (
-            <View style={[style.fileImageWrapper, {backgroundColor: wrapperBackgroundColor, height: wrapperHeight, width: wrapperWidth}]}>
+            <View style={[style.fileImageWrapper, {backgroundColor: wrapperBackgroundColor, height: wrapperHeight, width: wrapperWidth, overflow: 'hidden'}]}>
                 <AnimatedView style={{height: imageHeight, width: imageWidth, backgroundColor: wrapperBackgroundColor, opacity}}>
                     <Image
-                        style={{height: imageHeight, width: imageWidth}}
+                        style={imageStyle}
                         source={source}
                         resizeMode={resizeMode}
                         resizeMethod={resizeMethod}


### PR DESCRIPTION
#### Summary
Increases the quality of image thumbnails when shown in the post list. Also attempts to favor the top left corner of images that do not resize correctly 

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-256

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23