### PR TITLE
White labeing the file sharing functionality in Android

### DIFF
--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -2347,7 +2347,7 @@
   "mobile.extension.max_file_size": "File attachments shared in Mattermost must be less than {size}.",
   "mobile.extension.permission": "Mattermost needs access to the device storage to share files.",
   "mobile.extension.posting": "Posting...",
-  "mobile.extension.title": "Share in Mattermost",
+  "mobile.extension.title": "Share in {siteName}",
   "mobile.failed_network_action.description": "There seems to be a problem with your internet connection. Make sure you have an active connection and try again.",
   "mobile.failed_network_action.retry": "Try Again",
   "mobile.failed_network_action.title": "No internet connection",

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -58,6 +58,7 @@ const MAX_MESSAGE_LENGTH = 4000;
 
 export default class ExtensionPost extends PureComponent {
     static propTypes = {
+        config: PropTypes.object.isRequired,
         channelId: PropTypes.string.isRequired,
         currentUserId: PropTypes.string.isRequired,
         maxFileSize: PropTypes.number.isRequired,
@@ -120,11 +121,14 @@ export default class ExtensionPost extends PureComponent {
 
     constructor(props, context) {
         super(props, context);
+        const {config} = this.props;
 
         props.navigation.setParams({
             title: context.intl.formatMessage({
                 id: 'mobile.extension.title',
-                defaultMessage: 'Share in Mattermost',
+                defaultMessage: 'Share in {siteName}',
+            }, {
+                siteName: config.SiteName,
             }),
         });
 

--- a/share_extension/android/extension_post/index.js
+++ b/share_extension/android/extension_post/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -16,6 +17,7 @@ function mapStateToProps(state) {
     const {token, url} = credentials;
 
     return {
+        config: getConfig(state),
         channelId: getCurrentChannelId(state),
         currentUserId: getCurrentUserId(state),
         maxFileSize: getAllowedServerMaxFileSize(config),


### PR DESCRIPTION
#### Summary
When you share a file from your Android device then click "Mattermost" as the target.  A screen pops up that shows "Share in Mattermost". I have white labelled this functionality to use the SiteName config value.

The localization changes were made to the webapp repo:
https://github.com/mattermost/mattermost-webapp/pull/1368

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Nexus 5 API 24, Android 7.0 (Google APIs)

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3318766/41682976-5d03a2e2-74a7-11e8-898a-e9b565e3f4f7.png)
After:
![image](https://user-images.githubusercontent.com/3318766/41682948-4b2b88c8-74a7-11e8-8504-6e2be1e92649.png)

