### PR TITLE
[MM-11494] Add extra protection to those channel/object followed immediately by accessing its "channel_id" field

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -55,7 +55,7 @@ export function loadFromPushNotification(notification) {
         const {data} = notification;
         const {currentTeamId, teams, myMembers: myTeamMembers} = state.entities.teams;
         const {currentChannelId, channels} = state.entities.channels;
-        const channelId = data.channel_id;
+        const channelId = data ? data.channel_id : '';
 
         // when the notification does not have a team id is because its from a DM or GM
         const teamId = data.team_id || currentTeamId;

--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -32,7 +32,7 @@ import PostBody from './post_body';
 const POST_TIMEOUT = 20000;
 
 function mapStateToProps(state, ownProps) {
-    const post = getPost(state, ownProps.postId);
+    const post = getPost(state, ownProps.postId) || {};
     const channel = getChannel(state, post.channel_id) || {};
     const channelIsArchived = channel ? channel.delete_at !== 0 : false;
     const teamId = channel.team_id;

--- a/app/components/reactions/index.js
+++ b/app/components/reactions/index.js
@@ -21,7 +21,8 @@ function makeMapStateToProps() {
     const getReactionsForPostSelector = makeGetReactionsForPost();
     return function mapStateToProps(state, ownProps) {
         const post = getPost(state, ownProps.postId);
-        const channel = getChannel(state, post.channel_id) || {};
+        const channelId = post ? post.channel_id : '';
+        const channel = getChannel(state, channelId);
         const teamId = channel.team_id;
         const channelIsArchived = channel.delete_at !== 0;
 
@@ -33,12 +34,12 @@ function makeMapStateToProps() {
         } else if (hasNewPermissions(state)) {
             canAddReaction = haveIChannelPermission(state, {
                 team: teamId,
-                channel: post.channel_id,
+                channel: channelId,
                 permission: Permissions.ADD_REACTION,
             });
             canRemoveReaction = haveIChannelPermission(state, {
                 team: teamId,
-                channel: post.channel_id,
+                channel: channelId,
                 permission: Permissions.REMOVE_REACTION,
             });
         }

--- a/app/components/root/root.js
+++ b/app/components/root/root.js
@@ -51,7 +51,7 @@ export default class Root extends PureComponent {
         const {data} = notification;
         const {currentChannelId, navigator} = this.props;
 
-        if (data.channel_id !== currentChannelId) {
+        if (data && data.channel_id !== currentChannelId) {
             navigator.showInAppNotification({
                 screen: 'Notification',
                 position: 'top',

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -269,8 +269,9 @@ export default class Permalink extends PureComponent {
         }
 
         if (!channelId) {
-            focusChannelId = post.data.posts[focusedPostId].channel_id;
-            if (!this.props.myMembers[focusChannelId]) {
+            const focusedPost = post.data.posts[focusedPostId];
+            focusChannelId = focusedPost ? focusedPost.channel_id : '';
+            if (focusChannelId && !this.props.myMembers[focusChannelId]) {
                 const {data: channel} = await actions.getChannel(focusChannelId);
                 if (channel && channel.type === General.OPEN_CHANNEL) {
                     await actions.joinChannel(currentUserId, channel.team_id, channel.id);

--- a/app/screens/search/channel_display_name/index.js
+++ b/app/screens/search/channel_display_name/index.js
@@ -13,7 +13,7 @@ function makeMapStateToProps() {
     const getChannel = makeGetChannel();
     return (state, ownProps) => {
         const post = getPost(state, ownProps.postId);
-        const channel = getChannel(state, {id: post.channel_id});
+        const channel = post ? getChannel(state, {id: post.channel_id}) : null;
 
         return {
             displayName: channel ? channel.display_name : '',


### PR DESCRIPTION
#### Summary
Can't exactly pin point what's causing the `undefined is not an object (evaluating 'e.channel_id')` so I just add extra protection to those channel/object followed immediately by accessing its "channel_id" field.

#### Ticket Link
Jira ticket: [MM-11494](https://mattermost.atlassian.net/browse/MM-11494)

#### Device Information
This PR was tested on: [iOS simulator, Android emulator] 

