### PR TITLE
Handle the good, warning, danger status for post attachments

### DIFF
--- a/app/components/slack_attachments/slack_attachment.js
+++ b/app/components/slack_attachments/slack_attachment.js
@@ -17,6 +17,12 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import InteractiveAction from './interactive_action';
 
+const STATUS_COLORS = {
+    good: '#00c100',
+    warning: '#dede01',
+    danger: '#e40303'
+};
+
 export default class SlackAttachment extends PureComponent {
     static propTypes = {
         attachment: PropTypes.object.isRequired,
@@ -228,8 +234,12 @@ export default class SlackAttachment extends PureComponent {
         }
 
         let borderStyle;
-        if (attachment.color && attachment.color[0] === '#') {
-            borderStyle = {borderLeftColor: attachment.color};
+        if (attachment.color) {
+            if (attachment.color[0] === '#') {
+                borderStyle = {borderLeftColor: attachment.color};
+            } else if (STATUS_COLORS.hasOwnProperty(attachment.color)) {
+                borderStyle = {borderLeftColor: STATUS_COLORS[attachment.color]};
+            }
         }
 
         const author = [];


### PR DESCRIPTION
#### Summary
The post attachments were showing the border color if an hex was used a a color but didn't handle the case when the colors were `good`, `warning` and `danger`