### PR TITLE
Fix Unread indicator shown when unread channel visible

### DIFF
--- a/app/components/channel_drawer/channels_list/list/list.js
+++ b/app/components/channel_drawer/channels_list/list/list.js
@@ -333,7 +333,7 @@ class List extends PureComponent {
                     stickySectionHeadersEnabled={false}
                     viewabilityConfig={{
                         viewAreaCoveragePercentThreshold: 3,
-                        waitForInteraction: false
+                        waitForInteraction: true
                     }}
                 />
                 <UnreadIndicator


### PR DESCRIPTION
#### Summary
The unread indicator was being shown even if the unread channel was visible cause we weren't waiting for an interaction with the section list to occur.