### PR TITLE
Fetch posts when receive push notifications as soon as possible

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -6,7 +6,6 @@ import {Client4} from 'mattermost-redux/client';
 import {General} from 'mattermost-redux/constants';
 import {fetchMyChannelsAndMembers, markChannelAsRead} from 'mattermost-redux/actions/channels';
 import {getClientConfig, getDataRetentionPolicy, getLicenseConfig} from 'mattermost-redux/actions/general';
-import {getPosts} from 'mattermost-redux/actions/posts';
 import {getMyTeams, getMyTeamMembers, selectTeam} from 'mattermost-redux/actions/teams';
 
 import {ViewTypes} from 'app/constants';
@@ -15,7 +14,6 @@ import {recordTime} from 'app/utils/segment';
 import {
     handleSelectChannel,
     setChannelDisplayName,
-    retryGetPostsAction,
 } from 'app/actions/views/channel';
 
 export function startDataCleanup() {
@@ -83,12 +81,10 @@ export function loadFromPushNotification(notification) {
             dispatch(selectTeam({id: teamId}));
         }
 
-        // when the notification is from the same channel as the current channel
-        // we should get the posts
-        if (channelId === currentChannelId) {
-            dispatch(markChannelAsRead(channelId, null, false));
-            await retryGetPostsAction(getPosts(channelId), dispatch, getState);
-        } else {
+        // mark channel as read
+        dispatch(markChannelAsRead(channelId, channelId === currentChannelId ? null : currentChannelId, false));
+
+        if (channelId !== currentChannelId) {
             // when the notification is from a channel other than the current channel
             dispatch(markChannelAsRead(channelId, currentChannelId, false));
             dispatch(setChannelDisplayName(''));

--- a/app/utils/push_notifications.js
+++ b/app/utils/push_notifications.js
@@ -9,10 +9,12 @@ import {Client4} from 'mattermost-redux/client';
 
 import {markChannelAsRead} from 'mattermost-redux/actions/channels';
 import {setDeviceToken} from 'mattermost-redux/actions/general';
+import {getPosts} from 'mattermost-redux/actions/posts';
 import {General} from 'mattermost-redux/constants';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {ViewTypes} from 'app/constants';
+import {retryGetPostsAction} from 'app/actions/views/channel';
 import {
     createPost,
     loadFromPushNotification,
@@ -66,15 +68,20 @@ const onPushNotification = async (deviceNotification) => {
 
     if (data.type === 'clear') {
         dispatch(markChannelAsRead(data.channel_id, null, false));
-    } else if (foreground) {
-        EventEmitter.emit(ViewTypes.NOTIFICATION_IN_APP, notification);
-    } else if (userInteraction && !notification.localNotification) {
-        EventEmitter.emit('close_channel_drawer');
-        if (getState().views.root.hydrationComplete) {
-            await dispatch(loadFromPushNotification(notification));
-            if (!app.startAppFromPushNotification) {
-                EventEmitter.emit(ViewTypes.NOTIFICATION_TAPPED);
-                PushNotifications.resetNotification();
+    } else {
+        // get the posts for the channel as soon as possible
+        retryGetPostsAction(getPosts(data.channel_id), dispatch, getState);
+
+        if (foreground) {
+            EventEmitter.emit(ViewTypes.NOTIFICATION_IN_APP, notification);
+        } else if (userInteraction && !notification.localNotification) {
+            EventEmitter.emit('close_channel_drawer');
+            if (getState().views.root.hydrationComplete) {
+                await dispatch(loadFromPushNotification(notification));
+                if (!app.startAppFromPushNotification) {
+                    EventEmitter.emit(ViewTypes.NOTIFICATION_TAPPED);
+                    PushNotifications.resetNotification();
+                }
             }
         }
     }
@@ -112,8 +119,9 @@ export const onPushNotificationReply = (data, text, badge, completed) => {
             Client4.setToken(token);
         }
 
-        createPost(post)(dispatch, getState).then(() => {
-            markChannelAsRead(data.channel_id)(dispatch, getState);
+        dispatch(retryGetPostsAction(getPosts(data.channel_id)));
+        dispatch(createPost(post)).then(() => {
+            dispatch(markChannelAsRead(data.channel_id));
 
             if (badge >= 0) {
                 PushNotifications.setApplicationIconBadgeNumber(badge);


### PR DESCRIPTION
#### Summary
It was not possible to get the posts when the app is closed, it has to be done in native code and there is no bridge to send it back to the js code, so this PR attempts to get the posts as soon as possible

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10392