### PR TITLE
Force url's to be normalized

### DIFF
--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import {Parser} from 'commonmark';
-import Renderer, {uriTransformer} from 'commonmark-react-renderer';
+import Renderer from 'commonmark-react-renderer';
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -11,7 +11,6 @@ import {
     Text,
     View
 } from 'react-native';
-import urlParse from 'url-parse';
 
 import AtMention from 'app/components/at_mention';
 import ChannelLink from 'app/components/channel_link';
@@ -113,8 +112,7 @@ export default class Markdown extends PureComponent {
                 htmlBlock: this.renderHtml,
                 htmlInline: this.renderHtml
             },
-            renderParagraphsInLists: true,
-            transformLinkUri: this.transformLinkUri
+            renderParagraphsInLists: true
         });
     }
 
@@ -290,14 +288,6 @@ export default class Markdown extends PureComponent {
         }
 
         return rendered;
-    }
-
-    transformLinkUri = (uri) => {
-        const filteredUri = uriTransformer(uri);
-
-        const parsed = urlParse(filteredUri, {});
-
-        return parsed.href;
     }
 
     renderLink = ({children, href}) => {

--- a/app/components/markdown/index.js
+++ b/app/components/markdown/index.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import {Parser} from 'commonmark';
-import Renderer from 'commonmark-react-renderer';
+import Renderer, {uriTransformer} from 'commonmark-react-renderer';
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -11,6 +11,7 @@ import {
     Text,
     View
 } from 'react-native';
+import urlParse from 'url-parse';
 
 import AtMention from 'app/components/at_mention';
 import ChannelLink from 'app/components/channel_link';
@@ -112,7 +113,8 @@ export default class Markdown extends PureComponent {
                 htmlBlock: this.renderHtml,
                 htmlInline: this.renderHtml
             },
-            renderParagraphsInLists: true
+            renderParagraphsInLists: true,
+            transformLinkUri: this.transformLinkUri
         });
     }
 
@@ -288,6 +290,14 @@ export default class Markdown extends PureComponent {
         }
 
         return rendered;
+    }
+
+    transformLinkUri = (uri) => {
+        const filteredUri = uriTransformer(uri);
+
+        const parsed = urlParse(filteredUri, {});
+
+        return parsed.href;
     }
 
     renderLink = ({children, href}) => {

--- a/app/components/markdown/markdown_link.js
+++ b/app/components/markdown/markdown_link.js
@@ -7,6 +7,7 @@ import {Linking, Text} from 'react-native';
 import urlParse from 'url-parse';
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
+import Config from 'assets/config';
 
 export default class MarkdownLink extends PureComponent {
     static propTypes = {
@@ -65,7 +66,7 @@ export default class MarkdownLink extends PureComponent {
     }
 
     render() {
-        const children = this.parseChildren();
+        const children = Config.ExperimentalNormalizeMarkdownLinks ? this.parseChildren() : this.props.children;
 
         return (
             <Text

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -23,7 +23,9 @@
             "console": true
         }
     },
-
+    
+    "ExperimentalNormalizeMarkdownLinks": false,
+    
     "AutoSelectServerUrl": false,
 
     "EnableMobileClientUpgrade": false,


### PR DESCRIPTION
#### Summary
This PR normalizes markdown links by forcing the protocol and hostname to be lowercased while leaving other parts such as path and query string intact. 

![kapture 2017-10-24 at 10 59 21](https://user-images.githubusercontent.com/5090577/31967536-0901eaa0-b8c3-11e7-8ee6-119766778456.gif)