### PR TITLE
Fix youTube crash on iOS providing the right prop type

### DIFF
--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -369,7 +369,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
 
         const time = link.match(timeRegex);
         if (!time || !time[0]) {
-            return '';
+            return 0;
         }
 
         const hours = time[2] ? time[2].match(/([0-9]+)h/) : null;


### PR DESCRIPTION
#### Summary
The parser to extract the time was returning a blank string instead of 0 causing a crash for those youtube links without time on iOS

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11095