### PR TITLE
Update getJoinableTeams from redux which returns sorted array of teams

### DIFF
--- a/app/screens/select_team/index.js
+++ b/app/screens/select_team/index.js
@@ -12,24 +12,12 @@ import {logout} from 'mattermost-redux/actions/users';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getJoinableTeams} from 'mattermost-redux/selectors/entities/teams';
 
-import {getCurrentLocale} from 'app/selectors/i18n';
-
 import SelectTeam from './select_team.js';
 
 function mapStateToProps(state) {
-    const locale = getCurrentLocale(state);
-
-    function sortTeams(a, b) {
-        const options = {
-            numeric: true,
-            sensitivity: 'base',
-        };
-        return a.display_name.localeCompare(b.display_name, locale, options);
-    }
-
     return {
         teamsRequest: state.requests.teams.getMyTeams,
-        teams: Object.values(getJoinableTeams(state)).sort(sortTeams),
+        teams: getJoinableTeams(state),
         currentChannelId: getCurrentChannelId(state),
         joinTeamRequest: state.requests.teams.joinTeam,
     };

--- a/app/screens/settings/general/index.js
+++ b/app/screens/settings/general/index.js
@@ -24,7 +24,7 @@ function mapStateToProps(state) {
         currentUserId: state.entities.users.currentUserId,
         currentTeamId: state.entities.teams.currentTeamId,
         currentUrl: removeProtocol(getCurrentUrl(state)),
-        joinableTeams: getJoinableTeams(state),
+        hasJoinableTeams: getJoinableTeams(state).length > 0,
     };
 }
 

--- a/app/screens/settings/general/settings.js
+++ b/app/screens/settings/general/settings.js
@@ -32,7 +32,7 @@ class Settings extends PureComponent {
         currentUrl: PropTypes.string.isRequired,
         errors: PropTypes.array.isRequired,
         intl: intlShape.isRequired,
-        joinableTeams: PropTypes.object.isRequired,
+        hasJoinableTeams: PropTypes.bool.isRequired,
         navigator: PropTypes.object,
         theme: PropTypes.object,
     };
@@ -214,9 +214,8 @@ class Settings extends PureComponent {
     });
 
     render() {
-        const {config, joinableTeams, theme} = this.props;
+        const {config, hasJoinableTeams, theme} = this.props;
         const style = getStyleSheet(theme);
-        const showTeams = Object.keys(joinableTeams).length > 0;
         const showHelp = isValidUrl(config.HelpLink);
         const showArrow = Platform.OS === 'ios';
 
@@ -246,7 +245,7 @@ class Settings extends PureComponent {
                         showArrow={showArrow}
                         theme={theme}
                     />
-                    {showTeams &&
+                    {hasJoinableTeams &&
                     <SettingsItem
                         defaultMessage='Open teams you can join'
                         i18nId='mobile.select_team.join_open'


### PR DESCRIPTION
#### Summary
Update getJoinableTeams from redux which returns sorted array of teams

This is as per comment on webapp - https://github.com/mattermost/mattermost-webapp/pull/1073#discussion_r184318356 - which migrates SelectTeam component into redux-style

#### Ticket Link
none

#### Checklist
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (https://github.com/mattermost/mattermost-redux/pull/471)

#### Device Information
This PR was tested on: [mobile app on iOS 11.2/iPhone 8 simulator, Chrome/FF on MacOS]

