### PR TITLE
Clear iOS Keychain data on first run

### DIFF
--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -85,7 +85,6 @@
 		7FF7BE6E1FDEE5E8005E55FE /* MattermostBucket.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FF7BE6C1FDEE5E8005E55FE /* MattermostBucket.m */; };
 		7FF7BE6F1FDF3CE4005E55FE /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FDF290C1E1F4B4E00DBBE56 /* libRNVectorIcons.a */; };
 		7FF7BE701FDF3EE7005E55FE /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 2DCFD31D3F4A4154822AB532 /* Ionicons.ttf */; };
-		7FF7BE711FE004A3005E55FE /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37DD11281E79EBE1004111BA /* libRNDeviceInfo.a */; };
 		7FFDB3191FE3566C009E3BCF /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 005346E5C0E542BFABAE1411 /* FontAwesome.ttf */; };
 		7FFE329E1FD9CB650038C7A0 /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FFE329D1FD9CB650038C7A0 /* ShareViewController.m */; };
 		7FFE32A11FD9CB650038C7A0 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7FFE329F1FD9CB650038C7A0 /* MainInterface.storyboard */; };

--- a/ios/Mattermost/AppDelegate.m
+++ b/ios/Mattermost/AppDelegate.m
@@ -24,6 +24,23 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  // Clear keychain on first run in case of reinstallation
+  if (![[NSUserDefaults standardUserDefaults] objectForKey:@"FirstRun"]) {
+
+    NSString *service = [[NSBundle mainBundle] bundleIdentifier];
+    NSDictionary *query = @{
+                            (__bridge NSString *)kSecClass: (__bridge id)(kSecClassGenericPassword),
+                            (__bridge NSString *)kSecAttrService: service,
+                            (__bridge NSString *)kSecReturnAttributes: (__bridge id)kCFBooleanTrue,
+                            (__bridge NSString *)kSecReturnData: (__bridge id)kCFBooleanFalse
+                            };
+
+    SecItemDelete((__bridge CFDictionaryRef) query);
+
+    [[NSUserDefaults standardUserDefaults] setValue:@YES forKey:@"FirstRun"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+  }
+
   NSURL *jsCodeLocation;
 
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];


### PR DESCRIPTION
#### Summary
The Keychain on iOS does not get cleared when the app is uninstalled but the `NSUserDefaults` does, so this PR uses `NSUserDefaults` to keep track if the app is **FirstRun** so it removes the credentials stored in the app if any.

In the case the user is still logged in and the app is just upgrading the user will stay logged in, but if the app was uninstalled then the user is being forced to the select server URL.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11159
