### PR TITLE
Fix iOS post context menu

### DIFF
--- a/app/components/options_context/options_context.ios.js
+++ b/app/components/options_context/options_context.ios.js
@@ -26,6 +26,12 @@ export default class OptionsContext extends PureComponent {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (this.props.actions !== nextProps.actions) {
+            this.setState({actions: nextProps.actions});
+        }
+    }
+
     handleHideUnderlay = () => {
         if (!this.isShowing) {
             this.props.toggleSelected(false, false);


### PR DESCRIPTION
#### Summary
Post context menu wasn't being updated whenever the actions changed. ej: Once a post was flag the option wasn't changing to unflag