### PR TITLE
Add foss and play build variants

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,6 +152,21 @@ android {
             signingConfig null
         }
     }
+
+    flavorDimensions "type"
+
+    productFlavors {
+        // includes proprietary libs
+        play {
+            dimension "type"
+        }
+
+        // only foss
+        foss {
+            dimension "type"
+        }
+    }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
@@ -178,7 +193,7 @@ dependencies {
     compile project(':react-native-image-picker')
     compile project(':react-native-orientation')
     compile project(':react-native-bottom-sheet')
-    compile ('com.google.android.gms:play-services-gcm:9.4.0') {
+    playCompile ('com.google.android.gms:play-services-gcm:9.4.0') {
         force = true;
     }
     compile project(':react-native-device-info')
@@ -189,7 +204,7 @@ dependencies {
     compile project(':react-native-svg')
     compile project(':react-native-local-auth')
     compile project(':jail-monkey')
-    compile project(':react-native-youtube')
+    playCompile project(':react-native-youtube')
     compile project(':react-native-sentry')
     compile project(':react-native-exception-handler')
     compile project(':react-native-fetch-blob')

--- a/android/app/src/foss/java/com/mattermost/rnbeta/PackageManager.java
+++ b/android/app/src/foss/java/com/mattermost/rnbeta/PackageManager.java
@@ -1,0 +1,12 @@
+package com.mattermost.rnbeta;
+
+import com.facebook.react.ReactPackage;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PackageManager {
+  public static List<ReactPackage> getOptionalPackages() {
+    return Arrays.<ReactPackage>asList();
+  }
+}

--- a/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
@@ -10,7 +10,6 @@ import com.facebook.react.ReactApplication;
 import com.reactlibrary.RNReactNativeDocViewerPackage;
 import com.brentvatne.react.ReactVideoPackage;
 import com.horcrux.svg.SvgPackage;
-import com.inprogress.reactnativeyoutube.ReactNativeYouTube;
 import io.sentry.RNSentryPackage;
 import com.masteratul.exceptionhandler.ReactNativeExceptionHandlerPackage;
 import com.RNFetchBlob.RNFetchBlobPackage;
@@ -53,7 +52,7 @@ public class MainApplication extends NavigationApplication implements INotificat
   public List<ReactPackage> createAdditionalReactPackages() {
     // Add the packages you require here.
     // No need to add RnnPackage and MainReactPackage
-    return Arrays.<ReactPackage>asList(
+    List<ReactPackage> packages = Arrays.<ReactPackage>asList(
             new ImagePickerPackage(),
             new RNBottomSheetPackage(),
             new RNDeviceInfo(),
@@ -69,12 +68,15 @@ public class MainApplication extends NavigationApplication implements INotificat
             new MattermostPackage(this),
             new RNSentryPackage(this),
             new ReactNativeExceptionHandlerPackage(),
-            new ReactNativeYouTube(),
             new ReactVideoPackage(),
             new RNReactNativeDocViewerPackage(),
             new SharePackage()
     );
-  }
+
+    packages.addAll(PackageManager.getOptionalPackages());
+
+    return packages;
+}
 
   @Override
   public String getJSMainModuleName() {

--- a/android/app/src/play/java/com/mattermost/rnbeta/PackageManager.java
+++ b/android/app/src/play/java/com/mattermost/rnbeta/PackageManager.java
@@ -1,0 +1,15 @@
+package com.mattermost.rnbeta;
+
+import com.facebook.react.ReactPackage;
+import com.inprogress.reactnativeyoutube.ReactNativeYouTube;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PackageManager {
+  public static List<ReactPackage> getOptionalPackages() {
+    return Arrays.<ReactPackage>asList(
+        new ReactNativeYouTube()
+    );
+  }
+}


### PR DESCRIPTION
#### Summary
This PR adds a FOSS build variant. The main difference is that this variant does not include the react-native-youtube library (which itself includes a non-free Youtube library: https://github.com/inProgress-team/react-native-youtube/issues/288).

The variant is still not entirely FOSS because react-native-device-info and react-native-notifications still have non-free dependencies. But I think this would be easier to patch in the library themselves (see https://github.com/rebeccahughes/react-native-device-info/issues/381 and https://github.com/wix/react-native-notifications/issues/207).

`gradle assembleRelease` now produces two APKs: `app-foss-release-unsigned.apk` and `app-play-release-unsigned.apk`.
It is possible to build only one specific variant with `assembleFossRelease` or `assemblePlayRelease`.
(I'm not sure if something needs to be changed in your Fastlane config because of this.)

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/issues/566#issuecomment-386893071

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: Fairphone 2, Android 6.0.1

