### PR TITLE
MM-8604: handle SERVER_VERSION_CHANGED and CONFIG_CHANGED events

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4096,7 +4096,7 @@ makeerror@1.0.x:
 
 mattermost-redux@mattermost/mattermost-redux:
   version "1.2.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/fd8aa4400e8a6498e733e3895f16acaa0f4404fc"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/c30e547ba768d8c3e02432be0f1400a0d087d668"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"
@@ -4258,13 +4258,23 @@ mime-db@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.23.0.tgz#a31b4070adaea27d732ea333740a64d0ec9a6659"
 
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+
 mime-types@2.1.11:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.11.tgz#c259c471bda808a85d6cd193b430a5fae4473b3c"
   dependencies:
     mime-db "~1.23.0"
 
-mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.6, mime-types@~2.1.7, mime-types@~2.1.9:
+mime-types@^2.1.12:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  dependencies:
+    mime-db "~1.33.0"
+
+mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.6, mime-types@~2.1.7, mime-types@~2.1.9:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:


### PR DESCRIPTION
#### Summary
This pairs up with the corresponding mattermost-redux changes to split
apart these events. For now, we still assume a configuration change when
detecting a server version change, given that the app may run with older
mattermost servers. In the future, we could fine-tine or remove this duplicate
config/license loading.

TODO: Depend on mattermost-redux changes in yarn.lock.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8604

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux/pull/418)

#### Device Information
This PR was tested on: iPhone 6 (Simulator)