### PR TITLE
Unread badge background is always white

### DIFF
--- a/app/components/channel_drawer/channels_list/channel_item/channel_item.js
+++ b/app/components/channel_drawer/channels_list/channel_item/channel_item.js
@@ -229,7 +229,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.sidebarUnreadText,
         },
         badge: {
-            backgroundColor: theme.mentionBj,
+            backgroundColor: theme.mentionBg,
             borderColor: theme.sidebarHeaderBg,
             borderRadius: 10,
             borderWidth: 1,

--- a/app/components/channel_drawer/channels_list/channels_list.js
+++ b/app/components/channel_drawer/channels_list/channels_list.js
@@ -244,7 +244,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             lineHeight: 18,
         },
         above: {
-            backgroundColor: theme.mentionBj,
+            backgroundColor: theme.mentionBg,
             top: 9,
         },
     };

--- a/app/components/channel_drawer/channels_list/switch_teams_button/switch_teams_button.js
+++ b/app/components/channel_drawer/channels_list/switch_teams_button/switch_teams_button.js
@@ -116,7 +116,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 14,
         },
         badge: {
-            backgroundColor: theme.mentionBj,
+            backgroundColor: theme.mentionBg,
             borderColor: theme.sidebarHeaderBg,
             borderRadius: 10,
             borderWidth: 1,

--- a/app/components/channel_drawer/teams_list/teams_list_item/teams_list_item.js
+++ b/app/components/channel_drawer/teams_list/teams_list_item/teams_list_item.js
@@ -143,7 +143,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 20,
         },
         badge: {
-            backgroundColor: theme.mentionBj,
+            backgroundColor: theme.mentionBg,
             borderColor: theme.sidebarHeaderBg,
             borderRadius: 10,
             borderWidth: 1,

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -155,7 +155,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             paddingHorizontal: 10,
         },
         badge: {
-            backgroundColor: theme.mentionBj,
+            backgroundColor: theme.mentionBg,
             borderColor: theme.sidebarHeaderBg,
             borderRadius: 10,
             borderWidth: 1,


### PR DESCRIPTION
#### Summary
The unread badge background is always white and does not use the defined theme's "mentionBg". If the "mentionColor" is white the badge will be completely white with no number.

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Nexus 5 API 24, Android 7.0 (Google APIs)

#### Screenshots
Before:
![image-1](https://user-images.githubusercontent.com/3318766/41436423-9b05570a-6fef-11e8-9958-d4b18414099d.jpg)
![image-2 copy](https://user-images.githubusercontent.com/3318766/41436501-d9dc8868-6fef-11e8-97c1-ea30497ff06f.jpg)
After: (my mentionBg is #da202d)
![screen shot 2018-06-14 at 4 22 09 pm](https://user-images.githubusercontent.com/3318766/41436676-5c12a164-6ff0-11e8-987e-e32c74cbb450.png)
![screen shot 2018-06-14 at 4 21 35 pm](https://user-images.githubusercontent.com/3318766/41436687-611c05ec-6ff0-11e8-8f62-217811ef0eab.png)

