### PR TITLE
Android: Fix weird colors in radio buttons

### DIFF
--- a/app/components/radio_button/radio_button.js
+++ b/app/components/radio_button/radio_button.js
@@ -26,8 +26,8 @@ class RadioButton extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {
-            scaleValue: new Animated.Value(0.001),
-            opacityValue: new Animated.Value(0.1)
+            scaleValue: new Animated.Value(0),
+            opacityValue: new Animated.Value(0)
         };
 
         this.responder = {
@@ -134,7 +134,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         container: {
             flexDirection: 'row',
             alignItems: 'center',
-            backgroundColor: 'rgba(0,0,0,0)',
+            backgroundColor: theme.centerChannelBg,
             marginBottom: 15
         },
         ripple: {


### PR DESCRIPTION
#### Summary
Fixes a weird color behind the radio buttons on android caused by the initial values for opacity and scale

#### Ticket Link
https://pre-release.mattermost.com/core/pl/hdixdwx5obbd7naw1sago7k4zw

#### Screenshots
Android
![screenshot_1511873099](https://user-images.githubusercontent.com/6757047/33320381-d079fdf2-d420-11e7-9571-0ba323873428.png)

