### PR TITLE
Fix app crashes on iOS 9.3

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 /* eslint-disable global-require*/
-import {AsyncStorage, Linking, NativeModules} from 'react-native';
+import {AsyncStorage, Linking, NativeModules, Platform} from 'react-native';
 import {setGenericPassword, getGenericPassword, resetGenericPassword} from 'react-native-keychain';
 
 import {loadMe} from 'mattermost-redux/actions/users';
@@ -50,6 +50,14 @@ export default class App {
         this.currentUserId = null;
         this.token = null;
         this.url = null;
+
+        // Load polyfill for iOS 9
+        if (Platform.OS === 'ios') {
+            const majorVersionIOS = parseInt(Platform.Version, 10);
+            if (majorVersionIOS < 10) {
+                require('babel-polyfill');
+            }
+        }
 
         // Usage deeplinking
         Linking.addEventListener('url', this.handleDeepLink);


### PR DESCRIPTION
#### Summary

Mattermost mobile app crashes on iOS 9.3.
Here's debugger log when app crashes (It crashes both simulator and real iPhone, but real iPhone does not display this error screen because it builds production mode)

<img width="410" alt="2018-08-14 9 36 00" src="https://user-images.githubusercontent.com/4811664/44092333-1d3013c8-a00b-11e8-8ad6-f764c5352519.png">

I just added `babel-polyfill` to fix this crash issue. 
(`babel-polyfill` already contained in this project via dependency tree)

After this PR

<img width="401" alt="2018-08-14 9 40 35" src="https://user-images.githubusercontent.com/4811664/44092510-9bda82b2-a00b-11e8-9fc0-f3410224fb05.png">


#### Ticket Link
Github #1988 

#### Checklist

#### Device Information
This PR was tested on
* Apple iPad Pro 12.9 (2nd generation), iOS 11.4
* Apple iPhone 6, iOS 9.3
* Apple iPhone 5, iOS 11
* Samsung Galaxy S7 Edge, Android 7.0

#### Screenshots
I already uploaded in summary.

cc : @enahum 