### PR TITLE
RN-369 Added a maximum depth to the markdown renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "analytics-react-native": "1.1.0",
     "babel-polyfill": "6.23.0",
     "commonmark": "hmhealey/commonmark.js#25dc6a4c456db579631797e29847752cb5e7d8d7",
-    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#c5d00343664c89da40d5a2ffa8b083e7cc1615d7",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#6e259b66ae87d31d2f908effcd05776b9ea3446f",
     "deep-equal": "1.0.1",
     "intl": "1.2.5",
     "jail-monkey": "0.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,9 +1623,9 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
-commonmark-react-renderer@hmhealey/commonmark-react-renderer#c5d00343664c89da40d5a2ffa8b083e7cc1615d7:
+commonmark-react-renderer@hmhealey/commonmark-react-renderer#6e259b66ae87d31d2f908effcd05776b9ea3446f:
   version "4.3.3"
-  resolved "https://codeload.github.com/hmhealey/commonmark-react-renderer/tar.gz/c5d00343664c89da40d5a2ffa8b083e7cc1615d7"
+  resolved "https://codeload.github.com/hmhealey/commonmark-react-renderer/tar.gz/6e259b66ae87d31d2f908effcd05776b9ea3446f"
   dependencies:
     in-publish "^2.0.0"
     lodash.assign "^4.2.0"


### PR DESCRIPTION
This is to fix an issue where a deeply nested markdown structure causes the channel to not render. React does not like when you nest components too deeply

commonmark-react-renderer changes: https://github.com/hmhealey/commonmark-react-renderer/commit/6e259b66ae87d31d2f908effcd05776b9ea3446f

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-369

#### Device Information
This PR was tested on: iOS Simulator