### PR TITLE
[MM-10817] Add option to send message via user profile even coming from DM channel

### DIFF
--- a/app/screens/user_profile/index.js
+++ b/app/screens/user_profile/index.js
@@ -7,7 +7,6 @@ import {connect} from 'react-redux';
 import {setChannelDisplayName} from 'app/actions/views/channel';
 import {makeDirectChannel} from 'app/actions/views/more_dms';
 
-import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getTeammateNameDisplaySetting, getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -21,7 +20,6 @@ function mapStateToProps(state, ownProps) {
     return {
         config,
         createChannelRequest,
-        currentChannel: getCurrentChannel(state) || {},
         currentDisplayName: state.views.channel.displayName,
         currentUserId: getCurrentUserId(state),
         user: state.entities.users.profiles[ownProps.userId],

--- a/app/screens/user_profile/index.js
+++ b/app/screens/user_profile/index.js
@@ -8,7 +8,6 @@ import {setChannelDisplayName} from 'app/actions/views/channel';
 import {makeDirectChannel} from 'app/actions/views/more_dms';
 
 import {getTeammateNameDisplaySetting, getTheme} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import UserProfile from './user_profile';
@@ -21,7 +20,6 @@ function mapStateToProps(state, ownProps) {
         config,
         createChannelRequest,
         currentDisplayName: state.views.channel.displayName,
-        currentUserId: getCurrentUserId(state),
         user: state.entities.users.profiles[ownProps.userId],
         teammateNameDisplay: getTeammateNameDisplaySetting(state),
         theme: getTheme(state),

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -11,7 +11,6 @@ import {
 } from 'react-native';
 import {intlShape} from 'react-intl';
 
-import {getDirectChannelName} from 'mattermost-redux/utils/channel_utils';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import ProfilePicture from 'app/components/profile_picture';
@@ -29,7 +28,6 @@ export default class UserProfile extends PureComponent {
             setChannelDisplayName: PropTypes.func.isRequired,
         }).isRequired,
         config: PropTypes.object.isRequired,
-        currentChannel: PropTypes.object.isRequired,
         currentDisplayName: PropTypes.string,
         currentUserId: PropTypes.string.isRequired,
         navigator: PropTypes.object,
@@ -66,9 +64,9 @@ export default class UserProfile extends PureComponent {
     };
 
     displaySendMessageOption = () => {
-        const {currentChannel, currentUserId, user} = this.props;
+        const {currentUserId, user} = this.props;
 
-        return currentChannel.name !== getDirectChannelName(currentUserId, user.id);
+        return user.id !== currentUserId;
     };
 
     getDisplayName = () => {

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -29,7 +29,6 @@ export default class UserProfile extends PureComponent {
         }).isRequired,
         config: PropTypes.object.isRequired,
         currentDisplayName: PropTypes.string,
-        currentUserId: PropTypes.string.isRequired,
         navigator: PropTypes.object,
         teammateNameDisplay: PropTypes.string,
         theme: PropTypes.object.isRequired,
@@ -61,12 +60,6 @@ export default class UserProfile extends PureComponent {
                 screenBackgroundColor: theme.centerChannelBg,
             },
         });
-    };
-
-    displaySendMessageOption = () => {
-        const {currentUserId, user} = this.props;
-
-        return user.id !== currentUserId;
     };
 
     getDisplayName = () => {
@@ -197,7 +190,6 @@ export default class UserProfile extends PureComponent {
                         {config.ShowEmailAddress === 'true' && this.buildDisplayBlock('email')}
                         {this.buildDisplayBlock('position')}
                     </View>
-                    {this.displaySendMessageOption() &&
                     <UserProfileRow
                         action={this.sendMessage}
                         defaultMessage='Send Message'
@@ -206,7 +198,6 @@ export default class UserProfile extends PureComponent {
                         textId='mobile.routes.user_profile.send_message'
                         theme={theme}
                     />
-                    }
                     {this.renderAdditionalOptions()}
                 </ScrollView>
             </View>


### PR DESCRIPTION
#### Summary
Add option to send message via user profile even coming from DM channel, by just checking whether the user (on profile) is not the current user.

(Note:  I tried adding test but I kept getting error like `ReferenceError: self is not defined`.  Need to figure out separately.)

#### Ticket Link
Jira ticket: [MM-10817](https://mattermost.atlassian.net/browse/MM-10817)

#### Device Information
This PR was tested on: [iOS simulator, Android emulator] 

