### PR TITLE
MM-12025 Use KeyboardLayout in more places and have it change height instead of moving upwards

### DIFF
--- a/app/components/custom_list/index.js
+++ b/app/components/custom_list/index.js
@@ -216,7 +216,7 @@ export default class CustomList extends PureComponent {
         }
 
         return (
-            <View style={{flex: 1}}>
+            <View style={style.container}>
                 <ListView
                     style={style.listView}
                     dataSource={dataSource}
@@ -239,6 +239,9 @@ export default class CustomList extends PureComponent {
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
+        container: {
+            flex: 1,
+        },
         listView: {
             flex: 1,
             backgroundColor: theme.centerChannelBg,

--- a/app/components/layout/keyboard_layout/keyboard_layout.js
+++ b/app/components/layout/keyboard_layout/keyboard_layout.js
@@ -73,7 +73,7 @@ export default class KeyboardLayout extends PureComponent {
 
         return (
             <View
-                style={[style.keyboardLayout, {bottom: this.state.bottom}]}
+                style={[style.keyboardLayout, {marginBottom: this.state.bottom}]}
             >
                 {children}
             </View>

--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -14,11 +14,12 @@ import {
 import Loading from 'app/components/loading';
 import CustomList from 'app/components/custom_list';
 import UserListRow from 'app/components/custom_list/user_list_row';
+import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import SearchBar from 'app/components/search_bar';
 import StatusBar from 'app/components/status_bar';
 import {alertErrorIfInvalidPermissions} from 'app/utils/general';
 import {createMembersSections, loadingText, markSelectedProfiles} from 'app/utils/member_list';
-import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/utils/theme';
+import {changeOpacity, setNavigatorStyles} from 'app/utils/theme';
 
 import {General, RequestStatus} from 'mattermost-redux/constants';
 import {filterProfilesMatchingTerm} from 'mattermost-redux/utils/user_utils';
@@ -232,15 +233,14 @@ class ChannelAddMembers extends PureComponent {
         const {intl, preferences, theme} = this.props;
         const {adding, profiles, searching, term} = this.state;
         const {formatMessage} = intl;
-        const style = getStyleFromTheme(theme);
         const more = searching ? () => true : this.loadMoreMembers;
 
         if (adding) {
             return (
-                <View style={style.container}>
+                <KeyboardLayout>
                     <StatusBar/>
                     <Loading/>
-                </View>
+                </KeyboardLayout>
             );
         }
 
@@ -256,7 +256,7 @@ class ChannelAddMembers extends PureComponent {
         };
 
         return (
-            <View style={style.container}>
+            <KeyboardLayout>
                 <StatusBar/>
                 <View
                     style={{marginVertical: 5}}
@@ -294,18 +294,9 @@ class ChannelAddMembers extends PureComponent {
                     createSections={createMembersSections}
                     showNoResults={this.state.showNoResults}
                 />
-            </View>
+            </KeyboardLayout>
         );
     }
 }
-
-const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return {
-        container: {
-            flex: 1,
-            backgroundColor: theme.centerChannelBg,
-        },
-    };
-});
 
 export default injectIntl(ChannelAddMembers);

--- a/app/screens/channel_members/channel_members.js
+++ b/app/screens/channel_members/channel_members.js
@@ -13,12 +13,13 @@ import {injectIntl, intlShape} from 'react-intl';
 
 import Loading from 'app/components/loading';
 import CustomList from 'app/components/custom_list';
+import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import SearchBar from 'app/components/search_bar';
 import StatusBar from 'app/components/status_bar';
 import {alertErrorIfInvalidPermissions} from 'app/utils/general';
 import {createMembersSections, loadingText, markSelectedProfiles} from 'app/utils/member_list';
 import UserListRow from 'app/components/custom_list/user_list_row';
-import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/utils/theme';
+import {changeOpacity, setNavigatorStyles} from 'app/utils/theme';
 
 import {General, RequestStatus} from 'mattermost-redux/constants';
 import {filterProfilesMatchingTerm} from 'mattermost-redux/utils/user_utils';
@@ -275,14 +276,13 @@ class ChannelMembers extends PureComponent {
         const isLoading = (requestStatus === RequestStatus.STARTED) || (requestStatus.status === RequestStatus.NOT_STARTED) ||
             (searchRequestStatus === RequestStatus.STARTED);
         const more = searching ? () => true : this.loadMoreMembers;
-        const style = getStyleFromTheme(theme);
 
         if (removing) {
             return (
-                <View style={style.container}>
+                <KeyboardLayout>
                     <StatusBar/>
                     <Loading/>
-                </View>
+                </KeyboardLayout>
             );
         }
 
@@ -298,7 +298,7 @@ class ChannelMembers extends PureComponent {
         };
 
         return (
-            <View style={style.container}>
+            <KeyboardLayout>
                 <StatusBar/>
                 <View
                     style={{marginVertical: 5}}
@@ -334,18 +334,9 @@ class ChannelMembers extends PureComponent {
                     createSections={createMembersSections}
                     showNoResults={showNoResults}
                 />
-            </View>
+            </KeyboardLayout>
         );
     }
 }
-
-const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return {
-        container: {
-            flex: 1,
-            backgroundColor: theme.centerChannelBg,
-        },
-    };
-});
 
 export default injectIntl(ChannelMembers);

--- a/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
+++ b/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
@@ -60,13 +60,7 @@ ShallowWrapper {
     "props": Object {
       "children": Array [
         <Connect(StatusBar) />,
-        <Component
-          style={
-            Object {
-              "flex": 1,
-            }
-          }
-        >
+        <UNDEFINED>
           <Component
             style={
               Object {
@@ -139,12 +133,8 @@ ShallowWrapper {
               }
             }
           />
-        </Component>,
+        </UNDEFINED>,
       ],
-      "style": Object {
-        "backgroundColor": "#aaa",
-        "flex": 1,
-      },
     },
     "ref": null,
     "rendered": Array [
@@ -160,7 +150,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "children": Array [
             <Component
@@ -236,9 +226,6 @@ ShallowWrapper {
               }
             />,
           ],
-          "style": Object {
-            "flex": 1,
-          },
         },
         "ref": null,
         "rendered": Array [
@@ -353,7 +340,7 @@ ShallowWrapper {
             "type": [Function],
           },
         ],
-        "type": [Function],
+        "type": Symbol(react.fragment),
       },
     ],
     "type": [Function],
@@ -366,13 +353,7 @@ ShallowWrapper {
       "props": Object {
         "children": Array [
           <Connect(StatusBar) />,
-          <Component
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          >
+          <UNDEFINED>
             <Component
               style={
                 Object {
@@ -445,12 +426,8 @@ ShallowWrapper {
                 }
               }
             />
-          </Component>,
+          </UNDEFINED>,
         ],
-        "style": Object {
-          "backgroundColor": "#aaa",
-          "flex": 1,
-        },
       },
       "ref": null,
       "rendered": Array [
@@ -466,7 +443,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "children": Array [
               <Component
@@ -542,9 +519,6 @@ ShallowWrapper {
                 }
               />,
             ],
-            "style": Object {
-              "flex": 1,
-            },
           },
           "ref": null,
           "rendered": Array [
@@ -659,7 +633,7 @@ ShallowWrapper {
               "type": [Function],
             },
           ],
-          "type": [Function],
+          "type": Symbol(react.fragment),
         },
       ],
       "type": [Function],

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -15,6 +15,7 @@ import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import CustomList from 'app/components/custom_list';
 import ChannelListRow from 'app/components/custom_list/channel_list_row';
+import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import Loading from 'app/components/loading';
 import SearchBar from 'app/components/search_bar';
 import StatusBar from 'app/components/status_bar';
@@ -317,7 +318,7 @@ export default class MoreChannels extends PureComponent {
             };
 
             content = (
-                <View style={style.flex}>
+                <React.Fragment>
                     <View style={style.wrapper}>
                         <SearchBar
                             ref='search_bar'
@@ -350,24 +351,21 @@ export default class MoreChannels extends PureComponent {
                         loadingText={{id: 'mobile.loading_channels', defaultMessage: 'Loading Channels...'}}
                         showNoResults={this.state.showNoResults}
                     />
-                </View>
+                </React.Fragment>
             );
         }
 
         return (
-            <View style={style.container}>
+            <KeyboardLayout>
                 <StatusBar/>
                 {content}
-            </View>
+            </KeyboardLayout>
         );
     }
 }
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
-        flex: {
-            flex: 1,
-        },
         wrapper: {
             marginVertical: 5,
         },

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -7,6 +7,7 @@ import {injectIntl, intlShape} from 'react-intl';
 import {
     InteractionManager,
     Platform,
+    StyleSheet,
     View,
 } from 'react-native';
 
