### PR TITLE
Fix Android share extension and better handle errors

### DIFF
--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -2432,6 +2432,7 @@
   "mobile.error_handler.description": "\nClick relaunch to open the app again. After restart, you can report the problem from the settings menu.\n",
   "mobile.error_handler.title": "Unexpected error occurred",
   "mobile.extension.authentication_required": "Authentication required: Please first login using the app.",
+  "mobile.extension.file_error": "There was an error reading the file to be shared.\nPlease try again.",
   "mobile.extension.file_limit": "Sharing is limited to a maximum of 5 files.",
   "mobile.extension.max_file_size": "File attachments shared in Mattermost must be less than {size}.",
   "mobile.extension.permission": "Mattermost needs access to the device storage to share files.",


### PR DESCRIPTION
#### Summary
This PR changes the way the temporary files are created when using the share extension in a way that we can define the filename instead of having a random id.

Also the problem that we were seeing is that the use of `getLastPathSegment` was returning a decoded string and sometimes appended a `\n` new line to it, RNFetchBlob was failing cause it trims the new lines before checking for the existence of the file or getting the stats thus the file not found error.

More so now we handle the null or file not founds gracefully and we present the user with a message.

Note: the above will happen when trying to share a contact instead of a file.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11490

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Includes text changes and localization file updates
