### PR TITLE
Run podinstall if the OS is mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 ios_target := $(filter-out build-ios,$(MAKECMDGOALS))
 android_target := $(filter-out build-android,$(MAKECMDGOALS))
 POD := $(shell command -v pod 2> /dev/null)
+OS := $(shell sh -c 'uname -s 2>/dev/null')
 
 .yarninstall: package.json
 	@if ! [ $(shell command -v yarn 2> /dev/null) ]; then \
@@ -19,6 +20,7 @@ POD := $(shell command -v pod 2> /dev/null)
 	@touch $@
 
 .podinstall:
+ifeq ($(OS), Darwin)
 ifdef POD
 	@echo Getting Cocoapods dependencies;
 	@cd ios && pod install;
@@ -26,7 +28,7 @@ else
 	@echo "Cocoapods is not installed https://cocoapods.org/"
 	@exit 1
 endif
-
+endif
 	@touch $@
 
 BASE_ASSETS = $(shell find assets/base -type d) $(shell find assets/base -type f -name '*')


### PR DESCRIPTION
#### Summary
There are some who are trying to run the make commands on a linux machine and trying to install cocoapods fails, this change to the makefile will only check and run cocoapods if is ran from a mac