### PR TITLE
Fix empty serverVersion dispatch

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -162,7 +162,7 @@ export default class Mattermost {
                     {cancelable: false}
                 );
             } else {
-                setServerVersion('')(dispatch, getState);
+                setServerVersion(serverVersion)(dispatch, getState);
                 const data = await loadConfigAndLicense(serverVersion)(dispatch, getState);
                 this.configureAnalytics(data.config);
             }


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the serverVersion is set `''` when the config is changed.