### PR TITLE
iOS Share extension, fix teams and dm channels

### DIFF
--- a/share_extension/ios/extension_channels.js
+++ b/share_extension/ios/extension_channels.js
@@ -128,13 +128,22 @@ export default class ExtensionChannels extends PureComponent {
                 return (channel.type === General.DM_CHANNEL && usersInDms.includes(teammateId)) || channel.type === General.GM_CHANNEL;
             });
 
-            const dmProfiles = await Client4.getProfilesByIds(usersInDms);
+            let dmProfiles;
+            if (usersInDms.length) {
+                dmProfiles = await Client4.getProfilesByIds(usersInDms);
+            }
 
             for (let i = 0; i < dms.length; i++) {
                 const channel = dms[i];
                 if (channel.type === General.DM_CHANNEL) {
                     const teammateId = getUserIdFromChannelName(currentUserId, channel.name);
-                    const profile = dmProfiles.find((p) => p.id === teammateId);
+                    let profile;
+                    if (dmProfiles) {
+                        profile = dmProfiles.find((p) => p.id === teammateId);
+                    } else {
+                        const response = await Client4.getProfilesByIds([teammateId]);
+                        profile = response[0] || {username: 'Not Found'};
+                    }
                     channelsMap[channel.id] = displayUsername(profile, Preferences.DISPLAY_PREFER_FULL_NAME);
                 } else if (channel.type === General.GM_CHANNEL) {
                     const members = await Client4.getChannelMembers(channel.id, 0, General.MAX_USERS_IN_GM);

--- a/share_extension/ios/extension_channels.js
+++ b/share_extension/ios/extension_channels.js
@@ -117,7 +117,6 @@ export default class ExtensionChannels extends PureComponent {
     loadChannels = async () => {
         try {
             const {currentUserId, teamId} = this.props;
-            const usersInDms = [];
             const channelsMap = {};
 
             // get the channels for the specified team
@@ -125,14 +124,20 @@ export default class ExtensionChannels extends PureComponent {
 
             // filter channels that are direct and group messages
             const dms = myChannels.filter((channel) => {
-                if (channel.type === General.DM_CHANNEL) {
-                    const teammateId = getUserIdFromChannelName(currentUserId, channel.name);
-                    if (!usersInDms.includes(teammateId)) {
-                        usersInDms.push(teammateId);
-                    }
-                }
                 return channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
             });
+
+            const usersInDms = dms.filter((channel) => {
+                return channel.type === General.DM_CHANNEL;
+            }).map((channel) => {
+                return getUserIdFromChannelName(currentUserId, channel.name);
+            }).reduce((acc, teammateId) => {
+                if (!acc.includes(teammateId)) {
+                    acc.push(teammateId);
+                }
+
+                return acc;
+            }, []);
 
             // get the user ids that belong to DMs & GMs
             let dmProfiles;

--- a/share_extension/ios/extension_post.js
+++ b/share_extension/ios/extension_post.js
@@ -220,6 +220,7 @@ export default class ExtensionPost extends PureComponent {
 
                 Client4.setUrl(credentials.url);
                 Client4.setToken(credentials.token);
+                Client4.setUserId(currentUserId);
                 this.setState({channel, currentUserId, files, team, value});
             } catch (error) {
                 this.setState({error});

--- a/share_extension/ios/extension_teams.js
+++ b/share_extension/ios/extension_teams.js
@@ -57,14 +57,15 @@ export default class ExtensionTeams extends PureComponent {
             const myMembers = await Client4.getMyTeamMembers();
             const myTeams = [];
 
-            teams.forEach(async (team) => {
+            for (let i = 0; i < teams.length; i++) {
+                const team = teams[i];
                 const belong = myMembers.find((member) => member.team_id === team.id);
                 if (belong) {
                     const channels = await Client4.getMyChannels(team.id);
                     defaultChannels[team.id] = channels.find((channel) => channel.name === General.DEFAULT_CHANNEL);
                     myTeams.push(team);
                 }
-            });
+            }
 
             this.setState({
                 defaultChannels,


### PR DESCRIPTION
#### Summary
iOS Share extension was having some issues displaying the list of teams cause the loop through the teams was using an `async` inside a forEach, that was fix with a simple for loop.

Some User Profiles were not retrieved cause the user Preferences had some missing `CATEGORY_DIRECT_CHANNEL_SHOW` causing the request to **getProfilesByIds** to return an invalid argument.

Important: I've said this a few times now but I'll repeat. In iOS there is a known issue if a file that is being shared is too large causing the extension to be terminated, this is because the share extension on iOS has a memory limit and by reading the content of the file we surpass that limit.

The workaround for the above needs some server changes.