### PR TITLE
Render escaped HTML in FormattedMarkdownText; no throw error.

### DIFF
--- a/app/components/formatted_markdown_text.js
+++ b/app/components/formatted_markdown_text.js
@@ -61,6 +61,8 @@ class FormattedMarkdownText extends React.PureComponent {
                 softBreak: this.renderBreak,
                 paragraph: this.renderParagraph,
                 del: Renderer.forwardChildren,
+                html_inline: this.renderHTML,
+                html_block: this.renderHTML,
             },
         });
     }
@@ -90,6 +92,11 @@ class FormattedMarkdownText extends React.PureComponent {
 
     renderParagraph = ({children}) => {
         return <Text>{children}</Text>;
+    }
+
+    renderHTML = (props) => {
+        console.warn(`HTML used in FormattedMarkdownText component with id ${this.props.id}`); // eslint-disable-line no-console
+        return this.renderText(props);
     }
 
     render() {


### PR DESCRIPTION
#### Summary
Don't throw error when passing HTML to `FormattedMarkdownText` component, render it escaped and print console warning.

#### Ticket Link
n/a

#### Checklist
n/a

#### Device Information
iPhone 6 emulated.

#### Screenshots
![simulator screen shot - iphone 6 - 2018-07-11 at 09 49 48](https://user-images.githubusercontent.com/1149597/42576266-fa46bf00-84ef-11e8-930b-8b94b8f3da41.png)

![simulator screen shot - iphone 6 - 2018-07-11 at 09 51 47](https://user-images.githubusercontent.com/1149597/42576308-0c4e01b8-84f0-11e8-8c5e-cb9a8f22eaea.png)
