### PR TITLE
MM-11203 Adjust reply icon margins to not affect other components

### DIFF
--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -291,7 +291,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flexDirection: 'row',
             alignItems: 'center',
             justifyContent: 'center',
-            height: 35,
+            marginVertical: -10,
             minWidth: 40,
             paddingVertical: 10,
         },


### PR DESCRIPTION
When we increased the tappable area of that icon, it pushed the post username and timestamp down. Using a negative margin fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11203

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator, Nexus 5
#### Screenshots

The red area represents is the tappable area
<img width="391" alt="screen shot 2018-07-06 at 4 02 00 pm" src="https://user-images.githubusercontent.com/3277310/42398038-442b16ba-8136-11e8-8244-cd89c0c6b051.png">
