### PR TITLE
Changed makeStyleSheetFromTheme to take a function that returns a plain object

### DIFF
--- a/app/components/autocomplete/at_mention/at_mention.js
+++ b/app/components/autocomplete/at_mention/at_mention.js
@@ -5,7 +5,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     ListView,
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -300,7 +299,7 @@ export default class AtMention extends Component {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         section: {
             justifyContent: 'center',
             paddingLeft: 8,
@@ -368,5 +367,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             flexWrap: 'wrap',
             paddingRight: 8
         }
-    });
+    };
 });

--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -5,7 +5,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     ListView,
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -238,7 +237,7 @@ export default class ChannelMention extends Component {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         section: {
             justifyContent: 'center',
             paddingLeft: 8,
@@ -291,5 +290,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             opacity: 0.6
         }
-    });
+    };
 });

--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -5,7 +5,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     FlatList,
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -135,7 +134,7 @@ export default class EmojiSuggestion extends Component {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         emoji: {
             marginRight: 5
         },
@@ -160,5 +159,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             borderRightWidth: 1,
             borderRightColor: changeOpacity(theme.centerChannelColor, 0.2)
         }
-    });
+    };
 });

--- a/app/components/channel_drawer/channels_list/channel_item.js
+++ b/app/components/channel_drawer/channels_list/channel_item.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     TouchableHighlight,
     Text,
     View
@@ -112,7 +111,7 @@ export default class ChannelItem extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             flexDirection: 'row',
@@ -160,5 +159,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.mentionColor,
             fontSize: 10
         }
-    });
+    };
 });

--- a/app/components/channel_drawer/channels_list/index.js
+++ b/app/components/channel_drawer/channels_list/index.js
@@ -5,7 +5,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     Platform,
-    StyleSheet,
     Text,
     TouchableHighlight,
     View
@@ -245,7 +244,7 @@ class ChannelsList extends Component {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: theme.sidebarBg,
             flex: 1
@@ -401,7 +400,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             textAlign: 'center',
             textAlignVertical: 'center'
         }
-    });
+    };
 });
 
 export default injectIntl(ChannelsList);

--- a/app/components/channel_drawer/teams_list/teams_list.js
+++ b/app/components/channel_drawer/teams_list/teams_list.js
@@ -42,8 +42,7 @@ class TeamsList extends PureComponent {
     constructor(props) {
         super(props);
 
-        MaterialIcon.getImageSource('close', 20, props.theme.sidebarHeaderTextColor).
-        then((source) => {
+        MaterialIcon.getImageSource('close', 20, props.theme.sidebarHeaderTextColor).then((source) => {
             this.closeButton = source;
         });
     }

--- a/app/components/channel_drawer/teams_list/teams_list.js
+++ b/app/components/channel_drawer/teams_list/teams_list.js
@@ -7,7 +7,6 @@ import {
     InteractionManager,
     FlatList,
     Platform,
-    StyleSheet,
     Text,
     TouchableHighlight,
     View
@@ -218,7 +217,7 @@ class TeamsList extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: theme.sidebarBg,
             flex: 1
@@ -328,7 +327,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.mentionColor,
             fontSize: 10
         }
-    });
+    };
 });
 
 export default injectIntl(TeamsList);

--- a/app/components/channel_icon.js
+++ b/app/components/channel_icon.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -127,7 +126,7 @@ export default class ChannelIcon extends React.PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             marginRight: 12,
             alignItems: 'center'
@@ -174,5 +173,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         groupInfo: {
             color: theme.centerChannelColor
         }
-    });
+    };
 });

--- a/app/components/channel_intro/channel_intro.js
+++ b/app/components/channel_intro/channel_intro.js
@@ -300,7 +300,6 @@ class ChannelIntro extends PureComponent {
 
         case General.PRIVATE_CHANNEL:
             return this.buildPrivateChannelContent();
-
         }
     };
 

--- a/app/components/channel_intro/channel_intro.js
+++ b/app/components/channel_intro/channel_intro.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -327,7 +326,7 @@ class ChannelIntro extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         channelTitle: {
             color: theme.centerChannelColor,
             fontSize: 19,
@@ -368,7 +367,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flexWrap: 'wrap',
             justifyContent: 'flex-start'
         }
-    });
+    };
 });
 
 export default injectIntl(ChannelIntro);

--- a/app/components/channel_loader.js
+++ b/app/components/channel_loader.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     View
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
@@ -76,7 +75,7 @@ channelLoader.propTypes = {
 };
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         avatar: {
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
             borderRadius: 16,
@@ -102,5 +101,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             marginLeft: 12,
             flex: 1
         }
