### PR TITLE
Improved performance while autolinking emails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,7 +2763,7 @@
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "commonmark": {
-      "version": "github:mattermost/commonmark.js#c9c29834005af6eedd1a979d913b75e34f16a83b",
+      "version": "github:mattermost/commonmark.js#21742b9d51070b6abba82d88590a0c51ee552a47",
       "requires": {
         "entities": "1.1.1",
         "mdurl": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "analytics-react-native": "1.2.0",
     "babel-polyfill": "6.26.0",
     "base-64": "0.1.0",
-    "commonmark": "github:mattermost/commonmark.js#c9c29834005af6eedd1a979d913b75e34f16a83b",
+    "commonmark": "github:mattermost/commonmark.js#21742b9d51070b6abba82d88590a0c51ee552a47",
     "commonmark-react-renderer": "mattermost/commonmark-react-renderer#86fa63f898802953842526c2030f3b63c5d1ae7a",
     "deep-equal": "1.0.1",
     "fuse.js": "^3.2.0",


### PR DESCRIPTION
Commonmark changes here: https://github.com/mattermost/commonmark.js/commit/21742b9d51070b6abba82d88590a0c51ee552a47

The gist of those changes is that we're making `reMain` more efficient by making it look for what only might start an email instead of what does start an email. By doing that, it does less backtracking when it sees something that looks like an email but doesn't have an at sign. It still backtracks a fair bit which isn't ideal, but it's more than fast enough for the length of text that we support. A better fix would be to wait until we find an at sign and then backtrack to find which text is part of the email address, but that's not really possible with how this is written.

#### Device Information
This PR was tested on: iOS Simulator