### PR TITLE
Fix crash on search

### DIFF
--- a/app/components/autocomplete/autocomplete.js
+++ b/app/components/autocomplete/autocomplete.js
@@ -30,6 +30,7 @@ export default class Autocomplete extends PureComponent {
 
     static defaultProps = {
         isSearch: false,
+        cursorPosition: 0,
     };
 
     state = {

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -81,6 +81,7 @@ export default class Search extends PureComponent {
         this.isX = DeviceInfo.getModel() === 'iPhone X';
         this.state = {
             channelName: '',
+            cursorPosition: 0,
             value: '',
             managedConfig: {},
         };
@@ -122,10 +123,6 @@ export default class Search extends PureComponent {
     componentWillUnmount() {
         mattermostManaged.removeEventListener(this.listenerId);
     }
-
-    attachAutocomplete = (c) => {
-        this.autocomplete = c;
-    };
 
     cancelSearch = preventDoubleTap(() => {
         const {navigator} = this.props;
@@ -173,9 +170,10 @@ export default class Search extends PureComponent {
     };
 
     handleSelectionChange = (event) => {
-        if (this.autocomplete) {
-            this.autocomplete.getWrappedInstance().handleSelectionChange(event);
-        }
+        const cursorPosition = event.nativeEvent.selection.end;
+        this.setState({
+            cursorPosition,
+        });
     };
 
     handleTextChanged = (value, selectionChanged) => {
@@ -490,7 +488,10 @@ export default class Search extends PureComponent {
         } = this.props;
 
         const {intl} = this.context;
-        const {value} = this.state;
+        const {
+            cursorPosition,
+            value,
+        } = this.state;
         const style = getStyleFromTheme(theme);
         const sections = [{
             data: [{
@@ -625,7 +626,7 @@ export default class Search extends PureComponent {
                         stickySectionHeadersEnabled={Platform.OS === 'ios'}
                     />
                     <Autocomplete
-                        ref={this.attachAutocomplete}
+                        cursorPosition={cursorPosition}
                         onChangeText={this.handleTextChanged}
                         isSearch={true}
                         value={value}


### PR DESCRIPTION
#### Summary
Crash is first reported by Lindy on pre-release: https://pre-release.mattermost.com/core/pl/mudge638z78q7yie7ps311i59c

I think this is left behind when the cursor position of AutoComplete was refactored - https://github.com/mattermost/mattermost-mobile/pull/1547

#### Ticket Link
none

#### Device Information
This PR was tested on: [Simulator, iPhone7/iPhone6, 11.2] 

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
