### PR TITLE
Babel plugin to remove console.* in production

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,10 @@
 {
   "presets": [ "react-native" ],
+  "env": {
+    "production": {
+      "plugins": ["transform-remove-console"]
+    }
+  },
   "plugins": [
     ["module-resolver", {
       "root": ["./src", "."],

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 
 do-build-ios:
 	@echo "Building ios $(ios_target) app"
-	@cd fastlane && NODE_ENV=production bundle exec fastlane ios $(ios_target)
+	@cd fastlane && BABEL_ENV=production NODE_ENV=production bundle exec fastlane ios $(ios_target)
 
 
 build-ios: | check-ios-target pre-run check-style start-packager do-build-ios stop-packager
@@ -179,7 +179,7 @@ prepare-android-build:
 
 do-build-android:
 	@echo "Building android $(android_target) app"
-	@cd fastlane && NODE_ENV=production bundle exec fastlane android $(android_target)
+	@cd fastlane && BABEL_ENV=production NODE_ENV=production bundle exec fastlane android $(android_target)
 
 build-android: | check-android-target pre-run check-style start-packager prepare-android-build do-build-android stop-packager
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-cli": "6.26.0",
     "babel-eslint": "7.2.3",
     "babel-plugin-module-resolver": "2.7.1",
+    "babel-plugin-transform-remove-console": "6.8.5",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-latest": "6.24.1",
     "babel-preset-react": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,6 +881,10 @@ babel-plugin-transform-regenerator@^6.24.1, babel-plugin-transform-regenerator@^
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-remove-console@6.8.5:
+  version "6.8.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.5.tgz#fde9d2d3d725530b0fadd8d31078402410386810"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
#### Summary
When running a bundled app, these statements can cause a big bottleneck in the JavaScript thread. This includes calls from libraries, this PR make sure to remove them before bundling. 