### PR TITLE
Defensive fix for post list scrollToIndex

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -81,7 +81,7 @@ export default class PostList extends PureComponent {
 
     scrollList = () => {
         InteractionManager.runAfterInteractions(() => {
-            if (this.props.postIds.length && this.newMessagesIndex !== -1) {
+            if (this.props.postIds.length && this.newMessagesIndex !== -1 && this.newMessagesIndex <= this.props.postIds.length) {
                 if (this.refs.list) {
                     this.refs.list.scrollToIndex({
                         index: this.newMessagesIndex,


### PR DESCRIPTION
#### Summary
Makes sure that the message index we want to scroll to is not out of the range of postIds