### PR TITLE
Add Account Settings screen

### DIFF
--- a/app/actions/views/account_settings.js
+++ b/app/actions/views/account_settings.js
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {lookupMimeType} from 'mattermost-redux/utils/file_utils';
+import {uploadProfileImage, updateMe} from 'mattermost-redux/actions/users';
+
+export function updateUser(user, success, error) {
+    return async (dispatch, getState) => {
+        const result = await updateMe(user)(dispatch, getState);
+        const {data, error: err} = result;
+        if (data && success) {
+            success(data);
+        } else if (err && error) {
+            error({id: err.server_error_id, ...err});
+        }
+        return result;
+    };
+}
+
+export function handleUploadProfileImage(image, userId) {
+    return async (dispatch, getState) => {
+        let name = image.fileName;
+        let mimeType = lookupMimeType(name);
+        let extension = name.split('.').pop().replace('.', '');
+        const uri = image.uri;
+
+        if (extension === 'HEIC') {
+            extension = 'JPG';
+            name = name.replace(/HEIC/, 'jpg');
+            mimeType = 'image/jpeg';
+        }
+
+        const imageData = {
+            uri,
+            name,
+            type: mimeType,
+            extension
+        };
+
+        await uploadProfileImage(userId, imageData)(dispatch, getState);
+    };
+}

--- a/app/components/attachment_button.js
+++ b/app/components/attachment_button.js
@@ -17,7 +17,9 @@ class AttachmentButton extends PureComponent {
         intl: intlShape.isRequired,
         navigator: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
-        uploadFiles: PropTypes.func.isRequired
+        uploadFiles: PropTypes.func.isRequired,
+        wrapper: PropTypes.bool,
+        children: PropTypes.node
     };
 
     attachFileFromCamera = () => {
@@ -139,7 +141,7 @@ class AttachmentButton extends PureComponent {
                 action();
             }
         }, 100);
