### PR TITLE
RN-382 Refactor at_mention & channel_mention autocomplete

### DIFF
--- a/app/components/autocomplete/at_mention/at_mention.js
+++ b/app/components/autocomplete/at_mention/at_mention.js
@@ -61,7 +61,7 @@ export default class AtMention extends PureComponent {
             return;
         }
 
-        if (matchTerm !== this.props.matchTerm && requestStatus !== RequestStatus.STARTED) {
+        if (matchTerm !== this.props.matchTerm) {
             // if the term changed and we haven't made the request do that first
             const {currentTeamId, currentChannelId} = this.props;
             this.props.actions.autocompleteUsers(matchTerm, currentTeamId, isSearch ? currentChannelId : '');

--- a/app/components/autocomplete/at_mention_item/at_mention_item.js
+++ b/app/components/autocomplete/at_mention_item/at_mention_item.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {
+    Text,
+    TouchableOpacity,
+    View
+} from 'react-native';
+
+import ProfilePicture from 'app/components/profile_picture';
+import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
+
+export default class AtMentionItem extends PureComponent {
+    static propTypes = {
+        firstName: PropTypes.string,
+        lastName: PropTypes.string,
+        onPress: PropTypes.func.isRequired,
+        userId: PropTypes.string.isRequired,
+        username: PropTypes.string,
+        theme: PropTypes.object.isRequired
+    };
+
+    completeMention = (username) => {
+        this.props.onPress(username);
+    };
+
+    render() {
+        const {
+            firstName,
+            lastName,
+            userId,
+            username,
+            theme
+        } = this.props;
+
+        const style = getStyleFromTheme(theme);
+        const hasFullName = firstName.length > 0 && lastName.length > 0;
+
+        return (
+            <TouchableOpacity
+                key={userId}
+                onPress={this.completeMention.bind(this, username)}
+                style={style.row}
+            >
+                <View style={style.rowPicture}>
+                    <ProfilePicture
+                        userId={userId}
+                        theme={theme}
+                        size={20}
+                        status={null}
+                    />
+                </View>
+                <Text style={style.rowUsername}>{`@${username}`}</Text>
+                {hasFullName && <Text style={style.rowUsername}>{' - '}</Text>}
+                {hasFullName && <Text style={style.rowFullname}>{`${firstName} ${lastName}`}</Text>}
+            </TouchableOpacity>
+        );
+    }
+}
+const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
+    return {
+        row: {
+            paddingVertical: 8,
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: theme.centerChannelBg,
+            borderTopWidth: 1,
+            borderTopColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderLeftWidth: 1,
+            borderLeftColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderRightWidth: 1,
+            borderRightColor: changeOpacity(theme.centerChannelColor, 0.2)
+        },
+        rowPicture: {
+            marginHorizontal: 8,
+            width: 20,
+            alignItems: 'center',
+            justifyContent: 'center'
+        },
+        rowUsername: {
+            fontSize: 13,
+            color: theme.centerChannelColor
+        },
+        rowFullname: {
+            color: theme.centerChannelColor,
+            opacity: 0.6
+        }
+    };
+});

--- a/app/components/autocomplete/at_mention_item/index.js
+++ b/app/components/autocomplete/at_mention_item/index.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getUser} from 'mattermost-redux/selectors/entities/users';
+
+import {getTheme} from 'app/selectors/preferences';
+
+import AtMentionItem from './at_mention_item';
+
+function mapStateToProps(state, ownProps) {
+    const user = getUser(state, ownProps.userId);
+
+    return {
+        firstName: user.first_name,
+        lastName: user.last_name,
+        username: user.username,
+        theme: getTheme(state),
+        ...ownProps
+    };
+}
+
+export default connect(mapStateToProps)(AtMentionItem);

