### PR TITLE
ICU-642 Remove Check for Updates screen by default

### DIFF
--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -33,9 +33,9 @@
     
     "AutoSelectServerUrl": false,
 
-    "EnableMobileClientUpgrade": true,
-    "EnableMobileClientUpgradeUserSetting": true,
-    "EnableForceMobileClientUpgrade": true,
+    "EnableMobileClientUpgrade": false,
+    "EnableMobileClientUpgradeUserSetting": false,
+    "EnableForceMobileClientUpgrade": false,
     "MobileClientUpgradeAndroidApkLink": "https://about.mattermost.com/mattermost-android-app/",
     "MobileClientUpgradeIosIpaLink": "https://about.mattermost.com/mattermost-ios-app/",
 


### PR DESCRIPTION
#### Summary
As discussed the option for Check for Updates and App Upgrade is disabled by default, EE customers can enable it if needed by building the apps themselves.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-642