### PR TITLE
Fix warnings in running jest test

### DIFF
--- a/app/components/announcement_banner/announcement_banner.test.js
+++ b/app/components/announcement_banner/announcement_banner.test.js
@@ -2,9 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import AnnouncementBanner from './announcement_banner.js';
 

--- a/app/components/custom_list/__snapshots__/index.test.js.snap
+++ b/app/components/custom_list/__snapshots__/index.test.js.snap
@@ -214,7 +214,7 @@ exports[`CustomList should match snapshot, renderFooter 2`] = `
     }
   }
 >
-  <InjectIntl(FormattedText)
+  <FormattedText
     defaultMessage="Loading Members..."
     id="mobile.loading_members"
     style={

--- a/app/components/custom_list/index.test.js
+++ b/app/components/custom_list/index.test.js
@@ -2,9 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import {createMembersSections, loadingText} from 'app/utils/member_list';
 

--- a/app/components/formatted_text.js
+++ b/app/components/formatted_text.js
@@ -4,11 +4,10 @@
 import React, {createElement, isValidElement} from 'react';
 import PropTypes from 'prop-types';
 import {Text} from 'react-native';
-import {injectIntl, intlShape} from 'react-intl';
+import {intlShape} from 'react-intl';
 
-class FormattedText extends React.PureComponent {
+export default class FormattedText extends React.PureComponent {
     static propTypes = {
-        intl: intlShape.isRequired,
         id: PropTypes.string.isRequired,
         defaultMessage: PropTypes.string,
         values: PropTypes.object,
@@ -18,14 +17,18 @@ class FormattedText extends React.PureComponent {
         defaultMessage: '',
     };
 
+    static contextTypes = {
+        intl: intlShape.isRequired,
+    };
+
     render() {
         const {
             id,
             defaultMessage,
             values,
-            intl,
             ...props
         } = this.props;
+        const {formatMessage} = this.context.intl;
 
         let tokenDelimiter;
         let tokenizedValues;
@@ -70,7 +73,7 @@ class FormattedText extends React.PureComponent {
         }
 
         const descriptor = {id, defaultMessage};
-        const formattedMessage = intl.formatMessage(descriptor, tokenizedValues || values);
+        const formattedMessage = formatMessage(descriptor, tokenizedValues || values);
         const hasElements = elements && Object.keys(elements).length > 0;
 
         let nodes;
@@ -90,5 +93,3 @@ class FormattedText extends React.PureComponent {
         return createElement(Text, props, ...nodes);
     }
 }
-
-export default injectIntl(FormattedText);

--- a/app/components/post_list/date_header/date_header.test.js
+++ b/app/components/post_list/date_header/date_header.test.js
@@ -4,9 +4,7 @@
 /* eslint-disable max-nested-callbacks */
 
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import DateHeader from './date_header.js';
 

--- a/app/components/show_more_button/__snapshots__/show_more_button.test.js.snap
+++ b/app/components/show_more_button/__snapshots__/show_more_button.test.js.snap
@@ -12,7 +12,7 @@ exports[`ShowMoreButton should match, button snapshot 1`] = `
   >
     +
   </Text>
-  <InjectIntl(FormattedText)
+  <FormattedText
     defaultMessage="Show More"
     id="post_info.message.show_more"
     style={Object {}}
