### PR TITLE
MM-10016 Globe icon not centered to the channel title in LHS

### DIFF
--- a/app/components/channel_drawer/channels_list/channel_item/channel_item.js
+++ b/app/components/channel_drawer/channels_list/channel_item/channel_item.js
@@ -188,7 +188,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         item: {
             alignItems: 'center',
-            height: 44,
             flex: 1,
             flexDirection: 'row',
             paddingLeft: 16,
@@ -199,11 +198,13 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         text: {
             color: changeOpacity(theme.sidebarText, 0.4),
-            flex: 1,
             fontSize: 14,
             fontWeight: '600',
-            lineHeight: 16,
             paddingRight: 40,
+            height: '100%',
+            width: '100%',
+            textAlignVertical: 'center',
+            lineHeight: 44,
         },
         textActive: {
             color: theme.sidebarTextActiveColor,


### PR DESCRIPTION
#### Summary
Fixes the channel item to ensure that the icon and the text are centered

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10016