### PR TITLE
MM-11198: avoid duplicate date line keys

### DIFF
--- a/app/components/post_list/date_header/date_line.js
+++ b/app/components/post_list/date_header/date_line.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+
+import {DATE_LINE, DATE_LINE_SUFFIX} from 'app/selectors/post_list';
+import DateHeader from 'app/components/post_list/date_header';
+
+// DateLine builds a DateHeader given a date encoded as a string in a post list.
+export class DateLine extends PureComponent {
+    static propTypes = {
+        dateString: PropTypes.string.isRequired,
+        index: PropTypes.number.isRequired,
+    };
+
+    render() {
+        const {dateString, index} = this.props;
+        const date = new Date(dateString.substring(DATE_LINE.length, dateString.indexOf(DATE_LINE_SUFFIX)));
+
+        return (
+            <DateHeader
+                key={`${date}-${index}`}
+                date={date}
+                index={index}
+            />
+        );
+    }
+};
+
+export const isDateLine = (dateString) => dateString.indexOf(DATE_LINE) === 0;

--- a/app/screens/flagged_posts/flagged_posts.js
+++ b/app/screens/flagged_posts/flagged_posts.js
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 
 import ChannelLoader from 'app/components/channel_loader';
-import DateHeader from 'app/components/post_list/date_header';
+import {isDateLine, DateLine} from 'app/components/post_list/date_header/date_line';
 import FailedNetworkAction from 'app/components/failed_network_action';
 import NoResults from 'app/components/no_results';
 import PostSeparator from 'app/components/post_separator';
@@ -21,7 +21,6 @@ import StatusBar from 'app/components/status_bar';
 import mattermostManaged from 'app/mattermost_managed';
 import SearchResultPost from 'app/screens/search/search_result_post';
 import ChannelDisplayName from 'app/screens/search/channel_display_name';
