### PR TITLE
Fix UI when rendering link previews in a reply

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -370,6 +370,7 @@ class Post extends PureComponent {
         const style = getStyleSheet(theme);
         const selected = this.state && this.state.selected ? style.selected : null;
         const highlighted = highlight ? style.highlight : null;
+        const isReplyPost = this.isReplyPost();
 
         const onUsernamePress = Config.ExperimentalUsernamePressIsMention ? this.autofillUserMention : this.viewUserProfile;
 
@@ -414,7 +415,7 @@ class Post extends PureComponent {
                             toggleSelected={this.toggleSelected}
                             managedConfig={managedConfig}
                             isFlagged={isFlagged}
-                            isReplyPost={this.isReplyPost()}
+                            isReplyPost={isReplyPost}
                         />
                     </View>
                 </View>

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -287,17 +287,20 @@ class Post extends PureComponent {
         removePost(post);
     };
 
+    isReplyPost = () => {
+        const {renderReplies, post} = this.props;
+        return Boolean(renderReplies && post.root_id && !isPostEphemeral(post));
+    };
+
     renderReplyBar = () => {
         const {
             commentedOnPost,
             isFirstReply,
             isLastReply,
-            post,
-            renderReplies,
             theme
         } = this.props;
 
-        if (!renderReplies || !post.root_id || isPostEphemeral(post)) {
+        if (!this.isReplyPost()) {
             return null;
         }
 
@@ -411,6 +414,7 @@ class Post extends PureComponent {
                             toggleSelected={this.toggleSelected}
                             managedConfig={managedConfig}
                             isFlagged={isFlagged}
+                            isReplyPost={this.isReplyPost()}
                         />
                     </View>
                 </View>

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -26,6 +26,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
         actions: PropTypes.shape({
             getOpenGraphMetadata: PropTypes.func.isRequired
         }).isRequired,
+        isReplyPost: PropTypes.bool,
         link: PropTypes.string.isRequired,
         openGraphData: PropTypes.object,
         theme: PropTypes.object.isRequired
@@ -67,7 +68,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
     calculateLargeImageDimensions = (width, height) => {
         const {width: deviceWidth} = Dimensions.get('window');
         let maxHeight = MAX_IMAGE_HEIGHT;
-        let maxWidth = deviceWidth - 88;
+        let maxWidth = deviceWidth - 88 - (this.props.isReplyPost ? 15 : 0);
 
         if (height <= MAX_IMAGE_HEIGHT) {
             maxHeight = height;
@@ -160,7 +161,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
     };
 
     render() {
-        const {openGraphData, theme} = this.props;
+        const {isReplyPost, openGraphData, theme} = this.props;
         const {hasLargeImage, height, imageLoaded, imageUrl, offset, width} = this.state;
 
         if (!openGraphData || !openGraphData.description) {
@@ -187,7 +188,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
                         onPress={this.goToLink}
                     >
                         <Text
-                            style={style.siteSubtitle}
+                            style={[style.siteSubtitle, {marginRight: isReplyPost ? 10 : 0}]}
                             numberOfLines={3}
                             ellipsizeMode='tail'
                         >

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -41,6 +41,7 @@ class PostBody extends PureComponent {
         isFlagged: PropTypes.bool,
         isPending: PropTypes.bool,
         isPostEphemeral: PropTypes.bool,
+        isReplyPost: PropTypes.bool,
         isSearchResult: PropTypes.bool,
         isSystemMessage: PropTypes.bool,
         managedConfig: PropTypes.object,
@@ -142,6 +143,7 @@ class PostBody extends PureComponent {
             isFlagged,
             isPending,
             isPostEphemeral,
+            isReplyPost,
             isSearchResult,
             isSystemMessage,
             intl,
@@ -266,6 +268,7 @@ class PostBody extends PureComponent {
                                 postId={postId}
                                 postProps={postProps}
                                 textStyles={textStyles}
+                                isReplyPost={isReplyPost}
                             />
                             {this.renderFileAttachments()}
                         </View>
@@ -290,6 +293,7 @@ class PostBody extends PureComponent {
                             postProps={postProps}
                             textStyles={textStyles}
                             onLongPress={this.showOptionsContext}
+                            isReplyPost={isReplyPost}
                         />
                         {this.renderFileAttachments()}
                         {hasReactions && <Reactions postId={postId}/>}

--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -32,6 +32,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
         config: PropTypes.object,
         deviceHeight: PropTypes.number.isRequired,
         deviceWidth: PropTypes.number.isRequired,
+        isReplyPost: PropTypes.bool,
         link: PropTypes.string,
         message: PropTypes.string.isRequired,
         navigator: PropTypes.object.isRequired,
@@ -106,7 +107,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
             return null;
         }
 
-        const {link, openGraphData, showLinkPreviews, theme} = this.props;
+        const {isReplyPost, link, openGraphData, showLinkPreviews, theme} = this.props;
         const attachments = this.getSlackAttachment();
         if (attachments) {
             return attachments;
@@ -115,6 +116,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
         if (link && showLinkPreviews) {
             return (
                 <PostAttachmentOpenGraph
+                    isReplyPost={isReplyPost}
                     link={link}
                     openGraphData={openGraphData}
                     theme={theme}


### PR DESCRIPTION
#### Summary
When a post with opengraph (link previews) is render inside a thread now renders appropiately

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-569

#### Checklist
- [x] Has UI changes

#### Screenshots
Before
![before](https://user-images.githubusercontent.com/6757047/34273473-3ade72ea-e673-11e7-849b-5945e83adbc0.png)

Now
![after](https://user-images.githubusercontent.com/6757047/34273459-261ad95c-e673-11e7-8bba-29739990de35.png)

