### PR TITLE
Fix image preview zoom & scrolling jumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14492,7 +14492,7 @@
       }
     },
     "react-native-image-gallery": {
-      "version": "github:enahum/react-native-image-gallery#7dd88b037cbb7ee36866585357b33bddb20bd12e",
+      "version": "github:enahum/react-native-image-gallery#a98b1051e94f5a394541ca1ff9b15e2c9ffed84f",
       "requires": {
         "prop-types": "15.6.1",
         "react-mixin": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-native-exception-handler": "2.7.5",
     "react-native-fast-image": "4.0.8",
     "react-native-fetch-blob": "enahum/react-native-fetch-blob.git#75d5abfa1886665d7eaa947e70b9297b981f0983",
-    "react-native-image-gallery": "enahum/react-native-image-gallery#7dd88b037cbb7ee36866585357b33bddb20bd12e",
+    "react-native-image-gallery": "enahum/react-native-image-gallery#a98b1051e94f5a394541ca1ff9b15e2c9ffed84f",
     "react-native-image-picker": "0.26.7",
     "react-native-keyboard-aware-scroll-view": "0.5.0",
     "react-native-linear-gradient": "2.4.0",


### PR DESCRIPTION
#### Summary
Fixed the react-native-image-gallery to be able to perform zoom and panning the image, also fixes the scrolling between images and files to be smoother.

Actual fixes: https://github.com/enahum/react-native-image-gallery/commit/8a60c303a130b204bc717ebb67d6898deb3577ae and https://github.com/enahum/react-native-image-gallery/commit/a98b1051e94f5a394541ca1ff9b15e2c9ffed84f

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10302
