### PR TITLE
[MM-10519] Remove converted channel (into private) from "MoreChannels" screen of  joinable channels

### DIFF
--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -100,15 +100,30 @@ export default class MoreChannels extends PureComponent {
             setNavigatorStyles(this.props.navigator, nextProps.theme);
         }
 
+        const {page, searching, term} = this.state;
+
+        let channels;
+        if (nextProps.channels !== this.props.channels) {
+            channels = nextProps.channels.slice(0, (page + 1) * General.CHANNELS_CHUNK_SIZE);
+            if (term) {
+                channels = this.filterChannels(nextProps.channels, term);
+            }
+        }
+
         const {requestStatus} = this.props;
-        if (this.state.searching &&
-            nextProps.requestStatus.status === RequestStatus.SUCCESS) {
-            const channels = this.filterChannels(nextProps.channels, this.state.term);
-            this.setState({channels, showNoResults: true});
-        } else if (requestStatus.status === RequestStatus.STARTED &&
-            nextProps.requestStatus.status === RequestStatus.SUCCESS) {
-            const {page} = this.state;
-            const channels = nextProps.channels.slice(0, (page + 1) * General.CHANNELS_CHUNK_SIZE);
+        if (
+            searching &&
+            nextProps.requestStatus.status === RequestStatus.SUCCESS
+        ) {
+            channels = this.filterChannels(nextProps.channels, term);
+        } else if (
+            requestStatus.status === RequestStatus.STARTED &&
+            nextProps.requestStatus.status === RequestStatus.SUCCESS
+        ) {
+            channels = nextProps.channels.slice(0, (page + 1) * General.CHANNELS_CHUNK_SIZE);
+        }
+
+        if (channels) {
             this.setState({channels, showNoResults: true});
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9878,8 +9878,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#8870c690f2e29d301a65fc2f0cba77070f355fa3",
-      "from": "github:mattermost/mattermost-redux#8870c690f2e29d301a65fc2f0cba77070f355fa3",
+      "version": "github:mattermost/mattermost-redux#2ef52763c82ca1ad338e5a4dc3dc557a0ecfd528",
+      "from": "github:mattermost/mattermost-redux#2ef52763c82ca1ad338e5a4dc3dc557a0ecfd528",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "216113.0.3",
-    "mattermost-redux": "github:mattermost/mattermost-redux#8870c690f2e29d301a65fc2f0cba77070f355fa3",
+    "mattermost-redux": "github:mattermost/mattermost-redux#2ef52763c82ca1ad338e5a4dc3dc557a0ecfd528",
     "mime-db": "1.33.0",
     "prop-types": "15.6.1",
     "react": "16.3.2",


### PR DESCRIPTION
#### Summary
Remove converted channel (into private) from "MoreChannels" screen of  joinable channels

#### Ticket Link
Jira ticket: [MM-10519](https://mattermost.atlassian.net/browse/MM-10519)

#### Checklist
- [x] All new/modified APIs include changes to https://github.com/mattermost/mattermost-redux/pull/523

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
BEFORE:  Converted channel is not removed from the list.  Clicking the converted channel gets permission error (since that's already a private channel).
![morechannels before](https://user-images.githubusercontent.com/5334504/41113366-02ad6df2-6ab4-11e8-9438-348a3ed138d3.gif)

AFTER:
Converted channel is automatically removed from the list.
![morechannels all channels](https://user-images.githubusercontent.com/5334504/41113433-33289092-6ab4-11e8-84cc-01449c36984e.gif)

(With search term)
If with search term, remaining channel/s is still filtered with the term.
![morechannels with search term](https://user-images.githubusercontent.com/5334504/41113401-2269697a-6ab4-11e8-9ef8-c81e364a408a.gif)

