### PR TITLE
ICU-639- Fixes bug with Samsung keyboard

### DIFF
--- a/app/components/search_bar/search_bar.android.js
+++ b/app/components/search_bar/search_bar.android.js
@@ -71,7 +71,7 @@ export default class SearchBarAndroid extends PureComponent {
         };
     }
     componentWillReceiveProps(nextProps) {
-        if (this.state.value.toLowerCase() !== nextProps.value.toLowerCase()) {
+        if (this.state.value !== nextProps.value) {
             this.setState({value: nextProps.value});
         }
     }

--- a/app/components/search_bar/search_bar.android.js
+++ b/app/components/search_bar/search_bar.android.js
@@ -66,8 +66,14 @@ export default class SearchBarAndroid extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {
+            value: props.value,
             isFocused: false
         };
+    }
+    componentWillReceiveProps(nextProps) {
+        if (this.state.value.toLowerCase() !== nextProps.value.toLowerCase()) {
+            this.setState({value: nextProps.value});
+        }
     }
 
     cancel = () => {
@@ -102,7 +108,9 @@ export default class SearchBarAndroid extends PureComponent {
     };
 
     onChangeText = (value) => {
-        this.props.onChangeText(value);
+        this.setState({value}, () => {
+            this.props.onChangeText(value);
+        });
     };
 
     onSelectionChange = (event) => {
@@ -196,7 +204,7 @@ export default class SearchBarAndroid extends PureComponent {
                     <TextInput
                         ref='input'
                         blurOnSubmit={blurOnSubmit}
-                        value={value}
+                        value={this.state.value}
                         autoCapitalize={autoCapitalize}
                         autoCorrect={false}
                         returnKeyType={returnKeyType || 'search'}

--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -205,7 +205,7 @@ class ChannelAddMembers extends PureComponent {
     };
 
     searchProfiles = (text) => {
-        const term = text.toLowerCase();
+        const term = text;
         const {actions, currentChannel, currentTeam} = this.props;
 
         if (term) {
@@ -213,7 +213,7 @@ class ChannelAddMembers extends PureComponent {
             clearTimeout(this.searchTimeoutId);
 
             this.searchTimeoutId = setTimeout(() => {
-                actions.searchProfiles(term, {not_in_channel_id: currentChannel.id, team_id: currentTeam.id});
+                actions.searchProfiles(term.toLowerCase(), {not_in_channel_id: currentChannel.id, team_id: currentTeam.id});
             }, General.SEARCH_TIMEOUT_MILLISECONDS);
         } else {
             this.cancelSearch();

--- a/app/screens/channel_members/channel_members.js
+++ b/app/screens/channel_members/channel_members.js
@@ -253,14 +253,14 @@ class ChannelMembers extends PureComponent {
     };
 
     searchProfiles = (text) => {
-        const term = text.toLowerCase();
+        const term = text;
 
         if (term) {
             this.setState({searching: true, term});
             clearTimeout(this.searchTimeoutId);
 
             this.searchTimeoutId = setTimeout(() => {
-                this.props.actions.searchProfiles(term, {in_channel_id: this.props.currentChannel.id});
+                this.props.actions.searchProfiles(term.toLowerCase(), {in_channel_id: this.props.currentChannel.id});
             }, General.SEARCH_TIMEOUT_MILLISECONDS);
         } else {
             this.cancelSearch();

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -149,15 +149,15 @@ class MoreChannels extends PureComponent {
     };
 
     searchProfiles = (text) => {
-        const term = text.toLowerCase();
+        const term = text;
 
         if (term) {
-            const channels = this.filterChannels(this.state.channels, term);
+            const channels = this.filterChannels(this.state.channels, term.toLowerCase());
             this.setState({channels, term, searching: true});
             clearTimeout(this.searchTimeoutId);
 
             this.searchTimeoutId = setTimeout(() => {
-                this.props.actions.searchChannels(this.props.currentTeamId, term);
+                this.props.actions.searchChannels(this.props.currentTeamId, term.toLowerCase());
             }, General.SEARCH_TIMEOUT_MILLISECONDS);
         } else {
             this.cancelSearch();

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -149,15 +149,19 @@ class MoreChannels extends PureComponent {
     };
 
     searchProfiles = (text) => {
-        const term = text;
+        const term = text.toLowerCase();
 
         if (term) {
-            const channels = this.filterChannels(this.state.channels, term.toLowerCase());
-            this.setState({channels, term, searching: true});
+            const channels = this.filterChannels(this.state.channels, term);
+            this.setState({
+                channels,
+                term: text,
+                searching: true
+            });
             clearTimeout(this.searchTimeoutId);
 
             this.searchTimeoutId = setTimeout(() => {
-                this.props.actions.searchChannels(this.props.currentTeamId, term.toLowerCase());
+                this.props.actions.searchChannels(this.props.currentTeamId, term);
             }, General.SEARCH_TIMEOUT_MILLISECONDS);
         } else {
             this.cancelSearch();

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -162,14 +162,14 @@ class MoreDirectMessages extends PureComponent {
     };
 
     onSearch = (text) => {
-        const term = text.toLowerCase();
+        const term = text;
 
         if (term) {
             this.setState({searching: true, term});
             clearTimeout(this.searchTimeoutId);
 
             this.searchTimeoutId = setTimeout(() => {
-                this.searchProfiles(term);
+                this.searchProfiles(term.toLowerCase());
             }, General.SEARCH_TIMEOUT_MILLISECONDS);
         } else {
             this.cancelSearch();


### PR DESCRIPTION
#### Summary
This PR internalizes the android's search input's value to the local state. The issue seemed to be the slight delay between propogating the value up the component tree, then back into the component as a prop caused the keyboard to duplicate input. 
It now handles state internally, unless the prop sent in is different (**case insensitive**) than the state, then is uses the prop value.

See video : https://www.youtube.com/watch?v=S69bPljpRFc

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-639
#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: Emulated Nexus 5X with Samsung S8 Keyboard

#### Screenshots
https://www.youtube.com/watch?v=S69bPljpRFc