### PR TITLE
Add a timeout to avoid race conditions when opening the app from a push notification

### DIFF
--- a/app/utils/push_notifications.js
+++ b/app/utils/push_notifications.js
@@ -87,7 +87,9 @@ const onPushNotification = async (deviceNotification) => {
         } else if (userInteraction && !notification.localNotification) {
             EventEmitter.emit('close_channel_drawer');
             if (getState().views.root.hydrationComplete) {
-                loadFromNotification(notification);
+                setTimeout(() => {
+                    loadFromNotification(notification);
+                }, 0);
             } else {
                 const waitForHydration = () => {
                     if (getState().views.root.hydrationComplete && !stopLoadingNotification) {


### PR DESCRIPTION
#### Summary
Sometimes there seems to be a race condition when bringing the the app to the foreground after tapping a push notification so the user is not being sent to the right channel, I've added a setTimeout around the call to `loadFromNotification` so it is executed in the next cycle.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11729