### PR TITLE
MM-11139 Remember announcement banner dismissal after app closes

### DIFF
--- a/app/store/index.js
+++ b/app/store/index.js
@@ -51,7 +51,7 @@ const setTransforms = [
 export default function configureAppStore(initialState) {
     const viewsBlackListFilter = createBlacklistFilter(
         'views',
-        ['announcement', 'extension', 'login', 'root']
+        ['extension', 'login', 'root']
     );
 
     const typingBlackListFilter = createBlacklistFilter(


### PR DESCRIPTION
As part of my other PR, Eric and I discussed having the announcement banner dismiss permanently when you dismiss it instead of the current behaviour where it comes back after you close and re-open the app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11139

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator