### PR TITLE
Fix post with layout to not create new post components

### DIFF
--- a/app/components/post_list/with_layout.js
+++ b/app/components/post_list/with_layout.js
@@ -17,25 +17,22 @@ function withLayout(WrappedComponent) {
 
         static defaultProps = {
             onLayoutCalled: emptyFunction,
-        }
+        };
 
         onLayout = (event) => {
             const {height} = event.nativeEvent.layout;
-            this.props.onLayoutCalled(this.props.index, height);
+            const {shouldCallOnLayout} = this.props;
+            if (shouldCallOnLayout) {
+                this.props.onLayoutCalled(this.props.index, height);
+            }
         };
 
         render() {
-            const {index, onLayoutCalled, shouldCallOnLayout, ...otherProps} = this.props; //eslint-disable-line no-unused-vars
-
-            if (shouldCallOnLayout) {
-                return (
-                    <View onLayout={this.onLayout}>
-                        <WrappedComponent {...otherProps}/>
-                    </View>
-                );
-            }
-
-            return <WrappedComponent {...otherProps}/>;
+            return (
+                <View onLayout={this.onLayout}>
+                    <WrappedComponent {...this.props}/>
+                </View>
+            );
         }
     };
 }

--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -49,6 +49,7 @@ export default class ProfilePicture extends PureComponent {
 
     componentWillMount() {
         const {edit, imageUri, user} = this.props;
+        this.mounted = true;
 
         if (edit && imageUri) {
             this.setImageURL(imageUri);
@@ -65,9 +66,11 @@ export default class ProfilePicture extends PureComponent {
 
     componentWillUpdate(nextProps) {
         if (Boolean(nextProps.user) !== Boolean(this.props.user) || nextProps.user.id !== this.props.user.id) {
-            this.setState({pictureUrl: null});
-
             const nextUser = nextProps.user;
+
+            if (this.mounted) {
+                this.setState({pictureUrl: null});
+            }
 
             if (nextUser) {
                 ImageCacheManager.cache('', Client4.getProfilePictureUrl(nextUser.id, nextUser.last_picture_update), this.setImageURL);
@@ -75,8 +78,14 @@ export default class ProfilePicture extends PureComponent {
         }
     }
 
+    componentWillUnmount() {
+        this.mounted = false;
+    }
+
     setImageURL = (pictureUrl) => {
-        this.setState({pictureUrl});
+        if (this.mounted) {
+            this.setState({pictureUrl});
+        }
     };
 
     render() {


### PR DESCRIPTION
#### Summary
After submitting a post on a newly rendered channel that has the new messages indicator the channel was being scrolled to the indicator once more, the reason being that the `PostWithLayout` component was re-creating the post component and called the onLayout function that was causing the postlist to scroll after it updated.

This PR prevents the re-creation of the post component thus fixing two thing:
1. The post list is not re-rendering the items that do not need to be re-rendered
2. The post list won't scroll if not needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10236