-import {DATE_LINE} from 'app/selectors/post_list';
 import {changeOpacity} from 'app/utils/theme';
 
 export default class FlaggedPosts extends PureComponent {
@@ -150,13 +149,10 @@ export default class FlaggedPosts extends PureComponent {
     renderPost = ({item, index}) => {
         const {postIds, theme} = this.props;
         const {managedConfig} = this.state;
-        if (item.indexOf(DATE_LINE) === 0) {
-            const date = new Date(item.substring(DATE_LINE.length));
-
+        if (isDateLine(item)) {
             return (
-                <DateHeader
-                    key={`${date}-${index}`}
-                    date={date}
+                <DateLine
+                    dateString={item}
                     index={index}
                 />
             );
@@ -164,7 +160,7 @@ export default class FlaggedPosts extends PureComponent {
 
         let separator;
         const nextPost = postIds[index + 1];
-        if (nextPost && nextPost.indexOf(DATE_LINE) === -1) {
+        if (nextPost && !isDateLine(nextPost)) {
             separator = <PostSeparator theme={theme}/>;
         }
 

--- a/app/screens/recent_mentions/recent_mentions.js
+++ b/app/screens/recent_mentions/recent_mentions.js
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 
 import ChannelLoader from 'app/components/channel_loader';
-import DateHeader from 'app/components/post_list/date_header';
+import {isDateLine, DateLine} from 'app/components/post_list/date_header/date_line';
 import FailedNetworkAction from 'app/components/failed_network_action';
 import NoResults from 'app/components/no_results';
 import PostSeparator from 'app/components/post_separator';
@@ -21,7 +21,6 @@ import StatusBar from 'app/components/status_bar';
 import mattermostManaged from 'app/mattermost_managed';
 import SearchResultPost from 'app/screens/search/search_result_post';
 import ChannelDisplayName from 'app/screens/search/channel_display_name';
-import {DATE_LINE} from 'app/selectors/post_list';
 import {changeOpacity} from 'app/utils/theme';
 
 export default class RecentMentions extends PureComponent {
@@ -150,13 +149,10 @@ export default class RecentMentions extends PureComponent {
     renderPost = ({item, index}) => {
         const {postIds, theme} = this.props;
         const {managedConfig} = this.state;
-        if (item.indexOf(DATE_LINE) === 0) {
-            const date = new Date(item.substring(DATE_LINE.length));
-
+        if (isDateLine(item)) {
             return (
-                <DateHeader
-                    key={`${date}-${index}`}
-                    date={date}
+                <DateLine
+                    dateString={item}
                     index={index}
                 />
             );
@@ -164,7 +160,7 @@ export default class RecentMentions extends PureComponent {
 
         let separator;
         const nextPost = postIds[index + 1];
-        if (nextPost && nextPost.indexOf(DATE_LINE) === -1) {
+        if (nextPost && !isDateLine(nextPost)) {
             separator = <PostSeparator theme={theme}/>;
         }
 

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -20,7 +20,7 @@ import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import Autocomplete from 'app/components/autocomplete';
-import DateHeader from 'app/components/post_list/date_header';
+import {isDateLine, DateLine} from 'app/components/post_list/date_header/date_line';
 import FormattedText from 'app/components/formatted_text';
 import Loading from 'app/components/loading';
 import PostListRetry from 'app/components/post_list_retry';
@@ -29,7 +29,6 @@ import SafeAreaView from 'app/components/safe_area_view';
 import SearchBar from 'app/components/search_bar';
 import StatusBar from 'app/components/status_bar';
 import mattermostManaged from 'app/mattermost_managed';
-import {DATE_LINE} from 'app/selectors/post_list';
 import {preventDoubleTap} from 'app/utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
@@ -260,16 +259,6 @@ export default class Search extends PureComponent {
         actions.removeSearchTerms(currentTeamId, item.terms);
     });
 
-    renderDateHeader = (date, index) => {
-        return (
-            <DateHeader
-                key={`${date}-${index}`}
-                date={date}
-                index={index}
-            />
-        );
-    };
-
     renderModifiers = ({item}) => {
         const {theme} = this.props;
         const style = getStyleFromTheme(theme);
@@ -317,14 +306,18 @@ export default class Search extends PureComponent {
             );
         }
 
-        if (item.indexOf(DATE_LINE) === 0) {
-            const date = item.substring(DATE_LINE.length);
-            return this.renderDateHeader(new Date(date), index);
+        if (isDateLine(item)) {
+            return (
+                <DateLine
+                    dateString={item}
+                    index={index}
+                />
+            );
         }
 
         let separator;
         const nextPost = postIds[index + 1];
-        if (nextPost && nextPost.indexOf(DATE_LINE) === -1) {
+        if (nextPost && !isDateLine(nextPost)) {
             separator = <PostSeparator theme={theme}/>;
         }
 

--- a/app/selectors/post_list.js
+++ b/app/selectors/post_list.js
@@ -9,6 +9,7 @@ import {createIdsSelector} from 'mattermost-redux/utils/helpers';
 import {shouldFilterJoinLeavePost} from 'mattermost-redux/utils/post_utils';
 
 export const DATE_LINE = 'date-';
+export const DATE_LINE_SUFFIX = '-index-';
 export const START_OF_NEW_MESSAGES = 'start-of-new-messages';
 
 function shouldShowJoinLeaveMessages(state) {
@@ -107,7 +108,14 @@ export function makePreparePostIdsForSearchPosts() {
 
                 const postDate = new Date(post.create_at);
 
-                out.push(DATE_LINE + postDate.toString(), post.id);
+                // Render a date line for each post, even if displayed on the same date as the
+                // previous post. Since we don't deduplicate here like in other views, we need to
+                // ensure the resulting key is unique, even if the post timestamps (down to the
+                // second) are identical. The screens know to parse out the index before trying
+                // to consume the date value.
+                out.push(DATE_LINE + postDate.toString() + DATE_LINE_SUFFIX + i);
+
+                out.push(post.id);
             }
 
             return out;

--- a/app/selectors/post_list.test.js
+++ b/app/selectors/post_list.test.js
@@ -12,7 +12,7 @@ import {
 import {Posts, Preferences} from 'mattermost-redux/constants';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
-/* eslint-disable max-nested-callbacks, no-console */
+/* eslint-disable max-nested-callbacks */
 
 describe('Selectors.PostList', () => {
     describe('makePreparePostIdsForPostList', () => {
@@ -44,7 +44,11 @@ describe('Selectors.PostList', () => {
 
             // Defaults to show post
             let now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages});
-            assert.deepEqual(removeDateLines(now), ['1002', '1001']);
+            assert.deepEqual(now, [
+                '1002', 
+                '1001',
+                'date-Thu Jan 01 1970 00:00:00 GMT+0000 (GMT)',
+            ]);
 
             // Show join/leave posts
             state = {
@@ -66,7 +70,11 @@ describe('Selectors.PostList', () => {
             };
 
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages});
-            assert.deepEqual(removeDateLines(now), ['1002', '1001']);
+            assert.deepEqual(now, [
+                '1002', 
+                '1001',
+                'date-Thu Jan 01 1970 00:00:00 GMT+0000 (GMT)',
+            ]);
 
             // Hide join/leave posts
             state = {
@@ -88,7 +96,10 @@ describe('Selectors.PostList', () => {
             };
 
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages});
-            assert.deepEqual(removeDateLines(now), ['1001']);
+            assert.deepEqual(now, [
+                '1001',
+                'date-Thu Jan 01 1970 00:00:00 GMT+0000 (GMT)',
+            ]);
 
             // always show join/leave posts for the current user
             state = {
@@ -107,7 +118,11 @@ describe('Selectors.PostList', () => {
 
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages});
 
-            assert.deepEqual(removeDateLines(now), ['1002', '1001']);
+            assert.deepEqual(now, [
+                '1002', 
+                '1001',
+                'date-Thu Jan 01 1970 00:00:00 GMT+0000 (GMT)',
+            ]);
         });
 
         it('new messages indicator', () => {
@@ -138,28 +153,66 @@ describe('Selectors.PostList', () => {
 
             // Do not show new messages indicator before all posts
             let now = preparePostIdsForPostList(state, {postIds, lastViewedAt: 0, indicateNewMessages: true});
-            assert.deepEqual(removeDateLines(now), ['1010', '1005', '1000']);
+            assert.deepEqual(now, [
+                '1010', 
+                '1005', 
+                '1000',
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)',
+            ]);
 
             now = preparePostIdsForPostList(state, {postIds, indicateNewMessages: true});
-            assert.deepEqual(removeDateLines(now), ['1010', '1005', '1000']);
+            assert.deepEqual(now, [
+                '1010', 
+                '1005', 
+                '1000',
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)',
+            ]);
 
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt: 999, indicateNewMessages: false});
-            assert.deepEqual(removeDateLines(now), ['1010', '1005', '1000']);
+            assert.deepEqual(now, [
+                '1010', 
+                '1005', 
+                '1000',
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)',
+            ]);
 
             // Show new messages indicator before all posts
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt: 999, indicateNewMessages: true});
-            assert.deepEqual(removeDateLines(now), ['1010', '1005', '1000', START_OF_NEW_MESSAGES]);
+            assert.deepEqual(now, [
+                '1010', 
+                '1005', 
+                '1000',
+                START_OF_NEW_MESSAGES,
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)',
+            ]);
 
             // Show indicator between posts
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt: 1003, indicateNewMessages: true});
-            assert.deepEqual(removeDateLines(now), ['1010', '1005', START_OF_NEW_MESSAGES, '1000']);
+            assert.deepEqual(now, [
+                '1010', 
+                '1005', 
+                START_OF_NEW_MESSAGES, 
+                '1000',
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)',
+            ]);
 
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt: 1006, indicateNewMessages: true});
-            assert.deepEqual(removeDateLines(now), ['1010', START_OF_NEW_MESSAGES, '1005', '1000']);
+            assert.deepEqual(now, [
+                '1010', 
+                START_OF_NEW_MESSAGES, 
+                '1005', 
+                '1000',
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)',
+            ]);
 
             // Don't show indicator when all posts are read
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt: 1020});
-            assert.deepEqual(removeDateLines(now), ['1010', '1005', '1000']);
+            assert.deepEqual(now, [
+                '1010', 
+                '1005', 
+                '1000',
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)',
+            ]);
         });
 
         it('memoization', () => {
@@ -197,17 +250,38 @@ describe('Selectors.PostList', () => {
                 },
             };
 
-            let postIds = ['1006', '1004', '1003', '1001'];
+            let postIds = [
+                '1006', 
+                '1004', 
+                '1003', 
+                '1001', 
+            ];
             let lastViewedAt = initialPosts['1001'].create_at + 1;
 
             let now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', '1003', START_OF_NEW_MESSAGES, '1001']);
+            assert.deepEqual(now, [
+                '1006', 
+                '1004', 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)', 
+                '1003', 
+                START_OF_NEW_MESSAGES, 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             // No changes
             let prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.equal(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', '1003', START_OF_NEW_MESSAGES, '1001']);
+            assert.deepEqual(now, [
+                '1006', 
+                '1004', 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                START_OF_NEW_MESSAGES, 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             // lastViewedAt changed slightly
             lastViewedAt = initialPosts['1001'].create_at + 2;
@@ -215,7 +289,15 @@ describe('Selectors.PostList', () => {
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.equal(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', '1003', START_OF_NEW_MESSAGES, '1001']);
+            assert.deepEqual(now, [
+                '1006', 
+                '1004', 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                START_OF_NEW_MESSAGES, 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             // lastViewedAt changed a lot
             lastViewedAt += initialPosts['1003'].create_at + 1;
@@ -223,12 +305,28 @@ describe('Selectors.PostList', () => {
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.notEqual(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', START_OF_NEW_MESSAGES, '1003', '1001']);
+            assert.deepEqual(now, [
+                '1006', 
+                '1004', 
+                START_OF_NEW_MESSAGES, 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.equal(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', START_OF_NEW_MESSAGES, '1003', '1001']);
+            assert.deepEqual(now, [
+                '1006', 
+                '1004', 
+                START_OF_NEW_MESSAGES, 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             // postIds changed, but still shallowly equal
             postIds = [...postIds];
@@ -236,7 +334,15 @@ describe('Selectors.PostList', () => {
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.equal(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', START_OF_NEW_MESSAGES, '1003', '1001']);
+            assert.deepEqual(now, [
+                '1006',
+                '1004', 
+                START_OF_NEW_MESSAGES, 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             // Post changed, not in postIds
             state = {
@@ -256,7 +362,15 @@ describe('Selectors.PostList', () => {
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.equal(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', START_OF_NEW_MESSAGES, '1003', '1001']);
+            assert.deepEqual(now, [
+                '1006', 
+                '1004', 
+                START_OF_NEW_MESSAGES, 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             // Post changed, in postIds
             state = {
@@ -276,7 +390,15 @@ describe('Selectors.PostList', () => {
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.equal(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1006', '1004', START_OF_NEW_MESSAGES, '1003', '1001']);
+            assert.deepEqual(now, [
+                '1006', 
+                '1004',
+                START_OF_NEW_MESSAGES, 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             // Filter changed
             state = {
@@ -300,17 +422,26 @@ describe('Selectors.PostList', () => {
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.notEqual(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1004', START_OF_NEW_MESSAGES, '1003', '1001']);
+            assert.deepEqual(now, [
+                '1004', 
+                START_OF_NEW_MESSAGES, 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
 
             prev = now;
             now = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             assert.equal(now, prev);
-            assert.deepEqual(removeDateLines(now), ['1004', START_OF_NEW_MESSAGES, '1003', '1001']);
+            assert.deepEqual(now, [
+                '1004', 
+                START_OF_NEW_MESSAGES, 
+                'date-Fri Jan 02 1970 01:00:00 GMT+0000 (GMT)',
+                '1003', 
+                '1001',
+                'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
         });
     });
 });
-
-// Remove date lines when checking equality since those depend on time-zone of the computer running the tests
-function removeDateLines(list) {
-    return list.filter((item) => !item.startsWith(DATE_LINE));
-}

--- a/app/selectors/post_list.test.js
+++ b/app/selectors/post_list.test.js
@@ -6,6 +6,7 @@ import assert from 'assert';
 import {
     DATE_LINE,
     makePreparePostIdsForPostList,
+    makePreparePostIdsForSearchPosts,
     START_OF_NEW_MESSAGES,
 } from 'app/selectors/post_list';
 
@@ -441,6 +442,89 @@ describe('Selectors.PostList', () => {
                 '1003', 
                 '1001',
                 'date-Thu Jan 01 1970 01:00:00 GMT+0000 (GMT)',
+            ]);
+        });
+    });
+
+    describe('makePreparePostIdsForSearchPosts', () => {
+        it('should return an empty array if there are no posts specified', () => {
+            const preparePostIdsForSearchPosts = makePreparePostIdsForSearchPosts();
+
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {
+                            1001: {id: '1001', create_at: 0, type: ''},
+                            1002: {id: '1002', create_at: 1, type: ''},
+                        },
+                    },
+                    users: {
+                        currentUserId: '1234',
+                        profiles: {
+                            1234: {id: '1234', username: 'user'},
+                        },
+                    },
+                },
+            };
+
+            const postIds = [];
+            const actual = preparePostIdsForSearchPosts(state, postIds);
+            assert.deepEqual(actual, []);
+        });
+
+        it('should return an empty array if there are no matching posts', () => {
+            const preparePostIdsForSearchPosts = makePreparePostIdsForSearchPosts();
+
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {},
+                    },
+                    users: {
+                        currentUserId: '1234',
+                        profiles: {
+                            1234: {id: '1234', username: 'user'},
+                        },
+                    },
+                },
+            };
+
+            const postIds = ['1002', '1001'];
+            const actual = preparePostIdsForSearchPosts(state, postIds);
+            assert.deepEqual(actual, []);
+        });
+
+        it('should return results when there are posts', () => {
+            const preparePostIdsForSearchPosts = makePreparePostIdsForSearchPosts();
+
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {
+                            1001: {id: '1001', create_at: 0, type: ''},
+                            1002: {id: '1002', create_at: 1000, type: ''},
+                            // Same timestamp as 1002
+                            1003: {id: '1003', create_at: 1000, type: ''},
+                        },
+                    },
+                    users: {
+                        currentUserId: '1234',
+                        profiles: {
+                            1234: {id: '1234', username: 'user'},
+                        },
+                    },
+                },
+            };
+
+            const postIds = ['1003', '1002', '1001'];
+            const actual = preparePostIdsForSearchPosts(state, postIds);
+            assert.deepEqual(actual, [
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)-index-0',
+                '1003',
+                'date-Thu Jan 01 1970 00:00:01 GMT+0000 (GMT)-index-1',
+                '1002', 
+                'date-Thu Jan 01 1970 00:00:00 GMT+0000 (GMT)-index-2',
+                '1001',
             ]);
         });
     });

--- a/package.json
+++ b/package.json
@@ -104,9 +104,9 @@
     "check": "eslint --ignore-path .gitignore --ignore-pattern node_modules --quiet .",
     "fix": "eslint --ignore-path .gitignore --ignore-pattern node_modules --quiet . --fix",
     "postinstall": "make post-install",
-    "test": "jest --forceExit",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test": "TZ=utc jest --forceExit",
+    "test:watch": "TZ=utc jest --watch",
+    "test:coverage": "TZ=utc jest --coverage"
   },
   "rnpm": {
     "assets": [


### PR DESCRIPTION
#### Summary
Appends a `-index-N` suffix to the date line string to ensure uniqueness at render time, refactoring rendering support of same to streamline parsing out the date.

Added unit tests, expanding existing one for post list. Note that doing so depends on `TZ` being set via package.json (as this appears to to be the most reliable way to set same in Node). Let me know if you have any concerns re: same.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11198

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: Android Emulator, iOS emulator
