### PR TITLE
PLT-244/PLT-277 Made Delete Channel visibility always depend on policy setting

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -320,7 +320,7 @@ class ChannelInfo extends PureComponent {
                                 />
                             </View>
                         }
-                        {this.renderLeaveOrDeleteChannelRow() && currentChannelMemberCount > 1 &&
+                        {this.renderLeaveOrDeleteChannelRow() &&
                             <View>
                                 <View style={style.separator}/>
                                 <ChannelInfoRow

--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -233,6 +233,7 @@ class ChannelInfo extends PureComponent {
             currentChannelCreatorName,
             currentChannelMemberCount,
             canManageUsers,
+            navigator,
             status,
             theme
         } = this.props;
@@ -264,6 +265,7 @@ class ChannelInfo extends PureComponent {
                         creator={currentChannelCreatorName}
                         displayName={currentChannel.display_name}
                         header={currentChannel.header}
+                        navigator={navigator}
                         purpose={currentChannel.purpose}
                         status={status}
                         theme={theme}

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -23,6 +23,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
         memberCount: PropTypes.number,
         displayName: PropTypes.string.isRequired,
         header: PropTypes.string,
+        navigator: PropTypes.object.isRequired,
         purpose: PropTypes.string,
         status: PropTypes.string,
         theme: PropTypes.object.isRequired,
@@ -30,7 +31,18 @@ export default class ChannelInfoHeader extends React.PureComponent {
     }
 
     render() {
-        const {createAt, creator, displayName, header, memberCount, purpose, status, theme, type} = this.props;
+        const {
+            createAt,
+            creator,
+            displayName,
+            header,
+            memberCount,
+            navigator,
+            purpose,
+            status,
+            theme,
+            type
+        } = this.props;
 
         const style = getStyleSheet(theme);
         const textStyles = getMarkdownTextStyles(theme);
@@ -63,6 +75,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
                             defaultMessage='Purpose'
                         />
                         <Markdown
+                            navigator={navigator}
                             baseTextStyle={style.detail}
                             textStyles={textStyles}
                             blockStyles={blockStyles}
@@ -78,6 +91,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
                             defaultMessage='Header'
                         />
                         <Markdown
+                            navigator={navigator}
                             baseTextStyle={style.detail}
                             textStyles={textStyles}
                             blockStyles={blockStyles}


### PR DESCRIPTION
This removes the "the last user of a private channel can't leave it, but is always able to delete it" functionality since that kept getting reported as a bug. There's a corresponding ticket for the platform repo that will change the required permissions on the server side and web app.

I also fixed a warning on the ChannelInfo screen at the same time since it was driving me nuts

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-244
https://mattermost.atlassian.net/browse/RN-274
https://mattermost.atlassian.net/browse/RN-277

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator