### PR TITLE
Fix Posts cutoff

### DIFF
--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
     Image,
+    PixelRatio,
     Platform,
     StyleSheet,
     Text,
@@ -106,7 +107,7 @@ export default class Emoji extends React.PureComponent {
         if (!size && textStyle) {
             const flatten = StyleSheet.flatten(textStyle);
             fontSize = flatten.fontSize;
-            size = fontSize;
+            size = fontSize * (Platform.OS === 'android' ? PixelRatio.get() : 1);
         }
 
         if (displayTextOnly) {
@@ -116,6 +117,16 @@ export default class Emoji extends React.PureComponent {
         const width = size;
         const height = size;
 
+        let marginTop = 0;
+        if (textStyle) {
+            // hack to get the vertical alignment looking better
+            if (fontSize > 16) {
+                marginTop -= 2;
+            } else if (fontSize <= 16) {
+                marginTop += 1;
+            }
+        }
+
         // Android can't change the size of an image after its first render, so
         // force a new image to be rendered when the size changes
         const key = Platform.OS === 'android' ? (height + '-' + width) : null;
@@ -124,7 +135,7 @@ export default class Emoji extends React.PureComponent {
             return (
                 <Image
                     key={key}
-                    style={{width, height}}
+                    style={{width, height, marginTop}}
                 />
             );
         }
@@ -132,7 +143,7 @@ export default class Emoji extends React.PureComponent {
         return (
             <Image
                 key={key}
-                style={{width, height}}
+                style={{width, height, marginTop}}
                 source={{uri: imageUrl}}
                 onError={this.onError}
             />

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
     Image,
-    PixelRatio,
     Platform,
     StyleSheet,
     Text,
@@ -13,13 +12,6 @@ import {
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
 import ImageCacheManager from 'app/utils/image_cache_manager';
-
-const scaleEmojiBasedOnDevice = (size) => {
-    if (Platform.OS === 'ios') {
-        return size * 1.1; // slightly larger emojis look better on ios
-    }
-    return size * PixelRatio.get();
-};
 
 export default class Emoji extends React.PureComponent {
     static propTypes = {
@@ -60,30 +52,28 @@ export default class Emoji extends React.PureComponent {
 
         this.state = {
             imageUrl: null,
-            originalWidth: 0,
-            originalHeight: 0,
         };
     }
 
     componentWillMount() {
+        const {displayTextOnly, imageUrl} = this.props;
         this.mounted = true;
-        if (!this.props.displayTextOnly && this.props.imageUrl) {
-            ImageCacheManager.cache(this.props.imageUrl, this.props.imageUrl, this.updateImageHeight);
+        if (!displayTextOnly && imageUrl) {
+            ImageCacheManager.cache(imageUrl, imageUrl, this.setImageUrl);
         }
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.emojiName !== this.props.emojiName) {
+        const {displayTextOnly, emojiName, imageUrl} = nextProps;
+        if (emojiName !== this.props.emojiName) {
             this.setState({
                 imageUrl: null,
-                originalWidth: 0,
-                originalHeight: 0,
             });
         }
 
-        if (!nextProps.displayTextOnly && nextProps.imageUrl &&
-                nextProps.imageUrl !== this.props.imageUrl) {
-            ImageCacheManager.cache(nextProps.imageUrl, nextProps.imageUrl, this.updateImageHeight);
+        if (!displayTextOnly && imageUrl &&
+                imageUrl !== this.props.imageUrl) {
+            ImageCacheManager.cache(imageUrl, imageUrl, this.setImageUrl);
         }
     }
 
@@ -91,21 +81,15 @@ export default class Emoji extends React.PureComponent {
         this.mounted = false;
     }
 
-    updateImageHeight = (imageUrl) => {
+    setImageUrl = (imageUrl) => {
         let prefix = '';
         if (Platform.OS === 'android') {
             prefix = 'file://';
         }
 
         const uri = `${prefix}${imageUrl}`;
-        Image.getSize(uri, (originalWidth, originalHeight) => {
-            if (this.mounted) {
-                this.setState({
-                    imageUrl: uri,
-                    originalWidth,
-                    originalHeight,
-                });
-            }
+        this.setState({
+            imageUrl: uri,
         });
     };
 
@@ -122,36 +106,15 @@ export default class Emoji extends React.PureComponent {
         if (!size && textStyle) {
             const flatten = StyleSheet.flatten(textStyle);
             fontSize = flatten.fontSize;
-            size = scaleEmojiBasedOnDevice(fontSize);
+            size = fontSize;
         }
 
         if (displayTextOnly) {
             return <Text style={textStyle}>{literal}</Text>;
         }
 
-        let width = size;
-        let height = size;
-        let {originalHeight, originalWidth} = this.state;
-        originalHeight = scaleEmojiBasedOnDevice(originalHeight);
-        originalWidth = scaleEmojiBasedOnDevice(originalWidth);
-        if (originalHeight && originalWidth) {
-            if (originalWidth > originalHeight) {
-                height = (size * originalHeight) / originalWidth;
-            } else if (originalWidth < originalHeight) {
-                // This may cause text to reflow, but its impossible to add a horizontal margin
-                width = (size * originalWidth) / originalHeight;
-            }
-        }
-
-        let marginTop = 0;
-        if (textStyle) {
-            // hack to get the vertical alignment looking better
-            if (fontSize > 16) {
-                marginTop -= 2;
-            } else if (fontSize <= 16) {
-                marginTop += 1;
-            }
-        }
+        const width = size;
+        const height = size;
 
         // Android can't change the size of an image after its first render, so
         // force a new image to be rendered when the size changes
@@ -161,7 +124,7 @@ export default class Emoji extends React.PureComponent {
             return (
                 <Image
                     key={key}
-                    style={{width, height, marginTop}}
+                    style={{width, height}}
                 />
             );
         }
@@ -169,7 +132,7 @@ export default class Emoji extends React.PureComponent {
         return (
             <Image
                 key={key}
-                style={{width, height, marginTop}}
+                style={{width, height}}
                 source={{uri: imageUrl}}
                 onError={this.onError}
             />

--- a/app/components/emoji_picker/emoji_picker.js
+++ b/app/components/emoji_picker/emoji_picker.js
@@ -407,6 +407,7 @@ export default class EmojiPicker extends PureComponent {
                     renderItem={this.flatListRenderItem}
                     pageSize={10}
                     initialListSize={10}
+                    removeClippedSubviews={true}
                 />
             );
         } else {
@@ -558,6 +559,7 @@ const getStyleSheetFromTheme = makeStyleSheetFromTheme((theme) => {
             borderLeftColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderRightWidth: 1,
             borderRightColor: changeOpacity(theme.centerChannelColor, 0.2),
+            overflow: 'hidden',
         },
         listView: {
             backgroundColor: theme.centerChannelBg,

--- a/app/components/emoji_picker/emoji_picker_row.js
+++ b/app/components/emoji_picker/emoji_picker_row.js
@@ -64,7 +64,7 @@ export default class EmojiPickerRow extends Component {
                 />
             </TouchableOpacity>
         );
-    }
+    };
 
     render() {
         const {emojiGutter, items} = this.props;
@@ -86,6 +86,7 @@ const styles = StyleSheet.create({
     emoji: {
         alignItems: 'center',
         justifyContent: 'center',
+        overflow: 'hidden',
     },
     emojiLeft: {
         marginLeft: 0,

--- a/app/components/options_context/options_context.android.js
+++ b/app/components/options_context/options_context.android.js
@@ -8,7 +8,7 @@ import RNBottomSheet from 'react-native-bottom-sheet';
 
 export default class OptionsContext extends PureComponent {
     static propTypes = {
-        actions: PropTypes.array,
+        getPostActions: PropTypes.func,
         cancelText: PropTypes.string,
         children: PropTypes.node.isRequired,
         onPress: PropTypes.func.isRequired,
@@ -16,13 +16,13 @@ export default class OptionsContext extends PureComponent {
     };
 
     static defaultProps = {
-        actions: [],
+        getPostActions: () => [],
         cancelText: 'Cancel',
     };
 
     show = (additionalAction) => {
-        const {actions, cancelText} = this.props;
-        const nextActions = [...actions];
+        const {getPostActions, cancelText} = this.props;
+        const nextActions = getPostActions();
         if (additionalAction && !additionalAction.nativeEvent && additionalAction.text) {
             const copyPostIndex = nextActions.findIndex((action) => action.copyPost);
             nextActions.splice(copyPostIndex + 1, 0, additionalAction);
@@ -45,11 +45,11 @@ export default class OptionsContext extends PureComponent {
     };
 
     handleHideUnderlay = () => {
-        this.props.toggleSelected(false, this.props.actions.length > 0);
+        this.props.toggleSelected(false, this.props.getPostActions().length > 0);
     };
 
     handleShowUnderlay = () => {
-        this.props.toggleSelected(true, this.props.actions.length > 0);
+        this.props.toggleSelected(true, this.props.getPostActions().length > 0);
     };
 
     render() {

--- a/app/components/options_context/options_context.ios.js
+++ b/app/components/options_context/options_context.ios.js
@@ -8,14 +8,14 @@ import ToolTip from 'app/components/tooltip';
 
 export default class OptionsContext extends PureComponent {
     static propTypes = {
-        actions: PropTypes.array,
+        getPostActions: PropTypes.func,
         children: PropTypes.node.isRequired,
         onPress: PropTypes.func.isRequired,
         toggleSelected: PropTypes.func.isRequired,
     };
 
     static defaultProps = {
-        actions: [],
+        getPostActions: () => [],
         additionalActions: [],
     };
 
@@ -23,14 +23,8 @@ export default class OptionsContext extends PureComponent {
         super(props);
 
         this.state = {
-            actions: props.actions,
+            actions: props.getPostActions(),
         };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        if (this.props.actions !== nextProps.actions) {
-            this.setState({actions: nextProps.actions});
-        }
     }
 
     handleHideUnderlay = () => {
@@ -45,11 +39,11 @@ export default class OptionsContext extends PureComponent {
 
     handleHide = () => {
         this.isShowing = false;
-        this.props.toggleSelected(false, this.props.actions.length > 0);
+        this.props.toggleSelected(false, this.props.getPostActions().length > 0);
     };
 
     handleShow = () => {
-        this.isShowing = this.props.actions.length > 0;
+        this.isShowing = this.props.getPostActions().length > 0;
         this.props.toggleSelected(true, this.isShowing);
     };
 
@@ -59,12 +53,12 @@ export default class OptionsContext extends PureComponent {
         }
 
         this.setState({
-            actions: this.props.actions,
+            actions: this.props.getPostActions(),
         });
     };
 
     show = (additionalAction) => {
-        const nextActions = [...this.props.actions];
+        const nextActions = this.props.getPostActions();
         if (additionalAction && additionalAction.text && !additionalAction.nativeEvent) {
             const copyPostIndex = nextActions.findIndex((action) => action.copyPost);
             nextActions.splice(copyPostIndex + 1, 0, additionalAction);
@@ -80,7 +74,7 @@ export default class OptionsContext extends PureComponent {
     };
 
     handlePress = () => {
-        this.props.toggleSelected(false, this.props.actions.length > 0);
+        this.props.toggleSelected(false, this.props.getPostActions().length > 0);
         this.props.onPress();
     };
 

--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -90,7 +90,7 @@ function makeMapStateToProps() {
             if (canEdit && license.IsLicensed === 'true' &&
                 (config.AllowEditPost === General.ALLOW_EDIT_POST_TIME_LIMIT || (config.PostEditTimeLimit !== -1 && config.PostEditTimeLimit !== '-1'))
             ) {
-                canEditUntil = post.create_at + (config.PostEditTimeLimit * 1000) + 1000;
+                canEditUntil = post.create_at + (config.PostEditTimeLimit * 1000);
             }
         }
 

--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {createPost, deletePost, removePost} from 'mattermost-redux/actions/posts';
+import {General, Posts} from 'mattermost-redux/constants';
 import {getCurrentChannelId, isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 import {getPost, makeGetCommentCountForPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId, getCurrentUserRoles} from 'mattermost-redux/selectors/entities/users';
@@ -16,8 +17,6 @@ import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general
 
 import {insertToDraft, setPostTooltipVisible} from 'app/actions/views/channel';
 import {addReaction} from 'app/actions/views/emoji';
-import {getDimensions} from 'app/selectors/device';
-import {Posts} from 'mattermost-redux/constants';
 
 import Post from './post';
 
@@ -78,33 +77,36 @@ function makeMapStateToProps() {
                 }
             }
         }
-        const {deviceWidth} = getDimensions(state);
 
         const isAdmin = checkIsAdmin(roles);
         const isSystemAdmin = checkIsSystemAdmin(roles);
 
         let canDelete = false;
         let canEdit = false;
+        let canEditUntil = -1;
         if (post) {
             canDelete = canDeletePost(state, config, license, currentTeamId, currentChannelId, currentUserId, post, isAdmin, isSystemAdmin);
             canEdit = canEditPost(state, config, license, currentTeamId, currentChannelId, currentUserId, post);
+            if (canEdit && license.IsLicensed === 'true' &&
+                (config.AllowEditPost === General.ALLOW_EDIT_POST_TIME_LIMIT || (config.PostEditTimeLimit !== -1 && config.PostEditTimeLimit !== '-1'))
+            ) {
+                canEditUntil = post.create_at + (config.PostEditTimeLimit * 1000) + 1000;
+            }
         }
 
         return {
             channelIsReadOnly: isCurrentChannelReadOnly(state),
-            config,
             canDelete,
             canEdit,
+            canEditUntil,
             currentTeamUrl: getCurrentTeamUrl(state),
             currentUserId,
-            deviceWidth,
             post,
             isFirstReply,
             isLastReply,
             consecutivePost: isConsecutivePost(state, ownProps),
             hasComments: getCommentCountForPost(state, {post}) > 0,
             commentedOnPost,
-            license,
             theme: getTheme(state),
             isFlagged: isPostFlagged(post.id, myPreferences),
         };

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -25,9 +25,8 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 import {getToolTipVisible} from 'app/utils/tooltip';
 
 import {Posts} from 'mattermost-redux/constants';
-import DelayedAction from 'mattermost-redux/utils/delayed_action';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
-import {editDisable, isPostEphemeral, isPostPendingOrFailed, isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {isPostEphemeral, isPostPendingOrFailed, isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import Config from 'assets/config';
 
@@ -41,10 +40,8 @@ export default class Post extends PureComponent {
             removePost: PropTypes.func.isRequired,
         }).isRequired,
         channelIsReadOnly: PropTypes.bool,
-        config: PropTypes.object.isRequired,
         currentTeamUrl: PropTypes.string.isRequired,
         currentUserId: PropTypes.string.isRequired,
-        deviceWidth: PropTypes.number.isRequired,
         highlight: PropTypes.bool,
         style: ViewPropTypes.style,
         post: PropTypes.object,
@@ -56,10 +53,10 @@ export default class Post extends PureComponent {
         hasComments: PropTypes.bool,
         isSearchResult: PropTypes.bool,
         commentedOnPost: PropTypes.object,
-        license: PropTypes.object.isRequired,
         managedConfig: PropTypes.object.isRequired,
         navigator: PropTypes.object,
         canEdit: PropTypes.bool.isRequired,
+        canEditUntil: PropTypes.number.isRequired,
         canDelete: PropTypes.bool.isRequired,
         onPermalinkPress: PropTypes.func,
         shouldRenderReplyButton: PropTypes.bool,
@@ -82,37 +79,6 @@ export default class Post extends PureComponent {
     static contextTypes = {
         intl: intlShape.isRequired,
     };
-
-    constructor(props) {
-        super(props);
-
-        const {config, license, currentUserId, post} = props;
-        this.editDisableAction = new DelayedAction(this.handleEditDisable);
-        if (post) {
-            editDisable(config, license, currentUserId, post, this.editDisableAction);
-        }
-        this.state = {
-            canEdit: this.props.canEdit,
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.config !== this.props.config ||
-            nextProps.license !== this.props.license ||
-            nextProps.currentUserId !== this.props.currentUserId ||
-            nextProps.post !== this.props.post) {
-            const {config, license, currentUserId, post} = nextProps;
-
-            editDisable(config, license, currentUserId, post, this.editDisableAction);
-            this.setState({
-                canEdit: nextProps.canEdit,
-            });
-        }
-    }
-
-    componentWillUnmount() {
-        this.editDisableAction.cancel();
-    }
 
     goToUserProfile = () => {
         const {intl} = this.context;
@@ -165,7 +131,6 @@ export default class Post extends PureComponent {
                 text: formatMessage({id: 'post_info.del', defaultMessage: 'Delete'}),
                 style: 'destructive',
                 onPress: () => {
-                    this.editDisableAction.cancel();
                     actions.deletePost(post);
                     if (post.user_id === currentUserId) {
                         actions.removePost(post);
@@ -479,7 +444,8 @@ export default class Post extends PureComponent {
                         <PostBody
                             ref={'postBody'}
                             canDelete={this.props.canDelete}
-                            canEdit={this.state.canEdit}
+                            canEdit={this.props.canEdit}
+                            canEditUntil={this.props.canEditUntil}
                             highlight={highlight}
                             channelIsReadOnly={channelIsReadOnly}
                             isSearchResult={isSearchResult}

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -41,6 +41,7 @@ export default class PostBody extends PureComponent {
         canAddReaction: PropTypes.bool,
         canDelete: PropTypes.bool,
         canEdit: PropTypes.bool,
+        canEditUntil: PropTypes.number.isRequired,
         channelIsReadOnly: PropTypes.bool.isRequired,
         fileIds: PropTypes.array,
         hasBeenDeleted: PropTypes.bool,
@@ -120,6 +121,7 @@ export default class PostBody extends PureComponent {
         const {formatMessage} = this.context.intl;
         const {
             canEdit,
+            canEditUntil,
             canDelete,
             canAddReaction,
             channelIsReadOnly,
@@ -169,7 +171,7 @@ export default class PostBody extends PureComponent {
                 }
             }
 
-            if (canEdit) {
+            if (canEdit && (canEditUntil === -1 || canEditUntil > Date.now())) {
                 actions.push({text: formatMessage({id: 'post_info.edit', defaultMessage: 'Edit'}), onPress: onPostEdit});
             }
 
@@ -488,7 +490,7 @@ export default class PostBody extends PureComponent {
             body = (
                 <View style={style.messageBody}>
                     <OptionsContext
-                        actions={this.getPostActions()}
+                        getPostActions={this.getPostActions}
                         ref='options'
                         onPress={onPress}
                         toggleSelected={toggleSelected}

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -215,7 +215,7 @@ export default class PostHeader extends PureComponent {
         }
 
         return (
-            <View>
+            <React.Fragment>
                 <View style={[style.postInfoContainer, (isPendingOrFailedPost && style.pendingPost)]}>
                     <View style={{flexDirection: 'row', flex: 1}}>
                         {this.getDisplayName(style)}
@@ -253,7 +253,7 @@ export default class PostHeader extends PureComponent {
                     {this.renderCommentedOnMessage(style)}
                 </View>
                 }
-            </View>
+            </React.Fragment>
         );
     }
 }

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -234,9 +234,11 @@ export default class PostList extends PureComponent {
             nextConfig = await mattermostManaged.getLocalConfig();
         }
 
-        this.setState({
-            managedConfig: nextConfig,
-        });
+        if (Object.keys(nextConfig).length) {
+            this.setState({
+                managedConfig: nextConfig,
+            });
+        }
     };
 
     keyExtractor = (item) => {

--- a/app/components/post_list/with_layout.js
+++ b/app/components/post_list/with_layout.js
@@ -28,9 +28,10 @@ function withLayout(WrappedComponent) {
         };
 
         render() {
+            const {index, onLayoutCalled, shouldCallOnLayout, ...otherProps} = this.props; //eslint-disable-line no-unused-vars
             return (
                 <View onLayout={this.onLayout}>
-                    <WrappedComponent {...this.props}/>
+                    <WrappedComponent {...otherProps}/>
                 </View>
             );
         }

--- a/app/screens/entry/entry.js
+++ b/app/screens/entry/entry.js
@@ -11,6 +11,7 @@ import {
 
 import DeviceInfo from 'react-native-device-info';
 
+import {setSystemEmojis} from 'mattermost-redux/actions/emojis';
 import {Client4} from 'mattermost-redux/client';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
@@ -56,15 +57,14 @@ const lazyLoadReplyPushNotifications = () => {
  */
 export default class Entry extends PureComponent {
     static propTypes = {
-        config: PropTypes.object,
         theme: PropTypes.object,
         navigator: PropTypes.object,
         isLandscape: PropTypes.bool,
-        hydrationComplete: PropTypes.bool,
         enableTimezone: PropTypes.bool,
         deviceTimezone: PropTypes.string,
         initializeModules: PropTypes.func.isRequired,
         actions: PropTypes.shape({
+            autoUpdateTimezone: PropTypes.func.isRequired,
             setDeviceToken: PropTypes.func.isRequired,
         }).isRequired,
     };
@@ -132,6 +132,7 @@ export default class Entry extends PureComponent {
             this.setAppCredentials();
             this.setStartupThemes();
             this.handleNotification();
+            this.loadSystemEmojis();
 
             if (Platform.OS === 'android') {
                 this.launchForAndroid();
@@ -224,6 +225,11 @@ export default class Entry extends PureComponent {
         } else {
             app.launchApp();
         }
+    };
+
+    loadSystemEmojis = () => {
+        const EmojiIndicesByAlias = require('app/utils/emojis').EmojiIndicesByAlias;
+        setSystemEmojis(EmojiIndicesByAlias);
     };
 
     renderLogin = () => {

--- a/app/screens/entry/index.js
+++ b/app/screens/entry/index.js
@@ -6,7 +6,6 @@ import {connect} from 'react-redux';
 import {setDeviceToken} from 'mattermost-redux/actions/general';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {isLandscape} from 'app/selectors/device';
 import {getDeviceTimezone, isTimezoneEnabled} from 'app/utils/timezone';
@@ -16,16 +15,12 @@ const lazyLoadEntry = () => {
 };
 
 function mapStateToProps(state) {
-    const config = getConfig(state);
-
     const enableTimezone = isTimezoneEnabled(state);
     const deviceTimezone = getDeviceTimezone();
 
     return {
-        config,
         theme: getTheme(state),
         isLandscape: isLandscape(state),
-        hydrationComplete: state.views.root.hydrationComplete,
         enableTimezone,
         deviceTimezone,
     };
@@ -34,8 +29,8 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            setDeviceToken,
             autoUpdateTimezone,
+            setDeviceToken,
         }, dispatch),
     };
 }

--- a/app/utils/why_did_you_update.js
+++ b/app/utils/why_did_you_update.js
@@ -40,10 +40,10 @@ function deepDiff(o1, o2, p) {
   }
 }
 
-function whyDidYouUpdate(prevProps, prevState) {
+function whyDidYouUpdate(theClass, prevProps, prevState) {
     deepDiff({props: prevProps, state: prevState},
-             {props: this.props, state: this.state},
-             this.constructor.name);
+             {props: theClass.props, state: theClass.state},
+        theClass.constructor.name);
 }
 
 export default whyDidYouUpdate;


### PR DESCRIPTION
#### Summary
This PR fixes the text of the posts being cut off in some cases after replying to a post or even after sending a new message in the channel's post list, the main reason was the `PixelRatio` changing the dimension of the emoji's causing a disruption in the post layout.

Other fixes in this PR:
* Post was being re-rendered without need cause of the `config` and `license` props, those props were used to mark the post as it cannot be edited anymore (but that function was actually broken) now we handle the time a post can be edited in a different more effective way.
* Added an `overflow: hidden` to the emoji picker so the `FlatList` and `SectionList` can recycle the Views
* No system emoji's were being added and unnecessary request made to the server that returned an error
* WhyDidYouUpdate util wasn't working so now it uses the element as an argument