### PR TITLE
[MM-10825] Set solid background color on permalink header divider

### DIFF
--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -370,6 +370,9 @@ export default class Permalink extends PureComponent {
                                 </Text>
                             </View>
                         </View>
+                        <View style={style.dividerContainer}>
+                            <View style={style.divider}/>
+                        </View>
                         <View style={[style.postList, error ? style.bottom : null]}>
                             {postList}
                         </View>
@@ -407,14 +410,19 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         header: {
             alignItems: 'center',
             backgroundColor: theme.centerChannelBg,
-            borderBottomColor: changeOpacity(theme.centerChannelColor, 0.2),
-            borderBottomWidth: 1,
             borderTopLeftRadius: 6,
             borderTopRightRadius: 6,
             flexDirection: 'row',
             height: 44,
             paddingRight: 16,
             width: '100%',
+        },
+        dividerContainer: {
+            backgroundColor: theme.centerChannelBg,
+        },
+        divider: {
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.2),
+            height: 1,
         },
         close: {
             justifyContent: 'center',


### PR DESCRIPTION
#### Summary
Set solid background color on permalink header divider.

Though this works as expected (only a bit of a hack), I'd be happy to see a better solution out there (if any).

#### Ticket Link
Jira ticket: [MM-10825](https://mattermost.atlassian.net/browse/MM-10825)

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
Android:
![screen shot 2018-06-09 at 4 24 50 am](https://user-images.githubusercontent.com/5334504/41180713-acf376ce-6ba1-11e8-91ef-86b78319678a.png)

iOS:
![screen shot 2018-06-09 at 4 44 20 am](https://user-images.githubusercontent.com/5334504/41180725-b4962ed0-6ba1-11e8-9977-9f1dfc204a9e.png)

