### PR TITLE
MM-11098 Fix ios extension crash and ability to share from files app

### DIFF
--- a/ios/MattermostShare/SessionManager.m
+++ b/ios/MattermostShare/SessionManager.m
@@ -26,7 +26,7 @@
 -(void)setRequestWithGroup:(NSString *)requestWithGroup certificateName:(NSString *)certificateName {
   self.requestWithGroup = requestWithGroup;
   self.certificateName = certificateName;
-  self.isBackground = certificateName == nil;
+  self.isBackground = [certificateName length] == 0;
 }
 
 -(void)setDataForRequest:(NSDictionary *)data forRequestWithGroup:(NSString *)requestWithGroup {

--- a/share_extension/ios/extension_post.js
+++ b/share_extension/ios/extension_post.js
@@ -247,7 +247,7 @@ export default class ExtensionPost extends PureComponent {
                         break;
                     default: {
                         const fullPath = item.value;
-                        const filePath = fullPath.replace('file://', '');
+                        const filePath = decodeURIComponent(fullPath.replace('file://', ''));
                         const fileSize = await RNFetchBlob.fs.stat(filePath);
                         const filename = fullPath.replace(/^.*[\\/]/, '');
                         const extension = filename.split('.').pop();
@@ -612,7 +612,7 @@ export default class ExtensionPost extends PureComponent {
                     post,
                     requestId: generateId().replace(/-/g, ''),
                     useBackgroundUpload: this.useBackgroundUpload,
-                    certificate,
+                    certificate: certificate || '',
                 };
 
                 this.setState({sending: true});


### PR DESCRIPTION
#### Summary
Fixed crash for the iOS Share Extension when the cba certificate is not present.

Also this PR fixes the share extension when sharing files from the files app, the fix consists in decoding the uri for the file.