### PR TITLE
Do not show channel intro while posts are being loaded

### DIFF
--- a/app/components/channel_intro/channel_intro.js
+++ b/app/components/channel_intro/channel_intro.js
@@ -12,6 +12,7 @@ import {getFullName} from 'mattermost-redux/utils/user_utils';
 import {General} from 'mattermost-redux/constants';
 import {injectIntl, intlShape} from 'react-intl';
 
+import Loading from 'app/components/loading';
 import ProfilePicture from 'app/components/profile_picture';
 import {preventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
@@ -22,6 +23,7 @@ class ChannelIntro extends PureComponent {
         currentChannel: PropTypes.object.isRequired,
         currentChannelMembers: PropTypes.array.isRequired,
         intl: intlShape.isRequired,
+        isLoadingPosts: PropTypes.bool,
         navigator: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired
     };
@@ -304,9 +306,16 @@ class ChannelIntro extends PureComponent {
     };
 
     render() {
-        const {theme} = this.props;
-
+        const {isLoadingPosts, theme} = this.props;
         const style = getStyleSheet(theme);
+
+        if (isLoadingPosts) {
+            return (
+                <View style={style.container}>
+                    <Loading/>
+                </View>
+            );
+        }
 
         return (
             <View style={style.container}>

--- a/app/components/channel_intro/index.js
+++ b/app/components/channel_intro/index.js
@@ -1,9 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
-import {General} from 'mattermost-redux/constants';
+import {General, RequestStatus} from 'mattermost-redux/constants';
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUser, getProfilesInCurrentChannel} from 'mattermost-redux/selectors/entities/users';
 
@@ -14,6 +13,7 @@ import ChannelIntro from './channel_intro';
 function mapStateToProps(state) {
     const currentChannel = getCurrentChannel(state) || {};
     const currentUser = getCurrentUser(state) || {};
+    const {status: getPostsRequestStatus} = state.requests.posts.getPosts;
 
     let currentChannelMembers = [];
     if (currentChannel.type === General.DM_CHANNEL) {
@@ -33,15 +33,9 @@ function mapStateToProps(state) {
         creator,
         currentChannel,
         currentChannelMembers,
+        isLoadingPosts: getPostsRequestStatus === RequestStatus.STARTED,
         theme: getTheme(state)
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    // placeholder for invite and set header actions
-    return {
-        actions: bindActionCreators({}, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ChannelIntro);
+export default connect(mapStateToProps)(ChannelIntro);

--- a/app/components/channel_intro/index.js
+++ b/app/components/channel_intro/index.js
@@ -28,12 +28,13 @@ function mapStateToProps(state) {
     }
 
     const creator = currentChannel.creator_id === currentUser.id ? currentUser : state.entities.users.profiles[currentChannel.creator_id];
+    const postsInChannel = state.entities.posts.postsInChannel[currentChannel.id] || [];
 
     return {
         creator,
         currentChannel,
         currentChannelMembers,
-        isLoadingPosts: getPostsRequestStatus === RequestStatus.STARTED,
+        isLoadingPosts: !postsInChannel.length && getPostsRequestStatus === RequestStatus.STARTED,
         theme: getTheme(state)
     };
 }


### PR DESCRIPTION
#### Summary
This PR makes sure that the channel intro shows only when there are no more posts to load and the channel has posts, if the channel is loading the initial posts it will show a spinner indicating that the posts are loading

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-413