### PR TITLE
ICU-624 Added markdown tables

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -24,6 +24,9 @@ import MarkdownImage from './markdown_image';
 import MarkdownLink from './markdown_link';
 import MarkdownList from './markdown_list';
 import MarkdownListItem from './markdown_list_item';
+import MarkdownTable from './markdown_table';
+import MarkdownTableRow from './markdown_table_row';
+import MarkdownTableCell from './markdown_table_cell';
 import {addListItemIndices, pullOutImages} from './transform';
 
 export default class Markdown extends PureComponent {
@@ -82,6 +85,10 @@ export default class Markdown extends PureComponent {
 
                 htmlBlock: this.renderHtml,
                 htmlInline: this.renderHtml,
+
+                table: MarkdownTable,
+                table_row: MarkdownTableRow,
+                table_cell: MarkdownTableCell,
 
                 editedIndicator: this.renderEditedIndicator
             },

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -309,9 +309,7 @@ export default class Markdown extends PureComponent {
 
     renderTable = ({children}) => {
         return (
-            <MarkdownTable
-                navigator={this.props.navigator}
-            >
+            <MarkdownTable navigator={this.props.navigator}>
                 {children}
             </MarkdownTable>
         );

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -25,6 +25,7 @@ import MarkdownLink from './markdown_link';
 import MarkdownList from './markdown_list';
 import MarkdownListItem from './markdown_list_item';
 import MarkdownTable from './markdown_table';
+import MarkdownTableImage from './markdown_table_image';
 import MarkdownTableRow from './markdown_table_row';
 import MarkdownTableCell from './markdown_table_cell';
 import {addListItemIndices, pullOutImages} from './transform';
@@ -131,6 +132,21 @@ export default class Markdown extends PureComponent {
     }
 
     renderImage = ({linkDestination, reactChildren, context, src}) => {
+        if (context.indexOf('table') !== -1) {
+            // We have enough problems rendering images as is, so just render a link inside of a table
+            return (
+                <MarkdownTableImage
+                    linkDestination={linkDestination}
+                    onLongPress={this.props.onLongPress}
+                    source={src}
+                    textStyle={[this.computeTextStyle(this.props.baseTextStyle, context), this.props.textStyles.link]}
+                    navigator={this.props.navigator}
+                >
+                    {reactChildren}
+                </MarkdownTableImage>
+            );
+        }
+
         return (
             <MarkdownImage
                 linkDestination={linkDestination}

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -86,7 +86,7 @@ export default class Markdown extends PureComponent {
                 htmlBlock: this.renderHtml,
                 htmlInline: this.renderHtml,
 
-                table: MarkdownTable,
+                table: this.renderTable,
                 table_row: MarkdownTableRow,
                 table_cell: MarkdownTableCell,
 
@@ -291,6 +291,16 @@ export default class Markdown extends PureComponent {
         return rendered;
     }
 
+    renderTable = ({children}) => {
+        return (
+            <MarkdownTable
+                navigator={this.props.navigator}
+            >
+                {children}
+            </MarkdownTable>
+        );
+    }
+
     renderLink = ({children, href}) => {
         return (
             <MarkdownLink
@@ -344,7 +354,8 @@ export default class Markdown extends PureComponent {
                 ast.appendChild(node);
             }
         }
-        return <View>{this.renderer.render(ast)}</View>;
+
+        return this.renderer.render(ast);
     }
 }
 

--- a/app/components/markdown/markdown_code_block/markdown_code_block.js
+++ b/app/components/markdown/markdown_code_block/markdown_code_block.js
@@ -145,7 +145,7 @@ class MarkdownCodeBlock extends React.PureComponent {
                 <FormattedText
                     style={style.plusMoreLinesText}
                     id='mobile.markdown.code.plusMoreLines'
-                    defaultMessage='+{count, number} more lines'
+                    defaultMessage='+{count, number} more {count, plural, one {line} other {lines}}'
                     values={{
                         count: numberOfLines - MAX_LINES
                     }}

--- a/app/components/markdown/markdown_table/index.js
+++ b/app/components/markdown/markdown_table/index.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import MarkdownTable from './markdown_table';
+
+function mapStateToProps(state) {
+    return {
+        theme: getTheme(state)
+    };
+}
+
+export default connect(mapStateToProps)(MarkdownTable);

--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -1,0 +1,116 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {PropTypes} from 'prop-types';
+import React from 'react';
+import {injectIntl, intlShape} from 'react-intl';
+import {
+    Clipboard,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View
+} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+import FormattedText from 'app/components/formatted_text';
+import {getDisplayNameForLanguage} from 'app/utils/markdown';
+import {wrapWithPreventDoubleTap} from 'app/utils/tap';
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+import mattermostManaged from 'app/mattermost_managed';
+
+class MarkdownTable extends React.PureComponent {
+    static propTypes = {
+        children: PropTypes.node,
+        intl: intlShape.isRequired,
+        navigator: PropTypes.object.isRequired,
+        theme: PropTypes.object.isRequired,
+        maxRows: PropTypes.number,
+        // content: PropTypes.string.isRequired,
+        textStyle: CustomPropTypes.Style,
+        onLongPress: PropTypes.func.isRequired
+    };
+
+    static defaultProps = {
+    };
+
+    handlePress = wrapWithPreventDoubleTap(() => {
+        // const {intl, navigator, theme} = this.props;
+
+        // navigator.push({
+        //     screen: 'Code',
+        //     title: intl.formatMessage({
+        //         id: 'mobile.routes.code.noLanguage',
+        //         defaultMessage: 'Code'
+        //     }),
+        //     animated: true,
+        //     backButtonTitle: '',
+        //     passProps: {
+        //         content: this.props.content
+        //     },
+        //     navigatorStyle: {
+        //         navBarTextColor: theme.sidebarHeaderTextColor,
+        //         navBarBackgroundColor: theme.sidebarHeaderBg,
+        //         navBarButtonColor: theme.sidebarHeaderTextColor,
+        //         screenBackgroundColor: theme.centerChannelBg
+        //     }
+        // });
+    });
+
+    handleLongPress = async () => {
+        if (!this.props.handleLongPress) {
+            return;
+        }
+        // const {formatMessage} = this.props.intl;
+
+        // const config = await mattermostManaged.getLocalConfig();
+
+        // let action;
+        // if (config.copyAndPasteProtection !== 'true') {
+        //     action = {
+        //         text: formatMessage({id: 'mobile.markdown.code.copy_code', defaultMessage: 'Copy Code'}),
+        //         onPress: this.handleCopyCode
+        //     };
+        // }
+
+        // this.props.onLongPress(action);
+    }
+
+    // handleCopyCode = () => {
+    //     Clipboard.setString(this.props.content);
+    // }
+
+    render() {
+        const style = getStyleSheet(this.props.theme);
+
+        let rows;
+        if (this.props.maxRows && this.props.children.length > this.props.maxRows) {
+            rows = this.props.children.slice(0, this.props.maxRows);
+        } else {
+            rows = this.props.children;
+        }
+
+        return (
+            <TouchableOpacity
+                onPress={this.handlePress}
+                onLongPress={this.handleLongPress}
+            >
+                <View style={style.table}>
+                    {rows}
+                </View>
+            </TouchableOpacity>
+        );
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        table: {
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderTopWidth: 1,
+            borderLeftWidth: 1
+        }
+    };
+});
+
+export default injectIntl(MarkdownTable);

--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -5,62 +5,64 @@ import {PropTypes} from 'prop-types';
 import React from 'react';
 import {injectIntl, intlShape} from 'react-intl';
 import {
-    Clipboard,
-    StyleSheet,
-    Text,
+    ScrollView,
     TouchableOpacity,
     View
 } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 
-import CustomPropTypes from 'app/constants/custom_prop_types';
-import FormattedText from 'app/components/formatted_text';
-import {getDisplayNameForLanguage} from 'app/utils/markdown';
 import {wrapWithPreventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
-import mattermostManaged from 'app/mattermost_managed';
+
+// import mattermostManaged from 'app/mattermost_managed';
+
+const MAX_HEIGHT = 120;
 
 class MarkdownTable extends React.PureComponent {
     static propTypes = {
-        children: PropTypes.node,
+        children: PropTypes.node.isRequired,
         intl: intlShape.isRequired,
         navigator: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
-        maxRows: PropTypes.number,
-        // content: PropTypes.string.isRequired,
-        textStyle: CustomPropTypes.Style,
-        onLongPress: PropTypes.func.isRequired
+        onLongPress: PropTypes.func
     };
 
-    static defaultProps = {
-    };
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            contentCutOff: true
+        };
+    }
 
     handlePress = wrapWithPreventDoubleTap(() => {
-        // const {intl, navigator, theme} = this.props;
+        const {intl, navigator, theme} = this.props;
 
-        // navigator.push({
-        //     screen: 'Code',
-        //     title: intl.formatMessage({
-        //         id: 'mobile.routes.code.noLanguage',
-        //         defaultMessage: 'Code'
-        //     }),
-        //     animated: true,
-        //     backButtonTitle: '',
-        //     passProps: {
-        //         content: this.props.content
-        //     },
-        //     navigatorStyle: {
-        //         navBarTextColor: theme.sidebarHeaderTextColor,
-        //         navBarBackgroundColor: theme.sidebarHeaderBg,
-        //         navBarButtonColor: theme.sidebarHeaderTextColor,
-        //         screenBackgroundColor: theme.centerChannelBg
-        //     }
-        // });
+        navigator.push({
+            screen: 'Table',
+            title: intl.formatMessage({
+                id: 'mobile.routes.table',
+                defaultMessage: 'Table'
+            }),
+            animated: true,
+            backButtonTitle: '',
+            passProps: {
+                renderRows: this.renderRows
+            },
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg
+            }
+        });
     });
 
     handleLongPress = async () => {
-        if (!this.props.handleLongPress) {
+        if (!this.props.onLongPress) {
             return;
         }
+
         // const {formatMessage} = this.props.intl;
 
         // const config = await mattermostManaged.getLocalConfig();
@@ -80,14 +82,48 @@ class MarkdownTable extends React.PureComponent {
     //     Clipboard.setString(this.props.content);
     // }
 
+    handleContentHeightChange = (contentWidth, contentHeight) => {
+        this.setState({
+            contentCutOff: contentHeight >= MAX_HEIGHT
+        });
+    }
+
+    renderRows = (drawBottomBorder = true) => {
+        const style = getStyleSheet(this.props.theme);
+
+        const tableStyle = [style.table];
+        if (drawBottomBorder) {
+            tableStyle.push(style.tableBottomBorder);
+        }
+
+        // Add an extra prop to the last row of the table so that it knows not to render a bottom border
+        // since the container should be rendering that
+        const rows = React.Children.toArray(this.props.children);
+        rows[rows.length - 1] = React.cloneElement(rows[rows.length - 1], {
+            isLastRow: true
+        });
+
+        return (
+            <View style={tableStyle}>
+                {rows}
+            </View>
+        );
+    }
+
     render() {
         const style = getStyleSheet(this.props.theme);
 
-        let rows;
-        if (this.props.maxRows && this.props.children.length > this.props.maxRows) {
-            rows = this.props.children.slice(0, this.props.maxRows);
-        } else {
-            rows = this.props.children;
+        let moreIndicator = null;
+        if (this.state.contentCutOff) {
+            moreIndicator = (
+                <LinearGradient
+                    colors={[
+                        changeOpacity(this.props.theme.centerChannelColor, 0.0),
+                        changeOpacity(this.props.theme.centerChannelColor, 0.1)
+                    ]}
+                    style={style.moreIndicator}
+                />
+            );
         }
 
         return (
@@ -95,9 +131,14 @@ class MarkdownTable extends React.PureComponent {
                 onPress={this.handlePress}
                 onLongPress={this.handleLongPress}
             >
-                <View style={style.table}>
-                    {rows}
-                </View>
+                <ScrollView
+                    onContentSizeChange={this.handleContentHeightChange}
+                    style={style.container}
+                    scrollEnabled={false}
+                >
+                    {this.renderRows(false)}
+                </ScrollView>
+                {moreIndicator}
             </TouchableOpacity>
         );
     }
@@ -105,10 +146,27 @@ class MarkdownTable extends React.PureComponent {
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
+        container: {
+            borderBottomWidth: 1,
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            maxHeight: MAX_HEIGHT
+        },
         table: {
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderLeftWidth: 1, // The right border is drawn by the MarkdownTableCell component
             borderTopWidth: 1,
-            borderLeftWidth: 1
+            flex: 1
+        },
+        tableBottomBorder: {
+            borderBottomWidth: 1,
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2)
+        },
+        moreIndicator: {
+            bottom: 0,
+            height: 20,
+            position: 'absolute',
+            right: 0,
+            width: '100%'
         }
     };
 });

--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -3,7 +3,7 @@
 
 import {PropTypes} from 'prop-types';
 import React from 'react';
-import {injectIntl, intlShape} from 'react-intl';
+import {intlShape} from 'react-intl';
 import {
     ScrollView,
     TouchableOpacity,
@@ -14,17 +14,17 @@ import LinearGradient from 'react-native-linear-gradient';
 import {wrapWithPreventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
-// import mattermostManaged from 'app/mattermost_managed';
-
 const MAX_HEIGHT = 120;
 
-class MarkdownTable extends React.PureComponent {
+export default class MarkdownTable extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node.isRequired,
-        intl: intlShape.isRequired,
         navigator: PropTypes.object.isRequired,
-        theme: PropTypes.object.isRequired,
-        onLongPress: PropTypes.func
+        theme: PropTypes.object.isRequired
+    };
+
+    static contextTypes = {
+        intl: intlShape.isRequired
     };
 
     constructor(props) {
@@ -36,11 +36,11 @@ class MarkdownTable extends React.PureComponent {
     }
 
     handlePress = wrapWithPreventDoubleTap(() => {
-        const {intl, navigator, theme} = this.props;
+        const {navigator, theme} = this.props;
 
         navigator.push({
             screen: 'Table',
-            title: intl.formatMessage({
+            title: this.context.intl.formatMessage({
                 id: 'mobile.routes.table',
                 defaultMessage: 'Table'
             }),
@@ -57,30 +57,6 @@ class MarkdownTable extends React.PureComponent {
             }
         });
     });
-
-    handleLongPress = async () => {
-        if (!this.props.onLongPress) {
-            return;
-        }
-
-        // const {formatMessage} = this.props.intl;
-
-        // const config = await mattermostManaged.getLocalConfig();
-
-        // let action;
-        // if (config.copyAndPasteProtection !== 'true') {
-        //     action = {
-        //         text: formatMessage({id: 'mobile.markdown.code.copy_code', defaultMessage: 'Copy Code'}),
-        //         onPress: this.handleCopyCode
-        //     };
-        // }
-
-        // this.props.onLongPress(action);
-    }
-
-    // handleCopyCode = () => {
-    //     Clipboard.setString(this.props.content);
-    // }
 
     handleContentHeightChange = (contentWidth, contentHeight) => {
         this.setState({
@@ -127,10 +103,7 @@ class MarkdownTable extends React.PureComponent {
         }
 
         return (
-            <TouchableOpacity
-                onPress={this.handlePress}
-                onLongPress={this.handleLongPress}
-            >
+            <TouchableOpacity onPress={this.handlePress}>
                 <ScrollView
                     onContentSizeChange={this.handleContentHeightChange}
                     style={style.container}
@@ -170,5 +143,3 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         }
     };
 });
-
-export default injectIntl(MarkdownTable);

--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -108,6 +108,7 @@ export default class MarkdownTable extends React.PureComponent {
                     onContentSizeChange={this.handleContentHeightChange}
                     style={style.container}
                     scrollEnabled={false}
+                    showsVerticalScrollIndicator={false}
                 >
                     {this.renderRows(false)}
                 </ScrollView>

--- a/app/components/markdown/markdown_table_cell/index.js
+++ b/app/components/markdown/markdown_table_cell/index.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import MarkdownTableCell from './markdown_table_cell';
+
+function mapStateToProps(state) {
+    return {
+        theme: getTheme(state)
+    };
+}
+
+export default connect(mapStateToProps)(MarkdownTableCell);

--- a/app/components/markdown/markdown_table_cell/markdown_table_cell.js
+++ b/app/components/markdown/markdown_table_cell/markdown_table_cell.js
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {View} from 'react-native';
+import {Text, View} from 'react-native';
 
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
@@ -22,7 +22,13 @@ export default class MarkdownTableCell extends React.PureComponent {
             cellStyle.push(style.heading);
         }
 
-        return <View style={cellStyle}>{this.props.children}</View>;
+        return (
+            <View style={cellStyle}>
+                <Text>
+                    {this.props.children}
+                </Text>
+            </View>
+        );
     }
 }
 

--- a/app/components/markdown/markdown_table_cell/markdown_table_cell.js
+++ b/app/components/markdown/markdown_table_cell/markdown_table_cell.js
@@ -10,13 +10,19 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 export default class MarkdownTableCell extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
+        isHeading: PropTypes.bool.isRequired,
         theme: PropTypes.object.isRequired
     };
 
     render() {
         const style = getStyleSheet(this.props.theme);
 
-        return <View style={style.cell}>{this.props.children}</View>;
+        const cellStyle = [style.cell];
+        if (this.props.isHeading) {
+            cellStyle.push(style.heading);
+        }
+
+        return <View style={cellStyle}>{this.props.children}</View>;
     }
 }
 
@@ -26,6 +32,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderRightWidth: 1,
             flex: 1,
+            justifyContent: 'flex-start',
             paddingHorizontal: 13,
             paddingVertical: 6
         }

--- a/app/components/markdown/markdown_table_cell/markdown_table_cell.js
+++ b/app/components/markdown/markdown_table_cell/markdown_table_cell.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {View} from 'react-native';
+
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+
+export default class MarkdownTableCell extends React.PureComponent {
+    static propTypes = {
+        children: PropTypes.node,
+        theme: PropTypes.object.isRequired
+    };
+
+    render() {
+        const style = getStyleSheet(this.props.theme);
+
+        return <View style={style.cell}>{this.props.children}</View>;
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        cell: {
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderRightWidth: 1,
+            flex: 1,
+            paddingHorizontal: 13,
+            paddingVertical: 6
+        }
+    };
+});

--- a/app/components/markdown/markdown_table_image/index.js
+++ b/app/components/markdown/markdown_table_image/index.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getCurrentUrl} from 'mattermost-redux/selectors/entities/general';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import MarkdownTableImage from './markdown_table_image';
+
+function mapStateToProps(state) {
+    return {
+        serverURL: getCurrentUrl(state),
+        theme: getTheme(state)
+    };
+}
+
+export default connect(mapStateToProps)(MarkdownTableImage);

--- a/app/components/markdown/markdown_table_image/markdown_table_image.js
+++ b/app/components/markdown/markdown_table_image/markdown_table_image.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {PropTypes} from 'prop-types';
+import React from 'react';
+import {injectIntl, intlShape} from 'react-intl';
+import {Text} from 'react-native';
+
+import CustomPropTypes from 'app/constants/custom_prop_types';
+import {wrapWithPreventDoubleTap} from 'app/utils/tap';
+
+// import mattermostManaged from 'app/mattermost_managed';
+
+class MarkdownTableImage extends React.PureComponent {
+    static propTypes = {
+        children: PropTypes.node.isRequired,
+        source: PropTypes.string.isRequired,
+        textStyle: CustomPropTypes.Style.isRequired,
+        onLongPress: PropTypes.func.isRequired,
+        intl: intlShape.isRequired,
+        navigator: PropTypes.object.isRequired,
+        serverURL: PropTypes.string.isRequired,
+        theme: PropTypes.object.isRequired
+    };
+
+    handlePress = wrapWithPreventDoubleTap(() => {
+        const {intl, navigator, theme} = this.props;
+
+        navigator.push({
+            screen: 'TableImage',
+            title: intl.formatMessage({
+                id: 'mobile.routes.tableImage',
+                defaultMessage: 'Image'
+            }),
+            animated: true,
+            backButtonTitle: '',
+            passProps: {
+                imageSource: this.getImageSource()
+            },
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg
+            }
+        });
+    });
+
+    handleLongPress = async () => {
+        if (!this.props.onLongPress) {
+            return;
+        }
+
+        // const {formatMessage} = this.props.intl;
+
+        // const config = await mattermostManaged.getLocalConfig();
+
+        // let action;
+        // if (config.copyAndPasteProtection !== 'true') {
+        //     action = {
+        //         text: formatMessage({id: 'mobile.markdown.code.copy_code', defaultMessage: 'Copy Code'}),
+        //         onPress: this.handleCopyCode
+        //     };
+        // }
+
+        // this.props.onLongPress(action);
+    }
+
+    // handleCopyCode = () => {
+    //     Clipboard.setString(this.props.content);
+    // }
+
+    getImageSource = () => {
+        let source = this.props.source;
+
+        if (source.startsWith('/')) {
+            source = this.props.serverURL + '/' + source;
+        }
+
+        return source;
+    };
+
+    render() {
+        return (
+            <Text
+                onPress={this.handlePress}
+                onLongPress={this.handleLongPress}
+                style={this.props.textStyle}
+            >
+                {this.props.children}
+            </Text>
+        );
+    }
+}
+
+export default injectIntl(MarkdownTableImage);

--- a/app/components/markdown/markdown_table_image/markdown_table_image.js
+++ b/app/components/markdown/markdown_table_image/markdown_table_image.js
@@ -50,7 +50,7 @@ export default class MarkdownTableImage extends React.PureComponent {
         let source = this.props.source;
 
         if (source.startsWith('/')) {
-            source = this.props.serverURL + '/' + source;
+            source = `${this.props.serverURL}/${source}`;
         }
 
         return source;

--- a/app/components/markdown/markdown_table_image/markdown_table_image.js
+++ b/app/components/markdown/markdown_table_image/markdown_table_image.js
@@ -3,32 +3,32 @@
 
 import {PropTypes} from 'prop-types';
 import React from 'react';
-import {injectIntl, intlShape} from 'react-intl';
+import {intlShape} from 'react-intl';
 import {Text} from 'react-native';
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
 import {wrapWithPreventDoubleTap} from 'app/utils/tap';
 
-// import mattermostManaged from 'app/mattermost_managed';
-
-class MarkdownTableImage extends React.PureComponent {
+export default class MarkdownTableImage extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node.isRequired,
         source: PropTypes.string.isRequired,
         textStyle: CustomPropTypes.Style.isRequired,
-        onLongPress: PropTypes.func.isRequired,
-        intl: intlShape.isRequired,
         navigator: PropTypes.object.isRequired,
         serverURL: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired
     };
 
+    static contextTypes = {
+        intl: intlShape.isRequired
+    };
+
     handlePress = wrapWithPreventDoubleTap(() => {
-        const {intl, navigator, theme} = this.props;
+        const {navigator, theme} = this.props;
 
         navigator.push({
             screen: 'TableImage',
-            title: intl.formatMessage({
+            title: this.context.intl.formatMessage({
                 id: 'mobile.routes.tableImage',
                 defaultMessage: 'Image'
             }),
@@ -46,30 +46,6 @@ class MarkdownTableImage extends React.PureComponent {
         });
     });
 
-    handleLongPress = async () => {
-        if (!this.props.onLongPress) {
-            return;
-        }
-
-        // const {formatMessage} = this.props.intl;
-
-        // const config = await mattermostManaged.getLocalConfig();
-
-        // let action;
-        // if (config.copyAndPasteProtection !== 'true') {
-        //     action = {
-        //         text: formatMessage({id: 'mobile.markdown.code.copy_code', defaultMessage: 'Copy Code'}),
-        //         onPress: this.handleCopyCode
-        //     };
-        // }
-
-        // this.props.onLongPress(action);
-    }
-
-    // handleCopyCode = () => {
-    //     Clipboard.setString(this.props.content);
-    // }
-
     getImageSource = () => {
         let source = this.props.source;
 
@@ -84,7 +60,6 @@ class MarkdownTableImage extends React.PureComponent {
         return (
             <Text
                 onPress={this.handlePress}
-                onLongPress={this.handleLongPress}
                 style={this.props.textStyle}
             >
                 {this.props.children}
@@ -92,5 +67,3 @@ class MarkdownTableImage extends React.PureComponent {
         );
     }
 }
-
-export default injectIntl(MarkdownTableImage);

--- a/app/components/markdown/markdown_table_row/index.js
+++ b/app/components/markdown/markdown_table_row/index.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import MarkdownTableRow from './markdown_table_row';
+
+function mapStateToProps(state) {
+    return {
+        theme: getTheme(state)
+    };
+}
+
+export default connect(mapStateToProps)(MarkdownTableRow);

--- a/app/components/markdown/markdown_table_row/markdown_table_row.js
+++ b/app/components/markdown/markdown_table_row/markdown_table_row.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {View} from 'react-native';
+
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+
+export default class MarkdownTableRow extends React.PureComponent {
+    static propTypes = {
+        children: PropTypes.node,
+        theme: PropTypes.object.isRequired
+    };
+
+    render() {
+        const style = getStyleSheet(this.props.theme);
+
+        return <View style={style.row}>{this.props.children}</View>;
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        row: {
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderBottomWidth: 1,
+            flex: 1,
+            flexDirection: 'row'
+        }
+    };
+});

--- a/app/components/markdown/markdown_table_row/markdown_table_row.js
+++ b/app/components/markdown/markdown_table_row/markdown_table_row.js
@@ -10,23 +10,32 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 export default class MarkdownTableRow extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
+        isLastRow: PropTypes.bool,
         theme: PropTypes.object.isRequired
     };
 
     render() {
         const style = getStyleSheet(this.props.theme);
 
-        return <View style={style.row}>{this.props.children}</View>;
+        const rowStyle = [style.row];
+        if (!this.props.isLastRow) {
+            rowStyle.push(style.rowBottomBorder);
+        }
+
+        return <View style={rowStyle}>{this.props.children}</View>;
     }
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         row: {
-            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
-            borderBottomWidth: 1,
             flex: 1,
-            flexDirection: 'row'
+            flexDirection: 'row',
+            justifyContent: 'flex-start'
+        },
+        rowBottomBorder: {
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderBottomWidth: 1
         }
     };
 });

--- a/app/screens/index.js
+++ b/app/screens/index.js
@@ -40,6 +40,7 @@ import Search from 'app/screens/search';
 import SelectServer from 'app/screens/select_server';
 import SelectTeam from 'app/screens/select_team';
 import Settings from 'app/screens/settings/general';
+import Table from 'app/screens/table';
 import Thread from 'app/screens/thread';
 import UserProfile from 'app/screens/user_profile';
 
@@ -95,6 +96,7 @@ export function registerScreens(store, Provider) {
     Navigation.registerComponent('SelectTeam', () => wrapWithContextProvider(SelectTeam), store, Provider);
     Navigation.registerComponent('Settings', () => wrapWithContextProvider(Settings), store, Provider);
     Navigation.registerComponent('SSO', () => wrapWithContextProvider(SSO), store, Provider);
+    Navigation.registerComponent('Table', () => wrapWithContextProvider(Table), store, Provider);
     Navigation.registerComponent('Thread', () => wrapWithContextProvider(Thread), store, Provider);
     Navigation.registerComponent('UserProfile', () => wrapWithContextProvider(UserProfile), store, Provider);
 }

--- a/app/screens/index.js
+++ b/app/screens/index.js
@@ -41,6 +41,7 @@ import SelectServer from 'app/screens/select_server';
 import SelectTeam from 'app/screens/select_team';
 import Settings from 'app/screens/settings/general';
 import Table from 'app/screens/table';
+import TableImage from 'app/screens/table_image';
 import Thread from 'app/screens/thread';
 import UserProfile from 'app/screens/user_profile';
 
@@ -97,6 +98,7 @@ export function registerScreens(store, Provider) {
     Navigation.registerComponent('Settings', () => wrapWithContextProvider(Settings), store, Provider);
     Navigation.registerComponent('SSO', () => wrapWithContextProvider(SSO), store, Provider);
     Navigation.registerComponent('Table', () => wrapWithContextProvider(Table), store, Provider);
+    Navigation.registerComponent('TableImage', () => wrapWithContextProvider(TableImage), store, Provider);
     Navigation.registerComponent('Thread', () => wrapWithContextProvider(Thread), store, Provider);
     Navigation.registerComponent('UserProfile', () => wrapWithContextProvider(UserProfile), store, Provider);
 }

--- a/app/screens/table/index.js
+++ b/app/screens/table/index.js
@@ -1,0 +1,6 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import Table from './table';
+
+export default Table;

--- a/app/screens/table/table.js
+++ b/app/screens/table/table.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {ScrollView, StyleSheet} from 'react-native';
+
+export default class Table extends React.PureComponent {
+    static propTypes = {
+        renderRows: PropTypes.func.isRequired
+    };
+
+    render() {
+        return (
+            <ScrollView
+                style={style.scrollContainer}
+                contentContainerStyle={style.container}
+            >
+                {this.props.renderRows()}
+            </ScrollView>
+        );
+    }
+}
+
+const style = StyleSheet.create({
+    scrollContainer: {
+        flex: 1
+    },
+    container: {
+        flexDirection: 'row'
+    }
+});

--- a/app/screens/table_image/index.js
+++ b/app/screens/table_image/index.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getDimensions} from 'app/selectors/device';
+
+import TableImage from './table_image';
+
+function mapStateToProps(state) {
+    return {
+        deviceWidth: getDimensions(state).deviceWidth
+    };
+}
+
+export default connect(mapStateToProps)(TableImage);

--- a/app/screens/table_image/table_image.js
+++ b/app/screens/table_image/table_image.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+    ActivityIndicator,
+    Image,
+    ScrollView,
+    StyleSheet,
+    View
+} from 'react-native';
+
+export default class TableImage extends React.PureComponent {
+    static propTypes = {
+        deviceWidth: PropTypes.number.isRequired,
+        imageSource: PropTypes.string.isRequired
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            width: -1,
+            height: -1
+        };
+    }
+
+    componentWillMount() {
+        this.getImageSize(this.props.imageSource);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (this.props.imageSource !== nextProps.imageSource) {
+            this.setState({
+                width: -1,
+                height: -1
+            });
+
+            this.getImageSize(nextProps.imageSource);
+        }
+    }
+
+    getImageSize = (imageSource) => {
+        Image.getSize(imageSource, (width, height) => {
+            this.setState({
+                width,
+                height
+            });
+        });
+    }
+
+    render() {
+        let {width, height} = this.state;
+
+        if (width === -1 || height === -1) {
+            return (
+                <View style={style.loadingContainer}>
+                    <ActivityIndicator
+                        animating={true}
+                        size='large'
+                    />
+                </View>
+            );
+        }
+
+        if (width > this.props.deviceWidth) {
+            height = (height / width) * this.props.deviceWidth;
+            width = this.props.deviceWidth;
+        }
+
+        return (
+            <ScrollView
+                style={style.scrollContainer}
+                contentContainerStyle={style.container}
+            >
+                <Image
+                    style={[style.image, {width, height}]}
+                    source={{uri: this.props.imageSource}}
+                />
+            </ScrollView>
+        );
+    }
+}
+
+const style = StyleSheet.create({
+    scrollContainer: {
+        flex: 1
+    },
+    container: {
+        flex: 1,
+        flexDirection: 'column'
+    },
+    image: {
+        resizeMode: 'contain'
+    },
+    loadingContainer: {
+        alignItems: 'center',
+        flex: 1,
+        justifyContent: 'center'
+    }
+});

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -92,6 +92,9 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
         },
         error: {
             color: theme.errorTextColor
+        },
+        table_header_row: {
+            fontWeight: '700'
         }
     };
 });

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -2052,7 +2052,7 @@
   "mobile.managed.jailbreak": "Jailbroken devices are not trusted by {vendor}, please exit the app.",
   "mobile.managed.secured_by": "Secured by {vendor}",
   "mobile.markdown.code.copy_code": "Copy Code",
