### PR TITLE
Fix channel drawer lagging

### DIFF
--- a/app/components/channel_drawer/channel_drawer.js
+++ b/app/components/channel_drawer/channel_drawer.js
@@ -215,20 +215,22 @@ export default class ChannelDrawer extends Component {
 
         tracker.channelSwitch = Date.now();
 
-        this.closeChannelDrawer();
-
         InteractionManager.runAfterInteractions(() => {
-            setChannelLoading(channel.id !== currentChannelId);
-            setChannelDisplayName(channel.display_name);
+            this.closeChannelDrawer();
 
-            handleSelectChannel(channel.id);
-            requestAnimationFrame(() => {
-                // mark the channel as viewed after all the frame has flushed
-                markChannelAsRead(channel.id, currentChannelId);
-                if (channel.id !== currentChannelId) {
-                    markChannelAsViewed(currentChannelId);
-                }
-            });
+            InteractionManager.runAfterInteractions(() => {
+                setChannelLoading(channel.id !== currentChannelId);
+                setChannelDisplayName(channel.display_name);
+    
+                handleSelectChannel(channel.id);
+                requestAnimationFrame(() => {
+                    // mark the channel as viewed after all the frame has flushed
+                    markChannelAsRead(channel.id, currentChannelId);
+                    if (channel.id !== currentChannelId) {
+                        markChannelAsViewed(currentChannelId);
+                    }
+                });
+            });    
         });
     };
 


### PR DESCRIPTION

#### Summary
Sorry that I forgot that part of logic, without it channel drawer is lagging on channel switch.
I 100% tested it this time. 
It clearly fixes the effect of lagging drawer close.

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 
android 7, samsung s7
#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
