### PR TITLE
[XYZ-45] New permissions implementation

### DIFF
--- a/app/components/channel_drawer/channels_list/list/index.js
+++ b/app/components/channel_drawer/channels_list/list/index.js
@@ -12,6 +12,7 @@ import {
     getSortedDirectChannelIds
 } from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getCurrentUserRoles} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getTheme, getFavoritesPreferences} from 'mattermost-redux/selectors/entities/preferences';
 import {showCreateOption} from 'mattermost-redux/utils/channel_utils';
 import {isAdmin, isSystemAdmin} from 'mattermost-redux/utils/user_utils';
@@ -26,9 +27,10 @@ function mapStateToProps(state) {
     const publicChannelIds = getSortedPublicChannelIds(state);
     const privateChannelIds = getSortedPrivateChannelIds(state);
     const directChannelIds = getSortedDirectChannelIds(state);
+    const currentTeamId = getCurrentTeamId(state);
 
     return {
-        canCreatePrivateChannels: showCreateOption(config, license, General.PRIVATE_CHANNEL, isAdmin(roles), isSystemAdmin(roles)),
+        canCreatePrivateChannels: showCreateOption(state, config, license, currentTeamId, General.PRIVATE_CHANNEL, isAdmin(roles), isSystemAdmin(roles)),
         unreadChannelIds,
         favoriteChannelIds,
         publicChannelIds,

--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -8,8 +8,10 @@ import {createPost, deletePost, removePost} from 'mattermost-redux/actions/posts
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId, getCurrentUserRoles} from 'mattermost-redux/selectors/entities/users';
 import {getMyPreferences, getTheme} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentTeamUrl} from 'mattermost-redux/selectors/entities/teams';
-import {isPostFlagged} from 'mattermost-redux/utils/post_utils';
+import {getCurrentTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {canDeletePost, canEditPost, isPostFlagged} from 'mattermost-redux/utils/post_utils';
+import {isAdmin, isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
 import {insertToDraft, setPostTooltipVisible} from 'app/actions/views/channel';
 import {addReaction} from 'app/actions/views/emoji';
@@ -23,6 +25,9 @@ function mapStateToProps(state, ownProps) {
     const {config, license} = state.entities.general;
     const roles = getCurrentUserId(state) ? getCurrentUserRoles(state) : '';
     const myPreferences = getMyPreferences(state);
+    const currentUserId = getCurrentUserId(state);
+    const currentTeamId = getCurrentTeamId(state);
+    const currentChannelId = getCurrentChannelId(state);
 
     let isFirstReply = true;
     let isLastReply = true;
@@ -51,17 +56,25 @@ function mapStateToProps(state, ownProps) {
 
     const {deviceWidth} = getDimensions(state);
 
+    let canDelete = false;
+    let canEdit = false;
+    if (post) {
+        canDelete = canDeletePost(state, config, license, currentTeamId, currentChannelId, currentUserId, post, isAdmin(roles), isSystemAdmin(roles));
+        canEdit = canEditPost(state, config, license, currentTeamId, currentChannelId, currentUserId, post);
+    }
+
     return {
         config,
+        canDelete,
+        canEdit,
         currentTeamUrl: getCurrentTeamUrl(state),
-        currentUserId: getCurrentUserId(state),
+        currentUserId,
         deviceWidth,
         post,
         isFirstReply,
         isLastReply,
         commentedOnPost,
         license,
-        roles,
         theme: getTheme(state),
         isFlagged: isPostFlagged(post.id, myPreferences)
     };

--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -46,8 +46,8 @@ function mapStateToProps(state) {
     }
 
     return {
-        canDeleteChannel: showDeleteOption(config, license, currentChannel, isAdmin(roles), isSystemAdmin(roles), isChannelAdmin(roles)),
-        canEditChannel: showManagementOptions(config, license, currentChannel, isAdmin(roles), isSystemAdmin(roles), isChannelAdmin(roles)),
+        canDeleteChannel: showDeleteOption(state, config, license, currentChannel, isAdmin(roles), isSystemAdmin(roles), isChannelAdmin(roles)),
+        canEditChannel: showManagementOptions(state, config, license, currentChannel, isAdmin(roles), isSystemAdmin(roles), isChannelAdmin(roles)),
         currentChannel,
         currentChannelCreatorName,
         currentChannelMemberCount,

--- a/app/screens/more_channels/index.js
+++ b/app/screens/more_channels/index.js
@@ -36,7 +36,7 @@ function mapStateToProps(state) {
     const channels = joinableChannels(state);
 
     return {
-        canCreateChannels: showCreateOption(config, license, General.OPEN_CHANNEL, isAdmin(roles), isSystemAdmin(roles)),
+        canCreateChannels: showCreateOption(state, config, license, currentTeamId, General.OPEN_CHANNEL, isAdmin(roles), isSystemAdmin(roles)),
         currentUserId,
         currentTeamId,
         channels,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fuse.js": "^3.2.0",
     "intl": "1.2.5",
     "jail-monkey": "0.2.0",
-    "mattermost-redux": "mattermost/mattermost-redux",
+    "mattermost-redux": "mattermost/mattermost-redux#advanced-permissions-phase-1",
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-intl": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,9 +4016,9 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-mattermost-redux@mattermost/mattermost-redux:
+mattermost-redux@mattermost/mattermost-redux#advanced-permissions-phase-1:
   version "1.2.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/17237100e4ba15c73e158973044282d1dcb5562e"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/c8b3c171e77dbf09d459bd3de6b47a20617bc11e"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary
Use the new advanced permissions (mainly solved in the redux library)

Depends on mattermost/mattermost-redux#360 and the
mattermost/mattermost-server#8159 PRs.

#### Ticket Link
[XYZ-45](https://mattermost.atlassian.net/browse/XYZ-45)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [OnePlus5, Android 8]