### PR TITLE
Fix sso login onMessage handler

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -24,7 +24,7 @@ import {markChannelAsRead} from 'mattermost-redux/actions/channels';
 import {logError} from 'mattermost-redux/actions/errors';
 import {logout} from 'mattermost-redux/actions/users';
 import {close as closeWebSocket} from 'mattermost-redux/actions/websocket';
-import {Client4} from 'mattermost-redux/client';
+import {Client, Client4} from 'mattermost-redux/client';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {goToNotification, loadConfigAndLicense, queueNotification, setStatusBarHeight, purgeOfflineStore} from 'app/actions/views/root';
@@ -137,6 +137,8 @@ export default class Mattermost {
     handleReset = () => {
         const {dispatch, getState} = store;
         Client4.serverVersion = '';
+        Client.serverVersion = '';
+        Client.token = null;
         PushNotifications.cancelAllLocalNotifications();
         setServerVersion('')(dispatch, getState);
         this.startApp('fade');

--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -42,7 +42,8 @@ class SSO extends PureComponent {
 
         this.state = {
             error: null,
-            renderWebView: false
+            renderWebView: false,
+            onMessage: props.ssoType === ViewTypes.GITLAB ? this.onMessage : null
         };
 
         switch (props.ssoType) {
@@ -102,10 +103,9 @@ class SSO extends PureComponent {
                 const {
                     id,
                     message,
-                    request_id: rId,
                     status_code: statusCode
                 } = response;
-                if (rId && id && message && statusCode !== 200) {
+                if (id && message && statusCode !== 200) {
                     this.setState({error: message});
                 }
             }
@@ -115,9 +115,18 @@ class SSO extends PureComponent {
     };
 
     onNavigationStateChange = (navState) => {
-        const {url} = navState;
+        const {url, navigationType} = navState;
+
+        if (url.includes(this.completedUrl) && navigationType === 'formsubmit') {
+            this.setState({onMessage: this.onMessage});
+        }
+    };
+
+    onLoadEnd = (event) => {
+        const url = event.nativeEvent.url;
 
         if (url.includes(this.completedUrl)) {
+            // this.setState({onMessage: this.onMessage});
             CookieManager.get(this.props.serverUrl, (err, res) => {
                 const token = res.MMAUTHTOKEN;
 
@@ -166,8 +175,9 @@ class SSO extends PureComponent {
                     onNavigationStateChange={this.onNavigationStateChange}
                     onShouldStartLoadWithRequest={() => true}
                     renderLoading={() => (<Loading/>)}
-                    onMessage={this.onMessage}
+                    onMessage={this.state.onMessage}
                     injectedJavaScript={jsCode}
+                    onLoadEnd={this.onLoadEnd}
                 />
             );
         }

--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -126,7 +126,6 @@ class SSO extends PureComponent {
         const url = event.nativeEvent.url;
 
         if (url.includes(this.completedUrl)) {
-            // this.setState({onMessage: this.onMessage});
             CookieManager.get(this.props.serverUrl, (err, res) => {
                 const token = res.MMAUTHTOKEN;
 


### PR DESCRIPTION
#### Summary
When logging in using SSO, OKTA was causing [this error](https://github.com/facebook/react-native/issues/10865) because they use `postMessage` in their login page this PR is a workaround for that.

This PR also fixes the cleanup of the token and serverVersion for the APIv3 Client used for pinging the server, this getting rid of the `[EROR] Invalid session err=GetSession: api.context.invalid_token.error` and enable the ability to re-login
