### PR TITLE
MM-10360 Render OpenGraph previews for pages with an empty description

### DIFF
--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -217,7 +217,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
         const {isReplyPost, openGraphData, theme} = this.props;
         const {hasImage, height, imageUrl, width} = this.state;
 
-        if (!openGraphData || !openGraphData.description) {
+        if (!openGraphData || openGraphData.description == null) {
             return null;
         }
 
@@ -248,15 +248,17 @@ export default class PostAttachmentOpenGraph extends PureComponent {
                         </Text>
                     </TouchableOpacity>
                 </View>
-                <View style={style.flex}>
-                    <Text
-                        style={style.siteDescription}
-                        numberOfLines={5}
-                        ellipsizeMode='tail'
-                    >
-                        {openGraphData.description}
-                    </Text>
-                </View>
+                {openGraphData.description &&
+                    <View style={style.flex}>
+                        <Text
+                            style={style.siteDescription}
+                            numberOfLines={5}
+                            ellipsizeMode='tail'
+                        >
+                            {openGraphData.description}
+                        </Text>
+                    </View>
+                }
                 {hasImage &&
                     <View ref='item'>
                         <TouchableWithoutFeedback

--- a/package-lock.json
+++ b/package-lock.json
@@ -9864,7 +9864,7 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#c2cdd8fad33b97af4d0af2462b24f9cfd50a1913",
+      "version": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fuse.js": "^3.2.0",
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
-    "mattermost-redux": "mattermost/mattermost-redux#c2cdd8fad33b97af4d0af2462b24f9cfd50a1913",
+    "mattermost-redux": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
     "prop-types": "15.6.1",
     "react": "16.3.2",
     "react-intl": "2.4.0",


### PR DESCRIPTION
Some pages (like a GitHub PR with no description set) include an empty OpenGraph description, so this null check prevented the OpenGraph data for those pages from being saved into the store and eventually shown in a preview

Redux PR: https://github.com/mattermost/mattermost-redux/pull/478

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10360