### PR TITLE
[MM-9516] Add feature to add user to channel after at-mention

### DIFF
--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Posts} from 'mattermost-redux/constants';
+import {PostTypes} from 'mattermost-redux/action_types';
+
+import {generateId} from 'app/utils/file';
+
+export function sendAddToChannelEphemeralPost(user, addedUsername, message, channelId, postRootId = '') {
+    return async (dispatch) => {
+        const timestamp = Date.now();
+        const post = {
+            id: generateId(),
+            user_id: user.id,
+            channel_id: channelId,
+            message,
+            type: Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL,
+            create_at: timestamp,
+            update_at: timestamp,
+            root_id: postRootId,
+            parent_id: postRootId,
+            props: {
+                username: user.username,
+                addedUsername,
+            },
+        };
+
+        dispatch({
+            type: PostTypes.RECEIVED_POSTS,
+            data: {
+                order: [],
+                posts: {
+                    [post.id]: post,
+                },
+            },
+            channelId,
+        });
+    };
+}

--- a/app/components/post_add_channel_member/index.js
+++ b/app/components/post_add_channel_member/index.js
@@ -4,9 +4,6 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {Posts} from 'mattermost-redux/constants';
-import {PostTypes} from 'mattermost-redux/action_types';
-
 import {addChannelMember} from 'mattermost-redux/actions/channels';
 import {removePost} from 'mattermost-redux/actions/posts';
 
@@ -14,7 +11,7 @@ import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
-import {generateId} from 'app/utils/file';
+import {sendAddToChannelEphemeralPost} from 'app/actions/views/post';
 
 import PostAddChannelMember from './post_add_channel_member';
 
@@ -35,44 +32,12 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-function sendEphemeralPost(user, addedUsername, message, channelId, postRootId) {
-    return async (dispatch) => {
-        const timestamp = Date.now();
-        const post = {
-            id: generateId(),
-            user_id: user.id,
-            channel_id: channelId,
-            message,
-            type: Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL,
-            create_at: timestamp,
-            update_at: timestamp,
-            root_id: postRootId,
-            parent_id: postRootId,
-            props: {
-                username: user.username,
-                addedUsername,
-            },
-        };
-
-        dispatch({
-            type: PostTypes.RECEIVED_POSTS,
-            data: {
-                order: [],
-                posts: {
-                    [post.id]: post,
-                },
-            },
-            channelId,
-        });
-    };
-}
-
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             addChannelMember,
             removePost,
-            sendEphemeralPost,
+            sendAddToChannelEphemeralPost,
         }, dispatch),
     };
 }

