### PR TITLE
Show profile images and names only for DMs in channel intro

### DIFF
--- a/app/components/channel_intro/channel_intro.js
+++ b/app/components/channel_intro/channel_intro.js
@@ -306,8 +306,9 @@ class ChannelIntro extends PureComponent {
     };
 
     render() {
-        const {isLoadingPosts, theme} = this.props;
+        const {currentChannel, isLoadingPosts, theme} = this.props;
         const style = getStyleSheet(theme);
+        const channelType = currentChannel.type;
 
         if (isLoadingPosts) {
             return (
@@ -317,14 +318,23 @@ class ChannelIntro extends PureComponent {
             );
         }
 
+        let profiles;
+        if (channelType === General.DM_CHANNEL || channelType === General.GM_CHANNEL) {
+            profiles = (
+                <View>
+                    <View style={style.profilesContainer}>
+                        {this.buildProfiles()}
+                    </View>
+                    <View style={style.namesContainer}>
+                        {this.buildNames()}
+                    </View>
+                </View>
+            );
+        }
+
         return (
             <View style={style.container}>
-                <View style={style.profilesContainer}>
-                    {this.buildProfiles()}
-                </View>
-                <View style={style.namesContainer}>
-                    {this.buildNames()}
-                </View>
+                {profiles}
                 <View style={style.contentContainer}>
                     {this.buildContent()}
                 </View>


### PR DESCRIPTION
#### Summary
Channel intro was showing the members and names even if the channel wasn't a DM or GM

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-455