### PR TITLE
MM-11323 Added defensive code in LongPost makeMapStateToProps

### DIFF
--- a/app/screens/long_post/index.js
+++ b/app/screens/long_post/index.js
@@ -22,9 +22,9 @@ function makeMapStateToProps() {
 
         return {
             channelName: channel ? channel.display_name : '',
-            hasReactions: post.has_reactions,
+            hasReactions: post ? post.has_reactions : false,
             inThreadView: Boolean(state.entities.posts.selectedPostId),
-            fileIds: post.file_ids,
+            fileIds: post ? post.file_ids : false,
             theme: getTheme(state),
         };
     };


### PR DESCRIPTION
`post` can sometimes be undefined

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11323
https://sentry.io/mattermost-mr/mattermost-mobile-ios/issues/593176730
https://sentry.io/mattermost-mr/mattermost-mobile-android/issues/601120888
