### PR TITLE
Replace KeyboardAvoidingView with custom

### DIFF
--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -443,6 +443,7 @@ class PostTextbox extends PureComponent {
                             onFocus={this.handleFocus}
                             onBlur={this.handleBlur}
                             onEndEditing={this.handleEndEditing}
+                            disableFullscreenUI={true}
                         />
                         {this.renderSendButton()}
                     </View>

--- a/app/components/text_input_with_localized_placeholder.js
+++ b/app/components/text_input_with_localized_placeholder.js
@@ -33,6 +33,7 @@ class TextInputWithLocalizedPlaceholder extends PureComponent {
                 ref='input'
                 {...otherProps}
                 placeholder={placeholderString}
+                disableFullscreenUI={true}
             />
         );
     }

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -369,6 +369,7 @@ class Login extends PureComponent {
                             underlineColorAndroid='transparent'
                             onSubmitEditing={this.passwordFocus}
                             blurOnSubmit={false}
+                            disableFullscreenUI={true}
                         />
                         <TextInput
                             ref={this.passwordRef}
@@ -382,6 +383,7 @@ class Login extends PureComponent {
                             underlineColorAndroid='transparent'
                             returnKeyType='go'
                             onSubmitEditing={this.preSignIn}
+                            disableFullscreenUI={true}
                         />
                         {proceed}
                     </KeyboardAwareScrollView>


### PR DESCRIPTION
#### Summary
The KeyboardAvoidingView sometimes caused the keyboard to be placed on top of the postTextBox, this PR will prevent that.

also prevents Android for showing the textInput in fullscreen.

resolves #1239 