### PR TITLE
[MM-10646] Fix DM's channel displayname (instead of "Someone") after creating a DM

### DIFF
--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -382,11 +382,12 @@ class MoreDirectMessages extends PureComponent {
     makeDirectChannel = async (id) => {
         const {
             actions,
+            allProfiles,
             intl,
             teammateNameDisplay,
         } = this.props;
 
-        const user = this.state.profiles[id];
+        const user = allProfiles[id];
 
         const displayName = displayUsername(user, teammateNameDisplay);
         actions.setChannelDisplayName(displayName);


### PR DESCRIPTION
#### Summary
Fix DM's channel displayname (instead of "Someone") after creating a DM.

Note: I've attempted to add test but I'm getting weird `ReferenceError: self is not defined` after mocking `react-native-fetch-blob/fs`.  I may just deal with this separately.

#### Ticket Link
Jira ticket: [MM-10646](https://mattermost.atlassian.net/browse/MM-10646)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

