### PR TITLE
Request image quality 1 (=100%) to avoid scaling (and failing with OOME) (#1157)

### DIFF
--- a/app/components/post_textbox/components/attachment_button.js
+++ b/app/components/post_textbox/components/attachment_button.js
@@ -23,7 +23,7 @@ class AttachmentButton extends PureComponent {
     attachFileFromCamera = () => {
         const {formatMessage} = this.props.intl;
         const options = {
-            quality: 0.7,
+            quality: 1.0,
             noData: true,
             storageOptions: {
                 cameraRoll: true,
@@ -58,7 +58,7 @@ class AttachmentButton extends PureComponent {
     attachFileFromLibrary = () => {
         const {formatMessage} = this.props.intl;
         const options = {
-            quality: 0.7,
+            quality: 1.0,
             noData: true,
             permissionDenied: {
                 title: formatMessage({
@@ -93,7 +93,7 @@ class AttachmentButton extends PureComponent {
     attachVideoFromLibraryAndroid = () => {
         const {formatMessage} = this.props.intl;
         const options = {
-            quality: 0.7,
+            quality: 1.0,
             mediaType: 'video',
             noData: true,
             permissionDenied: {


### PR DESCRIPTION
#### Summary
This prevents OutOfMemoryErrors when posting images of e.g. 4MB size. See the ticket for more details.

#### Ticket Link
#1157 

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 
Samsung S7, Nougat, and a Lollipop device