### PR TITLE
Fix inApp notification handler

### DIFF
--- a/app/screens/entry/entry.js
+++ b/app/screens/entry/entry.js
@@ -227,7 +227,7 @@ export default class Entry extends PureComponent {
             navigator: this.props.navigator,
         };
 
-        return wrapWithContextProvider(ChannelScreen, true)(props);
+        return wrapWithContextProvider(ChannelScreen, false)(props);
     };
 
     render() {

--- a/app/screens/notification/notification.js
+++ b/app/screens/notification/notification.js
@@ -92,8 +92,28 @@ export default class Notification extends PureComponent {
         return icon;
     };
 
-    getNotificationTitle = (titleText) => {
+    getNotificationTitle = (notification) => {
         const {channel} = this.props;
+        const {message, data} = notification;
+
+        if (data.version === 'v2') {
+            if (data.channel_name) {
+                return (
+                    <Text
+                        numberOfLines={1}
+                        ellipsizeMode='tail'
+                        style={style.title}
+                    >
+                        {data.channel_name}
+                    </Text>
+                );
+            }
+
+            return null;
+        }
+
+        const msg = message.split(':');
+        const titleText = msg.shift();
 
         let title = (
             <Text
@@ -165,14 +185,20 @@ export default class Notification extends PureComponent {
 
     render() {
         const {deviceWidth, notification} = this.props;
-        const {message} = notification;
+        const {data, message} = notification;
 
         if (message) {
-            const msg = message.split(':');
-            const titleText = msg.shift();
-            const messageText = msg.join('').trim();
+            let messageText;
+            if (data.version !== 'v2') {
+                const msg = message.split(':');
+                messageText = msg.join('').trim();
+            } else if (Platform.OS === 'ios') {
+                messageText = message.body || message;
+            } else {
+                messageText = message;
+            }
 
-            const title = this.getNotificationTitle(titleText);
+            const title = this.getNotificationTitle(notification);
             const icon = this.getNotificationIcon();
 
             return (


### PR DESCRIPTION
#### Summary
Fixes a crash in iOS cause of the change in the way the notification is sent and fixes the way the in-app notification is parsed to be presented

**Important Note:** iOS 1.8 will crash if a notification is sent while the app is in the foreground with servers 5.0+