### PR TITLE
bug fix: use user's timezone setting for search date flags

### DIFF
--- a/app/screens/search/index.js
+++ b/app/screens/search/index.js
@@ -10,11 +10,14 @@ import {getCurrentChannelId, filterPostIds} from 'mattermost-redux/selectors/ent
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
+import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {loadChannelsByTeamName, loadThreadIfNecessary} from 'app/actions/views/channel';
 import {isLandscape} from 'app/selectors/device';
 import {makePreparePostIdsForSearchPosts} from 'app/selectors/post_list';
 import {handleSearchDraftChanged} from 'app/actions/views/search';
+import {getDeviceUtcOffset, getUtcOffsetForTimeZone, isTimezoneEnabled} from 'app/utils/timezone';
 
 import Search from './search';
 
@@ -30,6 +33,11 @@ function makeMapStateToProps() {
         const {recent} = state.entities.search;
         const {searchPosts: searchRequest} = state.requests.search;
 
+        const currentUser = getCurrentUser(state);
+        const enableTimezone = isTimezoneEnabled(state);
+        const userCurrentTimezone = enableTimezone ? getUserCurrentTimezone(currentUser.timezone) : '';
+        const timezoneOffsetInSeconds = (userCurrentTimezone.length > 0 ? getUtcOffsetForTimeZone(userCurrentTimezone) : getDeviceUtcOffset()) * 60;
+
         const serverVersion = state.entities.general.serverVersion;
         const enableDateSuggestion = isMinimumServerVersion(serverVersion, 5, 3);
 
@@ -43,6 +51,7 @@ function makeMapStateToProps() {
             searchingStatus: searchRequest.status,
             theme: getTheme(state),
             enableDateSuggestion,
+            timezoneOffsetInSeconds,
         };
     };
 }

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -31,7 +31,6 @@ import SearchBar from 'app/components/search_bar';
 import StatusBar from 'app/components/status_bar';
 import mattermostManaged from 'app/mattermost_managed';
 import {preventDoubleTap} from 'app/utils/tap';
-import {getDeviceUtcOffset} from 'app/utils/timezone';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import ChannelDisplayName from './channel_display_name';
@@ -65,6 +64,7 @@ export default class Search extends PureComponent {
         searchingStatus: PropTypes.string,
         theme: PropTypes.object.isRequired,
         enableDateSuggestion: PropTypes.bool,
+        timezoneOffsetInSeconds: PropTypes.number.isRequired,
     };
 
     static defaultProps = {
@@ -469,8 +469,7 @@ export default class Search extends PureComponent {
         });
 
         // timezone offset in seconds
-        const timeZoneOffset = getDeviceUtcOffset() * 60;
-        actions.searchPostsWithParams(currentTeamId, {terms: terms.trim(), is_or_search: isOrSearch, time_zone_offset: timeZoneOffset}, true);
+        actions.searchPostsWithParams(currentTeamId, {terms: terms.trim(), is_or_search: isOrSearch, time_zone_offset: this.props.timezoneOffsetInSeconds}, true);
     };
 
     handleSearchButtonPress = preventDoubleTap((text) => {

--- a/app/utils/timezone.js
+++ b/app/utils/timezone.js
@@ -5,13 +5,18 @@ import DeviceInfo from 'react-native-device-info';
 
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
+import moment from 'moment-timezone';
+
 export function getDeviceTimezone() {
     return DeviceInfo.getTimezone();
 }
 
 export function getDeviceUtcOffset() {
-    const reverseOffsetInMinutes = new Date().getTimezoneOffset();
-    return -reverseOffsetInMinutes;
+    return moment().utcOffset();
+}
+
+export function getUtcOffsetForTimeZone(timezone) {
+    return moment.tz(timezone).utcOffset();
 }
 
 export function isTimezoneEnabled(state) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10545,8 +10545,15 @@
     "moment": {
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
-      "dev": true
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "morgan": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jsc-android": "216113.0.3",
     "mattermost-redux": "github:mattermost/mattermost-redux#28be3683bff6ae8c563883bb0ff04d7bd9ea31ee",
     "mime-db": "1.33.0",
+    "moment-timezone": "0.5.21",
     "prop-types": "15.6.1",
     "react": "16.3.2",
     "react-intl": "2.4.0",


### PR DESCRIPTION
#### Summary
when retrieving the timezone to pass to the server during a date flag search (on: before: after:) check user's settings and use their selected timezone if present instead of the browser's timezone

#### Ticket Link
N/A

#### Checklist
N/A

#### Device Information
This PR was tested on: [iOS Simulator, OS 11.4] 

#### Screenshots
N/A
