### PR TITLE
RN-177 Updated commonmark.js to match web app list behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "analytics-react-native": "1.1.0",
     "babel-polyfill": "6.23.0",
-    "commonmark": "hmhealey/commonmark.js#3139568442da83c5520685dc033eaf417dada2c0",
+    "commonmark": "hmhealey/commonmark.js#9f33c90b5c82adfef30b87c7cd15aea2e2764b51",
     "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#c5d00343664c89da40d5a2ffa8b083e7cc1615d7",
     "deep-equal": "1.0.1",
     "intl": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,9 +1529,9 @@ commonmark-react-renderer@hmhealey/commonmark-react-renderer#11bf3a089900eda6f3e
     pascalcase "^0.1.1"
     xss-filters "^1.2.6"
 
-commonmark@hmhealey/commonmark.js#57e6f0244a474a0e7d990f868531af5d98a57316:
+commonmark@hmhealey/commonmark.js#9f33c90b5c82adfef30b87c7cd15aea2e2764b51:
   version "0.27.0"
-  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/57e6f0244a474a0e7d990f868531af5d98a57316"
+  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/9f33c90b5c82adfef30b87c7cd15aea2e2764b51"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"


### PR DESCRIPTION
This changes lists to work like the web app where
```
1. list
not list
```
renders as

1\. list
not list

instead of

1. list
not list

I also ported all the unit tests from https://github.com/mattermost/marked so that we have a full list of missing features and can keep track of any of our other custom behaviour.

commonmark.js changes here: https://github.com/hmhealey/commonmark.js/compare/7500afa285d7488932d7c4f805e6ff57cffeea1a...master

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-177

#### Checklist
- Added or updated unit tests (required for all new features)