### PR TITLE
MM-9940 Updated CommonMark to not use String.prototype.startsWith (1.7)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,7 +1774,7 @@ commonmark-react-renderer@hmhealey/commonmark-react-renderer:
 
 commonmark@hmhealey/commonmark.js:
   version "0.28.0"
-  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/bcd754c640ed8192fa959f2416f183acf9e1cfaf"
+  resolved "https://codeload.github.com/hmhealey/commonmark.js/tar.gz/7c20ebc1b60f5bb56c1ed9ad3239f53293278d5c"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"


### PR DESCRIPTION
As reported [here](https://github.com/mattermost/mattermost-mobile/issues/1534), React Native on Android has a bug with String.prototype.startsWith that causes it to return false for strings containing some unicode characters. It's supposedly fixed in React Native 0.54, but since we're not backporting this to 1.7, I went with just not using startsWith.

CommonMark changes here: https://github.com/hmhealey/commonmark.js/commit/7c20ebc1b60f5bb56c1ed9ad3239f53293278d5c

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9940

#### Device Information
This PR was tested on: Nexus 5

#### Screenshots
![image](https://user-images.githubusercontent.com/3277310/37931710-8e78ad12-3114-11e8-9986-c74ee4359d14.png)

