### PR TITLE
Android: Show center screen from user profile

### DIFF
--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -49,11 +49,11 @@ class UserProfile extends PureComponent {
     close = () => {
         const {navigator} = this.props;
 
-        if (Platform.OS === 'ios') {
-            navigator.popToRoot({
-                animated: true
-            });
-        } else {
+        navigator.popToRoot({
+            animated: true
+        });
+
+        if (Platform.OS === 'android') {
             navigator.dismissModal({
                 animationType: 'slide-down'
             });


### PR DESCRIPTION
#### Summary
Ensures that we send the user to the channel view regardless if the user profile was pushed or if it is a modal on Android when the send message button is pressed.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-550