### PR TITLE
Use post retry actions to avoid missing messages

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -12,7 +12,7 @@ import {
     selectChannel,
     leaveChannel as serviceLeaveChannel
 } from 'mattermost-redux/actions/channels';
-import {getPosts, getPostsWithRetry, getPostsBefore, getPostsSince, getPostsSinceWithRetry, getPostThread} from 'mattermost-redux/actions/posts';
+import {getPosts, getPostsWithRetry, getPostsBefore, getPostsSinceWithRetry, getPostThread} from 'mattermost-redux/actions/posts';
 import {getFilesForPost} from 'mattermost-redux/actions/files';
 import {savePreferences, deletePreferences} from 'mattermost-redux/actions/preferences';
 import {getTeamMembersByIds} from 'mattermost-redux/actions/teams';
@@ -133,25 +133,6 @@ export function loadProfilesAndTeamMembersForDMSidebar(teamId) {
         if (actions.length) {
             dispatch(batchActions(actions), getState);
         }
-    };
-}
-
-export function loadPostsIfNecessary(channelId) {
-    return async (dispatch, getState) => {
-        const state = getState();
-        const {posts, postsInChannel} = state.entities.posts;
-
-        const postsIds = postsInChannel[channelId];
-
-        // Get the first page of posts if it appears we haven't gotten it yet, like the webapp
-        if (!postsIds || postsIds.length < ViewTypes.POST_VISIBILITY_CHUNK_SIZE) {
-            return getPosts(channelId)(dispatch, getState);
-        }
-
-        const postsForChannel = postsIds.map((id) => posts[id]);
-        const latestPostTime = getLastCreateAt(postsForChannel);
-
-        return getPostsSince(channelId, latestPostTime)(dispatch, getState);
     };
 }
 
@@ -345,14 +326,6 @@ export function unmarkFavorite(channelId) {
     };
 }
 
-export function refreshChannel(channelId) {
-    return async (dispatch, getState) => {
-        dispatch(setChannelRefreshing());
-        await getPosts(channelId)(dispatch, getState);
-        dispatch(setChannelRefreshing(false));
-    };
-}
-
 export function refreshChannelWithRetry(channelId) {
     return (dispatch, getState) => {
         getPostsWithRetry(channelId)(dispatch, getState);
@@ -373,13 +346,6 @@ export function setChannelLoading(loading = true) {
     return {
         type: ViewTypes.SET_CHANNEL_LOADER,
         loading
-    };
-}
-
-export function setChannelRefreshing(refreshing = true) {
-    return {
-        type: ViewTypes.SET_CHANNEL_REFRESHING,
-        refreshing
     };
 }
 

--- a/app/components/post_list/index.js
+++ b/app/components/post_list/index.js
@@ -4,18 +4,14 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {refreshChannel} from 'app/actions/views/channel';
+import {refreshChannelWithRetry} from 'app/actions/views/channel';
 import {getTheme} from 'app/selectors/preferences';
 
 import PostList from './post_list';
 
 function mapStateToProps(state, ownProps) {
-    const {loading, refreshing} = state.views.channel;
-
     return {
         ...ownProps,
-        channelIsLoading: loading,
-        refreshing,
         theme: getTheme(state)
     };
 }
@@ -23,7 +19,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            refreshChannel
+            refreshChannelWithRetry
         }, dispatch)
     };
 }

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -22,7 +22,7 @@ const LOAD_MORE_POSTS = 'load-more-posts';
 export default class PostList extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            refreshChannel: PropTypes.func.isRequired
+            refreshChannelWithRetry: PropTypes.func.isRequired
         }).isRequired,
         channel: PropTypes.object,
         channelIsLoading: PropTypes.bool.isRequired,
