### PR TITLE
Keep user statuses for current channel and all post visibilities

### DIFF
--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -205,12 +205,26 @@ function cleanupState(action, keepCurrent = false) {
             }
         },
         views: {
-            ...resetPayload.views
+            ...resetPayload.views,
+            channel: {
+                ...resetPayload.views.channel,
+
+                // on data cleanup we need to keep the postVisibility
+                postVisibility: payload.views.channel.postVisibility
+            }
         }
     };
 
     if (keepCurrent) {
         nextState.errors = payload.errors;
+
+        // keep the statuses for users in the current channel
+        const profileIdsInCurrentChannel = payload.entities.users.profilesInChannel[currentChannelId];
+        const nextStatuses = {};
+        for (const id of profileIdsInCurrentChannel) {
+            nextStatuses[id] = statuses[id];
+        }
+        nextState.entities.users.statuses = nextStatuses;
     }
 
     return {


### PR DESCRIPTION
#### Summary
By keeping the post visibility we make sure that it doesn't gets reset to 0 when loading more messages by scrolling up in a channel.

Also we are going to keep the users statuses that are present in the current Channel

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-459