-  "mobile.markdown.code.plusMoreLines": "+{count, number} more lines",
+  "mobile.markdown.code.plusMoreLines": "+{count, number} more {count, plural, one {line} other {lines}}",
   "mobile.markdown.image.error": "Image failed to load:",
   "mobile.markdown.image.too_large": "Image exceeds max dimensions of {maxWidth} by {maxHeight}:",
   "mobile.markdown.link.copy_url": "Copy URL",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -2141,6 +2141,8 @@
   "mobile.routes.selectTeam": "Select Team",
   "mobile.routes.settings": "Settings",
   "mobile.routes.sso": "Single Sign-On",
+  "mobile.routes.table": "Table",
+  "mobile.routes.tableImage": "Image",
   "mobile.routes.thread": "{channelName} Thread",
   "mobile.routes.thread_dm": "Direct Message Thread",
   "mobile.routes.user_profile": "Profile",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "analytics-react-native": "1.2.0",
     "babel-polyfill": "6.26.0",
     "commonmark": "hmhealey/commonmark.js",
-    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#tables",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer",
     "deep-equal": "1.0.1",
     "fuse.js": "^3.2.0",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "analytics-react-native": "1.2.0",
     "babel-polyfill": "6.26.0",
-    "commonmark": "hmhealey/commonmark.js#dda6d89198252d5fd4bb04c4cc0668766c22fd77",
-    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#1f078d53b7993d30b2762dd7d78fdd21ee84dd21",
+    "commonmark": "hmhealey/commonmark.js",
+    "commonmark-react-renderer": "hmhealey/commonmark-react-renderer#tables",
     "deep-equal": "1.0.1",
     "fuse.js": "^3.2.0",
     "intl": "1.2.5",

