### PR TITLE
RN-9379 Updated react-native-sentry to 0.34.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,6 +80,11 @@ apply from: "../../node_modules/react-native/react.gradle"
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
 
 if (System.getenv("SENTRY_ENABLED") == "true") {
+    project.ext.sentryCli = [
+        logLevel: "debug",
+        flavorAware: true
+    ]
+
     apply from: "../../node_modules/react-native-sentry/sentry.gradle"
 }
 

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -96,6 +96,11 @@ export default class Mattermost {
     }
 
     errorHandler = (e, isFatal) => {
+        if (!e) {
+            // This method gets called for propTypes errors in dev mode without an exception
+            return;
+        }
+
         console.warn('Handling Javascript error ' + JSON.stringify(e)); // eslint-disable-line no-console
         captureException(e, LOGGER_JAVASCRIPT, this.store);
 

--- a/app/screens/settings/advanced_settings/advanced_settings.js
+++ b/app/screens/settings/advanced_settings/advanced_settings.js
@@ -12,6 +12,7 @@ import {
     Text,
     View
 } from 'react-native';
+import {Sentry} from 'react-native-sentry';
 
 import {getFormattedFileSize} from 'mattermost-redux/utils/file_utils';
 
@@ -20,6 +21,8 @@ import StatusBar from 'app/components/status_bar';
 import {deleteFileCache, getFileCacheSize} from 'app/utils/file';
 import {wrapWithPreventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+
+import Config from 'assets/config';
 
 class AdvancedSettings extends PureComponent {
     static propTypes = {
@@ -114,6 +117,42 @@ class AdvancedSettings extends PureComponent {
         return component;
     };
 
+    renderSentryDebugOptions = () => {
+        if (!Config.ShowSentryDebugOptions) {
+            return null;
+        }
+
+        const {theme} = this.props;
+        const style = getStyleSheet(theme);
+
+        return (
+            <View>
+                <SettingsItem
+                    defaultMessage='Throw JavaScript Exception'
+                    i18nId='mobile.advanced_settings.throw_javascript_exception'
+                    iconName='md-flame'
+                    iconType='ion'
+                    onPress={Sentry.crash}
+                    separator={false}
+                    showArrow={false}
+                    theme={theme}
+                />
+                <View style={style.divider}/>
+                <SettingsItem
+                    defaultMessage='Throw Native Exception'
+                    i18nId='mobile.advanced_settings.throw_native_exception'
+                    iconName='md-nuclear'
+                    iconType='ion'
+                    onPress={Sentry.nativeCrash}
+                    separator={false}
+                    showArrow={false}
+                    theme={theme}
+                />
+                <View style={style.divider}/>
+            </View>
+        );
+    }
+
     render() {
         const {theme} = this.props;
         const style = getStyleSheet(theme);
@@ -149,6 +188,7 @@ class AdvancedSettings extends PureComponent {
                         theme={theme}
                     />
                     <View style={style.divider}/>
+                    {this.renderSentryDebugOptions()}
                 </ScrollView>
             </View>
         );

--- a/app/screens/settings/advanced_settings/advanced_settings.js
+++ b/app/screens/settings/advanced_settings/advanced_settings.js
@@ -129,7 +129,6 @@ class AdvancedSettings extends PureComponent {
             <View>
                 <SettingsItem
                     defaultMessage='Throw JavaScript Exception'
-                    i18nId='mobile.advanced_settings.throw_javascript_exception'
                     iconName='md-flame'
                     iconType='ion'
                     onPress={Sentry.crash}
@@ -140,7 +139,6 @@ class AdvancedSettings extends PureComponent {
                 <View style={style.divider}/>
                 <SettingsItem
                     defaultMessage='Throw Native Exception'
-                    i18nId='mobile.advanced_settings.throw_native_exception'
                     iconName='md-nuclear'
                     iconType='ion'
                     onPress={Sentry.nativeCrash}

--- a/app/screens/settings/settings_item/index.js
+++ b/app/screens/settings/settings_item/index.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {TouchableOpacity, View} from 'react-native';
+import {Text, TouchableOpacity, View} from 'react-native';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
 
 import FormattedText from 'app/components/formatted_text';
@@ -14,7 +14,7 @@ import getStyleSheet from './style';
 export default class SettingsItem extends PureComponent {
     static propTypes = {
         defaultMessage: PropTypes.string.isRequired,
-        i18nId: PropTypes.string.isRequired,
+        i18nId: PropTypes.string,
         iconName: PropTypes.string,
         iconType: PropTypes.oneOf(['fontawesome', 'foundation', 'ion', 'material']),
         isDestructor: PropTypes.bool,
@@ -31,11 +31,41 @@ export default class SettingsItem extends PureComponent {
         separator: true
     };
 
-    render() {
+    renderText = () => {
         const {
             centered,
             defaultMessage,
             i18nId,
+            isDestructor,
+            theme
+        } = this.props;
+        const style = getStyleSheet(theme);
+
+        const textStyle = [style.label];
+
+        if (isDestructor) {
+            textStyle.push(style.destructor);
+        }
+
+        if (centered) {
+            textStyle.push(style.centerLabel);
+        }
+
+        if (!i18nId) {
+            return <Text style={textStyle}>{defaultMessage}</Text>;
+        }
+
+        return (
+            <FormattedText
+                id={i18nId}
+                defaultMessage={defaultMessage}
+                style={textStyle}
+            />
+        );
+    }
+
+    render() {
+        const {
             iconName,
             iconType,
             isDestructor,
@@ -47,11 +77,6 @@ export default class SettingsItem extends PureComponent {
         } = this.props;
         const style = getStyleSheet(theme);
 
-        const destructor = {};
-        if (isDestructor) {
-            destructor.color = theme.errorTextColor;
-        }
-
         let divider;
         if (separator) {
             divider = (<View style={style.divider}/>);
@@ -59,11 +84,16 @@ export default class SettingsItem extends PureComponent {
 
         let icon;
         if (iconType && iconName) {
+            const iconStyle = [style.icon];
+            if (isDestructor) {
+                iconStyle.push(style.destructor);
+            }
+
             icon = (
                 <VectorIcon
                     name={iconName}
                     type={iconType}
-                    style={[style.icon, destructor]}
+                    style={iconStyle}
                 />
             );
         }
@@ -92,11 +122,7 @@ export default class SettingsItem extends PureComponent {
                     }
                     <View style={style.wrapper}>
                         <View style={style.labelContainer}>
-                            <FormattedText
-                                id={i18nId}
-                                defaultMessage={defaultMessage}
-                                style={[style.label, destructor, centered ? style.centerLabel : {}]}
-                            />
+                            {this.renderText()}
                             {Boolean(additionalComponent) &&
                             <View style={style.arrowContainer}>
                                 {additionalComponent}

--- a/app/screens/settings/settings_item/style.android.js
+++ b/app/screens/settings/settings_item/style.android.js
@@ -48,6 +48,9 @@ export default makeStyleSheetFromTheme((theme) => {
         arrowContainer: {
             justifyContent: 'center',
             paddingRight: 15
+        },
+        destructor: {
+            color: theme.errorTextColor
         }
     };
 });

--- a/app/screens/settings/settings_item/style.ios.js
+++ b/app/screens/settings/settings_item/style.ios.js
@@ -53,6 +53,9 @@ export default makeStyleSheetFromTheme((theme) => {
         divider: {
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
             height: 1
+        },
+        destructor: {
+            color: theme.errorTextColor
         }
     };
 });

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -39,5 +39,7 @@
     "MobileClientUpgradeAndroidApkLink": "https://about.mattermost.com/mattermost-android-app/",
     "MobileClientUpgradeIosIpaLink": "https://about.mattermost.com/mattermost-ios-app/",
 
-    "AppGroupId": "group.com.mattermost.rnbeta"
+    "AppGroupId": "group.com.mattermost.rnbeta",
+
+    "ShowSentryDebugOptions": false
 }

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1934,8 +1934,6 @@
   "mobile.advanced_settings.reset_button": "Reset",
   "mobile.advanced_settings.reset_message": "\nThis will reset all offline data and restart the app. You will be automatically logged back in once the app restarts.\n",
   "mobile.advanced_settings.reset_title": "Reset Cache",
-  "mobile.advanced_settings.throw_javascript_exception": "Throw JavaScript Exception",
-  "mobile.advanced_settings.throw_nuclear_exception": "Throw Nuclear Exception",
   "mobile.advanced_settings.title": "Advanced Settings",
   "mobile.android.camera_permission_denied_description": "To take photos and videos with your camera, please change your permission settings.",
   "mobile.android.camera_permission_denied_title": "Camera access is required",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1934,6 +1934,8 @@
   "mobile.advanced_settings.reset_button": "Reset",
   "mobile.advanced_settings.reset_message": "\nThis will reset all offline data and restart the app. You will be automatically logged back in once the app restarts.\n",
   "mobile.advanced_settings.reset_title": "Reset Cache",
+  "mobile.advanced_settings.throw_javascript_exception": "Throw JavaScript Exception",
+  "mobile.advanced_settings.throw_nuclear_exception": "Throw Nuclear Exception",
   "mobile.advanced_settings.title": "Advanced Settings",
   "mobile.android.camera_permission_denied_description": "To take photos and videos with your camera, please change your permission settings.",
   "mobile.android.camera_permission_denied_title": "Camera access is required",

--- a/ios/bundleReactNative.sh
+++ b/ios/bundleReactNative.sh
@@ -8,7 +8,7 @@ if [[ "${SENTRY_ENABLED}" = "true" ]]; then
 	./makeSentryProperties.sh
 
 	export SENTRY_PROPERTIES=sentry.properties
-	../node_modules/sentry-cli-binary/bin/sentry-cli react-native xcode ./react-native-xcode.sh
+	../node_modules/@sentry/cli/bin/sentry-cli react-native xcode ./react-native-xcode.sh
 else
 	echo "Sentry native integration is not enabled"
 	./react-native-xcode.sh

--- a/ios/makeSentryProperties.sh
+++ b/ios/makeSentryProperties.sh
@@ -4,7 +4,7 @@ sentry_properties="defaults.url=https://sentry.io
 defaults.org=${SENTRY_ORG}
 defaults.project=${SENTRY_PROJECT_IOS}
 auth.token=${SENTRY_AUTH_TOKEN}
-cli.executable=../node_modules/sentry-cli-binary/bin/sentry-cli"
+cli.executable=../node_modules/@sentry/cli/bin/sentry-cli"
 
 if [[ "${SENTRY_ENABLED}" = "true" ]]; then
 	if [[ ! -f "sentry.properties" ]]; then

--- a/ios/uploadDebugSymbols.sh
+++ b/ios/uploadDebugSymbols.sh
@@ -8,7 +8,7 @@ if [[ "${SENTRY_ENABLED}" = "true" ]]; then
 	./makeSentryProperties.sh
 
 	export SENTRY_PROPERTIES=sentry.properties
-	../node_modules/sentry-cli-binary/bin/sentry-cli upload-dsym
+	../node_modules/@sentry/cli/bin/sentry-cli upload-dsym
 else
 	echo "Not uploading debugging symbols to Sentry because Sentry is disabled"
 fi

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native-permissions": "1.1.1",
     "react-native-safe-area": "0.2.3",
     "react-native-section-list-get-item-layout": "2.2.1",
-    "react-native-sentry": "0.15.1",
+    "react-native-sentry": "0.34.0",
     "react-native-slider": "0.11.0",
     "react-native-status-bar-size": "0.3.3",
     "react-native-svg": "6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,30 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@sentry/cli@^1.28.4":
+  version "1.29.1"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.29.1.tgz#2b6f3bb5efa49a06a189fc49caa87b42a7b878d8"
+  dependencies:
+    https-proxy-agent "^2.1.1"
+    node-fetch "^1.7.3"
+    progress "2.0.0"
+    proxy-from-env "^1.0.0"
+
+"@sentry/wizard@^0.8.1":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-0.8.2.tgz#d6e0c0fa229b395a2b26c8658115e72b448dffb9"
+  dependencies:
+    "@sentry/cli" "^1.28.4"
+    chalk "^2.3.0"
+    glob "^7.1.2"
+    inquirer "^5.0.1"
+    lodash "^4.17.4"
+    open "^0.0.5"
+    r2 "^2.0.0"
+    read-env "^1.1.1"
+    xcode "^1.0.0"
+    yargs "^11.0.0"
+
 "@types/node@^6.0.46":
   version "6.0.90"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.90.tgz#0ed74833fa1b73dcdb9409dcb1c97ec0a8b13b02"
@@ -112,6 +136,12 @@ acorn@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
+agent-base@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -168,6 +198,10 @@ ansi-escapes@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -180,7 +214,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -1334,8 +1368,8 @@ beeper@^1.0.0:
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
 
 big-integer@^1.6.7:
-  version "1.6.25"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.25.tgz#1de45a9f57542ac20121c682f8d642220a34e823"
+  version "1.6.26"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.26.tgz#3af1672fa62daf2d5ecafacf6e5aa0d25e02c1c8"
 
 binary-extensions@^1.0.0:
   version "1.10.0"
@@ -1412,8 +1446,8 @@ bplist-parser@0.1.1:
     big-integer "^1.6.7"
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1497,7 +1531,7 @@ caniuse-lite@^1.0.30000755:
   version "1.0.30000757"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000757.tgz#81e3bc029728a032933501994ef79db1c21159e3"
 
-caseless@~0.12.0:
+caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
@@ -1555,6 +1589,18 @@ chalk@^2.0.1:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 check-error@^1.0.1:
   version "1.0.2"
@@ -1624,6 +1670,14 @@ cliui@^3.2.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
+cliui@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
 clone-stats@^0.0.1:
@@ -2263,6 +2317,16 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-html@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.2.tgz#d77d32fa98e38c2f41ae85e9278e0e0e6ba1022c"
@@ -2505,13 +2569,21 @@ external-editor@^1.0.1:
     spawn-sync "^1.0.15"
     tmp "^0.0.29"
 
-external-editor@^2.0.1, external-editor@^2.0.4:
+external-editor@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
   dependencies:
     iconv-lite "^0.4.17"
     jschardet "^1.4.2"
     tmp "^0.0.31"
+
+external-editor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
 
 extglob@^0.3.1:
   version "0.3.2"
@@ -2903,17 +2975,6 @@ glob@7.0.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -3052,6 +3113,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
@@ -3172,6 +3237,13 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
 iconv-lite@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
@@ -3234,24 +3306,6 @@ inquirer@1.1.3:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-inquirer@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
-  dependencies:
-    ansi-escapes "^1.1.0"
-    chalk "^1.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^2.0.1"
-    figures "^2.0.0"
-    lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rx "^4.1.0"
-    string-width "^2.0.0"
-    strip-ansi "^3.0.0"
-    through "^2.3.6"
-
 inquirer@^3.0.6:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.3.tgz#1c7b1731cf77b934ec47d22c9ac5aa8fe7fbe095"
@@ -3267,6 +3321,24 @@ inquirer@^3.0.6:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.1.0.tgz#19da508931892328abbbdd4c477f1efc65abfd67"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -3481,7 +3553,7 @@ is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
@@ -3633,8 +3705,8 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
 jschardet@^1.4.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
 
 jsdom-global@3.0.2:
   version "3.0.2"
@@ -3983,7 +4055,7 @@ lodash.unset@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.unset/-/lodash.unset-4.5.2.tgz#370d1d3e85b72a7e1b0cdf2d272121306f23e4ed"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.8.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.6.1, lodash@^4.8.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3991,7 +4063,7 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.17.4:
+lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -4211,8 +4283,8 @@ mime@^1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.0.tgz#69e9e0db51d44f2a3b56e48b7817d7d137f1a343"
 
 mimic-fn@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -4358,12 +4430,16 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-node-fetch@^1.0.1, node-fetch@^1.3.3:
+node-fetch@^1.0.1, node-fetch@^1.3.3, node-fetch@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.0.0-alpha.8:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0.tgz#982bba43ecd4f2922a29cc186a6bbb0bb73fcba6"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4583,6 +4659,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
+
 opn@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/opn/-/opn-3.0.3.tgz#b6d99e7399f78d65c3baaffef1fb288e9b85243a"
@@ -4634,7 +4714,7 @@ os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -4881,6 +4961,10 @@ proxy-addr@~2.0.2:
     forwarded "~0.1.2"
     ipaddr.js "1.5.2"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -4912,6 +4996,14 @@ querystring@0.2.0, querystring@^0.2.0:
 querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+
+r2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/r2/-/r2-2.0.0.tgz#fadc6558ac96f230d3dfa5bc039f0f97771968d9"
+  dependencies:
+    caseless "^0.12.0"
+    node-fetch "^2.0.0-alpha.8"
+    typedarray-to-buffer "^3.1.2"
 
 raf@=3.2.0:
   version "3.2.0"
@@ -4965,9 +5057,9 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@^3.16.1:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.17.0.tgz#779457ac7910512c3c2cc9bb6d0a9eeb59a969ec"
+raven-js@^3.22.1:
+  version "3.22.3"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.22.3.tgz#8330dcc102b699ffbc2f48790978b997bf4d8f75"
 
 raw-body@2.3.2:
   version "2.3.2"
@@ -5278,16 +5370,12 @@ react-native-section-list-get-item-layout@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-native-section-list-get-item-layout/-/react-native-section-list-get-item-layout-2.2.1.tgz#2a946561f7318e2fb5fb6b03027ba4f630689a69"
 
-react-native-sentry@0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/react-native-sentry/-/react-native-sentry-0.15.1.tgz#fd5e685faa8de8fc4f472703b57e023d45ee53aa"
+react-native-sentry@0.34.0:
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/react-native-sentry/-/react-native-sentry-0.34.0.tgz#de015b8123d35d93644efe68bb91fb93a055b801"
   dependencies:
-    chalk "^1.1.1"
-    glob "7.1.1"
-    inquirer "3.0.6"
-    raven-js "^3.16.1"
-    sentry-cli-binary "^1.16.0"
-    xcode "0.9.3"
+    "@sentry/wizard" "^0.8.1"
+    raven-js "^3.22.1"
 
 react-native-slider@0.11.0:
   version "0.11.0"
@@ -5463,6 +5551,12 @@ react@16.2.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+read-env@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/read-env/-/read-env-1.1.1.tgz#561f16438792b19ed10ffede0315bde37f9f87fc"
+  dependencies:
+    camelcase "^4.1.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -5903,6 +5997,12 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
+rxjs@^5.5.2:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -6072,12 +6172,6 @@ send@0.16.1:
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.3.1"
-
-sentry-cli-binary@^1.16.0:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.19.1.tgz#0abc210ed7f35d7ec0680963e612b15bd2bc14c0"
-  dependencies:
-    progress "2.0.0"
 
 serialize-error@2.1.0, serialize-error@^2.1.0:
   version "2.1.0"
@@ -6410,7 +6504,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -6501,6 +6595,16 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-observable@^1.0.2, symbol-observable@^1.0.3:
   version "1.0.4"
@@ -6616,6 +6720,12 @@ tmp@^0.0.31:
   dependencies:
     os-tmpdir "~1.0.1"
 
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -6702,6 +6812,12 @@ type-is@~1.6.15, type-is@~1.6.6:
 type-of@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
+
+typedarray-to-buffer@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz#1017b32d984ff556eba100f501589aba1ace2e04"
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -7016,9 +7132,17 @@ ws@^4.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-xcode@0.9.3, xcode@^0.9.1:
+xcode@^0.9.1:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/xcode/-/xcode-0.9.3.tgz#910a89c16aee6cc0b42ca805a6d0b4cf87211cf3"
+  dependencies:
+    pegjs "^0.10.0"
+    simple-plist "^0.2.1"
+    uuid "3.0.1"
+
+xcode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-1.0.0.tgz#e1f5b1443245ded38c180796df1a10fdeda084ec"
   dependencies:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"
@@ -7084,6 +7208,12 @@ yargs-parser@^8.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.0.3.tgz#6542debd9080ad517ec5048fb454efe9e4d4aaae"
@@ -7100,6 +7230,23 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.0.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
The only real changes that we needed were to update the path of some files in node_modules and provide extra configuration during the Android build process. I also came across an odd behaviour that must've appeared in RN since the last time one of us worked on the exception handler since it was being triggered with no argument for PropType warnings, so that's been fixed.

This time, I also left in some extra Advanced Settings options to crash the app, but they're controlled by the local build config, so normal users won't see them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9379

#### Checklist
- Has UI changes
- Includes text changes and localization file updates

#### Device Information
This PR was tested on: Nexus 5 (Android 6.0) using `make run-android`, iPhone 6 (iOS 10.3.3) using `make run-ios` and building from XCode in release mode