### PR TITLE
Fix memory leak on combined_system_message component

### DIFF
--- a/app/components/combined_system_message/combined_system_message.js
+++ b/app/components/combined_system_message/combined_system_message.js
@@ -156,8 +156,8 @@ const postTypeMessage = {
 export default class CombinedSystemMessage extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            getProfilesByIds: PropTypes.func.isRequired,
-            getProfilesByUsernames: PropTypes.func.isRequired,
+            getMissingProfilesByIds: PropTypes.func.isRequired,
+            getMissingProfilesByUsernames: PropTypes.func.isRequired,
         }).isRequired,
         allUserIds: PropTypes.array.isRequired,
         allUsernames: PropTypes.array.isRequired,
@@ -192,11 +192,11 @@ export default class CombinedSystemMessage extends React.PureComponent {
 
     loadUserProfiles = (allUserIds, allUsernames) => {
         if (allUserIds.length > 0) {
-            this.props.actions.getProfilesByIds(allUserIds);
+            this.props.actions.getMissingProfilesByIds(allUserIds);
         }
 
         if (allUsernames.length > 0) {
-            this.props.actions.getProfilesByUsernames(allUsernames);
+            this.props.actions.getMissingProfilesByUsernames(allUsernames);
         }
     }
 

--- a/app/components/combined_system_message/combined_system_message.js
+++ b/app/components/combined_system_message/combined_system_message.js
@@ -168,6 +168,7 @@ export default class CombinedSystemMessage extends React.PureComponent {
         showJoinLeave: PropTypes.bool.isRequired,
         teammateNameDisplay: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
+        userProfiles: PropTypes.array.isRequired,
     };
 
     static defaultProps = {
@@ -179,14 +180,6 @@ export default class CombinedSystemMessage extends React.PureComponent {
         intl: intlShape,
     };
 
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            userProfiles: [],
-        };
-    }
-
     componentDidMount() {
         this.loadUserProfiles(this.props.allUserIds, this.props.allUsernames);
     }
@@ -197,34 +190,24 @@ export default class CombinedSystemMessage extends React.PureComponent {
         }
     }
 
