### PR TITLE
Quick fix on JS warnings on PostHeader and EditChannelInfo

### DIFF
--- a/app/components/edit_channel_info/index.js
+++ b/app/components/edit_channel_info/index.js
@@ -34,7 +34,7 @@ export default class EditChannelInfo extends PureComponent {
         enableRightButton: PropTypes.func,
         saving: PropTypes.bool.isRequired,
         editing: PropTypes.bool,
-        error: PropTypes.string,
+        error: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
         displayName: PropTypes.string,
         currentTeamUrl: PropTypes.string,
         channelURL: PropTypes.string,

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -25,7 +25,7 @@ export default class PostHeader extends PureComponent {
         commentCount: PropTypes.number,
         commentedOnDisplayName: PropTypes.string,
         createAt: PropTypes.number.isRequired,
-        displayName: PropTypes.string.isRequired,
+        displayName: PropTypes.string,
         enablePostUsernameOverride: PropTypes.bool,
         fromWebHook: PropTypes.bool,
         isPendingOrFailedPost: PropTypes.bool,
@@ -39,7 +39,7 @@ export default class PostHeader extends PureComponent {
         shouldRenderReplyButton: PropTypes.bool,
         showFullDate: PropTypes.bool,
         theme: PropTypes.object.isRequired,
-        username: PropTypes.string.isRequired,
+        username: PropTypes.string,
         isFlagged: PropTypes.bool,
     };
 
@@ -50,7 +50,9 @@ export default class PostHeader extends PureComponent {
     };
 
     handleUsernamePress = () => {
-        this.props.onUsernamePress(this.props.username);
+        if (this.props.username) {
+            this.props.onUsernamePress(this.props.username);
+        }
     }
 
     getDisplayName = (style) => {


### PR DESCRIPTION
#### Summary
Quick fix on JS warnings on PostHeader and EditChannelInfo.

PostHeader:
Make `displayName` and `username` props not required. The logic inside the code does not really expect those to be required like, so:
```
//
        if (displayName) {
            name = displayName;
        } else {...}

//
        } else if (this.props.displayName) {
            return (
                <TouchableOpacity onPress={this.handleUsernamePress}>
                    <Text style={style.displayName}>
                        {this.props.displayName}
                    </Text>
                </TouchableOpacity>
            );
        }

```
![screen shot 2018-03-26 at 8 14 24 pm](https://user-images.githubusercontent.com/5334504/37907168-dff2e974-3136-11e8-8a02-0f9a8383f27d.png)
![screen shot 2018-03-26 at 8 14 04 pm](https://user-images.githubusercontent.com/5334504/37907169-e03d055e-3136-11e8-9675-e8b985f1a356.png)

EditChannelInfo:
Make it accepts either string or object since the `ErrorText` expects it either of those as well
![screen shot 2018-03-26 at 8 09 32 pm](https://user-images.githubusercontent.com/5334504/37907243-1d73375e-3137-11e8-8e07-1d03c8f3c40f.png)

#### Ticket Link
none

#### Device Information
This PR was tested on: [iPhone 8, macOS] 