--- a/test/app/components/markdown/transform.test.js
+++ b/test/app/components/markdown/transform.test.js
@@ -338,6 +338,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -348,6 +349,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -383,6 +385,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -434,7 +437,8 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
-            assert.deepEqual(actual, expected);
+            assert.equal(astToString(actual), astToString(expected));
+            assert.deepStrictEqual(actual, expected);
         });
 
         it('paragraph with multiple images', () => {
@@ -487,6 +491,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -643,6 +648,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -684,6 +690,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -745,6 +752,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -844,6 +852,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -917,6 +926,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -1131,6 +1141,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -1397,6 +1408,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -1699,7 +1711,8 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
-            assert.deepEqual(actual, expected);
+            assert.equal(astToString(actual), astToString(expected));
+            assert.deepStrictEqual(actual, expected);
         });
 
         it('simple link', () => {
@@ -1743,6 +1756,7 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
 
@@ -1808,6 +1822,157 @@ describe('Components.Markdown.transform', () => {
             const actual = pullOutImages(input);
 
             assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('table', () => {
+            const input = makeAst({
+                type: 'document',
+                children: [{
+                    type: 'table',
+                    children: [{
+                        type: 'table_row',
+                        isHeading: true,
+                        children: [{
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }]
+                        }, {
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'text',
+                                literal: 'This is '
+                            }, {
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }, {
+                                type: 'text',
+                                literal: ' in a sentence.'
+                            }]
+                        }]
+                    }, {
+                        type: 'table_row',
+                        isHeading: true,
+                        children: [{
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'text',
+                                literal: 'This is '
+                            }, {
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }, {
+                                type: 'text',
+                                literal: ' in a sentence.'
+                            }]
+                        }, {
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }]
+                        }]
+                    }]
+                }]
+            });
+            const expected = makeAst({
+                type: 'document',
+                children: [{
+                    type: 'table',
+                    children: [{
+                        type: 'table_row',
+                        isHeading: true,
+                        children: [{
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }]
+                        }, {
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'text',
+                                literal: 'This is '
+                            }, {
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }, {
+                                type: 'text',
+                                literal: ' in a sentence.'
+                            }]
+                        }]
+                    }, {
+                        type: 'table_row',
+                        isHeading: true,
+                        children: [{
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'text',
+                                literal: 'This is '
+                            }, {
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }, {
+                                type: 'text',
+                                literal: ' in a sentence.'
+                            }]
+                        }, {
+                            type: 'table_cell',
+                            isHeading: true,
+                            children: [{
+                                type: 'image',
+                                destination: 'http://example.com/image',
+                                children: [{
+                                    type: 'text',
+                                    literal: 'image1'
+                                }]
+                            }]
+                        }]
+                    }]
+                }]
+            });
+            const actual = pullOutImages(input);
+
+            assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,9 +1702,9 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
-commonmark-react-renderer@hmhealey/commonmark-react-renderer#tables:
+commonmark-react-renderer@hmhealey/commonmark-react-renderer:
   version "4.3.3"
