### PR TITLE
Render SAML json errors and include special header in webview requests

### DIFF
--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {injectIntl, intlShape} from 'react-intl';
 import {
     InteractionManager,
-    Platform,
     Text,
     View,
     WebView,
@@ -22,19 +21,39 @@ import PushNotifications from 'app/push_notifications';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 import tracker from 'app/utils/time_tracker';
 
-const postMessageJS = "setTimeout(function() { postMessage(document.body.innerText, '*')});";
+const HEADERS = {
+    'X-Mobile-App': 'mattermost',
+};
+
+const postMessageJS = "setTimeout(function() { postMessage(document.body.innerText, '*')}, 0);";
 
 // Used to make sure that OneLogin forms scale appropriately on both platforms.
 const oneLoginFormScalingJS = `
     (function() {
-        document.getElementById('login-page').setAttribute('style', 'background-repeat: repeat-y;');
+        var loginPage = document.getElementById('login-page');
         var submitButton = document.getElementById('user_submit');
-        function resetPadding() {
-            document.getElementById('body-main').setAttribute('style', 'height: auto; padding: 10px 0;');
-            submitButton.removeEventListener('click', resetPadding);
+
+        if (loginPage) {
+            loginPage.setAttribute('style', 'background-repeat: repeat-y;');
         }
+        
+        function resetPadding() {
+            var mainBody = document.getElementById('body-main');
+            
+            if (mainBody) {
+                mainBody.setAttribute('style', 'height: auto; padding: 10px 0;');
+            }
+
+            if (submitButton) {
+                submitButton.removeEventListener('click', resetPadding);
+            }
+        }
+
         resetPadding();
-        submitButton.addEventListener('click', resetPadding);
+        
+        if (submitButton) {
+            submitButton.addEventListener('click', resetPadding);
+        }
     })();
 `;
 
@@ -58,8 +77,7 @@ class SSO extends PureComponent {
         this.state = {
             error: null,
             renderWebView: false,
-            onMessage: props.ssoType === ViewTypes.GITLAB ? this.onMessage : null,
-            jsCode: postMessageJS,
+            jsCode: '',
             scalePagesToFit: false,
         };
 
@@ -133,23 +151,16 @@ class SSO extends PureComponent {
     };
 
     onNavigationStateChange = (navState) => {
-        const {url, navigationType, loading} = navState;
-        let submitted = false;
-        if (Platform.OS === 'ios') {
-            submitted = url.includes(this.completedUrl) && navigationType === 'formsubmit';
-        } else {
-            submitted = url.includes(this.completedUrl) && loading;
-        }
-
+        const {url} = navState;
         const nextState = {};
 
         if (url.includes('.onelogin.com')) {
-            nextState.jsCode = `${oneLoginFormScalingJS}${postMessageJS}`;
+            nextState.jsCode = oneLoginFormScalingJS;
             nextState.scalePagesToFit = true;
-        }
-
-        if (submitted) {
-            nextState.onMessage = this.onMessage;
+        } else if (url.includes(this.props.serverUrl)) {
+            nextState.jsCode = postMessageJS;
+        } else {
+            nextState.jsCode = '';
         }
 
         if (Object.keys(nextState).length) {
@@ -188,7 +199,7 @@ class SSO extends PureComponent {
 
     render() {
         const {theme} = this.props;
-        const {error, renderWebView, onMessage, jsCode, scalePagesToFit} = this.state;
+        const {error, renderWebView, jsCode, scalePagesToFit} = this.state;
         const style = getStyleSheet(theme);
 
         let content;
@@ -203,7 +214,7 @@ class SSO extends PureComponent {
         } else {
             content = (
                 <WebView
-                    source={{uri: this.loginUrl}}
+                    source={{uri: this.loginUrl, headers: HEADERS}}
                     javaScriptEnabledAndroid={true}
                     automaticallyAdjustContentInsets={false}
                     scalesPageToFit={scalePagesToFit}
@@ -211,7 +222,7 @@ class SSO extends PureComponent {
                     onNavigationStateChange={this.onNavigationStateChange}
                     onShouldStartLoadWithRequest={() => true}
                     renderLoading={this.renderLoading}
-                    onMessage={onMessage}
+                    onMessage={this.onMessage}
                     injectedJavaScript={jsCode}
                     onLoadEnd={this.onLoadEnd}
                 />


### PR DESCRIPTION
#### Summary
This PR parses the SAML errors and display them in a friendly way, also makes use of a header that in combination with https://github.com/mattermost/mattermost-server/pull/8943 will make sure that the response for mobile SAML login is always in JSON format.

Also fixes some issues with the JS executed inside the webview for onelogin

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10905

#### Device Information
This PR was tested on: 
* Android 7.0 Emulator
* iOS 11.4 Simulator