### PR TITLE
Fix uploading files with blank spaces in the filename

### DIFF
--- a/app/components/attachment_button.js
+++ b/app/components/attachment_button.js
@@ -166,6 +166,9 @@ export default class AttachmentButton extends PureComponent {
                     }
                 }
 
+                // Decode file uri to get the actual path
+                res.uri = decodeURIComponent(res.uri);
+
                 this.uploadFiles([res]);
             });
         }


### PR DESCRIPTION
#### Summary
The file was not being found as the document picker returned the file path as encoded, this decodes the file path so the file is actually found when uploading it

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11019
