### PR TITLE
MM-11728: Reload channel on archived channel errors (on edit and archive channel)

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -29,6 +29,7 @@ export default class ChannelInfo extends PureComponent {
             closeGMChannel: PropTypes.func.isRequired,
             deleteChannel: PropTypes.func.isRequired,
             getChannelStats: PropTypes.func.isRequired,
+            getChannel: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired,
             loadChannelsByTeamName: PropTypes.func.isRequired,
             favoriteChannel: PropTypes.func.isRequired,
@@ -202,6 +203,9 @@ export default class ChannelInfo extends PureComponent {
                             displayName: channel.display_name,
                         }
                     );
+                    if (result.error.server_error_id === 'api.channel.delete_channel.deleted.app_error') {
+                        this.props.actions.getChannel(channel.id);
+                    }
                 } else {
                     this.close();
                 }

--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -7,6 +7,7 @@ import {connect} from 'react-redux';
 import {
     favoriteChannel,
     getChannelStats,
+    getChannel,
     deleteChannel,
     unfavoriteChannel,
     updateChannelNotifyProps,
@@ -89,6 +90,7 @@ function mapDispatchToProps(dispatch) {
             closeGMChannel,
             deleteChannel,
             getChannelStats,
+            getChannel,
             leaveChannel,
             loadChannelsByTeamName,
             favoriteChannel,

--- a/app/screens/edit_channel/edit_channel.js
+++ b/app/screens/edit_channel/edit_channel.js
@@ -52,6 +52,7 @@ export default class EditChannel extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
             patchChannel: PropTypes.func.isRequired,
+            getChannel: PropTypes.func.isRequired,
             setChannelDisplayName: PropTypes.func.isRequired,
         }),
         navigator: PropTypes.object.isRequired,
@@ -204,7 +205,7 @@ export default class EditChannel extends PureComponent {
         return {error: formatMessage(messages.name_lowercase)};
     };
 
-    onUpdateChannel = () => {
+    onUpdateChannel = async () => {
         Keyboard.dismiss();
         const {displayName, channelURL, purpose, header} = this.state;
         const {channel: {id, type}} = this.props;
@@ -230,7 +231,10 @@ export default class EditChannel extends PureComponent {
             }
         }
 
-        this.props.actions.patchChannel(id, channel);
+        const data = await this.props.actions.patchChannel(id, channel);
+        if (data.error && data.error.server_error_id === 'store.sql_channel.update.archived_channel.app_error') {
+            this.props.actions.getChannel(id);
+        }
     };
 
     onNavigatorEvent = (event) => {

--- a/app/screens/edit_channel/index.js
+++ b/app/screens/edit_channel/index.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamUrl} from 'mattermost-redux/selectors/entities/teams';
-import {patchChannel} from 'mattermost-redux/actions/channels';
+import {patchChannel, getChannel} from 'mattermost-redux/actions/channels';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {setChannelDisplayName} from 'app/actions/views/channel';
@@ -33,6 +33,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             patchChannel,
+            getChannel,
             setChannelDisplayName,
         }, dispatch),
     };


### PR DESCRIPTION
#### Summary
Reload channel on archived channel errors (on edit and archive channel).
When you are seing an archived channel and don't have the connection
active, you can miss the websocket event for mark the channel as
deleted. So you will see the channel in normal state. This will reload
the channel when the server returns the fail on edition or when you try
to archive the channel.

#### Ticket Link
[MM-11728](https://mattermost.atlassian.net/browse/11728)

#### Device Information
This PR was tested on: [One Plus 5, Android 8.1]