### PR TITLE
Clear Cookies before login in with SSO

### DIFF
--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -94,10 +94,14 @@ class SSO extends PureComponent {
     }
 
     componentDidMount() {
-        InteractionManager.runAfterInteractions(() => {
+        InteractionManager.runAfterInteractions(this.clearPreviousCookies);
+    }
+
+    clearPreviousCookies = () => {
+        CookieManager.clearAll().then(() => {
             this.setState({renderWebView: true});
         });
-    }
+    };
 
     goToLoadTeam = (expiresAt) => {
         const {intl, navigator} = this.props;
@@ -197,7 +201,7 @@ class SSO extends PureComponent {
     onLoadEndError = (e) => {
         console.warn('Failed to set store from local data', e); // eslint-disable-line no-console
         this.setState({error: e.message});
-    }
+    };
 
     renderLoading = () => {
         return <Loading/>;


### PR DESCRIPTION
#### Summary
When logging in using SAML or OAuth the cookies that are set in the WebView are kept after a logout making it so that when the user tries to re-login it will use the past entered credentials as they are kept in the Cookies.

This PR makes sure we clear all the cookies before loading the WebView so they need to enter their credentials again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11115