### PR TITLE
Fix opening video when file has localPath set

### DIFF
--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -275,64 +275,50 @@ export default class Downloader extends PureComponent {
     startDownload = async () => {
         const {file, downloadPath, prompt, saveToCameraRoll} = this.props;
         const {data} = file;
-        let downloadFile = true;
 
         try {
             if (this.state.didCancel) {
                 this.setState({didCancel: false});
             }
 
-            let path;
-            let res;
-            if (data && data.localPath) {
-                path = data.localPath;
-                downloadFile = false;
-                this.setState({
-                    progress: 100,
-                    started: true,
-                });
-            }
+            const imageUrl = Client4.getFileUrl(data.id);
+            const options = {
+                session: data.id,
+                timeout: 10000,
+                indicator: true,
+                overwrite: true,
+            };
 
-            if (downloadFile) {
-                const imageUrl = Client4.getFileUrl(data.id);
-                const options = {
-                    session: data.id,
-                    timeout: 10000,
-                    indicator: true,
-                    overwrite: true,
-                };
-
-                if (downloadPath && prompt) {
-                    const isDir = await RNFetchBlob.fs.isDir(downloadPath);
-                    if (!isDir) {
-                        try {
-                            await RNFetchBlob.fs.mkdir(downloadPath);
-                        } catch (error) {
-                            this.showDownloadFailedAlert();
-                            return;
-                        }
+            if (downloadPath && prompt) {
+                const isDir = await RNFetchBlob.fs.isDir(downloadPath);
+                if (!isDir) {
+                    try {
+                        await RNFetchBlob.fs.mkdir(downloadPath);
+                    } catch (error) {
+                        this.showDownloadFailedAlert();
+                        return;
                     }
-
-                    options.path = `${downloadPath}/${data.id}-${file.caption}`;
-                } else {
-                    options.fileCache = true;
-                    options.appendExt = data.extension;
                 }
 
-                this.downloadTask = RNFetchBlob.config(options).fetch('GET', imageUrl);
-                this.downloadTask.progress((received, total) => {
-                    const progress = (received / total) * 100;
-                    if (this.mounted) {
-                        this.setState({
-                            progress,
-                            started: true,
-                        });
-                    }
-                });
-
-                res = await this.downloadTask;
-                path = res.path();
+                options.path = `${downloadPath}/${data.id}-${file.caption}`;
+            } else {
+                options.fileCache = true;
+                options.appendExt = data.extension;
             }
+
+            this.downloadTask = RNFetchBlob.config(options).fetch('GET', imageUrl);
+            this.downloadTask.progress((received, total) => {
+                const progress = (received / total) * 100;
+                if (this.mounted) {
+                    this.setState({
+                        progress,
+                        started: true,
+                    });
+                }
+            });
+
+            const res = await this.downloadTask;
+            let path = res.path();
 
             if (saveToCameraRoll) {
                 path = await CameraRoll.saveToCameraRoll(path, 'photo');

--- a/app/screens/image_preview/video_preview.js
+++ b/app/screens/image_preview/video_preview.js
@@ -40,6 +40,12 @@ export default class VideoPreview extends PureComponent {
     constructor(props) {
         super(props);
 
+        let path = null;
+        const {file} = props;
+        if (file && file.data && file.data.localPath) {
+            path = file.data.localPath;
+        }
+
         this.state = {
             isLoading: true,
             isFullScreen: false,
@@ -47,7 +53,7 @@ export default class VideoPreview extends PureComponent {
             paused: true,
             currentTime: 0,
             duration: 0,
-            path: null,
+            path,
             showDownloader: true,
         };
     }
@@ -84,7 +90,7 @@ export default class VideoPreview extends PureComponent {
 
     onDownloadSuccess = () => {
         const {file} = this.props;
-        const path = `${VIDEOS_PATH}/${file.data.id}-${file.caption}`;
+        const path = file.data.localPath || `${VIDEOS_PATH}/${file.data.id}-${file.caption}`;
 
         this.setState({showDownloader: false, path});
     };


### PR DESCRIPTION
#### Summary
When uploading a video file it is not possible to playback the file unless the cache is cleaned as the object contains a `localPath` property, this PR fixes that.

#### Ticket
https://mattermost.atlassian.net/browse/MM-11020