### PR TITLE
Fix iOS Share Extension Crash and Bump build and version numbers (1.7)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,8 +111,8 @@ android {
         applicationId "com.mattermost.rnbeta"
         minSdkVersion 21
         targetSdkVersion 23
-        versionCode 91
-        versionName "1.7.0"
+        versionCode 92
+        versionName "1.7.1"
         multiDexEnabled true
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -82,5 +82,5 @@ export const encodeHeaderURIStringToUTF8 = (string) => {
 };
 
 export const getAllowedServerMaxFileSize = (config) => {
-    return config.MaxFileSize ? parseInt(config.MaxFileSize, 10) : DEFAULT_SERVER_MAX_FILE_SIZE;
+    return config && config.MaxFileSize ? parseInt(config.MaxFileSize, 10) : DEFAULT_SERVER_MAX_FILE_SIZE;
 };

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>91</string>
+	<string>92</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
@@ -54,6 +54,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Let Mattermost access your Media files</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Share post data accross devices with Mattermost</string>
 	<key>NSCalendarsUsageDescription</key>
@@ -68,8 +70,6 @@
 	<string>Upload Photos and Videos to your Mattermost instance or save them to your device</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Send voice messages to your Mattermost instance</string>
-	<key>NSAppleMusicUsageDescription</key>
-    <string>Let Mattermost access your Media files</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Entypo.ttf</string>

--- a/ios/MattermostShare/Info.plist
+++ b/ios/MattermostShare/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>91</string>
+	<string>92</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/ios/MattermostTests/Info.plist
+++ b/ios/MattermostTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>91</string>
+	<string>92</string>
 </dict>
 </plist>

--- a/share_extension/ios/index.js
+++ b/share_extension/ios/index.js
@@ -73,8 +73,12 @@ export default class SharedApp extends PureComponent {
     };
 
     userIsLoggedIn = () => {
-        return Boolean(this.entities && this.entities.general && this.entities.general.credentials &&
-            this.entities.general.credentials.token && this.entities.general.credentials.url);
+        if (this.entities && this.entities.general && this.entities.general.credentials &&
+            this.entities.general.credentials.token && this.entities.general.credentials.url) {
+            return true;
+        }
+
+        return false;
     };
 
     render() {


### PR DESCRIPTION
#### Summary
The iOS Share extension is crashing on the latest release, this PR fixes it