### PR TITLE
[MM-12166] Remove backgroundColor from styles.video of Android share extension that's probably causing app to crash

### DIFF
--- a/app/screens/entry/entry.js
+++ b/app/screens/entry/entry.js
@@ -62,7 +62,7 @@ export default class Entry extends PureComponent {
         isLandscape: PropTypes.bool,
         enableTimezone: PropTypes.bool,
         deviceTimezone: PropTypes.string,
-        initializeModules: PropTypes.func.isRequired,
+        initializeModules: PropTypes.func,
         actions: PropTypes.shape({
             autoUpdateTimezone: PropTypes.func.isRequired,
             setDeviceToken: PropTypes.func.isRequired,

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -638,7 +638,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             width: 38,
         },
         video: {
-            backgroundColor: theme.centerChannelBg,
             alignItems: 'center',
             height: 48,
             justifyContent: 'center',


### PR DESCRIPTION
#### Summary
Remove `backgroundColor` from styles.video of Android share extension that's probably causing app to crash.

Below is the screenshot of the error in local dev after sharing video file.  Note that it didn't occurred when image file type was shared.
![screen shot 2018-09-14 at 2 58 45 pm](https://user-images.githubusercontent.com/5334504/45536366-dae3b880-b833-11e8-877f-85daafadb062.png)

Note: Is it expected that the share extension theme (at least on Android) is always Mattermost (light) and does not change according to what is set by the user (e.g. if the user set it to Dark).

#### Ticket Link
Jira ticket: [MM-12166](https://mattermost.atlassian.net/browse/MM-12166)

#### Device Information
This PR was tested on: [Android emulator] 
