### PR TITLE
RN-303 fix small screen error overlap

### DIFF
--- a/app/screens/create_channel/create_channel.js
+++ b/app/screens/create_channel/create_channel.js
@@ -243,12 +243,12 @@ class CreateChannel extends PureComponent {
                     ref={this.scrollRef}
                     style={style.container}
                 >
+                    {displayError}
                     <TouchableWithoutFeedback onPress={this.blur}>
                         <View style={[style.scrollView, {height: height + (Platform.OS === 'android' ? 200 : 0)}]}>
-                            {displayError}
                             <View>
                                 <FormattedText
-                                    style={[style.title, {marginTop: (error ? 20 : 0)}]}
+                                    style={style.title}
                                     id='channel_modal.name'
                                     defaultMessage='Name'
                                 />
@@ -350,15 +350,14 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         scrollView: {
             flex: 1,
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.03),
-            paddingTop: 30
+            paddingTop: 10
         },
         errorContainer: {
-            position: 'absolute'
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.03)
         },
         errorWrapper: {
             justifyContent: 'center',
-            alignItems: 'center',
-            marginBottom: 10
+            alignItems: 'center'
         },
         inputContainer: {
             marginTop: 10,

--- a/app/screens/create_channel/create_channel.js
+++ b/app/screens/create_channel/create_channel.js
@@ -248,7 +248,7 @@ class CreateChannel extends PureComponent {
                             {displayError}
                             <View>
                                 <FormattedText
-                                    style={[style.title, {marginTop: (error ? 10 : 0)}]}
+                                    style={[style.title, {marginTop: (error ? 20 : 0)}]}
                                     id='channel_modal.name'
                                     defaultMessage='Name'
                                 />


### PR DESCRIPTION
#### Summary
on smaller screens the error was overlapping the "Name" label when creating new channels

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-303

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: iPhone 5s 

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
![image](https://user-images.githubusercontent.com/6757047/29432388-c9771256-8371-11e7-844f-7660069c66e1.png)

