### PR TITLE
Fixed dev-mode error relating to adjacent images

### DIFF
--- a/app/components/markdown/transform.js
+++ b/app/components/markdown/transform.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {Node} from 'commonmark';
+
 /* eslint-disable no-underscore-dangle */
 
 // Add indices to the items of every list
@@ -185,7 +187,15 @@ function pullOutImage(image) {
 // Copies a Node without its parent, children, or siblings
 function copyNodeWithoutNeighbors(node) {
     // commonmark uses classes so it takes a bit of work to copy them
-    const copy = Object.assign(Object.create(Reflect.getPrototypeOf(node)), node);
+    const copy = new Node();
+
+    for (const key in node) {
+        if (!node.hasOwnProperty(key)) {
+            continue;
+        }
+
+        copy[key] = node[key];
+    }
 
     copy._parent = null;
     copy._firstChild = null;

--- a/app/components/markdown/transform.test.js
+++ b/app/components/markdown/transform.test.js
@@ -1977,6 +1977,84 @@ describe('Components.Markdown.transform', () => {
             assert.equal(astToString(actual), astToString(expected));
             assert.deepStrictEqual(actual, expected);
         });
+
+        it('adjacent images and text', () => {
+            const input = makeAst({
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'First:',
+                    }, {
+                        type: 'softbreak',
+                    }, {
+                        type: 'image',
+                        destination: 'http://example.com/image',
+                        children: [{
+                            type: 'text',
+                            literal: 'Image',
+                        }],
+                    }, {
+                        type: 'softbreak',
+                    }, {
+                        type: 'text',
+                        literal: 'Second:',
+                    }, {
+                        type: 'softbreak',
+                    }, {
+                        type: 'image',
+                        destination: 'http://example.com/image',
+                        children: [{
+                            type: 'text',
+                            literal: 'Image',
+                        }],
+                    }],
+                }],
+            });
+            const expected = makeAst({
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'First:',
+                    }, {
+                        type: 'softbreak',
+                    }],
+                }, {
+                    type: 'image',
+                    destination: 'http://example.com/image',
+                    children: [{
+                        type: 'text',
+                        literal: 'Image',
+                    }],
+                }, {
+                    type: 'paragraph',
+                    continue: true,
+                    children: [{
+                        type: 'softbreak',
+                    }, {
+                        type: 'text',
+                        literal: 'Second:',
+                    }, {
+                        type: 'softbreak',
+                    }],
+                }, {
+                    type: 'image',
+                    destination: 'http://example.com/image',
+                    children: [{
+                        type: 'text',
+                        literal: 'Image',
+                    }],
+                }],
+            });
+            const actual = pullOutImages(input);
+
+            assert.ok(verifyAst(actual));
+            assert.equal(astToString(actual), astToString(expected));
+            assert.deepStrictEqual(actual, expected);
+        });
     });
 });
 


### PR DESCRIPTION
RN goes against spec and specifically disallows the previous `Object.assign(Object.create(Reflect.getPrototypeOf(node)), node)`, so we just need to manually create a new Node and copy the fields. Behaviour should be identical to what it was before

#### Checklist
- Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator