### PR TITLE
MM-11718: Show only non-archived channels on Share

### DIFF
--- a/share_extension/android/extension_channels/extension_channels.js
+++ b/share_extension/android/extension_channels/extension_channels.js
@@ -59,6 +59,10 @@ export default class ExtensionTeam extends PureComponent {
             publicChannels: publicFiltered,
         } = this.props;
 
+        directFiltered = directFiltered.filter((c) => c.delete_at === 0);
+        privateFiletered = privateFiletered.filter((c) => c.delete_at === 0);
+        publicFiltered = publicFiltered.filter((c) => c.delete_at === 0);
+
         if (term) {
             directFiltered = directFiltered.filter((c) => c.display_name.toLowerCase().includes(term.toLowerCase()));
             privateFiletered = privateFiletered.filter((c) => c.display_name.toLowerCase().includes(term.toLowerCase()));

--- a/share_extension/android/extension_post/index.js
+++ b/share_extension/android/extension_post/index.js
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 
-import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel, getDefaultChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -16,9 +16,13 @@ function mapStateToProps(state) {
     const config = getConfig(state);
     const {credentials} = state.entities.general;
     const {token, url} = credentials;
+    let channel = getCurrentChannel(state);
+    if (channel.delete_at !== 0) {
+        channel = getDefaultChannel(state);
+    }
 
     return {
-        channelId: getCurrentChannelId(state),
+        channelId: channel.id,
         currentUserId: getCurrentUserId(state),
         maxFileSize: getAllowedServerMaxFileSize(config),
         teamId: getCurrentTeamId(state),

--- a/share_extension/ios/extension_channels.js
+++ b/share_extension/ios/extension_channels.js
@@ -53,7 +53,7 @@ export default class ExtensionChannels extends PureComponent {
 
         channels.forEach((channel) => {
             const include = term ? channel.display_name.toLowerCase().includes(term.toLowerCase()) : true;
-            if (channel.display_name && include) {
+            if (channel.display_name && include && channel.delete_at === 0) {
                 switch (channel.type) {
                 case General.OPEN_CHANNEL:
                     publicChannels.push(channel);

--- a/share_extension/ios/extension_post.js
+++ b/share_extension/ios/extension_post.js
@@ -22,7 +22,7 @@ import RNFetchBlob from 'rn-fetch-blob';
 
 import {Client4} from 'mattermost-redux/client';
 import {General} from 'mattermost-redux/constants';
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getDefaultChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getFormattedFileSize, lookupMimeType} from 'mattermost-redux/utils/file_utils';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
@@ -235,6 +235,10 @@ export default class ExtensionPost extends PureComponent {
 
                 if (channel && (channel.type === General.GM_CHANNEL || channel.type === General.DM_CHANNEL)) {
                     channel = getChannel({entities}, channel.id);
+                }
+
+                if (channel.delete_at !== 0) {
+                    channel = getDefaultChannel({entities});
                 }
 
                 for (let i = 0; i < items.length; i++) {


### PR DESCRIPTION
#### Summary
Show only non-archived channels on Share, and if you share being in a
archived channel, the proposed channel become Town Square instead of
your current channel.

#### Ticket Link
[MM-11718](https://mattermost.atlassian.net/browse/11718)

#### Device Information
This PR was tested on: [One Plus 5, Android 8.1] 

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]