### PR TITLE
Fix uploading videos from Android

### DIFF
--- a/app/actions/views/file_upload.js
+++ b/app/actions/views/file_upload.js
@@ -19,7 +19,7 @@ export function handleUploadFiles(files, rootId) {
         const re = /heic/i;
 
         files.forEach((file) => {
-            let name = file.fileName;
+            let name = file.fileName || file.path;
             let mimeType = lookupMimeType(name);
             let extension = name.split('.').pop().replace('.', '');
             const uri = file.uri;

--- a/app/actions/views/file_upload.js
+++ b/app/actions/views/file_upload.js
@@ -19,7 +19,12 @@ export function handleUploadFiles(files, rootId) {
         const re = /heic/i;
 
         files.forEach((file) => {
-            let name = file.fileName || file.path;
+            let name = file.fileName || file.path || file.uri;
+
+            if (name.includes('/')) {
+                name = name.split('/').pop();
+            }
+
             let mimeType = lookupMimeType(name);
             let extension = name.split('.').pop().replace('.', '');
             const uri = file.uri;

--- a/app/components/file_upload_preview/file_upload_preview.js
+++ b/app/components/file_upload_preview/file_upload_preview.js
@@ -47,7 +47,7 @@ export default class FileUploadPreview extends PureComponent {
     buildFilePreviews = () => {
         return this.props.files.map((file) => {
             let filePreviewComponent;
-            if (file.loading | file.has_preview_image) {
+            if (file.loading | (file.has_preview_image || file.mime_type === 'image/gif')) {
                 filePreviewComponent = (
                     <FileAttachmentImage
                         addFileToFetchCache={this.props.actions.addFileToFetchCache}


### PR DESCRIPTION
#### Summary
When uploading a video from Android the returned object has a `path` property instead of `fileName`, this PR makes sure that if fileName is not defined it will fallback to use path instead

Also fixes the upload of gif files in iOS, this type of file returns just the uri of the file, so we make sure any of the three options is available when getting the name of the file, etc..

Also added support to show the preview of gif files in the image upload preview.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-572
https://mattermost.atlassian.net/browse/RN-574