-  resolved "https://codeload.github.com/hmhealey/commonmark-react-renderer/tar.gz/30c05832393d97009c1cb1081bf41e78a847c1ac"
+  resolved "https://codeload.github.com/hmhealey/commonmark-react-renderer/tar.gz/86fa63f898802953842526c2030f3b63c5d1ae7a"
   dependencies:
     in-publish "^2.0.0"
     lodash.assign "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,7 +1714,7 @@ commonmark-react-renderer@hmhealey/commonmark-react-renderer:
 
 commonmark@hmhealey/commonmark.js:
   version "0.28.0"
-  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/3a70bc2764d10e484ad0d5784987e78a070a5484"
+  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/f7bc747151e6d856ceffa196044112e23d04e541"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,9 +1702,9 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
-commonmark-react-renderer@hmhealey/commonmark-react-renderer#1f078d53b7993d30b2762dd7d78fdd21ee84dd21:
+commonmark-react-renderer@hmhealey/commonmark-react-renderer#tables:
   version "4.3.3"
-  resolved "https://codeload.github.com/hmhealey/commonmark-react-renderer/tar.gz/1f078d53b7993d30b2762dd7d78fdd21ee84dd21"
+  resolved "https://codeload.github.com/hmhealey/commonmark-react-renderer/tar.gz/30c05832393d97009c1cb1081bf41e78a847c1ac"
   dependencies:
     in-publish "^2.0.0"
     lodash.assign "^4.2.0"
