### PR TITLE
MM-10990: allow a pathname when selecting a server

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -251,7 +251,7 @@ export default class SelectServer extends PureComponent {
     onClick = preventDoubleTap(async () => {
         const urlParse = require('url-parse');
         const preUrl = urlParse(this.state.url, true);
-        const url = stripTrailingSlashes(preUrl.protocol + '//' + preUrl.host);
+        const url = stripTrailingSlashes(preUrl.protocol + '//' + preUrl.host + preUrl.pathname);
 
         Keyboard.dismiss();
 


### PR DESCRIPTION
#### Summary
This complements the subpath epic changes in the server and webapp to allow RN to connect to Mattermost when hosted at a `/subpath`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10990

#### Checklist
- [ ] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator
