### PR TITLE
Fix inline images in long posts

### DIFF
--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -294,7 +294,7 @@ export default class MarkdownImage extends React.Component {
                             ref='image'
                             defaultSource={source}
                             resizeMode='contain'
-                            style={[{width, height}, style.image]}
+                            style={{width, height}}
                         />
                     </TouchableWithoutFeedback>
                 );
@@ -337,9 +337,6 @@ export default class MarkdownImage extends React.Component {
 
 const style = StyleSheet.create({
     container: {
-        flex: 1,
-    },
-    image: {
-        marginVertical: 5,
+        marginBottom: 5,
     },
 });


### PR DESCRIPTION
#### Summary
Inline images in long post were being overlapped

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10720

#### Device Information
This PR was tested on: iPhone and Android

#### Screenshots
![simulator screen shot - iphone x - 2018-06-06 at 12 57 14](https://user-images.githubusercontent.com/6757047/41053378-57ca55a6-6989-11e8-8c8a-5f351f054eda.png)

![screenshot_1528304226](https://user-images.githubusercontent.com/6757047/41053380-57ff0512-6989-11e8-9921-3dd33a709a6a.png)

