### PR TITLE
Search Fixes

### DIFF
--- a/app/components/autocomplete/date_suggestion/date_suggestion.js
+++ b/app/components/autocomplete/date_suggestion/date_suggestion.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {PureComponent} from 'react';
-import {Keyboard, StyleSheet} from 'react-native';
+import {Dimensions, Platform, StyleSheet} from 'react-native';
 import PropTypes from 'prop-types';
 import {CalendarList} from 'react-native-calendars';
 
@@ -80,8 +80,6 @@ export default class DateSuggestion extends PureComponent {
         const currentDate = (new Date()).toDateString();
         const calendarStyle = calendarTheme(theme);
 
-        Keyboard.dismiss();
-
         return (
             <CalendarList
                 style={styles.calList}
@@ -96,10 +94,24 @@ export default class DateSuggestion extends PureComponent {
                 onDayPress={this.completeMention}
                 showWeekNumbers={false}
                 theme={calendarStyle}
+                keyboardShouldPersistTaps='always'
             />
         );
     }
 }
+
+const getDateFontSize = () => {
+    let fontSize = 14;
+
+    if (Platform.OS === 'ios') {
+        const {height, width} = Dimensions.get('window');
+        if (height < 375 || width < 375) {
+            fontSize = 13;
+        }
+    }
+
+    return fontSize;
+};
 
 const calendarTheme = memoizeResult((theme) => ({
     calendarBackground: theme.centerChannelBg,
@@ -107,11 +119,24 @@ const calendarTheme = memoizeResult((theme) => ({
     dayTextColor: theme.centerChannelColor,
     textSectionTitleColor: changeOpacity(theme.centerChannelColor, 0.25),
     'stylesheet.day.basic': {
+        base: {
+            width: 22,
+            height: 22,
+            alignItems: 'center',
+        },
+        text: {
+            marginTop: 0,
+            fontSize: getDateFontSize(),
+            fontWeight: '300',
+            color: theme.centerChannelColor,
+            backgroundColor: 'rgba(255, 255, 255, 0)',
+            lineHeight: 23,
+        },
         today: {
             backgroundColor: theme.buttonBg,
-            width: 33,
-            height: 33,
-            borderRadius: 16.5,
+            width: 24,
+            height: 24,
+            borderRadius: 12,
         },
         todayText: {
             color: theme.buttonColor,

--- a/app/components/quick_text_input.js
+++ b/app/components/quick_text_input.js
@@ -25,9 +25,11 @@ export default class QuickTextInput extends React.PureComponent {
          * The string value displayed in this input
          */
         value: PropTypes.string.isRequired,
+        refocusInput: PropTypes.bool,
     };
 
     static defaultProps = {
+        refocusInput: true,
         delayInputUpdate: false,
         editable: true,
         value: '',
@@ -57,7 +59,7 @@ export default class QuickTextInput extends React.PureComponent {
             });
         }
 
-        this.hadFocus = this.input.isFocused();
+        this.hadFocus = this.input.isFocused() && this.props.refocusInput;
     }
 
     componentDidUpdate(prevProps, prevState) {

--- a/app/components/search_bar/search_bar.android.js
+++ b/app/components/search_bar/search_bar.android.js
@@ -70,6 +70,7 @@ export default class SearchBarAndroid extends PureComponent {
         this.state = {
             value: props.value,
             isFocused: false,
+            refocusInput: true,
         };
     }
 
@@ -93,10 +94,12 @@ export default class SearchBarAndroid extends PureComponent {
 
     onSearchButtonPress = () => {
         const {value} = this.props;
-
-        if (value) {
-            this.props.onSearchButtonPress(value);
-        }
+        this.setState({refocusInput: false}, () => {
+            if (value) {
+                this.props.onSearchButtonPress(value);
+            }
+            this.setState({refocusInput: true});
+        });
     };
 
     onCancelButtonPress = () => {
@@ -215,6 +218,7 @@ export default class SearchBarAndroid extends PureComponent {
                     <QuickTextInput
                         ref='input'
                         blurOnSubmit={blurOnSubmit}
+                        refocusInput={this.state.refocusInput}
                         value={this.state.value}
                         autoCapitalize={autoCapitalize}
                         autoCorrect={false}

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -104,7 +104,7 @@ export default class Search extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        const {searchingStatus: status, recent} = this.props;
+        const {searchingStatus: status, recent, enableDateSuggestion} = this.props;
         const {searchingStatus: prevStatus} = prevProps;
         const recentLength = recent.length;
         const shouldScroll = prevStatus !== status && (status === RequestStatus.SUCCESS || status === RequestStatus.STARTED);
@@ -114,12 +114,13 @@ export default class Search extends PureComponent {
         }
 
         if (shouldScroll) {
-            requestAnimationFrame(() => {
+            setTimeout(() => {
+                const modifiersCount = enableDateSuggestion ? 5 : 2;
                 this.refs.list._wrapperListRef.getListRef().scrollToOffset({ //eslint-disable-line no-underscore-dangle
                     animated: true,
-                    offset: SECTION_HEIGHT + (2 * MODIFIER_LABEL_HEIGHT) + (recentLength * RECENT_LABEL_HEIGHT) + ((recentLength + 1) * RECENT_SEPARATOR_HEIGHT),
+                    offset: SECTION_HEIGHT + (modifiersCount * MODIFIER_LABEL_HEIGHT) + (recentLength * RECENT_LABEL_HEIGHT) + ((recentLength + 1) * RECENT_SEPARATOR_HEIGHT),
                 });
-            });
+            }, 100);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14712,9 +14712,8 @@
       }
     },
     "react-native-calendars": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.20.0.tgz",
-      "integrity": "sha512-VlRoDcnEAWYE1JBPBh/Bie6baLQCmtuOGhw7V5yk09Y4j7Hy8BtuZIHh2+LU/TFYso+wEHJAFdj6D0QFttDOlg==",
+      "version": "github:enahum/react-native-calendars#b96954bf85126222b311b638fe458a8194f25bed",
+      "from": "github:enahum/react-native-calendars#b96954bf85126222b311b638fe458a8194f25bed",
       "requires": {
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-native-animatable": "1.2.4",
     "react-native-bottom-sheet": "1.0.3",
     "react-native-button": "2.3.0",
-    "react-native-calendars": "1.20.0",
+    "react-native-calendars": "github:enahum/react-native-calendars#b96954bf85126222b311b638fe458a8194f25bed",
     "react-native-circular-progress": "0.2.0",
     "react-native-cookies": "3.2.0",
     "react-native-device-info": "github:enahum/react-native-device-info#a7bb3cff1086780b2c791a3e43e5b826fdf3ab11",


### PR DESCRIPTION
#### Summary
This PR fixes a couple of tickets, one for letting the user use the keyboard while having the date picker active and the second one that closes the Android keyboard when performing a search, the latter was caused by the QuickTextBox reclaiming the focus that we use for autocompletion, so this is a small hack that makes the QuickTextBox not reclaim the focus.

Note: When showing the calendar in order to allow selecting a date with the keyboard open we needed to fork the lib to add a prop for `keyboardShouldPeristTabs` we'll use the fork in the meantime but I already submitted a PR to the lib. PR can be found here https://github.com/wix/react-native-calendars/pull/620

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11996
https://mattermost.atlassian.net/browse/MM-12041