### PR TITLE
RN-523 Added a try-catch when cleaning up state following a rehydrate

### DIFF
--- a/app/utils/sentry/index.js
+++ b/app/utils/sentry/index.js
@@ -12,6 +12,7 @@ import {getCurrentTeam, getCurrentTeamMembership} from 'mattermost-redux/selecto
 import {getCurrentChannel, getMyCurrentChannelMembership} from 'mattermost-redux/selectors/entities/channels';
 
 export const LOGGER_JAVASCRIPT = 'javascript';
+export const LOGGER_JAVASCRIPT_WARNING = 'javascript_warning';
 export const LOGGER_NATIVE = 'native';
 export const LOGGER_REDUX = 'redux';
 


### PR DESCRIPTION
As we discussed last week, parts of the state in action.payload are empty for whatever reason, so we're wrapping the whole `cleanupState` action in a try-catch to keep the app from crashing, but we're still logging to Sentry to still be able to investigate the error itself

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-523
https://sentry.io/mattermost-mr/mattermost-mobile-android/issues/417670104/

#### Device Information
This PR was tested on: iOS Simulator (iPhone 6, iOS 11.2)