### PR TITLE
Fix keyboard layout for ios 9 and 10

### DIFF
--- a/app/components/layout/keyboard_layout/keyboard_layout.js
+++ b/app/components/layout/keyboard_layout/keyboard_layout.js
@@ -49,10 +49,11 @@ export default class KeyboardLayout extends PureComponent {
         const {endCoordinates, duration, startCoordinates} = e;
 
         let height = 0;
-        if (startCoordinates.height < endCoordinates.height) {
+        if (startCoordinates.height < endCoordinates.height || endCoordinates.screenY < startCoordinates.screenY) {
             height = endCoordinates.height;
         }
 
+        this.setState({bottom: new Animated.Value(height)});
         Animated.timing(this.state.bottom, {
             toValue: height,
             duration


### PR DESCRIPTION
#### Summary
Fixes the post textbox component staying behind the keyboard on ios 10 and 9.


#### Device Information
This PR was tested on: iOS simulators with version 11, 10 and 9
iPhone 6, iPhone 5s, iPhone X
