### PR TITLE
RN-566 Made ChannelIntro only show for the current channel

### DIFF
--- a/app/components/channel_intro/index.js
+++ b/app/components/channel_intro/index.js
@@ -2,46 +2,81 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {createSelector} from 'reselect';
+
 import {General, RequestStatus} from 'mattermost-redux/constants';
-import {makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getCurrentUser, makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentUserId, getUser, makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import ChannelIntro from './channel_intro';
 
-function makeMapStateToProps() {
-    const getChannel = makeGetChannel();
-    const getProfilesInChannel = makeGetProfilesInChannel();
+const getProfilesInCurrentChannel = makeGetProfilesInChannel();
 
-    return function mapStateToProps(state, ownProps) {
-        const currentChannel = getChannel(state, {id: ownProps.channelId}) || {};
-        const currentUser = getCurrentUser(state) || {};
-        const {status: getPostsRequestStatus} = state.requests.posts.getPosts;
-
-        let currentChannelMembers = [];
-        if (currentChannel.type === General.DM_CHANNEL) {
-            const otherChannelMember = currentChannel.name.split('__').find((m) => m !== currentUser.id);
-            const otherProfile = state.entities.users.profiles[otherChannelMember];
-            if (otherProfile) {
-                currentChannelMembers.push(otherProfile);
-            }
-        } else {
-            currentChannelMembers = getProfilesInChannel(state, ownProps.channelId) || [];
-            currentChannelMembers = currentChannelMembers.filter((m) => m.id !== currentUser.id);
+const getCurrentChannelMembers = createSelector(
+    getCurrentChannelId,
+    getCurrentUserId,
+    (state) => getProfilesInCurrentChannel(state, getCurrentChannelId(state)),
+    (currentChannelId, currentUserId, profilesInChannel) => {
+        if (!currentChannelId) {
+            return [];
         }
 
-        const creator = currentChannel.creator_id === currentUser.id ? currentUser : state.entities.users.profiles[currentChannel.creator_id];
-        const postsInChannel = state.entities.posts.postsInChannel[ownProps.channelId] || [];
+        const currentChannelMembers = profilesInChannel || [];
+        return currentChannelMembers.filter((m) => m.id !== currentUserId);
+    }
+);
 
-        return {
-            creator,
-            currentChannel,
-            currentChannelMembers,
-            isLoadingPosts: !postsInChannel.length && getPostsRequestStatus === RequestStatus.STARTED,
-            theme: getTheme(state)
-        };
+const getOtherUserIdForDm = createSelector(
+    getCurrentChannel,
+    getCurrentUserId,
+    (currentChannel, currentUserId) => {
+        if (!currentChannel) {
+            return '';
+        }
+
+        return currentChannel.name.split('__').find((m) => m !== currentUserId);
+    }
+);
+
+const getCurrentChannelMembersForDm = createSelector(
+    (state) => getUser(state, getOtherUserIdForDm(state)),
+    (otherUser) => {
+        if (!otherUser) {
+            return [];
+        }
+
+        return [otherUser];
+    }
+);
+
+function mapStateToProps(state) {
+    const currentChannel = getCurrentChannel(state);
+    const {status: getPostsRequestStatus} = state.requests.posts.getPosts;
+
+    let currentChannelMembers;
+    let creator;
+    let postsInChannel;
+
+    if (currentChannel) {
+        if (currentChannel.type === General.DM_CHANNEL) {
+            currentChannelMembers = getCurrentChannelMembersForDm(state);
+        } else {
+            currentChannelMembers = getCurrentChannelMembers(state);
+        }
+
+        creator = getUser(state, currentChannel.creator_id);
+        postsInChannel = state.entities.posts.postsInChannel[currentChannel.Id];
+    }
+
+    return {
+        creator,
+        currentChannel,
+        currentChannelMembers,
+        isLoadingPosts: (!postsInChannel || postsInChannel.length === 0) && getPostsRequestStatus === RequestStatus.STARTED,
+        theme: getTheme(state)
     };
 }
 
-export default connect(makeMapStateToProps)(ChannelIntro);
+export default connect(mapStateToProps)(ChannelIntro);

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -10,7 +10,6 @@ import {
     FlatList
 } from 'react-native';
 
-import ChannelIntro from 'app/components/channel_intro';
 import Post from 'app/components/post';
 import {DATE_LINE, START_OF_NEW_MESSAGES} from 'app/selectors/post_list';
 import mattermostManaged from 'app/mattermost_managed';
@@ -35,6 +34,7 @@ export default class PostList extends PureComponent {
         onPostPress: PropTypes.func,
         onRefresh: PropTypes.func,
         postIds: PropTypes.array.isRequired,
+        renderFooter: PropTypes.func,
         renderReplies: PropTypes.bool,
         showLoadMore: PropTypes.bool,
         shouldRenderReplyButton: PropTypes.bool,
@@ -205,12 +205,11 @@ export default class PostList extends PureComponent {
             );
         }
 
-        return (
-            <ChannelIntro
-                channelId={this.props.channelId}
-                navigator={this.props.navigator}
-            />
-        );
+        if (!this.props.renderFooter) {
+            return null;
+        }
+
+        return this.props.renderFooter();
     };
 
     render() {

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -10,6 +10,7 @@ import {
     View
 } from 'react-native';
 
+import ChannelIntro from 'app/components/channel_intro';
 import PostList from 'app/components/post_list';
 import PostListRetry from 'app/components/post_list_retry';
 import RetryBarIndicator from 'app/components/retry_bar_indicator';
@@ -118,6 +119,10 @@ class ChannelPostList extends PureComponent {
         actions.loadPostsIfNecessaryWithRetry(channelId);
     };
 
+    renderChannelIntro = () => {
+        return <ChannelIntro navigator={navigator}/>;
+    };
+
     render() {
         const {
             actions,
@@ -157,6 +162,7 @@ class ChannelPostList extends PureComponent {
                     lastViewedAt={lastViewedAt}
                     channelId={channelId}
                     navigator={navigator}
+                    renderFooter={this.renderChannelIntro}
                 />
             );
         }


### PR DESCRIPTION
The intro was only being re-rendered when something else in the PostList changed to trigger a re-render. Since we're only using the one ChannelIntro component in the one place, I just had it look for the current channel itself so that the ChannelPostList doesn't even need to re-render it.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-566

#### Device Information
This PR was tested on: iOS Simulator