### PR TITLE
RN-320 Tapping enter in channel header/purpose keeps the keyboard open

### DIFF
--- a/app/screens/create_channel/create_channel.js
+++ b/app/screens/create_channel/create_channel.js
@@ -289,6 +289,7 @@ class CreateChannel extends PureComponent {
                                     placeholder={{id: 'channel_modal.purposeEx', defaultMessage: 'E.g.: "A channel to file bugs and improvements"'}}
                                     placeholderTextColor={changeOpacity('#000', 0.5)}
                                     multiline={true}
+                                    blurOnSubmit={false}
                                     underlineColorAndroid='transparent'
                                 />
                             </View>
@@ -322,6 +323,7 @@ class CreateChannel extends PureComponent {
                                     placeholder={{id: 'channel_modal.headerEx', defaultMessage: 'E.g.: "[Link Title](http://example.com)"'}}
                                     placeholderTextColor={changeOpacity('#000', 0.5)}
                                     multiline={true}
+                                    blurOnSubmit={false}
                                     onFocus={this.scrollToEnd}
                                     underlineColorAndroid='transparent'
                                 />


### PR DESCRIPTION
#### Summary
On some Android devices for the header and purpose of a new channel tapping on Enter blurred the keyboard, now it keeps the keyboard up and creates a new line

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-320

#### Device Information
This PR was tested on: 
* Android 6.0.1 Samsung J5
* Android 7.1.1 emulator