### PR TITLE
Add mattermost:// url scheme to ios

### DIFF
--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -92,5 +92,16 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.mattermost.rnbeta</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mattermost</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
#### Summary
URL scheme added to IOS, for Android adding the intent filter is causing the app to crash, bug report is on [react-native-navigation](https://github.com/wix/react-native-navigation/issues/384) lets wait and see if there is a solution for this.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-262

