### PR TITLE
RN-335 Reaction shortcut

### DIFF
--- a/app/actions/views/emoji.js
+++ b/app/actions/views/emoji.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {addReaction} from 'mattermost-redux/actions/posts';
+import {getPostsInCurrentChannel, makeGetPostsForThread} from 'mattermost-redux/selectors/entities/posts';
+
+const getPostsForThread = makeGetPostsForThread();
+
+export function addReactionToLatestPost(emoji, rootId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const posts = rootId ? getPostsForThread(state, {rootId}) : getPostsInCurrentChannel(state);
+        const lastPost = posts[0];
+
+        dispatch(addReaction(lastPost.id, emoji));
+    };
+}

--- a/app/components/autocomplete/emoji_suggestion/index.js
+++ b/app/components/autocomplete/emoji_suggestion/index.js
@@ -3,9 +3,11 @@
 
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
+import {bindActionCreators} from 'redux';
 
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 
+import {addReactionToLatestPost} from 'app/actions/views/emoji';
 import {getTheme} from 'app/selectors/preferences';
 import {EmojiIndicesByAlias} from 'app/utils/emojis';
 
@@ -47,4 +49,12 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-export default connect(mapStateToProps)(EmojiSuggestion);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            addReactionToLatestPost
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(EmojiSuggestion);

--- a/app/components/post_textbox/index.js
+++ b/app/components/post_textbox/index.js
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 import {createPost} from 'mattermost-redux/actions/posts';
 import {userTyping} from 'mattermost-redux/actions/websocket';
 
+import {addReactionToLatestPost} from 'app/actions/views/emoji';
 import {handleClearFiles, handleRemoveLastFile, handleUploadFiles} from 'app/actions/views/file_upload';
 import {getTheme} from 'app/selectors/preferences';
 import {canUploadFilesOnMobile} from 'mattermost-redux/selectors/entities/general';
@@ -29,6 +30,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            addReactionToLatestPost,
             createPost,
             handleClearFiles,
             handleRemoveLastFile,

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -27,7 +27,7 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 const INITIAL_HEIGHT = Platform.OS === 'ios' ? 34 : 36;
 const MAX_CONTENT_HEIGHT = 100;
 const MAX_MESSAGE_LENGTH = 4000;
-const IS_REACTION_REGEX = /(^\+:([^\s]*):)$/i;
+const IS_REACTION_REGEX = /(^\+:([^:\s]*):)$/i;
 
 class PostTextbox extends PureComponent {
     static propTypes = {


### PR DESCRIPTION
#### Summary
Allows for reactions to be added using the `+` shortcut.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-335

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23