### PR TITLE
Optimize post header timestamp

### DIFF
--- a/app/components/formatted_date.js
+++ b/app/components/formatted_date.js
@@ -10,7 +10,7 @@ class FormattedDate extends React.PureComponent {
     static propTypes = {
         intl: intlShape.isRequired,
         value: PropTypes.any.isRequired,
-        // format: PropTypes.string,
+        format: PropTypes.string,
         children: PropTypes.func
     };
 
@@ -22,18 +22,9 @@ class FormattedDate extends React.PureComponent {
             ...props
         } = this.props;
 
-        // Reflect.deleteProperty(props, 'format');
+        Reflect.deleteProperty(props, 'format');
 
-        // const formattedDate = intl.formatDate(value, this.props);
-
-        const date = new Date(value);
-        let day = date.getDay();
-        let month = date.getMonth() + 1;
-        let year = date.getFullYear();
-        day = day < 10 ? ('0' + day) : day;
-        month = month < 10 ? ('0' + month) : month;
-
-        const formattedDate = day + '/' + month +'/' + year;
+        const formattedDate = intl.formatDate(value, this.props);
 
         if (typeof children === 'function') {
             return children(formattedDate);

--- a/app/components/formatted_date.js
+++ b/app/components/formatted_date.js
@@ -10,7 +10,7 @@ class FormattedDate extends React.PureComponent {
     static propTypes = {
         intl: intlShape.isRequired,
         value: PropTypes.any.isRequired,
-        format: PropTypes.string,
+        // format: PropTypes.string,
         children: PropTypes.func
     };
 
@@ -22,9 +22,18 @@ class FormattedDate extends React.PureComponent {
             ...props
         } = this.props;
 
-        Reflect.deleteProperty(props, 'format');
+        // Reflect.deleteProperty(props, 'format');
 
-        const formattedDate = intl.formatDate(value, this.props);
+        // const formattedDate = intl.formatDate(value, this.props);
+
+        const date = new Date(value);
+        let day = date.getDay();
+        let month = date.getMonth() + 1;
+        let year = date.getFullYear();
+        day = day < 10 ? ('0' + day) : day;
+        month = month < 10 ? ('0' + month) : month;
+
+        const formattedDate = day + '/' + month +'/' + year;
 
         if (typeof children === 'function') {
             return children(formattedDate);

--- a/app/components/formatted_time.js
+++ b/app/components/formatted_time.js
@@ -33,11 +33,13 @@ class FormattedTime extends React.PureComponent {
         const hour = militaryTime ? date.getHours() : (date.getHours() % 12 || 12);
         let minute = date.getMinutes();
         minute = minute >= 10 ? minute : ('0' + minute);
-        let formattedTime = '';
+        let time = '';
 
         if (!militaryTime) {
-            formattedTime = (date.getHours() >= 12 ? ' PM' : ' AM');
+            time = (date.getHours() >= 12 ? ' PM' : ' AM');
         }
+
+        const formattedTime = hour + ':' + minute + time;
 
         if (typeof children === 'function') {
             return children(formattedTime);

--- a/app/components/formatted_time.js
+++ b/app/components/formatted_time.js
@@ -3,12 +3,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {injectIntl, intlShape} from 'react-intl';
 import {Text} from 'react-native';
 
 class FormattedTime extends React.PureComponent {
     static propTypes = {
-        intl: intlShape.isRequired,
         value: PropTypes.any.isRequired,
         children: PropTypes.func,
         hour12: PropTypes.bool
@@ -16,16 +14,10 @@ class FormattedTime extends React.PureComponent {
 
     render() {
         const {
-            intl,
             value,
             children,
             hour12,
-            ...props
         } = this.props;
-
-        // Reflect.deleteProperty(props, 'format');
-
-        // const formattedTime = intl.formatDate(value, {...props, hour: 'numeric', minute: 'numeric'});
 
         const date = new Date(value);
         const militaryTime = !hour12;
@@ -49,4 +41,4 @@ class FormattedTime extends React.PureComponent {
     }
 }
 
-export default injectIntl(FormattedTime);
+export default FormattedTime;

--- a/app/components/formatted_time.js
+++ b/app/components/formatted_time.js
@@ -10,8 +10,8 @@ class FormattedTime extends React.PureComponent {
     static propTypes = {
         intl: intlShape.isRequired,
         value: PropTypes.any.isRequired,
-        format: PropTypes.string,
-        children: PropTypes.func
+        children: PropTypes.func,
+        hour12: PropTypes.bool
     };
 
     render() {
@@ -19,12 +19,25 @@ class FormattedTime extends React.PureComponent {
             intl,
             value,
             children,
+            hour12,
             ...props
         } = this.props;
 
-        Reflect.deleteProperty(props, 'format');
+        // Reflect.deleteProperty(props, 'format');
 
-        const formattedTime = intl.formatDate(value, {...props, hour: 'numeric', minute: 'numeric'});
+        // const formattedTime = intl.formatDate(value, {...props, hour: 'numeric', minute: 'numeric'});
+
+        const date = new Date(value);
+        const militaryTime = !hour12;
+
+        const hour = militaryTime ? date.getHours() : (date.getHours() % 12 || 12);
+        let minute = date.getMinutes();
+        minute = minute >= 10 ? minute : ('0' + minute);
+        let formattedTime = '';
+
+        if (!militaryTime) {
+            formattedTime = (date.getHours() >= 12 ? ' PM' : ' AM');
+        }
 
         if (typeof children === 'function') {
             return children(formattedTime);

--- a/app/components/formatted_time.js
+++ b/app/components/formatted_time.js
@@ -9,14 +9,14 @@ class FormattedTime extends React.PureComponent {
     static propTypes = {
         value: PropTypes.any.isRequired,
         children: PropTypes.func,
-        hour12: PropTypes.bool,
+        hour12: PropTypes.bool
     };
 
     render() {
         const {
             value,
             children,
-            hour12,
+            hour12
         } = this.props;
 
         const date = new Date(value);

--- a/app/components/formatted_time.js
+++ b/app/components/formatted_time.js
@@ -9,7 +9,7 @@ class FormattedTime extends React.PureComponent {
     static propTypes = {
         value: PropTypes.any.isRequired,
         children: PropTypes.func,
-        hour12: PropTypes.bool
+        hour12: PropTypes.bool,
     };
 
     render() {


### PR DESCRIPTION
#### Summary
Optimize post headers, avoid using heavy date formatting code.
Same as in webapp fixed recently.
Note: date header seems to always render dd/mm/yyyy so that's what I replaced it with

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
