### PR TITLE
PLT-7553/RN-319 Updated commonmark.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "analytics-react-native": "1.1.0",
     "babel-polyfill": "6.23.0",
-    "commonmark": "hmhealey/commonmark.js#9f33c90b5c82adfef30b87c7cd15aea2e2764b51",
+    "commonmark": "hmhealey/commonmark.js#25dc6a4c456db579631797e29847752cb5e7d8d7",
     "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#c5d00343664c89da40d5a2ffa8b083e7cc1615d7",
     "deep-equal": "1.0.1",
     "intl": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,9 +1535,9 @@ commonmark-react-renderer@hmhealey/commonmark-react-renderer#c5d00343664c89da40d
     pascalcase "^0.1.1"
     xss-filters "^1.2.6"
 
-commonmark@hmhealey/commonmark.js#9f33c90b5c82adfef30b87c7cd15aea2e2764b51:
+commonmark@hmhealey/commonmark.js#25dc6a4c456db579631797e29847752cb5e7d8d7:
   version "0.28.0"
-  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/9f33c90b5c82adfef30b87c7cd15aea2e2764b51"
+  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/25dc6a4c456db579631797e29847752cb5e7d8d7"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"


### PR DESCRIPTION
This fixes:
1. Linking www links that don't start words like `testwww.google.ca` (changes [here](https://github.com/hmhealey/commonmark.js/commit/092171c1533338320ba079ef17e848839ae2a51e))
2. Not capturing the closing square bracket in IPv6 links like `http://[::1]` (changes [here](https://github.com/hmhealey/commonmark.js/commit/25dc6a4c456db579631797e29847752cb5e7d8d7))

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-319
https://mattermost.atlassian.net/browse/PLT-7553

#### Checklist
- Added or updated unit tests (required for all new features)