### PR TITLE
Removed duplicate ChannelLoader instance

### DIFF
--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -246,7 +246,6 @@ class Channel extends PureComponent {
                             <View style={style.postList}>
                                 <ChannelPostList navigator={navigator}/>
                             </View>
-                            <ChannelLoader theme={theme}/>
                             <PostTextbox
                                 ref={this.attachPostTextbox}
                                 navigator={navigator}


### PR DESCRIPTION
If you look at the render method of the Channel screen, there's two ChannelLoader instances, one before the PostTextbox and one after it, so I removed the first one