### PR TITLE
[MM-11986 & MM-11987] Add bottom margin of 10 to "show more/less button"

### DIFF
--- a/app/components/show_more_button/__snapshots__/show_more_button.test.js.snap
+++ b/app/components/show_more_button/__snapshots__/show_more_button.test.js.snap
@@ -100,6 +100,7 @@ ShallowWrapper {
               "flex": 1,
               "flexDirection": "row",
               "justifyContent": "center",
+              "marginBottom": 10,
               "position": "relative",
               "top": 10,
             }
@@ -291,6 +292,7 @@ ShallowWrapper {
             "flex": 1,
             "flexDirection": "row",
             "justifyContent": "center",
+            "marginBottom": 10,
             "position": "relative",
             "top": 10,
           },
@@ -510,6 +512,7 @@ ShallowWrapper {
                 "flex": 1,
                 "flexDirection": "row",
                 "justifyContent": "center",
+                "marginBottom": 10,
                 "position": "relative",
                 "top": 10,
               }
@@ -701,6 +704,7 @@ ShallowWrapper {
               "flex": 1,
               "flexDirection": "row",
               "justifyContent": "center",
+              "marginBottom": 10,
               "position": "relative",
               "top": 10,
             },

--- a/app/components/show_more_button/show_more_button.js
+++ b/app/components/show_more_button/show_more_button.js
@@ -101,6 +101,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme, showMore) => {
             flexDirection: 'row',
             position: 'relative',
             top: showMore ? -7.5 : 10,
+            marginBottom: 10,
         },
         dividerLeft: {
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.2),


### PR DESCRIPTION
#### Summary
Add bottom margin of 10 to "show more/less button"

#### Ticket Link
Jira ticket: [MM-11986](https://mattermost.atlassian.net/browse/MM-11986) & [MM-11987](https://mattermost.atlassian.net/browse/MM-11987)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: [iPhone and Android simulator/emulator] 

#### Screenshots
iPhone:
![ios long post](https://user-images.githubusercontent.com/5334504/45159878-88464300-b21a-11e8-8dfb-bb0cb87e4fec.png)
![ios message attachment](https://user-images.githubusercontent.com/5334504/45159880-88ded980-b21a-11e8-8712-79bb0b5228d0.png)

Android:
![android long post](https://user-images.githubusercontent.com/5334504/45159885-9005e780-b21a-11e8-83e3-c0e4686d3b22.png)
![android message attachment](https://user-images.githubusercontent.com/5334504/45159886-909e7e00-b21a-11e8-993a-35a12d2efe5e.png)

