### PR TITLE
RN-255 Fix search box clear button to be more tappable

### DIFF
--- a/app/components/search_bar/search_box.js
+++ b/app/components/search_bar/search_box.js
@@ -415,20 +415,20 @@ export default class Search extends Component {
                         >
                             {this.props.iconDelete}
                         </Animated.View> :
-                        <AnimatedIcon
-                            name='ios-close-circle'
-                            size={iconSize}
-                            style={[
-                                styles.iconDelete,
-                                styles.iconDeleteDefault,
-                                this.props.tintColorDelete && {color: this.props.tintColorDelete},
-                                this.props.positionRightDelete && {right: this.props.positionRightDelete},
-                                {
-                                    opacity: this.iconDeleteAnimated,
-                                    top: middleHeight - (iconSize / 2)
-                                }
-                            ]}
-                        />
+                        <View style={[styles.iconDelete, this.props.inputHeight && {height: this.props.inputHeight, width: iconSize + 5}]}>
+                            <AnimatedIcon
+                                name='ios-close-circle'
+                                size={iconSize}
+                                style={[
+                                    styles.iconDeleteDefault,
+                                    this.props.tintColorDelete && {color: this.props.tintColorDelete},
+                                    this.props.positionRightDelete && {right: this.props.positionRightDelete},
+                                    {
+                                        opacity: this.iconDeleteAnimated
+                                    }
+                                ]}
+                            />
+                        </View>
                     )}
                 </TouchableWithoutFeedback>
                 <TouchableWithoutFeedback onPress={this.onCancel}>
@@ -462,10 +462,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         justifyContent: 'flex-start',
         alignItems: 'center',
-        paddingBottom: 5,
-        paddingLeft: 5,
-        paddingRight: 5,
-        paddingTop: 4
+        padding: 5
     },
     input: {
         height: containerHeight - 10,
@@ -485,6 +482,8 @@ const styles = StyleSheet.create({
         color: 'grey'
     },
     iconDelete: {
+        alignItems: 'center',
+        justifyContent: 'center',
         position: 'absolute',
         right: 70
     },


### PR DESCRIPTION
#### Summary
Made the clear button inside the search box more tappable by increasing the width and height of the container.

Also center the placeholder vertically

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-255
https://mattermost.atlassian.net/browse/RN-251

#### Checklist
- [x] Has UI changes


#### Device Information
This PR was tested on: 
* IOS 10.3 iPhone 6 (simulator)
* IOS 10.3.2 iPhone 6s