### PR TITLE
Fix Android sharing files without extension

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
+++ b/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.content.ContentUris;
+import android.content.ContentResolver;
 import android.os.Environment;
 import android.webkit.MimeTypeMap;
 
@@ -98,6 +99,7 @@ public class RealPathUtil {
                 cacheDir.mkdirs();
             }
 
+            String mimeType = getMimeType(uri.getPath());
             tmpFile = File.createTempFile("tmp", fileName, cacheDir);
 
             ParcelFileDescriptor pfd = context.getContentResolver().openFileDescriptor(uri, "r");
@@ -180,6 +182,11 @@ public class RealPathUtil {
     public static String getMimeType(String filePath) {
         File file = new File(filePath);
         return getMimeType(file);
+    }
+
+    public static String getMimeTypeFromUri(final Context context, final Uri uri) {
+        ContentResolver cR = context.getContentResolver();
+        return cR.getType(uri);
     }
 
     public static void deleteTempFiles(final File dir) {

--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -126,7 +126,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
                     map = Arguments.createMap();
                     text = "file://" + filePath;
                     map.putString("value", text);
-                    map.putString("type", RealPathUtil.getMimeType(filePath));
+                    map.putString("type", RealPathUtil.getMimeTypeFromUri(currentActivity, uri));
                     items.pushMap(map);
                 }
             }

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -6,6 +6,7 @@ import {NavigationActions} from 'react-navigation';
 import TouchableItem from 'react-navigation/src/views/TouchableItem';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
+
 import {
     Image,
     NativeModules,
@@ -25,6 +26,7 @@ import {getFormattedFileSize, lookupMimeType} from 'mattermost-redux/utils/file_
 
 import PaperPlane from 'app/components/paper_plane';
 import mattermostManaged from 'app/mattermost_managed';
+import {getExtensionFromMime} from 'app/utils/file';
 import {emptyFunction} from 'app/utils/general';
 import {preventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
@@ -278,15 +280,20 @@ export default class ExtensionPost extends PureComponent {
                     break;
                 default: {
                     const fullPath = item.value;
-                    const filename = fullPath.replace(/^.*[\\/]/, '');
-                    const extension = filename.split('.').pop();
                     const fileSize = await RNFetchBlob.fs.stat(fullPath);
+                    let filename = fullPath.replace(/^.*[\\/]/, '');
+                    let extension = filename.split('.').pop();
+                    if (extension === filename) {
+                        extension = getExtensionFromMime(item.type);
+                        filename = `${filename}.${extension}`;
+                    }
+
                     totalSize += fileSize.size;
                     files.push({
                         extension,
                         filename,
                         fullPath,
-                        mimeType: lookupMimeType(filename.toLowerCase()),
+                        mimeType: item.type || lookupMimeType(filename.toLowerCase()),
                         size: getFormattedFileSize(fileSize),
                         type: item.type,
                     });


### PR DESCRIPTION
#### Summary
When sharing a file that does not have an extension on Android was uploading the file without extension and with mime type `application/octet-stream`, with this fix we are retrieving the file extension and mime type so the file is correctly uploaded
