### PR TITLE
RN-472 Improved handling of deleted search results

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -256,11 +256,16 @@ class Post extends PureComponent {
     };
 
     handlePress = () => {
-        const {post, onPress} = this.props;
+        const {
+            isSearchResult,
+            onPress,
+            post
+        } = this.props;
+
         if (!isToolTipShowing) {
             if (onPress && post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostPendingOrFailed(post)) {
                 preventDoubleTap(onPress, null, post);
-            } else if (isPostEphemeral(post)) {
+            } else if (!isSearchResult && isPostEphemeral(post)) {
                 preventDoubleTap(this.onRemovePost, this, post);
             }
         }

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -22,7 +22,6 @@ import {RequestStatus} from 'mattermost-redux/constants';
 import Autocomplete from 'app/components/autocomplete';
 import FormattedText from 'app/components/formatted_text';
 import Loading from 'app/components/loading';
-import Post from 'app/components/post';
 import PostListRetry from 'app/components/post_list_retry';
 import SearchBar from 'app/components/search_bar';
 import SearchPreview from 'app/components/search_preview';
@@ -31,6 +30,7 @@ import {preventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import ChannelDisplayName from './channel_display_name';
+import SearchResultPost from './search_result_post';
 
 const SECTION_HEIGHT = 20;
 const RECENT_LABEL_HEIGHT = 42;
@@ -265,14 +265,10 @@ class Search extends PureComponent {
         return (
             <View>
                 <ChannelDisplayName postId={item}/>
-                <Post
+                <SearchResultPost
                     postId={item}
-                    renderReplies={true}
-                    onPress={this.previewPost}
-                    onReply={this.goToThread}
-                    isSearchResult={true}
-                    shouldRenderReplyButton={true}
-                    showFullDate={true}
+                    previewPost={this.previewPost}
+                    goToThread={this.goToThread}
                     navigator={this.props.navigator}
                 />
                 {separator}

--- a/app/screens/search/search_result_post/index.js
+++ b/app/screens/search/search_result_post/index.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {Posts} from 'mattermost-redux/constants';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+
+import SearchResultPost from './search_result_post';
+
+function mapStateToProps(state, ownProps) {
+    const post = getPost(state, ownProps.postId);
+
+    return {
+        isDeleted: post && post.state === Posts.POST_DELETED
+    };
+}
+
+export default connect(mapStateToProps)(SearchResultPost);

--- a/app/screens/search/search_result_post/search_result_post.js
+++ b/app/screens/search/search_result_post/search_result_post.js
@@ -1,0 +1,39 @@
+// Copyright (c) 201-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+
+import Post from 'app/components/post';
+
+export default class SearchResultPost extends PureComponent {
+    static propTypes = {
+        isDeleted: PropTypes.bool.isRequired,
+        goToThread: PropTypes.func.isRequired,
+        navigator: PropTypes.object.isRequired,
+        postId: PropTypes.string.isRequired,
+        previewPost: PropTypes.func.isRequired
+    };
+
+    render() {
+        const postComponentProps = {};
+
+        if (this.props.isDeleted) {
+            postComponentProps.shouldRenderReplyButton = false;
+        } else {
+            postComponentProps.onPress = this.props.previewPost;
+            postComponentProps.onReply = this.props.goToThread;
+            postComponentProps.shouldRenderReplyButton = true;
+        }
+
+        return (
+            <Post
+                postId={this.props.postId}
+                {...postComponentProps}
+                isSearchResult={true}
+                showFullDate={true}
+                navigator={this.props.navigator}
+            />
+        );
+    }
+}


### PR DESCRIPTION
When a post that appears in the search results is deleted, it no longer displays the reply icon, and the click handlers are removed from it.

Also, I removed the reply bar from appearing in search results since it felt out of place. This is how it used to look
<img width="374" alt="screen shot 2017-11-09 at 11 14 04 am" src="https://user-images.githubusercontent.com/3277310/32615965-2400af0c-c53f-11e7-909f-3dd4cce2d623.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-472

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
<img width="377" alt="screen shot 2017-11-09 at 11 14 41 am" src="https://user-images.githubusercontent.com/3277310/32615992-3951bef0-c53f-11e7-82e5-1c4747fb9ef7.png">

