### PR TITLE
Fix reply pending intent per channel

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -271,7 +271,7 @@ public class CustomPushNotification extends PushNotification {
             replyIntent.setAction(KEY_TEXT_REPLY);
             replyIntent.putExtra(NOTIFICATION_ID, notificationId);
             replyIntent.putExtra("pushNotification", bundle);
-            PendingIntent replyPendingIntent = PendingIntent.getService(mContext, 103, replyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent replyPendingIntent = PendingIntent.getService(mContext, notificationId, replyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
             RemoteInput remoteInput = new RemoteInput.Builder(KEY_TEXT_REPLY)
                     .setLabel("Reply")


### PR DESCRIPTION
#### Summary
On Android every time a push notification was received the pending intent was storing and updating the bundle for all channels, with this PR the bundle is stored and update but on a per channel basis, so notifications from two different channels will have two different pending intents for replying.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11309