### PR TITLE
Handle post deleted while image preview is open

### DIFF
--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -225,7 +225,7 @@ export default class ImagePreview extends PureComponent {
                     id: 'mobile.server_upgrade.button',
                     defaultMessage: 'OK'
                 }),
-                onPress: () => this.close()
+                onPress: this.close
             }]
         );
     }

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1955,6 +1955,8 @@
   "mobile.file_upload.more": "More",
   "mobile.file_upload.video": "Video Library",
   "mobile.help.title": "Help",
+  "mobile.image_preview.deleted_post_title": "Post Deleted",
+  "mobile.image_preview.deleted_post_message": "This post and it's files have been deleted. The previewer will now be closed.",
   "mobile.image_preview.save": "Save Image",
   "mobile.intro_messages.DM": "This is the start of your direct message history with {teammate}. Direct messages and files shared here are not shown to people outside this area.",
   "mobile.intro_messages.default_message": "This is the first channel teammates see when they sign up - use it for posting updates everyone needs to know.",


### PR DESCRIPTION
#### Summary
This PR fixes an issue where if a post was deleted while a user was previewing it's attachments on mobile the app would crash. With this PR if a post is deleted while a user has the previewer open on mobile, an alert showing that the post was deleted will be displayed and then the previewer screen will be closed once the OK button is pressed.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-420

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
#### Device Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23 