### PR TITLE
Switch android to use layout file for splash

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -154,6 +154,7 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:25.0.1"
+    compile 'com.android.support:percent:25.3.1'
     compile "com.facebook.react:react-native:+"  // From node_modules
     compile project(':react-native-navigation')
     compile project(':react-native-image-picker')

--- a/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
@@ -2,62 +2,9 @@ package com.mattermost.rnbeta;
 
 import com.reactnativenavigation.controllers.SplashActivity;
 
-import java.lang.ref.WeakReference;
-
-import android.content.Context;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.graphics.Color;
-import android.widget.TextView;
-import android.view.ViewGroup.LayoutParams;
-import android.view.Gravity;
-import android.util.TypedValue;
-
 public class MainActivity extends SplashActivity {
-
-    private static ImageView imageView;
-    private static WeakReference<MainActivity> wr_activity;
-    protected static MainActivity getActivity() {
-        return wr_activity.get();
-    }
-
-    /**
-     * Returns the name of the main component registered from JavaScript.
-     * This is used to schedule rendering of the component.
-     */
-    // @Override
-    // protected String getMainComponentName() {
-    //     return "Mattermost";
-    // }
-
-    @Override
-    public LinearLayout createSplashLayout() {
-        wr_activity = new WeakReference<>(this);
-        LayoutParams layoutParams = new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
-        Context context = getActivity();
-        final int drawableId = getImageId();
-
-        NotificationsLifecycleFacade.getInstance().LoadManagedConfig(getActivity());
-
-        imageView = new ImageView(context);
-        imageView.setImageResource(drawableId);
-
-        imageView.setLayoutParams(layoutParams);
-        imageView.setScaleType(ImageView.ScaleType.CENTER);
-
-        LinearLayout view = new LinearLayout(this);
-        view.setBackgroundColor(Color.parseColor("#FFFFFF"));
-        view.setGravity(Gravity.CENTER);
-        view.addView(imageView);
-
-        return view;
-    }
-
-    private static int getImageId() {
-        int drawableId = getActivity().getResources().getIdentifier("splash", "drawable", getActivity().getClass().getPackage().getName());
-        if (drawableId == 0) {
-            drawableId = getActivity().getResources().getIdentifier("splash", "drawable", getActivity().getPackageName());
-        }
-        return drawableId;
-    }
+  @Override
+  public int getSplashLayout() {
+      return R.layout.launch_screen;
+  }
 }

--- a/android/app/src/main/res/layout/launch_screen.xml
+++ b/android/app/src/main/res/layout/launch_screen.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.percent.PercentRelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#ffffff"
+    android:gravity="center_horizontal"
+    tools:context=".SplashScreenActivity">
+
+    <ImageView
+        android:id="@+id/imgLogo"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:src="@drawable/splash" />
+
+</android.support.percent.PercentRelativeLayout>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="white">#FFFFFF</color>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,7 +3,9 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
-        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowIsTranslucent">false</item>
+        <item name="android:windowBackground">@color/white</item>
+        <item name="android:colorBackground">@color/white</item>
     </style>
 
 </resources>

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -540,7 +540,7 @@ export default class Mattermost {
     launchApp = () => {
         this.handleManagedConfig().then((shouldStart) => {
             if (shouldStart) {
-                this.startApp();
+                this.startApp('fade');
             }
         });
     };
@@ -572,7 +572,8 @@ export default class Mattermost {
                 navigatorStyle: {
                     navBarHidden: true,
                     statusBarHidden: false,
-                    statusBarHideWithNavBar: false
+                    statusBarHideWithNavBar: false,
+                    screenBackgroundColor: 'transparent'
                 }
             },
             passProps: {

--- a/app/screens/load_team/load_team.js
+++ b/app/screens/load_team/load_team.js
@@ -67,7 +67,8 @@ export default class LoadTeam extends PureComponent {
         actions.initialize();
         navigator.resetTo({
             screen: 'Channel',
-            animated: false,
+            animated: true,
+            animationType: 'fade',
             navigatorStyle: {
                 navBarHidden: true,
                 statusBarHidden: false,

--- a/app/screens/root/root.js
+++ b/app/screens/root/root.js
@@ -34,7 +34,8 @@ export default class Root extends PureComponent {
         navigator.resetTo({
             screen: 'LoadTeam',
             title: '',
-            animated: false,
+            animated: true,
+            animationType: 'fade',
             backButtonTitle: '',
             navigatorStyle: {
                 statusBarHidden: false,
@@ -52,7 +53,8 @@ export default class Root extends PureComponent {
 
         navigator.resetTo({
             screen: 'SelectServer',
-            animated: false,
+            animated: true,
+            animationType: 'fade',
             navigatorStyle: {
                 navBarHidden: true,
                 navBarBackgroundColor: 'black',


### PR DESCRIPTION
#### Summary
This PR changes the Android splash screen to use a layout file as well as removes the initial screen flickering that occurs when the app is opening. By switching to an Android layout file we allow for me configuration of the splash screen.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

@jarredwitt will coordinate modifications
