### PR TITLE
Fix android seach field population for in and from keywords

### DIFF
--- a/app/components/search_bar/search_bar.android.js
+++ b/app/components/search_bar/search_bar.android.js
@@ -71,6 +71,16 @@ export default class SearchBarAndroid extends PureComponent {
         };
     }
 
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (nextProps.value !== prevState.value) {
+            return {
+                value: nextProps.value,
+            };
+        }
+
+        return null;
+    }
+
     cancel = () => {
         this.onCancelButtonPress();
     };


### PR DESCRIPTION
#### Summary
Fixes android issue of search input field population with in: and from: keywords

#### Ticket Link
[MM-11006](https://mattermost.atlassian.net/browse/MM-11006)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [Nexus emulator] 

