### PR TITLE
Left align title text in channel view navbar

### DIFF
--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -145,8 +145,7 @@ class ChannelDrawerButton extends PureComponent {
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         container: {
-            width: 40,
-            zIndex: 45
+            width: 55
         },
         wrapper: {
             alignItems: 'center',
@@ -154,8 +153,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             flexDirection: 'column',
             justifyContent: 'center',
             paddingHorizontal: 10,
-            paddingTop: 5,
-            zIndex: 30
+            paddingTop: 5
         },
         badge: {
             backgroundColor: theme.mentionBj,

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -152,8 +152,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             flexDirection: 'column',
             justifyContent: 'center',
-            paddingHorizontal: 10,
-            paddingTop: 5
+            paddingHorizontal: 10
         },
         badge: {
             backgroundColor: theme.mentionBj,

--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.js
@@ -50,11 +50,7 @@ export default class ChannelNavBar extends PureComponent {
         return (
             <View style={[style.header, padding, {height}]}>
                 <ChannelDrawerButton openDrawer={openChannelDrawer}/>
-                <ChannelTitle
-                    onPress={onPress}
-                    height={height}
-                />
-                <View style={{flex: 1}}/>
+                <ChannelTitle onPress={onPress}/>
                 <ChannelSearchButton
                     navigator={navigator}
                     theme={theme}

--- a/app/screens/channel/channel_nav_bar/channel_search_button/channel_search_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_search_button/channel_search_button.js
@@ -74,8 +74,7 @@ export default class ChannelSearchButton extends PureComponent {
 const getStyle = makeStyleSheetFromTheme((theme) => {
     return {
         container: {
-            width: 40,
-            zIndex: 45
+            width: 40
         },
         flex: {
             flex: 1

--- a/app/screens/channel/channel_nav_bar/channel_search_button/channel_search_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_search_button/channel_search_button.js
@@ -80,6 +80,8 @@ const getStyle = makeStyleSheetFromTheme((theme) => {
             flex: 1
         },
         wrapper: {
+            position: 'relative',
+            top: -1,
             alignItems: 'flex-end',
             flex: 1,
             flexDirection: 'column',

--- a/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
+++ b/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
@@ -70,6 +70,8 @@ const getStyle = makeStyleSheetFromTheme((theme) => {
         wrapper: {
             alignItems: 'center',
             flex: 1,
+            position: 'relative',
+            top: -1,
             flexDirection: 'row',
             justifyContent: 'flex-start'
         },

--- a/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
+++ b/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
@@ -16,9 +16,7 @@ import {makeStyleSheetFromTheme} from 'app/utils/theme';
 export default class ChannelTitle extends PureComponent {
     static propTypes = {
         currentChannelName: PropTypes.string,
-        deviceWidth: PropTypes.number,
         displayName: PropTypes.string,
-        height: PropTypes.number,
         onPress: PropTypes.func,
         theme: PropTypes.object
     };
@@ -30,7 +28,7 @@ export default class ChannelTitle extends PureComponent {
     };
 
     render() {
-        const {currentChannelName, deviceWidth, displayName, height, onPress, theme} = this.props;
+        const {currentChannelName, displayName, onPress, theme} = this.props;
         const channelName = displayName || currentChannelName;
         const style = getStyle(theme);
         let icon;
@@ -46,20 +44,18 @@ export default class ChannelTitle extends PureComponent {
 
         return (
             <TouchableOpacity
-                style={[style.container, {height, width: deviceWidth}]}
+                style={style.container}
                 onPress={onPress}
             >
-                <View style={[style.wrapper, {width: deviceWidth}]}>
-                    <View style={style.innerContainer}>
-                        <Text
-                            ellipsizeMode='tail'
-                            numberOfLines={1}
-                            style={style.text}
-                        >
-                            {channelName}
-                        </Text>
-                        {icon}
-                    </View>
+                <View style={style.wrapper}>
+                    <Text
+                        ellipsizeMode='tail'
+                        numberOfLines={1}
+                        style={style.text}
+                    >
+                        {channelName}
+                    </Text>
+                    {icon}
                 </View>
             </TouchableOpacity>
         );
@@ -69,18 +65,13 @@ export default class ChannelTitle extends PureComponent {
 const getStyle = makeStyleSheetFromTheme((theme) => {
     return {
         container: {
-            position: 'absolute',
-            zIndex: 40
+            flex: 1
         },
         wrapper: {
             alignItems: 'center',
             flex: 1,
-            justifyContent: 'center'
-        },
-        innerContainer: {
-            alignItems: 'center',
             flexDirection: 'row',
-            marginHorizontal: 55
+            justifyContent: 'flex-start'
         },
         icon: {
             color: theme.sidebarHeaderTextColor,
@@ -88,7 +79,7 @@ const getStyle = makeStyleSheetFromTheme((theme) => {
         },
         text: {
             color: theme.sidebarHeaderTextColor,
-            fontSize: 17,
+            fontSize: 18,
             fontWeight: 'bold',
             textAlign: 'center'
         }

--- a/app/screens/channel/channel_nav_bar/channel_title/index.js
+++ b/app/screens/channel/channel_nav_bar/channel_title/index.js
@@ -6,15 +6,12 @@ import {connect} from 'react-redux';
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {getDimensions} from 'app/selectors/device';
-
 import ChannelTitle from './channel_title';
 
 function mapStateToProps(state) {
     const currentChannel = getCurrentChannel(state);
 
     return {
-        ...getDimensions(state),
         currentChannelName: currentChannel ? currentChannel.display_name : '',
         displayName: state.views.channel.displayName,
         theme: getTheme(state)

--- a/app/screens/channel/channel_nav_bar/settings_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/settings_drawer_button.js
@@ -57,16 +57,14 @@ class SettingDrawerButton extends PureComponent {
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         container: {
-            width: 44,
-            zIndex: 45
+            width: 44
         },
         wrapper: {
             alignItems: 'center',
             flex: 1,
             flexDirection: 'column',
             justifyContent: 'center',
-            marginLeft: 8,
-            zIndex: 30
+            marginLeft: 8
         },
         mention: {
             color: theme.mentionColor,


### PR DESCRIPTION
#### Summary
With the inclusion of the right drawer, we are now moving the title in the channel view navbar to be aligned to the left in order to have more space for the title if needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-591

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: 
* iOS 11.2 iPhone X, iPhone 6 (simulator) and iPhone 6s (device)
* Android 7.1.1 Emulator
* Android 6.0.1 Samsung J5

#### Screenshots
Android
![screenshot_1514896807](https://user-images.githubusercontent.com/6757047/34484336-e1ac2922-efa2-11e7-9dc7-00c0378d6ff9.png)

iOS
![simulator screen shot - iphone 6 - 2018-01-02 at 09 14 48](https://user-images.githubusercontent.com/6757047/34484345-e82ad884-efa2-11e7-8958-60479b47e9c8.png)

