### PR TITLE
Fix badge render

### DIFF
--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -32,7 +32,6 @@ export default class Badge extends PureComponent {
     constructor(props) {
         super(props);
 
-        this.width = 0;
         this.mounted = false;
     }
 
@@ -67,6 +66,8 @@ export default class Badge extends PureComponent {
     };
 
     onLayout = (e) => {
+        const height = Math.max(e.nativeEvent.layout.height, this.props.minHeight);
+        const borderRadius = height / 2;
         let width;
 
         if (e.nativeEvent.layout.width <= e.nativeEvent.layout.height) {
@@ -75,26 +76,14 @@ export default class Badge extends PureComponent {
             width = e.nativeEvent.layout.width + this.props.extraPaddingHorizontal;
         }
         width = Math.max(width, this.props.minWidth);
-        if (this.width === width) {
-            return;
-        }
-        this.width = width;
-        const height = Math.max(e.nativeEvent.layout.height, this.props.minHeight);
-        const borderRadius = height / 2;
         this.setNativeProps({
             style: {
                 width,
                 height,
-                borderRadius
+                borderRadius,
+                opacity: 1
             }
         });
-        setTimeout(() => {
-            this.setNativeProps({
-                style: {
-                    opacity: 1
-                }
-            });
-        }, 100);
     };
 
     renderText = () => {

--- a/app/components/channel_drawer/teams_list/teams_list_item/index.js
+++ b/app/components/channel_drawer/teams_list/teams_list_item/index.js
@@ -11,18 +11,21 @@ import {removeProtocol} from 'app/utils/url';
 
 import TeamsListItem from './teams_list_item.js';
 
-function mapStateToProps(state, ownProps) {
-    const team = getTeam(state, ownProps.teamId);
+function makeMapStateToProps() {
     const getMentionCount = makeGetBadgeCountForTeamId();
 
-    return {
-        currentTeamId: getCurrentTeamId(state),
-        currentUrl: removeProtocol(getCurrentUrl(state)),
-        displayName: team.display_name,
-        mentionCount: getMentionCount(state, ownProps.teamId),
-        name: team.name,
-        theme: getTheme(state)
+    return function mapStateToProps(state, ownProps) {
+        const team = getTeam(state, ownProps.teamId);
+
+        return {
+            currentTeamId: getCurrentTeamId(state),
+            currentUrl: removeProtocol(getCurrentUrl(state)),
+            displayName: team.display_name,
+            mentionCount: getMentionCount(state, ownProps.teamId),
+            name: team.name,
+            theme: getTheme(state)
+        };
     };
 }
 
-export default connect(mapStateToProps)(TeamsListItem);
+export default connect(makeMapStateToProps)(TeamsListItem);


### PR DESCRIPTION
#### Summary
Fixes the badges for unread indicators on the Teams to always show when the team has unread messages

Cherry pick for 1.4.1

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-499