-    });
+    };
 });

--- a/app/components/custom_list/channel_list_row/channel_list_row.js
+++ b/app/components/custom_list/channel_list_row/channel_list_row.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -68,7 +67,7 @@ export default class ChannelListRow extends React.PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         titleContainer: {
             alignItems: 'center',
             flexDirection: 'row'
@@ -91,5 +90,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             fontSize: 13,
             color: changeOpacity(theme.centerChannelColor, 0.5)
         }
-    });
+    };
 });

--- a/app/components/custom_list/custom_list_row.js
+++ b/app/components/custom_list/custom_list_row.js
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
-    StyleSheet,
     View
 } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -57,7 +56,7 @@ export default class CustomListRow extends React.PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flexDirection: 'row',
             height: 65,
@@ -91,5 +90,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             backgroundColor: '#378FD2',
             borderWidth: 0
         }
-    });
+    };
 });

--- a/app/components/custom_list/index.js
+++ b/app/components/custom_list/index.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {ListView, Platform, StyleSheet, Text, View} from 'react-native';
+import {ListView, Platform, Text, View} from 'react-native';
 
 import Loading from 'app/components/loading';
 import FormattedText from 'app/components/formatted_text';
@@ -239,7 +239,7 @@ export default class CustomList extends PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         listView: {
             flex: 1,
             backgroundColor: theme.centerChannelBg,
@@ -285,5 +285,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             fontSize: 26,
             color: changeOpacity(theme.centerChannelColor, 0.5)
         }
-    });
+    };
 });

--- a/app/components/custom_list/user_list_row/user_list_row.js
+++ b/app/components/custom_list/user_list_row/user_list_row.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -66,7 +65,7 @@ export default class UserListRow extends React.PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flexDirection: 'row',
             height: 65,
@@ -113,5 +112,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             backgroundColor: '#378FD2',
             borderWidth: 0
         }
-    });
+    };
 });

--- a/app/components/custom_section_list.js
+++ b/app/components/custom_section_list.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import {
     Platform,
     SectionList,
-    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -255,7 +254,7 @@ export default class CustomSectionList extends React.PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         listView: {
             flex: 1,
             backgroundColor: theme.centerChannelBg,
@@ -307,5 +306,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             fontSize: 26,
             color: changeOpacity(theme.centerChannelColor, 0.5)
         }
-    });
+    };
 });

--- a/app/components/error_text.js
+++ b/app/components/error_text.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, Text} from 'react-native';
+import {Text} from 'react-native';
 
 import FormattedText from 'app/components/formatted_text';
 import {getTheme} from 'app/selectors/preferences';
@@ -51,11 +51,11 @@ class ErrorText extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         errorLabel: {
             color: (theme.errorTextColor || '#DA4A4A')
         }
-    });
+    };
 });
 
 function mapStateToProps(state, ownProps) {

--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -6,8 +6,7 @@ import PropTypes from 'prop-types';
 import {
     Text,
     TouchableOpacity,
-    View,
-    StyleSheet
+    View
 } from 'react-native';
 
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
@@ -100,7 +99,7 @@ export default class FileAttachment extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         downloadIcon: {
             color: changeOpacity(theme.centerChannelColor, 0.7),
             marginRight: 5
@@ -135,5 +134,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderWidth: 1,
             borderColor: changeOpacity(theme.centerChannelColor, 0.2)
         }
-    });
+    };
 });

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -127,8 +127,7 @@ class Post extends PureComponent {
 
     handlePostEdit = () => {
         const {intl, navigator, post, theme} = this.props;
-        MaterialIcon.getImageSource('close', 20, theme.sidebarHeaderTextColor).
-        then((source) => {
+        MaterialIcon.getImageSource('close', 20, theme.sidebarHeaderTextColor).then((source) => {
             navigator.showModal({
                 screen: 'EditPost',
                 title: intl.formatMessage({id: 'mobile.edit_post.title', defaultMessage: 'Editing Message'}),
@@ -318,7 +317,6 @@ class Post extends PureComponent {
             </View>
         );
     }
-
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -5,7 +5,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
     Alert,
-    StyleSheet,
     View,
     ViewPropTypes
 } from 'react-native';
@@ -323,7 +322,7 @@ class Post extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: theme.centerChannelBg,
             flexDirection: 'row'
@@ -368,7 +367,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         highlight: {
             backgroundColor: changeOpacity(theme.mentionHighlightBg, 0.5)
         }
-    });
+    };
 });
 
 export default injectIntl(Post);

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -5,7 +5,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
     Platform,
-    StyleSheet,
     TouchableHighlight,
     TouchableOpacity,
     View
@@ -283,7 +282,7 @@ class PostBody extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         message: {
             color: theme.centerChannelColor,
             fontSize: 15
@@ -298,7 +297,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         systemMessage: {
             opacity: 0.6
         }
-    });
+    };
 });
 
 export default injectIntl(PostBody);

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -187,7 +186,7 @@ export default class PostHeader extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         commentedOn: {
             color: changeOpacity(theme.centerChannelColor, 0.65),
             marginBottom: 3,
@@ -242,5 +241,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             marginRight: 5,
             marginBottom: 3
         }
