### PR TITLE
RN-113/RN-114 Updated markdown styles for lists and code

### DIFF
--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -236,10 +236,13 @@ export default class Markdown extends PureComponent {
         );
     }
 
-    renderListItem = ({children, ...otherProps}) => {
+    renderListItem = ({children, context, ...otherProps}) => {
+        const level = context.filter((type) => type === 'list').length;
+
         return (
             <MarkdownListItem
                 bulletStyle={this.props.baseTextStyle}
+                level={level}
                 {...otherProps}
             >
                 {children}

--- a/app/components/markdown/markdown_list_item.js
+++ b/app/components/markdown/markdown_list_item.js
@@ -18,7 +18,8 @@ export default class MarkdownListItem extends PureComponent {
         startAt: PropTypes.number,
         index: PropTypes.number.isRequired,
         tight: PropTypes.bool,
-        bulletStyle: CustomPropTypes.Style
+        bulletStyle: CustomPropTypes.Style,
+        level: PropTypes.number
     };
 
     static defaultProps = {
@@ -29,13 +30,15 @@ export default class MarkdownListItem extends PureComponent {
         let bullet;
         if (this.props.ordered) {
             bullet = (this.props.startAt + this.props.index) + '. ';
+        } else if (this.props.level % 2 === 0) {
+            bullet = '◦';
         } else {
-            bullet = '• ';
+            bullet = '•';
         }
 
         return (
             <View style={style.container}>
-                <View>
+                <View style={style.bullet}>
                     <Text style={this.props.bulletStyle}>
                         {bullet}
                     </Text>
@@ -49,6 +52,9 @@ export default class MarkdownListItem extends PureComponent {
 }
 
 const style = StyleSheet.create({
+    bullet: {
+        width: 15
+    },
     container: {
         flexDirection: 'row',
         alignItems: 'flex-start'

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -5,7 +5,7 @@ import {Platform, StyleSheet} from 'react-native';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
-    const codeFont = Platform.OS === 'ios' ? 'Courier New' : 'monospace';
+    const codeFont = Platform.OS === 'ios' ? 'Menlo' : 'monospace';
 
     return StyleSheet.create({
         emph: {
@@ -58,10 +58,8 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
         },
         code: {
             alignSelf: 'center',
-            backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
-            fontFamily: codeFont,
-            paddingHorizontal: 4,
-            paddingVertical: 2
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.07),
+            fontFamily: codeFont
         },
         codeBlock: {
             fontFamily: codeFont
@@ -78,7 +76,7 @@ export const getMarkdownBlockStyles = makeStyleSheetFromTheme((theme) => {
             marginTop: 6
         },
         codeBlock: {
-            backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.07),
             borderRadius: 4,
             paddingHorizontal: 4,
             paddingVertical: 2


### PR DESCRIPTION
@asaadmahmood For the code style, we can't apply padding or margin to inline text, so those stayed the same, but I updated font on iOS. There's not many selections for font on Android, so it's the same as it was before.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-113
https://mattermost.atlassian.net/browse/RN-114

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
<img width="393" alt="screen shot 2017-08-11 at 4 41 18 pm" src="https://user-images.githubusercontent.com/3277310/29231134-0c769c38-7eb4-11e7-9d4f-72c6f3e27c34.png">

