### PR TITLE
Support for blacklisting translation files

### DIFF
--- a/app/i18n/index.js
+++ b/app/i18n/index.js
@@ -6,6 +6,7 @@ import {addLocaleData} from 'react-intl';
 import enLocaleData from 'react-intl/locale-data/en';
 
 import en from 'assets/i18n/en.json';
+import Loader from './loader';
 
 const TRANSLATIONS = {en};
 
@@ -15,61 +16,8 @@ addLocaleData(enLocaleData);
 
 function loadTranslation(locale) {
     try {
-        let localeData;
-        switch (locale) {
-        case 'de':
-            TRANSLATIONS.de = require('assets/i18n/de.json');
-            localeData = require('react-intl/locale-data/de');
-            break;
-        case 'es':
-            TRANSLATIONS.es = require('assets/i18n/es.json');
-            localeData = require('react-intl/locale-data/es');
-            break;
-        case 'fr':
-            TRANSLATIONS.fr = require('assets/i18n/fr.json');
-            localeData = require('react-intl/locale-data/fr');
-            break;
-        case 'it':
-            TRANSLATIONS.it = require('assets/i18n/it.json');
-            localeData = require('react-intl/locale-data/it');
-            break;
-        case 'ja':
-            TRANSLATIONS.ja = require('assets/i18n/ja.json');
-            localeData = require('react-intl/locale-data/ja');
-            break;
-        case 'ko':
-            TRANSLATIONS.ko = require('assets/i18n/ko.json');
-            localeData = require('react-intl/locale-data/ko');
-            break;
-        case 'nl':
-            TRANSLATIONS.nl = require('assets/i18n/nl.json');
-            localeData = require('react-intl/locale-data/nl');
-            break;
-        case 'pl':
-            TRANSLATIONS.pl = require('assets/i18n/pl.json');
-            localeData = require('react-intl/locale-data/pl');
-            break;
-        case 'pt-BT':
-            TRANSLATIONS[locale] = require('assets/i18n/pt-BR.json');
-            localeData = require('react-intl/locale-data/pt');
-            break;
-        case 'tr':
-            TRANSLATIONS.tr = require('assets/i18n/tr.json');
-            localeData = require('react-intl/locale-data/tr');
-            break;
-        case 'ru':
-            TRANSLATIONS.ru = require('assets/i18n/ru.json');
-            localeData = require('react-intl/locale-data/ru');
-            break;
-        case 'zh-CN':
-            TRANSLATIONS[locale] = require('assets/i18n/zh-CN.json');
-            localeData = require('react-intl/locale-data/zh');
-            break;
-        case 'zh-TW':
-            TRANSLATIONS[locale] = require('assets/i18n/zh-TW.json');
-            localeData = require('react-intl/locale-data/zh');
-            break;
-        }
+        TRANSLATIONS[locale] = Loader[locale];
+        const localeData = Loader[`${locale}-Locale`];
 
         if (localeData) {
             addLocaleData(localeData);

--- a/app/i18n/loader.js
+++ b/app/i18n/loader.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+// Loader.js supports: [de, en, es, fr, it, ja, ko, nl, pl, pt-BR, ru, tr, zh-CN, zh-TW]
+export default {
+    'de': require('assets/i18n/de.json'),
+    'de-Locale': require('react-intl/locale-data/de'),
+    'en': require('assets/i18n/en.json'),
+    'en-Locale': require('react-intl/locale-data/en'),
+    'es': require('assets/i18n/es.json'),
+    'es-Locale': require('react-intl/locale-data/es'),
+    'fr': require('assets/i18n/fr.json'),
+    'fr-Locale': require('react-intl/locale-data/fr'),
+    'it': require('assets/i18n/it.json'),
+    'it-Locale': require('react-intl/locale-data/it'),
+    'ja': require('assets/i18n/ja.json'),
+    'ja-Locale': require('react-intl/locale-data/ja'),
+    'ko': require('assets/i18n/ko.json'),
+    'ko-Locale': require('react-intl/locale-data/ko'),
+    'nl': require('assets/i18n/nl.json'),
+    'nl-Locale': require('react-intl/locale-data/nl'),
+    'pl': require('assets/i18n/pl.json'),
+    'pl-Locale': require('react-intl/locale-data/pl'),
+    'pt-BR': require('assets/i18n/pt-BR.json'),
+    'pt-BR-Locale': require('react-intl/locale-data/pt'),
+    'ru': require('assets/i18n/ru.json'),
+    'ru-Locale': require('react-intl/locale-data/ru'),
+    'tr': require('assets/i18n/tr.json'),
+    'tr-Locale': require('react-intl/locale-data/tr'),
+    'zh-CN': require('assets/i18n/zh-CN.json'),
+    'zh-CN-Locale': require('react-intl/locale-data/zh'),
+    'zh-TW': require('assets/i18n/zh-TW.json'),
+    'zh-TW-Locale': require('react-intl/locale-data/zh'),
+};

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "jest": "22.4.3",
     "jest-cli": "22.4.3",
     "jsdom-global": "3.0.2",
+    "metro-bundler": "0.22.1",
     "nyc": "11.7.1",
     "react-dom": "16.3.2",
     "redux-mock-store": "1.5.1",

--- a/packager/config.js
+++ b/packager/config.js
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 /* eslint-disable no-console */
+const blacklist = require('metro-bundler/src/blacklist');
 const modulePaths = require('./modulePaths');
 const resolve = require('path').resolve;
 const fs = require('fs');
@@ -12,6 +13,34 @@ const modulesRegex = /\/(node_modules)/;
 // This script will let the react native packager what modules to include
 // in the main bundle and what modules to blacklist from the inline requires
 // this modules are taken from the modulePaths.js file
+
+// Also, includes blacklisting translation files that
+// you do not wish packaging into the build
+
+const supportedTranslations = require('./translations').supportedTranslations;
+const blacklistTranslations = require('./translations').blacklistTranslations;
+const whitelistTranslations = supportedTranslations.filter(t => !blacklistTranslations.includes(t));
+
+// creates /app/i18n/loader.js file
+const ex =
+    "{\n" +
+    whitelistTranslations.map(translation => {
+        // include json translation files
+        const jsonFile = `    '${translation}': require('assets/i18n/${translation}.json'),`;
+
+        // include locale data from react-intl
+        const locale = translation.split('-')[0];
+        const localeFile = `    '${translation}-Locale': require('react-intl/locale-data/${locale}'),`;
+
+        return jsonFile + '\n' + localeFile
+    }).join('\n') +
+    "\n};";
+
+const licenseHeader = "// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.\n" +
+    "// See License.txt for license information.\n\n";
+const loaderComment = `// Loader.js supports: [${whitelistTranslations.join(', ')}]\n`;
+const res = licenseHeader + loaderComment + "export default " + ex;
+fs.writeFileSync('./app/i18n/loader.js', res);
 
 const config = {
     getTransformOptions: (entryFile, {platform}) => {
@@ -41,6 +70,32 @@ const config = {
             },
         };
     },
+    getBlacklistRE: () => {
+        console.log('BLACKLISTING FILES FROM BUNDLE');
+        let blacklistFiles = [];
+
+        if (blacklistTranslations.length) {
+            console.log(`Blacklisting ${blacklistTranslations.length} translations!`)
+            console.log(`Blacklisting locales: [${blacklistTranslations.toString()}]`);
+        }
+
+        blacklistTranslations.forEach(translation => {
+            const locale = translation.split('-')[0];
+            blacklistFiles.push(`assets/i18n/${translation}.json`);
+            blacklistFiles.push(`react-intl/locale-data/${locale}`);
+        });
+
+        // Ignore locale-data/index.js and whitelisted translations
+        let localeData = whitelistTranslations.map(t => t.split('-')[0]);
+        localeData = Array.from(new Set(localeData));
+
+        const reactIntlLocaleDataRegex = new RegExp(`node_modules\\/react-intl\\/locale-data\\/(?!index|${localeData.join('|')})[a-z0-9]+.js`);
+
+        return blacklist([
+            reactIntlLocaleDataRegex,
+            ...blacklistFiles,
+        ]);
+    }
 };
 
 module.exports = config;

--- a/packager/translations.js
+++ b/packager/translations.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+const supportedTranslations = [
+    'de',
+    'en',
+    'es',
+    'fr',
+    'it',
+    'ja',
+    'ko',
+    'nl',
+    'pl',
+    'pt-BR',
+    'ru',
+    'tr',
+    'zh-CN',
+    'zh-TW',
+];
+
+// Add locales you DO NOT want packaged in Loader.js
+const blacklistTranslations = [];
+
+module.exports = {
+    supportedTranslations,
+    blacklistTranslations
+};


### PR DESCRIPTION
#### Summary
This adds support to blacklist translation files not needed for a build.
All logic is done in packager/config.js . 
It generages a files called `loader.js` which handles support for importing all locales specified.

Files that are blacklisted are ignored when packaging in the build reducing js bundle size.


#### All locales supported
<img width="627" alt="supported" src="https://user-images.githubusercontent.com/6182543/41177453-2ecd4ece-6b32-11e8-961a-517399af9c8c.png">

#### English locale supported
<img width="621" alt="blacklist" src="https://user-images.githubusercontent.com/6182543/41177452-2e9aabb8-6b32-11e8-84d2-a4180c8f7134.png">

#### JS Bundle size with all locales (14MB)
<img width="641" alt="screen shot 2018-06-08 at 1 25 56 pm" src="https://user-images.githubusercontent.com/6182543/41177455-2f00f4f4-6b32-11e8-8ba1-c0ef4904e8c4.png">

#### JS Bundle size with english locales (9MB)
<img width="641" alt="screen shot 2018-06-08 at 1 19 01 pm" src="https://user-images.githubusercontent.com/6182543/41177470-3bc6973e-6b32-11e8-98db-85382fa24ace.png">