### PR TITLE
Fix long message not displaying for message attachments in android

### DIFF
--- a/app/components/message_attachments/message_attachment.js
+++ b/app/components/message_attachments/message_attachment.js
@@ -409,7 +409,7 @@ export default class MessageAttachment extends PureComponent {
                 >
                     <View
                         style={[(isLongText && collapsed && {maxHeight, overflow: 'hidden'})]}
-                        removeClippedSubviews={isLongText && collapsed}
+                        removeClippedSubviews={isLongText && collapsed && Platform.OS !== 'android'}
                     >
                         <Markdown
                             baseTextStyle={baseTextStyle}
@@ -526,6 +526,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         moreLess: {
             color: theme.linkColor,
             fontSize: 12,
+            marginTop: 5,
         },
         headingContainer: {
             alignSelf: 'stretch',


### PR DESCRIPTION
#### Summary
Somehow the clipping subviews on Android was causing the rest of the post not to display on screen

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11719