### PR TITLE
Fix mention badges in channel drawer

### DIFF
--- a/app/components/channel_drawer/channels_list/channel_item/channel_item.js
+++ b/app/components/channel_drawer/channels_list/channel_item/channel_item.js
@@ -208,7 +208,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontWeight: '600',
             paddingRight: 40,
             height: '100%',
-            width: '100%',
+            flex: 1,
             textAlignVertical: 'center',
             lineHeight: 44,
         },


### PR DESCRIPTION
#### Summary
The badges were out of the view cause the text of the channel display name was taking 100% of the view

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10299