### PR TITLE
RN-248 Upload file and leave channel

### DIFF
--- a/app/components/file_upload_preview/file_upload_preview.js
+++ b/app/components/file_upload_preview/file_upload_preview.js
@@ -12,7 +12,6 @@ import {
     View
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
-import {RequestStatus} from 'mattermost-redux/constants';
 
 import FileAttachmentImage from 'app/components/file_attachment_list/file_attachment_image';
 import FileAttachmentIcon from 'app/components/file_attachment_list/file_attachment_icon';
@@ -102,7 +101,7 @@ export default class FileUploadPreview extends PureComponent {
     }
 
     render() {
-        if (this.props.channelIsLoading || (!this.props.files.length && this.props.filesUploadingForCurrentChannel !== RequestStatus.STARTED)) {
+        if (this.props.channelIsLoading || (!this.props.files.length && !this.props.filesUploadingForCurrentChannel)) {
             return null;
         }
 

--- a/app/components/file_upload_preview/file_upload_preview.js
+++ b/app/components/file_upload_preview/file_upload_preview.js
@@ -35,7 +35,7 @@ export default class FileUploadPreview extends PureComponent {
         inputHeight: PropTypes.number.isRequired,
         rootId: PropTypes.string,
         theme: PropTypes.object.isRequired,
-        uploadFileRequestStatus: PropTypes.string.isRequired
+        filesUploadingForCurrentChannel: PropTypes.bool.isRequired
     };
 
     handleRetryFileUpload = (file) => {
@@ -102,7 +102,7 @@ export default class FileUploadPreview extends PureComponent {
     }
 
     render() {
-        if (this.props.channelIsLoading || (!this.props.files.length && this.props.uploadFileRequestStatus !== RequestStatus.STARTED)) {
+        if (this.props.channelIsLoading || (!this.props.files.length && this.props.filesUploadingForCurrentChannel !== RequestStatus.STARTED)) {
             return null;
         }
 

--- a/app/components/file_upload_preview/index.js
+++ b/app/components/file_upload_preview/index.js
@@ -3,6 +3,7 @@
 
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
+import {createSelector} from 'reselect';
 
 import {handleRemoveFile, retryFileUpload} from 'app/actions/views/file_upload';
 import {addFileToFetchCache} from 'app/actions/views/file_preview';
@@ -10,13 +11,26 @@ import {getTheme} from 'app/selectors/preferences';
 
 import FileUploadPreview from './file_upload_preview';
 
+const checkForFileUploadingInChannel = createSelector(
+    (state, channelId, rootId) => {
+        if (rootId) {
+            return state.views.thread.drafts[rootId];
+        }
+
+        return state.views.channel.drafts[channelId];
+    },
+    (draft) => {
+        return draft.files.some((f) => f.loading);
+    }
+);
+
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
         channelIsLoading: state.views.channel.loading,
         createPostRequestStatus: state.requests.posts.createPost.status,
         fetchCache: state.views.fetchCache,
-        uploadFileRequestStatus: state.requests.files.uploadFiles.status,
+        filesUploadingForCurrentChannel: checkForFileUploadingInChannel(state, ownProps.channelId, ownProps.rootId),
         theme: getTheme(state)
     };
 }


### PR DESCRIPTION
#### Summary
Can now start file upload in one channel and leave the channel without disrupting the file upload.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-248

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23