### PR TITLE
White label login options screen - Experimental

### DIFF
--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -299,15 +299,28 @@ class Login extends PureComponent {
                 />
             );
         } else {
+            const additionalStyle = {};
+            if (this.props.config.EmailLoginButtonColor) {
+                additionalStyle.backgroundColor = this.props.config.EmailLoginButtonColor;
+            }
+            if (this.props.config.EmailLoginButtonBorderColor) {
+                additionalStyle.borderColor = this.props.config.EmailLoginButtonBorderColor;
+            }
+
+            const additionalTextStyle = {};
+            if (this.props.config.EmailLoginButtonTextColor) {
+                additionalTextStyle.color = this.props.config.EmailLoginButtonTextColor;
+            }
+
             proceed = (
                 <Button
                     onPress={this.preSignIn}
-                    containerStyle={GlobalStyles.signupButton}
+                    containerStyle={[GlobalStyles.signupButton, additionalStyle]}
                 >
                     <FormattedText
                         id='login.signIn'
                         defaultMessage='Sign in'
-                        style={GlobalStyles.signupButtonText}
+                        style={[GlobalStyles.signupButtonText, additionalTextStyle]}
                     />
                 </Button>
             );

--- a/app/screens/login_options/login_options.js
+++ b/app/screens/login_options/login_options.js
@@ -82,8 +82,8 @@ class LoginOptions extends PureComponent {
     };
 
     renderEmailOption = () => {
-        const {config, theme} = this.props;
-        const forceHideFromLocal = LocalConfig.HideEmailLogin;
+        const {config} = this.props;
+        const forceHideFromLocal = LocalConfig.HideEmailLoginExperimental;
 
         if (!forceHideFromLocal && (config.EnableSignInWithEmail === 'true' || config.EnableSignInWithUsername === 'true')) {
             const backgroundColor = config.EmailLoginButtonColor || '#2389d7';
@@ -116,8 +116,8 @@ class LoginOptions extends PureComponent {
     };
 
     renderLdapOption = () => {
-        const {config, license, theme} = this.props;
-        const forceHideFromLocal = LocalConfig.HideLDAPLogin;
+        const {config, license} = this.props;
+        const forceHideFromLocal = LocalConfig.HideLDAPLoginExperimental;
 
         if (!forceHideFromLocal && license.IsLicensed === 'true' && config.EnableLdap === 'true') {
             const backgroundColor = config.LDAPLoginButtonColor || '#2389d7';
@@ -164,10 +164,13 @@ class LoginOptions extends PureComponent {
 
     renderGitlabOption = () => {
         const {config, serverVersion} = this.props;
+
+        const forceHideFromLocal = LocalConfig.HideGitLabLoginExperimental;
+
         const match = serverVersion.match(/^[0-9]*.[0-9]*.[0-9]*(-[a-zA-Z0-9.-]*)?/g);
         if (match) {
             const version = match[0];
-            if (config.EnableSignUpWithGitLab === 'true' && semver.valid(version) && semver.gte(version, 'v3.10.0')) {
+            if (!forceHideFromLocal && config.EnableSignUpWithGitLab === 'true' && semver.valid(version) && semver.gte(version, 'v3.10.0')) {
                 return (
                     <Button
                         key='gitlab'
@@ -193,8 +196,8 @@ class LoginOptions extends PureComponent {
     };
 
     renderSamlOption = () => {
-        const {config, license, theme} = this.props;
-        const forceHideFromLocal = LocalConfig.HideSAMLLogin;
+        const {config, license} = this.props;
+        const forceHideFromLocal = LocalConfig.HideSAMLLoginExperimental;
 
         if (!forceHideFromLocal && config.EnableSaml === 'true' && license.IsLicensed === 'true' && license.SAML === 'true') {
             const backgroundColor = config.SamlLoginButtonColor || '#34a28b';

--- a/app/screens/login_options/login_options.js
+++ b/app/screens/login_options/login_options.js
@@ -86,16 +86,16 @@ class LoginOptions extends PureComponent {
         const forceHideFromLocal = LocalConfig.HideEmailLogin;
 
         if (!forceHideFromLocal && (config.EnableSignInWithEmail === 'true' || config.EnableSignInWithUsername === 'true')) {
-            const backgroundColor = theme.EmailLoginButtonColor || theme.linkColor;
+            const backgroundColor = config.EmailLoginButtonColor || '#2389d7';
             const additionalStyle = {
                 backgroundColor
             };
 
-            if (theme.hasOwnProperty('EmailLoginButtonBorder')) {
-                additionalStyle.borderColor = theme.EmailLoginButtonBorder;
+            if (config.hasOwnProperty('EmailLoginButtonBorderColor')) {
+                additionalStyle.borderColor = config.EmailLoginButtonBorderColor;
             }
 
-            const textColor = theme.EmailLoginButtonText || 'white';
+            const textColor = config.EmailLoginButtonTextColor || 'white';
 
             return (
                 <Button
@@ -120,16 +120,16 @@ class LoginOptions extends PureComponent {
         const forceHideFromLocal = LocalConfig.HideLDAPLogin;
 
         if (!forceHideFromLocal && license.IsLicensed === 'true' && config.EnableLdap === 'true') {
-            const backgroundColor = theme.LDAPLoginButtonColor || theme.linkColor;
+            const backgroundColor = config.LDAPLoginButtonColor || '#2389d7';
             const additionalStyle = {
                 backgroundColor
             };
 
-            if (theme.hasOwnProperty('LDAPLoginButtonBorder')) {
-                additionalStyle.borderColor = theme.LDAPLoginButtonBorder;
+            if (config.hasOwnProperty('LDAPLoginButtonBorderColor')) {
+                additionalStyle.borderColor = config.LDAPLoginButtonBorderColor;
             }
 
-            const textColor = theme.LDAPLoginButtonText || 'white';
+            const textColor = config.LDAPLoginButtonTextColor || 'white';
 
             let buttonText;
             if (config.LdapLoginFieldName) {
@@ -197,17 +197,17 @@ class LoginOptions extends PureComponent {
         const forceHideFromLocal = LocalConfig.HideSAMLLogin;
 
         if (!forceHideFromLocal && config.EnableSaml === 'true' && license.IsLicensed === 'true' && license.SAML === 'true') {
-            const backgroundColor = theme.SAMLLoginButtonColor || theme.linkColor;
+            const backgroundColor = config.SamlLoginButtonColor || '#34a28b';
 
             const additionalStyle = {
                 backgroundColor
             };
 
-            if (theme.SAMLLoginButtonBorder) {
-                additionalStyle.borderColor = theme.SAMLLoginButtonBorder;
+            if (config.SAMLLoginButtonBorderColor) {
+                additionalStyle.borderColor = config.SamlLoginButtonBorderColor;
             }
 
-            const textColor = theme.SAMLLoginButtonText || 'white';
+            const textColor = config.SamlLoginButtonTextColor || 'white';
 
             return (
                 <Button

--- a/app/screens/login_options/login_options.js
+++ b/app/screens/login_options/login_options.js
@@ -20,6 +20,7 @@ import StatusBar from 'app/components/status_bar';
 import {GlobalStyles} from 'app/styles';
 import {preventDoubleTap} from 'app/utils/tap';
 
+import LocalConfig from 'assets/config';
 import gitlab from 'assets/images/gitlab.png';
 import logo from 'assets/images/logo.png';
 
@@ -81,18 +82,31 @@ class LoginOptions extends PureComponent {
     };
 
     renderEmailOption = () => {
-        const {config} = this.props;
-        if (config.EnableSignInWithEmail === 'true' || config.EnableSignInWithUsername === 'true') {
+        const {config, theme} = this.props;
+        const forceHideFromLocal = LocalConfig.HideEmailLogin;
+
+        if (!forceHideFromLocal && (config.EnableSignInWithEmail === 'true' || config.EnableSignInWithUsername === 'true')) {
+            const backgroundColor = theme.EmailLoginButtonColor || theme.linkColor;
+            const additionalStyle = {
+                backgroundColor
+            };
+
+            if (theme.hasOwnProperty('EmailLoginButtonBorder')) {
+                additionalStyle.borderColor = theme.EmailLoginButtonBorder;
+            }
+
+            const textColor = theme.EmailLoginButtonText || 'white';
+
             return (
                 <Button
                     key='email'
                     onPress={() => preventDoubleTap(this.goToLogin, this)}
-                    containerStyle={[GlobalStyles.signupButton, {backgroundColor: '#2389d7'}]}
+                    containerStyle={[GlobalStyles.signupButton, additionalStyle]}
                 >
                     <FormattedText
                         id='signup.email'
                         defaultMessage='Email and Password'
-                        style={[GlobalStyles.signupButtonText, {color: 'white'}]}
+                        style={[GlobalStyles.signupButtonText, {color: textColor}]}
                     />
                 </Button>
             );
@@ -102,12 +116,25 @@ class LoginOptions extends PureComponent {
     };
 
     renderLdapOption = () => {
-        const {config, license} = this.props;
-        if (license.IsLicensed === 'true' && config.EnableLdap === 'true') {
+        const {config, license, theme} = this.props;
+        const forceHideFromLocal = LocalConfig.HideLDAPLogin;
+
+        if (!forceHideFromLocal && license.IsLicensed === 'true' && config.EnableLdap === 'true') {
+            const backgroundColor = theme.LDAPLoginButtonColor || theme.linkColor;
+            const additionalStyle = {
+                backgroundColor
+            };
+
+            if (theme.hasOwnProperty('LDAPLoginButtonBorder')) {
+                additionalStyle.borderColor = theme.LDAPLoginButtonBorder;
+            }
+
+            const textColor = theme.LDAPLoginButtonText || 'white';
+
             let buttonText;
             if (config.LdapLoginFieldName) {
                 buttonText = (
-                    <Text style={[GlobalStyles.signupButtonText, {color: 'white'}]}>
+                    <Text style={[GlobalStyles.signupButtonText, {color: textColor}]}>
                         {config.LdapLoginFieldName}
                     </Text>
                 );
@@ -116,7 +143,7 @@ class LoginOptions extends PureComponent {
                     <FormattedText
                         id='login.ldapUsernameLower'
                         defaultMessage='AD/LDAP username'
-                        style={[GlobalStyles.signupButtonText, {color: 'white'}]}
+                        style={[GlobalStyles.signupButtonText, {color: textColor}]}
                     />
                 );
             }
@@ -125,7 +152,7 @@ class LoginOptions extends PureComponent {
                 <Button
                     key='ldap'
                     onPress={() => preventDoubleTap(this.goToLogin, this)}
-                    containerStyle={[GlobalStyles.signupButton, {backgroundColor: '#2389d7'}]}
+                    containerStyle={[GlobalStyles.signupButton, additionalStyle]}
                 >
                     {buttonText}
                 </Button>
@@ -166,16 +193,30 @@ class LoginOptions extends PureComponent {
     };
 
     renderSamlOption = () => {
-        const {config, license} = this.props;
-        if (config.EnableSaml === 'true' && license.IsLicensed === 'true' && license.SAML === 'true') {
+        const {config, license, theme} = this.props;
+        const forceHideFromLocal = LocalConfig.HideSAMLLogin;
+
+        if (!forceHideFromLocal && config.EnableSaml === 'true' && license.IsLicensed === 'true' && license.SAML === 'true') {
+            const backgroundColor = theme.SAMLLoginButtonColor || theme.linkColor;
+
+            const additionalStyle = {
+                backgroundColor
+            };
+
+            if (theme.SAMLLoginButtonBorder) {
+                additionalStyle.borderColor = theme.SAMLLoginButtonBorder;
+            }
+
+            const textColor = theme.SAMLLoginButtonText || 'white';
+
             return (
                 <Button
                     key='saml'
                     onPress={() => preventDoubleTap(this.goToSSO, this, ViewTypes.SAML)}
-                    containerStyle={[GlobalStyles.signupButton, {backgroundColor: '#34a28b'}]}
+                    containerStyle={[GlobalStyles.signupButton, additionalStyle]}
                 >
                     <Text
-                        style={[GlobalStyles.signupButtonText, {color: 'white'}]}
+                        style={[GlobalStyles.signupButtonText, {color: textColor}]}
                     >
                         {config.SamlLoginButtonText}
                     </Text>

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -8,6 +8,10 @@
     "MobileNoticeURL": "https://about.mattermost.com/mobile-notice-txt/",
     "SegmentApiKey": "3MT7rAoC0OP7yy3ThzqFSAtKzmzqtUPX",
 
+    "HideEmailLogin": false,
+    "HideLDAPLogin": false,
+    "HideSAMLLogin": false,
+
     "SentryEnabled": false,
     "SentryDsnIos": "",
     "SentryDsnAndroid": "",

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -8,9 +8,10 @@
     "MobileNoticeURL": "https://about.mattermost.com/mobile-notice-txt/",
     "SegmentApiKey": "3MT7rAoC0OP7yy3ThzqFSAtKzmzqtUPX",
 
-    "HideEmailLogin": false,
-    "HideLDAPLogin": false,
-    "HideSAMLLogin": false,
+    "HideEmailLoginExperimental": false,
+    "HideGitLabLoginExperimental": false,
+    "HideLDAPLoginExperimental": false,
+    "HideSAMLLoginExperimental": false,
 
     "SentryEnabled": false,
     "SentryDsnIos": "",

--- a/scripts/make-dist-assets.js
+++ b/scripts/make-dist-assets.js
@@ -83,7 +83,33 @@ function leftMergeDirs(rootA, rootB, dest, path) {
     }
 }
 
+function mergeThemeOverrides(source, override, dest) {
+    var themeA = fs.readFileSync(source);
+
+    var themeB;
+    try {
+        themeB = fs.readFileSync(override);
+    } catch (error) {
+        // override theme doesn't exist
+        return;
+    }
+
+    var objA = JSON.parse(themeA);
+    var objB = JSON.parse(themeB);
+
+    var nextObj = {};
+    Object.keys(objA).forEach((t) => {
+        nextObj[t] = Object.assign({}, objA[t], objB[t]);
+        Reflect.deleteProperty(objB, t);
+    });
+
+    var finalObj = Object.assign({}, nextObj, objB);
+
+    var out = fs.createWriteStream(dest);
+    out.write(JSON.stringify(finalObj));
+}
+
 // Assumes dist/assets exists and is empty
 leftMergeDirs('assets/base/', 'assets/override/', 'dist/assets/', '');
-
+mergeThemeOverrides('assets/base/themes.json', 'assets/override/themes.json', 'dist/assets/themes.json');
 /* eslint-enable no-console */

--- a/scripts/make-dist-assets.js
+++ b/scripts/make-dist-assets.js
@@ -83,33 +83,6 @@ function leftMergeDirs(rootA, rootB, dest, path) {
     }
 }
 
-function mergeThemeOverrides(source, override, dest) {
-    var themeA = fs.readFileSync(source);
-
-    var themeB;
-    try {
-        themeB = fs.readFileSync(override);
-    } catch (error) {
-        // override theme doesn't exist
-        return;
-    }
-
-    var objA = JSON.parse(themeA);
-    var objB = JSON.parse(themeB);
-
-    var nextObj = {};
-    Object.keys(objA).forEach((t) => {
-        nextObj[t] = Object.assign({}, objA[t], objB[t]);
-        Reflect.deleteProperty(objB, t);
-    });
-
-    var finalObj = Object.assign({}, nextObj, objB);
-
-    var out = fs.createWriteStream(dest);
-    out.write(JSON.stringify(finalObj));
-}
-
 // Assumes dist/assets exists and is empty
 leftMergeDirs('assets/base/', 'assets/override/', 'dist/assets/', '');
-mergeThemeOverrides('assets/base/themes.json', 'assets/override/themes.json', 'dist/assets/themes.json');
 /* eslint-enable no-console */


### PR DESCRIPTION
BASH-4

#### Summary
This PR allows for the login options page to be white labled via the override.json and by overriding or adding to the themes.json. Each login option can be turned off via the override.json. If the property for the login option is set to false, the server config is then checked to see if the login option needs to be displayed. The following properties were added to the config.json:

`HideEmailLoginExperimental` - Default is false.
Set to true to hide the email login option
`HideLDAPLoginExperimental` - Default is false.
Set to true to hide the LDAP login option
`HideSAMLLoginExperimental` - Default is false.
Set to true to hide the SAML login option

The UI can also be modified according to different properties within the theme.json. The following properties can be used to the change the colors of the UI elements:

`EmailLoginButtonColor` - Default is the `theme.linkColor`
`EmailLoginButtonBorder` - Default is null
`EmailLoginButtonText` - Default is white
`LDAPLoginButtonColor` - Default is the `theme.linkColor`
`LDAPLoginButtonBorder` - Default is null
`LDAPLoginButtonText` - Default is white
`SAMLLoginButtonColor` - Default is the `theme.linkColor`
`SAMLLoginButtonBorder` - Default is null
`SAMLLoginButtonText` - Default is white

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

@jarredwitt will coordinate modifications
