### PR TITLE
Make sure that channelIdToNotification is not null

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -210,9 +210,15 @@ public class CustomPushNotification extends PushNotification {
             String summaryTitle = String.format("%s (%d)", title, numMessages);
 
             Notification.InboxStyle style = new Notification.InboxStyle();
-            List<Bundle> list = new ArrayList<Bundle>(channelIdToNotification.get(channelId));
+            List<Bundle> bundleArray = channelIdToNotification.get(channelId);
+            List<Bundle> list;
+            if (bundleArray != null) {
+                list = new ArrayList<Bundle>(bundleArray);
+            } else {
+                list = new ArrayList<Bundle>();
+            }
 
-            for (Bundle data : list){
+            for (Bundle data : list) {
                 String msg = data.getString("message");
                 if (msg != message) {
                     style.addLine(data.getString("message"));


### PR DESCRIPTION
#### Summary
Sometimes channelIdToNotification is null for certain channels that haven't received previous push notifications, with this PR we ensure that the app doesn't crashes when that happens.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-587