### PR TITLE
Applied correct text colour to (edited) indicator on Android

### DIFF
--- a/app/utils/theme.js
+++ b/app/utils/theme.js
@@ -17,7 +17,7 @@ export function makeStyleSheetFromTheme(getStyleFromTheme) {
     };
 }
 
-export function changeOpacity(oldColor, opacity) {
+function normalizeColor(oldColor) {
     let color = oldColor;
     if (color.length && color[0] === '#') {
         color = color.slice(1);
@@ -32,11 +32,44 @@ export function changeOpacity(oldColor, opacity) {
         color += tempColor[2] + tempColor[2];
     }
 
+    return color;
+}
+
+export function changeOpacity(oldColor, opacity) {
+    const color = normalizeColor(oldColor);
+
     const r = parseInt(color.substring(0, 2), 16);
     const g = parseInt(color.substring(2, 4), 16);
     const b = parseInt(color.substring(4, 6), 16);
 
-    return 'rgba(' + r + ',' + g + ',' + b + ',' + opacity + ')';
+    return `rgba(${r},${g},${b},${opacity})`;
+}
+
+function blendComponent(background, foreground, opacity) {
+    return ((1 - opacity) * background) + (opacity * foreground);
+}
+
+export function blendColors(background, foreground, opacity) {
+    const backgroundNormalized = normalizeColor(background);
+    const foregroundNormalized = normalizeColor(foreground);
+
+    const r = blendComponent(
+        parseInt(backgroundNormalized.substring(0, 2), 16),
+        parseInt(foregroundNormalized.substring(0, 2), 16),
+        opacity
+    );
+    const g = blendComponent(
+        parseInt(backgroundNormalized.substring(2, 4), 16),
+        parseInt(foregroundNormalized.substring(2, 4), 16),
+        opacity
+    );
+    const b = blendComponent(
+        parseInt(backgroundNormalized.substring(4, 6), 16),
+        parseInt(foregroundNormalized.substring(4, 6), 16),
+        opacity
+    );
+
+    return `rgb(${r},${g},${b})`;
 }
 
 export function concatStyles(...styles) {


### PR DESCRIPTION
#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: Nexus 5 (Android 6.0)

#### Screenshots

##### iOS Light Theme
<img width="390" alt="screen shot 2017-11-28 at 12 36 10 pm" src="https://user-images.githubusercontent.com/3277310/33334827-44027fca-d439-11e7-9a37-07d32d64adbc.png">

##### iOS Dark Theme
<img width="385" alt="screen shot 2017-11-28 at 12 35 22 pm" src="https://user-images.githubusercontent.com/3277310/33334832-4953a3dc-d439-11e7-86c1-cb05a0e97bbb.png">

##### Android Light Theme
![image](https://user-images.githubusercontent.com/3277310/33334846-5394684a-d439-11e7-8e4e-d5bace4fe7e1.png)

##### Android Dark Theme
![image](https://user-images.githubusercontent.com/3277310/33334862-619b889c-d439-11e7-8aa7-f5525b1cc157.png)
