### PR TITLE
Upgrade to Gradle 3.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -106,8 +106,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.mattermost.rnbeta"
@@ -151,6 +151,7 @@ android {
         unsigned.initWith(buildTypes.release)
         unsigned {
             signingConfig null
+            matchingFallbacks = ['debug', 'release']
         }
     }
     // applicationVariants are e.g. debug, release
@@ -185,39 +186,39 @@ configurations.all {
 }
 
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:25.0.1"
-    compile 'com.android.support:percent:25.3.1'
-    compile "com.facebook.react:react-native:+"  // From node_modules
-    compile project(':react-native-document-picker')
-    compile project(':react-native-keychain')
-    compile project(':react-native-doc-viewer')
-    compile project(':react-native-video')
-    compile project(':react-native-navigation')
-    compile project(':react-native-image-picker')
-    compile project(':react-native-bottom-sheet')
-    compile ('com.google.android.gms:play-services-gcm:9.4.0') {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:25.0.1"
+    implementation 'com.android.support:percent:25.3.1'
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':react-native-document-picker')
+    implementation project(':react-native-keychain')
+    implementation project(':react-native-doc-viewer')
+    implementation project(':react-native-video')
+    implementation project(':react-native-navigation')
+    implementation project(':react-native-image-picker')
+    implementation project(':react-native-bottom-sheet')
+    implementation ('com.google.android.gms:play-services-gcm:9.4.0') {
         force = true;
     }
-    compile project(':react-native-device-info')
-    compile project(':reactnativenotifications')
-    compile project(':react-native-cookies')
-    compile project(':react-native-linear-gradient')
-    compile project(':react-native-vector-icons')
-    compile project(':react-native-svg')
-    compile project(':react-native-local-auth')
-    compile project(':jail-monkey')
-    compile project(':react-native-youtube')
-    compile project(':react-native-sentry')
-    compile project(':react-native-exception-handler')
-    compile project(':react-native-fetch-blob')
+    implementation project(':react-native-device-info')
+    implementation project(':reactnativenotifications')
+    implementation project(':react-native-cookies')
+    implementation project(':react-native-linear-gradient')
+    implementation project(':react-native-vector-icons')
+    implementation project(':react-native-svg')
+    implementation project(':react-native-local-auth')
+    implementation project(':jail-monkey')
+    implementation project(':react-native-youtube')
+    implementation project(':react-native-sentry')
+    implementation project(':react-native-exception-handler')
+    implementation project(':react-native-fetch-blob')
 
     // For animated GIF support
-    compile 'com.facebook.fresco:animated-base-support:1.3.0'
+    implementation 'com.facebook.fresco:animated-base-support:1.3.0'
     // For WebP support, including animated WebP
-    compile 'com.facebook.fresco:animated-gif:1.3.0'
-    compile 'com.facebook.fresco:animated-webp:1.3.0'
-    compile  'com.facebook.fresco:webpsupport:1.3.0'
+    implementation 'com.facebook.fresco:animated-gif:1.3.0'
+    implementation 'com.facebook.fresco:animated-webp:1.3.0'
+    implementation  'com.facebook.fresco:webpsupport:1.3.0'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,8 +31,8 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = '25.0.2'
+    compileSdkVersion = 26
+    buildToolsVersion = '26.0.2'
 }
 subprojects { subproject ->
     afterEvaluate{

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.+'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.google.gms:google-services:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -15,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         mavenLocal()
         jcenter()
         maven {
@@ -24,6 +26,21 @@ allprojects {
         maven {
             // Local Maven repo containing AARs with JSC library built for Android
             url "$rootDir/../node_modules/jsc-android/android"
+        }
+    }
+}
+
+ext {
+    compileSdkVersion = 25
+    buildToolsVersion = '25.0.2'
+}
+subprojects { subproject ->
+    afterEvaluate{
+        if((subproject.plugins.hasPlugin('android') || subproject.plugins.hasPlugin('android-library'))) {
+            android {
+                compileSdkVersion rootProject.ext.compileSdkVersion
+                buildToolsVersion rootProject.ext.buildToolsVersion
+            }
         }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,4 +17,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
+android.enableAapt2=false
 android.useDeprecatedNdk=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
#### Summary
This is something I worked on during OOM issue.
Upgrading Gradle helps significantly in build times for the native Android app.
Release build still takes a while because of the way it bundles the JS code.

The gain is in debug/incremental builds.

## Comparison:

### Before: 2.29 mins
<img width="917" alt="android_debug" src="https://user-images.githubusercontent.com/6182543/41115968-0bed76e4-6a57-11e8-935d-279ef8d337ab.png">

### After 24 sec
<img width="919" alt="android_debug_3 0" src="https://user-images.githubusercontent.com/6182543/41115972-0d9c9cfe-6a57-11e8-8b6f-bdecf35595f3.png">