### PR TITLE
Make post_add_channel_member follow theme text style

### DIFF
--- a/app/components/post_add_channel_member/post_add_channel_member.js
+++ b/app/components/post_add_channel_member/post_add_channel_member.js
@@ -13,6 +13,7 @@ import {concatStyles} from 'app/utils/theme';
 
 import AtMention from 'app/components/at_mention';
 import FormattedText from 'app/components/formatted_text';
+import CustomPropTypes from 'app/constants/custom_prop_types';
 
 export default class PostAddChannelMember extends React.PureComponent {
     static propTypes = {
@@ -21,6 +22,7 @@ export default class PostAddChannelMember extends React.PureComponent {
             removePost: PropTypes.func.isRequired,
             sendAddToChannelEphemeralPost: PropTypes.func.isRequired,
         }).isRequired,
+        baseTextStyle: CustomPropTypes.Style,
         currentUser: PropTypes.object.isRequired,
         channelType: PropTypes.string,
         post: PropTypes.object.isRequired,
@@ -134,7 +136,8 @@ export default class PostAddChannelMember extends React.PureComponent {
     }
 
     render() {
-        const {channelType, postId, usernames} = this.props;
+        const {channelType, baseTextStyle, postId, usernames} = this.props;
+
         if (!postId || !channelType) {
             return null;
         }
@@ -168,6 +171,7 @@ export default class PostAddChannelMember extends React.PureComponent {
                 <FormattedText
                     id={messageId}
                     defaultMessage={messageText}
+                    style={baseTextStyle}
                 />
                 <Text
                     style={this.props.textStyles.link}
@@ -182,6 +186,7 @@ export default class PostAddChannelMember extends React.PureComponent {
                 <FormattedText
                     id={'post_body.check_for_out_of_channel_mentions.message_last'}
                     defaultMessage={'? They will have access to all message history.'}
+                    style={baseTextStyle}
                 />
             </Text>
         );

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -233,7 +233,7 @@ export default class PostBody extends PureComponent {
         }
     };
 
-    renderAddChannelMember = (style, textStyles) => {
+    renderAddChannelMember = (style, messageStyle, textStyles) => {
         const {onPermalinkPress, onPress, postProps} = this.props;
 
         if (!PostAddChannelMember) {
@@ -244,6 +244,7 @@ export default class PostBody extends PureComponent {
             <View style={style.row}>
                 <View style={style.flex}>
                     <PostAddChannelMember
+                        baseTextStyle={messageStyle}
                         navigator={navigator}
                         onLongPress={this.showOptionsContext}
                         onPermalinkPress={onPermalinkPress}
@@ -440,7 +441,7 @@ export default class PostBody extends PureComponent {
             );
             body = (<View>{messageComponent}</View>);
         } else if (isPostAddChannelMember) {
-            messageComponent = this.renderAddChannelMember(style, textStyles);
+            messageComponent = this.renderAddChannelMember(style, messageStyle, textStyles);
         } else if (postType === Posts.POST_TYPES.COMBINED_USER_ACTIVITY) {
             const {allUserIds, allUsernames, messageData} = postProps.user_activity;
             messageComponent = (


### PR DESCRIPTION
#### Summary
Makes the add user system message use the text styles from the theme.

#### Screenshots
Without theme text styles:
![image](https://user-images.githubusercontent.com/5090577/44685199-c1530c00-a9ff-11e8-8861-a20ad9295b00.png)


With theme text styles:
![image](https://user-images.githubusercontent.com/5090577/44685152-9a94d580-a9ff-11e8-9e2b-c9018d7c4c89.png)