### PR TITLE
Fix new message indicator

### DIFF
--- a/app/selectors/post_list.js
+++ b/app/selectors/post_list.js
@@ -46,16 +46,6 @@ export function makePreparePostIdsForPostList() {
                     continue;
                 }
 
-                // Only add the new messages line if a lastViewedAt time is set
-                if (lastViewedAt && !addedNewMessagesIndicator) {
-                    const postIsUnread = post.create_at > lastViewedAt;
-
-                    if (postIsUnread) {
-                        out.push(START_OF_NEW_MESSAGES);
-                        addedNewMessagesIndicator = true;
-                    }
-                }
-
                 // Push on a date header if the last post was on a different day than the current one
                 const postDate = new Date(post.create_at);
 
@@ -66,6 +56,16 @@ export function makePreparePostIdsForPostList() {
                 lastDate = postDate;
 
                 out.push(post.id);
+
+                // Only add the new messages line if a lastViewedAt time is set
+                if (lastViewedAt && !addedNewMessagesIndicator && post.user_id !== currentUserId) {
+                    const postIsUnread = post.create_at > lastViewedAt;
+
+                    if (postIsUnread) {
+                        out.push(START_OF_NEW_MESSAGES);
+                        addedNewMessagesIndicator = true;
+                    }
+                }
             }
 
             // Push on the date header for the oldest post

--- a/app/selectors/post_list.js
+++ b/app/selectors/post_list.js
@@ -46,6 +46,16 @@ export function makePreparePostIdsForPostList() {
                     continue;
                 }
 
+                // Only add the new messages line if a lastViewedAt time is set
+                if (lastViewedAt && !addedNewMessagesIndicator) {
+                    const postIsUnread = post.create_at > lastViewedAt;
+
+                    if (postIsUnread) {
+                        out.push(START_OF_NEW_MESSAGES);
+                        addedNewMessagesIndicator = true;
+                    }
+                }
+
                 // Push on a date header if the last post was on a different day than the current one
                 const postDate = new Date(post.create_at);
 
@@ -56,16 +66,6 @@ export function makePreparePostIdsForPostList() {
                 lastDate = postDate;
 
                 out.push(post.id);
-
-                // Only add the new messages line if a lastViewedAt time is set
-                if (lastViewedAt && !addedNewMessagesIndicator && post.user_id !== currentUserId) {
-                    const postIsUnread = post.create_at > lastViewedAt;
-
-                    if (postIsUnread) {
-                        out.push(START_OF_NEW_MESSAGES);
-                        addedNewMessagesIndicator = true;
-                    }
-                }
             }
 
             // Push on the date header for the oldest post


### PR DESCRIPTION
#### Summary
We are iterating through the posts from newest to oldest and the message indicator was the first thing being added that's why it was always rendering below all the messages.

Also the new message indicator now shows when someone else posts a message and not the current user.