### PR TITLE
Implement new image preview components

### DIFF
--- a/app/screens/image_preview/image_view.ios.js
+++ b/app/screens/image_preview/image_view.ios.js
@@ -1,0 +1,89 @@
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {
+    Animated,
+    ScrollView
+} from 'react-native';
+
+const {Image: AnimatedImage} = Animated;
+
+export default class ImageView extends PureComponent {
+    static propTypes = {
+        maximumZoomScale: PropTypes.number,
+        minimumZoomScale: PropTypes.number,
+        onZoom: PropTypes.func,
+        showsHorizontalScrollIndicator: PropTypes.bool,
+        showsVerticalScrollIndicator: PropTypes.bool,
+        wrapperHeight: PropTypes.number.isRequired,
+        wrapperWidth: PropTypes.number.isRequired
+    }
+
+    static defaultProps = {
+        maximumZoomScale: 3,
+        minimumZoomScale: 1,
+        onZoom: () => true,
+        showsHorizontalScrollIndicator: false,
+        showsVerticalScrollIndicator: false
+    }
+
+    attachScrollView = (c) => {
+        if (c) {
+            this.scrollView = c;
+            this.scrollResponder = c.getScrollResponder();
+        }
+    }
+
+    setZoom = (zoom, x, y) => {
+        const rect = {};
+        if (zoom) {
+            rect.x = x;
+            rect.y = y;
+        } else {
+            rect.height = this.props.wrapperHeight;
+            rect.width = this.props.wrapperWidth;
+        }
+
+        this.scrollResponder.scrollResponderZoomTo({
+            ...rect,
+            animated: true
+        });
+    }
+
+    handleScroll = (evt) => {
+        const {nativeEvent} = evt;
+
+        clearTimeout(this.scrollEventTimeout);
+        this.scrollEventTimeout = setTimeout(() => {
+            this.props.onZoom(nativeEvent.zoomScale > 1);
+        }, 100);
+    }
+
+    render() {
+        const {
+            maximumZoomScale,
+            minimumZoomScale,
+            showsHorizontalScrollIndicator,
+            showsVerticalScrollIndicator,
+            ...otherProps
+        } = this.props;
+
+        return (
+            <ScrollView
+                ref={this.attachScrollView}
+                alwaysBounceHorizontal={false}
+                alwaysBounceVertical={false}
+                bounces={false}
+                contentContainerStyle={{alignItems: 'center', justifyContent: 'center'}}
+                centerContent={true}
+                maximumZoomScale={maximumZoomScale}
+                minimumZoomScale={minimumZoomScale}
+                onScroll={this.handleScroll}
+                scrollEventThrottle={16}
+                showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
+                showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+            >
+                <AnimatedImage {...otherProps}/>
+            </ScrollView>
+        );
+    }
+}

