### PR TITLE
Update tooltip library

### DIFF
--- a/app/components/options_context/options_context.ios.js
+++ b/app/components/options_context/options_context.ios.js
@@ -3,7 +3,8 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import ToolTip from 'react-native-tooltip';
+
+import ToolTip from 'app/components/tooltip';
 
 export default class OptionsContext extends PureComponent {
     static propTypes = {

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -15,11 +15,11 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import PostBody from 'app/components/post_body';
 import PostHeader from 'app/components/post_header';
 import PostProfilePicture from 'app/components/post_profile_picture';
-import {isToolTipShowing} from 'app/components/tooltip';
 import {NavigationTypes} from 'app/constants';
 import {emptyFunction} from 'app/utils/general';
 import {preventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+import {getToolTipVisible} from 'app/utils/tooltip';
 
 import {Posts} from 'mattermost-redux/constants';
 import DelayedAction from 'mattermost-redux/utils/delayed_action';
@@ -265,7 +265,7 @@ class Post extends PureComponent {
             post
         } = this.props;
 
-        if (!isToolTipShowing) {
+        if (!getToolTipVisible()) {
             if (onPress && post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostPendingOrFailed(post)) {
                 preventDoubleTap(onPress, null, post);
             } else if (!isSearchResult && isPostEphemeral(post)) {
@@ -276,7 +276,7 @@ class Post extends PureComponent {
 
     handleReply = () => {
         const {post, onReply} = this.props;
-        if (!isToolTipShowing && onReply) {
+        if (!getToolTipVisible() && onReply) {
             return preventDoubleTap(onReply, null, post);
         }
 
@@ -322,13 +322,13 @@ class Post extends PureComponent {
     viewUserProfile = () => {
         const {isSearchResult} = this.props;
 
-        if (!isSearchResult && !isToolTipShowing) {
+        if (!isSearchResult && !getToolTipVisible()) {
             preventDoubleTap(this.goToUserProfile, this);
         }
     };
 
     toggleSelected = (selected) => {
-        if (!isToolTipShowing) {
+        if (!getToolTipVisible()) {
             this.setState({selected});
         }
     };

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -11,11 +11,11 @@ import {
 } from 'react-native';
 import {injectIntl, intlShape} from 'react-intl';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
-import {isToolTipShowing} from 'react-native-tooltip';
 
 import PostBody from 'app/components/post_body';
 import PostHeader from 'app/components/post_header';
 import PostProfilePicture from 'app/components/post_profile_picture';
+import {isToolTipShowing} from 'app/components/tooltip';
 import {NavigationTypes} from 'app/constants';
 import {emptyFunction} from 'app/utils/general';
 import {preventDoubleTap} from 'app/utils/tap';

--- a/app/components/tooltip.js
+++ b/app/components/tooltip.js
@@ -5,26 +5,28 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import RNToolTip from 'react-native-tooltip';
 
-export let isToolTipShowing = false;
+import {setToolTipVisible} from 'app/utils/tooltip';
 
-export default class Tooltip extends PureComponent {
+export default class ToolTip extends PureComponent {
     static propTypes = {
         onHide: PropTypes.func,
         onShow: PropTypes.func
     };
 
+    static isToolTipVisible = false;
+
     handleHide = () => {
         if (this.props.onHide) {
             this.props.onHide();
         }
-        isToolTipShowing = false;
+        setToolTipVisible(false);
     };
 
     handleShow = () => {
         if (this.props.onShow) {
             this.props.onShow();
         }
-        isToolTipShowing = true;
+        setToolTipVisible();
     };
 
     render() {

--- a/app/components/tooltip.js
+++ b/app/components/tooltip.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import RNToolTip from 'react-native-tooltip';
+
+export let isToolTipShowing = false;
+
+export default class Tooltip extends PureComponent {
+    static propTypes = {
+        onHide: PropTypes.func,
+        onShow: PropTypes.func
+    };
+
+    handleHide = () => {
+        if (this.props.onHide) {
+            this.props.onHide();
+        }
+        isToolTipShowing = false;
+    };
+
+    handleShow = () => {
+        if (this.props.onShow) {
+            this.props.onShow();
+        }
+        isToolTipShowing = true;
+    };
+
+    render() {
+        return (
+            <RNToolTip
+                {...this.props}
+                onHide={this.handleHide}
+                onShow={this.handleShow}
+            />
+        );
+    }
+}

--- a/app/components/tooltip.js
+++ b/app/components/tooltip.js
@@ -13,8 +13,6 @@ export default class ToolTip extends PureComponent {
         onShow: PropTypes.func
     };
 
-    static isToolTipVisible = false;
-
     handleHide = () => {
         if (this.props.onHide) {
             this.props.onHide();

--- a/app/utils/tooltip.js
+++ b/app/utils/tooltip.js
@@ -1,0 +1,12 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+let isToolTipVisible = false;
+
+export function setToolTipVisible(visible = true) {
+    isToolTipVisible = visible;
+}
+
+export function getToolTipVisible() {
+    return isToolTipVisible;
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-native-status-bar-size": "0.3.3",
     "react-native-svg": "6.1.3",
     "react-native-tableview": "2.1.0",
-    "react-native-tooltip": "enahum/react-native-tooltip",
+    "react-native-tooltip": "5.2.0",
     "react-native-vector-icons": "4.5.0",
     "react-native-video": "2.0.0",
     "react-native-youtube": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,9 +5317,9 @@ react-native-tableview@2.1.0:
   dependencies:
     prop-types "^15.6.0"
 
-react-native-tooltip@enahum/react-native-tooltip:
-  version "5.1.1"
-  resolved "https://codeload.github.com/enahum/react-native-tooltip/tar.gz/eb47f93a728813b58c01f23ec84f0b8b1bd70bd0"
+react-native-tooltip@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-tooltip/-/react-native-tooltip-5.2.0.tgz#4358ea1e9bdcb49dad28bf5881440b0182927422"
 
 react-native-vector-icons@4.5.0:
   version "4.5.0"


### PR DESCRIPTION
#### Summary
This PR helps us get rid of the fork for the react-native-tooltip, I'm going to keep the fork around for a couple of releases and then will delete it