### PR TITLE
RN-462 Allow user and channel lists to load more than one additional page of content

### DIFF
--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -184,7 +184,7 @@ class ChannelAddMembers extends PureComponent {
         let {page} = this.state;
         if (loadMoreRequestStatus !== RequestStatus.STARTED && next && !searching) {
             page = page + 1;
-            actions.getProfilesNotInChannel(currentTeam.id, currentChannel.id, page, General.PROFILE_CHUNK_SIZE).then((data) => {
+            actions.getProfilesNotInChannel(currentTeam.id, currentChannel.id, page, General.PROFILE_CHUNK_SIZE).then(({data}) => {
                 if (data && data.length) {
                     this.setState({
                         page

--- a/app/screens/channel_members/channel_members.js
+++ b/app/screens/channel_members/channel_members.js
@@ -212,7 +212,7 @@ class ChannelMembers extends PureComponent {
         if (requestStatus !== RequestStatus.STARTED && next && !searching) {
             page = page + 1;
             actions.getProfilesInChannel(currentChannel.id, page, General.PROFILE_CHUNK_SIZE).then(
-                (data) => {
+                ({data}) => {
                     if (data && data.length) {
                         this.setState({
                             page

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -181,7 +181,7 @@ class MoreChannels extends PureComponent {
                 this.props.currentTeamId,
                 page,
                 General.CHANNELS_CHUNK_SIZE
-            ).then((data) => {
+            ).then(({data}) => {
                 if (data && data.length) {
                     this.setState({
                         page

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -420,6 +420,8 @@ class MoreDirectMessages extends PureComponent {
                     sectionKeyExtractor={this.sectionKeyExtractor}
                     compareItems={this.compareItems}
                     extraData={this.state.selectedIds}
+                    onListEndReached={this.loadMoreProfiles}
+                    listScrollRenderAheadDistance={50}
                     onRowPress={this.handleSelectUser}
                     loading={isLoading}
                     loadingText={loadingText}

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -195,7 +195,7 @@ class MoreDirectMessages extends PureComponent {
         let {page} = this.state;
         if (this.props.getRequest.status !== RequestStatus.STARTED && this.state.next && !this.state.searching) {
             page = page + 1;
-            this.getProfiles(page).then((data) => {
+            this.getProfiles(page).then(({data}) => {
                 if (data && data.length) {
                     this.setState({
                         page


### PR DESCRIPTION
It turns out that these weren't updated to handle the actions an object with a data field.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-462

#### Device Information
This PR was tested on: iOS 6 Simulator (iOS 11.2)
