### PR TITLE
PLT-253 Made margins around settings button appear even

### DIFF
--- a/app/components/channel_drawer/channels_list/index.js
+++ b/app/components/channel_drawer/channels_list/index.js
@@ -293,10 +293,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             paddingHorizontal: 10,
             ...Platform.select({
                 android: {
-                    height: 46
+                    height: 46,
+                    marginRight: 6
                 },
                 ios: {
-                    height: 44
+                    height: 44,
+                    marginRight: 8
                 }
             })
         },


### PR DESCRIPTION
These margins are tricky because the settings button doesn't have a border and the search bar on iOS has padding that looks like a margin, so technically they were even before, but they didn't look that way. I tried to clean up the padding and make them actually even, but ended up being surprisingly difficult, so I didn't end up getting that working

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-253

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator, Nexus 5