--- a/app/components/autocomplete/autocomplete_section_header.js
+++ b/app/components/autocomplete/autocomplete_section_header.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {View} from 'react-native';
+
+import FormattedText from 'app/components/formatted_text';
+import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
+
+export default class AutocompleteSectionHeader extends PureComponent {
+    static propTypes = {
+        defaultMessage: PropTypes.string.isRequired,
+        id: PropTypes.string.isRequired,
+        theme: PropTypes.object.isRequired
+    };
+
+    render() {
+        const {defaultMessage, id, theme} = this.props;
+        const style = getStyleFromTheme(theme);
+
+        return (
+            <View style={style.sectionWrapper}>
+                <View style={style.section}>
+                    <FormattedText
+                        id={id}
+                        defaultMessage={defaultMessage}
+                        style={style.sectionText}
+                    />
+                </View>
+            </View>
+        );
+    }
+}
+
+const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
+    return {
+        section: {
+            justifyContent: 'center',
+            paddingLeft: 8,
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
+            borderTopWidth: 1,
+            borderTopColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderLeftWidth: 1,
+            borderLeftColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderRightWidth: 1,
+            borderRightColor: changeOpacity(theme.centerChannelColor, 0.2)
+        },
+        sectionText: {
+            fontSize: 12,
+            color: changeOpacity(theme.centerChannelColor, 0.7),
+            paddingVertical: 7
+        },
+        sectionWrapper: {
+            backgroundColor: theme.centerChannelBg
+        }
+    };
+});

--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -59,7 +59,7 @@ export default class ChannelMention extends PureComponent {
             return;
         }
 
