### PR TITLE
Make sure team is passed to initial getProfilesInTeam call

### DIFF
--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -212,7 +212,7 @@ class MoreDirectMessages extends PureComponent {
             return this.props.actions.getProfiles(page, General.PROFILE_CHUNK_SIZE);
         }
 
-        return this.props.actions.getProfilesInTeam(page, General.PROFILE_CHUNK_SIZE);
+        return this.props.actions.getProfilesInTeam(this.props.currentTeamId, page, General.PROFILE_CHUNK_SIZE);
     };
 
     searchProfiles = (term) => {


### PR DESCRIPTION
#### Summary
When opening the more_dms modal screen if `this.props.config.RestrictDirectMessage !== General.RESTRICT_DIRECT_MESSAGE_ANY` a blank screen is shown instead of a list of users(most noticeable after a cache clear). This is because the request fails due the `currentTeamId` not being passed in. This PR solves that issue by making sure that the teamId is passed to the `getProfilesInTeam` call.