-    });
+    };
 });

--- a/app/components/post_list/date_header.js
+++ b/app/components/post_list/date_header.js
@@ -40,7 +40,7 @@ DateHeader.propTypes = {
 };
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             alignItems: 'center',
             flexDirection: 'row',
@@ -60,7 +60,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 14,
             fontWeight: '600'
         }
-    });
+    };
 });
 
 export default DateHeader;

--- a/app/components/post_list/load_more_posts.js
+++ b/app/components/post_list/load_more_posts.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     TouchableOpacity,
     View,
     ViewPropTypes
@@ -58,7 +57,7 @@ export default class LoadMorePosts extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flexDirection: 'row',
             alignItems: 'center',
@@ -71,5 +70,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontWeight: '600',
             color: theme.linkColor
         }
-    });
+    };
 });

--- a/app/components/post_list/new_messages_divider.js
+++ b/app/components/post_list/new_messages_divider.js
@@ -36,7 +36,7 @@ NewMessagesDivider.propTypes = {
 };
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             alignItems: 'center',
             flexDirection: 'row',
@@ -54,7 +54,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             fontSize: 14,
             color: theme.newMessageSeparator
         }
-    });
+    };
 });
 
 export default NewMessagesDivider;

--- a/app/components/post_list_retry.js
+++ b/app/components/post_list_retry.js
@@ -5,7 +5,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
     Platform,
-    StyleSheet,
     TouchableOpacity,
     View
 } from 'react-native';
@@ -49,7 +48,7 @@ export default class PostListRetry extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         buttonContainer: {
             alignItems: 'center',
             justifyContent: 'center'
@@ -80,5 +79,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             marginTop: 15,
             color: theme.linkColor
         }
-    });
+    };
 });

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -8,7 +8,6 @@ import {
     BackHandler,
     Keyboard,
     Platform,
-    StyleSheet,
     Text,
     TextInput,
     TouchableOpacity,
@@ -527,7 +526,7 @@ class PostTextbox extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         buttonContainer: {
             height: Platform.select({
                 ios: 34,
@@ -609,7 +608,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             backgroundColor: 'transparent'
         }
-    });
+    };
 });
 
 export default injectIntl(PostTextbox, {withRef: true});

--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Image, Platform, StyleSheet, View} from 'react-native';
+import {Image, Platform, View} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
@@ -125,7 +125,7 @@ export default class ProfilePicture extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         statusWrapper: {
             position: 'absolute',
             bottom: 0,
@@ -154,5 +154,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         offlineIcon: {
             borderColor: '#bababa'
         }
-    });
+    };
 });

--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -112,8 +112,8 @@ export default class ProfilePicture extends PureComponent {
                                     borderRadius: (this.props.statusSize - this.props.statusBorderWidth) / 2,
                                     padding: this.props.statusBorderWidth
                                 },
-                                style[this.props.status
-                            ]]}
+                                style[this.props.status]
+                            ]}
                         >
                             {statusIcon}
                         </View>

--- a/app/components/reactions/reaction.js
+++ b/app/components/reactions/reaction.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Text,
     TouchableOpacity
 } from 'react-native';
@@ -47,7 +46,7 @@ export default class Reaction extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         count: {
             color: theme.linkColor,
             marginLeft: 6
@@ -66,5 +65,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             paddingVertical: 2,
             paddingHorizontal: 6
         }
-    });
+    };
 });

--- a/app/components/search_preview/search_preview.js
+++ b/app/components/search_preview/search_preview.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {
     Dimensions,
     Platform,
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -158,7 +157,7 @@ export default class SearchPreview extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             position: 'absolute',
             backgroundColor: changeOpacity('#000', 0.3),
@@ -230,5 +229,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontWeight: '600',
             textAlignVertical: 'center'
         }
