### PR TITLE
Fix Jump to Channel DMs not showing

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -75,7 +75,7 @@ function makeMapStateToProps() {
             theme: getTheme(state),
             type: channel.type,
             unreadMsgs,
-            isArchived: channel.delete_at !== 0,
+            isArchived: channel.delete_at > 0,
         };
     };
 }


### PR DESCRIPTION
#### Summary
The current implementation was checking if `channel.delete_at !== 0` and just because we do build some fake `channels` and do not set the value for `delete_at` we had that the condition was returning **true** when evaluating `undefined !== 0`, I changed it so it checks that the value fo deleted at is grater than 0
