### PR TITLE
Prevent notify props from causing a crash

### DIFF
--- a/app/screens/settings/notification_settings/index.js
+++ b/app/screens/settings/notification_settings/index.js
@@ -11,9 +11,8 @@ import {handleUpdateUserNotifyProps} from 'app/actions/views/account_notificatio
 
 import NotificationSettings from './notification_settings';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     return {
-        ...ownProps,
         config: state.entities.general.config,
         currentUser: getCurrentUser(state),
         myPreferences: getMyPreferences(state),

--- a/app/screens/settings/notification_settings/notification_settings.js
+++ b/app/screens/settings/notification_settings/notification_settings.js
@@ -21,6 +21,7 @@ import {RadioButton, RadioButtonGroup} from 'app/components/radio_button';
 import StatusBar from 'app/components/status_bar';
 import NotificationPreferences from 'app/notification_preferences';
 import SettingsItem from 'app/screens/settings/settings_item';
+import {getNotificationProps} from 'app/utils/notify_props';
 import {preventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
@@ -154,7 +155,7 @@ class NotificationSettings extends PureComponent {
             }
 
             this.saveNotificationProps({
-                ...currentUser.notify_props,
+                ...getNotificationProps(currentUser),
                 email,
                 interval
             });
@@ -165,7 +166,7 @@ class NotificationSettings extends PureComponent {
         const {currentUser} = this.props;
         const {user_id} = notifyProps;
         const previousProps = {
-            ...currentUser.notify_props,
+            ...getNotificationProps(currentUser),
             user_id
         };
 
@@ -184,7 +185,7 @@ class NotificationSettings extends PureComponent {
         }
 
         const {config, currentUser, intl, myPreferences} = this.props;
-        const notifyProps = currentUser.notify_props || {};
+        const notifyProps = getNotificationProps(currentUser);
         const sendEmailNotifications = config.SendEmailNotifications === 'true';
         const emailBatchingEnabled = sendEmailNotifications && config.EnableEmailBatching === 'true';
 

--- a/app/screens/settings/notification_settings_email/index.js
+++ b/app/screens/settings/notification_settings_email/index.js
@@ -8,9 +8,8 @@ import {getMyPreferences, getTheme} from 'mattermost-redux/selectors/entities/pr
 
 import NotificationSettingsEmail from './notification_settings_email';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     return {
-        ...ownProps,
         config: getConfig(state),
         myPreferences: getMyPreferences(state),
         theme: getTheme(state)

--- a/app/screens/settings/notification_settings_email/notification_settings_email.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.js
@@ -14,6 +14,7 @@ import {getPreferencesByCategory} from 'mattermost-redux/utils/preference_utils'
 
 import FormattedText from 'app/components/formatted_text';
 import StatusBar from 'app/components/status_bar';
+import {getNotificationProps} from 'app/utils/notify_props';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import Section from 'app/screens/settings/section';
@@ -33,7 +34,7 @@ export default class NotificationSettingsEmail extends PureComponent {
         super(props);
 
         const {currentUser} = props;
-        const notifyProps = currentUser.notify_props || {};
+        const notifyProps = getNotificationProps(currentUser);
 
         props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
         this.state = this.setStateFromNotifyProps(notifyProps);

--- a/app/screens/settings/notification_settings_mentions/index.js
+++ b/app/screens/settings/notification_settings_mentions/index.js
@@ -7,9 +7,8 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import NotificationSettingsMentions from './notification_settings_mentions';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     return {
-        ...ownProps,
         theme: getTheme(state)
     };
 }

--- a/app/screens/settings/notification_settings_mentions/notification_settings_mention_base.js
+++ b/app/screens/settings/notification_settings_mentions/notification_settings_mention_base.js
@@ -5,6 +5,8 @@ import {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
 
+import {getNotificationProps} from 'app/utils/notify_props';
+
 export default class NotificationSettingsMentionsBase extends PureComponent {
     static propTypes = {
         currentUser: PropTypes.object.isRequired,
@@ -18,7 +20,7 @@ export default class NotificationSettingsMentionsBase extends PureComponent {
         super(props);
 
         const {currentUser} = props;
-        const notifyProps = currentUser.notify_props || {};
+        const notifyProps = getNotificationProps(currentUser);
 
         props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
 
@@ -43,7 +45,7 @@ export default class NotificationSettingsMentionsBase extends PureComponent {
             mentionKeys.splice(usernameMentionIndex, 1);
         }
 
-        const comments = notifyProps.comments || 'never';
+        const comments = notifyProps.comments || 'any';
 
         const newState = {
             ...notifyProps,

--- a/app/screens/settings/notification_settings_mentions_keywords/index.js
+++ b/app/screens/settings/notification_settings_mentions_keywords/index.js
@@ -7,9 +7,8 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import NotificationSettingsMentionsKeywords from './notification_settings_mentions_keywords';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     return {
-        ...ownProps,
         theme: getTheme(state)
     };
 }

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile_base.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile_base.js
@@ -6,6 +6,8 @@ import {Platform} from 'react-native';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
 
+import {getNotificationProps} from 'app/utils/notify_props';
+
 export default class NotificationSettingsMobileBase extends PureComponent {
     static propTypes = {
         config: PropTypes.object.isRequired,
@@ -21,7 +23,7 @@ export default class NotificationSettingsMobileBase extends PureComponent {
         super(props);
 
         const {currentUser} = props;
-        const notifyProps = currentUser.notify_props || {};
+        const notifyProps = getNotificationProps(currentUser);
 
         this.state = {
             ...notifyProps,

--- a/app/utils/notify_props.js
+++ b/app/utils/notify_props.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+export function getNotificationProps(user) {
+    if (user && user.notify_props) {
+        return user.notify_props;
+    }
+
+    const props = {
+        channel: 'true',
+        comments: 'any',
+        desktop: 'all',
+        desktop_sound: 'true',
+        email: 'true',
+        mention_keys: user ? `${user.username},@${user.username}` : '',
+        push: 'mention',
+        push_status: 'online'
+    };
+
+    if (!user || !user.first_name) {
+        props.first_name = 'false';
+    } else {
+        props.first_name = 'true';
+    }
+
+    return props;
+}
+


### PR DESCRIPTION
#### Summary
In some edge cases the user's notify_props is null and the components were expecting some kind of value, now in the event that notify_props is not defined we'll be returning an object with the default values in order to avoid any kind of crash related to this

This PR will be cherry-picked for v1.4.1

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-412
https://mattermost.atlassian.net/browse/RN-426
https://mattermost.atlassian.net/browse/RN-483