### PR TITLE
Fix mention badge

### DIFF
--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -74,8 +74,6 @@ export default class Badge extends PureComponent {
 
     onLayout = (e) => {
         if (!this.layoutReady) {
-            const height = Math.max(e.nativeEvent.layout.height, this.props.minHeight);
-            const borderRadius = height / 2;
             let width;
 
             if (e.nativeEvent.layout.width <= e.nativeEvent.layout.height) {
@@ -83,11 +81,11 @@ export default class Badge extends PureComponent {
             } else {
                 width = e.nativeEvent.layout.width + this.props.extraPaddingHorizontal;
             }
-            width = Math.max(width, this.props.minWidth);
+            width = Math.max(width + 10, this.props.minWidth);
+            const borderRadius = width / 2;
             this.setNativeProps({
                 style: {
                     width,
-                    height,
                     borderRadius,
                     opacity: 1
                 }
@@ -141,14 +139,15 @@ export default class Badge extends PureComponent {
 
 const styles = StyleSheet.create({
     badge: {
-        top: 2,
+        backgroundColor: '#444',
+        borderRadius: 20,
+        height: 20,
         padding: 12,
         paddingTop: 3,
         paddingBottom: 3,
-        backgroundColor: '#444',
-        borderRadius: 20,
         position: 'absolute',
-        right: 30
+        right: 30,
+        top: 2
     },
     wrapper: {
         alignItems: 'center',


### PR DESCRIPTION
#### Summary
Fixes the flickering on the mention badge as well as the text wrapping in smaller screens for two digits

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-581

#### Device Information
This PR was tested on: 
* iOS 11.2 iPhone 5s and iPhone X (simulators)