### PR TITLE
Fix race condition in PostList's onEndReached

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -340,6 +340,17 @@ export default class PostList extends PureComponent {
         });
     };
 
+    onEndReached = () => {
+        if (!this.onEndReachedCalledDuringMomentum) {
+            this.props.loadMore();
+            this.onEndReachedCalledDuringMomentum = true;
+          } 
+    }
+
+    onMomentumScrollBegin = () => {
+        this.onEndReachedCalledDuringMomentum = false;
+    }
+
     render() {
         const {
             channelId,
@@ -364,12 +375,13 @@ export default class PostList extends PureComponent {
                 data={postIds}
                 extraData={this.makeExtraData(channelId, highlightPostId, showLoadMore)}
                 initialNumToRender={false}
-                maxToRenderPerBatch={INITAL_BATCH_TO_RENDER + 1}
+                maxToRenderPerBatch={INITIAL_BATCH_TO_RENDER}
                 inverted={true}
                 keyExtractor={this.keyExtractor}
                 ListFooterComponent={this.renderFooter}
-                onEndReached={loadMore}
-                onEndReachedThreshold={Platform.OS === 'ios' ? 0 : 1}
+                onEndReached={this.onEndReached}
+                onMomentumScrollBegin={this.onMomentumScrollBegin}
+                onEndReachedThreshold={Platform.OS === 'ios' ? 0 : 0.7}
                 removeClippedSubviews={Platform.OS === 'android'}
                 {...refreshControl}
                 renderItem={this.renderItem}


### PR DESCRIPTION
This caused additional posts to be loaded when channel was loading and so it did render more than 15 posts.

Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
[A brief description of what this pull request does.]

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 
samsung s7, android 7
#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
