### PR TITLE
MM-11035 Add loader when the Add Members to channel screen is loading

### DIFF
--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -63,6 +63,7 @@ class ChannelAddMembers extends PureComponent {
             selectedMembers: {},
             showNoResults: false,
             term: '',
+            isLoading: true,
         };
         this.addButton.title = props.intl.formatMessage({id: 'integrations.add', defaultMessage: 'Add'});
 
@@ -122,6 +123,12 @@ class ChannelAddMembers extends PureComponent {
                 this.setState({adding: false, canSelect: true});
                 break;
             }
+        }
+
+        if ((loadMoreRequestStatus !== nextProps.loadMoreRequestStatus) || (this.props.searchRequestStatus !== nextProps.searchRequestStatus)) {
+            const isLoading = (nextProps.loadMoreRequestStatus === RequestStatus.STARTED) ||
+                (nextProps.searchRequestStatus === RequestStatus.STARTED);
+            this.setState({isLoading});
         }
     }
 
@@ -222,11 +229,9 @@ class ChannelAddMembers extends PureComponent {
     };
 
     render() {
-        const {intl, loadMoreRequestStatus, searchRequestStatus, preferences, theme} = this.props;
+        const {intl, preferences, theme} = this.props;
         const {adding, profiles, searching, term} = this.state;
         const {formatMessage} = intl;
-        const isLoading = (loadMoreRequestStatus === RequestStatus.STARTED) ||
-            (searchRequestStatus === RequestStatus.STARTED);
         const style = getStyleFromTheme(theme);
         const more = searching ? () => true : this.loadMoreMembers;
 
@@ -281,12 +286,13 @@ class ChannelAddMembers extends PureComponent {
                     onListEndReached={more}
                     preferences={preferences}
                     listScrollRenderAheadDistance={50}
-                    loading={isLoading}
+                    loading={this.state.isLoading}
                     loadingText={loadingText}
                     selectable={this.state.canSelect}
                     onRowSelect={this.handleRowSelect}
                     renderRow={UserListRow}
                     createSections={createMembersSections}
+                    showNoResults={this.state.showNoResults}
                 />
             </View>
         );


### PR DESCRIPTION
#### Summary
Add missing loading screen when the Add Members to channel screen is loading
* Add showNoResults state to custom_list

#### Ticket Link
[MM-11035](https://mattermost.atlassian.net/browse/MM-11035)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [Ios emulator, Android emulator Pixel 7.1] 

#### Screenshots
![loader](https://user-images.githubusercontent.com/4973621/42029880-95de072c-7aee-11e8-939b-88d80b614a7f.gif)
