### PR TITLE
Fix team_icon to reference the pure component

### DIFF
--- a/app/components/channel_drawer/channels_list/switch_teams_button/switch_teams_button.js
+++ b/app/components/channel_drawer/channels_list/switch_teams_button/switch_teams_button.js
@@ -70,6 +70,7 @@ export default class SwitchTeamsButton extends React.PureComponent {
                             size={12}
                             style={styles.switcherArrow}
                         />
+                        <View style={styles.switcherDivider}/>
                         <TeamIcon
                             teamId={currentTeamId}
                             styleContainer={styles.teamIconContainer}
@@ -99,6 +100,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         switcherArrow: {
             color: theme.sidebarHeaderBg,
             marginRight: 3,
+        },
+        switcherDivider: {
+            backgroundColor: theme.sidebarHeaderBg,
+            height: 15,
+            marginHorizontal: 6,
+            width: 1,
         },
         teamIconContainer: {
             width: 26,

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -7,7 +7,6 @@ import {
     Alert,
     FlatList,
     InteractionManager,
-    StyleSheet,
     Text,
     TouchableOpacity,
     View,
@@ -261,7 +260,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         line: {
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.2),
             width: '100%',
-            height: StyleSheet.hairlineWidth,
+            height: 1,
         },
         teamWrapper: {
             marginTop: 20,
@@ -275,8 +274,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         teamIconContainer: {
             width: 40,
             height: 40,
+            backgroundColor: theme.sidebarBg,
         },
         teamIconText: {
+            color: theme.sidebarText,
             fontSize: 18,
         },
         noTeam: {

--- a/share_extension/android/extension_teams/team_item/team_item.js
+++ b/share_extension/android/extension_teams/team_item/team_item.js
@@ -96,7 +96,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             paddingRight: 5,
         },
         teamIconContainer: {
+            backgroundColor: theme.sidebarBg,
             marginRight: 10,
+        },
+        teamIconText: {
+            color: theme.sidebarText,
         },
         checkmarkContainer: {
             alignItems: 'flex-end',

--- a/share_extension/ios/extension_team_item.js
+++ b/share_extension/ios/extension_team_item.js
@@ -12,7 +12,7 @@ import {
 import {preventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
-import TeamIcon from 'app/components/team_icon';
+import TeamIcon from 'app/components/team_icon/team_icon';
 
 export default class TeamsListItem extends React.PureComponent {
     static propTypes = {
@@ -51,9 +51,11 @@ export default class TeamsListItem extends React.PureComponent {
                 <View style={styles.container}>
                     <View style={styles.item}>
                         <TeamIcon
-                            teamId={team.id}
                             styleContainer={styles.teamIconContainer}
                             styleText={styles.teamIconText}
+                            teamId={team.id}
+                            team={team}
+                            theme={theme}
                         />
                         <Text
                             style={[styles.text]}
@@ -96,7 +98,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             paddingRight: 5,
         },
         teamIconContainer: {
+            backgroundColor: theme.sidebarBg,
             marginRight: 10,
+        },
+        teamIconText: {
+            color: theme.sidebarText,
         },
         checkmarkContainer: {
             alignItems: 'flex-end',


### PR DESCRIPTION
#### Summary
Switching teams was crashing the extension as the TeamIcon component is a connected component and in the iOS Share extension we do not have access to the redux store.

Also fixes the style for the team icon when there is no image