### PR TITLE
Ensure the user has permission to access ringtones

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationPreferencesModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationPreferencesModule.java
@@ -69,7 +69,9 @@ public class NotificationPreferencesModule extends ReactContextBaseJavaModule {
             }
 
             Uri defaultUri = RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_NOTIFICATION);
-            result.putString("defaultUri", Uri.decode(defaultUri.toString()));
+            if (defaultUri != null) {
+                result.putString("defaultUri", Uri.decode(defaultUri.toString()));
+            }
             result.putString("selectedUri", mNotificationPreference.getNotificationSound());
             result.putBoolean("shouldVibrate", mNotificationPreference.getShouldVibrate());
             result.putBoolean("shouldBlink", mNotificationPreference.getShouldBlink());

--- a/app/notification_preferences/notification_preferences.android.js
+++ b/app/notification_preferences/notification_preferences.android.js
@@ -1,12 +1,36 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import {NativeModules} from 'react-native';
+import {NativeModules, PermissionsAndroid} from 'react-native';
 
 const {NotificationPreferences} = NativeModules;
 
+const defaultPreferences = {
+    sounds: [],
+    shouldBlink: false,
+    shouldVibrate: true
+};
+
 export default {
-    getPreferences: NotificationPreferences.getPreferences,
+    getPreferences: async () => {
+        try {
+            const hasPermission = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE);
+            let granted;
+            if (!hasPermission) {
+                granted = await PermissionsAndroid.request(
+                    PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE
+                );
+            }
+
+            if (hasPermission || granted === PermissionsAndroid.RESULTS.GRANTED) {
+                return await NotificationPreferences.getPreferences();
+            }
+
+            return defaultPreferences;
+        } catch (error) {
+            return defaultPreferences;
+        }
+    },
     setNotificationSound: NotificationPreferences.setNotificationSound,
     setShouldVibrate: NotificationPreferences.setShouldVibrate,
     setShouldBlink: NotificationPreferences.setShouldBlink,

--- a/app/screens/settings/notification_settings/notification_settings.js
+++ b/app/screens/settings/notification_settings/notification_settings.js
@@ -119,22 +119,24 @@ class NotificationSettings extends PureComponent {
         const {currentUser, intl, navigator, theme} = this.props;
 
         NotificationPreferences.getPreferences().then((notificationPreferences) => {
-            navigator.push({
-                backButtonTitle: '',
-                screen: 'NotificationSettingsMobile',
-                title: intl.formatMessage({id: 'mobile.notification_settings.mobile_title', defaultMessage: 'Mobile Notifications'}),
-                animated: true,
-                navigatorStyle: {
-                    navBarTextColor: theme.sidebarHeaderTextColor,
-                    navBarBackgroundColor: theme.sidebarHeaderBg,
-                    navBarButtonColor: theme.sidebarHeaderTextColor,
-                    screenBackgroundColor: theme.centerChannelBg
-                },
-                passProps: {
-                    currentUser,
-                    onBack: this.saveNotificationProps,
-                    notificationPreferences
-                }
+            requestAnimationFrame(() => {
+                navigator.push({
+                    backButtonTitle: '',
+                    screen: 'NotificationSettingsMobile',
+                    title: intl.formatMessage({id: 'mobile.notification_settings.mobile_title', defaultMessage: 'Mobile Notifications'}),
+                    animated: true,
+                    navigatorStyle: {
+                        navBarTextColor: theme.sidebarHeaderTextColor,
+                        navBarBackgroundColor: theme.sidebarHeaderBg,
+                        navBarButtonColor: theme.sidebarHeaderTextColor,
+                        screenBackgroundColor: theme.centerChannelBg
+                    },
+                    passProps: {
+                        currentUser,
+                        onBack: this.saveNotificationProps,
+                        notificationPreferences
+                    }
+                });
             });
         }).catch((e) => {
             Alert.alert('There was a problem getting the device preferences', e.message);


### PR DESCRIPTION
#### Summary
In some cases Android devices need permission for `READ_EXTERNAL_STORAGE` to access the RingtoneManager, with this PR we make sure that the user has set the permission before requesting the preferences with the `NotificationPreferencesModule`, if the user hasn't granted the permission yet we do ask for it before trying to get the Preferences, if the use denies it we still show the mobile notification screen but without loading the device specific prefs thus avoiding any potential crash.

Also if the device does not have a `RingtoneManager.getActualDefaultRingtoneUri` set, we just set the default sound as none.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-588

#### Device Information
This PR was tested on:
* Android 7.1.1 Nexus 5 emulator
* Android 6.0.1 Samsung J5
* iPhone simulator (just to make sure it doesn't break)