### PR TITLE
RN-337 Enable GIF support in image preview

### DIFF
--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -64,7 +64,7 @@ export default class FileAttachment extends PureComponent {
         const style = getStyleSheet(theme);
 
         let fileAttachmentComponent;
-        if (file.has_preview_image || file.loading) {
+        if (file.has_preview_image || file.loading || file.mime_type === 'image/gif') {
             fileAttachmentComponent = (
                 <FileAttachmentImage
                     addFileToFetchCache={this.props.addFileToFetchCache}

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -327,7 +327,7 @@ export default class ImagePreview extends PureComponent {
                     >
                         {this.props.files.map((file, index) => {
                             let component;
-                            if (file.has_preview_image) {
+                            if (file.has_preview_image || file.mime_type === 'image/gif') {
                                 component = (
                                     <Previewer
                                         ref={(c) => {

--- a/app/screens/image_preview/previewer.js
+++ b/app/screens/image_preview/previewer.js
@@ -195,6 +195,10 @@ export default class Previewer extends Component {
     handleGetImageURL = () => {
         const {file} = this.props;
 
+        if (file.mime_type === 'image/gif') {
+            return Client4.getFileUrl(file.id, this.state.timestamp);
+        }
+
         return Client4.getFilePreviewUrl(file.id, this.state.timestamp);
     };
 


### PR DESCRIPTION
#### Summary
Add GIF support to the image previewer

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-337

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23