### PR TITLE
iOS request permissions if needed to save files to the photo library

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2590,3 +2590,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ---
+
+## react-native-permissions
+
+Request user permissions from React Native, iOS + Android.
+
+* HOMEPAGE:
+  * https://github.com/yonahforst/react-native-permissions
+
+* LICENSE:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Yonah Forst
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -4,11 +4,13 @@
 import DeviceTypes from './device';
 import ListTypes from './list';
 import NavigationTypes from './navigation';
+import PermissionTypes from './permissions';
 import ViewTypes from './view';
 
 export {
     DeviceTypes,
     ListTypes,
     NavigationTypes,
+    PermissionTypes,
     ViewTypes
 };

--- a/app/constants/permissions.js
+++ b/app/constants/permissions.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+export default {
+    AUTHORIZED: 'authorized',
+    DENIED: 'denied',
+    UNDETERMINED: 'undetermined'
+};

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -2024,6 +2024,7 @@
   "mobile.intro_messages.DM": "This is the start of your direct message history with {teammate}. Direct messages and files shared here are not shown to people outside this area.",
   "mobile.intro_messages.default_message": "This is the first channel teammates see when they sign up - use it for posting updates everyone needs to know.",
   "mobile.intro_messages.default_welcome": "Welcome to {name}!",
+  "mobile.ios.photos_permission_denied_description": "To save images and videos to your library, please change your permission settings.",
   "mobile.join_channel.error": "We couldn't join the channel {displayName}. Please check your connection and try again.",
   "mobile.loading_channels": "Loading Channels...",
   "mobile.loading_members": "Loading Members...",

--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		7F43D6401F6BFA82001FC614 /* libRCTPushNotification.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F63D2811E6C957C001FAE12 /* libRCTPushNotification.a */; };
 		7F6877B31E7836070094B63F /* libToolTipMenu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F6877B01E7835E50094B63F /* libToolTipMenu.a */; };
 		7F6C47A51FE87E8C00F5A912 /* PerformRequests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F6C47A41FE87E8C00F5A912 /* PerformRequests.m */; };
+		7F7D7F98201645E100D31155 /* libReactNativePermissions.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F7D7F87201645D300D31155 /* libReactNativePermissions.a */; };
 		7FB6006B1FE3116800DB284F /* libRNFetchBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 375218411F4B9E320035444B /* libRNFetchBlob.a */; };
 		7FBB5E9B1E1F5A4B000DE18A /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FDF290C1E1F4B4E00DBBE56 /* libRNVectorIcons.a */; };
 		7FC200E81EBB65370099331B /* libReactNativeNavigation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FC200DF1EBB65100099331B /* libReactNativeNavigation.a */; };
@@ -460,6 +461,13 @@
 			remoteGlobalIDString = 4681C02C1B05271A004D67D4;
 			remoteInfo = ToolTipMenuTests;
 		};
+		7F7D7F86201645D300D31155 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7F7D7F52201645D300D31155 /* ReactNativePermissions.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9D23B34F1C767B80008B4819;
+			remoteInfo = ReactNativePermissions;
+		};
 		7F8AAB3B1F4E0FEB00F5A52C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 50ECB1D221E44F51B5690DF2 /* FastImage.xcodeproj */;
@@ -668,6 +676,7 @@
 		7F6877AA1E7835E50094B63F /* ToolTipMenu.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ToolTipMenu.xcodeproj; path = "../node_modules/react-native-tooltip/ToolTipMenu.xcodeproj"; sourceTree = "<group>"; };
 		7F6C47A31FE87E8C00F5A912 /* PerformRequests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PerformRequests.h; sourceTree = "<group>"; };
 		7F6C47A41FE87E8C00F5A912 /* PerformRequests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PerformRequests.m; sourceTree = "<group>"; };
+		7F7D7F52201645D300D31155 /* ReactNativePermissions.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReactNativePermissions.xcodeproj; path = "../node_modules/react-native-permissions/ios/ReactNativePermissions.xcodeproj"; sourceTree = "<group>"; };
 		7FC200BC1EBB65100099331B /* ReactNativeNavigation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReactNativeNavigation.xcodeproj; path = "../node_modules/react-native-navigation/ios/ReactNativeNavigation.xcodeproj"; sourceTree = "<group>"; };
 		7FDB92751F706F45006CDFD1 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
 		7FEB10961F6101710039A015 /* BlurAppScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlurAppScreen.h; path = Mattermost/BlurAppScreen.h; sourceTree = "<group>"; };
@@ -756,6 +765,7 @@
 				7F2691A11EE1DC6A007574FE /* libRNNotifications.a in Frameworks */,
 				7F43D5D61F6BF8C2001FC614 /* libRNLocalAuth.a in Frameworks */,
 				7F43D5D71F6BF8D0001FC614 /* libRNPasscodeStatus.a in Frameworks */,