-        if (matchTerm !== this.props.matchTerm && requestStatus !== RequestStatus.STARTED) {
+        if (matchTerm !== this.props.matchTerm) {
             // if the term changed and we haven't made the request do that first
             const {currentTeamId} = this.props;
             this.props.actions.searchChannels(currentTeamId, matchTerm);

--- a/app/components/autocomplete/channel_mention/index.js
+++ b/app/components/autocomplete/channel_mention/index.js
@@ -5,21 +5,43 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {searchChannels} from 'mattermost-redux/actions/channels';
-import {General} from 'mattermost-redux/constants';
-import {getMyChannels, getOtherChannels} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
+import {
+    filterMyChannels,
+    filterOtherChannels,
+    filterPublicChannels,
+    filterPrivateChannels
+} from 'app/selectors/autocomplete';
 import {getTheme} from 'app/selectors/preferences';
 
 import ChannelMention from './channel_mention';
 
+const CHANNEL_MENTION_REGEX = /\B(~([^~\r\n]*))$/i;
+const CHANNEL_SEARCH_REGEX = /\b(?:in|channel):\s*(\S*)$/i;
+
+const myChannels = [];
+const otherChannels = [];
+const publicChannels = [];
+const privateChannels = [];
+
+const autocompleteChannels = {
+    myChannels,
+    otherChannels,
+    publicChannels,
+    privateChannels
+};
+
 function mapStateToProps(state, ownProps) {
-    const {currentChannelId} = state.entities.channels;
+    const {cursorPosition, isSearch, rootId} = ownProps;
+    const currentChannelId = getCurrentChannelId(state);
+    const regex = isSearch ? CHANNEL_SEARCH_REGEX : CHANNEL_MENTION_REGEX;
 
     let postDraft;
-    if (ownProps.isSearch) {
+    if (isSearch) {
         postDraft = state.views.search;
-    } else if (ownProps.rootId) {
-        const threadDraft = state.views.thread.drafts[ownProps.rootId];
+    } else if (rootId) {
+        const threadDraft = state.views.thread.drafts[rootId];
         if (threadDraft) {
             postDraft = threadDraft.draft;
         }
@@ -30,17 +52,32 @@ function mapStateToProps(state, ownProps) {
         }
     }
 
-    const autocompleteChannels = {
-        myChannels: getMyChannels(state).filter((c) => c.type !== General.DM_CHANNEL && c.type !== General.GM_CHANNEL),
-        otherChannels: getOtherChannels(state)
+    const match = postDraft.substring(0, cursorPosition).match(regex);
+    let matchTerm = null;
+    if (match) {
+        matchTerm = isSearch ? match[1] : match[2];
+    }
+
+    const opts = {
+        matchTerm,
+        isSearch
     };
+
+    if (isSearch) {
+        filterPublicChannels(state, {...opts, array: publicChannels});
+        filterPrivateChannels(state, {...opts, array: privateChannels});
+    } else {
+        filterMyChannels(state, {...opts, array: myChannels});
+        filterOtherChannels(state, {...opts, array: otherChannels});
+    }
 
     return {
         ...ownProps,
-        currentChannelId,
-        currentTeamId: state.entities.teams.currentTeamId,
-        postDraft,
         autocompleteChannels,
+        currentTeamId: state.entities.teams.currentTeamId,
+        hasMatch: match !== null,
+        matchTerm,
+        postDraft,
         requestStatus: state.requests.channels.getChannels.status,
         theme: getTheme(state)
     };

--- a/app/components/autocomplete/channel_mention_item/channel_mention_item.js
+++ b/app/components/autocomplete/channel_mention_item/channel_mention_item.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {
+    Text,
+    TouchableOpacity
+} from 'react-native';
+
+import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
+
+export default class ChannelMentionItem extends PureComponent {
+    static propTypes = {
+        channelId: PropTypes.string.isRequired,
+        displayName: PropTypes.string,
+        name: PropTypes.string,
+        onPress: PropTypes.func.isRequired,
+        theme: PropTypes.object.isRequired
+    };
+
+    completeMention = (username) => {
+        this.props.onPress(username);
+    };
+
+    render() {
+        const {
+            channelId,
+            displayName,
+            name,
+            theme
+        } = this.props;
+
+        const style = getStyleFromTheme(theme);
+
+        return (
+            <TouchableOpacity
+                key={channelId}
+                onPress={this.completeMention.bind(this, name)}
+                style={style.row}
+            >
+                <Text style={style.rowDisplayName}>{displayName}</Text>
+                <Text style={style.rowName}>{` (~${name})`}</Text>
+            </TouchableOpacity>
+        );
+    }
+}
+const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
+    return {
+        row: {
+            padding: 8,
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: theme.centerChannelBg,
+            borderTopWidth: 1,
+            borderTopColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderLeftWidth: 1,
+            borderLeftColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderRightWidth: 1,
+            borderRightColor: changeOpacity(theme.centerChannelColor, 0.2)
+        },
+        rowDisplayName: {
+            fontSize: 13,
+            color: theme.centerChannelColor
+        },
+        rowName: {
+            color: theme.centerChannelColor,
+            opacity: 0.6
+        }
+    };
+});

--- a/app/components/autocomplete/channel_mention_item/channel_mention_item.js
+++ b/app/components/autocomplete/channel_mention_item/channel_mention_item.js
@@ -19,8 +19,9 @@ export default class ChannelMentionItem extends PureComponent {
         theme: PropTypes.object.isRequired
     };
 
-    completeMention = (username) => {
-        this.props.onPress(username);
+    completeMention = () => {
+        const {onPress, name} = this.props;
+        onPress(name);
     };
 
     render() {
@@ -36,7 +37,7 @@ export default class ChannelMentionItem extends PureComponent {
         return (
             <TouchableOpacity
                 key={channelId}
-                onPress={this.completeMention.bind(this, name)}
+                onPress={this.completeMention}
                 style={style.row}
             >
                 <Text style={style.rowDisplayName}>{displayName}</Text>

--- a/app/components/autocomplete/channel_mention_item/index.js
+++ b/app/components/autocomplete/channel_mention_item/index.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+
+import {getTheme} from 'app/selectors/preferences';
+
+import ChannelMentionItem from './channel_mention_item';
+
+function mapStateToProps(state, ownProps) {
+    const channel = getChannel(state, ownProps.channelId);
+
+    return {
+        displayName: channel.display_name,
+        name: channel.name,
+        theme: getTheme(state),
+        ...ownProps
+    };
+}
+
+export default connect(mapStateToProps)(ChannelMentionItem);

--- a/app/components/autocomplete/index.js
+++ b/app/components/autocomplete/index.js
@@ -68,10 +68,14 @@ const style = StyleSheet.create({
         overflow: 'hidden'
     },
     searchContainer: {
-        backgroundColor: 'white',
         elevation: 5,
         flex: 1,
+        left: 0,
+        maxHeight: 250,
+        overflow: 'hidden',
         position: 'absolute',
+        right: 0,
+        zIndex: 5,
         ...Platform.select({
             android: {
                 top: 47
@@ -79,11 +83,6 @@ const style = StyleSheet.create({
             ios: {
                 top: 64
             }
-        }),
-        left: 0,
-        right: 0,
-        maxHeight: 250,
-        overflow: 'hidden',
-        zIndex: 5
+        })
     }
 });

--- a/app/components/autocomplete/special_mention_item.js
+++ b/app/components/autocomplete/special_mention_item.js
@@ -8,54 +8,58 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
-import ProfilePicture from 'app/components/profile_picture';
+import FormattedText from 'app/components/formatted_text';
 import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
 
-export default class AtMentionItem extends PureComponent {
+export default class SpecialMentionItem extends PureComponent {
     static propTypes = {
-        firstName: PropTypes.string,
-        lastName: PropTypes.string,
+        completeHandle: PropTypes.string.isRequired,
+        defaultMessage: PropTypes.string.isRequired,
+        id: PropTypes.string.isRequired,
         onPress: PropTypes.func.isRequired,
-        userId: PropTypes.string.isRequired,
-        username: PropTypes.string,
-        theme: PropTypes.object.isRequired
+        theme: PropTypes.object.isRequired,
+        values: PropTypes.object
     };
 
     completeMention = () => {
-        const {onPress, username} = this.props;
-        onPress(username);
+        const {onPress, completeHandle} = this.props;
+        onPress(completeHandle);
     };
 
     render() {
         const {
-            firstName,
-            lastName,
-            userId,
-            username,
-            theme
+            defaultMessage,
+            id,
+            completeHandle,
+            theme,
+            values
         } = this.props;
 
         const style = getStyleFromTheme(theme);
-        const hasFullName = firstName.length > 0 && lastName.length > 0;
 
         return (
             <TouchableOpacity
-                key={userId}
                 onPress={this.completeMention}
                 style={style.row}
             >
                 <View style={style.rowPicture}>
-                    <ProfilePicture
-                        userId={userId}
-                        theme={theme}
-                        size={20}
-                        status={null}
+                    <Icon
+                        name='users'
+                        style={style.rowIcon}
                     />
                 </View>
-                <Text style={style.rowUsername}>{`@${username}`}</Text>
-                {hasFullName && <Text style={style.rowUsername}>{' - '}</Text>}
-                {hasFullName && <Text style={style.rowFullname}>{`${firstName} ${lastName}`}</Text>}
+                <Text style={style.textWrapper}>
+                    <Text style={style.rowUsername}>{`@${completeHandle}`}</Text>
+                    <Text style={style.rowUsername}>{' - '}</Text>
+                    <FormattedText
+                        id={id}
+                        defaultMessage={defaultMessage}
+                        values={values}
+                        style={style.rowFullname}
+                    />
+                </Text>
             </TouchableOpacity>
         );
     }
@@ -80,13 +84,23 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             alignItems: 'center',
             justifyContent: 'center'
         },
+        rowIcon: {
+            color: changeOpacity(theme.centerChannelColor, 0.7),
+            fontSize: 14
+        },
         rowUsername: {
             fontSize: 13,
             color: theme.centerChannelColor
         },
         rowFullname: {
             color: theme.centerChannelColor,
+            flex: 1,
             opacity: 0.6
+        },
+        textWrapper: {
+            flex: 1,
+            flexWrap: 'wrap',
+            paddingRight: 8
         }
     };
 });

--- a/app/components/channel_intro/channel_intro.js
+++ b/app/components/channel_intro/channel_intro.js
@@ -71,7 +71,7 @@ class ChannelIntro extends PureComponent {
                 style={style.profile}
             >
                 <ProfilePicture
-                    user={member}
+                    userId={member.id}
                     size={64}
                     statusBorderWidth={2}
                     statusSize={25}

--- a/app/components/custom_list/user_list_row/user_list_row.js
+++ b/app/components/custom_list/user_list_row/user_list_row.js
@@ -40,7 +40,7 @@ export default class UserListRow extends React.PureComponent {
                 selected={this.props.selected}
             >
                 <ProfilePicture
-                    user={this.props.user}
+                    userId={this.props.user.id}
                     size={32}
                 />
                 <View style={style.textContainer}>

--- a/app/components/post_profile_picture/post_profile_picture.js
+++ b/app/components/post_profile_picture/post_profile_picture.js
@@ -51,7 +51,7 @@ function PostProfilePicture(props) {
 
         return (
             <ProfilePicture
-                user={user}
+                userId={user.id}
                 size={PROFILE_PICTURE_SIZE}
             />
         );
@@ -60,7 +60,7 @@ function PostProfilePicture(props) {
     return (
         <TouchableOpacity onPress={onViewUserProfile}>
             <ProfilePicture
-                user={user}
+                userId={user.id}
                 size={PROFILE_PICTURE_SIZE}
             />
         </TouchableOpacity>

--- a/app/components/profile_picture/index.js
+++ b/app/components/profile_picture/index.js
@@ -6,19 +6,21 @@ import {connect} from 'react-redux';
 
 import {getTheme} from 'app/selectors/preferences';
 import {getStatusesByIdsBatchedDebounced} from 'mattermost-redux/actions/users';
-import {getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
+import {getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 
 import ProfilePicture from './profile_picture';
 
 function mapStateToProps(state, ownProps) {
     let status = ownProps.status;
-    if (!status && ownProps.user) {
-        status = ownProps.user.status || getStatusForUserId(state, ownProps.user.id);
+    const user = getUser(state, ownProps.userId);
+    if (!status && ownProps.userId) {
+        status = getStatusForUserId(state, ownProps.userId);
     }
 
     return {
         theme: ownProps.theme || getTheme(state),
         status,
+        user,
         ...ownProps
     };
 }

--- a/app/constants/autocomplete.js
+++ b/app/constants/autocomplete.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+export const AT_MENTION_REGEX = /\B(@([^@\r\n\s]*))$/i;
+
+export const AT_MENTION_SEARCH_REGEX = /\bfrom:\s*(\S*)$/i;
+
+export const CHANNEL_MENTION_REGEX = /\B(~([^~\r\n]*))$/i;
+
+export const CHANNEL_MENTION_SEARCH_REGEX = /\b(?:in|channel):\s*(\S*)$/i;

--- a/app/screens/notification/notification.js
+++ b/app/screens/notification/notification.js
@@ -80,7 +80,7 @@ export default class Notification extends PureComponent {
         } else if (user) {
             icon = (
                 <ProfilePicture
-                    user={user}
+                    userId={user.id}
                     size={IMAGE_SIZE}
                 />
             );

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -115,7 +115,7 @@ class UserProfile extends PureComponent {
                 >
                     <View style={style.top}>
                         <ProfilePicture
-                            user={user}
+                            userId={user.id}
                             size={150}
                             statusBorderWidth={6}
                             statusSize={40}

--- a/app/selectors/autocomplete.js
+++ b/app/selectors/autocomplete.js
@@ -1,0 +1,212 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {createSelector} from 'reselect';
+
+import {General} from 'mattermost-redux/constants';
+import {getMyChannels, getOtherChannels} from 'mattermost-redux/selectors/entities/channels';
+import {
+    getCurrentUser, getProfilesInCurrentChannel,
+    getProfilesNotInCurrentChannel, getProfilesInCurrentTeam
+} from 'mattermost-redux/selectors/entities/users';
+import {sortChannelsByDisplayName} from 'mattermost-redux/utils/channel_utils';
+import {sortByUsername} from 'mattermost-redux/utils/user_utils';
+
+import {getCurrentUserLocale} from 'app/selectors/i18n';
+
+export const filterMembersInChannel = createSelector(
+    getProfilesInCurrentChannel,
+    (state, opts) => opts,
+    (profilesInChannel, opts) => {
+        const {array} = opts;
+        array.splice(0, array.length);
+
+        let profiles;
+        const matchTerm = opts.matchTerm;
+        if (matchTerm) {
+            profiles = profilesInChannel.filter((p) => {
+                return ((p.id !== opts.currentUserId) && (
+                    p.username.toLowerCase().includes(matchTerm) || p.email.toLowerCase().includes(matchTerm) ||
+                    p.first_name.toLowerCase().includes(matchTerm) || p.last_name.toLowerCase().includes(matchTerm)));
+            });
+        } else {
+            profiles = profilesInChannel.filter((p) => p.id !== opts.currentUserId);
+        }
+
+        profiles.sort(sortByUsername).forEach((p) => {
+            array.push(p.id);
+        });
+
+        return array;
+    }
+);
+
+export const filterMembersNotInChannel = createSelector(
+    getProfilesNotInCurrentChannel,
+    (state, opts) => opts,
+    (profilesNotInChannel, opts) => {
+        const {array} = opts;
+        array.splice(0, array.length);
+
+        let profiles;
+        const matchTerm = opts.matchTerm;
+        if (matchTerm) {
+            profiles = profilesNotInChannel.filter((p) => {
+                return ((p.id !== opts.currentUserId) && (
+                    p.username.toLowerCase().includes(matchTerm) || p.email.toLowerCase().includes(matchTerm) ||
+                    p.first_name.toLowerCase().includes(matchTerm) || p.last_name.toLowerCase().includes(matchTerm)));
+            });
+        } else {
+            profiles = profilesNotInChannel;
+        }
+
+        profiles.sort(sortByUsername).forEach((p) => {
+            array.push(p.id);
+        });
+
+        return array;
+    }
+);
+
+export const filterMembersInCurrentTeam = createSelector(
+    getProfilesInCurrentTeam,
+    getCurrentUser,
+    (state, opts) => opts,
+    (profilesInTeam, currentUser, opts) => {
+        const {array} = opts;
+        array.splice(0, array.length);
+
+        let profiles;
+        const matchTerm = opts.matchTerm;
+        if (matchTerm) {
+            profiles = profilesInTeam.concat(currentUser).filter((p) => {
+                return (p.username.toLowerCase().includes(matchTerm) || p.email.toLowerCase().includes(matchTerm) ||
+                    p.first_name.toLowerCase().includes(matchTerm) || p.last_name.toLowerCase().includes(matchTerm));
+            });
+        } else {
+            profiles = profilesInTeam.concat(currentUser);
+        }
+
+        profiles.sort(sortByUsername).forEach((p) => {
+            array.push(p.id);
+        });
+
+        return array;
+    }
+);
+
+export const filterMyChannels = createSelector(
+    getMyChannels,
+    (state, opts) => opts,
+    (myChannels, opts) => {
+        const {array} = opts;
+        array.splice(0, array.length);
+
+        let channels;
+        const matchTerm = opts.matchTerm;
+        if (matchTerm) {
+            channels = myChannels.filter((c) => {
+                return (c.type === General.OPEN_CHANNEL || c.type === General.PRIVATE_CHANNEL) &&
+                    (c.name.startsWith(matchTerm) || c.display_name.startsWith(matchTerm));
+            });
+        } else {
+            channels = myChannels.filter((c) => {
+                return (c.type === General.OPEN_CHANNEL || c.type === General.PRIVATE_CHANNEL);
+            });
+        }
+
+        // this channels are already sorted by the selector
+        channels.forEach((c) => {
+            array.push(c.id);
+        });
+
+        return array;
+    }
+);
+
+export const filterOtherChannels = createSelector(
+    getOtherChannels,
+    (state, opts) => opts,
+    (otherChannels, opts) => {
+        const {array} = opts;
+        array.splice(0, array.length);
+
+        let channels;
+        const matchTerm = opts.matchTerm;
+        if (matchTerm) {
+            channels = otherChannels.filter((c) => {
+                return (c.name.startsWith(matchTerm) || c.display_name.startsWith(matchTerm));
+            });
+        } else {
+            channels = otherChannels;
+        }
+
+        // this channels are already sorted by the selector
+        channels.forEach((c) => {
+            array.push(c.id);
+        });
+
+        return array;
+    }
+);
+
+export const filterPublicChannels = createSelector(
+    getMyChannels,
+    getOtherChannels,
+    getCurrentUserLocale,
+    (state, opts) => opts,
+    (myChannels, otherChannels, locale, opts) => {
+        const {array} = opts;
+        array.splice(0, array.length);
+
+        let channels;
+        const matchTerm = opts.matchTerm;
+        if (matchTerm) {
+            channels = myChannels.filter((c) => {
+                return c.type === General.OPEN_CHANNEL &&
+                    (c.name.startsWith(matchTerm) || c.display_name.startsWith(matchTerm));
+            }).concat(
+                otherChannels.filter((c) => c.name.startsWith(matchTerm) || c.display_name.startsWith(matchTerm))
+            );
+        } else {
+            channels = myChannels.filter((c) => {
+                return (c.type === General.OPEN_CHANNEL || c.type === General.PRIVATE_CHANNEL);
+            }).concat(otherChannels);
+        }
+
+        channels.sort(sortChannelsByDisplayName.bind(null, locale)).forEach((c) => {
+            array.push(c.id);
+        });
+
+        return array;
+    }
+);
+
+export const filterPrivateChannels = createSelector(
+    getMyChannels,
+    (state, opts) => opts,
+    (myChannels, opts) => {
+        const {array} = opts;
+        array.splice(0, array.length);
+
+        let channels;
+        const matchTerm = opts.matchTerm;
+        if (matchTerm) {
+            channels = myChannels.filter((c) => {
+                return c.type === General.PRIVATE_CHANNEL &&
+                    (c.name.startsWith(matchTerm) || c.display_name.startsWith(matchTerm));
+            });
+        } else {
+            channels = myChannels.filter((c) => {
+                return c.type === General.PRIVATE_CHANNEL;
+            });
+        }
+
+        // this channels are already sorted by the selector
+        channels.forEach((c) => {
+            array.push(c.id);
+        });
+
+        return array;
+    }
+);

--- a/app/selectors/i18n.js
+++ b/app/selectors/i18n.js
@@ -11,7 +11,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 export const getCurrentUserLocale = createSelector(
     getCurrentUser,
     (currentUser) => {
-        return currentUser ? currentUser.locale : 'en';
+        return currentUser ? currentUser.locale : '';
     }
 );
 

--- a/app/selectors/i18n.js
+++ b/app/selectors/i18n.js
@@ -11,7 +11,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 export const getCurrentUserLocale = createSelector(
     getCurrentUser,
     (currentUser) => {
-        return currentUser ? currentUser.locale : '';
+        return currentUser ? currentUser.locale : 'en';
     }
 );
 


### PR DESCRIPTION
#### Summary
This PR refactors the autocomplete for at_mentions and channel_mentions, the same components are used for the `postTextBox` and the search screen.

I've added a few selectors that will take care of filtering depending on the term to match and they will only return the ids for users or channels, that way we'll prevent the *SectionList* from re-rendering if not necessary.

For the `postTextBox` the **at_mention** will show the sections for `Channel Members`, `Special Mentions` and `Not In Channel` and the **channel_mention** will show the sections for `My Channels` and `Other Channels`

For the search screen the autocomplete for **at_mentions** will show the `Members` section containing the search term for all the members in the current team, the **channel_mention** autocomplete will show the sections `Public Channels` and `Private Channels`

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-382

#### Device Information
This PR was tested on: 
* iOS 11 iPhone 6s and Simulator
* Android 7.1 Emulator
* Android 6.0.1 Samsung J5
