### PR TITLE
Show attachments in horizontal ScrollView

### DIFF
--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -19,6 +19,7 @@ import FileAttachmentImage from './file_attachment_image';
 export default class FileAttachment extends PureComponent {
     static propTypes = {
         addFileToFetchCache: PropTypes.func.isRequired,
+        deviceWidth: PropTypes.number.isRequired,
         fetchCache: PropTypes.object.isRequired,
         file: PropTypes.object.isRequired,
         onInfoPress: PropTypes.func,
@@ -45,7 +46,7 @@ export default class FileAttachment extends PureComponent {
         }
 
         return (
-            <View>
+            <View style={{flex: 1, justifyContent: 'center'}}>
                 <Text
                     numberOfLines={4}
                     style={style.fileName}
@@ -62,7 +63,7 @@ export default class FileAttachment extends PureComponent {
     }
 
     render() {
-        const {file, onInfoPress, theme, navigator} = this.props;
+        const {deviceWidth, file, onInfoPress, theme, navigator} = this.props;
         const style = getStyleSheet(theme);
 
         let mime = file.mime_type;
@@ -101,8 +102,10 @@ export default class FileAttachment extends PureComponent {
             );
         }
 
+        const width = deviceWidth * 0.72;
+
         return (
-            <View style={style.fileWrapper}>
+            <View style={[style.fileWrapper, {width}]}>
                 {fileAttachmentComponent}
                 <TouchableOpacity
                     onPress={onInfoPress}
@@ -148,8 +151,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             flexDirection: 'row',
             marginTop: 10,
+            marginRight: 10,
             borderWidth: 1,
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderRadius: 2,
+            maxWidth: 350,
         },
         circularProgress: {
             width: '100%',

--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -46,7 +46,7 @@ export default class FileAttachment extends PureComponent {
         }
 
         return (
-            <View style={{flex: 1, justifyContent: 'center'}}>
+            <View style={style.attachmentContainer}>
                 <Text
                     numberOfLines={4}
                     style={style.fileName}
@@ -120,6 +120,10 @@ export default class FileAttachment extends PureComponent {
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
+        attachmentContainer: {
+            flex: 1,
+            justifyContent: 'center',
+        },
         downloadIcon: {
             color: changeOpacity(theme.centerChannelColor, 0.7),
             marginRight: 5,

--- a/app/components/file_attachment_list/file_attachment_document.js
+++ b/app/components/file_attachment_list/file_attachment_document.js
@@ -49,10 +49,10 @@ export default class FileAttachmentDocument extends PureComponent {
     };
 
     static defaultProps = {
-        iconHeight: 65,
-        iconWidth: 65,
-        wrapperHeight: 100,
-        wrapperWidth: 100,
+        iconHeight: 50,
+        iconWidth: 50,
+        wrapperHeight: 80,
+        wrapperWidth: 80,
     };
 
     static contextTypes = {

--- a/app/components/file_attachment_list/file_attachment_icon.js
+++ b/app/components/file_attachment_list/file_attachment_icon.js
@@ -47,8 +47,8 @@ export default class FileAttachmentIcon extends PureComponent {
     static defaultProps = {
         iconHeight: 60,
         iconWidth: 60,
-        wrapperHeight: 100,
-        wrapperWidth: 100,
+        wrapperHeight: 80,
+        wrapperWidth: 80,
     };
 
     getFileIconPath(file) {
@@ -63,7 +63,7 @@ export default class FileAttachmentIcon extends PureComponent {
         return (
             <View style={[styles.fileIconWrapper, {height: wrapperHeight, width: wrapperWidth}]}>
                 <Image
-                    style={{height: iconHeight, width: iconWidth}}
+                    style={[styles.icon, {height: iconHeight, width: iconWidth}]}
                     source={source}
                     defaultSource={genericIcon}
                 />
@@ -77,5 +77,11 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         justifyContent: 'center',
         backgroundColor: '#fff',
+        borderTopLeftRadius: 2,
+        borderBottomLeftRadius: 2,
+    },
+    icon: {
+        borderTopLeftRadius: 2,
+        borderBottomLeftRadius: 2,
     },
 });

--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -45,16 +45,16 @@ export default class FileAttachmentImage extends PureComponent {
 
     static defaultProps = {
         fadeInOnLoad: false,
-        imageHeight: 100,
+        imageHeight: 80,
         imageSize: IMAGE_SIZE.Preview,
-        imageWidth: 100,
+        imageWidth: 80,
         loading: false,
         loadingBackgroundColor: '#fff',
         resizeMode: 'cover',
         resizeMethod: 'resize',
         wrapperBackgroundColor: '#fff',
-        wrapperHeigh: 100,
-        wrapperWidth: 100,
+        wrapperHeigh: 80,
+        wrapperWidth: 80,
     };
 
     state = {
@@ -163,9 +163,9 @@ export default class FileAttachmentImage extends PureComponent {
         let width = imageWidth;
         let imageStyle = {height, width};
         if (imageSize === IMAGE_SIZE.Preview) {
-            height = 100;
+            height = 80;
             width = this.calculateNeededWidth(file.height, file.width, height);
-            imageStyle = {height, width, position: 'absolute', top: 0, left: 0};
+            imageStyle = {height, width, position: 'absolute', top: 0, left: 0, borderBottomLeftRadius: 2, borderTopLeftRadius: 2};
         }
 
         return (
@@ -193,6 +193,8 @@ const style = StyleSheet.create({
     fileImageWrapper: {
         alignItems: 'center',
         justifyContent: 'center',
+        borderBottomLeftRadius: 2,
+        borderTopLeftRadius: 2,
     },
     loaderContainer: {
         position: 'absolute',

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -5,7 +5,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     Keyboard,
-    View,
+    ScrollView,
     TouchableOpacity,
 } from 'react-native';
 
@@ -17,6 +17,7 @@ import FileAttachment from './file_attachment';
 export default class FileAttachmentList extends Component {
     static propTypes = {
         actions: PropTypes.object.isRequired,
+        deviceWidth: PropTypes.number.isRequired,
         fetchCache: PropTypes.object.isRequired,
         fileIds: PropTypes.array.isRequired,
         files: PropTypes.array.isRequired,
@@ -84,7 +85,7 @@ export default class FileAttachmentList extends Component {
     };
 
     render() {
-        const {fileIds, files, isFailed, navigator} = this.props;
+        const {deviceWidth, fileIds, files, isFailed, navigator} = this.props;
 
         let fileAttachments;
         if (!files.length && fileIds.length > 0) {
@@ -92,6 +93,7 @@ export default class FileAttachmentList extends Component {
                 <FileAttachment
                     key={id}
                     addFileToFetchCache={this.props.actions.addFileToFetchCache}
+                    deviceWidth={deviceWidth}
                     fetchCache={this.props.fetchCache}
                     file={{loading: true}}
                     theme={this.props.theme}
@@ -106,6 +108,7 @@ export default class FileAttachmentList extends Component {
                     onPressOut={this.handlePressOut}
                 >
                     <FileAttachment
+                        deviceWidth={deviceWidth}
                         navigator={navigator}
                         addFileToFetchCache={this.props.actions.addFileToFetchCache}
                         fetchCache={this.props.fetchCache}
@@ -119,9 +122,13 @@ export default class FileAttachmentList extends Component {
         }
 
         return (
-            <View style={[{flex: 1}, (isFailed && {opacity: 0.5})]}>
+            <ScrollView
+                horizontal={true}
+                scrollEnabled={fileIds.length > 1}
+                style={[{flex: 1}, (isFailed && {opacity: 0.5})]}
+            >
                 {fileAttachments}
-            </View>
+            </ScrollView>
         );
     }
 }

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import {
     Keyboard,
     ScrollView,
+    StyleSheet,
     TouchableOpacity,
 } from 'react-native';
 
@@ -125,10 +126,19 @@ export default class FileAttachmentList extends Component {
             <ScrollView
                 horizontal={true}
                 scrollEnabled={fileIds.length > 1}
-                style={[{flex: 1}, (isFailed && {opacity: 0.5})]}
+                style={[styles.flex, (isFailed && styles.failed)]}
             >
                 {fileAttachments}
             </ScrollView>
         );
     }
 }
+
+const styles = StyleSheet.create({
+    flex: {
+        flex: 1,
+    },
+    failed: {
+        opacity: 0.5,
+    },
+});

--- a/app/components/file_attachment_list/index.js
+++ b/app/components/file_attachment_list/index.js
@@ -5,9 +5,11 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
 import {loadFilesForPostIfNecessary} from 'app/actions/views/channel';
 import {addFileToFetchCache} from 'app/actions/views/file_preview';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {getDimensions} from 'app/selectors/device';
 
 import FileAttachmentList from './file_attachment_list';
 
@@ -15,6 +17,7 @@ function makeMapStateToProps() {
     const getFilesForPost = makeGetFilesForPost();
     return function mapStateToProps(state, ownProps) {
         return {
+            ...getDimensions(state),
             fetchCache: state.views.fetchCache,
             files: getFilesForPost(state, ownProps.postId),
             theme: getTheme(state),


### PR DESCRIPTION
#### Summary
Show file attachments in one row inside an Horizontal ScrollView

#### Ticket Link
Part of the 4K post limit

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: 
* iOS 11.2 iPhone 5s, iPhone 6 and iPhone X (Simulator)
* Android 7.1.1 Nexus 5 (Emulator)

#### Screenshots
Android
![screenshot_1521190498](https://user-images.githubusercontent.com/6757047/37514006-61325a54-290f-11e8-8f87-8b06bebabbd4.png)

iOS
iPhone 5s
![simulator screen shot - iphone 5s - 2018-03-16 at 11 43 43](https://user-images.githubusercontent.com/6757047/37514051-80958b5a-290f-11e8-8191-02ff0ef75341.png)

iPhone 6
![simulator screen shot - iphone 6 - 2018-03-16 at 10 52 30](https://user-images.githubusercontent.com/6757047/37514061-890a5888-290f-11e8-82e8-b6e77904a5fc.png)

iPhone X
![simulator screen shot - iphone x - 2018-03-16 at 10 52 40](https://user-images.githubusercontent.com/6757047/37514068-900f5f02-290f-11e8-8af6-cd34af989679.png)
