### PR TITLE
RN-414 Reduce loading of posts in increasePostVisibility action

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -453,16 +453,31 @@ export function increasePostVisibility(channelId, focusedPostId) {
         const currentPostVisibility = postVisibility[channelId] || 0;
 
         if (loadingPosts[channelId]) {
-            return true;
+            return;
         }
 
-        dispatch(batchActions([
-            {
-                type: ViewTypes.LOADING_POSTS,
-                data: true,
-                channelId
+        // Check if we already have the posts that we want to show
+        if (!focusedPostId) {
+            const loadedPostCount = state.entities.posts.postsInChannel[channelId].length;
+            const desiredPostVisibility = currentPostVisibility + ViewTypes.POST_VISIBILITY_CHUNK_SIZE;
+
+            if (loadedPostCount >= desiredPostVisibility) {
+                // We already have the posts, so we just need to show them
+                dispatch({
+                    type: ViewTypes.INCREASE_POST_VISIBILITY,
+                    data: channelId,
+                    amount: ViewTypes.POST_VISIBILITY_CHUNK_SIZE
+                });
+
+                return;
             }
-        ]));
+        }
+
+        dispatch({
+            type: ViewTypes.LOADING_POSTS,
+            data: true,
+            channelId
+        });
 
         const page = Math.floor(currentPostVisibility / ViewTypes.POST_VISIBILITY_CHUNK_SIZE);
 
@@ -489,7 +504,5 @@ export function increasePostVisibility(channelId, focusedPostId) {
             data: false,
             channelId
         });
-
-        return posts && posts.order.length >= ViewTypes.POST_VISIBILITY_CHUNK_SIZE;
     };
 }


### PR DESCRIPTION
If you're wondering, the return value of that action wasn't actually used, so I removed it instead of having to figure out if we still needed had more posts to load when we already have the posts loaded already

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-414

#### Device Information
This PR was tested on: iOS Simulator