### PR TITLE
MM-9045 Sorted More Direct Messages by username

### DIFF
--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -402,15 +402,12 @@ class MoreDirectMessages extends PureComponent {
     };
 
     sectionKeyExtractor = (user) => {
-        // Group items alphabetically by first letter
-        return displayUsername(user, this.props.teammateNameDisplay)[0].toUpperCase();
+        // Group items alphabetically by first letter of username
+        return user.username[0].toUpperCase();
     }
 
     compareItems = (a, b) => {
-        const aName = displayUsername(a, this.props.teammateNameDisplay);
-        const bName = displayUsername(b, this.props.teammateNameDisplay);
-
-        return aName.localeCompare(bName);
+        return a.username.localeCompare(b.username);
     };
 
     renderItem = (props) => {


### PR DESCRIPTION
As discussed, the issue where it appeared that no more users were loading was either because of simple lag or because loaded users appeared before the currently displayed ones (due to the list being sorted by display name but the server sending the users by username)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9045

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
<img width="382" alt="screen shot 2018-04-11 at 9 59 24 am" src="https://user-images.githubusercontent.com/3277310/38621526-0ba73694-3d6f-11e8-8f51-1d25297d5e92.png">
