### PR TITLE
Increased clickable area around send post button

### DIFF
--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -261,47 +261,41 @@ class PostTextbox extends PureComponent {
         this.props.actions.handleUploadFiles(images, this.props.rootId);
     };
 
-    renderDisabledSendButton = () => {
-        const {theme} = this.props;
-        const style = getStyleSheet(theme);
-
-        return (
-            <View style={style.sendButtonContainer}>
-                <View style={[style.sendButton, style.disableButton]}>
-                    <PaperPlane
-                        height={13}
-                        width={15}
-                        color={theme.buttonColor}
-                    />
-                </View>
-            </View>
-        );
-    };
-
     renderSendButton = () => {
         const {theme, uploadFileRequestStatus} = this.props;
         const style = getStyleSheet(theme);
 
+        const icon = (
+            <PaperPlane
+                height={13}
+                width={15}
+                color={theme.buttonColor}
+            />
+        );
+
+        let button = null;
         if (uploadFileRequestStatus === RequestStatus.STARTED) {
-            return this.renderDisabledSendButton();
+            button = (
+                <View style={style.sendButtonContainer}>
+                    <View style={[style.sendButton, style.disableButton]}>
+                        {icon}
+                    </View>
+                </View>
+            );
         } else if (this.canSend()) {
-            return (
+            button = (
                 <TouchableOpacity
                     onPress={this.handleSendMessage}
                     style={style.sendButtonContainer}
                 >
                     <View style={style.sendButton}>
-                        <PaperPlane
-                            height={13}
-                            width={15}
-                            color={theme.buttonColor}
-                        />
+                        {icon}
                     </View>
                 </TouchableOpacity>
             );
         }
 
-        return null;
+        return button;
     };
 
     sendMessage = () => {
@@ -458,13 +452,13 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             flexDirection: 'row',
             backgroundColor: '#fff',
-            alignItems: 'flex-end'
+            alignItems: 'stretch',
+            marginRight: 10
         },
         inputContainerWithoutFileUpload: {
             marginLeft: 10
         },
         inputWrapper: {
-            alignItems: 'flex-end',
             flexDirection: 'row',
             paddingVertical: 4,
             backgroundColor: theme.centerChannelBg,
@@ -472,27 +466,17 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderTopColor: changeOpacity(theme.centerChannelColor, 0.20)
         },
         sendButtonContainer: {
-            paddingRight: 10
+            justifyContent: 'flex-end',
+            paddingHorizontal: 5,
+            paddingVertical: 3
         },
         sendButton: {
             backgroundColor: theme.buttonBg,
             borderRadius: 18,
-            marginRight: 5,
             height: 28,
             width: 28,
             alignItems: 'center',
-            justifyContent: 'center',
-            paddingLeft: 2,
-            ...Platform.select({
-                ios: {
-                    marginBottom: 3
-                },
-                android: {
-                    height: 29,
-                    marginBottom: 4,
-                    width: 29
-                }
-            })
+            justifyContent: 'center'
         }
     };
 });

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -459,6 +459,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             marginLeft: 10
         },
         inputWrapper: {
+            alignItems: 'flex-end',
             flexDirection: 'row',
             paddingVertical: 4,
             backgroundColor: theme.centerChannelBg,


### PR DESCRIPTION
The clickable area now includes the padding around the icon as well. The green area in the screenshots below is the new clickable area while the old one was just the square enclosing the actual icon.

Also, @asaadmahmood, I made a couple small UI tweaks to make this easier to work with. The buttons are now exactly the same size instead of the Android one being 1 pixel taller with slightly different margins

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iPhone 6 (iOS 10.3.3), iPhone 6 Simulator (iOS 11.1), Nexus 5 (Android 6.0.1)

#### Screenshots
The colours obviously aren't included in the PR, and the attachment icon is in the correct place in the submitted version.

iOS:
<img width="417" alt="screen shot 2017-11-13 at 3 34 11 pm" src="https://user-images.githubusercontent.com/3277310/32748586-b6ce5200-c88a-11e7-8a30-2a9f5d0ef957.png">
Android:
![image](https://user-images.githubusercontent.com/3277310/32748674-f34c7a2c-c88a-11e7-9919-b3eb4a5c7c9e.png)

