### PR TITLE
MM-11324 Added defensive code to hashCode function

### DIFF
--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -101,7 +101,7 @@ const hashCode = (str) => {
     let hash = 0;
     let i;
     let chr;
-    if (str.length === 0) {
+    if (!str || str.length === 0) {
         return hash;
     }
 


### PR DESCRIPTION
I haven't been able to track down the source of the undefined string here, so I added some defensive code instead. The only way `undefined` could be passed into that function is through `ImageCacheManager.cache` and the only time that I can find where that could happen is if a `ProgressiveImage` is created with a `thumbnailUri` prop but no `imageUri`, but we never do that outside of some weird state transition.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11324
https://sentry.io/mattermost-mr/mattermost-mobile-android/issues/585744399
https://sentry.io/mattermost-mr/mattermost-mobile-ios/issues/591176259
