### PR TITLE
Prevent duplicate flagged posts

### DIFF
--- a/app/screens/flagged_posts/flagged_posts.js
+++ b/app/screens/flagged_posts/flagged_posts.js
@@ -155,6 +155,7 @@ export default class FlaggedPosts extends PureComponent {
 
             return (
                 <DateHeader
+                    key={`${date}-${index}`}
                     date={date}
                     index={index}
                 />

--- a/app/screens/recent_mentions/recent_mentions.js
+++ b/app/screens/recent_mentions/recent_mentions.js
@@ -155,6 +155,7 @@ export default class RecentMentions extends PureComponent {
 
             return (
                 <DateHeader
+                    key={`${date}-${index}`}
                     date={date}
                     index={index}
                 />

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -263,6 +263,7 @@ export default class Search extends PureComponent {
     renderDateHeader = (date, index) => {
         return (
             <DateHeader
+                key={`${date}-${index}`}
                 date={date}
                 index={index}
             />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9864,7 +9864,7 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#e20f8881e6d1a8eaff76bb5ac98a2f3d884804d1",
+      "version": "github:mattermost/mattermost-redux#8d3c0a648519af973525e9c3d04b236ab7ec35d0",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fuse.js": "^3.2.0",
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#e20f8881e6d1a8eaff76bb5ac98a2f3d884804d1",
+    "mattermost-redux": "github:mattermost/mattermost-redux#8d3c0a648519af973525e9c3d04b236ab7ec35d0",
     "prop-types": "15.6.1",
     "react": "16.3.2",
     "react-intl": "2.4.0",


### PR DESCRIPTION
#### Summary
The code to prevent duplicate flagged posts is in the mattermost-redux lib which this PR is updating but it also includes keys for the date components to avoid render warnings

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10333
