### PR TITLE
MM-10888 Hide parts of combined system messages that don't affect the current user

### DIFF
--- a/app/components/combined_system_message/combined_system_message.js
+++ b/app/components/combined_system_message/combined_system_message.js
@@ -165,6 +165,7 @@ export default class CombinedSystemMessage extends React.PureComponent {
         currentUsername: PropTypes.string.isRequired,
         linkStyle: CustomPropTypes.Style,
         messageData: PropTypes.array.isRequired,
+        showJoinLeave: PropTypes.bool.isRequired,
         teammateNameDisplay: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
     };
@@ -357,15 +358,36 @@ export default class CombinedSystemMessage extends React.PureComponent {
         } = this.props;
         const style = getStyleSheet(theme);
 
+        const content = [];
+        for (const message of messageData) {
+            const {
+                postType,
+                actorId,
+            } = message;
+            let userIds = message.userIds;
+
+            if (!this.props.showJoinLeave && actorId !== this.props.currentUserId) {
+                const affectsCurrentUser = userIds.indexOf(this.props.currentUserId) !== -1;
+
+                if (affectsCurrentUser) {
+                    // Only show the message that the current user was added, etc
+                    userIds = [this.props.currentUserId];
+                } else {
+                    // Not something the current user did or was affected by
+                    continue;
+                }
+            }
+
+            content.push(
+                <React.Fragment key={postType + actorId}>
+                    {this.renderSystemMessage(postType, userIds, actorId, {activityType: style.activityType, link: linkStyle, text: style.text})}
+                </React.Fragment>
+            );
+        }
+
         return (
             <React.Fragment>
-                {messageData.map(({postType, userIds, actorId}) => {
-                    return (
-                        <React.Fragment key={postType + actorId}>
-                            {this.renderSystemMessage(postType, userIds, actorId, {activityType: style.activityType, link: linkStyle, text: style.text})}
-                        </React.Fragment>
-                    );
-                })}
+                {content}
             </React.Fragment>
         );
     }

--- a/app/components/combined_system_message/combined_system_message.test.js
+++ b/app/components/combined_system_message/combined_system_message.test.js
@@ -28,6 +28,7 @@ describe('CombinedSystemMessage', () => {
         messageData: [
             {postType: Posts.POST_TYPES.ADD_TO_TEAM, userIds: ['user_id_1'], actorId: 'user_id_2'},
         ],
+        showJoinLeave: true,
         teammateNameDisplay: 'username',
         theme: {centerChannelColor: '#aaa'},
     };

--- a/app/components/combined_system_message/index.js
+++ b/app/components/combined_system_message/index.js
@@ -5,8 +5,8 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getProfilesByIds, getProfilesByUsernames} from 'mattermost-redux/actions/users';
-
-import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+import {Preferences} from 'mattermost-redux/constants';
+import {getBool, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import CombinedSystemMessage from './combined_system_message';
@@ -16,6 +16,7 @@ function mapStateToProps(state) {
     return {
         currentUserId: currentUser.id,
         currentUsername: currentUser.username,
+        showJoinLeave: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true),
         teammateNameDisplay: getTeammateNameDisplaySetting(state),
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9878,8 +9878,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
-      "from": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
+      "version": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
+      "from": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9878,8 +9878,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#b81b6c647b226554cb0d410578562e5f876f4d9b",
-      "from": "github:mattermost/mattermost-redux#b81b6c647b226554cb0d410578562e5f876f4d9b",
+      "version": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
+      "from": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "216113.0.3",
-    "mattermost-redux": "github:mattermost/mattermost-redux#b81b6c647b226554cb0d410578562e5f876f4d9b",
+    "mattermost-redux": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
     "mime-db": "1.33.0",
     "prop-types": "15.6.1",
     "react": "16.3.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "216113.0.3",
-    "mattermost-redux": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
+    "mattermost-redux": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
     "mime-db": "1.33.0",
     "prop-types": "15.6.1",
     "react": "16.3.2",


### PR DESCRIPTION
The redux changes filter out combined system messages that don't relate to the current user while this makes combined system messages for the current user only show the parts that affect the current user. This only affects users that have join/leave messages turned off in Account Settings.

User adding and removing people:
<img width="376" alt="screen shot 2018-06-13 at 6 00 48 pm" src="https://user-images.githubusercontent.com/3277310/41380668-b844f5ee-6f33-11e8-835b-593a136e9f68.png">

User being added and removed:
<img width="372" alt="screen shot 2018-06-13 at 5 55 50 pm" src="https://user-images.githubusercontent.com/3277310/41380595-7cef6772-6f33-11e8-9a8c-49afa3767111.png">

Redux PR: https://github.com/mattermost/mattermost-redux/pull/532

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10888

#### Checklist
- Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator