### PR TITLE
Fix Android app stuck in splash screen when killed by the OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ post-install:
 	@sed -i'' -e 's|"./locale-data/complete.js": false|"./locale-data/complete.js": "./locale-data/complete.js"|g' node_modules/intl/package.json
 	@sed -i'' -e 's|auto("auto", Configuration.ORIENTATION_UNDEFINED, ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);|auto("auto", Configuration.ORIENTATION_UNDEFINED, ActivityInfo.SCREEN_ORIENTATION_FULL_USER);|g' node_modules/react-native-navigation/android/app/src/main/java/com/reactnativenavigation/params/Orientation.java
 	@sed -i'' -e "s|var AndroidTextInput = requireNativeComponent('AndroidTextInput', null);|var AndroidTextInput = requireNativeComponent('CustomTextInput', null);|g" node_modules/react-native/Libraries/Components/TextInput/TextInput.js
+	@sed -i'' -e "s|super.onBackPressed();|this.moveTaskToBack(true);|g" node_modules/react-native-navigation/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
 	@if [ $(shell grep "const Platform" node_modules/react-native/Libraries/Lists/VirtualizedList.js | grep -civ grep) -eq 0 ]; then \
 		sed $ -i'' -e "s|const ReactNative = require('ReactNative');|const ReactNative = require('ReactNative');`echo $\\\\\\r;`const Platform = require('Platform');|g" node_modules/react-native/Libraries/Lists/VirtualizedList.js; \
 	fi

--- a/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
@@ -94,6 +94,13 @@ public class MainApplication extends NavigationApplication implements INotificat
   }
 
   @Override
+  public boolean clearHostOnActivityDestroy() {
+    // This solves the issue where the splash screen does not go away
+    // after the app is killed by the OS cause of memory or a long time in the background
+    return false;
+  }
+
+  @Override
   public IPushNotification getPushNotification(Context context, Bundle bundle, AppLifecycleFacade defaultFacade, AppLaunchHelper defaultAppLaunchHelper) {
     return new CustomPushNotification(
             context,


### PR DESCRIPTION
#### Summary
There is a bug in `RNN` that causes the app to enter an infinite loop between the SplashActivity and the first activity of the app giving the sensation that the app is stuck in the Splash Screen, I've reported the [Bug](https://github.com/wix/react-native-navigation/issues/2610) and there seems to be a workaround for it (referenced in the issue).

But when closing the app with the hardware back button and re-open the app indeed was stuck, that is why I've added the changes in the Makefile to handle the back button with a different behavior and solving the issue.

RNN = react native navigation
RNN are saying that they are fixing this and other issues in their v2 but is not yet ready but we should be on the look out.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-592

cc: @grundleborg just to take a look at the PR and if you have some feedback is always welcome
