### PR TITLE
MM-9347 Added email autolinking

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,7 +1774,7 @@ commonmark-react-renderer@hmhealey/commonmark-react-renderer:
 
 commonmark@hmhealey/commonmark.js:
   version "0.28.0"
-  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/f7bc747151e6d856ceffa196044112e23d04e541"
+  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/bcd754c640ed8192fa959f2416f183acf9e1cfaf"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"


### PR DESCRIPTION
Commonmark changes here: https://github.com/hmhealey/commonmark.js/commit/bcd754c640ed8192fa959f2416f183acf9e1cfaf

Basically, it just adds a case for `reMain` to stop capturing text when it sees something that looks like an email, and then it adds a regex that looks for emails after that. We already support mailto links in the app, so no changes were needed outside of that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9347

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- Added or updated unit tests (required for all new features)
#### Device Information
This PR was tested on: iOS Simulator (iPhone 6, iOS 11.2), Nexus 5 (Android 6.0.1)