### PR TITLE
Fix network change status

### DIFF
--- a/app/actions/device/index.js
+++ b/app/actions/device/index.js
@@ -1,14 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {networkStatusChanged} from 'redux-offline/lib/actions';
+import {Client4} from 'mattermost-redux/client';
+
 import {DeviceTypes} from 'app/constants';
 
 export function connection(isOnline) {
-    return async (dispatch, getState) => {
+    return async (dispatch) => {
+        Client4.setOnline(isOnline);
+        dispatch(networkStatusChanged(isOnline));
         dispatch({
             type: DeviceTypes.CONNECTION_CHANGED,
             data: isOnline,
-        }, getState);
+        });
     };
 }
 

--- a/app/actions/device/index.js
+++ b/app/actions/device/index.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {networkStatusChanged} from 'redux-offline/lib/actions';
+import {networkStatusChangedAction} from 'redux-offline';
 import {Client4} from 'mattermost-redux/client';
 
 import {DeviceTypes} from 'app/constants';
@@ -9,7 +9,7 @@ import {DeviceTypes} from 'app/constants';
 export function connection(isOnline) {
     return async (dispatch) => {
         Client4.setOnline(isOnline);
-        dispatch(networkStatusChanged(isOnline));
+        dispatch(networkStatusChangedAction(isOnline));
         dispatch({
             type: DeviceTypes.CONNECTION_CHANGED,
             data: isOnline,


### PR DESCRIPTION
#### Summary
While doing some testing I came across the use case that when the app opened and you did not have a connection to the server the offline indicator was showing correctly but when reconnecting manually the redux-offline state wasn't updated nor the online indication in the client so no request could be made, this PR fixes that.