### PR TITLE
Fix slash command for post comment

### DIFF
--- a/app/actions/views/command.js
+++ b/app/actions/views/command.js
@@ -4,7 +4,7 @@
 import {executeCommand as executeCommandService} from 'mattermost-redux/actions/integrations';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
-export function executeCommand(message, channelId) {
+export function executeCommand(message, channelId, rootId) {
     return async (dispatch, getState) => {
         const state = getState();
 
@@ -12,7 +12,9 @@ export function executeCommand(message, channelId) {
 
         const args = {
             channel_id: channelId,
-            team_id: teamId
+            team_id: teamId,
+            root_id: rootId,
+            parent_id: rootId
         };
 
         let msg = message;

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -342,8 +342,8 @@ class PostTextbox extends PureComponent {
     };
 
     sendCommand = async (msg) => {
-        const {actions, channelId, intl} = this.props;
-        const {error} = await actions.executeCommand(msg, channelId);
+        const {actions, channelId, intl, rootId} = this.props;
+        const {error} = await actions.executeCommand(msg, channelId, rootId);
 
         if (error) {
             Alert.alert(


### PR DESCRIPTION
#### Summary
Fixes an issue where a slash command could not be used when commenting on a post.

via @jarredwitt 