-    }
+    };
 
     showFileAttachmentOptions = () => {
         this.props.blurTextBox();
@@ -190,7 +192,17 @@ class AttachmentButton extends PureComponent {
     };
 
     render() {
-        const {theme} = this.props;
+        const {theme, wrapper, children} = this.props;
+
+        if (wrapper) {
+            return (
+                <TouchableOpacity
+                    onPress={this.showFileAttachmentOptions}
+                >
+                    {children}
+                </TouchableOpacity>
+            );
+        }
 
         return (
             <TouchableOpacity

--- a/app/components/error_text.js
+++ b/app/components/error_text.js
@@ -48,7 +48,8 @@ class ErrorText extends PureComponent {
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         errorLabel: {
-            color: (theme.errorTextColor || '#DA4A4A')
+            color: (theme.errorTextColor || '#DA4A4A'),
+            textAlign: 'center'
         }
     };
 });

--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -7,12 +7,12 @@ import {Alert, BackHandler, Keyboard, Platform, Text, TextInput, TouchableOpacit
 import {injectIntl, intlShape} from 'react-intl';
 import {RequestStatus} from 'mattermost-redux/constants';
 
+import AttachmentButton from 'app/components/attachment_button';
 import Autocomplete from 'app/components/autocomplete';
 import FileUploadPreview from 'app/components/file_upload_preview';
 import PaperPlane from 'app/components/paper_plane';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
-import AttachmentButton from './components/attachment_button';
 import Typing from './components/typing';
 
 const INITIAL_HEIGHT = Platform.OS === 'ios' ? 34 : 36;

--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -8,7 +8,8 @@ import {Image, Platform, View} from 'react-native';
 import {General} from 'mattermost-redux/constants';
 
 import {AwayIcon, DndIcon, OfflineIcon, OnlineIcon} from 'app/components/status_icons';
-import {makeStyleSheetFromTheme} from 'app/utils/theme';
+import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import placeholder from 'assets/images/profile.jpg';
 
@@ -33,6 +34,8 @@ export default class ProfilePicture extends PureComponent {
         statusSize: PropTypes.number,
         user: PropTypes.object,
         status: PropTypes.string,
+        edit: PropTypes.bool,
+        imageUri: PropTypes.string,
         theme: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             getStatusForId: PropTypes.func.isRequired
@@ -42,7 +45,8 @@ export default class ProfilePicture extends PureComponent {
     static defaultProps = {
         size: 128,
         statusBorderWidth: 2,
-        statusSize: 14
+        statusSize: 14,
+        edit: false
     };
 
     componentDidMount() {
@@ -52,12 +56,16 @@ export default class ProfilePicture extends PureComponent {
     }
 
     render() {
-        const {theme} = this.props;
+        const {theme, edit, imageUri} = this.props;
         const style = getStyleSheet(theme);
 
         let pictureUrl;
         if (this.props.user) {
             pictureUrl = Client4.getProfilePictureUrl(this.props.user.id, this.props.user.last_picture_update);
+        }
+
+        if (edit && imageUri) {
+            pictureUrl = imageUri;
         }
 
         let Icon;
@@ -84,13 +92,47 @@ export default class ProfilePicture extends PureComponent {
             iconColor = theme.centerChannelColor;
         }
 
-        const statusIcon = (
+        let iconContainer;
+        let icon = (
             <Icon
                 height={this.props.statusSize}
                 width={this.props.statusSize}
                 color={iconColor}
             />
         );
+
+        if (edit) {
+            Icon = FontAwesomeIcon;
+            iconColor = changeOpacity(theme.centerChannelColor, 0.6);
+            icon = (
+                <Icon
+                    name='camera'
+                    size={this.props.statusSize / 1.7}
+                    color={iconColor}
+                />
+            );
+
+            iconContainer = (
+                <View
+                    style={[
+                        style.iconWrapper,
+                        {
+                            borderRadius: this.props.statusSize / 2,
+                            width: this.props.statusSize,
+                            height: this.props.statusSize,
+                            backgroundColor: 'white'
+                        }]}
+                >
+                    {icon}
+                </View>
+            );
+        } else if (this.props.status && !edit) {
+            iconContainer = (
+                <View style={[style.iconWrapper, {borderRadius: this.props.statusSize / 2}]}>
+                    {icon}
+                </View>
+            );
+        }
 
         return (
             <View style={{width: this.props.size + STATUS_BUFFER, height: this.props.size + STATUS_BUFFER}}>
@@ -100,11 +142,7 @@ export default class ProfilePicture extends PureComponent {
                     source={{uri: pictureUrl}}
                     defaultSource={placeholder}
                 />
-                {this.props.status &&
-                    <View style={[style.statusWrapper, {borderRadius: this.props.statusSize / 2}]}>
-                        {statusIcon}
-                    </View>
-                }
+                {iconContainer}
             </View>
         );
     }
@@ -112,7 +150,7 @@ export default class ProfilePicture extends PureComponent {
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
-        statusWrapper: {
+        iconWrapper: {
             position: 'absolute',
             bottom: 0,
             right: 0,

--- a/app/screens/index.js
+++ b/app/screens/index.js
@@ -7,6 +7,7 @@ import {Navigation} from 'react-native-navigation';
 import About from 'app/screens/about';
 
 import AddReaction from 'app/screens/add_reaction';
+import AccountSettings from 'app/screens/settings/account_settings';
 import AdvancedSettings from 'app/screens/settings/advanced_settings';
 import Channel from 'app/screens/channel';
 import ChannelAddMembers from 'app/screens/channel_add_members';
@@ -60,6 +61,7 @@ function wrapWithContextProvider(Comp, excludeEvents = true) {
 export function registerScreens(store, Provider) {
     Navigation.registerComponent('About', () => wrapWithContextProvider(About), store, Provider);
     Navigation.registerComponent('AddReaction', () => wrapWithContextProvider(AddReaction), store, Provider);
+    Navigation.registerComponent('AccountSettings', () => wrapWithContextProvider(AccountSettings), store, Provider);
     Navigation.registerComponent('AdvancedSettings', () => wrapWithContextProvider(AdvancedSettings), store, Provider);
     Navigation.registerComponent('Channel', () => wrapWithContextProvider(Channel, false), store, Provider);
     Navigation.registerComponent('ChannelAddMembers', () => wrapWithContextProvider(ChannelAddMembers), store, Provider);

--- a/app/screens/settings/account_settings/account_settings.js
+++ b/app/screens/settings/account_settings/account_settings.js
@@ -1,0 +1,485 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {intlShape} from 'react-intl';
+import {
+    View,
+    Platform,
+    InteractionManager,
+    TouchableWithoutFeedback
+} from 'react-native';
+
+import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
+import {RequestStatus} from 'mattermost-redux/constants';
+
+import Loading from 'app/components/loading';
+import ErrorText from 'app/components/error_text';
+import StatusBar from 'app/components/status_bar/index';
+import ProfilePicture from 'app/components/profile_picture/index';
+import AttachmentButton from 'app/components/attachment_button';
+import SettingsItem from './account_settings_item';
+
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+
+const holders = {
+    fullName: {
+        id: 'user.settings.general.fullName',
+        defaultMessage: 'Full Name'
+    },
+    username: {
+        id: 'user.settings.general.username',
+        defaultMessage: 'Username'
+    },
+    nickname: {
+        id: 'user.settings.general.nickname',
+        defaultMessage: 'Nickname'
+    },
+    position: {
+        id: 'user.settings.general.position',
+        defaultMessage: 'Position'
+    },
+    email: {
+        id: 'user.settings.general.email',
+        defaultMessage: 'Email'
+    }
+};
+
+export default class AccountSettings extends PureComponent {
+    static propTypes = {
+        navigator: PropTypes.object.isRequired,
+        theme: PropTypes.object.isRequired,
+        config: PropTypes.object.isRequired,
+        deviceWidth: PropTypes.number.isRequired,
+        deviceHeight: PropTypes.number.isRequired,
+        currentUser: PropTypes.object.isRequired,
+        updateRequest: PropTypes.object.isRequired,
+        actions: PropTypes.shape({
+            handleUploadProfileImage: PropTypes.func.isRequired,
+            updateUser: PropTypes.func.isRequired
+        }).isRequired
+    };
+
+    static contextTypes = {
+        intl: intlShape.isRequired
+    };
+
+    rightButton = {
+        id: 'update-profile',
+        disabled: true,
+        showAsAction: 'always'
+    };
+
+    constructor(props, context) {
+        super(props);
+
+        const {
+            currentUser,
+            currentUser: {
+                first_name: firstName,
+                last_name: lastName,
+                auth_service
+            }
+        } = props;
+        const authService = auth_service.toLowerCase();
+
+        // TODO: fullName edit support, may be problematic since db stores first and last name separately
+        let fullName = '';
+        if (firstName && lastName) {
+            fullName = `${firstName} ${lastName}`;
+        } else if (firstName) {
+            fullName = firstName;
+        }
+
+        this.state = {
+            fullName,
+            firstName,
+            lastName,
+            username: currentUser.username,
+            nickname: currentUser.nickname,
+            position: currentUser.position,
+            email: currentUser.email,
+            authService
+        };
+
+        this.rightButton.title = context.intl.formatMessage({id: 'mobile.account.settings.save', defaultMessage: 'Save'});
+
+        const buttons = {
+            rightButtons: [this.rightButton]
+        };
+
+        props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
+        props.navigator.setButtons(buttons);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const {updateRequest} = nextProps;
+
+        if (this.props.updateRequest !== updateRequest) {
+            switch (updateRequest.status) {
+            case RequestStatus.STARTED:
+                this.emitCanUpdateAccount(false);
+                this.setState({error: null, updating: true});
+                break;
+            case RequestStatus.SUCCESS:
+                InteractionManager.runAfterInteractions(() => {
+                    this.emitCanUpdateAccount(true);
+                    this.setState({error: null, updating: false});
+                    this.close();
+                });
+                break;
+            case RequestStatus.FAILURE:
+                this.emitCanUpdateAccount(true);
+                this.setState({error: updateRequest.error, updating: false});
+                break;
+            }
+        }
+    }
+
+    close = () => {
+        this.props.navigator.pop({animated: true});
+    };
+
+    onNavigatorEvent = (event) => {
+        if (event.type === 'NavBarButtonPress') {
+            switch (event.id) {
+            case 'update-profile':
+                this.submitUser();
+                break;
+            }
+        }
+    };
+
+    emitCanUpdateAccount = (enabled) => {
+        const buttons = {
+            rightButtons: [{...this.rightButton, disabled: !enabled}]
+        };
+
+        this.props.navigator.setButtons(buttons);
+    };
+
+    submitUser() {
+        const {
+            profileImage,
+            firstName,
+            lastName,
+            username,
+            nickname,
+            position,
+            email
+        } = this.state;
+        const user = {
+            first_name: firstName,
+            last_name: lastName,
+            username,
+            nickname,
+            position,
+            email
+        };
+
+        // TODO: have 1 request instead of 2
+        // since these request are in one screen and is triggered by the save action button,
+        // having to deal with 2 results can get complicated. see account_settings/index.js
+        if (profileImage) {
+            this.props.actions.handleUploadProfileImage(profileImage, this.props.currentUser.id);
+        }
+
+        if (this.canUpdate()) {
+            this.props.actions.updateUser(user);
+        }
+    }
+
+    handleUploadProfileImage = (images) => {
+        const image = images && images.length > 0 && images[0];
+        this.setState({profileImage: image});
+        this.emitCanUpdateAccount(true);
+    };
+
+    updateField = (field) => {
+        this.setState(field);
+        this.emitCanUpdateAccount(this.canUpdate(field));
+    };
+
+    canUpdate = (updatedField) => {
+        const {
+            firstName,
+            lastName,
+            username,
+            nickname,
+            position,
+            email
+        } = this.state;
+        const {
+            currentUser: {
+                first_name: oldFirstName,
+                last_name: oldLastName,
+                username: oldUsername,
+                nickname: oldNickname,
+                position: oldPosition,
+                email: oldEmail
+            }
+        } = this.props;
+
+        const fields = {
+            firstName,
+            lastName,
+            username,
+            nickname,
+            position,
+            email,
+            ...updatedField
+        };
+
+        const oldFields = {
+            firstName: oldFirstName,
+            lastName: oldLastName,
+            username: oldUsername,
+            nickname: oldNickname,
+            position: oldPosition,
+            email: oldEmail
+        };
+
+        return fields.firstName !== oldFields.firstName ||
+            fields.lastName !== oldFields.lastName ||
+            fields.username !== oldFields.username ||
+            fields.nickname !== oldFields.nickname ||
+            fields.position !== oldFields.position ||
+            fields.email !== oldFields.email;
+    };
+
+    canEdit = () => {
+        const {authService} = this.state;
+
+        return authService !== 'ldap' && authService !== 'saml';
+    };
+
+    renderNameSettings = () => {
+        const {theme} = this.props;
+        const {fullName} = this.state;
+
+        return (
+            <View>
+                <SettingsItem
+                    theme={theme}
+                    value={fullName}
+                    updateValue={(value) => this.updateField({fullName: value})}
+                    format={holders.fullName}
+                    editable={this.canEdit()}
+                />
+            </View>
+        );
+    };
+
+    renderUsernameSettings = () => {
+        const {theme} = this.props;
+        const {username} = this.state;
+
+        return (
+            <SettingsItem
+                theme={theme}
+                value={username}
+                updateValue={(value) => this.updateField({username: value})}
+                format={holders.username}
+                editable={this.canEdit()}
+            />
+        );
+    };
+
+    renderEmailSettings = () => {
+        const {theme} = this.props;
+        const {email} = this.state;
+
+        return (
+            <View>
+                <SettingsItem
+                    theme={theme}
+                    value={email}
+                    updateValue={(value) => this.updateField({email: value})}
+                    format={holders.email}
+                    editable={this.canEdit()}
+                />
+            </View>
+        );
+    };
+
+    renderNicknameSettings = () => {
+        const {theme} = this.props;
+        const {nickname} = this.state;
+
+        return (
+            <SettingsItem
+                theme={theme}
+                value={nickname}
+                updateValue={(value) => this.updateField({nickname: value})}
+                format={holders.nickname}
+                optional={true}
+                editable={this.canEdit()}
+            />
+        );
+    };
+
+    renderPositionSettings = () => {
+        const {theme} = this.props;
+        const {position} = this.state;
+
+        return (
+            <SettingsItem
+                theme={theme}
+                value={position}
+                updateValue={(value) => this.updateField({position: value})}
+                format={holders.position}
+                optional={true}
+                editable={this.canEdit()}
+            />
+        );
+    };
+
+    render() {
+        const {
+            currentUser: {
+                id
+            },
+            deviceWidth,
+            deviceHeight,
+            theme,
+            navigator
+        } = this.props;
+        const {
+            profileImage,
+            nickname,
+            position,
+            error,
+            updating
+        } = this.state;
+        const style = getStyleSheet(theme);
+
+        if (updating) {
+            return (
+                <View style={style.container}>
+                    <StatusBar/>
+                    <Loading/>
+                </View>
+            );
+        }
+
+        let displayError;
+        if (error) {
+            displayError = (
+                <View style={[style.errorContainer, {width: deviceWidth}]}>
+                    <View style={style.errorWrapper}>
+                        <ErrorText error={error}/>
+                    </View>
+                </View>
+            );
+        }
+
+        const fields = [];
+        const canEdit = this.canEdit();
+        const nicknameValid = nickname && nickname !== '';
+        const positionValid = position && position !== '';
+
+        fields.push({
+            id: 'fullName',
+            render: this.renderNameSettings
+        });
+        fields.push({
+            id: 'username',
+            render: this.renderUsernameSettings
+        });
+        fields.push({
+            id: 'email',
+            render: this.renderEmailSettings
+        });
+
+        if (canEdit || (!canEdit && nicknameValid)) {
+            fields.push({
+                id: 'nickname',
+                render: this.renderNicknameSettings
+            });
+        }
+
+        if (canEdit || (!canEdit && positionValid)) {
+            fields.push({
+                id: 'position',
+                render: this.renderPositionSettings
+            });
+        }
+
+        return (
+            <View style={{flex: 1}}>
+                <StatusBar/>
+                <KeyboardAwareScrollView
+                    ref={this.scrollRef}
+                    style={style.container}
+                >
+                    {displayError}
+                    <TouchableWithoutFeedback onPress={() => true}>
+                        <View style={[style.scrollView, {height: deviceHeight + (Platform.OS === 'android' ? 200 : 0)}]}>
+                            <View style={style.top}>
+                                <AttachmentButton
+                                    blurTextBox={() => true}
+                                    theme={theme}
+                                    navigator={navigator}
+                                    wrapper={true}
+                                    uploadFiles={this.handleUploadProfileImage}
+                                >
+                                    <ProfilePicture
+                                        userId={id}
+                                        size={150}
+                                        statusBorderWidth={6}
+                                        statusSize={40}
+                                        edit={true}
+                                        imageUri={profileImage && profileImage.uri}
+                                    />
+                                </AttachmentButton>
+                            </View>
+                            {fields.map((field) => (
+                                <View key={field.id}>
+                                    {field.render()}
+                                    <View style={style.separator}/>
+                                </View>
+                            ))}
+                        </View>
+                    </TouchableWithoutFeedback>
+                </KeyboardAwareScrollView>
+            </View>
+        );
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        container: {
+            flex: 1,
+            backgroundColor: theme.centerChannelBg
+        },
+        scrollView: {
+            flex: 1,
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.03),
+            paddingTop: 10
+        },
+        top: {
+            padding: 25,
+            alignItems: 'center',
+            justifyContent: 'center'
+        },
+        errorContainer: {
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.03)
+        },
+        errorWrapper: {
+            justifyContent: 'center',
+            alignItems: 'center'
+        },
+        helpText: {
+            fontSize: 14,
+            color: changeOpacity(theme.centerChannelColor, 0.5),
+            marginTop: 10,
+            marginHorizontal: 15
+        },
+        separator: {
+            height: 15
+        }
+    };
+});
+

--- a/app/screens/settings/account_settings/account_settings_item.js
+++ b/app/screens/settings/account_settings/account_settings_item.js
@@ -1,0 +1,106 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {
+    View,
+    TextInput
+} from 'react-native';
+
+import FormattedText from 'app/components/formatted_text';
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+
+export default class AccountSettingsItem extends PureComponent {
+    static propTypes = {
+        theme: PropTypes.object.isRequired,
+        format: PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            defaultMessage: PropTypes.string.isRequired
+        }),
+        value: PropTypes.string.isRequired,
+        updateValue: PropTypes.func.isRequired,
+        optional: PropTypes.bool,
+        editable: PropTypes.bool
+    };
+
+    static defaultProps = {
+        optional: false,
+        editable: true
+    };
+
+    render() {
+        const {
+            theme,
+            format,
+            optional,
+            editable,
+            value,
+            updateValue
+        } = this.props;
+        const style = getStyleSheet(theme);
+
+        return (
+            <View>
+                <View style={style.titleContainer15}>
+                    <FormattedText
+                        style={style.title}
+                        id={format.id}
+                        defaultMessage={format.defaultMessage}
+                    />
+                    {optional && (
+                        <FormattedText
+                            style={style.optional}
+                            id='channel_modal.optional'
+                            defaultMessage='(optional)'
+                        />
+                    )}
+                </View>
+                <View style={style.inputContainer}>
+                    <TextInput
+                        ref={this.channelNameRef}
+                        value={value}
+                        onChangeText={updateValue}
+                        style={style.input}
+                        autoCapitalize='none'
+                        autoCorrect={false}
+                        editable={editable}
+                        underlineColorAndroid='transparent'
+                    />
+                </View>
+            </View>
+        );
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        inputContainer: {
+            borderTopWidth: 1,
+            borderBottomWidth: 1,
+            borderTopColor: changeOpacity(theme.centerChannelColor, 0.1),
+            borderBottomColor: changeOpacity(theme.centerChannelColor, 0.1),
+            backgroundColor: theme.centerChannelBg
+        },
+        input: {
+            color: '#333',
+            fontSize: 14,
+            height: 40,
+            paddingHorizontal: 15
+        },
+        title: {
+            fontSize: 14,
+            color: theme.centerChannelColor,
+            marginLeft: 15
+        },
+        titleContainer15: {
+            flexDirection: 'row',
+            marginTop: 15
+        },
+        optional: {
+            color: changeOpacity(theme.centerChannelColor, 0.5),
+            fontSize: 14,
+            marginLeft: 5
+        }
+    };
+});

--- a/app/screens/settings/account_settings/index.js
+++ b/app/screens/settings/account_settings/index.js
@@ -1,0 +1,88 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {updateUser, handleUploadProfileImage} from 'app/actions/views/account_settings';
+
+import AccountSettings from './account_settings';
+
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {RequestStatus} from 'mattermost-redux/constants';
+import {getDimensions} from 'app/selectors/device';
+
+// TODO: may not be the best solution, the idea is to merge request results from
+// updateUser and handleUploadProfileImage actions
+function mergeRequest(updateMeRequest, updateProfilePictureRequest) {
+    let updateRequest = {};
+    const updateMeStatus = updateMeRequest.status;
+    const updateProfilePictureStatus = updateProfilePictureRequest.status;
+
+    let updateErrors = null;
+    const updateMeFailure = updateMeStatus === RequestStatus.FAILURE;
+    const updateProfilePictureFailure = updateProfilePictureStatus === RequestStatus.FAILURE;
+
+    if (updateProfilePictureFailure) {
+        updateErrors = updateProfilePictureRequest;
+    }
+
+    if (updateMeFailure) {
+        const updateProfilePictureError = updateErrors && updateErrors.error &&
+            (updateErrors.error.message || updateErrors.error);
+        const updateMeError = updateMeRequest && updateMeRequest.error &&
+            (updateMeRequest.error.message || updateMeRequest.error);
+        updateErrors = updateErrors ?
+            {
+                ...updateErrors,
+                error: `${updateProfilePictureError}\n${updateMeError}`
+            } : updateMeRequest;
+        updateRequest = updateErrors;
+    }
+
+    if (updateMeFailure || updateProfilePictureFailure) {
+        return updateRequest;
+    }
+
+    if (updateMeStatus === RequestStatus.STARTED || updateProfilePictureStatus === RequestStatus.STARTED) {
+        return {status: RequestStatus.STARTED};
+    }
+
+    if ((updateMeStatus === RequestStatus.SUCCESS && updateProfilePictureStatus === RequestStatus.NOT_STARTED) ||
+        (updateProfilePictureStatus === RequestStatus.SUCCESS && updateMeStatus === RequestStatus.NOT_STARTED) ||
+        (updateMeStatus === RequestStatus.SUCCESS && updateProfilePictureStatus === RequestStatus.SUCCESS)) {
+        updateRequest = {status: RequestStatus.SUCCESS};
+    }
+
+    return updateRequest;
+}
+
+function mapStateToProps(state) {
+    const {deviceWidth, deviceHeight} = getDimensions(state);
+    const {updateMe: updateMeRequest, updateUser: updateProfilePictureRequest} = state.requests.users;
+
+    const updateRequest = mergeRequest(updateMeRequest, updateProfilePictureRequest);
+
+    return {
+        currentUser: getCurrentUser(state),
+        config: getConfig(state),
+        theme: getTheme(state),
+        deviceWidth,
+        deviceHeight,
+        updateRequest
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            handleUploadProfileImage,
+            updateUser
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AccountSettings);

--- a/app/screens/settings/general/settings.js
+++ b/app/screens/settings/general/settings.js
@@ -89,6 +89,22 @@ class Settings extends PureComponent {
         });
     });
 
+    goToAccount = wrapWithPreventDoubleTap(() => {
+        const {intl, navigator, theme} = this.props;
+        navigator.push({
+            screen: 'AccountSettings',
+            backButtonTitle: '',
+            title: intl.formatMessage({id: 'user.settings.modal.title', defaultMessage: 'Account Settings'}),
+            animated: true,
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg
+            }
+        });
+    });
+
     goToNotifications = wrapWithPreventDoubleTap(() => {
         const {intl, navigator, theme} = this.props;
         navigator.push({
@@ -216,6 +232,15 @@ class Settings extends PureComponent {
                 <StatusBar/>
                 <View style={style.wrapper}>
                     <View style={style.divider}/>
+                    <SettingsItem
+                        defaultMessage='Account Settings'
+                        i18nId='user.settings.modal.title'
+                        iconName='ios-person'
+                        iconType='ion'
+                        onPress={this.goToAccount}
+                        showArrow={showArrow}
+                        theme={theme}
+                    />
                     <SettingsItem
                         defaultMessage='Notifications'
                         i18nId='user.settings.modal.notifications'

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -2120,6 +2120,7 @@
   "mobile.video.save_error_title": "Save Video Error",
   "mobile.video_playback.failed_description": "An error occurred while trying to play the video.\n",
   "mobile.video_playback.failed_title": "Video playback failed",
+  "mobile.account.settings.save": "Save",
   "modal.manaul_status.ask": "Do not ask me again",
   "modal.manaul_status.button": "Yes, set my status to \"Online\"",
   "modal.manaul_status.message": "Would you like to switch your status to \"Online\"?",


### PR DESCRIPTION
#### Summary
Add Account Settings screen.  This is a partially complete feature.  The `right-drawer` feature is blocking this PR.  Also, what remains is complete profile edit functionality.

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates

## iOS
![simulator screen shot - iphone 6 - 2017-12-04 at 13 00 50](https://user-images.githubusercontent.com/6182543/33568116-5ef86ec0-d8f3-11e7-9ce4-bce57f975028.png)

## Android
![screenshot_1512409485](https://user-images.githubusercontent.com/6182543/33568120-60f2ab0a-d8f3-11e7-8285-6dd410f9afb0.png)