@@ -79,7 +79,7 @@ export default class PostList extends PureComponent {
         const {actions, channel} = this.props;
 
         if (Object.keys(channel).length) {
-            actions.refreshChannel(channel.id);
+            actions.refreshChannelWithRetry(channel.id);
         }
     };
 

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -36,7 +36,6 @@ const ViewTypes = keyMirror({
     ADD_FILE_TO_FETCH_CACHE: null,
 
     SET_CHANNEL_LOADER: null,
-    SET_CHANNEL_REFRESHING: null,
     SET_CHANNEL_DISPLAY_NAME: null,
 
     POST_TOOLTIP_VISIBLE: null,

--- a/app/initial_state.js
+++ b/app/initial_state.js
@@ -251,7 +251,6 @@ const state = {
         channel: {
             drafts: {},
             loading: false,
-            refreshing: false,
             tooltipVisible: false
         },
         connection: true,

--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -181,15 +181,6 @@ function loading(state = false, action) {
     }
 }
 
-function refreshing(state = false, action) {
-    switch (action.type) {
-    case ViewTypes.SET_CHANNEL_REFRESHING:
-        return action.refreshing;
-    default:
-        return state;
-    }
-}
-
 function tooltipVisible(state = false, action) {
     switch (action.type) {
     case ViewTypes.POST_TOOLTIP_VISIBLE:
@@ -245,7 +236,6 @@ export default combineReducers({
     displayName,
     drafts,
     loading,
-    refreshing,
     tooltipVisible,
     postVisibility,
     loadingPosts

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -60,8 +60,12 @@ class ChannelPostList extends PureComponent {
     }
 
     componentDidMount() {
+        const {channel, posts, channelRefreshingFailed} = this.props;
         this.mounted = true;
         this.loadPosts(this.props.channel.id);
+        if (posts.length || channel.total_msg_count === 0 || channelRefreshingFailed) {
+            this.channelLoaded();
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -72,16 +76,16 @@ class ChannelPostList extends PureComponent {
         if (currentChannelId !== nextChannelId) {
             this.setState({
                 loaderOpacity: new Animated.Value(1)
+            }, () => {
+                if (nextPosts.length || nextChannel.total_msg_count === 0 || nextChannelRefreshingFailed) {
+                    this.channelLoaded();
+                }
             });
         }
 
         if (currentChannel.id !== nextChannel.id) {
             // Load the posts when the channel actually changes
             this.loadPosts(nextChannel.id);
-        }
-
-        if ((nextPosts.length) || nextChannel.total_msg_count === 0 || nextChannelRefreshingFailed) {
-            this.channelLoaded();
         }
 
         if (nextChannelRefreshingFailed && this.state.channelLoaded && nextPosts.length) {
@@ -115,9 +119,9 @@ class ChannelPostList extends PureComponent {
         const value = show ? 38 : 0;
         Animated.timing(this.state.retryMessageHeight, {
             toValue: value,
-            duration: 300
+            duration: 350
         }).start();
-    }
+    };
 
     goToThread = (post) => {
         const {actions, channel, intl, navigator, theme} = this.props;

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -8,6 +8,7 @@ import {
     Animated,
     Dimensions,
     Platform,
+    StyleSheet,
     View
 } from 'react-native';
 
@@ -237,7 +238,7 @@ class ChannelPostList extends PureComponent {
                 >
                     <ChannelLoader theme={theme}/>
                 </AnimatedView>
-                <AnimatedView style={{position: 'absolute', top: 0, height: retryMessageHeight, width: deviceWidth, backgroundColor: '#fb8000', flexDirection: 'row', alignItems: 'center', paddingHorizontal: 10}}>
+                <AnimatedView style={[style.refreshIndicator, {height: retryMessageHeight}]}>
                     <FormattedText
                         id='mobile.retry_message'
                         defaultMessage='Refreshing messages failed. Pull up to try again.'
@@ -248,5 +249,17 @@ class ChannelPostList extends PureComponent {
         );
     }
 }
+
+const style = StyleSheet.create({
+    refreshIndicator: {
+        alignItems: 'center',
+        backgroundColor: '#fb8000',
+        flexDirection: 'row',
+        paddingHorizontal: 10,
+        position: 'absolute',
+        top: 0,
+        width: deviceWidth
+    }
+});
 
 export default injectIntl(ChannelPostList);

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -80,7 +80,7 @@ class ChannelPostList extends PureComponent {
             this.loadPosts(nextChannel.id);
         }
 
-        if ((nextPosts.length && nextChannel.id === currentChannel.id) || nextChannel.total_msg_count === 0 || nextChannelRefreshingFailed) {
+        if ((nextPosts.length) || nextChannel.total_msg_count === 0 || nextChannelRefreshingFailed) {
             this.channelLoaded();
         }
 
@@ -112,7 +112,7 @@ class ChannelPostList extends PureComponent {
     };
 
     toggleRetryMessage = (show = true) => {
-        const value = show ? 40 : 0;
+        const value = show ? 38 : 0;
         Animated.timing(this.state.retryMessageHeight, {
             toValue: value,
             duration: 300
@@ -185,7 +185,7 @@ class ChannelPostList extends PureComponent {
             theme
         } = this.props;
 
-        const {channelLoaded, loaderOpacity, retryMessageHeight} = this.state;
+        const {loaderOpacity, retryMessageHeight} = this.state;
 
         let component;
         if (!posts.length && channelRefreshingFailed) {
@@ -195,7 +195,7 @@ class ChannelPostList extends PureComponent {
                     theme={theme}
                 />
             );
-        } else if ((channelIsLoading || !channelLoaded) && !channelIsRefreshing && !loadingPosts) {
+        } else if (channelIsLoading) {
             component = <ChannelLoader theme={theme}/>;
         } else {
             component = (

--- a/app/screens/channel/channel_post_list/index.js
+++ b/app/screens/channel/channel_post_list/index.js
@@ -20,7 +20,9 @@ function makeMapStateToProps() {
         const channelId = ownProps.channel.id;
         const {getPosts, getPostsRetryAttempts, getPostsSince, getPostsSinceRetryAttempts} = state.requests.posts;
         const posts = getPostsInChannel(state, channelId) || [];
-        const networkOnline = state.offline.online;
+        const {websocket: websocketRequest} = state.requests.general;
+        const {connection} = state.views;
+        const networkOnline = connection && websocketRequest.status === RequestStatus.SUCCESS;
 
         let getPostsStatus;
         if (getPostsRetryAttempts > 0) {

--- a/app/screens/channel/channel_post_list/index.js
+++ b/app/screens/channel/channel_post_list/index.js
@@ -20,6 +20,7 @@ function makeMapStateToProps() {
         const channelId = ownProps.channel.id;
         const {getPosts, getPostsRetryAttempts, getPostsSince, getPostsSinceRetryAttempts} = state.requests.posts;
         const posts = getPostsInChannel(state, channelId) || [];
+        const networkOnline = state.offline.online;
 
         let getPostsStatus;
         if (getPostsRetryAttempts > 0) {
@@ -28,16 +29,23 @@ function makeMapStateToProps() {
             getPostsStatus = getPostsSince.status;
         }
 
+        let channelIsRefreshing = getPostsStatus === RequestStatus.STARTED;
+        let channelRefreshingFailed = getPostsStatus === RequestStatus.FAILURE;
+        if (!networkOnline) {
+            channelIsRefreshing = false;
+            channelRefreshingFailed = true;
+        }
+
         return {
             channelIsLoading: state.views.channel.loading,
-            channelIsRefreshing: getPostsStatus === RequestStatus.STARTED,
-            channelRefreshingFailed: getPostsStatus === RequestStatus.FAILURE,
+            channelIsRefreshing,
+            channelRefreshingFailed,
             currentChannelId: getCurrentChannelId(state),
             posts,
             postVisibility: state.views.channel.postVisibility[channelId],
             loadingPosts: state.views.channel.loadingPosts[channelId],
             myMember: getMyCurrentChannelMembership(state),
-            networkOnline: state.offline.online,
+            networkOnline,
             theme: getTheme(state),
             ...ownProps
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4791,7 +4791,7 @@ redux-devtools-instrument@^1.3.3:
 
 "redux-offline@git+https://github.com/enahum/redux-offline.git":
   version "1.1.4"
-  resolved "git+https://github.com/enahum/redux-offline.git#454d32a14ae50b9727bccbcdd295cad3cd037335"
+  resolved "git+https://github.com/enahum/redux-offline.git#3907341aa13fe913ec02a939af76e381d369a91d"
   dependencies:
     redux-persist "^4.5.0"
 


### PR DESCRIPTION
#### Summary
This PR takes advantage of the post retry actions in the redux lib. It will show a loading spinner if the first request fails and then shows a failure message above the post list instructing the user to pull up to refresh the channel if all requests fail. If the channel has not been cached and the requests fail the retry post loading component is shown.