### PR TITLE
[MM-11613] Use profile image from local after editing a profile image

### DIFF
--- a/app/actions/views/edit_profile.js
+++ b/app/actions/views/edit_profile.js
@@ -3,6 +3,8 @@
 
 import {updateMe} from 'mattermost-redux/actions/users';
 
+import {ViewTypes} from 'app/constants';
+
 export function updateUser(user, success, error) {
     return async (dispatch, getState) => {
         const result = await updateMe(user)(dispatch, getState);
@@ -15,3 +17,15 @@ export function updateUser(user, success, error) {
         return result;
     };
 }
+
+export function setProfileImageUri(imageUri = '') {
+    return {
+        type: ViewTypes.SET_PROFILE_IMAGE_URI,
+        imageUri,
+    };
+}
+
+export default {
+    updateUser,
+    setProfileImageUri,
+};

--- a/app/components/profile_picture/index.js
+++ b/app/components/profile_picture/index.js
@@ -6,7 +6,10 @@ import {connect} from 'react-redux';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getStatusesByIdsBatchedDebounced} from 'mattermost-redux/actions/users';
-import {getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
+
+import {setProfileImageUri} from 'app/actions/views/edit_profile';
+import {getProfileImageUri} from 'app/selectors/views';
 
 import ProfilePicture from './profile_picture';
 
@@ -17,8 +20,16 @@ function mapStateToProps(state, ownProps) {
         status = getStatusForUserId(state, ownProps.userId);
     }
 
+    const isCurrentUser = getCurrentUserId(state) === ownProps.userId;
+    let profileImageUri = '';
+    if (isCurrentUser) {
+        profileImageUri = getProfileImageUri(state);
+    }
+
     return {
+        isCurrentUser,
         theme: getTheme(state),
+        profileImageUri,
         status,
         user,
     };
@@ -27,6 +38,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            setProfileImageUri,
             getStatusForId: getStatusesByIdsBatchedDebounced,
         }, dispatch),
     };

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -69,6 +69,8 @@ const ViewTypes = keyMirror({
     LAUNCH_CHANNEL: null,
 
     SET_DEEP_LINK_URL: null,
+
+    SET_PROFILE_IMAGE_URI: null,
 });
 
 export default {

--- a/app/reducers/views/index.js
+++ b/app/reducers/views/index.js
@@ -15,6 +15,7 @@ import search from './search';
 import selectServer from './select_server';
 import team from './team';
 import thread from './thread';
+import user from './user';
 import emoji from './emoji';
 
 export default combineReducers({
@@ -30,5 +31,6 @@ export default combineReducers({
     selectServer,
     team,
     thread,
+    user,
     emoji,
 });

--- a/app/reducers/views/user.js
+++ b/app/reducers/views/user.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {combineReducers} from 'redux';
+
+import {ViewTypes} from 'app/constants';
+
+function profileImageUri(state = '', action) {
+    switch (action.type) {
+    case ViewTypes.SET_PROFILE_IMAGE_URI: {
+        return action.imageUri;
+    }
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    profileImageUri,
+});

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -53,6 +53,7 @@ const holders = {
 export default class EditProfile extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
+            setProfileImageUri: PropTypes.func.isRequired,
             updateUser: PropTypes.func.isRequired,
         }).isRequired,
         config: PropTypes.object.isRequired,
@@ -166,13 +167,15 @@ export default class EditProfile extends PureComponent {
             position,
             email,
         };
+        const {actions} = this.props;
 
         if (profileImage) {
+            actions.setProfileImageUri(profileImage.uri);
             this.uploadProfileImage().catch(this.handleUploadError);
         }
 
         if (this.canUpdate()) {
-            const {error} = await this.props.actions.updateUser(user);
+            const {error} = await actions.updateUser(user);
             if (error) {
                 this.handleRequestError(error);
                 return;

--- a/app/screens/edit_profile/index.js
+++ b/app/screens/edit_profile/index.js
@@ -7,7 +7,7 @@ import {bindActionCreators} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {updateUser} from 'app/actions/views/edit_profile';
+import {setProfileImageUri, updateUser} from 'app/actions/views/edit_profile';
 
 import EditProfile from './edit_profile';
 
@@ -21,6 +21,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            setProfileImageUri,
             updateUser,
         }, dispatch),
     };

--- a/app/selectors/views.js
+++ b/app/selectors/views.js
@@ -33,3 +33,7 @@ export const getThreadDraft = createSelector(
         return drafts[rootId] || emptyDraft;
     }
 );
+
+export function getProfileImageUri(state) {
+    return state.views.user.profileImageUri;
+}


### PR DESCRIPTION
#### Summary
Use profile image from local after editing a profile image.

The way it works is:
- set profile image to local views (`state.views.user.profileImageUri`) whenever the user uploads a profile image
- use that profile image as profile picture for every post of the user
- when the user's picture URL is available, it replaces the profile picture using that URL and clear the profile image in local views/store (`state.views.user.profileImageUri`)

Note:  ~~In the screen capture below, you'll notice that the profile picture is being used in the post messages as soon as the user is taken out of the EditProfile screen.  However, once the picture URL becomes available, there's a short flicker during transition in switching profile image from local view to picture URL. Not sure what's the better approach to that issue.~~ Fix now, thanks to @enahum.  Just a brief flicker on Android but probably it's fine.  Will try one more before releasing for dev review.

#### Ticket Link
Jira ticket: [MM-11613](https://mattermost.atlassian.net/browse/MM-11613)

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
[Old]
![edit_profile_image](https://user-images.githubusercontent.com/5334504/43907719-b4692766-9c28-11e8-8ef6-017f86971e13.gif)

[New - thanks to @enahum]
![edit_profile_image_1](https://user-images.githubusercontent.com/5334504/43918851-e125d326-9c46-11e8-8f27-3ec9d1670c82.gif)
