### PR TITLE
Fix saving Android notification preferences

### DIFF
--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
@@ -621,12 +621,12 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
     };
 
     toggleBlink = () => {
-        NotificationPreferences.setShouldBlink(this.state.shouldBlink);
+        NotificationPreferences.setShouldBlink(!this.state.shouldBlink);
         this.setState({shouldBlink: !this.state.shouldBlink});
     };
 
     toggleVibrate = () => {
-        NotificationPreferences.setShouldVibrate(this.state.shouldVibrate);
+        NotificationPreferences.setShouldVibrate(!this.state.shouldVibrate);
         this.setState({shouldVibrate: !this.state.shouldVibrate});
     };
 


### PR DESCRIPTION
#### Summary
When saving the vibrate and lights preferences we weren't updating them correctly when toggling the option, this PR fixes it