@@ -32,7 +32,7 @@ exports[`ShowMoreButton should match, button snapshot 2`] = `
   >
     -
   </Text>
-  <InjectIntl(FormattedText)
+  <FormattedText
     defaultMessage="Show Less"
     id="post_info.message.show_less"
     style={Object {}}
@@ -153,7 +153,7 @@ ShallowWrapper {
               >
                 +
               </Text>
-              <InjectIntl(FormattedText)
+              <FormattedText
                 defaultMessage="Show More"
                 id="post_info.message.show_more"
                 style={
@@ -262,7 +262,7 @@ ShallowWrapper {
                 >
                   +
                 </Text>
-                <InjectIntl(FormattedText)
+                <FormattedText
                   defaultMessage="Show More"
                   id="post_info.message.show_more"
                   style={
@@ -343,7 +343,7 @@ ShallowWrapper {
                 >
                   +
                 </Text>
-                <InjectIntl(FormattedText)
+                <FormattedText
                   defaultMessage="Show More"
                   id="post_info.message.show_more"
                   style={
@@ -387,7 +387,7 @@ ShallowWrapper {
                   >
                     +
                   </Text>,
-                  <InjectIntl(FormattedText)
+                  <FormattedText
                     defaultMessage="Show More"
                     id="post_info.message.show_more"
                     style={
@@ -563,7 +563,7 @@ ShallowWrapper {
                 >
                   +
                 </Text>
-                <InjectIntl(FormattedText)
+                <FormattedText
                   defaultMessage="Show More"
                   id="post_info.message.show_more"
                   style={
@@ -672,7 +672,7 @@ ShallowWrapper {
                   >
                     +
                   </Text>
-                  <InjectIntl(FormattedText)
+                  <FormattedText
                     defaultMessage="Show More"
                     id="post_info.message.show_more"
                     style={
@@ -753,7 +753,7 @@ ShallowWrapper {
                   >
                     +
                   </Text>
-                  <InjectIntl(FormattedText)
+                  <FormattedText
                     defaultMessage="Show More"
                     id="post_info.message.show_more"
                     style={
@@ -797,7 +797,7 @@ ShallowWrapper {
                     >
                       +
                     </Text>,
-                    <InjectIntl(FormattedText)
+                    <FormattedText
                       defaultMessage="Show More"
                       id="post_info.message.show_more"
                       style={

--- a/app/components/show_more_button/show_more_button.test.js
+++ b/app/components/show_more_button/show_more_button.test.js
@@ -3,9 +3,7 @@
 
 import React from 'react';
 import {TouchableOpacity} from 'react-native';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import LinearGradient from 'react-native-linear-gradient';
 

--- a/app/components/sidebars/main/channels_list/channel_item/channel_item.test.js
+++ b/app/components/sidebars/main/channels_list/channel_item/channel_item.test.js
@@ -2,9 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import ChannelItem from './channel_item.js';
 

--- a/app/screens/forgot_password/__snapshots__/forgot_password.test.js.snap
+++ b/app/screens/forgot_password/__snapshots__/forgot_password.test.js.snap
@@ -47,7 +47,7 @@ ShallowWrapper {
               }
             />
             <Component>
-              <UNDEFINED
+              <FormattedText
                 defaultMessage="To reset your password, enter the email address you used to sign up"
                 id="password_send.description"
                 style={
@@ -105,7 +105,7 @@ ShallowWrapper {
                 disabled={false}
                 onPress={[Function]}
               >
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="Reset my password"
                   id="password_send.reset"
                   style={
@@ -163,7 +163,7 @@ ShallowWrapper {
               }
             />
             <Component>
-              <UNDEFINED
+              <FormattedText
                 defaultMessage="To reset your password, enter the email address you used to sign up"
                 id="password_send.description"
                 style={
@@ -221,7 +221,7 @@ ShallowWrapper {
                 disabled={false}
                 onPress={[Function]}
               >
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="Reset my password"
                   id="password_send.reset"
                   style={
@@ -255,7 +255,7 @@ ShallowWrapper {
               />,
               undefined,
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -313,7 +313,7 @@ ShallowWrapper {
                   disabled={false}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -359,7 +359,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "children": Array [
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="To reset your password, enter the email address you used to sign up"
                     id="password_send.description"
                     style={
@@ -417,7 +417,7 @@ ShallowWrapper {
                     disabled={false}
                     onPress={[Function]}
                   >
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -438,7 +438,7 @@ ShallowWrapper {
                 Object {
                   "instance": null,
                   "key": undefined,
-                  "nodeType": "function",
+                  "nodeType": "class",
                   "props": Object {
                     "defaultMessage": "To reset your password, enter the email address you used to sign up",
                     "id": "password_send.description",
@@ -458,7 +458,7 @@ ShallowWrapper {
                   },
                   "ref": null,
                   "rendered": null,
-                  "type": undefined,
+                  "type": [Function],
                 },
                 Object {
                   "instance": null,
@@ -495,7 +495,7 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "children": <UNDEFINED
+                    "children": <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -524,7 +524,7 @@ ShallowWrapper {
                   "rendered": Object {
                     "instance": null,
                     "key": undefined,
-                    "nodeType": "function",
+                    "nodeType": "class",
                     "props": Object {
                       "defaultMessage": "Reset my password",
                       "id": "password_send.reset",
@@ -538,7 +538,7 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": null,
-                    "type": undefined,
+                    "type": [Function],
                   },
                   "type": [Function],
                 },
@@ -583,7 +583,7 @@ ShallowWrapper {
                 }
               />
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -641,7 +641,7 @@ ShallowWrapper {
                   disabled={false}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -699,7 +699,7 @@ ShallowWrapper {
                 }
               />
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -757,7 +757,7 @@ ShallowWrapper {
                   disabled={false}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -791,7 +791,7 @@ ShallowWrapper {
                 />,
                 undefined,
                 <Component>
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="To reset your password, enter the email address you used to sign up"
                     id="password_send.description"
                     style={
@@ -849,7 +849,7 @@ ShallowWrapper {
                     disabled={false}
                     onPress={[Function]}
                   >
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -895,7 +895,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "children": Array [
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="To reset your password, enter the email address you used to sign up"
                       id="password_send.description"
                       style={
@@ -953,7 +953,7 @@ ShallowWrapper {
                       disabled={false}
                       onPress={[Function]}
                     >
-                      <UNDEFINED
+                      <FormattedText
                         defaultMessage="Reset my password"
                         id="password_send.reset"
                         style={
@@ -974,7 +974,7 @@ ShallowWrapper {
                   Object {
                     "instance": null,
                     "key": undefined,
-                    "nodeType": "function",
+                    "nodeType": "class",
                     "props": Object {
                       "defaultMessage": "To reset your password, enter the email address you used to sign up",
                       "id": "password_send.description",
@@ -994,7 +994,7 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": null,
-                    "type": undefined,
+                    "type": [Function],
                   },
                   Object {
                     "instance": null,
@@ -1031,7 +1031,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "children": <UNDEFINED
+                      "children": <FormattedText
                         defaultMessage="Reset my password"
                         id="password_send.reset"
                         style={
@@ -1060,7 +1060,7 @@ ShallowWrapper {
                     "rendered": Object {
                       "instance": null,
                       "key": undefined,
-                      "nodeType": "function",
+                      "nodeType": "class",
                       "props": Object {
                         "defaultMessage": "Reset my password",
                         "id": "password_send.reset",
@@ -1074,7 +1074,7 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": null,
-                      "type": undefined,
+                      "type": [Function],
                     },
                     "type": [Function],
                   },
@@ -1167,7 +1167,7 @@ ShallowWrapper {
               }
             />
             <Component>
-              <UNDEFINED
+              <FormattedText
                 defaultMessage="To reset your password, enter the email address you used to sign up"
                 id="password_send.description"
                 style={
@@ -1225,7 +1225,7 @@ ShallowWrapper {
                 disabled={true}
                 onPress={[Function]}
               >
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="Reset my password"
                   id="password_send.reset"
                   style={
@@ -1283,7 +1283,7 @@ ShallowWrapper {
               }
             />
             <Component>
-              <UNDEFINED
+              <FormattedText
                 defaultMessage="To reset your password, enter the email address you used to sign up"
                 id="password_send.description"
                 style={
@@ -1341,7 +1341,7 @@ ShallowWrapper {
                 disabled={true}
                 onPress={[Function]}
               >
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="Reset my password"
                   id="password_send.reset"
                   style={
@@ -1375,7 +1375,7 @@ ShallowWrapper {
               />,
               undefined,
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -1433,7 +1433,7 @@ ShallowWrapper {
                   disabled={true}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -1479,7 +1479,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "children": Array [
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="To reset your password, enter the email address you used to sign up"
                     id="password_send.description"
                     style={
@@ -1537,7 +1537,7 @@ ShallowWrapper {
                     disabled={true}
                     onPress={[Function]}
                   >
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -1558,7 +1558,7 @@ ShallowWrapper {
                 Object {
                   "instance": null,
                   "key": undefined,
-                  "nodeType": "function",
+                  "nodeType": "class",
                   "props": Object {
                     "defaultMessage": "To reset your password, enter the email address you used to sign up",
                     "id": "password_send.description",
@@ -1578,7 +1578,7 @@ ShallowWrapper {
                   },
                   "ref": null,
                   "rendered": null,
-                  "type": undefined,
+                  "type": [Function],
                 },
                 Object {
                   "instance": null,
@@ -1615,7 +1615,7 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "children": <UNDEFINED
+                    "children": <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -1644,7 +1644,7 @@ ShallowWrapper {
                   "rendered": Object {
                     "instance": null,
                     "key": undefined,
-                    "nodeType": "function",
+                    "nodeType": "class",
                     "props": Object {
                       "defaultMessage": "Reset my password",
                       "id": "password_send.reset",
@@ -1658,7 +1658,7 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": null,
-                    "type": undefined,
+                    "type": [Function],
                   },
                   "type": [Function],
                 },
@@ -1703,7 +1703,7 @@ ShallowWrapper {
                 }
               />
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -1761,7 +1761,7 @@ ShallowWrapper {
                   disabled={true}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -1819,7 +1819,7 @@ ShallowWrapper {
                 }
               />
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -1877,7 +1877,7 @@ ShallowWrapper {
                   disabled={true}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -1911,7 +1911,7 @@ ShallowWrapper {
                 />,
                 undefined,
                 <Component>
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="To reset your password, enter the email address you used to sign up"
                     id="password_send.description"
                     style={
@@ -1969,7 +1969,7 @@ ShallowWrapper {
                     disabled={true}
                     onPress={[Function]}
                   >
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -2015,7 +2015,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "children": Array [
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="To reset your password, enter the email address you used to sign up"
                       id="password_send.description"
                       style={
@@ -2073,7 +2073,7 @@ ShallowWrapper {
                       disabled={true}
                       onPress={[Function]}
                     >
-                      <UNDEFINED
+                      <FormattedText
                         defaultMessage="Reset my password"
                         id="password_send.reset"
                         style={
@@ -2094,7 +2094,7 @@ ShallowWrapper {
                   Object {
                     "instance": null,
                     "key": undefined,
-                    "nodeType": "function",
+                    "nodeType": "class",
                     "props": Object {
                       "defaultMessage": "To reset your password, enter the email address you used to sign up",
                       "id": "password_send.description",
@@ -2114,7 +2114,7 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": null,
-                    "type": undefined,
+                    "type": [Function],
                   },
                   Object {
                     "instance": null,
@@ -2151,7 +2151,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "children": <UNDEFINED
+                      "children": <FormattedText
                         defaultMessage="Reset my password"
                         id="password_send.reset"
                         style={
@@ -2180,7 +2180,7 @@ ShallowWrapper {
                     "rendered": Object {
                       "instance": null,
                       "key": undefined,
-                      "nodeType": "function",
+                      "nodeType": "class",
                       "props": Object {
                         "defaultMessage": "Reset my password",
                         "id": "password_send.reset",
@@ -2194,7 +2194,7 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": null,
-                      "type": undefined,
+                      "type": [Function],
                     },
                     "type": [Function],
                   },
@@ -2281,7 +2281,7 @@ ShallowWrapper {
               }
             />
             <Component>
-              <UNDEFINED
+              <FormattedText
                 defaultMessage="To reset your password, enter the email address you used to sign up"
                 id="password_send.description"
                 style={
@@ -2339,7 +2339,7 @@ ShallowWrapper {
                 disabled={false}
                 onPress={[Function]}
               >
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="Reset my password"
                   id="password_send.reset"
                   style={
@@ -2397,7 +2397,7 @@ ShallowWrapper {
               }
             />
             <Component>
-              <UNDEFINED
+              <FormattedText
                 defaultMessage="To reset your password, enter the email address you used to sign up"
                 id="password_send.description"
                 style={
@@ -2455,7 +2455,7 @@ ShallowWrapper {
                 disabled={false}
                 onPress={[Function]}
               >
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="Reset my password"
                   id="password_send.reset"
                   style={
@@ -2489,7 +2489,7 @@ ShallowWrapper {
               />,
               undefined,
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -2547,7 +2547,7 @@ ShallowWrapper {
                   disabled={false}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -2593,7 +2593,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "children": Array [
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="To reset your password, enter the email address you used to sign up"
                     id="password_send.description"
                     style={
@@ -2651,7 +2651,7 @@ ShallowWrapper {
                     disabled={false}
                     onPress={[Function]}
                   >
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -2672,7 +2672,7 @@ ShallowWrapper {
                 Object {
                   "instance": null,
                   "key": undefined,
-                  "nodeType": "function",
+                  "nodeType": "class",
                   "props": Object {
                     "defaultMessage": "To reset your password, enter the email address you used to sign up",
                     "id": "password_send.description",
@@ -2692,7 +2692,7 @@ ShallowWrapper {
                   },
                   "ref": null,
                   "rendered": null,
-                  "type": undefined,
+                  "type": [Function],
                 },
                 Object {
                   "instance": null,
@@ -2729,7 +2729,7 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "children": <UNDEFINED
+                    "children": <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -2758,7 +2758,7 @@ ShallowWrapper {
                   "rendered": Object {
                     "instance": null,
                     "key": undefined,
-                    "nodeType": "function",
+                    "nodeType": "class",
                     "props": Object {
                       "defaultMessage": "Reset my password",
                       "id": "password_send.reset",
@@ -2772,7 +2772,7 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": null,
-                    "type": undefined,
+                    "type": [Function],
                   },
                   "type": [Function],
                 },
@@ -2817,7 +2817,7 @@ ShallowWrapper {
                 }
               />
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -2875,7 +2875,7 @@ ShallowWrapper {
                   disabled={false}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -2933,7 +2933,7 @@ ShallowWrapper {
                 }
               />
               <Component>
-                <UNDEFINED
+                <FormattedText
                   defaultMessage="To reset your password, enter the email address you used to sign up"
                   id="password_send.description"
                   style={
@@ -2991,7 +2991,7 @@ ShallowWrapper {
                   disabled={false}
                   onPress={[Function]}
                 >
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="Reset my password"
                     id="password_send.reset"
                     style={
@@ -3025,7 +3025,7 @@ ShallowWrapper {
                 />,
                 undefined,
                 <Component>
-                  <UNDEFINED
+                  <FormattedText
                     defaultMessage="To reset your password, enter the email address you used to sign up"
                     id="password_send.description"
                     style={
@@ -3083,7 +3083,7 @@ ShallowWrapper {
                     disabled={false}
                     onPress={[Function]}
                   >
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="Reset my password"
                       id="password_send.reset"
                       style={
@@ -3129,7 +3129,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "children": Array [
-                    <UNDEFINED
+                    <FormattedText
                       defaultMessage="To reset your password, enter the email address you used to sign up"
                       id="password_send.description"
                       style={
@@ -3187,7 +3187,7 @@ ShallowWrapper {
                       disabled={false}
                       onPress={[Function]}
                     >
-                      <UNDEFINED
+                      <FormattedText
                         defaultMessage="Reset my password"
                         id="password_send.reset"
                         style={
@@ -3208,7 +3208,7 @@ ShallowWrapper {
                   Object {
                     "instance": null,
                     "key": undefined,
-                    "nodeType": "function",
+                    "nodeType": "class",
                     "props": Object {
                       "defaultMessage": "To reset your password, enter the email address you used to sign up",
                       "id": "password_send.description",
@@ -3228,7 +3228,7 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": null,
-                    "type": undefined,
+                    "type": [Function],
                   },
                   Object {
                     "instance": null,
@@ -3265,7 +3265,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "children": <UNDEFINED
+                      "children": <FormattedText
                         defaultMessage="Reset my password"
                         id="password_send.reset"
                         style={
@@ -3294,7 +3294,7 @@ ShallowWrapper {
                     "rendered": Object {
                       "instance": null,
                       "key": undefined,
-                      "nodeType": "function",
+                      "nodeType": "class",
                       "props": Object {
                         "defaultMessage": "Reset my password",
                         "id": "password_send.reset",
@@ -3308,7 +3308,7 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": null,
-                      "type": undefined,
+                      "type": [Function],
                     },
                     "type": [Function],
                   },

--- a/app/screens/forgot_password/forgot_password.test.js
+++ b/app/screens/forgot_password/forgot_password.test.js
@@ -2,9 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import ForgotPassword from './forgot_password.js';
 

--- a/app/screens/more_channels/more_channels.test.js
+++ b/app/screens/more_channels/more_channels.test.js
@@ -2,9 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import MoreChannels from './more_channels.js';
 

--- a/app/screens/select_team/__snapshots__/select_team.test.js.snap
+++ b/app/screens/select_team/__snapshots__/select_team.test.js.snap
@@ -172,7 +172,7 @@ ShallowWrapper {
               }
             }
           >
-            <InjectIntl(FormattedText)
+            <FormattedText
               defaultMessage="Open teams you can join"
               id="mobile.select_team.join_open"
               style={
@@ -251,7 +251,7 @@ ShallowWrapper {
                 }
               }
             >
-              <InjectIntl(FormattedText)
+              <FormattedText
                 defaultMessage="Open teams you can join"
                 id="mobile.select_team.join_open"
                 style={
@@ -286,7 +286,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
-              "children": <InjectIntl(FormattedText)
+              "children": <FormattedText
                 defaultMessage="Open teams you can join"
                 id="mobile.select_team.join_open"
                 style={
@@ -397,7 +397,7 @@ ShallowWrapper {
                 }
               }
             >
-              <InjectIntl(FormattedText)
+              <FormattedText
                 defaultMessage="Open teams you can join"
                 id="mobile.select_team.join_open"
                 style={
@@ -476,7 +476,7 @@ ShallowWrapper {
                   }
                 }
               >
-                <InjectIntl(FormattedText)
+                <FormattedText
                   defaultMessage="Open teams you can join"
                   id="mobile.select_team.join_open"
                   style={
@@ -511,7 +511,7 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "class",
               "props": Object {
-                "children": <InjectIntl(FormattedText)
+                "children": <FormattedText
                   defaultMessage="Open teams you can join"
                   id="mobile.select_team.join_open"
                   style={

--- a/app/screens/select_team/select_team.test.js
+++ b/app/screens/select_team/select_team.test.js
@@ -1,10 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import {shallow} from 'enzyme';
+
 import {RequestStatus} from 'mattermost-redux/constants';
-configure({adapter: new Adapter()});
 
 import SelectTeam from './select_team.js';
 

--- a/app/screens/settings/notification_settings_email/__snapshots__/notification_settings_email.android.test.js.snap
+++ b/app/screens/settings/notification_settings_email/__snapshots__/notification_settings_email.android.test.js.snap
@@ -5,13 +5,13 @@ exports[`NotificationSettingsEmailAndroid should match snapshot 1`] = `
   action={[Function]}
   actionType="default"
   description={
-    <InjectIntl(FormattedText)
+    <FormattedText
       defaultMessage="Immediately"
       id="user.settings.notifications.email.immediately"
     />
   }
   label={
-    <InjectIntl(FormattedText)
+    <FormattedText
       defaultMessage="Send email notifications"
       id="user.settings.notifications.email.send"
     />
@@ -45,7 +45,7 @@ exports[`NotificationSettingsEmailAndroid should match snapshot 2`] = `
         <Component
           style={Object {}}
         >
-          <InjectIntl(FormattedText)
+          <FormattedText
             defaultMessage="Send email notifications"
             id="user.settings.notifications.email.send"
             style={Object {}}
@@ -69,7 +69,7 @@ exports[`NotificationSettingsEmailAndroid should match snapshot 2`] = `
             ]
           }
         />
