### PR TITLE
Fix max length prop to be a number

### DIFF
--- a/app/components/post_textbox/index.js
+++ b/app/components/post_textbox/index.js
@@ -44,7 +44,7 @@ function mapStateToProps(state, ownProps) {
         currentUserId: getCurrentUserId(state),
         deactivatedChannel,
         files: currentDraft.files,
-        maxMessageLength: (config && config.MaxPostSize) || MAX_MESSAGE_LENGTH,
+        maxMessageLength: (config && parseInt(config.MaxPostSize || 0, 10)) || MAX_MESSAGE_LENGTH,
         theme: getTheme(state),
         uploadFileRequestStatus: state.requests.files.uploadFiles.status,
         value: currentDraft.draft,


### PR DESCRIPTION
#### Summary
The prop was being passed as a string instead of a number