### PR TITLE
Fix iOS Options modal cancel press

### DIFF
--- a/app/screens/options_modal/options_modal.js
+++ b/app/screens/options_modal/options_modal.js
@@ -80,7 +80,7 @@ export default class OptionsModal extends PureComponent {
         } = this.props;
 
         return (
-            <TouchableWithoutFeedback onPress={this.close}>
+            <TouchableWithoutFeedback onPress={this.handleCancel}>
                 <View style={style.wrapper}>
                     <AnimatedView style={{height: this.props.deviceHeight, left: 0, top: this.state.top, width: this.props.deviceWidth}}>
                         <OptionsModalList

--- a/app/screens/options_modal/options_modal_list.ios.js
+++ b/app/screens/options_modal/options_modal_list.ios.js
@@ -25,8 +25,8 @@ export default class OptionsModalList extends PureComponent {
     };
 
     handleCancelPress = preventDoubleTap(() => {
-        if (this.onCancelPress) {
-            this.onCancelPress();
+        if (this.props.onCancelPress) {
+            this.props.onCancelPress();
         }
     });
 


### PR DESCRIPTION
#### Summary
on iOS the Cancel option in the options modal screen (ActionSheet) wasn't working, this PR fixes it