### PR TITLE
Bold unread channels in jump to channel

### DIFF
--- a/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
+++ b/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
@@ -114,7 +114,7 @@ class FilteredList extends Component {
                 channelId={channel.id}
                 channel={channel}
                 isSearchResult={true}
-                isUnread={false}
+                isUnread={channel.isUnread}
                 mentions={0}
                 onSelectChannel={this.onSelectChannel}
             />
@@ -173,8 +173,11 @@ class FilteredList extends Component {
     buildUnreadChannelsForSearch = (props, term) => {
         const {unreadChannels} = props.channels;
 
-        return this.filterChannels(unreadChannels, term);
-    }
+        return this.filterChannels(unreadChannels, term).map((item) => {
+            item.isUnread = true;
+            return item;
+        });
+    };
 
     buildCurrentDMSForSearch = (props, term) => {
         const {channels, teammateNameDisplay, profiles, statuses, pastDirectMessages, groupChannelMemberDetails} = props;


### PR DESCRIPTION
#### Summary
On the Jump to Channel search drawer now the unread channels are being bolded.

I do not like this hack as I think the whole component should be refactored, but for now I think this is more than enough

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11033