### PR TITLE
RN-295 Make search results scroll after a period of time

### DIFF
--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -92,10 +92,12 @@ class Search extends Component {
         const recentLenght = recent.length;
 
         if (posts.length && !this.state.isFocused) {
-            this.refs.list.getWrapperRef().getListRef().scrollToOffset({
-                animated: true,
-                offset: SECTION_HEIGHT + (recentLenght * RECENT_LABEL_HEIGHT) + ((recentLenght - 1) * RECENT_SEPARATOR_HEIGHT)
-            });
+            setTimeout(() => {
+                this.refs.list.getWrapperRef().getListRef().scrollToOffset({
+                    animated: true,
+                    offset: SECTION_HEIGHT + (recentLenght * RECENT_LABEL_HEIGHT) + ((recentLenght - 1) * RECENT_SEPARATOR_HEIGHT)
+                });
+            }, 200);
         }
     }
 


### PR DESCRIPTION
#### Summary
When using the Sticky Section Header functionality from the **RN SectionList** the section will stay at one position and then jump to the right position when it finishes rendering, so I'm adding a little timeout to give it time to render before scrolling automatically to the section

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-295
