### PR TITLE
Force formatted_time to use device time zone

### DIFF
--- a/app/components/formatted_time.js
+++ b/app/components/formatted_time.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {injectIntl, intlShape} from 'react-intl';
 import {Text} from 'react-native';
+import deviceInfo from 'react-native-device-info';
 
 class FormattedTime extends React.PureComponent {
     static propTypes = {
@@ -24,7 +25,9 @@ class FormattedTime extends React.PureComponent {
 
         Reflect.deleteProperty(props, 'format');
 
-        const formattedTime = intl.formatTime(value, this.props);
+        const timeZone = deviceInfo.getTimezone();
+
+        const formattedTime = intl.formatDate(value, {...props, timeZone, hour: 'numeric', minute: 'numeric'});
 
         if (typeof children === 'function') {
             return children(formattedTime);
@@ -35,4 +38,3 @@ class FormattedTime extends React.PureComponent {
 }
 
 export default injectIntl(FormattedTime);
-


### PR DESCRIPTION
#### Summary
This PR fixes an issue where users would report that post timestamps were wrongly based on a previous time zone that they traveled from.