### PR TITLE
MM-10460: avoid double post on restore

### DIFF
--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -341,7 +341,7 @@ function cleanupState(action, keepCurrent = false) {
     nextState.errors = payload.errors;
 
     return {
-        type: 'persist/REHYDRATE',
+        type: action.type,
         payload: nextState,
         error: action.error,
     };

--- a/app/store/middleware.test.js
+++ b/app/store/middleware.test.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+import DeviceInfo from 'react-native-device-info';
+
+import {ViewTypes} from 'app/constants';
+import {messageRetention} from 'app/store/middleware';
+
+jest.mock('react-native-fetch-blob', () => {
+  return {
+    DocumentDir: () => {},
+    polyfill: () => {},
+    fs: {
+        dirs: {
+        },
+    },
+  }
+});
+
+jest.mock('react-native-device-info', () => {
+  return {
+    getVersion: () => '0.0.0',
+    getBuildNumber: () => '0',
+  };
+});
+
+describe('store/middleware', () => {
+    describe('messageRetention', () => {
+        describe('should chain the same incoming action type', () => {
+            const actions = [
+                {
+                    type: 'persist/REHYDRATE',
+                    payload: {
+                        views: {
+                            team: {
+                            },
+                        },
+                    },
+                },
+                {
+                    type: ViewTypes.DATA_CLEANUP,
+                    payload: {
+                        entities: {
+                            channels: {
+                            },
+                            posts: {
+                            },
+                        },
+                        views: {
+                            team: {
+                            },
+                        },
+                    },
+                },
+                {
+                    type: 'other',
+                },
+            ];
+
+            actions.forEach((action) => {
+                it(`for action type ${action.type}`, () => {
+                    const store = {};
+                    const next = (action) => action;
+
+                    nextAction = messageRetention(store)(next)(action);
+                    assert.equal(action.type, nextAction.type);
+                });
+            });
+        });
+    });
+});

--- a/app/store/middleware.test.js
+++ b/app/store/middleware.test.js
@@ -1,28 +1,29 @@
 // Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+/* eslint-disable max-nested-callbacks */
+
 import assert from 'assert';
-import DeviceInfo from 'react-native-device-info';
 
 import {ViewTypes} from 'app/constants';
 import {messageRetention} from 'app/store/middleware';
 
 jest.mock('react-native-fetch-blob', () => {
-  return {
-    DocumentDir: () => {},
-    polyfill: () => {},
-    fs: {
-        dirs: {
+    return {
+        DocumentDir: () => null,
+        polyfill: () => null,
+        fs: {
+            dirs: {
+            },
         },
-    },
-  }
+    };
 });
 
 jest.mock('react-native-device-info', () => {
-  return {
-    getVersion: () => '0.0.0',
-    getBuildNumber: () => '0',
-  };
+    return {
+        getVersion: () => '0.0.0',
+        getBuildNumber: () => '0',
+    };
 });
 
 describe('store/middleware', () => {
@@ -61,9 +62,9 @@ describe('store/middleware', () => {
             actions.forEach((action) => {
                 it(`for action type ${action.type}`, () => {
                     const store = {};
-                    const next = (action) => action;
+                    const next = (a) => a;
 
-                    nextAction = messageRetention(store)(next)(action);
+                    const nextAction = messageRetention(store)(next)(action);
                     assert.equal(action.type, nextAction.type);
                 });
             });


### PR DESCRIPTION
#### Summary
When the application was suspended while a post was in-flight, the subsequent restoration would duplicate the `effect` of the redux-offline action. This turned out to be due to a bug in the middleware which returned a spurious `"persist/REHYDRATE"` action type when the incoming action had actually been `ViewTypes.DATA_CLEANUP`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10460

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Mobile Simulator