-    });
+    };
 });

--- a/app/components/slack_attachments/slack_attachment.js
+++ b/app/components/slack_attachments/slack_attachment.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {
     Image,
     Linking,
-    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -335,7 +334,7 @@ export default class SlackAttachment extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             borderColor: changeOpacity(theme.centerChannelColor, 0.15),
             borderWidth: 1,
@@ -407,5 +406,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             height: 50
         }
-    });
+    };
 });

--- a/app/screens/about/about.js
+++ b/app/screens/about/about.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {
     Linking,
     ScrollView,
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -282,7 +281,7 @@ export default class About extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         wrapper: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
@@ -366,5 +365,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 11,
             lineHeight: 13
         }
-    });
+    };
 });

--- a/app/screens/account_notifications/account_notifications.js
+++ b/app/screens/account_notifications/account_notifications.js
@@ -8,7 +8,6 @@ import {
     Keyboard,
     Platform,
     ScrollView,
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -573,7 +572,7 @@ class AccountNotifications extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         wrapper: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
@@ -596,7 +595,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         scrollViewContent: {
             paddingBottom: 30
         }
-    });
+    };
 });
 
 export default injectIntl(AccountNotifications);

--- a/app/screens/account_notifications/section.js
+++ b/app/screens/account_notifications/section.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -12,7 +11,7 @@ import FormattedText from 'app/components/formatted_text';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             marginTop: 30
         },
@@ -35,7 +34,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderTopColor: changeOpacity(theme.centerChannelColor, 0.1),
             borderBottomColor: changeOpacity(theme.centerChannelColor, 0.1)
         }
-    });
+    };
 });
 
 function section(props) {

--- a/app/screens/account_notifications/section_item.js
+++ b/app/screens/account_notifications/section_item.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Switch,
     TouchableWithoutFeedback,
     View
@@ -21,7 +20,7 @@ const ActionTypes = {
 };
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flexDirection: 'row',
             alignItems: 'center'
@@ -35,7 +34,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         wrapper: {
             paddingHorizontal: 15
         }
-    });
+    };
 });
 
 function sectionItem(props) {

--- a/app/screens/account_settings/account_settings.js
+++ b/app/screens/account_settings/account_settings.js
@@ -5,7 +5,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {injectIntl, intlShape} from 'react-intl';
 import {
-    StyleSheet,
     TouchableOpacity,
     View
 } from 'react-native';
@@ -108,7 +107,7 @@ class AccountSettings extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.03)
@@ -154,7 +153,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             backgroundColor: theme.centerChannelBg
         }
-    });
+    };
 });
 
 export default injectIntl(AccountSettings);

--- a/app/screens/advanced_settings/advanced_settings.js
+++ b/app/screens/advanced_settings/advanced_settings.js
@@ -7,7 +7,6 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     Alert,
     TouchableOpacity,
-    StyleSheet,
     View
 } from 'react-native';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -108,7 +107,7 @@ class AdvancedSettings extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.03)
@@ -154,7 +153,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             backgroundColor: theme.centerChannelBg
         }
-    });
+    };
 });
 
 export default injectIntl(AdvancedSettings);

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -8,7 +8,6 @@ import {
     Dimensions,
     NetInfo,
     Platform,
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -250,7 +249,7 @@ class Channel extends PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         headerContainer: {
             flex: 1,
             position: 'absolute'
@@ -292,7 +291,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             paddingBottom: 0
         }
-    });
+    };
 });
 
 export default injectIntl(Channel);

--- a/app/screens/channel/channel_drawer_button.js
+++ b/app/screens/channel/channel_drawer_button.js
@@ -7,7 +7,6 @@ import {connect} from 'react-redux';
 import {
     PanResponder,
     Platform,
-    StyleSheet,
     TouchableOpacity,
     View
 } from 'react-native';
@@ -144,7 +143,7 @@ class ChannelDrawerButton extends PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             width: 40
         },
@@ -180,7 +179,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: theme.mentionColor,
             fontSize: 10
         }
-    });
+    };
 });
 
 function mapStateToProps(state) {

--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -7,7 +7,6 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     Alert,
     InteractionManager,
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -279,12 +278,12 @@ class ChannelAddMembers extends PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
         }
-    });
+    };
 });
 
 export default injectIntl(ChannelAddMembers);

