### PR TITLE
RN-189/RN-241 Updated emoji appearance

### DIFF
--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -99,7 +99,7 @@ export default class EmojiSuggestion extends Component {
                 <View style={style.emoji}>
                     <Emoji
                         emojiName={item}
-                        size={10}
+                        size={20}
                     />
                 </View>
                 <Text style={style.emojiName}>{`:${item}:`}</Text>

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -131,7 +131,7 @@ export default class Emoji extends React.PureComponent {
         let marginTop = 0;
         if (fontSize) {
             // Center the image vertically on iOS (does nothing on Android)
-            marginTop = ((height - fontSize) / 2) + 1;
+            marginTop = (height - fontSize) / 2;
         }
 
         // Android can't change the size of an image after its first render, so

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -132,6 +132,13 @@ export default class Emoji extends React.PureComponent {
         if (fontSize) {
             // Center the image vertically on iOS (does nothing on Android)
             marginTop = (height - fontSize) / 2;
+
+            // hack to get the vertical alignment looking better
+            if (fontSize === 17) {
+                marginTop -= 2;
+            } else if (fontSize === 15) {
+                marginTop += 1;
+            }
         }
 
         // Android can't change the size of an image after its first render, so

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -117,10 +117,15 @@ export default class Emoji extends React.PureComponent {
             }
         };
 
-        const width = size;
+        let width = size;
         let height = size;
         if (this.state.originalHeight && this.state.originalWidth) {
-            height = (size * this.state.originalHeight) / this.state.originalWidth;
+            if (this.state.originalWidth > this.state.originalHeight) {
+                height = (size * this.state.originalHeight) / this.state.originalWidth;
+            } else if (this.state.originalWidth < this.state.originalHeight) {
+                // This may cause text to reflow, but its impossible to add a horizontal margin
+                width = (size * this.state.originalWidth) / this.state.originalHeight;
+            }
         }
 
         let marginTop = 0;
@@ -130,8 +135,8 @@ export default class Emoji extends React.PureComponent {
         }
 
         // Android can't change the size of an image after its first render, so
-        // force a new image to be rendered when height changes
-        const key = Platform.OS === 'android' ? String(height) : null;
+        // force a new image to be rendered when the size changes
+        const key = Platform.OS === 'android' ? (height + '-' + width) : null;
 
         return (
             <ImageComponent

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -16,7 +16,6 @@ export default class Emoji extends React.PureComponent {
         customEmojis: PropTypes.object,
         emojiName: PropTypes.string.isRequired,
         literal: PropTypes.string,
-        padding: PropTypes.number,
         size: PropTypes.number.isRequired,
         textStyle: CustomPropTypes.Style,
         token: PropTypes.string.isRequired
@@ -24,8 +23,7 @@ export default class Emoji extends React.PureComponent {
 
     static defaultProps = {
         customEmojis: new Map(),
-        literal: '',
-        padding: 10
+        literal: ''
     };
 
     render() {
@@ -33,7 +31,6 @@ export default class Emoji extends React.PureComponent {
             customEmojis,
             emojiName,
             literal,
-            padding,
             size,
             textStyle,
             token
@@ -66,7 +63,7 @@ export default class Emoji extends React.PureComponent {
 
         return (
             <ImageComponent
-                style={{width: size, height: size, padding}}
+                style={{width: size, height: size}}
                 source={source}
                 onError={this.onError}
             />

--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -52,13 +52,13 @@ export default class Markdown extends PureComponent {
                     text: 20
                 },
                 android: {
-                    heading1: 80,
-                    heading2: 80,
-                    heading3: 80,
-                    heading4: 80,
-                    heading5: 80,
-                    heading6: 80,
-                    text: 65
+                    heading1: 60,
+                    heading2: 60,
+                    heading3: 60,
+                    heading4: 60,
+                    heading5: 60,
+                    heading6: 60,
+                    text: 50
                 }
             })
         },

--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -59,7 +59,7 @@ export default class Markdown extends PureComponent {
                     heading4: 60,
                     heading5: 60,
                     heading6: 60,
-                    text: 50
+                    text: 45
                 }
             })
         },

--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -29,6 +29,7 @@ export default class Markdown extends PureComponent {
         baseTextStyle: CustomPropTypes.Style,
         blockStyles: PropTypes.object,
         emojiSizes: PropTypes.object,
+        fontSizes: PropTypes.object,
         isSearchResult: PropTypes.bool,
         navigator: PropTypes.object.isRequired,
         onLongPress: PropTypes.func,
@@ -61,6 +62,15 @@ export default class Markdown extends PureComponent {
                     text: 50
                 }
             })
+        },
+        fontSizes: {
+            heading1: 17,
+            heading2: 17,
+            heading3: 17,
+            heading4: 17,
+            heading5: 17,
+            heading6: 17,
+            text: 15
         },
         onLongPress: () => true
     };
