### PR TITLE
[MM-11254] Fix mention keywords on edit by changing defaultValue to value in using TextInputWithLocalizedPlaceholder

### DIFF
--- a/app/screens/settings/notification_settings_mentions/notification_settings_mentions.android.js
+++ b/app/screens/settings/notification_settings_mentions/notification_settings_mentions.android.js
@@ -61,7 +61,7 @@ class NotificationSettingsMentionsAndroid extends NotificationSettingsMentionsBa
                             </View>
                             <TextInputWithLocalizedPlaceholder
                                 autoFocus={true}
-                                defaultValue={this.keywords}
+                                value={this.keywords}
                                 blurOnSubmit={false}
                                 onChangeText={this.onKeywordsChangeText}
                                 multiline={false}


### PR DESCRIPTION
#### Summary
Fix mention keywords on edit by changing defaultValue to value in using TextInputWithLocalizedPlaceholder

#### Ticket Link
Jira ticket: [MM-11254](https://mattermost.atlassian.net/browse/MM-11254)

#### Device Information
This PR was tested on: [Android emulator] 
