### PR TITLE
Fix Application Not Responding (ANR) executing service android

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -165,6 +165,7 @@ export default class Mattermost {
             popInitialNotification: true,
             requestPermissions: true
         });
+        this.isConfigured = true;
     };
 
     handleAppStateChange = async (appState) => {
@@ -424,7 +425,6 @@ export default class Mattermost {
             } else if (isNotActive) {
                 // for IOS replying from push notification starts the app in the background
                 this.shouldRelaunchonActive = true;
-                this.configurePushNotifications();
                 this.startFakeApp();
             } else {
                 this.launchApp();
@@ -433,6 +433,7 @@ export default class Mattermost {
     };
 
     onRegisterDevice = (data) => {
+        this.isConfigured = true;
         const {dispatch, getState} = this.store;
         let prefix;
         if (Platform.OS === 'ios') {
@@ -445,7 +446,6 @@ export default class Mattermost {
         }
 
         setDeviceToken(`${prefix}:${data.token}`)(dispatch, getState);
-        this.isConfigured = true;
     };
 
     onPushNotification = (deviceNotification) => {

--- a/app/push_notifications/push_notifications.android.js
+++ b/app/push_notifications/push_notifications.android.js
@@ -11,6 +11,11 @@ class PushNotification {
         this.onNotification = null;
         this.onReply = null;
         this.deviceNotification = null;
+        this.deviceToken = null;
+
+        NotificationsAndroid.setRegistrationTokenUpdateListener((deviceToken) => {
+            this.deviceToken = deviceToken;
+        });
 
         NotificationsAndroid.setNotificationReceivedListener((notification) => {
             if (notification) {
@@ -61,12 +66,9 @@ class PushNotification {
         this.onNotification = options.onNotification;
         this.onReply = options.onReply;
 
-        NotificationsAndroid.refreshToken();
-        NotificationsAndroid.setRegistrationTokenUpdateListener((deviceToken) => {
-            if (this.onRegister) {
-                this.onRegister({token: deviceToken});
-            }
-        });
+        if (this.onRegister && this.deviceToken) {
+            this.onRegister({token: this.deviceToken});
+        }
 
         if (options.popInitialNotification) {
             PendingNotifications.getInitialNotification().


### PR DESCRIPTION
#### Summary
On Android sometimes when requesting the refreshToken it was causing the app to not respond.

This is being fixed by:
Instead of requesting a refresh token in the configure method, we now request the token when to class is initiated removing the need to ask for the token a second time.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-585