### PR TITLE
MM-11256 Update mattermost-redux to properly get current user on update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7525,6 +7525,14 @@
       "integrity": "sha1-q93z1dHnfdlnzPorA2oKH7Jv1/c=",
       "dev": true
     },
+    "gfycat-sdk": {
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/gfycat-sdk/-/gfycat-sdk-1.4.18.tgz",
+      "integrity": "sha512-BrINtO6rj8Nr0pm38Qr3epayOuvlKcEFcDCw6yL9T4SrsWTECct6FS/isli766kdij2GGG6bWU6bRp+fDS2Cbg==",
+      "requires": {
+        "babel-runtime": "^6.23.0"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -10100,12 +10108,13 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#1bc11c578b1dc2e5a508a00de65e4e9a549d72b1",
-      "from": "github:mattermost/mattermost-redux#1bc11c578b1dc2e5a508a00de65e4e9a549d72b1",
+      "version": "github:mattermost/mattermost-redux#707dc6926ae3eecb4c7b4ae08dca9be17b933568",
+      "from": "github:mattermost/mattermost-redux#707dc6926ae3eecb4c7b4ae08dca9be17b933568",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",
         "form-data": "2.3.2",
+        "gfycat-sdk": "1.4.18",
         "harmony-reflect": "1.6.0",
         "isomorphic-fetch": "2.2.1",
         "mime-db": "1.33.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "216113.0.3",
-    "mattermost-redux": "github:mattermost/mattermost-redux#1bc11c578b1dc2e5a508a00de65e4e9a549d72b1",
+    "mattermost-redux": "github:mattermost/mattermost-redux#707dc6926ae3eecb4c7b4ae08dca9be17b933568",
     "mime-db": "1.33.0",
     "prop-types": "15.6.1",
     "react": "16.3.2",


### PR DESCRIPTION
Redux changes: https://github.com/mattermost/mattermost-redux/commit/707dc6926ae3eecb4c7b4ae08dca9be17b933568

Note that this also includes a bunch of other Redux changes that hadn't been merged yet like [channel selector changes for the sidebar reorganization](https://github.com/mattermost/mattermost-redux/pull/549), [switching gfycat-sdk to use npm](0c4479035bb11223b7c360855bc9c566c0dc2699), and [some plugin stuff](https://github.com/mattermost/mattermost-redux/commit/a634d4157d60b99c0302ce08826982fa2a94f3df) [that we don't care about](https://github.com/mattermost/mattermost-redux/commit/c2fbd399cc0a3cdf1020b89bc07fc9f63320e110). I did some quick testing to make sure those didn't cause any problems.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11256

#### Device Information
This PR was tested on: iOS Simulator