--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -8,7 +8,6 @@ import {
     Alert,
     Platform,
     ScrollView,
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -367,7 +366,7 @@ class ChannelInfo extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
@@ -395,7 +394,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             height: 1,
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.1)
         }
-    });
+    };
 });
 
 export default injectIntl(ChannelInfo);

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -122,7 +121,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: theme.centerChannelBg,
             marginBottom: 40,
@@ -161,5 +160,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         section: {
             marginTop: 15
         }
-    });
+    };
 });

--- a/app/screens/channel_info/channel_info_row.js
+++ b/app/screens/channel_info/channel_info_row.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Switch,
     Text,
     TouchableHighlight,
@@ -89,7 +88,7 @@ channelInfoRow.defaultProps = {
 };
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: theme.centerChannelBg,
             paddingHorizontal: 15,
@@ -113,7 +112,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         rightIcon: {
             color: changeOpacity(theme.centerChannelColor, 0.5)
         }
-    });
+    };
 });
 
 export default channelInfoRow;

--- a/app/screens/channel_members/channel_members.js
+++ b/app/screens/channel_members/channel_members.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {
     Alert,
     InteractionManager,
-    StyleSheet,
     View
 } from 'react-native';
 import {injectIntl, intlShape} from 'react-intl';
@@ -325,12 +324,12 @@ class ChannelMembers extends PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
         }
-    });
+    };
 });
 
 export default injectIntl(ChannelMembers);

--- a/app/screens/create_channel/create_channel.js
+++ b/app/screens/create_channel/create_channel.js
@@ -8,7 +8,6 @@ import {
     Keyboard,
     InteractionManager,
     Platform,
-    StyleSheet,
     TouchableWithoutFeedback,
     View,
     findNodeHandle
@@ -343,7 +342,7 @@ class CreateChannel extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
@@ -406,7 +405,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
                 }
             })
         }
-    });
+    };
 });
 
 export default injectIntl(CreateChannel);

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -6,7 +6,6 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     Dimensions,
     Platform,
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -210,7 +209,7 @@ class EditPost extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
@@ -239,7 +238,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             padding: 15,
             textAlignVertical: 'top'
         }
-    });
+    };
 });
 
 export default injectIntl(EditPost);

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -7,7 +7,6 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     Platform,
     InteractionManager,
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -330,7 +329,7 @@ class MoreChannels extends PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
@@ -346,7 +345,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
                 }
             })
         }
-    });
+    };
 });
 
 export default injectIntl(MoreChannels);

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {injectIntl, intlShape} from 'react-intl';
 import {
     InteractionManager,
-    StyleSheet,
     View
 } from 'react-native';
 
@@ -426,7 +425,7 @@ class MoreDirectMessages extends PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
@@ -434,7 +433,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
         searchContainer: {
             marginVertical: 5
         }
-    });
+    };
 });
 
 export default injectIntl(MoreDirectMessages);

--- a/app/screens/more_dms/selected_users/selected_user.js
+++ b/app/screens/more_dms/selected_users/selected_user.js
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
-    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -67,7 +66,7 @@ export default class SelectedUser extends React.PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             alignItems: 'center',
             flexDirection: 'row',
@@ -86,5 +85,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             fontSize: 13
         }
-    });
+    };
 });

--- a/app/screens/more_dms/selected_users/selected_users.js
+++ b/app/screens/more_dms/selected_users/selected_users.js
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {View} from 'react-native';
 
 import FormattedText from 'app/components/formatted_text';
 import SelectedUser from 'app/screens/more_dms/selected_users/selected_user';
@@ -115,7 +115,7 @@ export default class SelectedUsers extends React.PureComponent {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             marginLeft: 5,
             marginBottom: 5
@@ -132,5 +132,5 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             marginTop: 10,
             marginBottom: 2
         }
-    });
+    };
 });

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -530,7 +530,7 @@ class Search extends Component {
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         header: {
             backgroundColor: theme.sidebarHeaderBg,
             width: Dimensions.get('window').width,
@@ -617,7 +617,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
         searching: {
             marginTop: 25
         }
-    });
+    };
 });
 
 export default injectIntl(Search);

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -234,7 +234,7 @@ export default class SelectTeam extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: theme.centerChannelBg,
             flex: 1
@@ -297,5 +297,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.5),
             fontSize: 12
         }
-    });
+    };
 });

--- a/app/screens/settings/settings.js
+++ b/app/screens/settings/settings.js
@@ -8,7 +8,6 @@ import {
     InteractionManager,
     Linking,
     Platform,
-    StyleSheet,
     View
 } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
