### PR TITLE
[MM-11072] On search success and other user/s are selected already, remove current user first before profile match filtering

### DIFF
--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -95,10 +95,17 @@ class MoreDirectMessages extends PureComponent {
             nextProps.getRequest.status === RequestStatus.SUCCESS) {
             const profiles = this.sliceProfiles(nextProps.profiles);
             this.setState({profiles, showNoResults: true});
-        } else if (this.state.searching &&
-            nextProps.searchRequest.status === RequestStatus.SUCCESS) {
+        } else if (
+            this.state.searching &&
+            nextProps.searchRequest.status === RequestStatus.SUCCESS
+        ) {
+            let profiles = nextProps.profiles;
+            if (this.state.selectedCount > 0) {
+                profiles = this.removeCurrentUserFromProfiles(profiles);
+            }
+
             const exactMatches = [];
-            let results = filterProfilesMatchingTerm(nextProps.profiles, this.state.term).filter((p) => {
+            const results = filterProfilesMatchingTerm(profiles, this.state.term).filter((p) => {
                 if (p.username === this.state.term || p.username.startsWith(this.state.term)) {
                     exactMatches.push(p);
                     return false;
@@ -106,10 +113,6 @@ class MoreDirectMessages extends PureComponent {
 
                 return true;
             });
-
-            if (this.state.selectedCount > 0) {
-                results = this.removeCurrentUserFromProfiles(results);
-            }
 
             this.setState({profiles: [...exactMatches, ...results], showNoResults: true});
         }


### PR DESCRIPTION
#### Summary
On search success and other user/s are selected already, remove current user first before profile match filtering

#### Ticket Link
Jira ticket: [MM-11072](https://mattermost.atlassian.net/browse/MM-11072)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

