### PR TITLE
Save credentials immediately after login

### DIFF
--- a/app/actions/views/login.js
+++ b/app/actions/views/login.js
@@ -4,8 +4,10 @@
 import {getDataRetentionPolicy} from 'mattermost-redux/actions/general';
 import {GeneralTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {ViewTypes} from 'app/constants';
+import {app} from 'app/mattermost';
 
 export function handleLoginIdChanged(loginId) {
     return async (dispatch, getState) => {
@@ -27,9 +29,14 @@ export function handlePasswordChanged(password) {
 
 export function handleSuccessfulLogin() {
     return async (dispatch, getState) => {
-        const {config, license} = getState().entities.general;
+        const state = getState();
+        const {config, license} = state.entities.general;
         const token = Client4.getToken();
         const url = Client4.getUrl();
+        const deviceToken = state.entities.general.deviceToken;
+        const currentUserId = getCurrentUserId(state);
+
+        app.setAppCredentials(deviceToken, currentUserId, token, url);
 
         dispatch({
             type: GeneralTypes.RECEIVED_APP_CREDENTIALS,

--- a/app/actions/views/login.test.js
+++ b/app/actions/views/login.test.js
@@ -18,6 +18,12 @@ jest.mock('react-native-fetch-blob/fs', () => ({
     },
 }));
 
+jest.mock('app/mattermost', () => ({
+    app: {
+        setAppCredentials: () => jest.fn(),
+    },
+}));
+
 const mockStore = configureStore([thunk]);
 
 describe('Actions.Views.Login', () => {


### PR DESCRIPTION
#### Summary
We made a change to use cached credentials from Keychain/KeyStore instead of redux after rehydration to either route to `SelectServer` or `Channel`.  This works once the credentials are stored.  Unfortunately that was only happening after redux rehydration.

So now this change stores the credentials immediately after login.