### PR TITLE
RN-616 Added a fallback to prevent posts from being stuck as pending

### DIFF
--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -12,8 +12,19 @@ import {isEdited, isPostEphemeral, isSystemMessage} from 'mattermost-redux/utils
 
 import PostBody from './post_body';
 
+const POST_TIMEOUT = 20000;
+
 function mapStateToProps(state, ownProps) {
     const post = getPost(state, ownProps.postId);
+
+    let isFailed = post.failed;
+    let isPending = post.id === post.pending_post_id;
+    if (isPending && Date.now() - post.create_at > POST_TIMEOUT) {
+        // Something has prevented the post from being set to failed, so it's safe to assume
+        // that it has actually failed by this point
+        isFailed = true;
+        isPending = false;
+    }
 
     return {
         postProps: post.props || {},
@@ -21,8 +32,8 @@ function mapStateToProps(state, ownProps) {
         hasBeenDeleted: post.state === Posts.POST_DELETED,
         hasBeenEdited: isEdited(post),
         hasReactions: post.has_reactions,
-        isFailed: post.failed,
-        isPending: post.id === post.pending_post_id,
+        isFailed,
+        isPending,
         isPostEphemeral: isPostEphemeral(post),
         isSystemMessage: isSystemMessage(post),
         message: post.message,


### PR DESCRIPTION
I still wasn't able to cause the post to get stuck as pending naturally, but I tested with some code that always made the first request fail.

This isn't the nicest since it relies on something else causing the post to re-render, but since the post should only get stuck in this state after the app is closed, I don't think that's a problem.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-616

#### Device Information
This PR was tested on: iOS Simulator