### PR TITLE
RN-305/RN-310 Allow tapping buttons on post and DM lists without closing keyboard

### DIFF
--- a/app/components/custom_section_list.js
+++ b/app/components/custom_section_list.js
@@ -248,6 +248,7 @@ export default class CustomSectionList extends React.PureComponent {
                 sections={this.state.sections}
                 keyExtractor={this.props.keyExtractor}
                 renderItem={this.renderItem}
+                keyboardShouldPersistTaps='handled'
             />
         );
     }

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -4,6 +4,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
+    Keyboard,
     View,
     TouchableOpacity
 } from 'react-native';
@@ -69,6 +70,7 @@ export default class FileAttachmentList extends Component {
 
     handlePreviewPress = (file) => {
         this.props.hideOptionsContext();
+        Keyboard.dismiss();
         preventDoubleTap(this.goToImagePreview, this, this.props.postId, file.id);
     };
 

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -176,6 +176,7 @@ export default class PostList extends PureComponent {
                 {...refreshControl}
                 renderItem={this.renderItem}
                 theme={theme}
+                keyboardShouldPersistTaps='handled'
             />
         );
     }


### PR DESCRIPTION
Despite not being included in the documentation, both FlatList and Section list support the keyboardShouldPersistTaps prop from ScrollView

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-305
https://mattermost.atlassian.net/browse/RN-310

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator
