### PR TITLE
RN-566 Re-rendered PostList footer when channel ID changes

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -14,6 +14,7 @@ import ChannelIntro from 'app/components/channel_intro';
 import Post from 'app/components/post';
 import {DATE_LINE, START_OF_NEW_MESSAGES} from 'app/selectors/post_list';
 import mattermostManaged from 'app/mattermost_managed';
+import {makeExtraData} from 'app/utils/list_view';
 
 import DateHeader from './date_header';
 import LoadMorePosts from './load_more_posts';
@@ -49,6 +50,9 @@ export default class PostList extends PureComponent {
         super(props);
 
         this.newMessagesIndex = -1;
+
+        this.makeExtraData = makeExtraData();
+
         this.state = {
             managedConfig: {}
         };
@@ -233,7 +237,7 @@ export default class PostList extends PureComponent {
             <FlatList
                 ref='list'
                 data={postIds}
-                extraData={highlightPostId}
+                extraData={this.makeExtraData(channelId, highlightPostId)}
                 initialNumToRender={15}
                 inverted={true}
                 keyExtractor={this.keyExtractor}

--- a/app/utils/list_view.js
+++ b/app/utils/list_view.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import shallowEqual from 'shallow-equals';
+
+// Returns a function that will construct a memoized array of its arguments for use as
+// the extraData prop for a ListView so that its rows can be re-rendered even if the items
+// themselves don't change.
+export function makeExtraData() {
+    let lastArgs = [];
+
+    // Returns an array containing the arguments provided to this function.
+    // If this function is called twice in a row with the same arguments,
+    // it will return the exact same array.
+    return (...args) => {
+        if (!shallowEqual(lastArgs, args)) {
+            lastArgs = args;
+        }
+
+        return lastArgs;
+    };
+}


### PR DESCRIPTION
The PostList footer (aka the ChannelInfo component) wasn't being re-rendered in certain circumstances when the channel changed, so adding the channel ID to the extraData prop will force it to re-render. The other refactoring is just left over from my other PR

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-566

#### Device Information
This PR was tested on: iPhone 7 Simulator (iOS 11.2)