### PR TITLE
Gracefully handle http and https redirection

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -319,7 +319,7 @@ export default class SelectServer extends PureComponent {
         });
     };
 
-    pingServer = (url, retryWithHttp = false) => {
+    pingServer = (url, retryWithHttp = true) => {
         const {
             getPing,
             handleServerUrlChanged,

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -14,7 +14,7 @@ export function isValidUrl(url = '') {
 }
 
 export function stripTrailingSlashes(url = '') {
-    return url.trim().replace(/\/+$/, '');
+    return url.replace(/ /g, '').replace(/^\/+/, '').replace(/\/+$/, '');
 }
 
 export function removeProtocol(url = '') {

--- a/app/utils/url.test.js
+++ b/app/utils/url.test.js
@@ -61,4 +61,29 @@ describe('UrlUtils', () => {
             });
         }
     });
+
+    describe('stripTrailingSlashes', () => {
+        it('should return the same url', () => {
+            const url = 'https://www.youtube.com/watch?v=zrFWrmPgfzc&feature=youtu.be';
+            expect(UrlUtils.stripTrailingSlashes(url)).toEqual(url);
+        });
+
+        it('should return an url without the initial //', () => {
+            const url = '//www.youtube.com/watch?v=zrFWrmPgfzc&feature=youtu.be';
+            const expected = 'www.youtube.com/watch?v=zrFWrmPgfzc&feature=youtu.be';
+            expect(UrlUtils.stripTrailingSlashes(url)).toEqual(expected);
+        });
+
+        it('should return an url without the initial // and the lasts ////', () => {
+            const url = '//www.youtube.com/watch?v=zrFWrmPgfzc&feature=youtu.be////';
+            const expected = 'www.youtube.com/watch?v=zrFWrmPgfzc&feature=youtu.be';
+            expect(UrlUtils.stripTrailingSlashes(url)).toEqual(expected);
+        });
+
+        it('should return an url without the initial // and the lasts //// or spaces', () => {
+            const url = 'https: //www .y o u t u be .co m/watch   ?v=z r FW r mP gf zc& fe atu r e = you  tu .be////';
+            const expected = 'https://www.youtube.com/watch?v=zrFWrmPgfzc&feature=youtu.be';
+            expect(UrlUtils.stripTrailingSlashes(url)).toEqual(expected);
+        });
+    });
 });


### PR DESCRIPTION
#### Summary
This PR does a few things
1. When connecting to a server if there is no protocol we will try to connect first using `https` and then `http`
2. When connecting to a server using the protocol `http` we will try to first connect with `https`
3. SSO login will get the cookie based on the last redirected URL thus getting rid of the `{status: "OK"}` message that was preventing the login
4. Just in case we are going to handle `http` to `https` redirection when connecting to a server with `Forward80to443` enabled

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11587
https://mattermost.atlassian.net/browse/MM-11778