### PR TITLE
MM-9709 Fixed max width of markdown list items

### DIFF
--- a/app/components/markdown/markdown_list.js
+++ b/app/components/markdown/markdown_list.js
@@ -1,9 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, View} from 'react-native';
+import React, {PureComponent} from 'react';
 
 export default class MarkdownList extends PureComponent {
     static propTypes = {
@@ -33,15 +32,9 @@ export default class MarkdownList extends PureComponent {
         });
 
         return (
-            <View style={style.indent}>
+            <React.Fragment>
                 {children}
-            </View>
+            </React.Fragment>
         );
     }
 }
-
-const style = StyleSheet.create({
-    indent: {
-        marginRight: 20,
-    },
-});

--- a/app/components/markdown/markdown_list_item.js
+++ b/app/components/markdown/markdown_list_item.js
@@ -51,7 +51,6 @@ export default class MarkdownListItem extends PureComponent {
 
 const style = StyleSheet.create({
     container: {
-        flex: 1,
         flexDirection: 'row',
         alignItems: 'flex-start',
     },

--- a/app/components/markdown/markdown_list_item.js
+++ b/app/components/markdown/markdown_list_item.js
@@ -41,7 +41,7 @@ export default class MarkdownListItem extends PureComponent {
                         {bullet}
                     </Text>
                 </View>
-                <View>
+                <View style={style.contents}>
                     {this.props.children}
                 </View>
             </View>
@@ -50,12 +50,16 @@ export default class MarkdownListItem extends PureComponent {
 }
 
 const style = StyleSheet.create({
+    container: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+    },
     bullet: {
         alignItems: 'flex-end',
         marginRight: 5,
     },
-    container: {
-        flexDirection: 'row',
-        alignItems: 'flex-start',
+    contents: {
+        flex: 1,
     },
 });


### PR DESCRIPTION
We weren't specifying that the body of list items could flex, so they wouldn't shrink as we got deeper into the list

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9709

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iPhone 6 Simulator, iPhone X Simulator, Nexus 5

<img width="380" alt="screen shot 2018-03-16 at 6 03 36 pm" src="https://user-images.githubusercontent.com/3277310/37546696-641c555a-2944-11e8-9375-cbb78dc4ede2.png">
