### PR TITLE
[MM-11491] Add protection (empty object) when accessing id after declaring an object.

### DIFF
--- a/app/components/combined_system_message/index.js
+++ b/app/components/combined_system_message/index.js
@@ -15,7 +15,7 @@ function makeMapStateToProps() {
     const getProfilesByIdsAndUsernames = makeGetProfilesByIdsAndUsernames();
 
     return (state, ownProps) => {
-        const currentUser = getCurrentUser(state);
+        const currentUser = getCurrentUser(state) || {};
         const {allUserIds, allUsernames} = ownProps;
         return {
             currentUserId: currentUser.id,

--- a/app/components/sidebars/main/channels_list/switch_teams_button/index.js
+++ b/app/components/sidebars/main/channels_list/switch_teams_button/index.js
@@ -9,7 +9,7 @@ import {getCurrentTeam, getMyTeamsCount, getChannelDrawerBadgeCount} from 'matte
 import SwitchTeamsButton from './switch_teams_button';
 
 function mapStateToProps(state) {
-    const team = getCurrentTeam(state);
+    const team = getCurrentTeam(state) || {};
 
     return {
         currentTeamId: team.id,

--- a/app/components/sidebars/settings/index.js
+++ b/app/components/sidebars/settings/index.js
@@ -13,7 +13,7 @@ import {getDimensions} from 'app/selectors/device';
 import SettingsSidebar from './settings_sidebar';
 
 function mapStateToProps(state) {
-    const currentUser = getCurrentUser(state);
+    const currentUser = getCurrentUser(state) || {};
     const status = getStatusForUserId(state, currentUser.id);
 
     return {

--- a/app/screens/settings/notification_settings/index.js
+++ b/app/screens/settings/notification_settings/index.js
@@ -15,7 +15,7 @@ import NotificationSettings from './notification_settings';
 
 function mapStateToProps(state) {
     const config = getConfig(state);
-    const currentUser = getCurrentUser(state);
+    const currentUser = getCurrentUser(state) || {};
     const currentUserStatus = getStatusForUserId(state, currentUser.id);
     const serverVersion = state.entities.general.serverVersion;
     const enableAutoResponder = isMinimumServerVersion(serverVersion, 4, 9) && config.ExperimentalEnableAutomaticReplies === 'true';

--- a/app/screens/timezone/index.js
+++ b/app/screens/timezone/index.js
@@ -16,7 +16,7 @@ import Timezone from './timezone';
 
 function mapStateToProps(state) {
     const timezones = getTimezones(state);
-    const currentUser = getCurrentUser(state);
+    const currentUser = getCurrentUser(state) || {};
     const userTimezone = getUserTimezone(state, currentUser.id);
 
     return {


### PR DESCRIPTION
#### Summary
Can;t exactly pinpoint the reason why getting this error `undefined is not an object (evaluating 'c.id')`.  So just add protection (empty object) when immediately accessing id after declaring an object.

#### Ticket Link
Jira ticket: [MM-11491](https://mattermost.atlassian.net/browse/MM-11491)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

