### PR TITLE
Fix user being "logged out" after upgrading

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -76,6 +76,7 @@ export default class App {
                     return Initialization.credentials;
                 },
                 () => {
+                    this.waitForRehydration = true;
                     return getGenericPassword();
                 }
             );
@@ -153,6 +154,13 @@ export default class App {
         }
         const username = `${deviceToken}, ${currentUserId}`;
         const password = `${token},${url}`;
+
+        if (this.waitForRehydration) {
+            this.waitForRehydration = false;
+            this.token = token;
+            this.url = url;
+        }
+
         setGenericPassword(username, password);
     };
 
@@ -215,7 +223,7 @@ export default class App {
     };
 
     startApp = () => {
-        if (this.appStarted) {
+        if (this.appStarted || this.waitForRehydration) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
The first time the user opens the app after upgrading from 1.8 to 1.9 the app didn't recognized that the user was logged in and presented the select server screen instead.

This PR makes sure that case is handled when the user upgrades.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10993
