### PR TITLE
[MM-11492] Add protection in accessing ".team_id" field when it's immediately accessed after the object is created

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -260,7 +260,6 @@ export function selectInitialChannel(teamId) {
             isGroupChannelVisible(myPreferences, lastChannel);
 
         if (
-            lastChannelId &&
             myMembers[lastChannelId] &&
             lastChannel &&
             (lastChannel.team_id === teamId || isDMVisible || isGMVisible)

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -259,8 +259,12 @@ export function selectInitialChannel(teamId) {
         const isGMVisible = lastChannel && lastChannel.type === General.GM_CHANNEL &&
             isGroupChannelVisible(myPreferences, lastChannel);
 
-        if (lastChannelId && myMembers[lastChannelId] &&
-            (lastChannel.team_id === teamId || isDMVisible || isGMVisible)) {
+        if (
+            lastChannelId &&
+            myMembers[lastChannelId] &&
+            lastChannel &&
+            (lastChannel.team_id === teamId || isDMVisible || isGMVisible)
+        ) {
             handleSelectChannel(lastChannelId)(dispatch, getState);
             markChannelAsRead(lastChannelId)(dispatch, getState);
             return;

--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -55,10 +55,15 @@ export function loadFromPushNotification(notification) {
         const {data} = notification;
         const {currentTeamId, teams, myMembers: myTeamMembers} = state.entities.teams;
         const {currentChannelId, channels} = state.entities.channels;
-        const channelId = data ? data.channel_id : '';
 
-        // when the notification does not have a team id is because its from a DM or GM
-        const teamId = data.team_id || currentTeamId;
+        let channelId = '';
+        let teamId = currentTeamId;
+        if (data) {
+            channelId = data.channel_id;
+
+            // when the notification does not have a team id is because its from a DM or GM
+            teamId = data.team_id || currentTeamId;
+        }
 
         // load any missing data
         const loading = [];

--- a/app/components/reactions/index.js
+++ b/app/components/reactions/index.js
@@ -22,7 +22,7 @@ function makeMapStateToProps() {
     return function mapStateToProps(state, ownProps) {
         const post = getPost(state, ownProps.postId);
         const channelId = post ? post.channel_id : '';
-        const channel = getChannel(state, channelId);
+        const channel = getChannel(state, channelId) || {};
         const teamId = channel.team_id;
         const channelIsArchived = channel.delete_at !== 0;
 


### PR DESCRIPTION
#### Summary
Can't exactly tell the root cause of`Undefined is not an object (evaluating 'y.team_id')` so I just added protection in accessing ".team_id" field when it's immediately accessed after the object is created.

#### Ticket Link
Jira ticket: [MM-11492](https://mattermost.atlassian.net/browse/MM-11492)

#### Device Information
This PR was tested on: [iOS simulator, Android emulator] 
