### PR TITLE
Removed fontSize prop from Emoji

### DIFF
--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -3,7 +3,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Image, Platform, Text} from 'react-native';
+import {
+    Image,
+    Platform,
+    StyleSheet,
+    Text
+} from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
@@ -15,7 +20,6 @@ export default class Emoji extends React.PureComponent {
     static propTypes = {
         customEmojis: PropTypes.object,
         emojiName: PropTypes.string.isRequired,
-        fontSize: PropTypes.number,
         literal: PropTypes.string,
         size: PropTypes.number.isRequired,
         textStyle: CustomPropTypes.Style,
@@ -99,7 +103,6 @@ export default class Emoji extends React.PureComponent {
 
     render() {
         const {
-            fontSize,
             literal,
             size,
             textStyle,
@@ -136,7 +139,9 @@ export default class Emoji extends React.PureComponent {
         }
 
         let marginTop = 0;
-        if (fontSize) {
+        if (textStyle) {
+            const fontSize = StyleSheet.flatten(textStyle).fontSize;
+
             // Center the image vertically on iOS (does nothing on Android)
             marginTop = (height - 16) / 2;
 

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -31,7 +31,6 @@ export default class Markdown extends PureComponent {
         baseTextStyle: CustomPropTypes.Style,
         blockStyles: PropTypes.object,
         emojiSizes: PropTypes.object,
-        fontSizes: PropTypes.object,
         isEdited: PropTypes.bool,
         isSearchResult: PropTypes.bool,
         navigator: PropTypes.object.isRequired,
@@ -66,15 +65,6 @@ export default class Markdown extends PureComponent {
                     text: 45
                 }
             })
-        },
-        fontSizes: {
-            heading1: 17,
-            heading2: 17,
-            heading3: 17,
-            heading4: 17,
-            heading5: 17,
-            heading6: 17,
-            text: 15
         },
         onLongPress: () => true
     };
@@ -194,14 +184,11 @@ export default class Markdown extends PureComponent {
 
     renderEmoji = ({context, emojiName, literal}) => {
         let size;
-        let fontSize;
         const headingType = context.find((type) => type.startsWith('heading'));
         if (headingType) {
             size = this.props.emojiSizes[headingType];
-            fontSize = this.props.fontSizes[headingType];
         } else {
             size = this.props.emojiSizes.text;
-            fontSize = this.props.fontSizes.text;
         }
 
         return (
@@ -209,7 +196,6 @@ export default class Markdown extends PureComponent {
                 emojiName={emojiName}
                 literal={literal}
                 size={size}
-                fontSize={fontSize}
                 textStyle={this.computeTextStyle(this.props.baseTextStyle, context)}
             />
         );


### PR DESCRIPTION
I did this as part of the markdown tables PR, but it relates to Stephen's work, so I submitted it early. It now calculates the fontSize from the text style instead of passing it in separately

#### Device Information
This PR was tested on: iOS Simulator