@@ -157,11 +167,14 @@ export default class Markdown extends PureComponent {
 
     renderEmoji = ({context, emojiName, literal}) => {
         let size;
+        let fontSize;
         const headingType = context.find((type) => type.startsWith('heading'));
         if (headingType) {
             size = this.props.emojiSizes[headingType];
+            fontSize = this.props.fontSizes[headingType];
         } else {
             size = this.props.emojiSizes.text;
+            fontSize = this.props.fontSizes.text;
         }
 
         return (
@@ -169,6 +182,7 @@ export default class Markdown extends PureComponent {
                 emojiName={emojiName}
                 literal={literal}
                 size={size}
+                fontSize={fontSize}
                 textStyle={this.computeTextStyle(this.props.baseTextStyle, context)}
             />
         );

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -292,7 +292,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         message: {
             color: theme.centerChannelColor,
-            fontSize: 15
+            fontSize: 15,
+            lineHeight: 20
         },
         messageContainerWithReplyBar: {
             flexDirection: 'row',

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -26,39 +26,27 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
         },
         heading1: {
             fontSize: 17,
-            fontWeight: '700',
-            marginTop: 10,
-            marginBottom: 10
+            fontWeight: '700'
         },
         heading2: {
             fontSize: 17,
-            fontWeight: '700',
-            marginTop: 10,
-            marginBottom: 10
+            fontWeight: '700'
         },
         heading3: {
             fontSize: 17,
-            fontWeight: '700',
-            marginTop: 10,
-            marginBottom: 10
+            fontWeight: '700'
         },
         heading4: {
             fontSize: 17,
-            fontWeight: '700',
-            marginTop: 10,
-            marginBottom: 10
+            fontWeight: '700'
         },
         heading5: {
             fontSize: 17,
-            fontWeight: '700',
-            marginTop: 10,
-            marginBottom: 10
+            fontWeight: '700'
         },
         heading6: {
             fontSize: 17,
-            fontWeight: '700',
-            marginTop: 10,
-            marginBottom: 10
+            fontWeight: '700'
         },
         code: {
             alignSelf: 'center',

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -26,27 +26,33 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
         },
         heading1: {
             fontSize: 17,
-            fontWeight: '700'
+            fontWeight: '700',
+            lineHeight: 25
         },
         heading2: {
             fontSize: 17,
-            fontWeight: '700'
+            fontWeight: '700',
+            lineHeight: 25
         },
         heading3: {
             fontSize: 17,
-            fontWeight: '700'
+            fontWeight: '700',
+            lineHeight: 25
         },
         heading4: {
             fontSize: 17,
-            fontWeight: '700'
+            fontWeight: '700',
+            lineHeight: 25
         },
         heading5: {
             fontSize: 17,
-            fontWeight: '700'
+            fontWeight: '700',
+            lineHeight: 25
         },
         heading6: {
             fontSize: 17,
-            fontWeight: '700'
+            fontWeight: '700',
+            lineHeight: 25
         },
         code: {
             alignSelf: 'center',


### PR DESCRIPTION
- Makes non-square emojis render correctly
- Vertically centres emojis on iOS (Android doesn't support this). This looks pretty good on regular text, but is a bit off on headers. It's still much better than it was before.
- Adjusted line height and emoji sizes so that emojis don't push text out of the way

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-189
https://mattermost.atlassian.net/browse/RN-241

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator (iPhone 6, iOS 10.3), Nexus 5 (Android 6.0.1)

#### Screenshots
Before (iOS): 
<img width="372" alt="screen shot 2017-09-12 at 11 24 40 am" src="https://user-images.githubusercontent.com/3277310/30334569-fcc4abc8-97ad-11e7-9036-10c112d90116.png">

After (iOS):
<img width="372" alt="screen shot 2017-09-12 at 11 35 13 am" src="https://user-images.githubusercontent.com/3277310/30334739-79291e1a-97ae-11e7-8ba4-a09b4054bb2d.png">

Before (Android):
<img width="372" src="https://user-images.githubusercontent.com/3277310/30334753-879804a2-97ae-11e7-8a99-fd1714f22f93.jpg">

After (Android):
<img width="372" src="https://user-images.githubusercontent.com/3277310/30334792-9c19d3a6-97ae-11e7-94a8-c78a0dd8ec04.jpg">


