### PR TITLE
RN-480 Fixed emoji autocomplete removing spaces before emoji

### DIFF
--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -14,6 +14,7 @@ import Emoji from 'app/components/emoji';
 import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
 
 const EMOJI_REGEX = /(^|\s|^\+|^-)(:([^:\s]*))$/i;
+const EMOJI_REGEX_WITHOUT_PREFIX = /\B(:([^:\s]*))$/i;
 
 export default class EmojiSuggestion extends Component {
     static propTypes = {
@@ -81,7 +82,7 @@ export default class EmojiSuggestion extends Component {
             actions.addReactionToLatestPost(emoji, rootId);
             onChangeText('');
         } else {
-            let completedDraft = emojiPart.replace(EMOJI_REGEX, `:${emoji}: `);
+            let completedDraft = emojiPart.replace(EMOJI_REGEX_WITHOUT_PREFIX, `:${emoji}: `);
 
             if (value.length > cursorPosition) {
                 completedDraft += value.substring(cursorPosition);


### PR DESCRIPTION
When doing the actual replacement, it won't capture the preceding character any more.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-480

#### Device Information
This PR was tested on: iOS Simulator
