### PR TITLE
Add setNativeProps to QuickTextInput (1.9)

### DIFF
--- a/app/components/quick_text_input.js
+++ b/app/components/quick_text_input.js
@@ -77,6 +77,10 @@ export default class QuickTextInput extends React.PureComponent {
         this.storedValue = this.props.value;
     }
 
+    setNativeProps(nativeProps) {
+        this.input.setNativeProps(nativeProps);
+    }
+
     focus() {
         this.input.focus();
     }


### PR DESCRIPTION
I also went through and checked everywhere I could find us using refs on a TextInput to make sure there weren't any other methods of QuickTextInput that were missing

#### Ticket Link
https://sentry.io/mattermost-mr/mattermost-mobile-android/issues/597592442/

#### Device Information
This PR was tested on: iOS Simulator