--- a/app/screens/image_preview/previewer.js
+++ b/app/screens/image_preview/previewer.js
@@ -1,0 +1,277 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {
+    ActivityIndicator,
+    Animated,
+    PanResponder,
+    Platform,
+    View,
+    StyleSheet
+} from 'react-native';
+import {Client} from 'mattermost-redux/client';
+
+import imageIcon from 'assets/images/icons/image.png';
+
+import ImageView from './image_view';
+
+const {View: AnimatedView} = Animated;
+
+const DOUBLE_CLICK_THRESHOLD = 250;
+
+export default class Previewer extends Component {
+    static propTypes = {
+        addFileToFetchCache: PropTypes.func.isRequired,
+        fetchCache: PropTypes.object.isRequired,
+        file: PropTypes.object,
+        gutter: PropTypes.number,
+        imageHeight: PropTypes.number,
+        imageWidth: PropTypes.number,
+        onImageTap: PropTypes.func,
+        onImageDoubleTap: PropTypes.func,
+        onZoom: PropTypes.func,
+        shrink: PropTypes.bool,
+        wrapperHeight: PropTypes.number,
+        wrapperWidth: PropTypes.number
+    };
+
+    static defaultProps = {
+        fadeInOnLoad: false,
+        gutter: 20,
+        loading: false,
+        onImageTap: () => true,
+        onImageDoubleTap: () => true,
+        onZoom: () => true
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            imageHeight: new Animated.Value(props.imageHeight),
+            imageWidth: new Animated.Value(props.imageWidth),
+            opacity: new Animated.Value(0),
+            requesting: true,
+            retry: 0,
+            zooming: false
+        };
+    }
+
+    componentWillMount() {
+        this.panResponder = PanResponder.create({
+            onStartShouldSetPanResponderCapture: (evt, gestureState) => {
+                const {numberActiveTouches} = gestureState;
+                if (numberActiveTouches === 1 && !this.state.isZooming) {
+                    return true;
+                } else if (numberActiveTouches === 1) {
+                    this.handleResponderRelease(evt);
+                }
+
+                return false;
+            },
+            onPanResponderGrant: () => {
+                return;
+            },
+            onPanResponderTerminate: () => {
+                return;
+            },
+            onShouldBlockNativeResponder: () => false
+        });
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (this.props.shrink && !nextProps.shrink) {
+            this.setShrink();
+        } else if (!this.props.shrink && nextProps.shrink) {
+            this.setShrink(true);
+        }
+    }
+
+    setShrink = (shrink = false) => {
+        const {gutter, imageHeight, imageWidth} = this.props;
+
+        let height = imageHeight;
+        let width = imageWidth;
+        const duration = 150;
+        if (shrink) {
+            height = height - gutter;
+            width = width - gutter;
+        }
+
+        const animations = [
+            Animated.timing(this.state.imageWidth, {
+                toValue: width,
+                duration
+            })
+        ];
+
+        if (Platform.OS === 'android') {
+            animations.push(
+                Animated.timing(this.state.imageHeight, {
+                    toValue: height,
+                    duration
+                })
+            );
+        }
+
+        Animated.parallel(animations).start();
+    }
+
+    handleResponderRelease = (evt) => {
+        clearTimeout(this.singleTap);
+        let cancelSingleTap = false;
+        if (this.lastTap && Date.now() - this.lastTap < DOUBLE_CLICK_THRESHOLD) {
+            cancelSingleTap = true;
+        } else {
+            this.lastTap = Date.now();
+        }
+
+        if (cancelSingleTap) {
+            const {nativeEvent} = evt;
+            const x = nativeEvent.locationX;
+            const y = nativeEvent.locationY;
+
+            cancelSingleTap = false;
+            this.lastTap = null;
+
+            this.props.onImageDoubleTap(x, y);
+        } else if (!this.state.isZooming) {
+            this.singleTap = setTimeout(() => {
+                this.props.onImageTap();
+            }, DOUBLE_CLICK_THRESHOLD);
+        }
+    }
+
+    handleLoadError = () => {
+        if (this.state.retry < 4) {
+            setTimeout(() => {
+                this.setState({
+                    retry: (this.state.retry + 1),
+                    timestamp: Date.now()
+                });
+            }, 300);
+        }
+    };
+
+    handleLoad = () => {
+        this.setState({
+            requesting: false
+        });
+
+        Animated.timing(this.state.opacity, {
+            toValue: 1,
+            duration: 300
+        }).start(() => {
+            this.props.addFileToFetchCache(this.handleGetImageURL());
+        });
+    };
+
+    handleLoadStart = () => {
+        this.setState({
+            requesting: true
+        });
+    };
+
+    handleGetImageURL = () => {
+        const {file} = this.props;
+
+        return Client.getFilePreviewUrl(file.id, this.state.timestamp);
+    };
+
+    attachImageView = (c) => {
+        this.imageView = c;
+    }
+
+    handleZoom = (zoom) => {
+        this.setState({
+            isZooming: zoom
+        });
+
+        this.props.onZoom(zoom);
+    }
+
+    toggleZoom = (x, y) => {
+        const zoom = !this.state.isZooming;
+
+        this.imageView.setZoom(zoom, x, y);
+        this.handleZoom(zoom);
+    }
+
+    render() {
+        const {
+            fetchCache,
+            imageHeight,
+            imageWidth,
+            wrapperHeight,
+            wrapperWidth
+        } = this.props;
+
+        let source = {};
+        let usingIcon = false;
+        if (this.state.retry === 4) {
+            source = imageIcon;
+            usingIcon = true;
+        } else {
+            source = {uri: this.handleGetImageURL()};
+        }
+
+        let isInFetchCache = fetchCache[source.uri];
+        if (usingIcon) {
+            isInFetchCache = true;
+        }
+
+        const imageComponentLoaders = {
+            onError: (isInFetchCache) ? null : this.handleLoadError,
+            onLoadStart: isInFetchCache ? null : this.handleLoadStart,
+            onLoad: isInFetchCache ? null : this.handleLoad
+        };
+
+        const opacity = isInFetchCache ? 1 : this.state.opacity;
+
+        return (
+            <View
+                {...this.panResponder.panHandlers}
+                onResponderRelease={this.handleResponderRelease}
+                style={[style.fileImageWrapper, {height: wrapperHeight, width: wrapperWidth}]}
+            >
+                <AnimatedView style={{height: imageHeight, width: this.state.imageWidth, backgroundColor: '#000', opacity}}>
+                    <ImageView
+                        ref={this.attachImageView}
+                        source={source}
+                        minimumZoomScale={1}
+                        maximumZoomScale={3}
+                        onZoom={this.handleZoom}
+                        resizeMode='contain'
+                        imageHeight={imageHeight}
+                        imageWidth={imageWidth}
+                        style={{height: this.state.imageHeight, width: this.state.imageWidth}}
+                        wrapperHeight={wrapperHeight}
+                        wrapperWidth={wrapperWidth}
+                        {...imageComponentLoaders}
+                    />
+                </AnimatedView>
+                {(!isInFetchCache && this.state.requesting) &&
+                <View style={[style.loaderContainer, {backgroundColor: 'white'}]}>
+                    <ActivityIndicator size='small'/>
+                </View>
+                }
+            </View>
+        );
+    }
+}
+
+const style = StyleSheet.create({
+    fileImageWrapper: {
+        alignItems: 'center',
+        justifyContent: 'center'
+    },
+    loaderContainer: {
+        position: 'absolute',
+        height: '100%',
+        width: '100%',
+        alignItems: 'center',
+        justifyContent: 'center'
+    }
+});

--- a/app/screens/image_preview/previewer.js
+++ b/app/screens/image_preview/previewer.js
@@ -147,9 +147,11 @@ export default class Previewer extends Component {
     handleLoadError = () => {
         if (this.state.retry < 4) {
             setTimeout(() => {
-                this.setState({
-                    retry: (this.state.retry + 1),
-                    timestamp: Date.now()
+                this.setState((prevState) => {
+                    return {
+                        retry: (prevState.retry + 1),
+                        timestamp: Date.now()
+                    };
                 });
             }, 300);
         }


### PR DESCRIPTION
#### Summary
Adds double tap zoom in/out and image gutters to the image preview screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-25

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23