### PR TITLE
Add message retention middleware and config

### DIFF
--- a/app/store/index.js
+++ b/app/store/index.js
@@ -11,10 +11,12 @@ import {General, RequestStatus} from 'mattermost-redux/constants';
 import configureStore from 'mattermost-redux/store';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
+import Config from 'assets/config';
 import {NavigationTypes, ViewTypes} from 'app/constants';
 import appReducer from 'app/reducers';
 import {createSentryMiddleware} from 'app/utils/sentry/middleware';
 
+import {messageRetention} from './middleware';
 import {transformSet} from './utils';
 
 function getAppReducer() {
@@ -170,7 +172,12 @@ export default function configureAppStore(initialState) {
         }
     };
 
+    const additionalMiddleware = [createSentryMiddleware()];
+    if (Config.EnableMessageRetention) {
+        additionalMiddleware.push(messageRetention);
+    }
+
     return configureStore(initialState, appReducer, offlineOptions, getAppReducer, {
-        additionalMiddleware: createSentryMiddleware()
+        additionalMiddleware
     });
 }

--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import Config from 'assets/config';
+
+export function messageRetention() {
+    return (next) => (action) => {
+        if (action.type === 'persist/REHYDRATE') {
+            const {entities, ...payload} = action.payload;
+            const retentionPeriod = Config.MessageRetentionPeriod + 1;
+
+            if (!entities) {
+                return next(action);
+            }
+
+            const {posts: postEntities, ...otherEntities} = entities;
+            const {posts, postsInChannel, ...otherPostEntities} = postEntities;
+
+            const nextPosts = Object.values(posts).reduce((reducedPosts, post) => {
+                if ((Date.now() - post.create_at) / (1000 * 3600 * 24) < retentionPeriod) {
+                    reducedPosts[post.id] = post;
+                }
+
+                return reducedPosts;
+            }, {});
+
+            const nextPostsInChannel = Object.keys(postsInChannel).reduce((reducedPostsInChannel, channel) => {
+                reducedPostsInChannel[channel] = postsInChannel[channel].filter((p) => nextPosts.hasOwnProperty(p));
+
+                return reducedPostsInChannel;
+            }, {});
+
+            const nextEntities = Object.assign({}, otherEntities, {
+                posts: {
+                    ...otherPostEntities,
+                    posts: nextPosts,
+                    postsInChannel: nextPostsInChannel
+                }
+            });
+
+            const nextPayload = Object.assign({}, payload, {
+                entities: nextEntities
+            });
+
+            return next({
+                type: action.type,
+                payload: nextPayload,
+                error: action.error
+            });
+        }
+
+        return next(action);
+    };
+}

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -1,5 +1,7 @@
 {
     "DefaultServerUrl": "",
+    "EnableMessageRetention": false,
+    "MessageRetentionPeriod": 30,
     "TestServerUrl": "http://localhost:8065",
     "DefaultTheme": "default",
     "ShowErrorsList": false,


### PR DESCRIPTION
#### Summary
This PR adds a client side redux milddleware to managing message persistence on the mobile client. The middleware ensures that when the client is started and the state is rehydrated that any messages that are beyond the message retention period defined by the `MessageRetentionPeriod` in the config.json are not displayed on the client and are removed from the offline cache. The following properties have been added to the config.json:

EnableMessageRetention
Default is false.
Set to true to enable the message retention middleware.
MessageRetentionPeriod
Default is 30.
The number of days that a message can remain in the offline cache before it is removed.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates


@jarredwitt will coordinate modifications