--- a/app/components/post_add_channel_member/index.js
+++ b/app/components/post_add_channel_member/index.js
@@ -36,25 +36,24 @@ function mapStateToProps(state, ownProps) {
 }
 
 function sendEphemeralPost(user, addedUsername, message, channelId, postRootId) {
-    const timestamp = Date.now();
-
-    const post = {
-        id: generateId(),
-        user_id: user.id,
-        channel_id: channelId,
-        message,
-        type: Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL,
-        create_at: timestamp,
-        update_at: timestamp,
-        root_id: postRootId,
-        parent_id: postRootId,
-        props: {
-            username: user.username,
-            addedUsername,
-        },
-    };
-
     return async (dispatch) => {
+        const timestamp = Date.now();
+        const post = {
+            id: generateId(),
+            user_id: user.id,
+            channel_id: channelId,
+            message,
+            type: Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL,
+            create_at: timestamp,
+            update_at: timestamp,
+            root_id: postRootId,
+            parent_id: postRootId,
+            props: {
+                username: user.username,
+                addedUsername,
+            },
+        };
+
         dispatch({
             type: PostTypes.RECEIVED_POSTS,
             data: {

--- a/app/components/post_add_channel_member/index.js
+++ b/app/components/post_add_channel_member/index.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {Posts} from 'mattermost-redux/constants';
+import {PostTypes} from 'mattermost-redux/action_types';
+
+import {addChannelMember} from 'mattermost-redux/actions/channels';
+import {removePost} from 'mattermost-redux/actions/posts';
+
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {generateId} from 'app/utils/file';
+
+import PostAddChannelMember from './post_add_channel_member';
+
+function mapStateToProps(state, ownProps) {
+    const post = getPost(state, ownProps.postId) || {};
+    let channelType = '';
+    if (post && post.channel_id) {
+        const channel = getChannel(state, post.channel_id);
+        if (channel && channel.type) {
+            channelType = channel.type;
+        }
+    }
+
+    return {
+        channelType,
+        currentUser: getCurrentUser(state),
+        post,
+    };
+}
+
+function sendEphemeralPost(user, addedUsername, message, channelId, postRootId) {
+    const timestamp = Date.now();
+
+    const post = {
+        id: generateId(),
+        user_id: user.id,
+        channel_id: channelId,
+        message,
+        type: Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL,
+        create_at: timestamp,
+        update_at: timestamp,
+        root_id: postRootId,
+        parent_id: postRootId,
+        props: {
+            username: user.username,
+            addedUsername,
+        },
+    };
+
+    return async (dispatch) => {
+        dispatch({
+            type: PostTypes.RECEIVED_POSTS,
+            data: {
+                order: [],
+                posts: {
+                    [post.id]: post,
+                },
+            },
+            channelId,
+        });
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            addChannelMember,
+            removePost,
+            sendEphemeralPost,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PostAddChannelMember);

--- a/app/components/post_add_channel_member/post_add_channel_member.js
+++ b/app/components/post_add_channel_member/post_add_channel_member.js
@@ -3,10 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {
-    defineMessages,
-    intlShape,
-} from 'react-intl';
+import {intlShape} from 'react-intl';
 
 import {Text} from 'react-native';
 
@@ -25,7 +22,7 @@ export default class PostAddChannelMember extends React.PureComponent {
             sendEphemeralPost: PropTypes.func.isRequired,
         }).isRequired,
         currentUser: PropTypes.object.isRequired,
-        channelType: PropTypes.string.isRequired,
+        channelType: PropTypes.string,
         post: PropTypes.object.isRequired,
         postId: PropTypes.string.isRequired,
         userIds: PropTypes.array.isRequired,
@@ -60,15 +57,11 @@ export default class PostAddChannelMember extends React.PureComponent {
                 actions.addChannelMember(post.channel_id, userId);
 
                 if (post.root_id) {
-                    const holder = defineMessages({
-                        message: {
+                    const message = formatMessage(
+                        {
                             id: 'api.channel.add_member.added',
                             defaultMessage: '{addedUsername} added to the channel by {username}.',
                         },
-                    });
-
-                    const message = formatMessage(
-                        holder.message,
                         {
                             username: currentUser.username,
                             addedUsername: usernames[index],

--- a/app/components/post_add_channel_member/post_add_channel_member.js
+++ b/app/components/post_add_channel_member/post_add_channel_member.js
@@ -19,7 +19,7 @@ export default class PostAddChannelMember extends React.PureComponent {
         actions: PropTypes.shape({
             addChannelMember: PropTypes.func.isRequired,
             removePost: PropTypes.func.isRequired,
-            sendEphemeralPost: PropTypes.func.isRequired,
+            sendAddToChannelEphemeralPost: PropTypes.func.isRequired,
         }).isRequired,
         currentUser: PropTypes.object.isRequired,
         channelType: PropTypes.string,
@@ -65,10 +65,10 @@ export default class PostAddChannelMember extends React.PureComponent {
                         {
                             username: currentUser.username,
                             addedUsername: usernames[index],
-                        },
+                        }
                     );
 
-                    actions.sendEphemeralPost(currentUser, usernames[index], message, post.channel_id, post.root_id);
+                    actions.sendAddToChannelEphemeralPost(currentUser, usernames[index], message, post.channel_id, post.root_id);
                 }
             });
 

--- a/app/components/post_add_channel_member/post_add_channel_member.js
+++ b/app/components/post_add_channel_member/post_add_channel_member.js
@@ -1,0 +1,196 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+    defineMessages,
+    intlShape,
+} from 'react-intl';
+
+import {Text} from 'react-native';
+
+import {General} from 'mattermost-redux/constants';
+
+import {concatStyles} from 'app/utils/theme';
+
+import AtMention from 'app/components/at_mention';
+import FormattedText from 'app/components/formatted_text';
+
+export default class PostAddChannelMember extends React.PureComponent {
+    static propTypes = {
+        actions: PropTypes.shape({
+            addChannelMember: PropTypes.func.isRequired,
+            removePost: PropTypes.func.isRequired,
+            sendEphemeralPost: PropTypes.func.isRequired,
+        }).isRequired,
+        currentUser: PropTypes.object.isRequired,
+        channelType: PropTypes.string.isRequired,
+        post: PropTypes.object.isRequired,
+        postId: PropTypes.string.isRequired,
+        userIds: PropTypes.array.isRequired,
+        usernames: PropTypes.array.isRequired,
+        navigator: PropTypes.object.isRequired,
+        onLongPress: PropTypes.func,
+        onPostPress: PropTypes.func,
+        textStyles: PropTypes.object,
+    };
+
+    static contextTypes = {
+        intl: intlShape,
+    };
+
+    computeTextStyle = (baseStyle, context) => {
+        return concatStyles(baseStyle, context.map((type) => this.props.textStyles[type]));
+    }
+
+    handleAddChannelMember = () => {
+        const {
+            actions,
+            currentUser,
+            post,
+            userIds,
+            usernames,
+        } = this.props;
+
+        const {formatMessage} = this.context.intl;
+
+        if (post && post.channel_id) {
+            userIds.forEach((userId, index) => {
+                actions.addChannelMember(post.channel_id, userId);
+
+                if (post.root_id) {
+                    const holder = defineMessages({
+                        message: {
+                            id: 'api.channel.add_member.added',
+                            defaultMessage: '{addedUsername} added to the channel by {username}.',
+                        },
+                    });
+
+                    const message = formatMessage(
+                        holder.message,
+                        {
+                            username: currentUser.username,
+                            addedUsername: usernames[index],
+                        },
+                    );
+
+                    actions.sendEphemeralPost(currentUser, usernames[index], message, post.channel_id, post.root_id);
+                }
+            });
+
+            actions.removePost(post);
+        }
+    }
+
+    generateAtMentions(usernames = []) {
+        if (usernames.length === 1) {
+            return (
+                <AtMention
+                    mentionStyle={this.props.textStyles.mention}
+                    mentionName={usernames[0]}
+                    onLongPress={this.props.onLongPress}
+                    onPostPress={this.props.onPostPress}
+                    navigator={this.props.navigator}
+                />
+            );
+        } else if (usernames.length > 1) {
+            function andSeparator(key) {
+                return (
+                    <FormattedText
+                        key={key}
+                        id={'post_body.check_for_out_of_channel_mentions.link.and'}
+                        defaultMessage={' and '}
+                    />
+                );
+            }
+
+            function commaSeparator(key) {
+                return <Text key={key}>{', '}</Text>;
+            }
+
+            return (
+                <Text>
+                    {
+                        usernames.map((username) => {
+                            return (
+                                <AtMention
+                                    key={username}
+                                    mentionStyle={this.props.textStyles.mention}
+                                    mentionName={username}
+                                    onLongPress={this.props.onLongPress}
+                                    onPostPress={this.props.onPostPress}
+                                    navigator={this.props.navigator}
+                                />
+                            );
+                        }).reduce((acc, el, idx, arr) => {
+                            if (idx === 0) {
+                                return [el];
+                            } else if (idx === arr.length - 1) {
+                                return [...acc, andSeparator(idx), el];
+                            }
+
+                            return [...acc, commaSeparator(idx), el];
+                        }, [])
+                    }
+                </Text>
+            );
+        }
+
+        return '';
+    }
+
+    render() {
+        const {channelType, postId, usernames} = this.props;
+        if (!postId || !channelType) {
+            return null;
+        }
+
+        let linkId;
+        let linkText;
+        if (channelType === General.PRIVATE_CHANNEL) {
+            linkId = 'post_body.check_for_out_of_channel_mentions.link.private';
+            linkText = 'add them to this private channel';
+        } else if (channelType === General.OPEN_CHANNEL) {
+            linkId = 'post_body.check_for_out_of_channel_mentions.link.public';
+            linkText = 'add them to the channel';
+        }
+
+        let messageId;
+        let messageText;
+        if (usernames.length === 1) {
+            messageId = 'post_body.check_for_out_of_channel_mentions.message.one';
+            messageText = 'was mentioned but is not in the channel. Would you like to ';
+        } else if (usernames.length > 1) {
+            messageId = 'post_body.check_for_out_of_channel_mentions.message.multiple';
+            messageText = 'were mentioned but they are not in the channel. Would you like to ';
+        }
+
+        const atMentions = this.generateAtMentions(usernames);
+
+        return (
+            <Text>
+                {atMentions}
+                {' '}
+                <FormattedText
+                    id={messageId}
+                    defaultMessage={messageText}
+                />
+                <Text
+                    style={this.props.textStyles.link}
+                    id='add_channel_member_link'
+                    onPress={this.handleAddChannelMember}
+                >
+                    <FormattedText
+                        id={linkId}
+                        defaultMessage={linkText}
+                    />
+                </Text>
+                <FormattedText
+                    id={'post_body.check_for_out_of_channel_mentions.message_last'}
+                    defaultMessage={'? They will have access to all message history.'}
+                />
+            </Text>
+        );
+    }
+}

--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -63,13 +63,7 @@ function mapStateToProps(state, ownProps) {
         isPostAddChannelMember = true;
     }
 
-    let addMemberProps = {};
-    if (post.props && post.props.add_channel_member) {
-        addMemberProps = post.props.add_channel_member;
-    }
-
     return {
-        addMemberProps,
         postProps: post.props || {},
         fileIds: post.file_ids,
         hasBeenDeleted: post.state === Posts.POST_DELETED,

--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -41,16 +41,13 @@ function mapStateToProps(state, ownProps) {
         isPending = false;
     }
 
-    const isEphemeralPost = isPostEphemeral(post);
-    const isSystemPost = isSystemMessage(post);
-
     const channel = getCurrentChannel(state);
     const user = getCurrentUser(state);
     const teamMember = getCurrentTeamMembership(state);
     const channelMember = getMyCurrentChannelMembership(state);
     const {config, license} = state.entities.general;
-
     const isUserCanManageMembers = canManageMembers(channel, user, teamMember, channelMember, config, license);
+    const isEphemeralPost = isPostEphemeral(post);
 
     let isPostAddChannelMember = false;
     if (
@@ -73,7 +70,7 @@ function mapStateToProps(state, ownProps) {
         isPending,
         isPostAddChannelMember,
         isPostEphemeral: isEphemeralPost,
-        isSystemMessage: isSystemPost,
+        isSystemMessage: isSystemMessage(post),
         message: post.message,
         theme: getTheme(state),
     };

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -35,7 +35,6 @@ export default class PostBody extends PureComponent {
             flagPost: PropTypes.func.isRequired,
             unflagPost: PropTypes.func.isRequired,
         }).isRequired,
-        addMemberProps: PropTypes.object,
         canDelete: PropTypes.bool,
         canEdit: PropTypes.bool,
         fileIds: PropTypes.array,
@@ -343,7 +342,6 @@ export default class PostBody extends PureComponent {
     render() {
         const {formatMessage} = this.context.intl;
         const {
-            addMemberProps,
             hasBeenDeleted,
             hasBeenEdited,
             isFailed,
@@ -396,9 +394,9 @@ export default class PostBody extends PureComponent {
                             onPermalinkPress={onPermalinkPress}
                             onPostPress={onPress}
                             textStyles={textStyles}
-                            postId={addMemberProps.post_id}
-                            userIds={addMemberProps.user_ids}
-                            usernames={addMemberProps.usernames}
+                            postId={postProps.add_channel_member.post_id}
+                            userIds={postProps.add_channel_member.user_ids}
+                            usernames={postProps.add_channel_member.usernames}
                         />
                     </View>
                 </View>

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -19,6 +19,7 @@ import FileAttachmentList from 'app/components/file_attachment_list';
 import FormattedText from 'app/components/formatted_text';
 import Markdown from 'app/components/markdown';
 import OptionsContext from 'app/components/options_context';
+import PostAddChannelMember from 'app/components/post_add_channel_member';
 
 import PostBodyAdditionalContent from 'app/components/post_body_additional_content';
 
@@ -34,6 +35,7 @@ export default class PostBody extends PureComponent {
             flagPost: PropTypes.func.isRequired,
             unflagPost: PropTypes.func.isRequired,
         }).isRequired,
+        addMemberProps: PropTypes.object,
         canDelete: PropTypes.bool,
         canEdit: PropTypes.bool,
         fileIds: PropTypes.array,
@@ -44,6 +46,7 @@ export default class PostBody extends PureComponent {
         isFailed: PropTypes.bool,
         isFlagged: PropTypes.bool,
         isPending: PropTypes.bool,
+        isPostAddChannelMember: PropTypes.bool,
         isPostEphemeral: PropTypes.bool,
         isReplyPost: PropTypes.bool,
         isSearchResult: PropTypes.bool,
@@ -340,6 +343,7 @@ export default class PostBody extends PureComponent {
     render() {
         const {formatMessage} = this.context.intl;
         const {
+            addMemberProps,
             hasBeenDeleted,
             hasBeenEdited,
             isFailed,
@@ -382,6 +386,23 @@ export default class PostBody extends PureComponent {
                 </TouchableHighlight>
             );
             body = (<View>{messageComponent}</View>);
+        } else if (isPostAddChannelMember) {
+            messageComponent = (
+                <View style={style.row}>
+                    <View style={[{flex: 1}, (isPendingOrFailedPost && style.pendingPost)]}>
+                        <PostAddChannelMember
+                            navigator={navigator}
+                            onLongPress={this.showOptionsContext}
+                            onPermalinkPress={onPermalinkPress}
+                            onPostPress={onPress}
+                            textStyles={textStyles}
+                            postId={addMemberProps.post_id}
+                            userIds={addMemberProps.user_ids}
+                            usernames={addMemberProps.usernames}
+                        />
+                    </View>
+                </View>
+            );
         } else if (message.length) {
             messageComponent = (
                 <View style={style.row}>

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -346,6 +346,7 @@ export default class PostBody extends PureComponent {
             hasBeenEdited,
             isFailed,
             isPending,
+            isPostAddChannelMember,
             isSearchResult,
             isSystemMessage,
             message,
@@ -353,6 +354,7 @@ export default class PostBody extends PureComponent {
             onFailedPostPress,
             onPermalinkPress,
             onPress,
+            postProps,
             renderReplyBar,
             theme,
             toggleSelected,
@@ -387,7 +389,7 @@ export default class PostBody extends PureComponent {
         } else if (isPostAddChannelMember) {
             messageComponent = (
                 <View style={style.row}>
-                    <View style={[{flex: 1}, (isPendingOrFailedPost && style.pendingPost)]}>
+                    <View style={style.flex}>
                         <PostAddChannelMember
                             navigator={navigator}
                             onLongPress={this.showOptionsContext}

--- a/app/selectors/post_list.js
+++ b/app/selectors/post_list.js
@@ -24,11 +24,12 @@ export function makePreparePostIdsForPostList() {
 
     return createIdsSelector(
         (state, props) => getMyPosts(state, props.postIds),
+        (state) => state.entities.posts.selectedPostId,
         (state, props) => props.lastViewedAt,
         (state, props) => props.indicateNewMessages,
         getCurrentUser,
         shouldShowJoinLeaveMessages,
-        (posts, lastViewedAt, indicateNewMessages, currentUser, showJoinLeave) => {
+        (posts, selectedPostId, lastViewedAt, indicateNewMessages, currentUser, showJoinLeave) => {
             if (posts.length === 0 || !currentUser) {
                 return [];
             }
@@ -41,6 +42,10 @@ export function makePreparePostIdsForPostList() {
             // Iterating through the posts from oldest to newest
             for (let i = posts.length - 1; i >= 0; i--) {
                 const post = posts[i];
+
+                if (post.type === Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL && !selectedPostId) {
+                    continue;
+                }
 
                 if (post.state === Posts.POST_DELETED && post.user_id === currentUser.id) {
                     continue;

--- a/test/app/selectors/post_list.test.js
+++ b/test/app/selectors/post_list.test.js
@@ -21,7 +21,7 @@ describe('Selectors.PostList', () => {
                 entities: {
                     posts: {
                         posts: {
-                            1001: {id: '1001', create_at: 0},
+                            1001: {id: '1001', create_at: 0, type: ''},
                             1002: {id: '1002', create_at: 1, type: Posts.POST_TYPES.JOIN_CHANNEL},
                         },
                     },
@@ -115,9 +115,9 @@ describe('Selectors.PostList', () => {
                 entities: {
                     posts: {
                         posts: {
-                            1000: {id: '1000', create_at: 1000},
-                            1005: {id: '1005', create_at: 1005},
-                            1010: {id: '1010', create_at: 1010},
+                            1000: {id: '1000', create_at: 1000, type: ''},
+                            1005: {id: '1005', create_at: 1005, type: ''},
+                            1010: {id: '1010', create_at: 1010, type: ''},
                         },
                     },
                     preferences: {
@@ -152,11 +152,11 @@ describe('Selectors.PostList', () => {
 
             // Posts 7 hours apart so they should appear on multiple days
             const initialPosts = {
-                1001: {id: '1001', create_at: 1 * 60 * 60 * 1000},
-                1002: {id: '1002', create_at: (1 * 60 * 60 * 1000) + 5},
-                1003: {id: '1003', create_at: (1 * 60 * 60 * 1000) + 10},
-                1004: {id: '1004', create_at: 25 * 60 * 60 * 1000},
-                1005: {id: '1005', create_at: (25 * 60 * 60 * 1000) + 5},
+                1001: {id: '1001', create_at: 1 * 60 * 60 * 1000, type: ''},
+                1002: {id: '1002', create_at: (1 * 60 * 60 * 1000) + 5, type: ''},
+                1003: {id: '1003', create_at: (1 * 60 * 60 * 1000) + 10, type: ''},
+                1004: {id: '1004', create_at: 25 * 60 * 60 * 1000, type: ''},
+                1005: {id: '1005', create_at: (25 * 60 * 60 * 1000) + 5, type: ''},
                 1006: {id: '1006', create_at: (25 * 60 * 60 * 1000) + 10, type: Posts.POST_TYPES.JOIN_CHANNEL},
             };
             let state = {


### PR DESCRIPTION
#### Summary
Add feature to add user to channel after at-mention

#### Ticket Link
Jira ticket: [MM-9516](https://mattermost.atlassian.net/browse/MM-9516)

#### Checklist
- [x] Has change on redux https://github.com/mattermost/mattermost-redux/pull/426
- [x] Has UI changes

#### Device Information
This PR was tested on: [iPhone 8, iOS 11, Android]

#### Screenshots

### At-mentioned  a user at Channel view of public channel
<img width="332" alt="screen shot 2018-03-17 at 1 57 59 am" src="https://user-images.githubusercontent.com/5334504/37547620-c68e4fae-29ad-11e8-9a43-5f495b0bbbce.png">

### At-mentioned a user at Thread screen of private channel
![screen shot 2018-03-19 at 7 04 28 pm](https://user-images.githubusercontent.com/5334504/37592111-abd22968-2ba8-11e8-9fa5-62e37c08bb9f.png)

### Added a user at private channel (ephemeral post is posted on Thread screen)
![screen shot 2018-03-19 at 7 04 01 pm](https://user-images.githubusercontent.com/5334504/37592112-abfe1ce4-2ba8-11e8-93fb-44fa1de001b5.png)

### At-mentioned multiple users at Thread screen of private channel
![screen shot 2018-03-19 at 7 05 28 pm](https://user-images.githubusercontent.com/5334504/37592110-aba17c28-2ba8-11e8-8f37-f37d16110796.png)

### Added one and multiple users at private channel (ephemeral posts are posted on Thread screen)
![screen shot 2018-03-19 at 7 05 46 pm](https://user-images.githubusercontent.com/5334504/37592109-ab4e98c8-2ba8-11e8-8586-9d268a49a41e.png)
