### PR TITLE
Fix images transition

### DIFF
--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -379,7 +379,7 @@ export default class Downloader extends PureComponent {
 
     render() {
         const {show, downloadPath} = this.props;
-        if ((!show || this.state.didCancel) && !this.state.force) {
+        if (!show && !this.state.force) {
             return null;
         }
 

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -392,6 +392,7 @@ export default class ImagePreview extends PureComponent {
         const {getPreviewProps} = this.props;
         const containerStyle = this.getSwipeableStyle();
         const previewProps = getPreviewProps(index);
+        Reflect.deleteProperty(previewProps, 'thumbnailUri');
 
         return (
             <ScrollView scrollEnabled={false}>


### PR DESCRIPTION
#### Summary
Fixes images transition when showing the preview and fixes the download button not to disappear when the download of the video fails
