### PR TITLE
MM-9612 Better handled out of order posts causing duplicate date headers

### DIFF
--- a/app/selectors/post_list.js
+++ b/app/selectors/post_list.js
@@ -55,7 +55,7 @@ export function makePreparePostIdsForPostList() {
                 const postDate = new Date(post.create_at);
 
                 if (!lastDate || lastDate.toDateString() !== postDate.toDateString()) {
-                    out.push(DATE_LINE + postDate.toDateString());
+                    out.push(DATE_LINE + postDate.toString());
 
                     lastDate = postDate;
                 }


### PR DESCRIPTION
I think this issue occurred because we ended up with multiple date lines due to an old pending post from a previous day, and then RN freaked out because we had multiple items with the same key. If I simulated that situation and switched channels, the duplicated date lines were still left on the screen

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9612