### PR TITLE
Fix issue where auto closed DMs would not show again

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -346,7 +346,7 @@ export function toggleDMChannel(otherUserId, visible, channelId) {
             user_id: currentUserId,
             category: Preferences.CATEGORY_CHANNEL_OPEN_TIME,
             name: channelId,
-            value: new Date().getTime().toString(),
+            value: Date.now().toString(),
         }];
 
         savePreferences(currentUserId, dm)(dispatch, getState);

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -332,7 +332,7 @@ export function insertToDraft(value) {
     };
 }
 
-export function toggleDMChannel(otherUserId, visible) {
+export function toggleDMChannel(otherUserId, visible, channelId) {
     return async (dispatch, getState) => {
         const state = getState();
         const {currentUserId} = state.entities.users;
@@ -342,6 +342,11 @@ export function toggleDMChannel(otherUserId, visible) {
             category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
             name: otherUserId,
             value: visible,
+        }, {
+            user_id: currentUserId,
+            category: Preferences.CATEGORY_CHANNEL_OPEN_TIME,
+            name: channelId,
+            value: new Date().getTime().toString(),
         }];
 
         savePreferences(currentUserId, dm)(dispatch, getState);

--- a/app/actions/views/more_dms.js
+++ b/app/actions/views/more_dms.js
@@ -13,22 +13,22 @@ export function makeDirectChannel(otherUserId) {
         const channelName = getDirectChannelName(currentUserId, otherUserId);
         const {channels, myMembers} = state.entities.channels;
 
-        getProfilesByIds([otherUserId])(dispatch, getState);
-        getStatusesByIds([otherUserId])(dispatch, getState);
+        dispatch(getProfilesByIds([otherUserId]));
+        dispatch(getStatusesByIds([otherUserId]));
 
         let result;
         let channel = Object.values(channels).find((c) => c.name === channelName);
         if (channel && myMembers[channel.id]) {
             result = {data: channel};
 
-            toggleDMChannel(otherUserId, 'true', channel.id)(dispatch, getState);
+            dispatch(toggleDMChannel(otherUserId, 'true', channel.id));
         } else {
             result = await createDirectChannel(currentUserId, otherUserId)(dispatch, getState);
             channel = result.data;
         }
 
         if (channel) {
-            handleSelectChannel(channel.id)(dispatch, getState);
+            dispatch(handleSelectChannel(channel.id));
         }
 
         return result;
@@ -40,15 +40,15 @@ export function makeGroupChannel(otherUserIds) {
         const state = getState();
         const {currentUserId} = state.entities.users;
 
-        getProfilesByIds(otherUserIds)(dispatch, getState);
-        getStatusesByIds(otherUserIds)(dispatch, getState);
+        dispatch(getProfilesByIds(otherUserIds));
+        dispatch(getStatusesByIds(otherUserIds));
 
         const result = await createGroupChannel([currentUserId, ...otherUserIds])(dispatch, getState);
         const channel = result.data;
 
         if (channel) {
-            toggleGMChannel(channel.id, 'true')(dispatch, getState);
-            handleSelectChannel(channel.id)(dispatch, getState);
+            dispatch(toggleGMChannel(channel.id, 'true'));
+            dispatch(handleSelectChannel(channel.id));
         }
 
         return result;

--- a/app/actions/views/more_dms.js
+++ b/app/actions/views/more_dms.js
@@ -18,7 +18,6 @@ export function makeDirectChannel(otherUserId) {
 
         let result;
         let channel = Object.values(channels).find((c) => c.name === channelName);
-        console.log(Object.values(channels).filter((c) => c.name === channelName), myMembers[channel.id]);
         if (channel && myMembers[channel.id]) {
             result = {data: channel};
 

--- a/app/actions/views/more_dms.js
+++ b/app/actions/views/more_dms.js
@@ -18,10 +18,11 @@ export function makeDirectChannel(otherUserId) {
 
         let result;
         let channel = Object.values(channels).find((c) => c.name === channelName);
+        console.log(Object.values(channels).filter((c) => c.name === channelName), myMembers[channel.id]);
         if (channel && myMembers[channel.id]) {
             result = {data: channel};
 
-            toggleDMChannel(otherUserId, 'true')(dispatch, getState);
+            toggleDMChannel(otherUserId, 'true', channel.id)(dispatch, getState);
         } else {
             result = await createDirectChannel(currentUserId, otherUserId)(dispatch, getState);
             channel = result.data;


### PR DESCRIPTION
#### Summary
This PR fixes an issue where auto closed DMs would not show if they were reopened.

The issue occurs when the following is true:

- Automatically close DM's set to true
- Try to start a DM with a user who's DM's have been automatically closed

This PR updates the `CATEGORY_CHANNEL_OPEN_TIME` value for the channel to ensure that it is shown if the user has auto close DMs set to true.