### PR TITLE
Create post timeout

### DIFF
--- a/app/store/index.js
+++ b/app/store/index.js
@@ -110,7 +110,14 @@ export default function configureAppStore(initialState) {
                 throw new Error('Offline Action: commit action must be present.');
             }
 
-            return promiseTimeout(effect(), 10000);
+            if (action.meta.offline.canTimeout) {
+                const defaultTimeout = 10000;
+                const timeout = action.meta.offline.timeout || defaultTimeout;
+
+                return promiseTimeout(effect(), timeout);
+            }
+
+            return effect();
         },
         detectNetwork: (callback) => networkConnectionListener(callback),
         persist: (store, options) => {

--- a/app/utils/promise_timeout.js
+++ b/app/utils/promise_timeout.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+export function promiseTimeout(promise, ms) {
+    const timeout = new Promise((resolve, reject) => {
+        const id = setTimeout(() => {
+            clearTimeout(id);
+            reject('Timed out in ' + ms + 'ms.');
+        }, ms);
+    });
+
+    return Promise.race([
+        promise,
+        timeout
+    ]);
+}


### PR DESCRIPTION
#### Summary
Add a timeout around any api calls so we can assure the `effect` decorate action always returns.

This will allow any api call that takes too long to fail faster.

Specially for the Client4.createPost method.  If the api never returns, the post is in a pending state and the user is not able to retry.

This PR depends on: https://github.com/mattermost/mattermost-redux/pull/342

For some context this behavior may occur with a flaky network connection.  User in a train, elevator or switching from LTE to Wifi.

@miguelespinoza 