### PR TITLE
update java package when preparing for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,9 @@ do-unsigned-android:
 	@cd fastlane && NODE_ENV=production bundle exec fastlane android unsigned
 	@mv android/app/build/outputs/apk/app-unsigned-unsigned.apk ./Mattermost-unsigned.apk
 
-unsigned-android: pre-run check-style start-packager do-unsigned-android stop-packager
+unsigned-android: pre-run check-style start-build-packager do-unsigned-android stop-packager
 
-unsigned-ios: pre-run check-style start-packager do-unsigned-ios stop-packager
+unsigned-ios: pre-run check-style start-build-packager do-unsigned-ios stop-packager
 
 alpha:
 	@:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -372,73 +372,16 @@ platform :android do
     android_change_string_app_name(newName: 'Mattermost', stringsFile: './android/app/src/main/res/values/strings.xml')
     android_update_application_id(app_folder_name: 'android/app', application_id: 'com.mattermost.rn')
 
-    sh 'mv ../android/app/src/main/java/com/mattermost/rnbeta/ ../android/app/src/main/java/com/mattermost/rn/'
+    beta_dir = '../android/app/src/main/java/com/mattermost/rnbeta/'
+    release_dir = '../android/app/src/main/java/com/mattermost/rn/'
+
+    sh "mv #{beta_dir} #{release_dir}"
     sh 'cp -R ../assets/release/icons/android/* ../android/app/src/main/res/'
 
     find_replace_string(
         path_to_file: './android/app/src/main/java/com/mattermost/rn/MainApplication.java',
         old_string: 'return BuildConfig.DEBUG;',
         new_string: 'return false;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/MainApplication.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/CustomPushNotification.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/MainActivity.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/NotificationsLifecycleFacade.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/NotificationDismissService.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/NotificationReplyService.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/NotificationPreferencesModule.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/NotificationPreferences.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/MattermostManagedModule.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
-    )
-
-    find_replace_string(
-        path_to_file: './android/app/src/main/java/com/mattermost/rn/MattermostPackage.java',
-        old_string: 'package com.mattermost.rnbeta;',
-        new_string: 'package com.mattermost.rn;'
     )
 
     find_replace_string(
@@ -452,6 +395,14 @@ platform :android do
         old_string: 'Mattermost Beta',
         new_string: 'Mattermost'
     )
+
+    Dir.glob("#{release_dir}*.java") do |item|
+      find_replace_string(
+          path_to_file: item[1..-1],
+          old_string: 'package com.mattermost.rnbeta;',
+          new_string: 'package com.mattermost.rn;'
+      )
+    end
 
     configure_from_env()
   end


### PR DESCRIPTION
This update will let us add new java files inside the **com.mattermost.rnbeta** package without the need to include them in the *fastlane* script when building for release