### PR TITLE
MM-11477 Attempt to capture uncaught redux errors as Sentry breadcrumbs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,8 @@
         "expect": true,
         "it": true,
         "jest": true,
-        "test": true
+        "test": true,
+        "__DEV__": true
     },
     "rules": {
         "array-bracket-spacing": [2, "never"],

--- a/app/mattermost_managed/mattermost-managed.android.js
+++ b/app/mattermost_managed/mattermost-managed.android.js
@@ -56,7 +56,7 @@ export default {
         }
     },
     isTrustedDevice: () => {
-        if (__DEV__) { //eslint-disable-line no-undef
+        if (__DEV__) {
             return true;
         }
 

--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -55,7 +55,7 @@ export default {
         }
     },
     isTrustedDevice: () => {
-        if (__DEV__) { //eslint-disable-line no-undef
+        if (__DEV__) {
             return true;
         }
 

--- a/app/utils/sentry/index.js
+++ b/app/utils/sentry/index.js
@@ -17,6 +17,9 @@ export const LOGGER_JAVASCRIPT_WARNING = 'javascript_warning';
 export const LOGGER_NATIVE = 'native';
 export const LOGGER_REDUX = 'redux';
 
+export const BREADCRUMB_UNCAUGHT_APP_ERROR = 'uncaught-app-error';
+export const BREADCRUMB_UNCAUGHT_NON_ERROR = 'uncaught-non-error';
+
 export function initializeSentry() {
     if (!Config.SentryEnabled) {
         // Still allow Sentry to configure itself in case other code tries to call it
@@ -44,12 +47,28 @@ function getDsn() {
     return '';
 }
 
-export function captureException(error, logger, store) {
-    if (error && logger && store) {
-        capture(() => {
-            Sentry.captureException(error, {logger});
-        }, store);
+export function captureJSException(error, isFatal, store) {
+    if (!error || !store) {
+        console.warn('captureJSException called with missing arguments', error, store); // eslint-disable-line no-console
+        return;
     }
+
+    if (error instanceof Error) {
+        captureException(error, LOGGER_JAVASCRIPT, store);
+    } else {
+        captureNonErrorAsBreadcrumb(error, isFatal);
+    }
+}
+
+export function captureException(error, logger, store) {
+    if (!error || !logger || !store) {
+        console.warn('captureException called with missing arguments', error, logger, store); // eslint-disable-line no-console
+        return;
+    }
+
+    capture(() => {
+        Sentry.captureException(error, {logger});
+    }, store);
 }
 
 export function captureExceptionWithoutState(err, logger) {
@@ -71,6 +90,54 @@ export function captureMessage(message, logger, store) {
         capture(() => {
             Sentry.captureMessage(message, {logger});
         }, store);
+    }
+}
+
+export function captureNonErrorAsBreadcrumb(obj, isFatal) {
+    if (!obj || typeof obj !== 'object') {
+        console.warning('Invalid object passed to captureNonErrorAsBreadcrumb', obj); // eslint-disable-line no-console
+        return;
+    }
+
+    const isAppError = Boolean(obj.server_error_id);
+
+    const breadcrumb = {
+        category: isAppError ? BREADCRUMB_UNCAUGHT_APP_ERROR : BREADCRUMB_UNCAUGHT_NON_ERROR,
+        data: {
+            isFatal: String(isFatal),
+        },
+        level: 'warn',
+    };
+
+    if (obj.message) {
+        breadcrumb.message = obj.message;
+    } else if (obj.intl && obj.intl.defaultMessage) {
+        breadcrumb.message = breadcrumb.intl.defaultMessage;
+    } else {
+        breadcrumb.message = 'no message provided';
+    }
+
+    if (obj.server_error_id) {
+        breadcrumb.data.server_error_id = obj.server_error_id;
+    }
+
+    if (obj.status_code) {
+        breadcrumb.data.status_code = obj.status_code;
+    }
+
+    if (obj.url) {
+        const index = obj.url.indexOf('/');
+
+        if (index !== -1) {
+            breadcrumb.data.url = obj.url.substring(index);
+        }
+    }
+
+    try {
+        Sentry.captureBreadcrumb(breadcrumb);
+    } catch (e) {
+        // Do nothing since this is only here to make sure we don't crash when handling an exception
+        console.warn('Failed to capture breadcrumb of non-error', e); // eslint-disable-line no-console
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ if (Platform.OS === 'android') {
 
 /*
 /!* eslint-disable no-console *!/
-/!* eslint-disable no-undef *!/
 if (__DEV__) {
     const modules = require.getModules();
     const moduleIds = Object.keys(modules);


### PR DESCRIPTION
First part of an attempted fix for https://mattermost.atlassian.net/browse/MM-11477. This'll catch any uncaught promise rejections that we can handle and turn them into Sentry breadcrumbs so that we can see them when other errors are logged, although it won't prevent Sentry from handling them on it's own.

Also adds some defensive code to the error handler to prevent errors that happen in dev mode with the error handler enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11477

#### Device Information
This PR was tested on: iOS Simulator
