### PR TITLE
Fixed warnings on login screen

### DIFF
--- a/app/screens/login_options/login_options.js
+++ b/app/screens/login_options/login_options.js
@@ -89,7 +89,7 @@ class LoginOptions extends PureComponent {
                 backgroundColor,
             };
 
-            if (config.hasOwnProperty('EmailLoginButtonBorderColor')) {
+            if (config.EmailLoginButtonBorderColor) {
                 additionalStyle.borderColor = config.EmailLoginButtonBorderColor;
             }
 
@@ -123,7 +123,7 @@ class LoginOptions extends PureComponent {
                 backgroundColor,
             };
 
-            if (config.hasOwnProperty('LDAPLoginButtonBorderColor')) {
+            if (config.LDAPLoginButtonBorderColor) {
                 additionalStyle.borderColor = config.LDAPLoginButtonBorderColor;
             }
 


### PR DESCRIPTION
Nothing fancy here. The previous version was sometimes passing an empty string as the `borderColor` style, so RN was complaining about it.