### PR TITLE
ABC-123 Add handling for loading custom emojis asynchronously

### DIFF
--- a/app/actions/views/emoji.js
+++ b/app/actions/views/emoji.js
@@ -32,3 +32,13 @@ export function addRecentEmoji(emoji) {
         emoji
     };
 }
+
+export function incrementEmojiPickerPage() {
+    return async (dispatch) => {
+        dispatch({
+            type: ViewTypes.INCREMENT_EMOJI_PICKER_PAGE
+        });
+
+        return {data: true};
+    };
+}

--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -20,7 +20,8 @@ const EMOJI_REGEX_WITHOUT_PREFIX = /\B(:([^:\s]*))$/i;
 export default class EmojiSuggestion extends Component {
     static propTypes = {
         actions: PropTypes.shape({
-            addReactionToLatestPost: PropTypes.func.isRequired
+            addReactionToLatestPost: PropTypes.func.isRequired,
+            autocompleteCustomEmojis: PropTypes.func.isRequired
         }).isRequired,
         cursorPosition: PropTypes.number,
         emojis: PropTypes.array.isRequired,
@@ -43,6 +44,12 @@ export default class EmojiSuggestion extends Component {
         dataSource: []
     };
 
+    constructor(props) {
+        super(props);
+
+        this.matchTerm = '';
+    }
+
     componentWillReceiveProps(nextProps) {
         if (nextProps.isSearch) {
             return;
@@ -54,7 +61,6 @@ export default class EmojiSuggestion extends Component {
         if (!match || this.state.emojiComplete) {
             this.setState({
                 active: false,
-                matchTerm: null,
                 emojiComplete: false
             });
 
@@ -63,18 +69,17 @@ export default class EmojiSuggestion extends Component {
             return;
         }
 
-        const matchTerm = match[3];
+        const oldMatchTerm = this.matchTerm;
+        this.matchTerm = match[3];
 
-        const matchTermChanged = matchTerm !== this.state.matchTerm;
-        if (matchTermChanged) {
-            this.setState({
-                matchTerm
-            });
+        if (this.matchTerm !== oldMatchTerm && this.matchTerm.length) {
+            this.props.actions.autocompleteCustomEmojis(this.matchTerm);
+            return;
         }
 
-        if (matchTermChanged) {
-            this.handleFuzzySearch(matchTerm, nextProps);
-        } else if (!matchTerm.length) {
+        if (this.props.emojis !== nextProps.emojis) {
+            this.handleFuzzySearch(this.matchTerm, nextProps);
+        } else if (!this.matchTerm.length) {
             const initialEmojis = [...nextProps.emojis];
             initialEmojis.splice(0, 300);
             const data = initialEmojis.sort();

--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -10,6 +10,9 @@ import {
     View
 } from 'react-native';
 
+import {Client4} from 'mattermost-redux/client';
+import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
+
 import AutocompleteDivider from 'app/components/autocomplete/autocomplete_divider';
 import Emoji from 'app/components/emoji';
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
@@ -72,12 +75,14 @@ export default class EmojiSuggestion extends Component {
         const oldMatchTerm = this.matchTerm;
         this.matchTerm = match[3];
 
-        if (this.matchTerm !== oldMatchTerm && this.matchTerm.length) {
+        const pre47 = !isMinimumServerVersion(Client4.getServerVersion(), 4, 7);
+
+        if (!pre47 && this.matchTerm !== oldMatchTerm && this.matchTerm.length) {
             this.props.actions.autocompleteCustomEmojis(this.matchTerm);
             return;
         }
 
-        if (this.props.emojis !== nextProps.emojis) {
+        if (pre47 || this.props.emojis !== nextProps.emojis) {
             this.handleFuzzySearch(this.matchTerm, nextProps);
         } else if (!this.matchTerm.length) {
             const initialEmojis = [...nextProps.emojis];

--- a/app/components/autocomplete/emoji_suggestion/index.js
+++ b/app/components/autocomplete/emoji_suggestion/index.js
@@ -6,6 +6,7 @@ import {createSelector} from 'reselect';
 import {bindActionCreators} from 'redux';
 
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+import {autocompleteCustomEmojis} from 'mattermost-redux/actions/emojis';
 
 import {addReactionToLatestPost} from 'app/actions/views/emoji';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -50,7 +51,8 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            addReactionToLatestPost
+            addReactionToLatestPost,
+            autocompleteCustomEmojis
         }, dispatch)
     };
 }

--- a/app/components/autocomplete/emoji_suggestion/index.js
+++ b/app/components/autocomplete/emoji_suggestion/index.js
@@ -7,6 +7,7 @@ import {bindActionCreators} from 'redux';
 
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {autocompleteCustomEmojis} from 'mattermost-redux/actions/emojis';
+import {Client4} from 'mattermost-redux/client';
 
 import {addReactionToLatestPost} from 'app/actions/views/emoji';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -45,7 +46,7 @@ function mapStateToProps(state) {
         fuse,
         emojis,
         theme: getTheme(state),
-        serverVersion: state.entities.general.serverVersion
+        serverVersion: state.entities.general.serverVersion || Client4.getServerVersion()
     };
 }
 

--- a/app/components/autocomplete/emoji_suggestion/index.js
+++ b/app/components/autocomplete/emoji_suggestion/index.js
@@ -44,7 +44,8 @@ function mapStateToProps(state) {
     return {
         fuse,
         emojis,
-        theme: getTheme(state)
+        theme: getTheme(state),
+        serverVersion: state.entities.general.serverVersion
     };
 }
 

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -159,8 +159,15 @@ export default class Emoji extends React.PureComponent {
         const key = Platform.OS === 'android' ? (height + '-' + width) : null;
 
         if (!imageUrl) {
+            let BlankComponent;
+            if (Platform.OS === 'android') {
+                BlankComponent = Image;
+            } else {
+                BlankComponent = View;
+            }
+
             return (
-                <View
+                <BlankComponent
                     key={key}
                     style={{width, height, marginTop}}
                 />

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -8,8 +8,7 @@ import {
     PixelRatio,
     Platform,
     StyleSheet,
-    Text,
-    View
+    Text
 } from 'react-native';
 import FastImage from 'react-native-fast-image';
 
@@ -158,27 +157,20 @@ export default class Emoji extends React.PureComponent {
         // force a new image to be rendered when the size changes
         const key = Platform.OS === 'android' ? (height + '-' + width) : null;
 
-        if (!imageUrl) {
-            let BlankComponent;
-            if (Platform.OS === 'android') {
-                BlankComponent = Image;
-            } else {
-                BlankComponent = View;
-            }
-
-            return (
-                <BlankComponent
-                    key={key}
-                    style={{width, height, marginTop}}
-                />
-            );
-        }
-
         let ImageComponent;
         if (Platform.OS === 'android') {
             ImageComponent = Image;
         } else {
             ImageComponent = FastImage;
+        }
+
+        if (!imageUrl) {
+            return (
+                <ImageComponent
+                    key={key}
+                    style={{width, height, marginTop}}
+                />
+            );
         }
 
         return (

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -8,14 +8,12 @@ import {
     PixelRatio,
     Platform,
     StyleSheet,
-    Text
+    Text,
+    View
 } from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
-import {EmojiIndicesByAlias, Emojis} from 'app/utils/emojis';
-
-import {Client4} from 'mattermost-redux/client';
 
 const scaleEmojiBasedOnDevice = (size) => {
     if (Platform.OS === 'ios') {
@@ -26,8 +24,26 @@ const scaleEmojiBasedOnDevice = (size) => {
 
 export default class Emoji extends React.PureComponent {
     static propTypes = {
-        customEmojis: PropTypes.object,
+
+        /*
+         * Emoji text name.
+         */
         emojiName: PropTypes.string.isRequired,
+
+        /*
+         * Image URL for the emoji.
+         */
+        imageUrl: PropTypes.string.isRequired,
+
+        /*
+         * Set if this is a custom emoji.
+         */
+        isCustomEmoji: PropTypes.bool.isRequired,
+
+        /*
+         * Set to render only the text and no image.
+         */
+        displayTextOnly: PropTypes.bool,
         literal: PropTypes.string,
         size: PropTypes.number,
         textStyle: CustomPropTypes.Style,
@@ -36,14 +52,15 @@ export default class Emoji extends React.PureComponent {
 
     static defaultProps = {
         customEmojis: new Map(),
-        literal: ''
+        literal: '',
+        imageUrl: '',
+        isCustomEmoji: false
     };
 
     constructor(props) {
         super(props);
 
         this.state = {
-            ...this.getImageUrl(props),
             originalWidth: 0,
             originalHeight: 0
         };
@@ -51,51 +68,27 @@ export default class Emoji extends React.PureComponent {
 
     componentWillMount() {
         this.mounted = true;
-        if (this.state.imageUrl && this.state.isCustomEmoji) {
-            this.updateImageHeight(this.state.imageUrl);
+        if (!this.props.displayTextOnly && this.props.imageUrl && this.props.isCustomEmoji) {
+            this.updateImageHeight(this.props.imageUrl);
         }
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.customEmojis !== this.props.customEmojis || nextProps.emojiName !== this.props.emojiName) {
+        if (nextProps.emojiName !== this.props.emojiName) {
             this.setState({
-                ...this.getImageUrl(nextProps),
                 originalWidth: 0,
                 originalHeight: 0
             });
         }
-    }
 
-    componentWillUpdate(nextProps, nextState) {
-        if (nextState.imageUrl !== this.state.imageUrl && nextState.imageUrl && nextState.isCustomEmoji) {
-            this.updateImageHeight(nextState.imageUrl);
+        if (!nextProps.displayTextOnly && nextProps.imageUrl && nextProps.isCustomEmoji &&
+                nextProps.imageUrl !== this.props.imageUrl) {
+            this.updateImageHeight(nextProps.imageUrl);
         }
     }
 
     componentWillUnmount() {
         this.mounted = false;
-    }
-
-    getImageUrl = (props = this.props) => {
-        const emojiName = props.emojiName;
-
-        let imageUrl = '';
-        let isCustomEmoji = false;
-        if (EmojiIndicesByAlias.has(emojiName)) {
-            const emoji = Emojis[EmojiIndicesByAlias.get(emojiName)];
-
-            imageUrl = Client4.getSystemEmojiImageUrl(emoji.filename);
-        } else if (props.customEmojis.has(emojiName)) {
-            const emoji = props.customEmojis.get(emojiName);
-
-            imageUrl = Client4.getCustomEmojiImageUrl(emoji.id);
-            isCustomEmoji = true;
-        }
-
-        return {
-            imageUrl,
-            isCustomEmoji
-        };
     }
 
     updateImageHeight = (imageUrl) => {
@@ -113,7 +106,9 @@ export default class Emoji extends React.PureComponent {
         const {
             literal,
             textStyle,
-            token
+            token,
+            imageUrl,
+            displayTextOnly
         } = this.props;
 
         let size = this.props.size;
@@ -124,19 +119,12 @@ export default class Emoji extends React.PureComponent {
             size = scaleEmojiBasedOnDevice(fontSize);
         }
 
-        if (!this.state.imageUrl) {
+        if (displayTextOnly) {
             return <Text style={textStyle}>{literal}</Text>;
         }
 
-        let ImageComponent;
-        if (Platform.OS === 'android') {
-            ImageComponent = Image;
-        } else {
-            ImageComponent = FastImage;
-        }
-
         const source = {
-            uri: this.state.imageUrl,
+            uri: imageUrl,
             headers: {
                 Authorization: `Bearer ${token}`
             }
@@ -169,6 +157,22 @@ export default class Emoji extends React.PureComponent {
         // Android can't change the size of an image after its first render, so
         // force a new image to be rendered when the size changes
         const key = Platform.OS === 'android' ? (height + '-' + width) : null;
+
+        if (!imageUrl) {
+            return (
+                <View
+                    key={key}
+                    style={{width, height, marginTop}}
+                />
+            );
+        }
+
+        let ImageComponent;
+        if (Platform.OS === 'android') {
+            ImageComponent = Image;
+        } else {
+            ImageComponent = FastImage;
+        }
 
         return (
             <ImageComponent

--- a/app/components/emoji/index.js
+++ b/app/components/emoji/index.js
@@ -4,12 +4,38 @@
 import {connect} from 'react-redux';
 
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {Client4} from 'mattermost-redux/client';
+
+import {EmojiIndicesByAlias, Emojis} from 'app/utils/emojis';
 
 import Emoji from './emoji';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
+    const emojiName = ownProps.emojiName;
+    const customEmojis = getCustomEmojisByName(state);
+
+    let imageUrl = '';
+    let isCustomEmoji = false;
+    let displayTextOnly = false;
+    if (EmojiIndicesByAlias.has(emojiName)) {
+        const emoji = Emojis[EmojiIndicesByAlias.get(emojiName)];
+        imageUrl = Client4.getSystemEmojiImageUrl(emoji.filename);
+    } else if (customEmojis.has(emojiName)) {
+        const emoji = customEmojis.get(emojiName);
+        imageUrl = Client4.getCustomEmojiImageUrl(emoji.id);
+        isCustomEmoji = true;
+    } else {
+        displayTextOnly = state.entities.emojis.nonExistentEmoji.has(emojiName) ||
+            getConfig(state).EnableCustomEmoji !== 'true' ||
+            getCurrentUserId(state) === '';
+    }
+
     return {
-        customEmojis: getCustomEmojisByName(state),
+        imageUrl,
+        isCustomEmoji,
+        displayTextOnly,
         token: state.entities.general.credentials.token
     };
 }

--- a/app/components/emoji/index.js
+++ b/app/components/emoji/index.js
@@ -7,6 +7,7 @@ import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis'
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {Client4} from 'mattermost-redux/client';
+import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
 import {EmojiIndicesByAlias, Emojis} from 'app/utils/emojis';
 
@@ -29,7 +30,8 @@ function mapStateToProps(state, ownProps) {
     } else {
         displayTextOnly = state.entities.emojis.nonExistentEmoji.has(emojiName) ||
             getConfig(state).EnableCustomEmoji !== 'true' ||
-            getCurrentUserId(state) === '';
+            getCurrentUserId(state) === '' ||
+            !isMinimumServerVersion(Client4.getServerVersion(), 4, 7);
     }
 
     return {

--- a/app/components/emoji_picker/emoji_picker.js
+++ b/app/components/emoji_picker/emoji_picker.js
@@ -5,14 +5,14 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
 import {
+    ActivityIndicator,
     FlatList,
     KeyboardAvoidingView,
     Platform,
     SectionList,
     Text,
     TouchableOpacity,
-    View,
-    ActivityIndicator
+    View
 } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
@@ -37,16 +37,16 @@ const EMOJIS_PER_PAGE = 200;
 
 export default class EmojiPicker extends PureComponent {
     static propTypes = {
-        fuse: PropTypes.object.isRequired,
-        emojis: PropTypes.array.isRequired,
-        emojisBySection: PropTypes.array.isRequired,
-        deviceWidth: PropTypes.number.isRequired,
-        isLandscape: PropTypes.bool.isRequired,
-        onEmojiPress: PropTypes.func,
-        theme: PropTypes.object.isRequired,
         customEmojisEnabled: PropTypes.bool.isRequired,
         customEmojiPage: PropTypes.number.isRequired,
+        deviceWidth: PropTypes.number.isRequired,
+        emojis: PropTypes.array.isRequired,
+        emojisBySection: PropTypes.array.isRequired,
+        fuse: PropTypes.object.isRequired,
+        isLandscape: PropTypes.bool.isRequired,
+        onEmojiPress: PropTypes.func,
         serverVersion: PropTypes.string,
+        theme: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             getCustomEmojis: PropTypes.func.isRequired,
             incrementEmojiPickerPage: PropTypes.func.isRequired,

--- a/app/components/emoji_picker/emoji_picker.js
+++ b/app/components/emoji_picker/emoji_picker.js
@@ -83,7 +83,7 @@ export default class EmojiPicker extends PureComponent {
             filteredEmojis: [],
             searchTerm: '',
             currentSectionIndex: 0,
-            missingPages: true
+            missingPages: isMinimumServerVersion(this.props.serverVersion, 4, 7)
         };
     }
 
@@ -248,7 +248,7 @@ export default class EmojiPicker extends PureComponent {
     };
 
     loadMoreCustomEmojis = async () => {
-        if (!this.props.customEmojisEnabled) {
+        if (!this.props.customEmojisEnabled || !isMinimumServerVersion(this.props.serverVersion, 4, 7)) {
             return;
         }
 
@@ -338,9 +338,13 @@ export default class EmojiPicker extends PureComponent {
         );
     };
 
-    handleSectionIconPress = (index) => {
+    handleSectionIconPress = (index, isCustomSection = false) => {
         this.scrollToSectionTries = 0;
         this.scrollToSection(index);
+
+        if (isCustomSection && this.props.customEmojiPage === 0) {
+            this.loadMoreCustomEmojis();
+        }
     }
 
     renderSectionIcons = () => {
@@ -348,7 +352,7 @@ export default class EmojiPicker extends PureComponent {
         const styles = getStyleSheetFromTheme(theme);
 
         return this.state.emojis.map((section, index) => {
-            const onPress = () => this.handleSectionIconPress(index);
+            const onPress = () => this.handleSectionIconPress(index, section.key === 'custom');
 
             return (
                 <TouchableOpacity

--- a/app/components/emoji_picker/emoji_picker.js
+++ b/app/components/emoji_picker/emoji_picker.js
@@ -18,6 +18,8 @@ import DeviceInfo from 'react-native-device-info';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import sectionListGetItemLayout from 'react-native-section-list-get-item-layout';
 
+import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
+
 import Emoji from 'app/components/emoji';
 import FormattedText from 'app/components/formatted_text';
 import SafeAreaView from 'app/components/safe_area_view';
@@ -44,6 +46,7 @@ export default class EmojiPicker extends PureComponent {
         theme: PropTypes.object.isRequired,
         customEmojisEnabled: PropTypes.bool.isRequired,
         customEmojiPage: PropTypes.number.isRequired,
+        serverVersion: PropTypes.string,
         actions: PropTypes.shape({
             getCustomEmojis: PropTypes.func.isRequired,
             incrementEmojiPickerPage: PropTypes.func.isRequired,
@@ -166,7 +169,9 @@ export default class EmojiPicker extends PureComponent {
         clearTimeout(this.searchTermTimeout);
         const timeout = text ? 100 : 0;
         this.searchTermTimeout = setTimeout(async () => {
-            await this.props.actions.searchCustomEmojis(text);
+            if (isMinimumServerVersion(this.props.serverVersion, 4, 7)) {
+                await this.props.actions.searchCustomEmojis(text);
+            }
             const filteredEmojis = this.searchEmojis(text);
             this.setState({
                 filteredEmojis
@@ -363,8 +368,11 @@ export default class EmojiPicker extends PureComponent {
             return null;
         }
 
+        const {theme} = this.props;
+
+        const styles = getStyleSheetFromTheme(theme);
         return (
-            <View style={{flex: 1, alignItems: 'center'}}>
+            <View style={styles.loading}>
                 <ActivityIndicator/>
             </View>
         );
@@ -567,6 +575,10 @@ const getStyleSheetFromTheme = makeStyleSheetFromTheme((theme) => {
         },
         wrapper: {
             flex: 1
+        },
+        loading: {
+            flex: 1,
+            alignItems: 'center'
         }
     };
 });

--- a/app/components/emoji_picker/emoji_picker.js
+++ b/app/components/emoji_picker/emoji_picker.js
@@ -162,9 +162,15 @@ export default class EmojiPicker extends PureComponent {
     };
 
     changeSearchTerm = (text) => {
-        this.setState({
+        const nextState = {
             searchTerm: text
-        });
+        };
+
+        if (!text) {
+            nextState.currentSectionIndex = 0;
+        }
+
+        this.setState(nextState);
 
         clearTimeout(this.searchTermTimeout);
         const timeout = text ? 100 : 0;
@@ -181,6 +187,7 @@ export default class EmojiPicker extends PureComponent {
 
     cancelSearch = () => {
         this.setState({
+            currentSectionIndex: 0,
             filteredEmojis: [],
             searchTerm: ''
         });

--- a/app/components/emoji_picker/emoji_picker_row.js
+++ b/app/components/emoji_picker/emoji_picker_row.js
@@ -8,6 +8,7 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import shallowEqual from 'shallow-equals';
 
 import Emoji from 'app/components/emoji';
 
@@ -20,7 +21,7 @@ export default class EmojiPickerRow extends Component {
     }
 
     shouldComponentUpdate(nextProps) {
-        return this.props.items.length !== nextProps.items.length;
+        return !shallowEqual(this.props.items, nextProps.items);
     }
 
     renderEmojis = (emoji, index, emojis) => {

--- a/app/components/emoji_picker/index.js
+++ b/app/components/emoji_picker/index.js
@@ -3,11 +3,15 @@
 
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
+import {bindActionCreators} from 'redux';
 
-import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
-
-import {getDimensions, isLandscape} from 'app/selectors/device';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCustomEmojis, searchCustomEmojis} from 'mattermost-redux/actions/emojis';
+
+import {incrementEmojiPickerPage} from 'app/actions/views/emoji';
+import {getDimensions, isLandscape} from 'app/selectors/device';
 import {CategoryNames, Emojis, EmojiIndicesByAlias, EmojiIndicesByCategory} from 'app/utils/emojis';
 
 import EmojiPicker from './emoji_picker';
@@ -152,8 +156,20 @@ function mapStateToProps(state) {
         emojisBySection,
         deviceWidth,
         isLandscape: isLandscape(state),
-        theme: getTheme(state)
+        theme: getTheme(state),
+        customEmojisEnabled: getConfig(state).EnableCustomEmoji === 'true',
+        customEmojiPage: state.views.emoji.emojiPickerCustomPage
     };
 }
 
-export default connect(mapStateToProps)(EmojiPicker);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getCustomEmojis,
+            incrementEmojiPickerPage,
+            searchCustomEmojis
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(EmojiPicker);

--- a/app/components/emoji_picker/index.js
+++ b/app/components/emoji_picker/index.js
@@ -158,7 +158,8 @@ function mapStateToProps(state) {
         isLandscape: isLandscape(state),
         theme: getTheme(state),
         customEmojisEnabled: getConfig(state).EnableCustomEmoji === 'true',
-        customEmojiPage: state.views.emoji.emojiPickerCustomPage
+        customEmojiPage: state.views.emoji.emojiPickerCustomPage,
+        serverVersion: state.entities.general.serverVersion
     };
 }
 

--- a/app/components/emoji_picker/index.js
+++ b/app/components/emoji_picker/index.js
@@ -9,6 +9,7 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCustomEmojis, searchCustomEmojis} from 'mattermost-redux/actions/emojis';
+import {Client4} from 'mattermost-redux/client';
 
 import {incrementEmojiPickerPage} from 'app/actions/views/emoji';
 import {getDimensions, isLandscape} from 'app/selectors/device';
@@ -159,7 +160,7 @@ function mapStateToProps(state) {
         theme: getTheme(state),
         customEmojisEnabled: getConfig(state).EnableCustomEmoji === 'true',
         customEmojiPage: state.views.emoji.emojiPickerCustomPage,
-        serverVersion: state.entities.general.serverVersion
+        serverVersion: state.entities.general.serverVersion || Client4.getServerVersion()
     };
 }
 

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -62,7 +62,9 @@ const ViewTypes = keyMirror({
 
     ADD_RECENT_EMOJI: null,
     EXTENSION_SELECTED_TEAM_ID: null,
-    ANNOUNCEMENT_BANNER: null
+    ANNOUNCEMENT_BANNER: null,
+
+    INCREMENT_EMOJI_PICKER_PAGE: null
 });
 
 export default {

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -22,6 +22,7 @@ import semver from 'semver';
 import {General} from 'mattermost-redux/constants';
 import {setAppState, setDeviceToken, setServerVersion} from 'mattermost-redux/actions/general';
 import {markChannelAsRead} from 'mattermost-redux/actions/channels';
+import {setSystemEmojis} from 'mattermost-redux/actions/emojis';
 import {logError} from 'mattermost-redux/actions/errors';
 import {loadMe, logout} from 'mattermost-redux/actions/users';
 import {close as closeWebSocket} from 'mattermost-redux/actions/websocket';
@@ -56,6 +57,7 @@ import {init as initAnalytics} from 'app/utils/segment';
 import {captureException, initializeSentry, LOGGER_JAVASCRIPT, LOGGER_NATIVE} from 'app/utils/sentry';
 import tracker from 'app/utils/time_tracker';
 import {stripTrailingSlashes} from 'app/utils/url';
+import {EmojiIndicesByAlias} from 'app/utils/emojis';
 
 import LocalConfig from 'assets/config';
 
@@ -90,6 +92,7 @@ export default class Mattermost {
 
         setJSExceptionHandler(this.errorHandler, false);
         setNativeExceptionHandler(this.nativeErrorHandler, false);
+        setSystemEmojis(EmojiIndicesByAlias);
     }
 
     errorHandler = (e, isFatal) => {

--- a/app/reducers/views/emoji.js
+++ b/app/reducers/views/emoji.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {combineReducers} from 'redux';
+import {UserTypes} from 'mattermost-redux/action_types';
+
+import {ViewTypes} from 'app/constants';
+
+function emojiPickerCustomPage(state = 0, action) {
+    switch (action.type) {
+    case ViewTypes.INCREMENT_EMOJI_PICKER_PAGE:
+        return state + 1;
+    case UserTypes.LOGOUT_SUCCESS:
+        return 0;
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    emojiPickerCustomPage
+});
+

--- a/app/reducers/views/index.js
+++ b/app/reducers/views/index.js
@@ -16,6 +16,7 @@ import search from './search';
 import selectServer from './select_server';
 import team from './team';
 import thread from './thread';
+import emoji from './emoji';
 
 export default combineReducers({
     announcement,
@@ -30,5 +31,6 @@ export default combineReducers({
     search,
     selectServer,
     team,
-    thread
+    thread,
+    emoji
 });

--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -43,7 +43,8 @@ class ChannelInfo extends PureComponent {
             getChannelStats: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired,
             favoriteChannel: PropTypes.func.isRequired,
-            unfavoriteChannel: PropTypes.func.isRequired
+            unfavoriteChannel: PropTypes.func.isRequired,
+            getCustomEmojisInText: PropTypes.func.isRequired
         })
     };
 
@@ -57,6 +58,7 @@ class ChannelInfo extends PureComponent {
 
     componentDidMount() {
         this.props.actions.getChannelStats(this.props.currentChannel.id);
+        this.props.actions.getCustomEmojisInText(this.props.currentChannel.header);
     }
 
     componentWillReceiveProps(nextProps) {

--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -11,6 +11,7 @@ import {
 } from 'app/actions/views/channel';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
+import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis';
 import {favoriteChannel, getChannelStats, deleteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {General} from 'mattermost-redux/constants';
 import {
@@ -68,7 +69,8 @@ function mapDispatchToProps(dispatch) {
             getChannelStats,
             leaveChannel,
             favoriteChannel,
-            unfavoriteChannel
+            unfavoriteChannel,
+            getCustomEmojisInText
         }, dispatch)
     };
 }

--- a/app/screens/select_server/index.js
+++ b/app/screens/select_server/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {getPing, resetPing} from 'mattermost-redux/actions/general';
+import {getPing, resetPing, setServerVersion} from 'mattermost-redux/actions/general';
 
 import {setLastUpgradeCheck} from 'app/actions/views/client_upgrade';
 import {loadConfigAndLicense} from 'app/actions/views/root';
@@ -37,7 +37,8 @@ function mapDispatchToProps(dispatch) {
             handleServerUrlChanged,
             loadConfigAndLicense,
             resetPing,
-            setLastUpgradeCheck
+            setLastUpgradeCheck,
+            setServerVersion
         }, dispatch)
     };
 }

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -40,7 +40,8 @@ class SelectServer extends PureComponent {
             handleServerUrlChanged: PropTypes.func.isRequired,
             loadConfigAndLicense: PropTypes.func.isRequired,
             resetPing: PropTypes.func.isRequired,
-            setLastUpgradeCheck: PropTypes.func.isRequired
+            setLastUpgradeCheck: PropTypes.func.isRequired,
+            setServerVersion: PropTypes.func.isRequired
         }).isRequired,
         allowOtherServers: PropTypes.bool,
         config: PropTypes.object,
@@ -214,7 +215,8 @@ class SelectServer extends PureComponent {
         const {
             getPing,
             handleServerUrlChanged,
-            loadConfigAndLicense
+            loadConfigAndLicense,
+            setServerVersion
         } = this.props.actions;
 
         this.setState({
@@ -245,6 +247,7 @@ class SelectServer extends PureComponent {
 
             if (!result.error) {
                 loadConfigAndLicense();
+                setServerVersion(Client4.getServerVersion());
             }
 
             this.setState({

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -94,26 +94,6 @@ export default function configureAppStore(initialState) {
         {whitelist: ['entities']} // Only run this filter on the entities state (or any other entry that ends up being named entities)
     );
 
-    const emojiBlackList = {nonExistentEmoji: true};
-    const emojiBlackListFilter = createTransform(
-        (inboundState) => {
-            const emojis = {};
-
-            for (const emojiKey of Object.keys(inboundState.emojis)) {
-                if (!emojiBlackList[emojiKey]) {
-                    emojis[emojiKey] = inboundState.emojis[emojiKey];
-                }
-            }
-
-            return {
-                ...inboundState,
-                emojis
-            };
-        },
-        null,
-        {whitelist: ['entities']} // Only run this filter on the entities state (or any other entry that ends up being named entities)
-    );
-
     const setTransformer = createTransform(
         (inboundState, key) => {
             if (key === 'entities') {

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -71,7 +71,27 @@ export default function configureAppStore(initialState) {
             };
         },
         null,
-        {whitelist: ['views']} // Only run this filter the views state (or any other entry that ends up being named views)
+        {whitelist: ['views']} // Only run this filter on the views state (or any other entry that ends up being named views)
+    );
+
+    const emojiBlackList = {nonExistentEmoji: true};
+    const emojiBlackListFilter = createTransform(
+        (inboundState) => {
+            const emojis = {};
+
+            for (const emojiKey of Object.keys(inboundState.emojis)) {
+                if (!emojiBlackList[emojiKey]) {
+                    emojis[emojiKey] = inboundState.emojis[emojiKey];
+                }
+            }
+
+            return {
+                ...inboundState,
+                emojis
+            };
+        },
+        null,
+        {whitelist: ['entities']} // Only run this filter on the entities state (or any other entry that ends up being named entities)
     );
 
     const emojiBlackList = {nonExistentEmoji: true};

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -176,5 +176,5 @@ const languages = {
 };
 
 export function getDisplayNameForLanguage(language) {
-    return languages[language.toLowerCase()] || '';
+    return languages[language.toLowerCase()] || '' || null;
 }

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -176,5 +176,5 @@ const languages = {
 };
 
 export function getDisplayNameForLanguage(language) {
-    return languages[language.toLowerCase()] || '' || null;
+    return languages[language.toLowerCase()] || '';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,7 +1684,13 @@ colors@0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5:
+combined-stream@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
@@ -4018,7 +4024,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux:
   version "1.2.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/17237100e4ba15c73e158973044282d1dcb5562e"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/624b545605695ade03aa0604ef14ba44c4f06d9f"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary
This PR does the following:
* Modified emojis to show blank until either the emoji metadata is loaded or found not to exist
* Adds an action when the channel info is shown to load any missing emojis in the channel header
* Adds a server request to emoji autocomplete (similar to how it's done for users)
* Adds custom emoji paging to the emoji picker

Two things to note:
1. I did not add any clearing of the new `nonExistentEmoji` entity when bringing the app to the foreground. The consequence of this is that if someone posts `:some_emoji_that_does_not_exist:`, you switch your app to the background, someone adds that emoji, you're not going to get the new emoji until close and re-open the app. I don't think it's worth clearing it every time you switch to the foreground but let me know if this is unacceptable
2. If someone deletes an emoji while you're not connected to the WS on the app, your store is going to think that emoji still exists and try to load an image for it. This will persist until next log out/in. Not sure how the app handles this for other entities and whether it's acceptable or not

This is my first RN PR, so let me know if I need to be doing something differently :)

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-123

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: iPhone 6 simulator, Nexus 6P
