### PR TITLE
Fix Android stuck when opening from push notification

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
@@ -1,10 +1,31 @@
 package com.mattermost.rnbeta;
 
+import android.os.Bundle;
+import android.support.annotation.Nullable;
 import com.reactnativenavigation.controllers.SplashActivity;
 
 public class MainActivity extends SplashActivity {
-  @Override
-  public int getSplashLayout() {
-      return R.layout.launch_screen;
-  }
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        /**
+         * Reference: https://stackoverflow.com/questions/7944338/resume-last-activity-when-launcher-icon-is-clicked
+         * 1. Open app from launcher/appDrawer
+         * 2. Go home
+         * 3. Send notification and open
+         * 4. It creates a new Activity and Destroys the old
+         * 5. Causing an unnecessary app restart
+         * 6. This solution short-circuits the restart
+         */
+        if (!isTaskRoot()) {
+            finish();
+            return;
+        }
+    }
+
+    @Override
+    public int getSplashLayout() {
+        return R.layout.launch_screen;
+    }
 }


### PR DESCRIPTION
#### Summary
When the app is running in the background and a push notification is tapped to open the app it was getting stuck in the Splash Screen (yes another thing causing the same issue)

This fix was found by Shift.

To be cherry-picked for a 1.6.1 dot release