@@ -1712,9 +1712,9 @@ commonmark-react-renderer@hmhealey/commonmark-react-renderer#1f078d53b7993d30b27
     pascalcase "^0.1.1"
     xss-filters "^1.2.6"
 
-commonmark@hmhealey/commonmark.js#dda6d89198252d5fd4bb04c4cc0668766c22fd77:
+commonmark@hmhealey/commonmark.js:
   version "0.28.0"
-  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/dda6d89198252d5fd4bb04c4cc0668766c22fd77"
+  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/3a70bc2764d10e484ad0d5784987e78a070a5484"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"


### PR DESCRIPTION
A large portion of the changes for this are in the commonmark.js fork. The rest is mostly styling to render them as `<table><tr><td>...` is rendered in the web app.

The only really notable thing that doesn't work quite as expected is that images inside of markdown tables are rendered as links that open the image when you click on them. This is because getting images to work inside a table is incredibly difficult

commonmark changes: https://github.com/hmhealey/commonmark.js/pull/3
commonmark-react-renderer changes: https://github.com/hmhealey/commonmark-react-renderer/commit/86fa63f898802953842526c2030f3b63c5d1ae7a

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-624

#### Checklist
- Added or updated unit tests (required for all new features)
- Has UI changes
- Includes text changes and localization file updates

#### Device Information
This PR was tested on: iOS Simulator (iPhone 6, iOS 11.2), Nexus 5 (Android 6.0.1)

#### Screenshots
<img width="399" alt="screen shot 2018-02-13 at 2 51 18 pm" src="https://user-images.githubusercontent.com/3277310/36170439-62d7a1e8-10cd-11e8-90f7-21188181cb03.png">
![screenshot_20180214-025906](https://user-images.githubusercontent.com/3277310/36170832-925c3dd8-10ce-11e8-9ec9-d75e51354dbb.png)

