### PR TITLE
MM-11725: Using the new server endpoint to autocomplete channels

### DIFF
--- a/app/components/autocomplete/channel_mention/index.js
+++ b/app/components/autocomplete/channel_mention/index.js
@@ -7,7 +7,6 @@ import {connect} from 'react-redux';
 import {searchChannels, autocompleteChannelsForSearch} from 'mattermost-redux/actions/channels';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import {Client4} from 'mattermost-redux/client';
 
 import {
     filterMyChannels,
@@ -50,7 +49,7 @@ function mapStateToProps(state, ownProps) {
         matchTerm,
         requestStatus: state.requests.channels.getChannels.status,
         theme: getTheme(state),
-        serverVersion: state.entities.general.serverVersion || Client4.getServerVersion(),
+        serverVersion: state.entities.general.serverVersion,
     };
 }
 

--- a/app/components/autocomplete/channel_mention/index.js
+++ b/app/components/autocomplete/channel_mention/index.js
@@ -4,9 +4,10 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {searchChannels} from 'mattermost-redux/actions/channels';
+import {searchChannels, autocompleteChannelsForSearch} from 'mattermost-redux/actions/channels';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {Client4} from 'mattermost-redux/client';
 
 import {
     filterMyChannels,
@@ -49,6 +50,7 @@ function mapStateToProps(state, ownProps) {
         matchTerm,
         requestStatus: state.requests.channels.getChannels.status,
         theme: getTheme(state),
+        serverVersion: state.entities.general.serverVersion || Client4.getServerVersion(),
     };
 }
 
@@ -56,6 +58,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             searchChannels,
+            autocompleteChannelsForSearch,
         }, dispatch),
     };
 }

--- a/app/components/autocomplete/emoji_suggestion/index.js
+++ b/app/components/autocomplete/emoji_suggestion/index.js
@@ -7,7 +7,6 @@ import {bindActionCreators} from 'redux';
 
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {autocompleteCustomEmojis} from 'mattermost-redux/actions/emojis';
-import {Client4} from 'mattermost-redux/client';
 
 import {addReactionToLatestPost} from 'app/actions/views/emoji';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -46,7 +45,7 @@ function mapStateToProps(state) {
         fuse,
         emojis,
         theme: getTheme(state),
-        serverVersion: state.entities.general.serverVersion || Client4.getServerVersion(),
+        serverVersion: state.entities.general.serverVersion,
     };
 }
 

--- a/app/components/emoji_picker/index.js
+++ b/app/components/emoji_picker/index.js
@@ -9,7 +9,6 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCustomEmojis, searchCustomEmojis} from 'mattermost-redux/actions/emojis';
-import {Client4} from 'mattermost-redux/client';
 
 import {incrementEmojiPickerPage} from 'app/actions/views/emoji';
 import {getDimensions, isLandscape} from 'app/selectors/device';
@@ -160,7 +159,7 @@ function mapStateToProps(state) {
         theme: getTheme(state),
         customEmojisEnabled: getConfig(state).EnableCustomEmoji === 'true',
         customEmojiPage: state.views.emoji.emojiPickerCustomPage,
-        serverVersion: state.entities.general.serverVersion || Client4.getServerVersion(),
+        serverVersion: state.entities.general.serverVersion,
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10178,8 +10178,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#f7a515c54b30fbb6aa0e8c374f3618eb7935c4c3",
-      "from": "github:mattermost/mattermost-redux#f7a515c54b30fbb6aa0e8c374f3618eb7935c4c3",
+      "version": "github:mattermost/mattermost-redux#c7aa1f1dc8dd67f9806b2cbb3a6103ff8a9c16fd",
+      "from": "github:mattermost/mattermost-redux#c7aa1f1dc8dd67f9806b2cbb3a6103ff8a9c16fd",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "216113.0.3",
-    "mattermost-redux": "github:mattermost/mattermost-redux#f7a515c54b30fbb6aa0e8c374f3618eb7935c4c3",
+    "mattermost-redux": "github:mattermost/mattermost-redux#c7aa1f1dc8dd67f9806b2cbb3a6103ff8a9c16fd",
     "mime-db": "1.33.0",
     "moment-timezone": "0.5.21",
     "prop-types": "15.6.1",


### PR DESCRIPTION
#### Summary
Using the new server endpoint to autocomplete channels for search (list
the searchable channels, where you are member, archived or not).

#### Ticket Link
[MM-11725](https://mattermost.atlassian.net/browse/11725)

#### Checklist
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (mattermost/mattermost-redux#621)

#### Device Information
This PR was tested on: [One Plus 5, Android 8.1]