-        <InjectIntl(FormattedText)
+        <FormattedText
           defaultMessage="Email notifications are sent for mentions and direct messages when you are offline or away from {siteName} for more than 5 minutes."
           id="user.settings.notifications.emailInfo"
           style={Object {}}
@@ -94,7 +94,7 @@ exports[`NotificationSettingsEmailAndroid should match snapshot 2`] = `
             onPress={[Function]}
             style={Object {}}
           >
-            <InjectIntl(FormattedText)
+            <FormattedText
               defaultMessage="CANCEL"
               id="mobile.notification_settings.modal_cancel"
               style={Object {}}
@@ -113,7 +113,7 @@ exports[`NotificationSettingsEmailAndroid should match snapshot 2`] = `
               onPress={[Function]}
               style={Object {}}
             >
-              <InjectIntl(FormattedText)
+              <FormattedText
                 defaultMessage="SAVE"
                 id="mobile.notification_settings.modal_save"
                 style={Object {}}

--- a/app/screens/settings/notification_settings_email/__snapshots__/notification_settings_email.ios.test.js.snap
+++ b/app/screens/settings/notification_settings_email/__snapshots__/notification_settings_email.ios.test.js.snap
@@ -25,7 +25,7 @@ exports[`NotificationSettingsEmailIos should match snapshot, renderEmailSection 
       actionType="select"
       actionValue="30"
       label={
-        <InjectIntl(FormattedText)
+        <FormattedText
           defaultMessage="Immediately"
           id="user.settings.notifications.email.immediately"
         />
@@ -53,7 +53,7 @@ exports[`NotificationSettingsEmailIos should match snapshot, renderEmailSection 
       actionType="select"
       actionValue="0"
       label={
-        <InjectIntl(FormattedText)
+        <FormattedText
           defaultMessage="Never"
           id="user.settings.notifications.email.never"
         />

--- a/app/screens/settings/notification_settings_email/notification_settings_email.android.test.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.android.test.js
@@ -2,9 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {configure} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
 
 import {shallowWithIntl} from 'test/intl-test-helper';
 import {emptyFunction} from 'app/utils/general';

--- a/app/screens/settings/notification_settings_email/notification_settings_email.ios.test.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.ios.test.js
@@ -2,9 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {configure, shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-configure({adapter: new Adapter()});
+import {shallow} from 'enzyme';
 
 import {emptyFunction} from 'app/utils/general';
 

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
       "text-summary"
     ],
     "preset": "react-native",
+    "setupTestFrameworkScriptFile": "<rootDir>/test/setup.js",
     "testPathIgnorePatterns": [
       "/node_modules/"
     ]

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {configure} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+configure({adapter: new Adapter()});
+
+/* eslint-disable no-console */
+
+let logs;
+let warns;
+let errors;
+beforeAll(() => {
+    console.originalLog = console.log;
+    console.log = jest.fn((...params) => {
+        console.originalLog(...params);
+        logs.push(params);
+    });
+
+    console.originalWarn = console.warn;
+    console.warn = jest.fn((...params) => {
+        console.originalWarn(...params);
+        warns.push(params);
+    });
+
+    console.originalError = console.error;
+    console.error = jest.fn((...params) => {
+        console.originalError(...params);
+        errors.push(params);
+    });
+});
+
+beforeEach(() => {
+    logs = [];
+    warns = [];
+    errors = [];
+});
+
+afterEach(() => {
+    if (logs.length > 0 || warns.length > 0 || errors.length > 0) {
+        throw new Error('Unexpected console logs' + logs + warns + errors);
+    }
+});


### PR DESCRIPTION
#### Summary
Fix warnings in running unit tests, by:
- Using context for `intl` at FormattedText component
- Add `setup.js` at Jest config to let all requirements run before all tests
- Add console checks to not allow JS warning in the future.  This makes the test faster (similar to web app).

This eliminates warnings like in the screenshot:
![screen shot 2018-09-07 at 10 25 02 pm](https://user-images.githubusercontent.com/5334504/45224632-fc511b80-b2ec-11e8-9186-a11a6da724c6.png)

#### Ticket Link
none

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [iPhone simulator, Android emulator] 

