### PR TITLE
Fixed empty OpenGraph previews from trying to render an empty string

### DIFF
--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -223,6 +223,21 @@ export default class PostAttachmentOpenGraph extends PureComponent {
 
         const style = getStyleSheet(theme);
 
+        let description = null;
+        if (openGraphData.description) {
+            description = (
+                <View style={style.flex}>
+                    <Text
+                        style={style.siteDescription}
+                        numberOfLines={5}
+                        ellipsizeMode='tail'
+                    >
+                        {openGraphData.description}
+                    </Text>
+                </View>
+            );
+        }
+
         return (
             <View style={style.container}>
                 <View style={style.flex}>
@@ -248,17 +263,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
                         </Text>
                     </TouchableOpacity>
                 </View>
-                {openGraphData.description &&
-                    <View style={style.flex}>
-                        <Text
-                            style={style.siteDescription}
-                            numberOfLines={5}
-                            ellipsizeMode='tail'
-                        >
-                            {openGraphData.description}
-                        </Text>
-                    </View>
-                }
+                {description}
                 {hasImage &&
                     <View ref='item'>
                         <TouchableWithoutFeedback


### PR DESCRIPTION
Fix for an issue introduced in https://github.com/mattermost/mattermost-mobile/commit/3b33b51f11349ba7fd22f9ce39d7fd1879670aa5 where an empty string is rendered outside of a <Text> node causing RN to crash.
