### PR TITLE
MM-10012 Added Markdown rendering to expanded announcement banner

### DIFF
--- a/app/components/announcement_banner/__snapshots__/announcement_banner.test.js.snap
+++ b/app/components/announcement_banner/__snapshots__/announcement_banner.test.js.snap
@@ -58,7 +58,9 @@ ShallowWrapper {
             ]
           }
         >
-          Banner Text
+          <RemoveMarkdown
+            value="Banner Text"
+          />
         </Text>
         <Icon
           allowFontScaling={false}
@@ -107,7 +109,9 @@ ShallowWrapper {
               ]
             }
           >
-            Banner Text
+            <RemoveMarkdown
+              value="Banner Text"
+            />
           </Text>,
           <Icon
             allowFontScaling={false}
@@ -132,7 +136,9 @@ ShallowWrapper {
           "props": Object {
             "accessible": true,
             "allowFontScaling": true,
-            "children": "Banner Text",
+            "children": <RemoveMarkdown
+              value="Banner Text"
+            />,
             "ellipsizeMode": "tail",
             "numberOfLines": 1,
             "style": Array [
@@ -147,7 +153,17 @@ ShallowWrapper {
             ],
           },
           "ref": null,
-          "rendered": "Banner Text",
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "value": "Banner Text",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           "type": [Function],
         },
         Object {
@@ -204,7 +220,9 @@ ShallowWrapper {
               ]
             }
           >
-            Banner Text
+            <RemoveMarkdown
+              value="Banner Text"
+            />
           </Text>
           <Icon
             allowFontScaling={false}
@@ -253,7 +271,9 @@ ShallowWrapper {
                 ]
               }
             >
-              Banner Text
+              <RemoveMarkdown
+                value="Banner Text"
+              />
             </Text>,
             <Icon
               allowFontScaling={false}
