### PR TITLE
ScrollToNewMessage: Fix onLayoutCalled issue and improve accuracy

### DIFF
--- a/app/components/post_list/with_layout.js
+++ b/app/components/post_list/with_layout.js
@@ -5,13 +5,19 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 
+import {emptyFunction} from 'app/utils/general';
+
 function withLayout(WrappedComponent) {
     return class WithLayoutComponent extends PureComponent {
         static propTypes = {
             index: PropTypes.number.isRequired,
-            onLayoutCalled: PropTypes.func.isRequired,
+            onLayoutCalled: PropTypes.func,
             shouldCallOnLayout: PropTypes.bool
         };
+
+        static defaultProps = {
+            onLayoutCalled: emptyFunction
+        }
 
         onLayout = (event) => {
             const {height} = event.nativeEvent.layout;


### PR DESCRIPTION
#### Summary
This PR fixes an issue where `onLayoutCalled` would not always be called by the new message or date headers which causes the list not to scroll to the new message. Accuracy has also been improved for the placement of the new message header within the view window.

via @jarredwitt 