### PR TITLE
MM-11270: Disallow to react to posts in archived channels

### DIFF
--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -38,7 +38,9 @@ function mapStateToProps(state, ownProps) {
     const teamId = channel.team_id;
 
     let canAddReaction = true;
-    if (hasNewPermissions(state)) {
+    if (channelIsArchived) {
+        canAddReaction = false;
+    } else if (hasNewPermissions(state)) {
         canAddReaction = haveIChannelPermission(state, {
             team: teamId,
             channel: post.channel_id,


### PR DESCRIPTION
#### Summary
Disallow in the interface to react to any archived channel. (The remove
reaction part was already implemented).

#### Ticket Link
[MM-11270](https://mattermost.atlassian.net/browse/11270)

#### Device Information
This PR was tested on: [Android 8.1] 