### PR TITLE
RN-298 Fixed profile pictures not being shown when creating new group message channel

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3878,7 +3878,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/850e7df06cd7dcae7e592f78ca7bbdd6ab2ec56a"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/437f943ebc12f5947fc7da9e5d69e526d80fd6c5"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
state.entities.users.profilesInChannel wasn't being populated before by the actions that create new group and direct channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-298

#### Device Information
This PR was tested on: iOS Simulator