### PR TITLE
Fix video playback when filename contains spaces

### DIFF
--- a/app/screens/image_preview/downloader.android.js
+++ b/app/screens/image_preview/downloader.android.js
@@ -17,10 +17,10 @@ import {Client4} from 'mattermost-redux/client';
 
 import {DeviceTypes} from 'app/constants/';
 import FormattedText from 'app/components/formatted_text';
-import {isDocument, isVideo} from 'app/utils/file';
+import {getVideoPathFromFile, isDocument, isVideo} from 'app/utils/file';
 import {emptyFunction} from 'app/utils/general';
 
-const {DOCUMENTS_PATH, VIDEOS_PATH} = DeviceTypes;
+const {DOCUMENTS_PATH} = DeviceTypes;
 const EXTERNAL_STORAGE_PERMISSION = 'android.permission.WRITE_EXTERNAL_STORAGE';
 const HEADER_HEIGHT = 64;
 const OPTION_LIST_WIDTH = 39;
@@ -89,7 +89,7 @@ export default class Downloader extends PureComponent {
             ToastAndroid.show(started, ToastAndroid.SHORT);
             onDownloadStart();
 
-            const dest = `${RNFetchBlob.fs.dirs.DownloadDir}/${data.id}-${file.caption}`;
+            let dest = `${RNFetchBlob.fs.dirs.DownloadDir}/${data.id}-${file.caption}`;
             let downloadFile = true;
 
             if (data.localPath) {
@@ -100,11 +100,12 @@ export default class Downloader extends PureComponent {
                     await RNFetchBlob.fs.cp(data.localPath, dest);
                 }
             } else if (isVideo(data)) {
-                const path = `${VIDEOS_PATH}/${data.id}-${file.caption}`;
+                const path = getVideoPathFromFile(file);
                 const exists = await RNFetchBlob.fs.exists(path);
 
                 if (exists) {
                     downloadFile = false;
+                    dest = `${RNFetchBlob.fs.dirs.DownloadDir}/${data.id}-${decodeURIComponent(file.caption).replace(/\s+/g, '-')}`;
                     await RNFetchBlob.fs.cp(path, dest);
                 }
             } else if (isDocument(data)) {

--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -23,12 +23,13 @@ export default class Downloader extends PureComponent {
     static propTypes = {
         deviceHeight: PropTypes.number.isRequired,
         deviceWidth: PropTypes.number.isRequired,
+        downloadDirectory: PropTypes.string,
+        downloadPath: PropTypes.string,
         file: PropTypes.object.isRequired,
         onDownloadCancel: PropTypes.func,
         onDownloadSuccess: PropTypes.func,
         prompt: PropTypes.bool,
         show: PropTypes.bool,
-        downloadPath: PropTypes.string,
         saveToCameraRoll: PropTypes.bool,
     };
 
@@ -276,7 +277,7 @@ export default class Downloader extends PureComponent {
     };
 
     startDownload = async () => {
-        const {file, downloadPath, prompt, saveToCameraRoll} = this.props;
+        const {file, downloadDirectory, downloadPath, prompt, saveToCameraRoll} = this.props;
         const {data} = file;
 
         try {
@@ -294,18 +295,18 @@ export default class Downloader extends PureComponent {
                 certificate,
             };
 
-            if (downloadPath && prompt) {
-                const isDir = await RNFetchBlob.fs.isDir(downloadPath);
+            if (downloadDirectory && downloadPath && prompt) {
+                const isDir = await RNFetchBlob.fs.isDir(downloadDirectory);
                 if (!isDir) {
                     try {
-                        await RNFetchBlob.fs.mkdir(downloadPath);
+                        await RNFetchBlob.fs.mkdir(downloadDirectory);
                     } catch (error) {
                         this.showDownloadFailedAlert();
                         return;
                     }
                 }
 
-                options.path = `${downloadPath}/${data.id}-${file.caption}`;
+                options.path = downloadPath;
             } else {
                 options.fileCache = true;
                 options.appendExt = data.extension;
@@ -356,7 +357,7 @@ export default class Downloader extends PureComponent {
         } catch (error) {
             // cancellation throws so we need to catch
             if (downloadPath) {
-                RNFetchBlob.fs.unlink(`${downloadPath}/${data.id}-${file.caption}`);
+                RNFetchBlob.fs.unlink(downloadPath);
             }
             if (error.message !== 'cancelled' && this.mounted) {
                 this.showDownloadFailedAlert();
@@ -382,7 +383,7 @@ export default class Downloader extends PureComponent {
     };
 
     render() {
-        const {show, downloadPath} = this.props;
+        const {show, downloadDirectory, downloadPath} = this.props;
         if (!show && !this.state.force) {
             return null;
         }
@@ -392,7 +393,7 @@ export default class Downloader extends PureComponent {
         const containerHeight = show ? '100%' : 0;
 
         let component;
-        if (downloadPath && !started) {
+        if (downloadDirectory && downloadPath && !started) {
             component = this.renderStartDownload;
         } else {
             component = this.renderProgress;

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -25,20 +25,17 @@ import Gallery from 'react-native-image-gallery';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
-import {DeviceTypes} from 'app/constants/';
 import FileAttachmentDocument from 'app/components/file_attachment_list/file_attachment_document';
 import FileAttachmentIcon from 'app/components/file_attachment_list/file_attachment_icon';
+import ProgressiveImage from 'app/components/progressive_image';
 import {NavigationTypes, PermissionTypes} from 'app/constants';
-import {isDocument, isVideo} from 'app/utils/file';
+import {getVideoPathFromFile, isDocument, isVideo} from 'app/utils/file';
 import {emptyFunction} from 'app/utils/general';
 import {calculateDimensions} from 'app/utils/images';
 
 import Downloader from './downloader';
 import VideoPreview from './video_preview';
 
-import ProgressiveImage from 'app/components/progressive_image';
-
-const {VIDEOS_PATH} = DeviceTypes;
 const {View: AnimatedView} = Animated;
 const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView);
 const HEADER_HEIGHT = 48;
@@ -455,11 +452,10 @@ export default class ImagePreview extends PureComponent {
 
     saveVideoIOS = () => {
         const file = this.getCurrentFile();
-        const {data} = file;
 
         if (this.refs.downloader) {
             EventEmitter.emit(NavigationTypes.NAVIGATION_CLOSE_MODAL);
-            this.refs.downloader.saveVideo(`${VIDEOS_PATH}/${data.id}-${file.caption}`);
+            this.refs.downloader.saveVideo(getVideoPathFromFile(file));
         }
     };
 
@@ -540,7 +536,7 @@ export default class ImagePreview extends PureComponent {
         }
 
         if (isVideo(file.data)) {
-            const path = `${VIDEOS_PATH}/${file.data.id}-${file.caption}`;
+            const path = getVideoPathFromFile(file);
             const exist = await RNFetchBlob.fs.exists(path);
             if (exist) {
                 items.push({

--- a/app/screens/image_preview/video_preview.js
+++ b/app/screens/image_preview/video_preview.js
@@ -18,6 +18,7 @@ import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import VideoControls, {PLAYER_STATE} from 'app/components/video_controls';
 import {DeviceTypes} from 'app/constants/';
+import {getVideoPathFromFile} from 'app/utils/file';
 
 import Downloader from './downloader.ios';
 
@@ -70,7 +71,7 @@ export default class VideoPreview extends PureComponent {
     async initializeComponent() {
         const {file} = this.props;
         const prefix = Platform.OS === 'android' ? 'file:/' : '';
-        const path = `${VIDEOS_PATH}/${file.data.id}-${file.caption}`;
+        const path = getVideoPathFromFile(file);
         const exist = await RNFetchBlob.fs.exists(`${prefix}${path}`);
 
         if (exist) {
@@ -90,7 +91,7 @@ export default class VideoPreview extends PureComponent {
 
     onDownloadSuccess = () => {
         const {file} = this.props;
-        const path = file.data.localPath || `${VIDEOS_PATH}/${file.data.id}-${file.caption}`;
+        const path = file.data.localPath || getVideoPathFromFile(file);
 
         this.setState({showDownloader: false, path});
     };
@@ -193,7 +194,8 @@ export default class VideoPreview extends PureComponent {
                     file={file}
                     deviceHeight={deviceHeight}
                     deviceWidth={deviceWidth}
-                    downloadPath={VIDEOS_PATH}
+                    downloadDirectory={VIDEOS_PATH}
+                    downloadPath={getVideoPathFromFile(file)}
                     prompt={true}
                     saveToCameraRoll={false}
                     onDownloadSuccess={this.onDownloadSuccess}

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -215,3 +215,7 @@ function populateMaps() {
         }
     });
 }
+
+export function getVideoPathFromFile(file) {
+    return `${VIDEOS_PATH}/${file.data.id}-${decodeURIComponent(file.caption).replace(/\s+/g, '-')}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14928,9 +14928,9 @@
       }
     },
     "react-native-video": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-2.0.0.tgz",
-      "integrity": "sha1-8z+m+35+PJOrV4eUTO/Vi/c1WGc=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-3.2.0.tgz",
+      "integrity": "sha512-LLqyV9xK67FQTcQDpYruyRODlkQdE59uLExGoXjBngBHrf0q/R13yYaLk3G4CU2Bz+bi3cVzzI6E+q03eNeVYQ==",
       "requires": {
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-native-tableview": "2.1.0",
     "react-native-tooltip": "5.2.0",
     "react-native-vector-icons": "4.6.0",
-    "react-native-video": "2.0.0",
+    "react-native-video": "3.2.0",
     "react-native-youtube": "enahum/react-native-youtube#3f395b620ae4e05a3f1c6bdeef3a1158e78daadc",
     "react-navigation": "1.5.11",
     "react-redux": "5.0.7",

--- a/share_extension/ios/extension_post.js
+++ b/share_extension/ios/extension_post.js
@@ -250,7 +250,7 @@ export default class ExtensionPost extends PureComponent {
                         const fullPath = item.value;
                         const filePath = decodeURIComponent(fullPath.replace('file://', ''));
                         const fileSize = await RNFetchBlob.fs.stat(filePath);
-                        const filename = fullPath.replace(/^.*[\\/]/, '');
+                        const filename = decodeURIComponent(fullPath.replace(/^.*[\\/]/, ''));
                         const extension = filename.split('.').pop();
 
                         if (this.useBackgroundUpload) {


### PR DESCRIPTION
#### Summary
When a video file contained spaces or was URI encoded the video player was not able to play the file even if the file actually existed in the the storage, this PR converts the spaces into dashes when saving the file so it can be played.

Also the iOS Share Extension will set the filename as decoded

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11640

#### Device Information
This PR was tested on: iOS 11.4 and Android 7.1
