### PR TITLE
Fix bundling failed with "mime-db" error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6277,6 +6277,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.5",
@@ -7476,9 +7477,9 @@
       }
     },
     "harmony-reflect": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.5.1.tgz",
-      "integrity": "sha1-tUymF7AMyK71Wbuxez2FQx3H4yk="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.0.tgz",
+      "integrity": "sha512-0kZ1XcoelFOLEjEtvWAZyq/1S55eDSieWEJwme311MNVNcRpvjlr2zA66kBV6WAB8C1XI1p1cXCnFPqd1BxlPg=="
     },
     "has": {
       "version": "1.0.1",
@@ -9878,7 +9879,7 @@
     },
     "mattermost-redux": {
       "version": "github:mattermost/mattermost-redux#1cc600992b9560a4d41cc622352cf440ae905ab1",
-      "from": "mattermost-redux@github:mattermost/mattermost-redux#1cc600992b9560a4d41cc622352cf440ae905ab1",
+      "from": "github:mattermost/mattermost-redux#1cc600992b9560a4d41cc622352cf440ae905ab1",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",
@@ -9897,21 +9898,20 @@
         "shallow-equals": "1.0.0"
       },
       "dependencies": {
-        "redux": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
-            "lodash": "^4.2.1",
-            "lodash-es": "^4.2.1",
-            "loose-envify": "^1.1.0",
-            "symbol-observable": "^1.0.3"
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
           }
         },
         "redux-batched-actions": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.2.0.tgz",
-          "integrity": "sha1-2gAAyIKw5shhqW1YI702rfXZwN0="
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.3.0.tgz",
+          "integrity": "sha512-RsXFTY6F7jXYFXTVC/8/Zb+A4Im2uk4/9Dx/hO7B0hxLGdACmm2WC5vIYUXgP9B+ZLp7bwJTaF/iALfeJV+/zg=="
         },
         "redux-persist": {
           "version": "4.9.1",
@@ -10162,9 +10162,9 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
       "version": "2.1.18",
@@ -14893,9 +14893,9 @@
       }
     },
     "redux-action-buffer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.1.0.tgz",
-      "integrity": "sha1-nGkqtlMrBC0NQ6nwGkitoSD8lBo="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
+      "integrity": "sha1-LsCh2JnMn29EzN60Me5SrUHdl1U="
     },
     "redux-batched-actions": {
       "version": "0.2.1",
@@ -14923,7 +14923,7 @@
     },
     "redux-offline": {
       "version": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
-      "from": "redux-offline@git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
+      "from": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
       "requires": {
         "redux-persist": "^4.5.0"
       }


### PR DESCRIPTION
#### Summary
Fix bundling failed with "mime-db" error.

```
error: bundling failed: Error: Unable to resolve module `mime-db` from `/mattermost-mobile/app/utils/file.js`: Module `mime-db` does not exist in the Haste module map
```

Not sure what happened with my latest upgrade to redux but this one works for me. 

Build successfully completed for iOS and Android.

#### Ticket Link
None but reported here https://pre-release.mattermost.com/core/pl/g9otpe1mafgwuby88b8uzhdahe
