### PR TITLE
MM-10180 Better handle characters after periods in URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3179,7 +3179,7 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "commonmark": {
-      "version": "github:mattermost/commonmark.js#1496b5d11f245e00aae51f8fa1b2c4f12b4ddd7b",
+      "version": "github:mattermost/commonmark.js#c9c29834005af6eedd1a979d913b75e34f16a83b",
       "requires": {
         "entities": "1.1.1",
         "mdurl": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "analytics-react-native": "1.2.0",
     "babel-polyfill": "6.26.0",
     "base-64": "0.1.0",
-    "commonmark": "mattermost/commonmark.js#1496b5d11f245e00aae51f8fa1b2c4f12b4ddd7b",
+    "commonmark": "github:mattermost/commonmark.js#c9c29834005af6eedd1a979d913b75e34f16a83b",
     "commonmark-react-renderer": "mattermost/commonmark-react-renderer#86fa63f898802953842526c2030f3b63c5d1ae7a",
     "deep-equal": "1.0.1",
     "fuse.js": "^3.2.0",


### PR DESCRIPTION
This is to make our link parsing slightly more forgiving and GitHub-like since we don't currently allow links containing periods followed by punctuation like https://example.com/?text=Test+phrase.+Please+ignore

This is based off https://github.com/mattermost/mattermost-mobile/pull/1602

Commonmark changes here: https://github.com/mattermost/commonmark.js/commit/c9c29834005af6eedd1a979d913b75e34f16a83b

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10180

#### Checklist
- Added or updated unit tests (required for all new features)