### PR TITLE
Wrap interactive buttons when needed

### DIFF
--- a/app/components/slack_attachments/slack_attachment.js
+++ b/app/components/slack_attachments/slack_attachment.js
@@ -447,7 +447,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         actionsContainer: {
             flex: 1,
-            flexDirection: 'row'
+            flexDirection: 'row',
+            flexWrap: 'wrap'
         }
     };
 });


### PR DESCRIPTION
#### Summary
This PR wraps the interactive buttons within the view instead of just placing one after the other.

Resolves #1326

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-600

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
Android 7.1.1 Nexus 5 emulator
iOS 11.2 iPhone X simulator

#### Screenshots
Android
![screenshot_1515157916](https://user-images.githubusercontent.com/6757047/34610748-33ed8b4e-f201-11e7-9aec-f610e2ecc936.png)

iOS
![simulator screen shot - iphone x - 2018-01-05 at 10 03 47](https://user-images.githubusercontent.com/6757047/34610751-3ac6022a-f201-11e7-8767-7d5f054519a1.png)

