### PR TITLE
Android: Fix inverted list deprecated warnings

### DIFF
--- a/app/components/inverted_flat_list/index.js
+++ b/app/components/inverted_flat_list/index.js
@@ -133,7 +133,10 @@ const styles = StyleSheet.create({
     },
     vertical: Platform.select({
         android: {
-            scaleY: -1
+            transform: [
+                {perspective: 1},
+                {scaleY: -1}
+            ]
         },
         ios: {
             transform: [{scaleY: -1}]
@@ -141,7 +144,10 @@ const styles = StyleSheet.create({
     }),
     horizontal: Platform.select({
         android: {
-            scaleX: -1
+            transform: [
+                {perspective: 1},
+                {scaleY: -1}
+            ]
         },
         ios: {
             transform: [{scaleX: -1}]


### PR DESCRIPTION
#### Summary
On Android we had the transform for the inverted list use a deprecated API cause it was causing issues rendering the post list in Huawei devices, this PR removes the deprecation and should work on Huawei devices as expected but needs to be tested.

Fix taken from https://github.com/facebook/react-native/issues/16213#issuecomment-338936748
