### PR TITLE
Fix Team icon background and radius in team lists

### DIFF
--- a/app/components/channel_drawer/teams_list/teams_list_item/teams_list_item.js
+++ b/app/components/channel_drawer/teams_list/teams_list_item/teams_list_item.js
@@ -77,7 +77,6 @@ export default class TeamsListItem extends React.PureComponent {
                             teamId={teamId}
                             styleContainer={styles.teamIconContainer}
                             styleText={styles.teamIconText}
-                            styleImage={styles.imageContainer}
                         />
                         <View style={styles.teamNameContainer}>
                             <Text
@@ -127,6 +126,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         teamIconContainer: {
             width: 40,
             height: 40,
+            backgroundColor: '#ffffff',
         },
         teamIconText: {
             fontSize: 18,
@@ -134,9 +134,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         teamUrl: {
             color: changeOpacity(theme.sidebarText, 0.5),
             fontSize: 12,
-        },
-        imageContainer: {
-            backgroundColor: '#ffffff',
         },
         checkmarkContainer: {
             alignItems: 'flex-end',


### PR DESCRIPTION
#### Summary
Fixes the border radius on Android and makes sure the background is always white for the team icons.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10799