### PR TITLE
WIP: Working on improving push notifications user experience

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -143,13 +143,9 @@ public class CustomPushNotification extends PushNotification {
         // First, get a builder initialized with defaults from the core class.
         final Notification.Builder notification = new Notification.Builder(mContext);
         Bundle bundle = mNotificationProps.asBundle();
-        String title = bundle.getString("title");
-        if (title == null) {
-            ApplicationInfo appInfo = mContext.getApplicationInfo();
-            title = mContext.getPackageManager().getApplicationLabel(appInfo).toString();
-        }
 
         String channelId = bundle.getString("channel_id");
+        String channelName = bundle.getString("channel_name");
         String postId = bundle.getString("post_id");
         int notificationId = channelId != null ? channelId.hashCode() : MESSAGE_NOTIFICATION_ID;
         String message = bundle.getString("message");
@@ -157,6 +153,12 @@ public class CustomPushNotification extends PushNotification {
         String numberString = bundle.getString("badge");
         String smallIcon = bundle.getString("smallIcon");
         String largeIcon = bundle.getString("largeIcon");
+
+        String title = channelName != null ? channelName : bundle.getString("title");
+        if (title == null) {
+            ApplicationInfo appInfo = mContext.getApplicationInfo();
+            title = mContext.getPackageManager().getApplicationLabel(appInfo).toString();
+        }
 
         Bundle b = bundle.getBundle("userInfo");
         if (b != null) {
@@ -220,12 +222,10 @@ public class CustomPushNotification extends PushNotification {
 
             for (Bundle data : list) {
                 String msg = data.getString("message");
-                if (msg != message) {
-                    style.addLine(data.getString("message"));
-                }
+                style.addLine(data.getString("message"));
             }
 
-            style.setBigContentTitle(message)
+            style.setBigContentTitle(title)
                     .setSummaryText(String.format("+%d more", (numMessages - 1)));
             notification.setStyle(style)
                     .setContentTitle(summaryTitle);


### PR DESCRIPTION
#### Summary
I am working on improving user experience related to push notifications.
I did some initial work and would appreciate help in finishing this PR.

Related mattermost-server PR: https://github.com/mattermost/mattermost-server/pull/8331

Basically, current push notifications are wasting a lot of space, repeating the same things without need(channel name, username etc.) for example.
Good examples we can follow are Slack and Discord on this.

So the new design(a pretty basic thing actually) would look like this:
1) One grouped notification per channel/DM - this is done already
2) Channel notification:
Header: Channel Name
Content:
koxen: hello
someone: hello there!
3) DM notification
Header: koxen (the username)
Content: 
you around?
hello there, what's up?

Currently it looks like
1) Channel notification:
Header: Mattermost
Content:
koxen in Channel Name: hello
someone in Channel Name: hello there!
2) DM notification
Header: Mattermost
Content:
koxen: you around?
koxen: hello there, what's up?

I am not sure how these push notifications look on iOS at the moment.
I could not find the equivalent code for iOS in the mobile app.

Tests need update for this PR.

While I successfully set up my dev environment for Android and compiled the app, I cannot test push notifications without getting new API keys; I understand how it works though so I might be able to set it up within next days.
And on iOS I can't test at all without the paid Apple Developer account that gets me the cloud messaging api keys.

#### The code changes
I changed the code so that
1) The title of notification is not Mattermost but channel name/DM user name
2) This also accounts for receiving system push notifications where channel_name is unset - then title is Mattermost
3) In case of message grouping within one channel, the latest notification stays in content not in "header" - removed ``` msg != message ```
4) Backwards compatibility; I would prefer to change push notification format so that the username is specified in push, when the push comes from a "channel"(see that in case of DM the channel name acts as username which makes things easier), instead of being joined on the server side to the message. (username: hello there), this would give more freedom to the mobile apps in rendering the notifications.
But the current schema would work too and this way it's backwards compatible.

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [*] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 
Samsung Galaxy S7, Android 7.0

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
Screenshots not available yet :(!