### PR TITLE
Previewer

### DIFF
--- a/app/actions/views/file_upload.js
+++ b/app/actions/views/file_upload.js
@@ -24,9 +24,9 @@ export function handleUploadFiles(files, rootId) {
             const uri = file.uri;
             const clientId = generateId();
 
-            if (extension === 'HEIC') {
+            if (extension.toUpperCase() === 'HEIC') {
                 extension = 'JPG';
-                name = name.replace(/HEIC/, 'jpg');
+                name = name.replace(/(HEIC|heic)/, 'jpg');
                 mimeType = 'image/jpeg';
             }
 

--- a/app/actions/views/file_upload.js
+++ b/app/actions/views/file_upload.js
@@ -16,6 +16,7 @@ export function handleUploadFiles(files, rootId) {
         const channelId = state.entities.channels.currentChannelId;
         const formData = new FormData();
         const clientIds = [];
+        const re = /heic/i;
 
         files.forEach((file) => {
             let name = file.fileName;
@@ -24,9 +25,9 @@ export function handleUploadFiles(files, rootId) {
             const uri = file.uri;
             const clientId = generateId();
 
-            if (extension.toUpperCase() === 'HEIC') {
+            if (re.test(extension)) {
                 extension = 'JPG';
-                name = name.replace(/(HEIC|heic)/, 'jpg');
+                name = name.replace(re, 'jpg');
                 mimeType = 'image/jpeg';
             }
 

--- a/app/components/swiper.js
+++ b/app/components/swiper.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    InteractionManager,
     View,
     ScrollView,
     ViewPagerAndroid,
@@ -30,7 +29,8 @@ export default class Swiper extends PureComponent {
             PropTypes.object,
             PropTypes.number
         ]),
-        width: PropTypes.number
+        width: PropTypes.number,
+        onScrollBegin: PropTypes.func
     };
 
     static defaultProps = {
@@ -38,7 +38,8 @@ export default class Swiper extends PureComponent {
         keyboardShouldPersistTaps: 'handled',
         onIndexChanged: () => null,
         scrollEnabled: true,
-        showsPagination: true
+        showsPagination: true,
+        onScrollBegin: () => true
     };
 
     constructor(props) {
@@ -84,6 +85,7 @@ export default class Swiper extends PureComponent {
 
     onScrollBegin = () => {
         this.isScrolling = true;
+        this.props.onScrollBegin();
     };
 
     onScrollEnd = (e) => {
@@ -98,11 +100,15 @@ export default class Swiper extends PureComponent {
         this.updateIndex(e.nativeEvent.contentOffset.x);
     };
 
-    scrollToStart = () => {
-        if (Platform.OS === 'ios') {
-            InteractionManager.runAfterInteractions(() => {
-                this.scrollView.scrollTo({x: 0, animated: false});
-            });
+    onPageScrollStateChanged = (e) => {
+        switch (e) {
+        case 'idle':
+            this.isScrolling = false;
+            break;
+        case 'dragging':
+            this.isScrolling = true;
+            this.props.onScrollBegin();
+            break;
         }
     };
 
@@ -141,8 +147,8 @@ export default class Swiper extends PureComponent {
             <ViewPagerAndroid
                 ref={this.refScrollView}
                 initialPage={this.props.initialPage}
-                onScrollBeginDrag={this.onScrollBegin}
                 onPageSelected={this.onScrollEnd}
+                onPageScrollStateChanged={this.onPageScrollStateChanged}
                 scrollEnabled={scrollEnabled}
                 key={pages.length}
                 style={[styles.wrapperAndroid, this.props.style]}

--- a/app/screens/image_preview/previewer.js
+++ b/app/screens/image_preview/previewer.js
@@ -262,7 +262,7 @@ export default class Previewer extends Component {
                 onResponderRelease={this.handleResponderRelease}
                 style={[style.fileImageWrapper, {height: '100%', width: '100%'}]}
             >
-                <AnimatedView style={{height: imageHeight, width: this.state.imageWidth, backgroundColor: '#000', opacity}}>
+                <AnimatedView style={{flex: 1, backgroundColor: '#000', opacity}}>
                     <ImageView
                         ref={this.attachImageView}
                         source={source}


### PR DESCRIPTION
With the previous previewer we had issues when rotating the device that made the transition show briefly the previews for other images/videos until it was able to re-align the current preview, also that was forcing the video being played to stop and for narrow images the zoom functionality was just awful.

This PR uses the same swiper as the drawer to prevent the issue when rotating the device and also corrects the problem when zooming on narrow images.