### PR TITLE
RN-281 Fix GM channel info memberCount

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -265,6 +265,7 @@ class ChannelInfo extends PureComponent {
                         creator={currentChannelCreatorName}
                         displayName={currentChannel.display_name}
                         header={currentChannel.header}
+                        memberCount={currentChannelMemberCount}
                         navigator={navigator}
                         purpose={currentChannel.purpose}
                         status={status}

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -28,7 +28,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
         status: PropTypes.string,
         theme: PropTypes.object.isRequired,
         type: PropTypes.string.isRequired
-    }
+    };
 
     render() {
         const {


### PR DESCRIPTION
#### Summary
The channel info for GM's was showing `NaN` as the amount of members of the GM cause a property was removed by mistake.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-281