### PR TITLE
PLT-6924 Added setting to disable mobile file uploads

### DIFF
--- a/app/components/post_textbox/index.js
+++ b/app/components/post_textbox/index.js
@@ -8,7 +8,7 @@ import {userTyping} from 'mattermost-redux/actions/websocket';
 
 import {handleClearFiles, handleRemoveLastFile, handleUploadFiles} from 'app/actions/views/file_upload';
 import {getTheme} from 'app/selectors/preferences';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {canUploadFilesOnMobile} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getUsersTyping} from 'mattermost-redux/selectors/entities/typing';
 
@@ -17,8 +17,8 @@ import PostTextbox from './post_textbox';
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
+        canUploadFiles: canUploadFilesOnMobile(state),
         channelIsLoading: state.views.channel.loading,
-        config: getConfig(state),
         currentUserId: getCurrentUserId(state),
         typing: getUsersTyping(state),
         theme: getTheme(state),

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -38,9 +38,9 @@ class PostTextbox extends PureComponent {
             handleUploadFiles: PropTypes.func.isRequired,
             userTyping: PropTypes.func.isRequired
         }).isRequired,
+        canUploadFiles: PropTypes.bool.isRequired,
         channelId: PropTypes.string.isRequired,
         channelIsLoading: PropTypes.bool.isRequired,
-        config: PropTypes.object.isRequired,
         currentUserId: PropTypes.string.isRequired,
         files: PropTypes.array,
         intl: intlShape.isRequired,
@@ -432,7 +432,13 @@ class PostTextbox extends PureComponent {
     }
 
     render() {
-        const {channelIsLoading, config, intl, theme, value} = this.props;
+        const {
+            canUploadFiles,
+            channelIsLoading,
+            intl,
+            theme,
+            value
+        } = this.props;
 
         const style = getStyleSheet(theme);
         const textInputHeight = Math.min(this.state.contentHeight, MAX_CONTENT_HEIGHT);
@@ -448,7 +454,7 @@ class PostTextbox extends PureComponent {
 
         let fileUpload = null;
         const inputContainerStyle = [style.inputContainer];
-        if (!config.EnableFileAttachments || config.EnableFileAttachments === 'true') {
+        if (canUploadFiles) {
             fileUpload = (
                 <TouchableOpacity
                     onPress={this.showFileAttachmentOptions}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,7 +3645,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/9797cb8bd8fa61252336a7c6150bd364f7ca28b1"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/5b676e2737c526617cd9b4e9c7dbb16f3615e269"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
I tested this with both a master server and a 3.10 server to make sure it behaves correctly with older servers. It needs https://github.com/mattermost/mattermost-redux/pull/213 to be merged first so that yarn.lock can be updated

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6924

#### Device Information
This PR was tested on: iOS Simulator (iOS 10.3)