### PR TITLE
RN-483 Ensured switch statements used for i18n have a default case

### DIFF
--- a/app/components/offline_indicator/offline_indicator.js
+++ b/app/components/offline_indicator/offline_indicator.js
@@ -172,6 +172,7 @@ export default class OfflineIndicator extends Component {
             );
             break;
         case CONNECTED:
+        default:
             i18nId = 'mobile.offlineIndicator.connected';
             defaultMessage = 'Connected';
             action = (

--- a/app/components/vector_icon.js
+++ b/app/components/vector_icon.js
@@ -1,62 +1,64 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React, {PureComponent} from 'react';
 import {Text} from 'react-native';
-import IonIcon from 'react-native-vector-icons/Ionicons';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
-import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import FoundationIcon from 'react-native-vector-icons/Foundation';
+import IonIcon from 'react-native-vector-icons/Ionicons';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
-export default function vectorIcon(props) {
-    const {name, type, style, size} = props;
+export default class VectorIcon extends PureComponent {
+    static propTypes = {
+        name: PropTypes.string,
+        type: PropTypes.string,
+        size: PropTypes.number,
+        style: Text.propTypes.style
+    };
 
-    switch (type) {
-    case 'fontawesome':
-        return (
-            <FontAwesomeIcon
-                name={name}
-                style={style}
-                size={size}
-            />
-        );
-    case 'foundation':
-        return (
-            <FoundationIcon
-                name={name}
-                style={style}
-                size={size}
-            />
-        );
-    case 'ion':
-        return (
-            <IonIcon
-                name={name}
-                style={style}
-                size={size}
-            />
-        );
-    case 'material':
-        return (
-            <MaterialIcon
-                name={name}
-                style={style}
-                size={size}
-            />
-        );
+    static defaultProps = {
+        size: 14
+    };
+
+    render() {
+        const {name, type, style, size} = this.props;
+
+        switch (type) {
+        case 'fontawesome':
+            return (
+                <FontAwesomeIcon
+                    name={name}
+                    style={style}
+                    size={size}
+                />
+            );
+        case 'foundation':
+            return (
+                <FoundationIcon
+                    name={name}
+                    style={style}
+                    size={size}
+                />
+            );
+        case 'ion':
+            return (
+                <IonIcon
+                    name={name}
+                    style={style}
+                    size={size}
+                />
+            );
+        case 'material':
+            return (
+                <MaterialIcon
+                    name={name}
+                    style={style}
+                    size={size}
+                />
+            );
+        }
+
+        return null;
     }
-
-    return null;
 }
-
-vectorIcon.propTypes = {
-    name: PropTypes.string,
-    type: PropTypes.string,
-    size: PropTypes.number,
-    style: Text.propTypes.style
-};
-
-vectorIcon.defaultProps = {
-    size: 14
-};

--- a/app/screens/settings/notification_settings_mentions/notification_settings_mentions.android.js
+++ b/app/screens/settings/notification_settings_mentions/notification_settings_mentions.android.js
@@ -201,10 +201,6 @@ class NotificationSettingsMentionsIos extends NotificationSettingsMentionsBase {
         let i18nId;
         let i18nMessage;
         switch (this.state.comments) {
-        case 'any':
-            i18nId = 'mobile.account_notifications.threads_start_participate';
-            i18nMessage = 'Threads that I start or participate in';
-            break;
         case 'root':
             i18nId = 'mobile.account_notifications.threads_start';
             i18nMessage = 'Threads that I start';
@@ -212,6 +208,11 @@ class NotificationSettingsMentionsIos extends NotificationSettingsMentionsBase {
         case 'never':
             i18nId = 'mobile.account_notifications.threads_mentions';
             i18nMessage = 'Mentions in threads';
+            break;
+        case 'any':
+        default:
+            i18nId = 'mobile.account_notifications.threads_start_participate';
+            i18nMessage = 'Threads that I start or participate in';
             break;
         }
 

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
@@ -361,13 +361,14 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
                 i18nId = 'user.settings.notifications.allActivity';
                 i18nMessage = 'For all activity';
                 break;
-            case 'mention':
-                i18nId = 'user.settings.notifications.onlyMentions';
-                i18nMessage = 'Only for mentions and direct messages';
-                break;
             case 'none':
                 i18nId = 'user.settings.notifications.never';
                 i18nMessage = 'Never';
+                break;
+            case 'mention':
+            default:
+                i18nId = 'user.settings.notifications.onlyMentions';
+                i18nMessage = 'Only for mentions and direct messages';
                 break;
             }
             props.description = (
@@ -412,10 +413,6 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
         let i18nId;
         let i18nMessage;
         switch (this.state.push_status) {
-        case 'online':
-            i18nId = 'user.settings.push_notification.online';
-            i18nMessage = 'Online, away or offline';
-            break;
         case 'away':
             i18nId = 'user.settings.push_notification.away';
             i18nMessage = 'Away or offline';
@@ -423,6 +420,11 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
         case 'offline':
             i18nId = 'user.settings.push_notification.offline';
             i18nMessage = 'Offline';
+            break;
+        case 'online':
+        default:
+            i18nId = 'user.settings.push_notification.online';
+            i18nMessage = 'Online, away or offline';
             break;
         }
 


### PR DESCRIPTION
Some older users may be missing those fields on their notification props, so we need to provide a default case for them.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-483