### PR TITLE
Android: Avoid crash when clearing notifications (1.5)

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -56,8 +56,10 @@ public class CustomPushNotification extends PushNotification {
         if (notificationId != -1) {
             channelIdToNotificationCount.remove(channelId);
             channelIdToNotification.remove(channelId);
-            final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            notificationManager.cancel(notificationId);
+            if (context != null) {
+                final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                notificationManager.cancel(notificationId);
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Report from google play
```
java.lang.RuntimeException: 
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:3314)
  at android.app.ActivityThread.-wrap21 (ActivityThread.java)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1565)
  at android.os.Handler.dispatchMessage (Handler.java:102)
  at android.os.Looper.loop (Looper.java:154)
  at android.app.ActivityThread.main (ActivityThread.java:6077)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:865)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:755)
Caused by: java.lang.NullPointerException: 
  at com.mattermost.rn.CustomPushNotification.clearNotification (CustomPushNotification.java:59)
  at com.mattermost.rn.NotificationReplyService.getTaskConfig (NotificationReplyService.java:30)
  at com.facebook.react.HeadlessJsTaskService.onStartCommand (HeadlessJsTaskService.java:51)
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:3297)
```