### PR TITLE
RN-268 Updated mattermost-redux to fix teams not being correctly marked as read

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3878,7 +3878,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/3f8bad7d1569949e0c7eeabac91bad06bfe7c1c3"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/9042b154c85f65b4e91b30bf2bc612048e3d194b"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
Submitting this as a placeholder PR so that I'll remember to add the redux changes here. yarn.lock will need to be updated once https://github.com/mattermost/mattermost-redux/pull/264 is merged

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-268

#### Checklist
- Added or updated unit tests (required for all new features)
- All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