@@ -259,7 +258,7 @@ class Settings extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         leftComponent: {
             alignItems: 'center',
             flex: 1,
@@ -287,7 +286,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
                 }
             })
         }
-    });
+    };
 });
 
 export default injectIntl(Settings);

--- a/app/screens/settings/settings_item.js
+++ b/app/screens/settings/settings_item.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, TouchableOpacity, View} from 'react-native';
+import {TouchableOpacity, View} from 'react-native';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import IonIcon from 'react-native-vector-icons/Ionicons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -104,7 +104,7 @@ export default class SettingsItem extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: theme.centerChannelBg,
             height: 51,
@@ -139,5 +139,5 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             height: 1,
             marginHorizontal: 16
         }
-    });
+    };
 });

--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -138,9 +138,9 @@ class SSO extends PureComponent {
 
                     Client4.setToken(token);
                     setStoreFromLocalData({url: this.props.serverUrl, token}).
-                    then(handleSuccessfulLogin).
-                    then(getSession).
-                    then(this.goToLoadTeam);
+                        then(handleSuccessfulLogin).
+                        then(getSession).
+                        then(this.goToLoadTeam);
                 }
             });
         }

--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -7,7 +7,6 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     InteractionManager,
     Text,
-    StyleSheet,
     View,
     WebView
 } from 'react-native';
@@ -191,7 +190,7 @@ class SSO extends PureComponent {
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         errorContainer: {
             alignItems: 'center',
             flex: 1,
@@ -204,7 +203,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             lineHeight: 23,
             paddingHorizontal: 30
         }
-    });
+    };
 });
 
 export default injectIntl(SSO);

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -3,7 +3,6 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet} from 'react-native';
 
 import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import PostList from 'app/components/post_list';
@@ -91,10 +90,10 @@ export default class Thread extends PureComponent {
 }
 
 const getStyle = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1,
             backgroundColor: theme.centerChannelBg
         }
-    });
+    };
 });

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -5,7 +5,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
     ScrollView,
-    StyleSheet,
     Text,
     View
 } from 'react-native';
@@ -146,7 +145,7 @@ class UserProfile extends PureComponent {
 }
 
 const createStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             flex: 1
         },
@@ -185,7 +184,7 @@ const createStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             fontSize: 15
         }
-    });
+    };
 });
 
 export default injectIntl(UserProfile);

--- a/app/screens/user_profile/user_profile_row.js
+++ b/app/screens/user_profile/user_profile_row.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    StyleSheet,
     Switch,
     Text,
     TouchableHighlight,
@@ -16,7 +15,7 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 import FormattedText from 'app/components/formatted_text';
 
 const createStyleSheet = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         container: {
             backgroundColor: changeOpacity(theme.centerChannelBg, 0.7),
             paddingHorizontal: 15,
@@ -50,7 +49,7 @@ const createStyleSheet = makeStyleSheetFromTheme((theme) => {
         wrapper: {
             backgroundColor: '#ddd'
         }
-    });
+    };
 });
 
 function createTouchableComponent(children, action) {

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -7,7 +7,7 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
     const codeFont = Platform.OS === 'ios' ? 'Courier New' : 'monospace';
 
-    return StyleSheet.create({
+    return {
         emph: {
             fontStyle: 'italic'
         },
@@ -69,11 +69,11 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
         mention: {
             color: theme.linkColor
         }
-    });
+    };
 });
 
 export const getMarkdownBlockStyles = makeStyleSheetFromTheme((theme) => {
-    return StyleSheet.create({
+    return {
         adjacentParagraph: {
             marginTop: 6
         },
@@ -93,7 +93,7 @@ export const getMarkdownBlockStyles = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.5),
             padding: 5
         }
-    });
+    };
 });
 
 export default {

--- a/app/utils/theme.js
+++ b/app/utils/theme.js
@@ -1,13 +1,15 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {StyleSheet} from 'react-native';
+
 export function makeStyleSheetFromTheme(getStyleFromTheme) {
     let lastTheme = null;
     let style = null;
 
     return (theme) => {
         if (theme !== lastTheme) {
-            style = getStyleFromTheme(theme);
+            style = StyleSheet.create(getStyleFromTheme(theme));
             lastTheme = theme;
         }
 


### PR DESCRIPTION
It was bugging me that I keep having to import StyleSheet every time I use makeStyleSheetFromTheme, so I just have makeStyleSheetFromTheme do that now. This also fixes a few style issues that my local environment reported

#### Device Information
This PR was tested on: iOS Simulator