### PR TITLE
Ping server after setting app offline/online.  Also include timeout

### DIFF
--- a/app/utils/network.js
+++ b/app/utils/network.js
@@ -1,6 +1,6 @@
 import {NetInfo} from 'react-native';
 
-import RNFetchBlob from 'react-native-fetch-blob'
+import RNFetchBlob from 'react-native-fetch-blob';
 
 import {Client4} from 'mattermost-redux/client';
 

--- a/app/utils/network.js
+++ b/app/utils/network.js
@@ -1,6 +1,10 @@
 import {NetInfo} from 'react-native';
 
+import RNFetchBlob from 'react-native-fetch-blob'
+
 import {Client4} from 'mattermost-redux/client';
+
+const PING_TIMEOUT = 10000;
 
 export async function checkConnection(isConnected) {
     if (Client4.getBaseRoute() === '/api/v4') {
@@ -12,7 +16,7 @@ export async function checkConnection(isConnected) {
     const server = `${Client4.getBaseRoute()}/system/ping?time=${Date.now()}`;
 
     try {
-        await fetch(server, {method: 'get'});
+        await RNFetchBlob.config({timeout: PING_TIMEOUT}).fetch('GET', server);
         return true;
     } catch (error) {
         return false;
@@ -21,6 +25,10 @@ export async function checkConnection(isConnected) {
 
 function handleConnectionChange(onChange) {
     return async (isConnected) => {
+        // Set device internet connectivity immediately
+        onChange(isConnected);
+
+        // Check if connected to server
         const result = await checkConnection(isConnected);
         onChange(result);
     };


### PR DESCRIPTION
#### Summary
Related to the OOM Error, this avoids tricking logic that depends on `networkChangeListener` to still think the app is online.
1.  The app immediately sets the state in redux as offline/online
2. Afterwards, makes a call to the server if a connection exists
3. If there's no connection a timeout exists so the call doesn't take the entirety of the app being offline.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10773