### PR TITLE
bug: enable arrows on the calendar for date search flags

### DIFF
--- a/app/components/autocomplete/date_suggestion/date_suggestion.js
+++ b/app/components/autocomplete/date_suggestion/date_suggestion.js
@@ -90,7 +90,7 @@ export default class DateSuggestion extends PureComponent {
                 futureScrollRange={0}
                 scrollingEnabled={true}
                 pagingEnabled={true}
-                hideArrows={true}
+                hideArrows={false}
                 horizontal={true}
                 showScrollIndicator={true}
                 onDayPress={this.completeMention}


### PR DESCRIPTION
#### Summary
bug: enable arrows on the calendar for date search flags

#### Ticket Link
N/A

#### Checklist
N/A

#### Device Information
This PR was tested on: [ios 11.4 iphone 6 simulator] 

#### Screenshots
N/A
