### PR TITLE
MM-10855 Fix password characters being hidden too quickly

### DIFF
--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -381,7 +381,6 @@ export default class Login extends PureComponent {
                         />
                         <TextInput
                             ref={this.passwordRef}
-                            value={this.props.password}
                             onChangeText={this.props.actions.handlePasswordChanged}
                             style={GlobalStyles.inputBox}
                             placeholder={this.context.intl.formatMessage({id: 'login.password', defaultMessage: 'Password'})}


### PR DESCRIPTION

#### Summary
PR adds the default hiding speed of password characters
* Remove the value prop on input as it triggers a render and hides it quickly.

#### Ticket Link
[MM-10855](https://mattermost.atlassian.net/browse/MM-10855)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [ios emulator, android pixel emulator running on 7.1] 

#### Screenshots
![jun-29-2018 21-20-59](https://user-images.githubusercontent.com/4973621/42102052-803f2a6e-7be2-11e8-8a82-07efd1d21173.gif)
