### PR TITLE
Use ImageBackground for youtube videos instead of nested Images

### DIFF
--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -5,6 +5,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
     Image,
+    ImageBackground,
     Linking,
     Platform,
     StyleSheet,
@@ -185,7 +186,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
                         {...this.responder}
                         onPress={this.playYouTubeVideo}
                     >
-                        <Image
+                        <ImageBackground
                             style={[styles.image, {width, height}]}
                             source={{uri: imgUrl}}
                             resizeMode={'cover'}
@@ -197,7 +198,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
                                     onPress={this.playYouTubeVideo}
                                 />
                             </TouchableWithoutFeedback>
-                        </Image>
+                        </ImageBackground>
                     </TouchableWithoutFeedback>
                 );
             }


### PR DESCRIPTION
#### Summary
Posts with youtube videos used to have nested Image components but that was deprecated by RN and instead they ask for the use of ImageBackground