### PR TITLE
Post header priority

### DIFF
--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -61,15 +61,7 @@ export default class PostHeader extends PureComponent {
             overrideUsername
         } = this.props;
 
-        if (isSystemMessage) {
-            return (
-                <FormattedText
-                    id='post_info.system'
-                    defaultMessage='System'
-                    style={style.displayName}
-                />
-            );
-        } else if (fromWebHook) {
+        if (fromWebHook) {
             let name = this.props.displayName;
             if (overrideUsername && enablePostUsernameOverride) {
                 name = overrideUsername;
@@ -84,6 +76,14 @@ export default class PostHeader extends PureComponent {
                         {BOT_NAME}
                     </Text>
                 </View>
+            );
+        } else if (isSystemMessage) {
+            return (
+                <FormattedText
+                    id='post_info.system'
+                    defaultMessage='System'
+                    style={style.displayName}
+                />
             );
         } else if (this.props.displayName) {
             return (


### PR DESCRIPTION
#### Summary
When a slash commands responds with an ephemeral post, the post is marked as system message but it also has a from_webhook prop, this PR will render the header giving priority to the from_webhook prop.

This was found during the investigation of https://mattermost.atlassian.net/browse/ICU-634 which is working just fine and I couldn't replicate the behavior.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-634
