### PR TITLE
MM-11018 Provide default message for Sentry breadcrumbs (1.9.2)

### DIFF
--- a/app/utils/sentry/middleware.js
+++ b/app/utils/sentry/middleware.js
@@ -19,15 +19,14 @@ export function createSentryMiddleware() {
 }
 
 function makeBreadcrumbFromAction(action) {
+    if (!action.type) {
+        console.warn('dispatching action with undefined type', action); // eslint-disable-line no-console
+    }
+
     const breadcrumb = {
         category: BREADCRUMB_REDUX_ACTION,
-        message: action.type,
+        message: action.type || 'undefined action',
     };
-
-    if (action.type === BATCH) {
-        // Attach additional information so that batched actions display what they're doing
-        breadcrumb.data = action.payload.map((a) => a.type);
-    }
 
     if (action.type === BATCH) {
         // Attach additional information so that batched actions display what they're doing, and make it
@@ -35,7 +34,7 @@ function makeBreadcrumbFromAction(action) {
         breadcrumb.data = {};
 
         action.payload.forEach((a, index) => {
-            breadcrumb.data[index] = a.type;
+            breadcrumb.data[index] = a.type || 'undefined action';
         });
     }
 


### PR DESCRIPTION
I don't know what is dispatching an invalid action, but the warnings should help us track it down later

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11018

#### Device Information
This PR was tested on: Nexus 5