### PR TITLE
RN-174 Added support for strikethrough text in markdown

### DIFF
--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -79,6 +79,7 @@ export default class Markdown extends PureComponent {
 
                 emph: Renderer.forwardChildren,
                 strong: Renderer.forwardChildren,
+                del: Renderer.forwardChildren,
                 code: this.renderCodeSpan,
                 link: this.renderLink,
                 image: this.renderImage,

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -14,6 +14,9 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
         strong: {
             fontWeight: 'bold'
         },
+        del: {
+            textDecorationLine: 'line-through'
+        },
         link: {
             color: theme.linkColor
         },

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "private": true,
   "dependencies": {
     "babel-polyfill": "6.23.0",
-    "commonmark": "hmhealey/commonmark.js#57e6f0244a474a0e7d990f868531af5d98a57316",
-    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#11bf3a089900eda6f3e951f8b8c80663cff4d6a3",
+    "commonmark": "hmhealey/commonmark.js#3139568442da83c5520685dc033eaf417dada2c0",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#c5d00343664c89da40d5a2ffa8b083e7cc1615d7",
     "deep-equal": "1.0.1",
     "intl": "1.2.5",
     "mattermost-redux": "mattermost/mattermost-redux#master",


### PR DESCRIPTION
commonmark.js changes: https://github.com/hmhealey/commonmark.js/compare/57e6f0244a474a0e7d990f868531af5d98a57316...3139568442da83c5520685dc033eaf417dada2c0
commonmark-react-renderer changes: https://github.com/hmhealey/commonmark-react-renderer/commit/09d44ca4f64755e9ebf4616de676b34fc5935cd8

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-174

#### Checklist
- Added or updated unit tests (required for all new features)
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
<img width="388" alt="screen shot 2017-08-03 at 1 33 05 pm" src="https://user-images.githubusercontent.com/3277310/28934815-507247f8-7850-11e7-8557-372700a86204.png">
