### PR TITLE
MM-10826 Show error when viewing permalink for locally deleted post

### DIFF
--- a/app/screens/permalink/index.js
+++ b/app/screens/permalink/index.js
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 
 import {getChannel as getChannelAction, joinChannel, markChannelAsRead, markChannelAsViewed} from 'mattermost-redux/actions/channels';
 import {getPostsAfter, getPostsBefore, getPostThread, selectPost} from 'mattermost-redux/actions/posts';
+import {Posts} from 'mattermost-redux/constants';
 import {makeGetChannel, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetPostIdsAroundPost, getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -29,11 +30,13 @@ function makeMapStateToProps() {
     return function mapStateToProps(state) {
         const {currentFocusedPostId} = state.entities.posts;
         const post = getPost(state, currentFocusedPostId);
-        const channel = post ? getChannel(state, {id: post.channel_id}) : null;
+
+        let channel;
         let postIds;
 
-        if (channel && channel.id) {
-            postIds = getPostIdsAroundPost(state, currentFocusedPostId, channel.id, {
+        if (post && post.delete_at === 0 && post.state !== Posts.POST_DELETED) {
+            channel = getChannel(state, {id: post.channel_id});
+            postIds = getPostIdsAroundPost(state, currentFocusedPostId, post.channel_id, {
                 postsBeforeCount: 10,
                 postsAfterCount: 10,
             });

--- a/app/selectors/post_list.js
+++ b/app/selectors/post_list.js
@@ -47,10 +47,6 @@ export function makePreparePostIdsForPostList() {
                     continue;
                 }
 
-                if (post.state === Posts.POST_DELETED && post.user_id === currentUser.id) {
-                    continue;
-                }
-
                 // Filter out join/leave messages if necessary
                 if (shouldFilterJoinLeavePost(post, showJoinLeave, currentUser.username)) {
                     continue;


### PR DESCRIPTION
The reason the previous fix for the issue wasn't working sometimes is that it didn't show the error message when the user deleted the post from their own app, leaving a "(message deleted)" message in the redux store. Since that post existed, we displayed it instead of the error message.

I also fixed some weird code that I couldn't identify that hid any of the current user's posts that were marked as deleted, so the current user couldn't see their own posts as "(message deleted)" if another user deleted them. I couldn't identify the cause of that since it was added in the PR that split mattermost-redux into its own repo, so I assume it was added by accident.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10826

#### Device Information
This PR was tested on: iOS Simulator