### PR TITLE
Use TextInput instead of QuickTextInput on Android

### DIFF
--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Alert, BackHandler, Keyboard, Platform, Text, TouchableOpacity, View} from 'react-native';
+import {Alert, BackHandler, Keyboard, Platform, Text, TextInput, TouchableOpacity, View} from 'react-native';
 import {intlShape} from 'react-intl';
 import {General, RequestStatus} from 'mattermost-redux/constants';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
@@ -507,6 +507,8 @@ export default class PostTextbox extends PureComponent {
             inputContainerStyle.push(style.inputContainerWithoutFileUpload);
         }
 
+        const InputComponent = Platform.OS === 'android' ? TextInput : QuickTextInput;
+
         return (
             <View>
                 <Typing/>
@@ -527,7 +529,7 @@ export default class PostTextbox extends PureComponent {
                 <View style={style.inputWrapper}>
                     {!channelIsReadOnly && attachmentButton}
                     <View style={[inputContainerStyle, (channelIsReadOnly && {marginLeft: 10})]}>
-                        <QuickTextInput
+                        <InputComponent
                             ref='input'
                             value={textValue}
                             onChangeText={this.handleTextChange}


### PR DESCRIPTION
#### Summary
Reverting QuickTextInput to use TextInput on Android, the QuickTextInput was causing the Android's input lose focus when submitting a post, the same is not happening on iOS.

It seems that the reason for the QuickTextInput existence is actually to properly fix iOS input in Chinese/Japanese (this after talking to @hmhealey)

Anyway I believe once this is merged QA should verify and validate that, if that's not the case and we start seeing issues with Japanese/Chinese on Android then we should consider trying a different approach.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11240
