### PR TITLE
Hide TownSquare leave/join messages using local config

### DIFF
--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -17,5 +17,7 @@
             "xhr": false,
             "console": true
         }
-    }
+    },
+
+    "DisableTownSquareLeaveJoinMessage": false
 }


### PR DESCRIPTION
#### Summary
This PR allows for leave/join messages within the `town-square` channel to be suppressed. 

The following properties were added to the config.json file:

`"DisableTownSquareLeaveJoinMessage": false`

Setting this property to `true` in the override.json will allow for the leave/join messages to be suppressed for the `town-square` channel.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

@jarredwitt will coordinate modifications
