### PR TITLE
Fix share from SwiftKey Keyboard and clear temp files

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
+++ b/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
@@ -93,7 +93,12 @@ public class RealPathUtil {
         File tmpFile;
         try {
             String fileName = uri.getLastPathSegment();
-            tmpFile = File.createTempFile("mmShare", fileName, context.getCacheDir());
+            File cacheDir = new File(context.getCacheDir(), "mmShare");
+            if (!cacheDir.exists()) {
+                cacheDir.mkdirs();
+            }
+
+            tmpFile = File.createTempFile("tmp", fileName, cacheDir);
 
             ParcelFileDescriptor pfd = context.getContentResolver().openFileDescriptor(uri, "r");
 
@@ -177,21 +182,21 @@ public class RealPathUtil {
         return getMimeType(file);
     }
 
-    public static void deleteTempFiles(final String tempFolder) {
+    public static void deleteTempFiles(final File dir) {
         try {
-            File dir = new File(tempFolder);
             if (dir.isDirectory()) {
-                String[] files = dir.list();
-                for (int i =0; i < files.length; i++) {
-                    String file = files[i];
-                    if (file.startsWith("mmShare") || file.startsWith("tmp")) {
-                        File f = new File(dir, files[i]);
-                        f.delete();
-                    }
-                }
+                deleteRecursive(dir);
             }
         } catch (Exception e) {
             // do nothing
         }
+    }
+
+    private static void deleteRecursive(File fileOrDirectory) {
+        if (fileOrDirectory.isDirectory())
+            for (File child : fileOrDirectory.listFiles())
+                deleteRecursive(child);
+
+        fileOrDirectory.delete();
     }
 }

--- a/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
+++ b/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
@@ -70,10 +70,14 @@ public class RealPathUtil {
                 return uri.getLastPathSegment();
             }
 
-            String path = getDataColumn(context, uri, null, null);
+            try {
+                String path = getDataColumn(context, uri, null, null);
 
-            if (path != null) {
-                return path;
+                if (path != null) {
+                    return path;
+                }
+            } catch (Exception e) {
+                // do nothing and try to get a temp file
             }
 
             // Try save to tmp file, and return tmp file path
@@ -89,7 +93,7 @@ public class RealPathUtil {
         File tmpFile;
         try {
             String fileName = uri.getLastPathSegment();
-            tmpFile = File.createTempFile("tmp", fileName, context.getCacheDir());
+            tmpFile = File.createTempFile("mmShare", fileName, context.getCacheDir());
 
             ParcelFileDescriptor pfd = context.getContentResolver().openFileDescriptor(uri, "r");
 
@@ -171,5 +175,23 @@ public class RealPathUtil {
     public static String getMimeType(String filePath) {
         File file = new File(filePath);
         return getMimeType(file);
+    }
+
+    public static void deleteTempFiles(final String tempFolder) {
+        try {
+            File dir = new File(tempFolder);
+            if (dir.isDirectory()) {
+                String[] files = dir.list();
+                for (int i =0; i < files.length; i++) {
+                    String file = files[i];
+                    if (file.startsWith("mmShare") || file.startsWith("tmp")) {
+                        File f = new File(dir, files[i]);
+                        f.delete();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // do nothing
+        }
     }
 }

--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -40,6 +40,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
     public ShareModule(ReactApplicationContext reactContext) {
         super(reactContext);
     }
+    private String tempFolder;
 
     @Override
     public String getName() {
@@ -60,6 +61,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void close(ReadableMap data) {
+        this.clear();
         getCurrentActivity().finish();
 
         if (data != null) {
@@ -78,6 +80,8 @@ public class ShareModule extends ReactContextBaseJavaModule {
                 }
             }
         }
+
+        RealPathUtil.deleteTempFiles(this.tempFolder);
     }
 
     @ReactMethod
@@ -96,6 +100,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
         Activity currentActivity = getCurrentActivity();
 
         if (currentActivity != null) {
+            this.tempFolder = currentActivity.getCacheDir() + "/";
             Intent intent = currentActivity.getIntent();
             action = intent.getAction();
             type = intent.getType();

--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -40,7 +40,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
     public ShareModule(ReactApplicationContext reactContext) {
         super(reactContext);
     }
-    private String tempFolder;
+    private File tempFolder;
 
     @Override
     public String getName() {
@@ -100,7 +100,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
         Activity currentActivity = getCurrentActivity();
 
         if (currentActivity != null) {
-            this.tempFolder = currentActivity.getCacheDir() + "/";
+            this.tempFolder = new File(currentActivity.getCacheDir(), "mmShare");
             Intent intent = currentActivity.getIntent();
             action = intent.getAction();
             type = intent.getType();


### PR DESCRIPTION
#### Summary
Fixes a crash when trying to share content from a custom keyboard (SwiftKey in this case was used to test) and also removes the temp files from the cache dir if there were some created while sharing content.

#### Ticket Link
Fixes #1532 

#### Device Information
This PR was tested on: 
* Android 7.1.1 Emulator