### PR TITLE
Changed PostProfilePicture to be a PureComponent

### DIFF
--- a/app/components/post_profile_picture/post_profile_picture.js
+++ b/app/components/post_profile_picture/post_profile_picture.js
@@ -12,29 +12,47 @@ import webhookIcon from 'assets/images/icons/webhook.jpg';
 
 const PROFILE_PICTURE_SIZE = 32;
 
-function PostProfilePicture(props) {
-    const {
-        enablePostIconOverride,
-        fromWebHook,
-        isSystemMessage,
-        onViewUserProfile,
-        overrideIconUrl,
-        theme,
-        userId
-    } = props;
-    if (isSystemMessage) {
-        return (
-            <View>
-                <AppIcon
-                    color={theme.centerChannelColor}
-                    height={PROFILE_PICTURE_SIZE}
-                    width={PROFILE_PICTURE_SIZE}
-                />
-            </View>
-        );
-    } else if (fromWebHook) {
-        if (enablePostIconOverride) {
+export default class PostProfilePicture extends React.PureComponent {
+    static propTypes = {
+        enablePostIconOverride: PropTypes.bool,
+        fromWebHook: PropTypes.bool,
+        isSystemMessage: PropTypes.bool,
+        overrideIconUrl: PropTypes.string,
+        onViewUserProfile: PropTypes.func,
+        theme: PropTypes.object,
+        userId: PropTypes.string
+    };
+
+    static defaultProps = {
+        onViewUserProfile: emptyFunction
+    };
+
+    render() {
+        const {
+            enablePostIconOverride,
+            fromWebHook,
+            isSystemMessage,
+            onViewUserProfile,
+            overrideIconUrl,
+            theme,
+            userId
+        } = this.props;
+
+        if (isSystemMessage) {
+            return (
+                <View>
+                    <AppIcon
+                        color={theme.centerChannelColor}
+                        height={PROFILE_PICTURE_SIZE}
+                        width={PROFILE_PICTURE_SIZE}
+                    />
+                </View>
+            );
+        }
+
+        if (fromWebHook && enablePostIconOverride) {
             const icon = overrideIconUrl ? {uri: overrideIconUrl} : webhookIcon;
+
             return (
                 <View>
                     <Image
@@ -49,36 +67,21 @@ function PostProfilePicture(props) {
             );
         }
 
-        return (
+        let component = (
             <ProfilePicture
                 userId={userId}
                 size={PROFILE_PICTURE_SIZE}
             />
         );
+
+        if (!fromWebHook) {
+            component = (
+                <TouchableOpacity onPress={onViewUserProfile}>
+                    {component}
+                </TouchableOpacity>
+            );
+        }
+
+        return component;
     }
-
-    return (
-        <TouchableOpacity onPress={onViewUserProfile}>
-            <ProfilePicture
-                userId={userId}
-                size={PROFILE_PICTURE_SIZE}
-            />
-        </TouchableOpacity>
-    );
 }
-
-PostProfilePicture.propTypes = {
-    enablePostIconOverride: PropTypes.bool,
-    fromWebHook: PropTypes.bool,
-    isSystemMessage: PropTypes.bool,
-    overrideIconUrl: PropTypes.string,
-    onViewUserProfile: PropTypes.func,
-    theme: PropTypes.object,
-    userId: PropTypes.string
-};
-
-PostProfilePicture.defaultProps = {
-    onViewUserProfile: emptyFunction
-};
-
-export default PostProfilePicture;

--- a/app/components/post_profile_picture/post_profile_picture.js
+++ b/app/components/post_profile_picture/post_profile_picture.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import React from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {Image, TouchableOpacity, View} from 'react-native';
 
@@ -12,7 +12,7 @@ import webhookIcon from 'assets/images/icons/webhook.jpg';
 
 const PROFILE_PICTURE_SIZE = 32;
 
-export default class PostProfilePicture extends React.PureComponent {
+export default class PostProfilePicture extends PureComponent {
     static propTypes = {
         enablePostIconOverride: PropTypes.bool,
         fromWebHook: PropTypes.bool,


### PR DESCRIPTION
Something I did while trying to repro an issue that couldn't be reproed.

#### Device Information
This PR was tested on: iOS Simulator