@@ -278,7 +298,9 @@ ShallowWrapper {
             "props": Object {
               "accessible": true,
               "allowFontScaling": true,
-              "children": "Banner Text",
+              "children": <RemoveMarkdown
+                value="Banner Text"
+              />,
               "ellipsizeMode": "tail",
               "numberOfLines": 1,
               "style": Array [
@@ -293,7 +315,17 @@ ShallowWrapper {
               ],
             },
             "ref": null,
-            "rendered": "Banner Text",
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "value": "Banner Text",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             "type": [Function],
           },
           Object {

--- a/app/components/announcement_banner/__snapshots__/announcement_banner.test.js.snap
+++ b/app/components/announcement_banner/__snapshots__/announcement_banner.test.js.snap
@@ -5,12 +5,6 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <AnnouncementBanner
-    actions={
-      Object {
-        "dismissBanner": [MockFunction],
-      }
-    }
-    allowDismissal={true}
     bannerColor="#ddd"
     bannerDismissed={false}
     bannerEnabled={true}
@@ -363,12 +357,6 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <AnnouncementBanner
-    actions={
-      Object {
-        "dismissBanner": [MockFunction],
-      }
-    }
-    allowDismissal={true}
     bannerColor="#ddd"
     bannerDismissed={false}
     bannerEnabled={false}

--- a/app/components/announcement_banner/announcement_banner.js
+++ b/app/components/announcement_banner/announcement_banner.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    Alert,
     Animated,
     StyleSheet,
     Text,
@@ -12,6 +11,8 @@ import {
 } from 'react-native';
 import {intlShape} from 'react-intl';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+
+import RemoveMarkdown from 'app/components/remove_markdown';
 
 const {View: AnimatedView} = Animated;
 
@@ -26,6 +27,8 @@ export default class AnnouncementBanner extends PureComponent {
         bannerEnabled: PropTypes.bool,
         bannerText: PropTypes.string,
         bannerTextColor: PropTypes.string,
+        navigator: PropTypes.object.isRequired,
+        theme: PropTypes.object.isRequired,
     };
 
     static contextTypes = {
@@ -58,24 +61,25 @@ export default class AnnouncementBanner extends PureComponent {
     };
 
     handlePress = () => {
-        const {formatMessage} = this.context.intl;
-        const options = [{
-            text: formatMessage({id: 'mobile.announcement_banner.ok', defaultMessage: 'OK'}),
-        }];
+        const {navigator, theme} = this.props;
 
-        if (this.props.allowDismissal) {
-            options.push({
-                text: formatMessage({id: 'mobile.announcement_banner.dismiss', defaultMessage: 'Dismiss'}),
-                onPress: this.handleDismiss,
-            });
-        }
+        // TODO figure out how to dismiss banner
 
-        Alert.alert(
-            formatMessage({id: 'mobile.announcement_banner.title', defaultMessage: 'Announcement'}),
-            this.props.bannerText,
-            options,
-            {cancelable: false}
-        );
+        navigator.push({
+            screen: 'ExpandedAnnouncementBanner',
+            title: this.context.intl.formatMessage({
+                id: 'mobile.announcement_banner.title',
+                defaultMessage: 'Announcement',
+            }),
+            animated: true,
+            backButtonTitle: '',
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg,
+            },
+        });
     };
 
     toggleBanner = (show = true) => {
@@ -120,7 +124,7 @@ export default class AnnouncementBanner extends PureComponent {
                         numberOfLines={1}
                         style={[style.bannerText, bannerTextStyle]}
                     >
-                        {bannerText}
+                        <RemoveMarkdown value={bannerText}/>
                     </Text>
                     <MaterialIcons
                         color={bannerTextColor}

--- a/app/components/announcement_banner/announcement_banner.js
+++ b/app/components/announcement_banner/announcement_banner.js
@@ -18,10 +18,6 @@ const {View: AnimatedView} = Animated;
 
 export default class AnnouncementBanner extends PureComponent {
     static propTypes = {
-        actions: PropTypes.shape({
-            dismissBanner: PropTypes.func.isRequired,
-        }).isRequired,
-        allowDismissal: PropTypes.bool,
         bannerColor: PropTypes.string,
         bannerDismissed: PropTypes.bool,
         bannerEnabled: PropTypes.bool,
@@ -55,15 +51,8 @@ export default class AnnouncementBanner extends PureComponent {
         }
     }
 
-    handleDismiss = () => {
-        const {actions, bannerText} = this.props;
-        actions.dismissBanner(bannerText);
-    };
-
     handlePress = () => {
         const {navigator, theme} = this.props;
-
-        // TODO figure out how to dismiss banner
 
         navigator.push({
             screen: 'ExpandedAnnouncementBanner',

--- a/app/components/announcement_banner/announcement_banner.test.js
+++ b/app/components/announcement_banner/announcement_banner.test.js
@@ -12,10 +12,6 @@ jest.useFakeTimers();
 
 describe('AnnouncementBanner', () => {
     const baseProps = {
-        actions: {
-            dismissBanner: jest.fn(),
-        },
-        allowDismissal: true,
         bannerColor: '#ddd',
         bannerDismissed: false,
         bannerEnabled: true,
@@ -32,17 +28,5 @@ describe('AnnouncementBanner', () => {
 
         wrapper.setProps({bannerEnabled: false});
         expect(wrapper).toMatchSnapshot();
-    });
-
-    test('should call actions.dismissBanner on handleDismiss', () => {
-        const actions = {dismissBanner: jest.fn()};
-        const props = {...baseProps, actions};
-        const wrapper = shallow(
-            <AnnouncementBanner {...props}/>
-        );
-
-        wrapper.instance().handleDismiss();
-        expect(actions.dismissBanner).toHaveBeenCalledTimes(1);
-        expect(actions.dismissBanner).toHaveBeenCalledWith(props.bannerText);
     });
 });

--- a/app/components/announcement_banner/index.js
+++ b/app/components/announcement_banner/index.js
@@ -1,13 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-
-import {dismissBanner} from 'app/actions/views/announcement';
 
 import AnnouncementBanner from './announcement_banner';
 
@@ -17,7 +14,6 @@ function mapStateToProps(state) {
     const {announcement} = state.views;
 
     return {
-        allowDismissal: config.AllowBannerDismissal === 'true',
         bannerColor: config.BannerColor,
         bannerDismissed: config.BannerText === announcement,
         bannerEnabled: config.EnableBanner === 'true' && license.IsLicensed === 'true',
@@ -27,12 +23,4 @@ function mapStateToProps(state) {
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            dismissBanner,
-        }, dispatch),
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(AnnouncementBanner);
+export default connect(mapStateToProps)(AnnouncementBanner);

--- a/app/components/announcement_banner/index.js
+++ b/app/components/announcement_banner/index.js
@@ -5,6 +5,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {dismissBanner} from 'app/actions/views/announcement';
 
@@ -22,6 +23,7 @@ function mapStateToProps(state) {
         bannerEnabled: config.EnableBanner === 'true' && license.IsLicensed === 'true',
         bannerText: config.BannerText,
         bannerTextColor: config.BannerTextColor || '#000',
+        theme: getTheme(state),
     };
 }
 

--- a/app/components/channel_link/channel_link.js
+++ b/app/components/channel_link/channel_link.js
@@ -11,6 +11,7 @@ export default class ChannelLink extends React.PureComponent {
     static propTypes = {
         channelName: PropTypes.string.isRequired,
         linkStyle: CustomPropTypes.Style,
+        onChannelLinkPress: PropTypes.func,
         textStyle: CustomPropTypes.Style,
         channelsByName: PropTypes.object.isRequired,
         actions: PropTypes.shape({
@@ -57,6 +58,10 @@ export default class ChannelLink extends React.PureComponent {
     handlePress = () => {
         this.props.actions.setChannelDisplayName(this.state.channel.display_name);
         this.props.actions.handleSelectChannel(this.state.channel.id);
+
+        if (this.props.onChannelLinkPress) {
+            this.props.onChannelLinkPress(this.state.channel);
+        }
     }
 
     render() {

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -39,6 +39,7 @@ export default class Markdown extends PureComponent {
         isEdited: PropTypes.bool,
         isSearchResult: PropTypes.bool,
         navigator: PropTypes.object.isRequired,
+        onChannelLinkPress: PropTypes.func,
         onLongPress: PropTypes.func,
         onPermalinkPress: PropTypes.func,
         onPostPress: PropTypes.func,
@@ -194,6 +195,7 @@ export default class Markdown extends PureComponent {
             <ChannelLink
                 linkStyle={this.props.textStyles.link}
                 textStyle={this.computeTextStyle(this.props.baseTextStyle, context)}
+                onChannelLinkPress={this.props.onChannelLinkPress}
                 channelName={channelName}
             />
         );

--- a/app/components/remove_markdown.js
+++ b/app/components/remove_markdown.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Parser} from 'commonmark';
+import Renderer from 'commonmark-react-renderer';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Text} from 'react-native';
+
+export default class RemoveMarkdown extends React.PureComponent {
+    static propTypes = {
+        value: PropTypes.string.isRequired,
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.parser = this.createParser();
+        this.renderer = this.createRenderer();
+    }
+
+    createParser = () => {
+        return new Parser();
+    };
+
+    createRenderer = () => {
+        return new Renderer({
+            renderers: {
+                text: this.renderText,
+
+                emph: Renderer.forwardChildren,
+                strong: Renderer.forwardChildren,
+                del: Renderer.forwardChildren,
+                code: Renderer.forwardChildren,
+                link: Renderer.forwardChildren,
+                atMention: Renderer.forwardChildren,
+                channelLink: Renderer.forwardChildren,
+                emoji: this.renderNull,
+
+                paragraph: Renderer.forwardChildren,
+                heading: Renderer.forwardChildren,
+                codeBlock: this.renderNull,
+                blockQuote: this.renderNull,
+
+                list: this.renderNull,
+                item: this.renderNull,
+
+                hardBreak: this.renderNull,
+                thematicBreak: this.renderNull,
+                softBreak: this.renderNull,
+
+                htmlBlock: this.renderNull,
+                htmlInline: this.renderNull,
+
+                table: this.renderNull,
+                table_row: this.renderNull,
+                table_cell: this.renderNull,
+            },
+        });
+    };
+
+    renderText = ({literal}) => {
+        return <Text>{literal}</Text>;
+    };
+
+    renderNull = () => {
+        return null;
+    };
+
+    render() {
+        const ast = this.parser.parse(this.props.value);
+
+        return <Text>{this.renderer.render(ast)}</Text>;
+    }
+}

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -228,7 +228,7 @@ export default class ChannelPostList extends PureComponent {
         return (
             <View style={style.container}>
                 {component}
-                <AnnouncementBanner/>
+                <AnnouncementBanner navigator={navigator}/>
                 <RetryBarIndicator/>
             </View>
         );

--- a/app/screens/expanded_announcement_banner/expanded_announcement_banner.js
+++ b/app/screens/expanded_announcement_banner/expanded_announcement_banner.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {ScrollView} from 'react-native';
+
+import Markdown from 'app/components/markdown';
+
+import {getMarkdownTextStyles, getMarkdownBlockStyles} from 'app/utils/markdown';
+import {makeStyleSheetFromTheme} from 'app/utils/theme';
+
+export default class ExpandedAnnouncementBanner extends React.PureComponent {
+    static propTypes = {
+        bannerText: PropTypes.string,
+        navigator: PropTypes.object.isRequired,
+        theme: PropTypes.object.isRequired,
+    }
+
+    handleChannelLinkPress = () => {
+        this.props.navigator.pop();
+    };
+
+    render() {
+        const style = getStyleSheet(this.props.theme);
+
+        return (
+            <ScrollView
+                style={style.scrollContainer}
+                contentContainerStyle={style.container}
+            >
+                <Markdown
+                    baseTextStyle={style.baseTextStyle}
+                    blockStyles={getMarkdownBlockStyles(this.props.theme)}
+                    navigator={this.props.navigator}
+                    onChannelLinkPress={this.handleChannelLinkPress}
+                    textStyles={getMarkdownTextStyles(this.props.theme)}
+                    value={this.props.bannerText}
+                />
+            </ScrollView>
+        );
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        scrollContainer: {
+            flex: 1,
+        },
+        container: {
+            padding: 15,
+        },
+        baseTextStyle: {
+            color: theme.centerChannelColor,
+            fontSize: 15,
+            lineHeight: 20,
+        },
+    };
+});

--- a/app/screens/expanded_announcement_banner/expanded_announcement_banner.js
+++ b/app/screens/expanded_announcement_banner/expanded_announcement_banner.js
@@ -108,6 +108,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         dismissButtonText: {
             color: theme.sidebarHeaderTextColor,
+            fontSize: 15,
+            fontWeight: '600',
             textAlign: 'center',
         },
     };

--- a/app/screens/expanded_announcement_banner/expanded_announcement_banner.js
+++ b/app/screens/expanded_announcement_banner/expanded_announcement_banner.js
@@ -3,57 +3,112 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {ScrollView} from 'react-native';
+import {ScrollView, View} from 'react-native';
+import Button from 'react-native-button';
 
+import FormattedText from 'app/components/formatted_text';
 import Markdown from 'app/components/markdown';
 
 import {getMarkdownTextStyles, getMarkdownBlockStyles} from 'app/utils/markdown';
-import {makeStyleSheetFromTheme} from 'app/utils/theme';
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 export default class ExpandedAnnouncementBanner extends React.PureComponent {
     static propTypes = {
-        bannerText: PropTypes.string,
+        actions: PropTypes.shape({
+            dismissBanner: PropTypes.func.isRequired,
+        }).isRequired,
+        allowDismissal: PropTypes.bool.isRequired,
+        bannerText: PropTypes.string.isRequired,
         navigator: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
     }
 
-    handleChannelLinkPress = () => {
+    close = () => {
         this.props.navigator.pop();
+    };
+
+    dismissBanner = () => {
+        this.props.actions.dismissBanner(this.props.bannerText);
+
+        this.close();
+    };
+
+    handleChannelLinkPress = () => {
+        this.close();
     };
 
     render() {
         const style = getStyleSheet(this.props.theme);
 
+        let dismissButton = null;
+        if (this.props.allowDismissal) {
+            dismissButton = (
+                <View style={style.dismissContainer}>
+                    <Button
+                        containerStyle={style.dismissButton}
+                        onPress={this.dismissBanner}
+                    >
+                        <FormattedText
+                            id='asdf'
+                            defaultMessage={'Don\'t show again'}
+                            style={style.dismissButtonText}
+                        />
+                    </Button>
+                </View>
+            );
+        }
+
         return (
-            <ScrollView
-                style={style.scrollContainer}
-                contentContainerStyle={style.container}
-            >
-                <Markdown
-                    baseTextStyle={style.baseTextStyle}
-                    blockStyles={getMarkdownBlockStyles(this.props.theme)}
-                    navigator={this.props.navigator}
-                    onChannelLinkPress={this.handleChannelLinkPress}
-                    textStyles={getMarkdownTextStyles(this.props.theme)}
-                    value={this.props.bannerText}
-                />
-            </ScrollView>
+            <View style={style.container}>
+                <ScrollView
+                    style={style.scrollContainer}
+                    contentContainerStyle={style.textContainer}
+                >
+                    <Markdown
+                        baseTextStyle={style.baseTextStyle}
+                        blockStyles={getMarkdownBlockStyles(this.props.theme)}
+                        navigator={this.props.navigator}
+                        onChannelLinkPress={this.handleChannelLinkPress}
+                        textStyles={getMarkdownTextStyles(this.props.theme)}
+                        value={this.props.bannerText}
+                    />
+                </ScrollView>
+                {dismissButton}
+            </View>
         );
     }
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
+        container: {
+            flex: 1,
+        },
         scrollContainer: {
             flex: 1,
         },
-        container: {
+        textContainer: {
             padding: 15,
         },
         baseTextStyle: {
             color: theme.centerChannelColor,
             fontSize: 15,
             lineHeight: 20,
+        },
+        dismissContainer: {
+            borderTopColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderTopWidth: 1,
+            padding: 10,
+        },
+        dismissButton: {
+            alignSelf: 'stretch',
+            backgroundColor: theme.sidebarHeaderBg,
+            borderRadius: 3,
+            padding: 15,
+        },
+        dismissButtonText: {
+            color: theme.sidebarHeaderTextColor,
+            textAlign: 'center',
         },
     };
 });

--- a/app/screens/expanded_announcement_banner/index.js
+++ b/app/screens/expanded_announcement_banner/index.js
@@ -1,18 +1,32 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
+import {dismissBanner} from 'app/actions/views/announcement';
+
 import ExpandedAnnouncementBanner from './expanded_announcement_banner';
 
 function mapStateToProps(state) {
+    const config = getConfig(state);
+
     return {
-        bannerText: getConfig(state).BannerText,
+        allowDismissal: config.AllowBannerDismissal === 'true',
+        bannerText: config.BannerText,
         theme: getTheme(state),
     };
 }
 
-export default connect(mapStateToProps)(ExpandedAnnouncementBanner);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            dismissBanner,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExpandedAnnouncementBanner);

--- a/app/screens/expanded_announcement_banner/index.js
+++ b/app/screens/expanded_announcement_banner/index.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import ExpandedAnnouncementBanner from './expanded_announcement_banner';
+
+function mapStateToProps(state) {
+    return {
+        bannerText: getConfig(state).BannerText,
+        theme: getTheme(state),
+    };
+}
+
+export default connect(mapStateToProps)(ExpandedAnnouncementBanner);

--- a/app/screens/index.js
+++ b/app/screens/index.js
@@ -26,6 +26,7 @@ export function registerScreens(store, Provider) {
     Navigation.registerComponent('EditPost', () => wrapWithContextProvider(require('app/screens/edit_post').default), store, Provider);
     Navigation.registerComponent('EditProfile', () => wrapWithContextProvider(require('app/screens/edit_profile').default), store, Provider);
     Navigation.registerComponent('Entry', () => Entry, store, Provider);
+    Navigation.registerComponent('ExpandedAnnouncementBanner', () => wrapWithContextProvider(require('app/screens/expanded_announcement_banner').default), store, Provider);
     Navigation.registerComponent('FlaggedPosts', () => wrapWithContextProvider(require('app/screens/flagged_posts').default), store, Provider);
     Navigation.registerComponent('ImagePreview', () => wrapWithContextProvider(require('app/screens/image_preview').default), store, Provider);
     Navigation.registerComponent('Login', () => wrapWithContextProvider(require('app/screens/login').default), store, Provider);

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -2292,7 +2292,6 @@
   "mobile.android.videos_permission_denied_description": "To upload videos from your library, please change your permission settings.",
   "mobile.android.videos_permission_denied_title": "Video library access is required",
   "mobile.announcement_banner.dismiss": "Dismiss",
-  "mobile.announcement_banner.ok": "OK",
   "mobile.announcement_banner.title": "Announcement",
   "mobile.channel.markAsRead": "Mark As Read",
   "mobile.channel_drawer.search": "Jump to...",


### PR DESCRIPTION
Based on the new design, the announcement banner strips all Markdown from the banner when it's collapsed, but the new expanded view will have full Markdown support. There's an outstanding design issue where you can't permanently dismiss the banner on mobile that we want to address before merging this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10012

#### Checklist
- Has UI changes
- Includes text changes and localization file updates

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
<img width="385" alt="screen shot 2018-06-29 at 4 11 09 pm" src="https://user-images.githubusercontent.com/3277310/42112940-9909e384-7bb7-11e8-984f-e45a8a62d753.png">
<img width="380" alt="screen shot 2018-06-29 at 4 11 16 pm" src="https://user-images.githubusercontent.com/3277310/42112942-9a2de486-7bb7-11e8-9707-374988c5d57f.png">

