### PR TITLE
Don't try to open empty Markdown links

### DIFF
--- a/app/components/markdown/markdown_link.js
+++ b/app/components/markdown/markdown_link.js
@@ -32,6 +32,10 @@ export default class MarkdownLink extends PureComponent {
     handlePress = () => {
         const url = normalizeProtocol(this.props.href);
 
+        if (!url) {
+            return;
+        }
+
         Linking.canOpenURL(url).then((supported) => {
             if (supported) {
                 Linking.openURL(url);


### PR DESCRIPTION
This fixes a crash that occurs on Android if you post `[click me]()` and then click on it.

#### Ticket Link
https://sentry.io/mattermost-mr/mattermost-mobile-android/issues/421001308/