### PR TITLE
RN-497 Updated commonmark to better handle non-latin characters in URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "analytics-react-native": "1.2.0",
     "babel-polyfill": "6.26.0",
-    "commonmark": "hmhealey/commonmark.js#25dc6a4c456db579631797e29847752cb5e7d8d7",
+    "commonmark": "hmhealey/commonmark.js#78bf827868303900d376e1d197c2e25a6f2d4081",
     "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#6e259b66ae87d31d2f908effcd05776b9ea3446f",
     "deep-equal": "1.0.1",
     "intl": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,9 +1730,9 @@ commonmark-react-renderer@hmhealey/commonmark-react-renderer#6e259b66ae87d31d2f9
     pascalcase "^0.1.1"
     xss-filters "^1.2.6"
 
-commonmark@hmhealey/commonmark.js#25dc6a4c456db579631797e29847752cb5e7d8d7:
+commonmark@hmhealey/commonmark.js#78bf827868303900d376e1d197c2e25a6f2d4081:
   version "0.28.0"
-  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/25dc6a4c456db579631797e29847752cb5e7d8d7"
+  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/78bf827868303900d376e1d197c2e25a6f2d4081"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"


### PR DESCRIPTION
Adds the XRegExp library (which I thought we already used there) and changes the URL pattern to use `\pL` which matches all unicode letters (including CJK characters, Cyrillic letters, accented letters, etc) instead of using `[a-z]` which only matches latin letters

Commonmark.js changes here: https://github.com/hmhealey/commonmark.js/commit/fe78a8538cd080fa6765f94589870458b59958d1

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-497

#### Checklist
- Added or updated unit tests
