### PR TITLE
MM-11449 Show OpenGraph previews for pages with any of the required fields

### DIFF
--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -168,7 +168,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
         const {isReplyPost, openGraphData, theme} = this.props;
         const {hasImage, height, imageUrl, width} = this.state;
 
-        if (!openGraphData || !openGraphData.url) {
+        if (!openGraphData) {
             return null;
         }
 
@@ -210,7 +210,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
                             numberOfLines={3}
                             ellipsizeMode='tail'
                         >
-                            {openGraphData.title}
+                            {openGraphData.title || openGraphData.url}
                         </Text>
                     </TouchableOpacity>
                 </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10178,8 +10178,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#45ae4849c2810b56cb5a420fb7d49d2621145969",
-      "from": "github:mattermost/mattermost-redux#45ae4849c2810b56cb5a420fb7d49d2621145969",
+      "version": "github:mattermost/mattermost-redux#28be3683bff6ae8c563883bb0ff04d7bd9ea31ee",
+      "from": "github:mattermost/mattermost-redux#28be3683bff6ae8c563883bb0ff04d7bd9ea31ee",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",
@@ -10806,7 +10806,6 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -12115,8 +12114,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "216113.0.3",
-    "mattermost-redux": "github:mattermost/mattermost-redux#45ae4849c2810b56cb5a420fb7d49d2621145969",
+    "mattermost-redux": "github:mattermost/mattermost-redux#28be3683bff6ae8c563883bb0ff04d7bd9ea31ee",
     "mime-db": "1.33.0",
     "prop-types": "15.6.1",
     "react": "16.3.2",


### PR DESCRIPTION
mattermost-redux will no longer save the OpenGraph data if it isn't valid, so we don't need to check it in the render function

Required redux changes: https://github.com/mattermost/mattermost-redux/pull/619

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11449
