### PR TITLE
Keep server version after cache clear

### DIFF
--- a/app/store/index.js
+++ b/app/store/index.js
@@ -245,6 +245,10 @@ export default function configureAppStore(initialState) {
                             type: ViewTypes.SERVER_URL_CHANGED,
                             serverUrl: state.entities.general.credentials.url || state.views.selectServer.serverUrl,
                         },
+                        {
+                            type: GeneralTypes.RECEIVED_SERVER_VERSION,
+                            data: state.entities.general.serverVersion,
+                        },
                     ], 'BATCH_FOR_RESTART'));
 
                     setTimeout(() => {


### PR DESCRIPTION
#### Summary
After a user clears their cache, settings like Timezone that depend on a specific server version do not show until the user kills the app and restarts. This PR solves that issue by keeping the serverVersion around during the cache clear.