@@ -18,12 +19,13 @@ import {displayUsername, filterProfilesMatchingTerm} from 'mattermost-redux/util
 import CustomFlatList from 'app/components/custom_flat_list';
 import CustomSectionList from 'app/components/custom_section_list';
 import UserListRow from 'app/components/custom_list/user_list_row';
+import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import Loading from 'app/components/loading';
 import SearchBar from 'app/components/search_bar';
 import StatusBar from 'app/components/status_bar';
 import {alertErrorWithFallback} from 'app/utils/general';
 import {loadingText} from 'app/utils/member_list';
-import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/utils/theme';
+import {changeOpacity, setNavigatorStyles} from 'app/utils/theme';
 
 import SelectedUsers from './selected_users';
 
@@ -445,7 +447,6 @@ class MoreDirectMessages extends PureComponent {
         const isLoading = (
             getRequest.status === RequestStatus.STARTED) || (getRequest.status === RequestStatus.NOT_STARTED) ||
             (searchRequest.status === RequestStatus.STARTED);
-        const style = getStyleFromTheme(theme);
 
         if (loadingChannel) {
             return (
@@ -501,7 +502,7 @@ class MoreDirectMessages extends PureComponent {
         }
 
         return (
-            <View style={style.container}>
+            <KeyboardLayout>
                 <StatusBar/>
                 <View style={style.searchContainer}>
                     <SearchBar
@@ -531,21 +532,15 @@ class MoreDirectMessages extends PureComponent {
                     />
                 </View>
                 {listComponent}
-            </View>
+            </KeyboardLayout>
         );
     }
 }
 
-const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
-    return {
-        container: {
-            flex: 1,
-            backgroundColor: theme.centerChannelBg,
-        },
-        searchContainer: {
-            marginVertical: 5,
-        },
-    };
+const style = StyleSheet.create({
+    searchContainer: {
+        marginVertical: 5,
+    },
 });
 
 export default injectIntl(MoreDirectMessages);

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -20,6 +20,7 @@ import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import Autocomplete from 'app/components/autocomplete';
+import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import DateHeader from 'app/components/post_list/date_header';
 import {isDateLine} from 'app/components/post_list/date_header/utils';
 import FormattedText from 'app/components/formatted_text';
@@ -647,7 +648,7 @@ export default class Search extends PureComponent {
                 excludeHeader={isLandscape && this.isX}
                 forceTop={44}
             >
-                <View style={style.container}>
+                <KeyboardLayout>
                     <StatusBar/>
                     <View style={style.header}>
                         <SearchBar
@@ -688,7 +689,7 @@ export default class Search extends PureComponent {
                         value={value}
                         enableDateSuggestion={this.props.enableDateSuggestion}
                     />
-                </View>
+                </KeyboardLayout>
             </SafeAreaView>
         );
     }
@@ -696,9 +697,6 @@ export default class Search extends PureComponent {
 
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
-        container: {
-            flex: 1,
-        },
         header: {
             backgroundColor: theme.sidebarHeaderBg,
             width: '100%',


### PR DESCRIPTION
The current version of KeyboardLayout just moves the child upwards, so some of the contents get cut off at the top of the screen.

This adds the KeyboardLayout to the following screens:
- More DMs
- More channels
- Manage channel members
- Add channel members
- Search results

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12025

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator (iPhone 6, iOS 11.4), Nexus 5 (Android 6.0.1)