### PR TITLE
Added selector for getting sorted teams list

### DIFF
--- a/app/components/channel_drawer/teams_list/index.js
+++ b/app/components/channel_drawer/teams_list/index.js
@@ -7,33 +7,23 @@ import {connect} from 'react-redux';
 import {markChannelAsRead} from 'mattermost-redux/actions/channels';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUrl} from 'mattermost-redux/selectors/entities/general';
-import {getCurrentTeamId, getJoinableTeams, getMyTeams, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentTeamId, getJoinableTeams, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 
 import {handleTeamChange} from 'app/actions/views/select_team';
 import {getTheme} from 'app/selectors/preferences';
+import {getMySortedTeams} from 'app/selectors/teams';
 import {removeProtocol} from 'app/utils/url';
 
 import TeamsList from './teams_list';
 
 function mapStateToProps(state, ownProps) {
-    const user = getCurrentUser(state);
-
-    function sortTeams(locale, a, b) {
-        if (a.display_name !== b.display_name) {
-            return a.display_name.toLowerCase().localeCompare(b.display_name.toLowerCase(), locale, {numeric: true});
-        }
-
-        return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale, {numeric: true});
-    }
-
     return {
         canCreateTeams: false,
         joinableTeams: getJoinableTeams(state),
         currentChannelId: getCurrentChannelId(state),
         currentTeamId: getCurrentTeamId(state),
         currentUrl: removeProtocol(getCurrentUrl(state)),
-        teams: getMyTeams(state).sort(sortTeams.bind(null, (user.locale))),
+        teams: getMySortedTeams(state),
         theme: getTheme(state),
         myTeamMembers: getTeamMemberships(state),
         ...ownProps

--- a/app/selectors/teams.js
+++ b/app/selectors/teams.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {createSelector} from 'reselect';
+
+import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+export const getMySortedTeams = createSelector(
+    getMyTeams,
+    getCurrentUser,
+    (teams, currentUser) => {
+        const locale = currentUser.locale;
+
+        return teams.sort((a, b) => {
+            if (a.display_name !== b.display_name) {
+                return a.display_name.toLowerCase().localeCompare(b.display_name.toLowerCase(), locale, {numeric: true});
+            }
+
+            return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale, {numeric: true});
+        });
+    }
+);


### PR DESCRIPTION
We were generating a new, sorted teams list every time the store changed so we're re-rendering this component more often than we need to