-    loadUserProfiles = async (allUserIds, allUsernames) => {
-        const {actions} = this.props;
-        const userProfiles = [];
+    loadUserProfiles = (allUserIds, allUsernames) => {
         if (allUserIds.length > 0) {
-            const {data} = await actions.getProfilesByIds(allUserIds);
-            if (data.length > 0) {
-                userProfiles.push(...data);
-            }
+            this.props.actions.getProfilesByIds(allUserIds);
         }
 
         if (allUsernames.length > 0) {
-            const {data} = await actions.getProfilesByUsernames(allUsernames);
-            if (data.length > 0) {
-                userProfiles.push(...data);
-            }
+            this.props.actions.getProfilesByUsernames(allUsernames);
         }
-
-        this.setState({userProfiles});
     }
 
     getAllUsersDisplayName = () => {
-        const {userProfiles} = this.state;
         const {
             allUserIds,
             allUsernames,
             currentUserId,
             currentUsername,
             teammateNameDisplay,
+            userProfiles,
         } = this.props;
         const {formatMessage} = this.context.intl;
         const usersDisplayName = userProfiles.reduce((acc, user) => {
@@ -248,7 +231,11 @@ export default class CombinedSystemMessage extends React.PureComponent {
         const usersDisplayName = this.getAllUsersDisplayName();
         const displayNames = userIds.
             filter((userId) => {
-                return userId !== currentUserId && userId !== currentUsername;
+                return (
+                    usersDisplayName[userId] &&
+                    userId !== currentUserId &&
+                    userId !== currentUsername
+                );
             }).
             map((userId) => {
                 return usersDisplayName[userId];

--- a/app/components/combined_system_message/combined_system_message.test.js
+++ b/app/components/combined_system_message/combined_system_message.test.js
@@ -18,8 +18,8 @@ import CombinedSystemMessage from './combined_system_message';
 describe('CombinedSystemMessage', () => {
     const baseProps = {
         actions: {
-            getProfilesByIds: emptyFunction,
-            getProfilesByUsernames: emptyFunction,
+            getMissingProfilesByIds: emptyFunction,
+            getMissingProfilesByUsernames: emptyFunction,
         },
         allUserIds: ['user_id_1', 'user_id_2', 'user_id_3'],
         currentUserId: 'user_id_3',
@@ -38,8 +38,8 @@ describe('CombinedSystemMessage', () => {
         const props = {
             ...baseProps,
             actions: {
-                getProfilesByIds: jest.fn(),
-                getProfilesByUsernames: emptyFunction,
+                getMissingProfilesByIds: jest.fn(),
+                getMissingProfilesByUsernames: emptyFunction,
             },
         };
         const wrapper = shallowWithIntl(
@@ -50,8 +50,8 @@ describe('CombinedSystemMessage', () => {
         expect(wrapper.instance().renderSystemMessage(postType, userIds, actorId, {activityType: {fontSize: 14}, text: {opacity: 0.6}}, 1)).toMatchSnapshot();
 
         // on componentDidMount
-        expect(props.actions.getProfilesByIds).toHaveBeenCalledTimes(1);
-        expect(props.actions.getProfilesByIds).toHaveBeenCalledWith(props.allUserIds);
+        expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledTimes(1);
+        expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledWith(props.allUserIds);
     });
 
     test('should match snapshot', () => {
@@ -66,13 +66,13 @@ describe('CombinedSystemMessage', () => {
         expect(wrapper.instance().renderFormattedMessage(localeFormat, 'first_user', 'second_user', 'actor', {activityType: {fontSize: 14}, text: {opacity: 0.6}})).toMatchSnapshot();
     });
 
-    test('should call getProfilesByIds and/or getProfilesByUsernames on loadUserProfiles', () => {
+    test('should call getMissingProfilesByIds and/or getMissingProfilesByUsernames on loadUserProfiles', () => {
         const props = {
             ...baseProps,
             allUserIds: [],
             actions: {
-                getProfilesByIds: jest.fn(),
-                getProfilesByUsernames: jest.fn(),
+                getMissingProfilesByIds: jest.fn(),
+                getMissingProfilesByUsernames: jest.fn(),
             },
         };
 
@@ -81,18 +81,18 @@ describe('CombinedSystemMessage', () => {
         );
 
         wrapper.instance().loadUserProfiles([], []);
-        expect(props.actions.getProfilesByIds).toHaveBeenCalledTimes(0);
-        expect(props.actions.getProfilesByUsernames).toHaveBeenCalledTimes(0);
+        expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledTimes(0);
+        expect(props.actions.getMissingProfilesByUsernames).toHaveBeenCalledTimes(0);
 
         wrapper.instance().loadUserProfiles(['user_id_1'], []);
-        expect(props.actions.getProfilesByIds).toHaveBeenCalledTimes(1);
-        expect(props.actions.getProfilesByIds).toHaveBeenCalledWith(['user_id_1']);
-        expect(props.actions.getProfilesByUsernames).toHaveBeenCalledTimes(0);
+        expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledTimes(1);
+        expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledWith(['user_id_1']);
+        expect(props.actions.getMissingProfilesByUsernames).toHaveBeenCalledTimes(0);
 
         wrapper.instance().loadUserProfiles(['user_id_1', 'user_id_2'], ['user1']);
-        expect(props.actions.getProfilesByIds).toHaveBeenCalledTimes(2);
-        expect(props.actions.getProfilesByIds).toHaveBeenCalledWith(['user_id_1', 'user_id_2']);
-        expect(props.actions.getProfilesByUsernames).toHaveBeenCalledTimes(1);
-        expect(props.actions.getProfilesByUsernames).toHaveBeenCalledWith(['user1']);
+        expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledTimes(2);
+        expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledWith(['user_id_1', 'user_id_2']);
+        expect(props.actions.getMissingProfilesByUsernames).toHaveBeenCalledTimes(1);
+        expect(props.actions.getMissingProfilesByUsernames).toHaveBeenCalledWith(['user1']);
     });
 });

--- a/app/components/combined_system_message/index.js
+++ b/app/components/combined_system_message/index.js
@@ -3,21 +3,61 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {createSelector} from 'reselect';
 
 import {getProfilesByIds, getProfilesByUsernames} from 'mattermost-redux/actions/users';
 import {Preferences} from 'mattermost-redux/constants';
 import {getBool, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, getProfiles} from 'mattermost-redux/selectors/entities/users';
 
 import CombinedSystemMessage from './combined_system_message';
 
-function mapStateToProps(state) {
+const getUserProfiles = createSelector(
+    getProfiles,
+    (state, props) => props.allUserIds,
+    (state, props) => props.allUsernames,
+    (profiles, allUserIds, allUsernames) => {
+        const allProfiles = profiles.reduce((acc, profile) => {
+            acc[profile.id] = profile;
+            acc[profile.username] = profile;
+            return acc;
+        }, {});
+
+        const userProfiles = [];
+
+        if (allUserIds.length > 0) {
+            const profilesById = allUserIds.
+                filter((userId) => allProfiles[userId]).
+                map((userId) => allProfiles[userId]);
+
+            if (profilesById && profilesById.length > 0) {
+                userProfiles.push(...profilesById);
+            }
+        }
+
+        if (allUsernames.length > 0) {
+            const profilesByUsername = allUsernames.
+                filter((username) => allProfiles[username]).
+                map((username) => allProfiles[username]);
+
+            if (profilesByUsername && profilesByUsername.length > 0) {
+                userProfiles.push(...profilesByUsername);
+            }
+        }
+
+        return userProfiles;
+    }
+);
+
+function mapStateToProps(state, ownProps) {
     const currentUser = getCurrentUser(state);
+    const {allUserIds, allUsernames} = ownProps;
     return {
         currentUserId: currentUser.id,
         currentUsername: currentUser.username,
         showJoinLeave: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true),
         teammateNameDisplay: getTeammateNameDisplaySetting(state),
+        userProfiles: getUserProfiles(state, {allUserIds, allUsernames}),
     };
 }
 

--- a/app/components/combined_system_message/index.js
+++ b/app/components/combined_system_message/index.js
@@ -3,51 +3,16 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {createSelector} from 'reselect';
 
 import {getMissingProfilesByIds, getMissingProfilesByUsernames} from 'mattermost-redux/actions/users';
 import {Preferences} from 'mattermost-redux/constants';
 import {getBool, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUser, getProfiles, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
 
 import CombinedSystemMessage from './combined_system_message';
 
-function makeGetUserProfiles() {
-    return createSelector(
-        getProfiles,
-        getUsersByUsername,
-        (state, props) => props.allUserIds,
-        (state, props) => props.allUsernames,
-        (allProfilesById, allProfilesByUsername, allUserIds, allUsernames) => {
-            const userProfiles = [];
-
-            if (allUserIds.length > 0) {
-                const profilesById = allUserIds.
-                    filter((userId) => allProfilesById[userId]).
-                    map((userId) => allProfilesById[userId]);
-
-                if (profilesById && profilesById.length > 0) {
-                    userProfiles.push(...profilesById);
-                }
-            }
-
-            if (allUsernames.length > 0) {
-                const profilesByUsername = allUsernames.
-                    filter((username) => allProfilesByUsername[username]).
-                    map((username) => allProfilesByUsername[username]);
-
-                if (profilesByUsername && profilesByUsername.length > 0) {
-                    userProfiles.push(...profilesByUsername);
-                }
-            }
-
-            return userProfiles;
-        }
-    );
-}
-
 function makeMapStateToProps() {
-    const getUserProfiles = makeGetUserProfiles();
+    const getProfilesByIdsAndUsernames = makeGetProfilesByIdsAndUsernames();
 
     return (state, ownProps) => {
         const currentUser = getCurrentUser(state);
@@ -57,7 +22,7 @@ function makeMapStateToProps() {
             currentUsername: currentUser.username,
             showJoinLeave: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true),
             teammateNameDisplay: getTeammateNameDisplaySetting(state),
-            userProfiles: getUserProfiles(state, {allUserIds, allUsernames}),
+            userProfiles: getProfilesByIdsAndUsernames(state, {allUserIds, allUsernames}),
         };
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9878,8 +9878,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
-      "from": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
+      "version": "github:mattermost/mattermost-redux#c9b633da7fc3fc9ba3cc40ecc9665e088defbe73",
+      "from": "github:mattermost/mattermost-redux#c9b633da7fc3fc9ba3cc40ecc9665e088defbe73",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "216113.0.3",
-    "mattermost-redux": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
+    "mattermost-redux": "github:mattermost/mattermost-redux#c9b633da7fc3fc9ba3cc40ecc9665e088defbe73",
     "mime-db": "1.33.0",
     "prop-types": "15.6.1",
     "react": "16.3.2",


### PR DESCRIPTION
#### Summary
Fix memory leak on combined_system_message component
- by removing async call which sometimes resolves and sets state even after the component is unmounted
- eliminating undefined user profile (of `actions.getProfilesByIds` and/or `actions.getProfilesByUsernames`) when server is unreachable (network problem) or the server returns an error by letting redux to handle such user's state.
- [UPDATE] only get missing profiles

#### Ticket Link
None but was reported on pre-release:
- https://pre-release.mattermost.com/core/pl/ofbk3xz7jp8u38ckm78usbe5ih
- https://pre-release.mattermost.com/core/pl/ck75xrjispd8mdn4h9edzw1y8c

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [Primarily Android emulator, and iOS simulator] 