+				7F7D7F98201645E100D31155 /* libReactNativePermissions.a in Frameworks */,
 				7F43D5D81F6BF8E9001FC614 /* libJailMonkey.a in Frameworks */,
 				7F43D5D91F6BF8F4001FC614 /* libFastImage.a in Frameworks */,
 				7F43D5DA1F6BF92C001FC614 /* libRNFetchBlob.a in Frameworks */,
@@ -1118,6 +1128,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		7F7D7F53201645D300D31155 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7F7D7F87201645D300D31155 /* libReactNativePermissions.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		7F8AAB371F4E0FEB00F5A52C /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1241,6 +1259,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				7F7D7F52201645D300D31155 /* ReactNativePermissions.xcodeproj */,
 				7FDB92751F706F45006CDFD1 /* RNImagePicker.xcodeproj */,
 				37ABD3971F4CE13B001FDE6B /* ART.xcodeproj */,
 				3752184A1F4B9E980035444B /* RCTCameraRoll.xcodeproj */,
@@ -1415,7 +1434,7 @@
 					7FFE32991FD9CB640038C7A0 = {
 						CreatedOnToolsVersion = 9.1;
 						DevelopmentTeam = UQ8HT4Q2XM;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 920;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
@@ -1524,6 +1543,10 @@
 				{
 					ProductGroup = 7FC200BD1EBB65100099331B /* Products */;
 					ProjectRef = 7FC200BC1EBB65100099331B /* ReactNativeNavigation.xcodeproj */;
+				},
+				{
+					ProductGroup = 7F7D7F53201645D300D31155 /* Products */;
+					ProjectRef = 7F7D7F52201645D300D31155 /* ReactNativePermissions.xcodeproj */;
 				},
 				{
 					ProductGroup = 372E25631F5F0E1800A2BFAB /* Products */;
@@ -1929,6 +1952,13 @@
 			fileType = wrapper.cfbundle;
 			path = ToolTipMenuTests.xctest;
 			remoteRef = 7F6877B11E7835E50094B63F /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		7F7D7F87201645D300D31155 /* libReactNativePermissions.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libReactNativePermissions.a;
+			remoteRef = 7F7D7F86201645D300D31155 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		7F8AAB3C1F4E0FEB00F5A52C /* libFastImage.a */ = {

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -59,7 +59,7 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Upload Photos and Videos to your Mattermost instance or Save them to your device</string>
+	<string>Upload Photos and Videos to your Mattermost instance or save them to your device</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Entypo.ttf</string>

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -59,7 +59,7 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Upload Photos and Videos to your Mattermost instance</string>
+	<string>Upload Photos and Videos to your Mattermost instance or Save them to your device</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Entypo.ttf</string>

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-native-notifications": "enahum/react-native-notifications.git",
     "react-native-orientation": "enahum/react-native-orientation.git",
     "react-native-passcode-status": "1.1.0",
+    "react-native-permissions": "1.0.6",
     "react-native-safe-area": "0.2.1",
     "react-native-section-list-get-item-layout": "2.1.0",
     "react-native-sentry": "0.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5186,6 +5186,10 @@ react-native-passcode-status@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-native-passcode-status/-/react-native-passcode-status-1.1.0.tgz#e5922d5f4d79bc09849438d620406e5ccd31168a"
 
+react-native-permissions@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-1.0.6.tgz#504f01728191431ad4b82895c4a349981fb5802b"
+
 react-native-safe-area@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/react-native-safe-area/-/react-native-safe-area-0.2.1.tgz#9bf8eb8dd052b76fc4e830addcd63235dd29cf3c"


### PR DESCRIPTION
#### Summary
When downloading an image or saving a video in a iOS device which hasn't granted the permission to write to the Photo library, the app was crashing with a SIGNAL 6, this PR checks and requests the needed permissions to avoid the crash.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-479

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 
* iOS 11.2 iPhone 5s, iPhone 6 and iPhone X (Simulators)
* iOS 11.2 iPhone 6s
