### PR TITLE
Make profile camera icon use theme.centerChannelBg for background

### DIFF
--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -118,7 +118,7 @@ export default class ProfilePicture extends PureComponent {
             statusStyle = {
                 width: this.props.statusSize,
                 height: this.props.statusSize,
-                backgroundColor: 'white',
+                backgroundColor: theme.centerChannelBg,
             };
             statusIcon = (
                 <FontAwesomeIcon


### PR DESCRIPTION
#### Summary
Set the user profile camera icon background to use the `theme.centerChannelBg` instead of `white`.