### PR TITLE
Fix login after session expires or is revoked

### DIFF
--- a/app/actions/views/select_server.js
+++ b/app/actions/views/select_server.js
@@ -1,14 +1,18 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {batchActions} from 'redux-batched-actions';
+import {GeneralTypes} from 'mattermost-redux/action_types';
+
 import {ViewTypes} from 'app/constants';
 
 export function handleServerUrlChanged(serverUrl) {
     return async (dispatch, getState) => {
-        dispatch({
-            type: ViewTypes.SERVER_URL_CHANGED,
-            serverUrl
-        }, getState);
+        dispatch(batchActions([
+            {type: GeneralTypes.CLIENT_CONFIG_RESET},
+            {type: GeneralTypes.CLIENT_LICENSE_RESET},
+            {type: ViewTypes.SERVER_URL_CHANGED, serverUrl}
+        ]), getState);
     };
 }
 

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -233,6 +233,7 @@ export default class Mattermost {
         const {dispatch, getState} = this.store;
         const version = serverVersion.match(/^[0-9]*.[0-9]*.[0-9]*(-[a-zA-Z0-9.-]*)?/g)[0];
         const intl = this.getIntl();
+        const state = getState();
 
         if (serverVersion) {
             if (semver.valid(version) && semver.lt(version, Config.MinServerVersion)) {
@@ -245,7 +246,7 @@ export default class Mattermost {
                     }],
                     {cancelable: false}
                 );
-            } else {
+            } else if (state.entities.users && state.entities.users.currentUserId) {
                 setServerVersion(serverVersion)(dispatch, getState);
                 const data = await loadConfigAndLicense()(dispatch, getState);
                 this.configureAnalytics(data.config);

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -343,6 +343,7 @@ class Login extends PureComponent {
                         style={style.container}
                         contentContainerStyle={style.innerContainer}
                         keyboardShouldPersistTaps='handled'
+                        enableOnAndroid={true}
                     >
                         <Image
                             source={logo}

--- a/app/screens/select_server/index.js
+++ b/app/screens/select_server/index.js
@@ -5,9 +5,9 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getPing, resetPing} from 'mattermost-redux/actions/general';
-import {RequestStatus} from 'mattermost-redux/constants';
 
 import {setLastUpgradeCheck} from 'app/actions/views/client_upgrade';
+import {loadConfigAndLicense} from 'app/actions/views/root';
 import {handleServerUrlChanged} from 'app/actions/views/select_server';
 import getClientUpgrade from 'app/selectors/client_upgrade';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -15,7 +15,6 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import SelectServer from './select_server';
 
 function mapStateToProps(state) {
-    const {config: configRequest, license: licenseRequest} = state.requests.general;
     const {config, license} = state.entities.general;
     const {currentVersion, latestVersion, minVersion} = getClientUpgrade(state);
 
@@ -23,7 +22,7 @@ function mapStateToProps(state) {
         ...state.views.selectServer,
         config,
         currentVersion,
-        hasConfigAndLicense: configRequest.status === RequestStatus.SUCCESS && licenseRequest.status === RequestStatus.SUCCESS,
+        hasConfigAndLicense: Object.keys(config).length > 0 && Object.keys(license).length > 0,
         latestVersion,
         license,
         minVersion,
@@ -36,6 +35,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getPing,
             handleServerUrlChanged,
+            loadConfigAndLicense,
             resetPing,
             setLastUpgradeCheck
         }, dispatch)

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -38,6 +38,7 @@ class SelectServer extends PureComponent {
         actions: PropTypes.shape({
             getPing: PropTypes.func.isRequired,
             handleServerUrlChanged: PropTypes.func.isRequired,
+            loadConfigAndLicense: PropTypes.func.isRequired,
             resetPing: PropTypes.func.isRequired,
             setLastUpgradeCheck: PropTypes.func.isRequired
         }).isRequired,
@@ -205,6 +206,14 @@ class SelectServer extends PureComponent {
     });
 
     pingServer = (url) => {
+        const {actions, config} = this.props;
+
+        const {
+            getPing,
+            handleServerUrlChanged,
+            loadConfigAndLicense
+        } = actions;
+
         this.setState({
             connected: false,
             connecting: true,
@@ -213,7 +222,7 @@ class SelectServer extends PureComponent {
 
         Client4.setUrl(url);
         Client.setUrl(url);
-        this.props.actions.handleServerUrlChanged(url);
+        handleServerUrlChanged(url);
 
         let cancel = false;
         this.cancelPing = () => {
@@ -227,9 +236,13 @@ class SelectServer extends PureComponent {
             this.cancelPing = null;
         };
 
-        this.props.actions.getPing().then((result) => {
+        getPing().then((result) => {
             if (cancel) {
                 return;
+            }
+
+            if (!result.error && !Object.keys(config).length) {
+                loadConfigAndLicense();
             }
 
             this.setState({

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -61,7 +61,8 @@ class SelectServer extends PureComponent {
         this.state = {
             connected: false,
             connecting: false,
-            error: null
+            error: null,
+            url: props.serverUrl
         };
 
         this.cancelPing = null;
@@ -177,6 +178,10 @@ class SelectServer extends PureComponent {
         this.blur();
     };
 
+    handleTextChanged = (url) => {
+        this.setState({url});
+    };
+
     onClick = wrapWithPreventDoubleTap(async () => {
         const preUrl = urlParse(this.props.serverUrl, true);
         const url = stripTrailingSlashes(preUrl.protocol + '//' + preUrl.host);
@@ -206,13 +211,11 @@ class SelectServer extends PureComponent {
     });
 
     pingServer = (url) => {
-        const {actions, config} = this.props;
-
         const {
             getPing,
             handleServerUrlChanged,
             loadConfigAndLicense
-        } = actions;
+        } = this.props.actions;
 
         this.setState({
             connected: false,
@@ -241,7 +244,7 @@ class SelectServer extends PureComponent {
                 return;
             }
 
-            if (!result.error && !Object.keys(config).length) {
+            if (!result.error) {
                 loadConfigAndLicense();
             }
 
@@ -272,14 +275,12 @@ class SelectServer extends PureComponent {
     };
 
     render() {
-        const {
-            allowOtherServers,
-            serverUrl
-        } = this.props;
+        const {allowOtherServers} = this.props;
         const {
             connected,
             connecting,
-            error
+            error,
+            url
         } = this.state;
 
         let buttonIcon;
@@ -340,9 +341,9 @@ class SelectServer extends PureComponent {
                         </View>
                         <TextInputWithLocalizedPlaceholder
                             ref={this.inputRef}
-                            value={serverUrl}
+                            value={url}
                             editable={!inputDisabled}
-                            onChangeText={this.props.actions.handleServerUrlChanged}
+                            onChangeText={this.handleTextChanged}
                             onSubmitEditing={this.onClick}
                             style={inputStyle}
                             autoCapitalize='none'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,8 +3962,8 @@ makeerror@1.0.x:
     tmpl "1.0.x"
 
 mattermost-redux@mattermost/mattermost-redux:
-  version "1.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/fb083f67b5560ff64fe251415460a1af5d690e5a"
+  version "1.1.0"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/cd3dfbb7f6a1d08676d39730d3801dce482cf4c7"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3963,7 +3963,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux:
   version "1.1.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/cd3dfbb7f6a1d08676d39730d3801dce482cf4c7"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/94861ab29626f54fa8c40a2a6a5fa3f3850c7299"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary
Sometimes when the session expires or is revoked the user was unable to get past the server url screen because we were waiting for the config and license request to be executed, but becase once the user was logged out some other request were setting the server url we didn't made the request for the config and license, this PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-594