### PR TITLE
[MM-9490] Add reaction list

### DIFF
--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -329,7 +329,14 @@ export default class PostBody extends PureComponent {
     };
 
     renderReactions = () => {
-        const {hasReactions, isSearchResult, postId, onAddReaction, showLongPost} = this.props;
+        const {
+            hasReactions,
+            isSearchResult,
+            navigator,
+            onAddReaction,
+            postId,
+            showLongPost,
+        } = this.props;
 
         if (!hasReactions || isSearchResult || showLongPost) {
             return null;
@@ -343,6 +350,7 @@ export default class PostBody extends PureComponent {
             <Reactions
                 postId={postId}
                 onAddReaction={onAddReaction}
+                navigator={navigator}
             />
         );
     };

--- a/app/components/reactions/reactions.js
+++ b/app/components/reactions/reactions.js
@@ -9,6 +9,9 @@ import {
     TouchableOpacity,
     View,
 } from 'react-native';
+import {intlShape} from 'react-intl';
+
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 import addReactionIcon from 'assets/images/icons/reaction.png';
@@ -23,6 +26,7 @@ export default class Reactions extends PureComponent {
             removeReaction: PropTypes.func.isRequired,
         }).isRequired,
         highlightedReactions: PropTypes.array.isRequired,
+        navigator: PropTypes.object.isRequired,
         onAddReaction: PropTypes.func.isRequired,
         position: PropTypes.oneOf(['right', 'left']),
         postId: PropTypes.string.isRequired,
@@ -35,6 +39,18 @@ export default class Reactions extends PureComponent {
     static defaultProps = {
         position: 'right',
     };
+
+    static contextTypes = {
+        intl: intlShape,
+    };
+
+    constructor(props) {
+        super(props);
+
+        MaterialIcon.getImageSource('close', 20, props.theme.sidebarHeaderTextColor).then((source) => {
+            this.closeButton = source;
+        });
+    }
 
     componentDidMount() {
         const {actions, postId} = this.props;
@@ -50,8 +66,37 @@ export default class Reactions extends PureComponent {
         }
     };
 
+    showReactionList = () => {
+        const {navigator, postId, theme} = this.props;
+        const {formatMessage} = this.context.intl;
+        const options = {
+            screen: 'ReactionList',
+            title: formatMessage({id: 'mobile.reaction_list.title', defaultMessage: 'Reactions'}),
+            animationType: 'slide-up',
+            animated: true,
+            backButtonTitle: '',
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg,
+            },
+            navigatorButtons: {
+                leftButtons: [{
+                    id: 'close-reaction-list',
+                    icon: this.closeButton,
+                }],
+            },
+            passProps: {
+                postId,
+            },
+        };
+
+        navigator.showModal(options);
+    }
+
     renderReactions = () => {
-        const {highlightedReactions, reactions, theme} = this.props;
+        const {highlightedReactions, navigator, reactions, theme, postId} = this.props;
 
         return Array.from(reactions.keys()).map((r) => {
             return (
@@ -60,7 +105,10 @@ export default class Reactions extends PureComponent {
                     count={reactions.get(r).length}
                     emojiName={r}
                     highlight={highlightedReactions.includes(r)}
+                    navigator={navigator}
                     onPress={this.handleReactionPress}
+                    onLongPress={this.showReactionList}
+                    postId={postId}
                     theme={theme}
                 />
             );

--- a/app/constants/emoji.js
+++ b/app/constants/emoji.js
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const ALL_EMOJIS = 'all_emojis';

--- a/app/screens/index.js
+++ b/app/screens/index.js
@@ -46,6 +46,7 @@ export function registerScreens(store, Provider) {
     Navigation.registerComponent('NotificationSettingsMobile', () => wrapWithContextProvider(require('app/screens/settings/notification_settings_mobile').default), store, Provider);
     Navigation.registerComponent('OptionsModal', () => wrapWithContextProvider(require('app/screens/options_modal').default), store, Provider);
     Navigation.registerComponent('Permalink', () => wrapWithContextProvider(require('app/screens/permalink').default), store, Provider);
+    Navigation.registerComponent('ReactionList', () => wrapWithContextProvider(require('app/screens/reaction_list').default), store, Provider);
     Navigation.registerComponent('RecentMentions', () => wrapWithContextProvider(require('app/screens/recent_mentions').default), store, Provider);
     Navigation.registerComponent('Root', () => require('app/screens/root').default, store, Provider);
     Navigation.registerComponent('Search', () => wrapWithContextProvider(require('app/screens/search').default), store, Provider);

--- a/app/screens/reaction_list/__snapshots__/reaction_header.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_header.test.js.snap
@@ -6,7 +6,7 @@ exports[`ReactionHeader should match snapshot 1`] = `
     Object {
       "backgroundColor": "#ffffff",
       "height": 37,
-      "paddingHorizontal": 2,
+      "paddingHorizontal": 0,
     }
   }
 >

--- a/app/screens/reaction_list/__snapshots__/reaction_header.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_header.test.js.snap
@@ -4,9 +4,9 @@ exports[`ReactionHeader should match snapshot 1`] = `
 <Component
   style={
     Object {
-      "backgroundColor": "#aaa",
+      "backgroundColor": "#ffffff",
       "height": 37,
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 2,
     }
   }
 >
@@ -22,7 +22,30 @@ exports[`ReactionHeader should match snapshot 1`] = `
       onPress={[Function]}
       theme={
         Object {
-          "centerChannelBg": "#aaa",
+          "awayIndicator": "#ffbc42",
+          "buttonBg": "#166de0",
+          "buttonColor": "#ffffff",
+          "centerChannelBg": "#ffffff",
+          "centerChannelColor": "#3d3c40",
+          "codeTheme": "github",
+          "dndIndicator": "#f74343",
+          "errorTextColor": "#fd5960",
+          "linkColor": "#2389d7",
+          "mentionBj": "#ffffff",
+          "mentionColor": "#145dbf",
+          "mentionHighlightBg": "#ffe577",
+          "mentionHighlightLink": "#166de0",
+          "newMessageSeparator": "#ff8800",
+          "onlineIndicator": "#06d6a0",
+          "sidebarBg": "#145dbf",
+          "sidebarHeaderBg": "#1153ab",
+          "sidebarHeaderTextColor": "#ffffff",
+          "sidebarText": "#ffffff",
+          "sidebarTextActiveBorder": "#579eff",
+          "sidebarTextActiveColor": "#ffffff",
+          "sidebarTextHoverBg": "#4578bf",
+          "sidebarUnreadText": "#ffffff",
+          "type": "Mattermost",
         }
       }
     />
@@ -33,7 +56,30 @@ exports[`ReactionHeader should match snapshot 1`] = `
       onPress={[Function]}
       theme={
         Object {
-          "centerChannelBg": "#aaa",
+          "awayIndicator": "#ffbc42",
+          "buttonBg": "#166de0",
+          "buttonColor": "#ffffff",
+          "centerChannelBg": "#ffffff",
+          "centerChannelColor": "#3d3c40",
+          "codeTheme": "github",
+          "dndIndicator": "#f74343",
+          "errorTextColor": "#fd5960",
+          "linkColor": "#2389d7",
+          "mentionBj": "#ffffff",
+          "mentionColor": "#145dbf",
+          "mentionHighlightBg": "#ffe577",
+          "mentionHighlightLink": "#166de0",
+          "newMessageSeparator": "#ff8800",
+          "onlineIndicator": "#06d6a0",
+          "sidebarBg": "#145dbf",
+          "sidebarHeaderBg": "#1153ab",
+          "sidebarHeaderTextColor": "#ffffff",
+          "sidebarText": "#ffffff",
+          "sidebarTextActiveBorder": "#579eff",
+          "sidebarTextActiveColor": "#ffffff",
+          "sidebarTextHoverBg": "#4578bf",
+          "sidebarUnreadText": "#ffffff",
+          "type": "Mattermost",
         }
       }
     />
@@ -50,7 +96,30 @@ Array [
     onPress={[Function]}
     theme={
       Object {
-        "centerChannelBg": "#aaa",
+        "awayIndicator": "#ffbc42",
+        "buttonBg": "#166de0",
+        "buttonColor": "#ffffff",
+        "centerChannelBg": "#ffffff",
+        "centerChannelColor": "#3d3c40",
+        "codeTheme": "github",
+        "dndIndicator": "#f74343",
+        "errorTextColor": "#fd5960",
+        "linkColor": "#2389d7",
+        "mentionBj": "#ffffff",
+        "mentionColor": "#145dbf",
+        "mentionHighlightBg": "#ffe577",
+        "mentionHighlightLink": "#166de0",
+        "newMessageSeparator": "#ff8800",
+        "onlineIndicator": "#06d6a0",
+        "sidebarBg": "#145dbf",
+        "sidebarHeaderBg": "#1153ab",
+        "sidebarHeaderTextColor": "#ffffff",
+        "sidebarText": "#ffffff",
+        "sidebarTextActiveBorder": "#579eff",
+        "sidebarTextActiveColor": "#ffffff",
+        "sidebarTextHoverBg": "#4578bf",
+        "sidebarUnreadText": "#ffffff",
+        "type": "Mattermost",
       }
     }
   />,
@@ -61,7 +130,30 @@ Array [
     onPress={[Function]}
     theme={
       Object {
-        "centerChannelBg": "#aaa",
+        "awayIndicator": "#ffbc42",
+        "buttonBg": "#166de0",
+        "buttonColor": "#ffffff",
+        "centerChannelBg": "#ffffff",
+        "centerChannelColor": "#3d3c40",
+        "codeTheme": "github",
+        "dndIndicator": "#f74343",
+        "errorTextColor": "#fd5960",
+        "linkColor": "#2389d7",
+        "mentionBj": "#ffffff",
+        "mentionColor": "#145dbf",
+        "mentionHighlightBg": "#ffe577",
+        "mentionHighlightLink": "#166de0",
+        "newMessageSeparator": "#ff8800",
+        "onlineIndicator": "#06d6a0",
+        "sidebarBg": "#145dbf",
+        "sidebarHeaderBg": "#1153ab",
+        "sidebarHeaderTextColor": "#ffffff",
+        "sidebarText": "#ffffff",
+        "sidebarTextActiveBorder": "#579eff",
+        "sidebarTextActiveColor": "#ffffff",
+        "sidebarTextHoverBg": "#4578bf",
+        "sidebarUnreadText": "#ffffff",
+        "type": "Mattermost",
       }
     }
   />,

--- a/app/screens/reaction_list/__snapshots__/reaction_header.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_header.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactionHeader should match snapshot 1`] = `
+<Component
+  style={
+    Object {
+      "backgroundColor": "#aaa",
+      "height": 37,
+      "paddingHorizontal": 10,
+    }
+  }
+>
+  <ScrollView
+    alwaysBounceHorizontal={false}
+    horizontal={true}
+    overScrollMode="never"
+  >
+    <ReactionHeaderItem
+      count={2}
+      emojiName="smile"
+      highlight={true}
+      onPress={[Function]}
+      theme={
+        Object {
+          "centerChannelBg": "#aaa",
+        }
+      }
+    />
+    <ReactionHeaderItem
+      count={1}
+      emojiName="+1"
+      highlight={false}
+      onPress={[Function]}
+      theme={
+        Object {
+          "centerChannelBg": "#aaa",
+        }
+      }
+    />
+  </ScrollView>
+</Component>
+`;
+
+exports[`ReactionHeader should match snapshot, renderContent 1`] = `
+Array [
+  <ReactionHeaderItem
+    count={2}
+    emojiName="smile"
+    highlight={true}
+    onPress={[Function]}
+    theme={
+      Object {
+        "centerChannelBg": "#aaa",
+      }
+    }
+  />,
+  <ReactionHeaderItem
+    count={1}
+    emojiName="+1"
+    highlight={false}
+    onPress={[Function]}
+    theme={
+      Object {
+        "centerChannelBg": "#aaa",
+      }
+    }
+  />,
+]
+`;

--- a/app/screens/reaction_list/__snapshots__/reaction_header_item.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_header_item.test.js.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactionHeaderItem should match snapshot 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "height": 35,
+        "marginBottom": 5,
+        "marginRight": 6,
+        "marginTop": 3,
+        "paddingHorizontal": 6,
+        "paddingVertical": 2,
+      },
+      false,
+    ]
+  }
+>
+  <React.Fragment>
+    <Connect(Emoji)
+      emojiName="smile"
+      padding={5}
+      size={16}
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#aaa",
+          "fontSize": 16,
+          "marginLeft": 3,
+        }
+      }
+    >
+      3
+    </Text>
+  </React.Fragment>
+</TouchableOpacity>
+`;
+
+exports[`ReactionHeaderItem should match snapshot, renderContent 1`] = `
+<React.Fragment>
+  <Connect(Emoji)
+    emojiName="smile"
+    padding={5}
+    size={16}
+  />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#aaa",
+        "fontSize": 16,
+        "marginLeft": 3,
+      }
+    }
+  >
+    3
+  </Text>
+</React.Fragment>
+`;
+
+exports[`ReactionHeaderItem should match snapshot, renderContent 2`] = `
+<React.Fragment>
+  <FormattedText
+    defaultMessage="All"
+    id="mobile.reaction_header.all_emojis"
+    style={
+      Object {
+        "color": "#aaa",
+        "fontSize": 16,
+        "marginLeft": 3,
+      }
+    }
+  />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#aaa",
+        "fontSize": 16,
+        "marginLeft": 3,
+      }
+    }
+  >
+    3
+  </Text>
+</React.Fragment>
+`;

--- a/app/screens/reaction_list/__snapshots__/reaction_header_item.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_header_item.test.js.snap
@@ -16,6 +16,10 @@ exports[`ReactionHeaderItem should match snapshot 1`] = `
         "paddingHorizontal": 6,
         "paddingVertical": 2,
       },
+      Object {
+        "borderBottomWidth": 2,
+        "borderColor": "#ffffff",
+      },
       false,
     ]
   }
@@ -26,20 +30,17 @@ exports[`ReactionHeaderItem should match snapshot 1`] = `
       padding={5}
       size={16}
     />
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
+    <Component
       style={
         Object {
-          "color": "#aaa",
+          "color": "#2389d7",
           "fontSize": 16,
-          "marginLeft": 3,
+          "marginLeft": 4,
         }
       }
     >
       3
-    </Text>
+    </Component>
   </React.Fragment>
 </TouchableOpacity>
 `;
@@ -51,20 +52,17 @@ exports[`ReactionHeaderItem should match snapshot, renderContent 1`] = `
     padding={5}
     size={16}
   />
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
+  <Component
     style={
       Object {
-        "color": "#aaa",
+        "color": "#2389d7",
         "fontSize": 16,
-        "marginLeft": 3,
+        "marginLeft": 4,
       }
     }
   >
     3
-  </Text>
+  </Component>
 </React.Fragment>
 `;
 
@@ -75,25 +73,22 @@ exports[`ReactionHeaderItem should match snapshot, renderContent 2`] = `
     id="mobile.reaction_header.all_emojis"
     style={
       Object {
-        "color": "#aaa",
+        "color": "#2389d7",
         "fontSize": 16,
-        "marginLeft": 3,
+        "marginLeft": 4,
       }
     }
   />
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
+  <Component
     style={
       Object {
-        "color": "#aaa",
+        "color": "#2389d7",
         "fontSize": 16,
-        "marginLeft": 3,
+        "marginLeft": 4,
       }
     }
   >
     3
-  </Text>
+  </Component>
 </React.Fragment>
 `;

--- a/app/screens/reaction_list/__snapshots__/reaction_list.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_list.test.js.snap
@@ -4,7 +4,7 @@ exports[`ReactionList should match snapshot 1`] = `
 <Component
   style={
     Object {
-      "backgroundColor": "#aaa",
+      "backgroundColor": "#ffffff",
       "flex": 1,
     }
   }
@@ -13,7 +13,7 @@ exports[`ReactionList should match snapshot 1`] = `
     style={
       Object {
         "borderBottomWidth": 1,
-        "borderColor": "rgba(238,238,238,0.2)",
+        "borderColor": "rgba(61,60,64,0.2)",
         "height": 38,
       }
     }
@@ -51,8 +51,30 @@ exports[`ReactionList should match snapshot 1`] = `
       selected="all_emojis"
       theme={
         Object {
-          "centerChannelBg": "#aaa",
-          "centerChannelColor": "#eee",
+          "awayIndicator": "#ffbc42",
+          "buttonBg": "#166de0",
+          "buttonColor": "#ffffff",
+          "centerChannelBg": "#ffffff",
+          "centerChannelColor": "#3d3c40",
+          "codeTheme": "github",
+          "dndIndicator": "#f74343",
+          "errorTextColor": "#fd5960",
+          "linkColor": "#2389d7",
+          "mentionBj": "#ffffff",
+          "mentionColor": "#145dbf",
+          "mentionHighlightBg": "#ffe577",
+          "mentionHighlightLink": "#166de0",
+          "newMessageSeparator": "#ff8800",
+          "onlineIndicator": "#06d6a0",
+          "sidebarBg": "#145dbf",
+          "sidebarHeaderBg": "#1153ab",
+          "sidebarHeaderTextColor": "#ffffff",
+          "sidebarText": "#ffffff",
+          "sidebarTextActiveBorder": "#579eff",
+          "sidebarTextActiveColor": "#ffffff",
+          "sidebarTextHoverBg": "#4578bf",
+          "sidebarUnreadText": "#ffffff",
+          "type": "Mattermost",
         }
       }
     />
@@ -98,8 +120,30 @@ exports[`ReactionList should match snapshot 1`] = `
         teammateNameDisplay="username"
         theme={
           Object {
-            "centerChannelBg": "#aaa",
-            "centerChannelColor": "#eee",
+            "awayIndicator": "#ffbc42",
+            "buttonBg": "#166de0",
+            "buttonColor": "#ffffff",
+            "centerChannelBg": "#ffffff",
+            "centerChannelColor": "#3d3c40",
+            "codeTheme": "github",
+            "dndIndicator": "#f74343",
+            "errorTextColor": "#fd5960",
+            "linkColor": "#2389d7",
+            "mentionBj": "#ffffff",
+            "mentionColor": "#145dbf",
+            "mentionHighlightBg": "#ffe577",
+            "mentionHighlightLink": "#166de0",
+            "newMessageSeparator": "#ff8800",
+            "onlineIndicator": "#06d6a0",
+            "sidebarBg": "#145dbf",
+            "sidebarHeaderBg": "#1153ab",
+            "sidebarHeaderTextColor": "#ffffff",
+            "sidebarText": "#ffffff",
+            "sidebarTextActiveBorder": "#579eff",
+            "sidebarTextActiveColor": "#ffffff",
+            "sidebarTextHoverBg": "#4578bf",
+            "sidebarUnreadText": "#ffffff",
+            "type": "Mattermost",
           }
         }
         user={
@@ -112,7 +156,7 @@ exports[`ReactionList should match snapshot 1`] = `
       <Component
         style={
           Object {
-            "backgroundColor": "rgba(238,238,238,0.2)",
+            "backgroundColor": "rgba(61,60,64,0.2)",
             "height": 1,
           }
         }
@@ -148,8 +192,30 @@ exports[`ReactionList should match snapshot 1`] = `
         teammateNameDisplay="username"
         theme={
           Object {
-            "centerChannelBg": "#aaa",
-            "centerChannelColor": "#eee",
+            "awayIndicator": "#ffbc42",
+            "buttonBg": "#166de0",
+            "buttonColor": "#ffffff",
+            "centerChannelBg": "#ffffff",
+            "centerChannelColor": "#3d3c40",
+            "codeTheme": "github",
+            "dndIndicator": "#f74343",
+            "errorTextColor": "#fd5960",
+            "linkColor": "#2389d7",
+            "mentionBj": "#ffffff",
+            "mentionColor": "#145dbf",
+            "mentionHighlightBg": "#ffe577",
+            "mentionHighlightLink": "#166de0",
+            "newMessageSeparator": "#ff8800",
+            "onlineIndicator": "#06d6a0",
+            "sidebarBg": "#145dbf",
+            "sidebarHeaderBg": "#1153ab",
+            "sidebarHeaderTextColor": "#ffffff",
+            "sidebarText": "#ffffff",
+            "sidebarTextActiveBorder": "#579eff",
+            "sidebarTextActiveColor": "#ffffff",
+            "sidebarTextHoverBg": "#4578bf",
+            "sidebarUnreadText": "#ffffff",
+            "type": "Mattermost",
           }
         }
         user={
@@ -162,7 +228,7 @@ exports[`ReactionList should match snapshot 1`] = `
       <Component
         style={
           Object {
-            "backgroundColor": "rgba(238,238,238,0.2)",
+            "backgroundColor": "rgba(61,60,64,0.2)",
             "height": 1,
           }
         }
@@ -204,8 +270,30 @@ Array [
       teammateNameDisplay="username"
       theme={
         Object {
-          "centerChannelBg": "#aaa",
-          "centerChannelColor": "#eee",
+          "awayIndicator": "#ffbc42",
+          "buttonBg": "#166de0",
+          "buttonColor": "#ffffff",
+          "centerChannelBg": "#ffffff",
+          "centerChannelColor": "#3d3c40",
+          "codeTheme": "github",
+          "dndIndicator": "#f74343",
+          "errorTextColor": "#fd5960",
+          "linkColor": "#2389d7",
+          "mentionBj": "#ffffff",
+          "mentionColor": "#145dbf",
+          "mentionHighlightBg": "#ffe577",
+          "mentionHighlightLink": "#166de0",
+          "newMessageSeparator": "#ff8800",
+          "onlineIndicator": "#06d6a0",
+          "sidebarBg": "#145dbf",
+          "sidebarHeaderBg": "#1153ab",
+          "sidebarHeaderTextColor": "#ffffff",
+          "sidebarText": "#ffffff",
+          "sidebarTextActiveBorder": "#579eff",
+          "sidebarTextActiveColor": "#ffffff",
+          "sidebarTextHoverBg": "#4578bf",
+          "sidebarUnreadText": "#ffffff",
+          "type": "Mattermost",
         }
       }
       user={
@@ -218,7 +306,7 @@ Array [
     <Component
       style={
         Object {
-          "backgroundColor": "rgba(238,238,238,0.2)",
+          "backgroundColor": "rgba(61,60,64,0.2)",
           "height": 1,
         }
       }
@@ -254,8 +342,30 @@ Array [
       teammateNameDisplay="username"
       theme={
         Object {
-          "centerChannelBg": "#aaa",
-          "centerChannelColor": "#eee",
+          "awayIndicator": "#ffbc42",
+          "buttonBg": "#166de0",
+          "buttonColor": "#ffffff",
+          "centerChannelBg": "#ffffff",
+          "centerChannelColor": "#3d3c40",
+          "codeTheme": "github",
+          "dndIndicator": "#f74343",
+          "errorTextColor": "#fd5960",
+          "linkColor": "#2389d7",
+          "mentionBj": "#ffffff",
+          "mentionColor": "#145dbf",
+          "mentionHighlightBg": "#ffe577",
+          "mentionHighlightLink": "#166de0",
+          "newMessageSeparator": "#ff8800",
+          "onlineIndicator": "#06d6a0",
+          "sidebarBg": "#145dbf",
+          "sidebarHeaderBg": "#1153ab",
+          "sidebarHeaderTextColor": "#ffffff",
+          "sidebarText": "#ffffff",
+          "sidebarTextActiveBorder": "#579eff",
+          "sidebarTextActiveColor": "#ffffff",
+          "sidebarTextHoverBg": "#4578bf",
+          "sidebarUnreadText": "#ffffff",
+          "type": "Mattermost",
         }
       }
       user={
@@ -268,7 +378,7 @@ Array [
     <Component
       style={
         Object {
-          "backgroundColor": "rgba(238,238,238,0.2)",
+          "backgroundColor": "rgba(61,60,64,0.2)",
           "height": 1,
         }
       }

--- a/app/screens/reaction_list/__snapshots__/reaction_list.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_list.test.js.snap
@@ -1,0 +1,278 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactionList should match snapshot 1`] = `
+<Component
+  style={
+    Object {
+      "backgroundColor": "#aaa",
+      "flex": 1,
+    }
+  }
+>
+  <Component
+    style={
+      Object {
+        "borderBottomWidth": 1,
+        "borderColor": "rgba(238,238,238,0.2)",
+        "height": 38,
+      }
+    }
+  >
+    <ReactionHeader
+      onSelectReaction={[Function]}
+      reactions={
+        Array [
+          Object {
+            "count": 2,
+            "name": "all_emojis",
+          },
+          Object {
+            "count": 1,
+            "name": "+1",
+            "reactions": Array [
+              Object {
+                "emoji_name": "+1",
+                "user_id": "user_id_2",
+              },
+            ],
+          },
+          Object {
+            "count": 1,
+            "name": "smile",
+            "reactions": Array [
+              Object {
+                "emoji_name": "smile",
+                "user_id": "user_id_1",
+              },
+            ],
+          },
+        ]
+      }
+      selected="all_emojis"
+      theme={
+        Object {
+          "centerChannelBg": "#aaa",
+          "centerChannelColor": "#eee",
+        }
+      }
+    />
+  </Component>
+  <KeyboardAwareScrollView
+    bounces={true}
+    enableAutomaticScroll={true}
+    enableOnAndroid={false}
+    enableResetScrollToCoords={true}
+    extraHeight={75}
+    extraScrollHeight={0}
+    innerRef={[Function]}
+    keyboardOpeningTime={250}
+    viewIsInsideTabBar={false}
+  >
+    <Component
+      style={
+        Object {
+          "height": 45,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <ReactionRow
+        emojiName="+1"
+        navigator={
+          Object {
+            "setOnNavigatorEvent": [MockFunction] {
+              "calls": Array [
+                Array [
+                  [Function],
+                ],
+              ],
+              "results": Array [
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+              ],
+            },
+          }
+        }
+        teammateNameDisplay="username"
+        theme={
+          Object {
+            "centerChannelBg": "#aaa",
+            "centerChannelColor": "#eee",
+          }
+        }
+        user={
+          Object {
+            "id": "user_id_2",
+            "username": "username_2",
+          }
+        }
+      />
+      <Component
+        style={
+          Object {
+            "backgroundColor": "rgba(238,238,238,0.2)",
+            "height": 1,
+          }
+        }
+      />
+    </Component>
+    <Component
+      style={
+        Object {
+          "height": 45,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <ReactionRow
+        emojiName="smile"
+        navigator={
+          Object {
+            "setOnNavigatorEvent": [MockFunction] {
+              "calls": Array [
+                Array [
+                  [Function],
+                ],
+              ],
+              "results": Array [
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+              ],
+            },
+          }
+        }
+        teammateNameDisplay="username"
+        theme={
+          Object {
+            "centerChannelBg": "#aaa",
+            "centerChannelColor": "#eee",
+          }
+        }
+        user={
+          Object {
+            "id": "user_id_1",
+            "username": "username_1",
+          }
+        }
+      />
+      <Component
+        style={
+          Object {
+            "backgroundColor": "rgba(238,238,238,0.2)",
+            "height": 1,
+          }
+        }
+      />
+    </Component>
+  </KeyboardAwareScrollView>
+</Component>
+`;
+
+exports[`ReactionList should match snapshot, renderReactionRows 1`] = `
+Array [
+  <Component
+    style={
+      Object {
+        "height": 45,
+        "justifyContent": "center",
+      }
+    }
+  >
+    <ReactionRow
+      emojiName="+1"
+      navigator={
+        Object {
+          "setOnNavigatorEvent": [MockFunction] {
+            "calls": Array [
+              Array [
+                [Function],
+              ],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+            ],
+          },
+        }
+      }
+      teammateNameDisplay="username"
+      theme={
+        Object {
+          "centerChannelBg": "#aaa",
+          "centerChannelColor": "#eee",
+        }
+      }
+      user={
+        Object {
+          "id": "user_id_2",
+          "username": "username_2",
+        }
+      }
+    />
+    <Component
+      style={
+        Object {
+          "backgroundColor": "rgba(238,238,238,0.2)",
+          "height": 1,
+        }
+      }
+    />
+  </Component>,
+  <Component
+    style={
+      Object {
+        "height": 45,
+        "justifyContent": "center",
+      }
+    }
+  >
+    <ReactionRow
+      emojiName="smile"
+      navigator={
+        Object {
+          "setOnNavigatorEvent": [MockFunction] {
+            "calls": Array [
+              Array [
+                [Function],
+              ],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+            ],
+          },
+        }
+      }
+      teammateNameDisplay="username"
+      theme={
+        Object {
+          "centerChannelBg": "#aaa",
+          "centerChannelColor": "#eee",
+        }
+      }
+      user={
+        Object {
+          "id": "user_id_1",
+          "username": "username_1",
+        }
+      }
+    />
+    <Component
+      style={
+        Object {
+          "backgroundColor": "rgba(238,238,238,0.2)",
+          "height": 1,
+        }
+      }
+    />
+  </Component>,
+]
+`;

--- a/app/screens/reaction_list/__snapshots__/reaction_row.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_row.test.js.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactionRow should match snapshot, renderContent 1`] = `
+<Component
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": undefined,
+      "flexDirection": "row",
+      "height": 44,
+      "justifyContent": "flex-start",
+      "width": "100%",
+    }
+  }
+>
+  <Component
+    style={
+      Object {
+        "alignItems": "center",
+        "width": "15%",
+      }
+    }
+  >
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}
+    >
+      <Connect(ProfilePicture)
+        showStatus={false}
+        size={24}
+        userId="user_id"
+      />
+    </TouchableOpacity>
+  </Component>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginLeft": 5,
+        "width": "70%",
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#aaa",
+          "fontSize": 14,
+          "paddingRight": 5,
+        }
+      }
+    >
+      @username
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+        
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "rgba(170,170,170,0.5)",
+          "fontSize": 14,
+          "marginLeft": 5,
+        }
+      }
+    >
+      username
+    </Text>
+  </Text>
+  <Component
+    style={
+      Object {
+        "alignItems": "center",
+        "justifyContent": "center",
+        "width": "15%",
+      }
+    }
+  >
+    <Connect(Emoji)
+      emojiName="smile"
+      size={26}
+    />
+  </Component>
+</Component>
+`;

--- a/app/screens/reaction_list/__snapshots__/reaction_row.test.js.snap
+++ b/app/screens/reaction_list/__snapshots__/reaction_row.test.js.snap
@@ -5,7 +5,7 @@ exports[`ReactionRow should match snapshot, renderContent 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "backgroundColor": undefined,
+      "backgroundColor": "#ffffff",
       "flexDirection": "row",
       "height": 44,
       "justifyContent": "flex-start",
@@ -17,7 +17,7 @@ exports[`ReactionRow should match snapshot, renderContent 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "width": "15%",
+        "width": "13%",
       }
     }
   >
@@ -25,74 +25,68 @@ exports[`ReactionRow should match snapshot, renderContent 1`] = `
       activeOpacity={0.2}
       onPress={[Function]}
     >
-      <Connect(ProfilePicture)
-        showStatus={false}
-        size={24}
-        userId="user_id"
-      />
+      <Component
+        style={
+          Object {
+            "paddingTop": 3,
+          }
+        }
+      >
+        <Connect(ProfilePicture)
+          showStatus={false}
+          size={24}
+          userId="user_id"
+        />
+      </Component>
     </TouchableOpacity>
   </Component>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
+  <Component
     ellipsizeMode="tail"
     numberOfLines={1}
     style={
       Object {
         "flexDirection": "row",
-        "marginLeft": 5,
-        "width": "70%",
+        "width": "74%",
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
+    <Component
       style={
         Object {
-          "color": "#aaa",
+          "color": "#3d3c40",
           "fontSize": 14,
           "paddingRight": 5,
         }
       }
     >
       @username
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    </Component>
+    <Component>
         
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
+    </Component>
+    <Component
       style={
         Object {
-          "color": "rgba(170,170,170,0.5)",
+          "color": "rgba(61,60,64,0.5)",
           "fontSize": 14,
-          "marginLeft": 5,
         }
       }
     >
       username
-    </Text>
-  </Text>
+    </Component>
+  </Component>
   <Component
     style={
       Object {
         "alignItems": "center",
         "justifyContent": "center",
-        "width": "15%",
+        "width": "13%",
       }
     }
   >
     <Connect(Emoji)
       emojiName="smile"
-      size={26}
+      size={24}
     />
   </Component>
 </Component>

--- a/app/screens/reaction_list/index.js
+++ b/app/screens/reaction_list/index.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+
+import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
+import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentUserId, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
+import {getTeammateNameDisplaySetting, getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import ReactionList from './reaction_list';
+
+function makeMapStateToProps() {
+    const getReactionsForPostSelector = makeGetReactionsForPost();
+    const getProfilesByIdsAndUsernames = makeGetProfilesByIdsAndUsernames();
+
+    return function mapStateToProps(state, ownProps) {
+        const reactions = getReactionsForPostSelector(state, ownProps.postId) || [];
+
+        const allUserIds = reactions.reduce((acc, reaction) => {
+            acc.push(reaction.user_id);
+            return acc;
+        }, []);
+
+        return {
+            allUserIds,
+            currentUserId: getCurrentUserId(state),
+            reactions,
+            teammateNameDisplay: getTeammateNameDisplaySetting(state),
+            theme: getTheme(state),
+            userProfiles: getProfilesByIdsAndUsernames(state, {allUserIds}) || [],
+        };
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getMissingProfilesByIds,
+        }, dispatch),
+    };
+}
+
+export default connect(makeMapStateToProps, mapDispatchToProps)(ReactionList);

--- a/app/screens/reaction_list/index.js
+++ b/app/screens/reaction_list/index.js
@@ -5,7 +5,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
-import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
+import {getUserIdsFromReactions, makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
 import {getTeammateNameDisplaySetting, getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
@@ -16,17 +16,12 @@ function makeMapStateToProps() {
     const getProfilesByIdsAndUsernames = makeGetProfilesByIdsAndUsernames();
 
     return function mapStateToProps(state, ownProps) {
-        const reactions = getReactionsForPostSelector(state, ownProps.postId) || [];
-
-        const allUserIds = reactions.reduce((acc, reaction) => {
-            acc.push(reaction.user_id);
-            return acc;
-        }, []);
+        const allUserIds = getUserIdsFromReactions(state, ownProps.postId);
 
         return {
             allUserIds,
             currentUserId: getCurrentUserId(state),
-            reactions,
+            reactions: getReactionsForPostSelector(state, ownProps.postId),
             teammateNameDisplay: getTeammateNameDisplaySetting(state),
             theme: getTheme(state),
             userProfiles: getProfilesByIdsAndUsernames(state, {allUserIds}) || [],

--- a/app/screens/reaction_list/index.js
+++ b/app/screens/reaction_list/index.js
@@ -5,9 +5,11 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
-import {getUserIdsFromReactions, makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
+import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
 import {getTeammateNameDisplaySetting, getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import {getUniqueUserIds} from 'app/utils/reaction';
 
 import ReactionList from './reaction_list';
 
@@ -16,12 +18,12 @@ function makeMapStateToProps() {
     const getProfilesByIdsAndUsernames = makeGetProfilesByIdsAndUsernames();
 
     return function mapStateToProps(state, ownProps) {
-        const allUserIds = getUserIdsFromReactions(state, ownProps.postId);
+        const reactions = getReactionsForPostSelector(state, ownProps.postId);
+        const allUserIds = getUniqueUserIds(reactions);
 
         return {
-            allUserIds,
             currentUserId: getCurrentUserId(state),
-            reactions: getReactionsForPostSelector(state, ownProps.postId),
+            reactions,
             teammateNameDisplay: getTeammateNameDisplaySetting(state),
             theme: getTheme(state),
             userProfiles: getProfilesByIdsAndUsernames(state, {allUserIds}) || [],

--- a/app/screens/reaction_list/reaction_header.js
+++ b/app/screens/reaction_list/reaction_header.js
@@ -62,7 +62,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         container: {
             backgroundColor: theme.centerChannelBg,
             height: 37,
-            paddingHorizontal: 10,
+            paddingHorizontal: 2,
         },
     };
 });

--- a/app/screens/reaction_list/reaction_header.js
+++ b/app/screens/reaction_list/reaction_header.js
@@ -1,0 +1,63 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {
+    ScrollView,
+    View,
+} from 'react-native';
+
+import {makeStyleSheetFromTheme} from 'app/utils/theme';
+
+import ReactionHeaderItem from './reaction_header_item';
+
+export default class ReactionHeader extends PureComponent {
+    static propTypes = {
+        selected: PropTypes.string.isRequired,
+        onSelectReaction: PropTypes.func.isRequired,
+        reactions: PropTypes.array.isRequired,
+        theme: PropTypes.object.isRequired,
+    }
+
+    handleOnPress = (emoji) => {
+        this.props.onSelectReaction(emoji);
+    };
+
+    render() {
+        const {selected, reactions, theme} = this.props;
+
+        const styles = getStyleSheet(theme);
+
+        return (
+            <View style={styles.container}>
+                <ScrollView
+                    alwaysBounceHorizontal={false}
+                    horizontal={true}
+                    overScrollMode='never'
+                >
+                    {reactions.map((reaction) => (
+                        <ReactionHeaderItem
+                            key={reaction.name}
+                            count={reaction.count}
+                            emojiName={reaction.name}
+                            highlight={selected === reaction.name}
+                            onPress={this.handleOnPress}
+                            theme={theme}
+                        />
+                    ))}
+                </ScrollView>
+            </View>
+        );
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        container: {
+            backgroundColor: theme.centerChannelBg,
+            height: 50,
+            paddingHorizontal: 10,
+        },
+    };
+});

--- a/app/screens/reaction_list/reaction_header.js
+++ b/app/screens/reaction_list/reaction_header.js
@@ -62,7 +62,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         container: {
             backgroundColor: theme.centerChannelBg,
             height: 37,
-            paddingHorizontal: 2,
+            paddingHorizontal: 0,
         },
     };
 });

--- a/app/screens/reaction_list/reaction_header.js
+++ b/app/screens/reaction_list/reaction_header.js
@@ -24,9 +24,23 @@ export default class ReactionHeader extends PureComponent {
         this.props.onSelectReaction(emoji);
     };
 
-    render() {
+    renderReactionHeaderItems = () => {
         const {selected, reactions, theme} = this.props;
 
+        return reactions.map((reaction) => (
+            <ReactionHeaderItem
+                key={reaction.name}
+                count={reaction.count}
+                emojiName={reaction.name}
+                highlight={selected === reaction.name}
+                onPress={this.handleOnPress}
+                theme={theme}
+            />
+        ));
+    }
+
+    render() {
+        const {theme} = this.props;
         const styles = getStyleSheet(theme);
 
         return (
@@ -36,16 +50,7 @@ export default class ReactionHeader extends PureComponent {
                     horizontal={true}
                     overScrollMode='never'
                 >
-                    {reactions.map((reaction) => (
-                        <ReactionHeaderItem
-                            key={reaction.name}
-                            count={reaction.count}
-                            emojiName={reaction.name}
-                            highlight={selected === reaction.name}
-                            onPress={this.handleOnPress}
-                            theme={theme}
-                        />
-                    ))}
+                    {this.renderReactionHeaderItems()}
                 </ScrollView>
             </View>
         );
@@ -56,7 +61,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         container: {
             backgroundColor: theme.centerChannelBg,
-            height: 50,
+            height: 37,
             paddingHorizontal: 10,
         },
     };

--- a/app/screens/reaction_list/reaction_header.test.js
+++ b/app/screens/reaction_list/reaction_header.test.js
@@ -2,8 +2,9 @@
 // See LICENSE.txt for license information.
 import React from 'react';
 import {shallow} from 'enzyme';
-
 import {ScrollView} from 'react-native';
+
+import Preferences from 'mattermost-redux/constants/preferences';
 
 import ReactionHeader from './reaction_header';
 
@@ -12,9 +13,7 @@ describe('ReactionHeader', () => {
         selected: 'smile',
         onSelectReaction: jest.fn(),
         reactions: [{name: 'smile', count: 2}, {name: '+1', count: 1}],
-        theme: {
-            centerChannelBg: '#aaa',
-        },
+        theme: Preferences.THEMES.default,
     };
 
     test('should match snapshot', () => {

--- a/app/screens/reaction_list/reaction_header.test.js
+++ b/app/screens/reaction_list/reaction_header.test.js
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {ScrollView} from 'react-native';
+
+import ReactionHeader from './reaction_header';
+
+describe('ReactionHeader', () => {
+    const baseProps = {
+        selected: 'smile',
+        onSelectReaction: jest.fn(),
+        reactions: [{name: 'smile', count: 2}, {name: '+1', count: 1}],
+        theme: {
+            centerChannelBg: '#aaa',
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <ReactionHeader {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+        expect(wrapper.find(ScrollView).exists()).toEqual(true);
+    });
+
+    test('should match snapshot, renderContent', () => {
+        const wrapper = shallow(
+            <ReactionHeader {...baseProps}/>
+        );
+
+        expect(wrapper.instance().renderReactionHeaderItems()).toMatchSnapshot();
+    });
+
+    test('should call props.onSelectReaction on handlePress', () => {
+        const onSelectReaction = jest.fn();
+        const wrapper = shallow(
+            <ReactionHeader
+                {...baseProps}
+                onSelectReaction={onSelectReaction}
+            />
+        );
+
+        wrapper.instance().handleOnPress();
+        expect(onSelectReaction).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/screens/reaction_list/reaction_header_item.js
+++ b/app/screens/reaction_list/reaction_header_item.js
@@ -24,42 +24,50 @@ export default class ReactionHeaderItem extends PureComponent {
         theme: PropTypes.object.isRequired,
     }
 
-    handlePress = () => {
+    handleOnPress = () => {
         const {emojiName, highlight, onPress} = this.props;
         onPress(emojiName, highlight);
     }
 
-    renderEmoji = (emojiName, styles) => {
+    renderContent = () => {
+        const {count, emojiName, theme} = this.props;
+        const styles = getStyleSheet(theme);
+
         if (emojiName === ALL_EMOJIS) {
             return (
-                <FormattedText
-                    id='mobile.reaction_header.all_emojis'
-                    defaultMessage={'All'}
-                    style={styles.text}
-                />
+                <React.Fragment>
+                    <FormattedText
+                        id='mobile.reaction_header.all_emojis'
+                        defaultMessage={'All'}
+                        style={styles.text}
+                    />
+                    <Text style={styles.text}>{count}</Text>
+                </React.Fragment>
             );
         }
 
         return (
-            <Emoji
-                emojiName={emojiName}
-                size={25}
-                padding={5}
-            />
+            <React.Fragment>
+                <Emoji
+                    emojiName={emojiName}
+                    size={16}
+                    padding={5}
+                />
+                <Text style={styles.text}>{count}</Text>
+            </React.Fragment>
         );
     }
 
     render() {
-        const {count, emojiName, highlight, theme} = this.props;
+        const {highlight, theme} = this.props;
         const styles = getStyleSheet(theme);
 
         return (
             <TouchableOpacity
-                onPress={this.handlePress}
+                onPress={this.handleOnPress}
                 style={[styles.reaction, (highlight && styles.highlight)]}
             >
-                {this.renderEmoji(emojiName, styles)}
-                <Text style={styles.text}>{count}</Text>
+                {this.renderContent()}
             </TouchableOpacity>
         );
     }
@@ -70,7 +78,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         text: {
             color: theme.linkColor,
             marginLeft: 3,
-            fontSize: 20,
+            fontSize: 16,
         },
         highlight: {
             borderColor: changeOpacity(theme.linkColor, 1),
@@ -79,10 +87,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         reaction: {
             alignItems: 'center',
             flexDirection: 'row',
-            height: 40,
+            height: 35,
             marginRight: 6,
             marginBottom: 5,
-            marginTop: 10,
+            marginTop: 3,
             paddingVertical: 2,
             paddingHorizontal: 6,
         },

--- a/app/screens/reaction_list/reaction_header_item.js
+++ b/app/screens/reaction_list/reaction_header_item.js
@@ -59,13 +59,13 @@ export default class ReactionHeaderItem extends PureComponent {
     }
 
     render() {
-        const {highlight, theme} = this.props;
+        const {emojiName, highlight, theme} = this.props;
         const styles = getStyleSheet(theme);
 
         return (
             <TouchableOpacity
                 onPress={this.handleOnPress}
-                style={[styles.reaction, (highlight && styles.highlight)]}
+                style={[styles.reaction, (highlight ? styles.highlight : styles.regular), (emojiName === ALL_EMOJIS && styles.allText)]}
             >
                 {this.renderContent()}
             </TouchableOpacity>
@@ -75,13 +75,20 @@ export default class ReactionHeaderItem extends PureComponent {
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
+        allText: {
+            marginLeft: 7,
+        },
         text: {
             color: theme.linkColor,
-            marginLeft: 3,
+            marginLeft: 4,
             fontSize: 16,
         },
         highlight: {
             borderColor: changeOpacity(theme.linkColor, 1),
+            borderBottomWidth: 2,
+        },
+        regular: {
+            borderColor: theme.centerChannelBg,
             borderBottomWidth: 2,
         },
         reaction: {

--- a/app/screens/reaction_list/reaction_header_item.js
+++ b/app/screens/reaction_list/reaction_header_item.js
@@ -11,13 +11,16 @@ import {
 import Emoji from 'app/components/emoji';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
-export default class Reaction extends PureComponent {
+import FormattedText from 'app/components/formatted_text';
+
+import {ALL_EMOJIS} from 'app/constants/emoji';
+
+export default class ReactionHeaderItem extends PureComponent {
     static propTypes = {
         count: PropTypes.number.isRequired,
         emojiName: PropTypes.string.isRequired,
         highlight: PropTypes.bool.isRequired,
         onPress: PropTypes.func.isRequired,
-        onLongPress: PropTypes.func.isRequired,
         theme: PropTypes.object.isRequired,
     }
 
@@ -26,28 +29,37 @@ export default class Reaction extends PureComponent {
         onPress(emojiName, highlight);
     }
 
+    renderEmoji = (emojiName, styles) => {
+        if (emojiName === ALL_EMOJIS) {
+            return (
+                <FormattedText
+                    id='mobile.reaction_header.all_emojis'
+                    defaultMessage={'All'}
+                    style={styles.text}
+                />
+            );
+        }
+
+        return (
+            <Emoji
+                emojiName={emojiName}
+                size={25}
+                padding={5}
+            />
+        );
+    }
+
     render() {
-        const {
-            count,
-            emojiName,
-            highlight,
-            onLongPress,
-            theme,
-        } = this.props;
+        const {count, emojiName, highlight, theme} = this.props;
         const styles = getStyleSheet(theme);
 
         return (
             <TouchableOpacity
                 onPress={this.handlePress}
-                onLongPress={onLongPress}
                 style={[styles.reaction, (highlight && styles.highlight)]}
             >
-                <Emoji
-                    emojiName={emojiName}
-                    size={20}
-                    padding={5}
-                />
-                <Text style={styles.count}>{count}</Text>
+                {this.renderEmoji(emojiName, styles)}
+                <Text style={styles.text}>{count}</Text>
             </TouchableOpacity>
         );
     }
@@ -55,20 +67,19 @@ export default class Reaction extends PureComponent {
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
-        count: {
+        text: {
             color: theme.linkColor,
-            marginLeft: 6,
+            marginLeft: 3,
+            fontSize: 20,
         },
         highlight: {
-            backgroundColor: changeOpacity(theme.linkColor, 0.1),
+            borderColor: changeOpacity(theme.linkColor, 1),
+            borderBottomWidth: 2,
         },
         reaction: {
             alignItems: 'center',
-            borderRadius: 2,
-            borderColor: changeOpacity(theme.linkColor, 0.4),
-            borderWidth: 1,
             flexDirection: 'row',
-            height: 30,
+            height: 40,
             marginRight: 6,
             marginBottom: 5,
             marginTop: 10,

--- a/app/screens/reaction_list/reaction_header_item.test.js
+++ b/app/screens/reaction_list/reaction_header_item.test.js
@@ -2,8 +2,9 @@
 // See LICENSE.txt for license information.
 import React from 'react';
 import {shallow} from 'enzyme';
-
 import {TouchableOpacity} from 'react-native';
+
+import Preferences from 'mattermost-redux/constants/preferences';
 
 import ReactionHeaderItem from './reaction_header_item';
 
@@ -15,9 +16,7 @@ describe('ReactionHeaderItem', () => {
         emojiName: 'smile',
         highlight: false,
         onPress: jest.fn(),
-        theme: {
-            linkColor: '#aaa',
-        },
+        theme: Preferences.THEMES.default,
     };
 
     test('should match snapshot', () => {

--- a/app/screens/reaction_list/reaction_header_item.test.js
+++ b/app/screens/reaction_list/reaction_header_item.test.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {TouchableOpacity} from 'react-native';
+
+import ReactionHeaderItem from './reaction_header_item';
+
+import {ALL_EMOJIS} from 'app/constants/emoji';
+
+describe('ReactionHeaderItem', () => {
+    const baseProps = {
+        count: 3,
+        emojiName: 'smile',
+        highlight: false,
+        onPress: jest.fn(),
+        theme: {
+            linkColor: '#aaa',
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <ReactionHeaderItem {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+        expect(wrapper.find(TouchableOpacity).exists()).toEqual(true);
+    });
+
+    test('should match snapshot, renderContent', () => {
+        const wrapper = shallow(
+            <ReactionHeaderItem {...baseProps}/>
+        );
+
+        expect(wrapper.instance().renderContent()).toMatchSnapshot();
+
+        wrapper.setProps({emojiName: ALL_EMOJIS});
+        expect(wrapper.instance().renderContent()).toMatchSnapshot();
+    });
+
+    test('should call props.onPress on handleOnPress', () => {
+        const onPress = jest.fn();
+        const wrapper = shallow(
+            <ReactionHeaderItem
+                {...baseProps}
+                onPress={onPress}
+            />
+        );
+
+        wrapper.instance().handleOnPress();
+        expect(onPress).toHaveBeenCalledTimes(1);
+        expect(onPress).toHaveBeenCalledWith(baseProps.emojiName, baseProps.highlight);
+    });
+});

--- a/app/screens/reaction_list/reaction_list.js
+++ b/app/screens/reaction_list/reaction_list.js
@@ -1,0 +1,241 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {View} from 'react-native';
+import {intlShape} from 'react-intl';
+import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
+
+import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+
+import ReactionHeader from './reaction_header';
+import ReactionRow from './reaction_row';
+
+import {ALL_EMOJIS} from 'app/constants/emoji';
+
+export default class ReactionList extends PureComponent {
+    static propTypes = {
+        actions: PropTypes.shape({
+            getMissingProfilesByIds: PropTypes.func.isRequired,
+        }).isRequired,
+        allUserIds: PropTypes.array,
+        navigator: PropTypes.object,
+        reactions: PropTypes.array.isRequired,
+        theme: PropTypes.object.isRequired,
+        teammateNameDisplay: PropTypes.string,
+        userProfiles: PropTypes.array,
+    };
+
+    static contextTypes = {
+        intl: intlShape.isRequired,
+    };
+
+    constructor(props) {
+        super(props);
+        const {allUserIds, reactions, userProfiles} = props;
+
+        this.userProfilesById = ReactionList.generateUserProfilesById(userProfiles);
+        this.getMissingProfiles(allUserIds, userProfiles);
+
+        const reactionsByName = ReactionList.getReactionsByName(reactions);
+
+        this.state = {
+            selected: ALL_EMOJIS,
+            reactions,
+            reactionsByName,
+            sortedReactions: ReactionList.sortReactions(reactionsByName),
+            sortedReactionsForHeader: ReactionList.getSortedReactionsForHeader(reactionsByName),
+        };
+
+        props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
+    }
+
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (!nextProps.reactions.length !== prevState.reactions.length) {
+            const {reactions} = nextProps;
+
+            const reactionsByName = ReactionList.getReactionsByName(reactions);
+
+            return {
+                reactions,
+                reactionsByName,
+                sortedReactions: ReactionList.sortReactions(reactionsByName),
+                sortedReactionsForHeader: ReactionList.getSortedReactionsForHeader(reactionsByName),
+            };
+        }
+
+        return null;
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.userProfiles.length !== this.props.userProfiles.length) {
+            this.userProfilesById = ReactionList.generateUserProfilesById(this.props.userProfiles);
+        }
+
+        if (prevProps.allUserIds.length !== this.props.allUserIds.length) {
+            this.getMissingProfiles(this.props.allUserIds, this.props.userProfiles);
+        }
+    }
+
+    onNavigatorEvent = (event) => {
+        if (event.type === 'NavBarButtonPress') {
+            if (event.id === 'close-reaction-list') {
+                this.props.navigator.dismissModal({
+                    animationType: 'slide-down',
+                });
+            }
+        }
+    };
+
+    getMissingProfiles = (allUserIds, userProfiles) => {
+        if (userProfiles.length !== allUserIds.length) {
+            const missingUserIds = ReactionList.getMissingUserIds(this.userProfilesById, allUserIds);
+
+            if (missingUserIds.length > 0) {
+                this.props.actions.getMissingProfilesByIds(missingUserIds);
+            }
+        }
+    }
+
+    scrollViewRef = (ref) => {
+        this.scrollView = ref;
+    };
+
+    handleOnSelectReaction = (emoji) => {
+        this.setState({selected: emoji});
+    }
+
+    render() {
+        const {
+            navigator,
+            teammateNameDisplay,
+            theme,
+        } = this.props;
+        const {
+            reactionsByName,
+            selected,
+            sortedReactions,
+            sortedReactionsForHeader,
+        } = this.state;
+
+        const style = getStyleSheet(theme);
+        const reactions = selected === ALL_EMOJIS ? sortedReactions : reactionsByName[selected];
+
+        return (
+            <View style={style.flex}>
+                <View style={style.headerContainer}>
+                    <ReactionHeader
+                        selected={selected}
+                        onSelectReaction={this.handleOnSelectReaction}
+                        reactions={sortedReactionsForHeader}
+                        theme={theme}
+                    />
+                </View>
+                <KeyboardAwareScrollView
+                    bounces={true}
+                    innerRef={this.scrollViewRef}
+                >
+                    {reactions.map(({emoji_name: emojiName, user_id: userId}) => (
+                        <View
+                            key={emojiName + userId}
+                            style={style.rowContainer}
+                        >
+                            <ReactionRow
+                                emojiName={emojiName}
+                                navigator={navigator}
+                                teammateNameDisplay={teammateNameDisplay}
+                                theme={theme}
+                                user={this.userProfilesById[userId]}
+                            />
+                        </View>
+                    ))}
+                </KeyboardAwareScrollView>
+            </View>
+        );
+    }
+
+    static generateUserProfilesById = (userProfiles = []) => {
+        return userProfiles.reduce((acc, userProfile) => {
+            acc[userProfile.id] = userProfile;
+
+            return acc;
+        }, []);
+    }
+
+    static getMissingUserIds = (userProfilesById = {}, allUserIds = []) => {
+        return allUserIds.reduce((acc, userId) => {
+            if (userProfilesById[userId]) {
+                acc.push(userId);
+            }
+
+            return acc;
+        }, []);
+    }
+
+    static compareReactions(a, b) {
+        if (a.count !== b.count) {
+            return b.count - a.count;
+        }
+
+        return a.name.localeCompare(b.name);
+    }
+
+    static getReactionsByName(reactions = []) {
+        return reactions.reduce((acc, reaction) => {
+            const byName = acc[reaction.emoji_name] || [];
+            acc[reaction.emoji_name] = [...byName, reaction];
+
+            return acc;
+        }, {});
+    }
+
+    static sortReactionsByName(reactionsByName = {}) {
+        return Object.entries(reactionsByName).
+            map(([name, reactions]) => ({name, reactions, count: reactions.length})).
+            sort(ReactionList.compareReactions);
+    }
+
+    static sortReactions(reactionsByName = {}) {
+        return ReactionList.sortReactionsByName(reactionsByName).
+            reduce((acc, {reactions}) => {
+                reactions.forEach((r) => acc.push(r));
+                return acc;
+            }, []);
+    }
+
+    static getSortedReactionsForHeader(reactionsByName = {}) {
+        const sortedReactionsForHeader = ReactionList.sortReactionsByName(reactionsByName);
+
+        const totalCount = sortedReactionsForHeader.reduce((acc, reaction) => {
+            return acc + reaction.count;
+        }, 0);
+
+        return [{name: ALL_EMOJIS, count: totalCount}, ...sortedReactionsForHeader];
+    }
+}
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        flex: {
+            backgroundColor: theme.centerChannelBg,
+            flex: 1,
+        },
+        headerContainer: {
+            height: 51,
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderBottomWidth: 1,
+        },
+        rowContainer: {
+            alignItems: 'center',
+            width: '100%',
+            height: 66,
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderBottomWidth: 1,
+        },
+        separator: {
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.2),
+            height: 1,
+        },
+    };
+});

--- a/app/screens/reaction_list/reaction_list.js
+++ b/app/screens/reaction_list/reaction_list.js
@@ -59,28 +59,30 @@ export default class ReactionList extends PureComponent {
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
-        let hasNewState = false;
-        const newState = {};
-        if (!nextProps.reactions.length !== prevState.reactions.length) {
+        let newState = null;
+        if (nextProps.reactions !== prevState.reactions) {
             const {reactions} = nextProps;
             const reactionsByName = getReactionsByName(reactions);
 
-            newState.allUserIds = getUniqueUserIds(reactions);
-            newState.reactions = reactions;
-            newState.reactionsByName = reactionsByName;
-            newState.sortedReactions = sortReactions(reactionsByName);
-            newState.sortedReactionsForHeader = getSortedReactionsForHeader(reactionsByName);
-
-            hasNewState = true;
+            newState = {
+                allUserIds: getUniqueUserIds(reactions),
+                reactions,
+                reactionsByName,
+                sortedReactions: sortReactions(reactionsByName),
+                sortedReactionsForHeader: getSortedReactionsForHeader(reactionsByName),
+            };
         }
 
         if (nextProps.userProfiles !== prevState.userProfiles) {
-            newState.userProfilesById = generateUserProfilesById(nextProps.userProfiles);
-
-            hasNewState = true;
+            const userProfilesById = generateUserProfilesById(nextProps.userProfiles);
+            if (newState) {
+                newState.userProfilesById = userProfilesById;
+            } else {
+                newState = {userProfilesById};
+            }
         }
 
-        return hasNewState ? newState : null;
+        return newState;
     }
 
     componentDidMount() {

--- a/app/screens/reaction_list/reaction_list.test.js
+++ b/app/screens/reaction_list/reaction_list.test.js
@@ -4,6 +4,8 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 
+import Preferences from 'mattermost-redux/constants/preferences';
+
 import ReactionList from './reaction_list';
 
 jest.mock('react-intl');
@@ -16,10 +18,7 @@ describe('ReactionList', () => {
         allUserIds: ['user_id_1', 'user_id_2'],
         navigator: {setOnNavigatorEvent: jest.fn()},
         reactions: [{emoji_name: 'smile', user_id: 'user_id_1'}, {emoji_name: '+1', user_id: 'user_id_2'}],
-        theme: {
-            centerChannelBg: '#aaa',
-            centerChannelColor: '#eee',
-        },
+        theme: Preferences.THEMES.default,
         teammateNameDisplay: 'username',
         userProfiles: [{id: 'user_id_1', username: 'username_1'}, {id: 'user_id_2', username: 'username_2'}],
     };

--- a/app/screens/reaction_list/reaction_list.test.js
+++ b/app/screens/reaction_list/reaction_list.test.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
+
+import ReactionList from './reaction_list';
+
+jest.mock('react-intl');
+
+describe('ReactionList', () => {
+    const baseProps = {
+        actions: {
+            getMissingProfilesByIds: jest.fn(),
+        },
+        allUserIds: ['user_id_1', 'user_id_2'],
+        navigator: {setOnNavigatorEvent: jest.fn()},
+        reactions: [{emoji_name: 'smile', user_id: 'user_id_1'}, {emoji_name: '+1', user_id: 'user_id_2'}],
+        theme: {
+            centerChannelBg: '#aaa',
+            centerChannelColor: '#eee',
+        },
+        teammateNameDisplay: 'username',
+        userProfiles: [{id: 'user_id_1', username: 'username_1'}, {id: 'user_id_2', username: 'username_2'}],
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <ReactionList {...baseProps}/>,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+        expect(wrapper.find(KeyboardAwareScrollView).exists()).toEqual(true);
+    });
+
+    test('should match snapshot, renderReactionRows', () => {
+        const wrapper = shallow(
+            <ReactionList {...baseProps}/>,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        expect(wrapper.instance().renderReactionRows()).toMatchSnapshot();
+    });
+
+    test('should match state on handleOnSelectReaction', () => {
+        const wrapper = shallow(
+            <ReactionList {...baseProps}/>,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        wrapper.setState({selected: 'smile'});
+        wrapper.instance().handleOnSelectReaction('+1');
+        expect(wrapper.state('selected')).toEqual('+1');
+    });
+});

--- a/app/screens/reaction_list/reaction_row.js
+++ b/app/screens/reaction_list/reaction_row.js
@@ -35,8 +35,8 @@ export default class ReactionRow extends React.PureComponent {
         intl: intlShape,
     };
 
-    goToUserProfile = (userId) => {
-        const {navigator, theme} = this.props;
+    goToUserProfile = () => {
+        const {navigator, theme, user} = this.props;
         const {formatMessage} = this.context.intl;
 
         const options = {
@@ -45,7 +45,7 @@ export default class ReactionRow extends React.PureComponent {
             animated: true,
             backButtonTitle: '',
             passProps: {
-                userId,
+                userId: user.id,
             },
             navigatorStyle: {
                 navBarTextColor: theme.sidebarHeaderTextColor,
@@ -76,16 +76,18 @@ export default class ReactionRow extends React.PureComponent {
 
         return (
             <View style={style.container}>
-                <View style={style.profile}>
+                <View style={style.profileContainer}>
                     <TouchableOpacity
                         key={user.id}
-                        onPress={preventDoubleTap(() => this.goToUserProfile(user.id))}
+                        onPress={preventDoubleTap(this.goToUserProfile)}
                     >
-                        <ProfilePicture
-                            userId={id}
-                            showStatus={false}
-                            size={24}
-                        />
+                        <View style={style.profile}>
+                            <ProfilePicture
+                                userId={id}
+                                showStatus={false}
+                                size={24}
+                            />
+                        </View>
                     </TouchableOpacity>
                 </View>
                 <Text
@@ -104,7 +106,7 @@ export default class ReactionRow extends React.PureComponent {
                 <View style={style.emoji}>
                     <Emoji
                         emojiName={emojiName}
-                        size={26}
+                        size={24}
                     />
                 </View>
             </View>
@@ -122,14 +124,16 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             width: '100%',
             alignItems: 'center',
         },
-        profile: {
+        profileContainer: {
             alignItems: 'center',
-            width: '15%',
+            width: '13%',
+        },
+        profile: {
+            paddingTop: 3,
         },
         textContainer: {
-            width: '70%',
+            width: '74%',
             flexDirection: 'row',
-            marginLeft: 5,
         },
         username: {
             fontSize: 14,
@@ -137,13 +141,12 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             paddingRight: 5,
         },
         displayName: {
-            marginLeft: 5,
             fontSize: 14,
             color: changeOpacity(theme.centerChannelColor, 0.5),
         },
         emoji: {
             alignItems: 'center',
-            width: '15%',
+            width: '13%',
             justifyContent: 'center',
         },
     };

--- a/app/screens/reaction_list/reaction_row.js
+++ b/app/screens/reaction_list/reaction_row.js
@@ -1,0 +1,166 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {intlShape} from 'react-intl';
+import {
+    Platform,
+    Text,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+
+import {displayUsername} from 'mattermost-redux/utils/user_utils';
+
+import ProfilePicture from 'app/components/profile_picture';
+import {preventDoubleTap} from 'app/utils/tap';
+import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
+
+import CustomListRow from 'app/components/custom_list/custom_list_row';
+import Emoji from 'app/components/emoji';
+
+export default class ReactionRow extends React.PureComponent {
+    static propTypes = {
+        emojiName: PropTypes.string.isRequired,
+        navigator: PropTypes.object,
+        teammateNameDisplay: PropTypes.string.isRequired,
+        theme: PropTypes.object.isRequired,
+        user: PropTypes.object.isRequired,
+    };
+
+    static defaultProps = {
+        user: {},
+    }
+
+    static contextTypes = {
+        intl: intlShape,
+    };
+
+    goToUserProfile = (userId) => {
+        const {navigator, theme} = this.props;
+        const {formatMessage} = this.context.intl;
+
+        const options = {
+            screen: 'UserProfile',
+            title: formatMessage({id: 'mobile.routes.user_profile', defaultMessage: 'Profile'}),
+            animated: true,
+            backButtonTitle: '',
+            passProps: {
+                userId,
+            },
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg,
+            },
+        };
+
+        if (Platform.OS === 'ios') {
+            navigator.push(options);
+        } else {
+            navigator.showModal(options);
+        }
+    };
+
+    render() {
+        const {
+            emojiName,
+            teammateNameDisplay,
+            theme,
+            user,
+        } = this.props;
+
+        if (!user.id) {
+            return null;
+        }
+
+        const {id, username} = user;
+        const style = getStyleFromTheme(theme);
+        const usernameDisplay = '@' + username;
+
+        return (
+            <View style={style.container}>
+                <CustomListRow
+                    id={id}
+                    theme={theme}
+                    onPress={this.onPress}
+                    enabled={true}
+                    selectable={false}
+                    selected={false}
+                >
+                    <View style={style.profile}>
+                        <TouchableOpacity
+                            key={user.id}
+                            onPress={preventDoubleTap(() => this.goToUserProfile(user.id))}
+                        >
+                            <ProfilePicture
+                                userId={id}
+                                showStatus={false}
+                                size={32}
+                            />
+                        </TouchableOpacity>
+                    </View>
+                    <View style={style.textContainer}>
+                        <View>
+                            <Text style={style.username}>
+                                {usernameDisplay}
+                            </Text>
+                        </View>
+                        <View>
+                            <Text
+                                style={style.displayName}
+                                ellipsizeMode='tail'
+                                numberOfLines={1}
+                            >
+                                {displayUsername(user, teammateNameDisplay)}
+                            </Text>
+                        </View>
+                    </View>
+                    <View style={style.emoji}>
+                        <Emoji
+                            emojiName={emojiName}
+                            size={32}
+                        />
+                    </View>
+                </CustomListRow>
+            </View>
+        );
+    }
+}
+
+const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
+    return {
+        container: {
+            backgroundColor: theme.centerChannelBg,
+            flexDirection: 'row',
+            justifyContent: 'flex-start',
+            height: 65,
+            width: '100%',
+            zIndex: 10,
+        },
+        profile: {
+            alignItems: 'center',
+            width: '10%',
+        },
+        textContainer: {
+            width: '80%',
+            flexDirection: 'row',
+            marginLeft: 5,
+        },
+        username: {
+            fontSize: 15,
+            color: theme.centerChannelColor,
+        },
+        displayName: {
+            marginLeft: 5,
+            fontSize: 15,
+            color: changeOpacity(theme.centerChannelColor, 0.5),
+        },
+        emoji: {
+            alignItems: 'center',
+            width: '10%',
+        },
+    };
+});

--- a/app/screens/reaction_list/reaction_row.js
+++ b/app/screens/reaction_list/reaction_row.js
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
 import {
-    Platform,
     Text,
     TouchableOpacity,
     View,
@@ -17,7 +16,6 @@ import ProfilePicture from 'app/components/profile_picture';
 import {preventDoubleTap} from 'app/utils/tap';
 import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
 
-import CustomListRow from 'app/components/custom_list/custom_list_row';
 import Emoji from 'app/components/emoji';
 
 export default class ReactionRow extends React.PureComponent {
@@ -57,11 +55,7 @@ export default class ReactionRow extends React.PureComponent {
             },
         };
 
-        if (Platform.OS === 'ios') {
-            navigator.push(options);
-        } else {
-            navigator.showModal(options);
-        }
+        navigator.push(options);
     };
 
     render() {
@@ -82,49 +76,37 @@ export default class ReactionRow extends React.PureComponent {
 
         return (
             <View style={style.container}>
-                <CustomListRow
-                    id={id}
-                    theme={theme}
-                    onPress={this.onPress}
-                    enabled={true}
-                    selectable={false}
-                    selected={false}
-                >
-                    <View style={style.profile}>
-                        <TouchableOpacity
-                            key={user.id}
-                            onPress={preventDoubleTap(() => this.goToUserProfile(user.id))}
-                        >
-                            <ProfilePicture
-                                userId={id}
-                                showStatus={false}
-                                size={32}
-                            />
-                        </TouchableOpacity>
-                    </View>
-                    <View style={style.textContainer}>
-                        <View>
-                            <Text style={style.username}>
-                                {usernameDisplay}
-                            </Text>
-                        </View>
-                        <View>
-                            <Text
-                                style={style.displayName}
-                                ellipsizeMode='tail'
-                                numberOfLines={1}
-                            >
-                                {displayUsername(user, teammateNameDisplay)}
-                            </Text>
-                        </View>
-                    </View>
-                    <View style={style.emoji}>
-                        <Emoji
-                            emojiName={emojiName}
-                            size={32}
+                <View style={style.profile}>
+                    <TouchableOpacity
+                        key={user.id}
+                        onPress={preventDoubleTap(() => this.goToUserProfile(user.id))}
+                    >
+                        <ProfilePicture
+                            userId={id}
+                            showStatus={false}
+                            size={24}
                         />
-                    </View>
-                </CustomListRow>
+                    </TouchableOpacity>
+                </View>
+                <Text
+                    style={style.textContainer}
+                    ellipsizeMode='tail'
+                    numberOfLines={1}
+                >
+                    <Text style={style.username}>
+                        {usernameDisplay}
+                    </Text>
+                    <Text>{'  '}</Text>
+                    <Text style={style.displayName}>
+                        {displayUsername(user, teammateNameDisplay)}
+                    </Text>
+                </Text>
+                <View style={style.emoji}>
+                    <Emoji
+                        emojiName={emojiName}
+                        size={26}
+                    />
+                </View>
             </View>
         );
     }
@@ -136,31 +118,33 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             backgroundColor: theme.centerChannelBg,
             flexDirection: 'row',
             justifyContent: 'flex-start',
-            height: 65,
+            height: 44,
             width: '100%',
-            zIndex: 10,
+            alignItems: 'center',
         },
         profile: {
             alignItems: 'center',
-            width: '10%',
+            width: '15%',
         },
         textContainer: {
-            width: '80%',
+            width: '70%',
             flexDirection: 'row',
             marginLeft: 5,
         },
         username: {
-            fontSize: 15,
+            fontSize: 14,
             color: theme.centerChannelColor,
+            paddingRight: 5,
         },
         displayName: {
             marginLeft: 5,
-            fontSize: 15,
+            fontSize: 14,
             color: changeOpacity(theme.centerChannelColor, 0.5),
         },
         emoji: {
             alignItems: 'center',
-            width: '10%',
+            width: '15%',
+            justifyContent: 'center',
         },
     };
 });

--- a/app/screens/reaction_list/reaction_row.test.js
+++ b/app/screens/reaction_list/reaction_row.test.js
@@ -3,6 +3,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
+import Preferences from 'mattermost-redux/constants/preferences';
+
 import ReactionRow from './reaction_row';
 
 describe('ReactionRow', () => {
@@ -10,9 +12,7 @@ describe('ReactionRow', () => {
         emojiName: 'smile',
         navigator: {},
         teammateNameDisplay: 'username',
-        theme: {
-            centerChannelColor: '#aaa',
-        },
+        theme: Preferences.THEMES.default,
         user: {id: 'user_id', username: 'username'},
     };
 

--- a/app/screens/reaction_list/reaction_row.test.js
+++ b/app/screens/reaction_list/reaction_row.test.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import ReactionRow from './reaction_row';
+
+describe('ReactionRow', () => {
+    const baseProps = {
+        emojiName: 'smile',
+        navigator: {},
+        teammateNameDisplay: 'username',
+        theme: {
+            centerChannelColor: '#aaa',
+        },
+        user: {id: 'user_id', username: 'username'},
+    };
+
+    test('should match snapshot, renderContent', () => {
+        const wrapper = shallow(
+            <ReactionRow {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/app/utils/reaction.js
+++ b/app/utils/reaction.js
@@ -61,3 +61,7 @@ export function getSortedReactionsForHeader(reactionsByName = {}) {
 
     return [{name: ALL_EMOJIS, count: totalCount}, ...sortedReactionsForHeader];
 }
+
+export function getUniqueUserIds(reactions = []) {
+    return reactions.map((reaction) => reaction.user_id).filter((id, index, arr) => arr.indexOf(id) === index);
+}

--- a/app/utils/reaction.js
+++ b/app/utils/reaction.js
@@ -1,0 +1,63 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {ALL_EMOJIS} from 'app/constants/emoji';
+
+export function generateUserProfilesById(userProfiles = []) {
+    return userProfiles.reduce((acc, userProfile) => {
+        acc[userProfile.id] = userProfile;
+
+        return acc;
+    }, []);
+}
+
+export function getMissingUserIds(userProfilesById = {}, allUserIds = []) {
+    return allUserIds.reduce((acc, userId) => {
+        if (userProfilesById[userId]) {
+            acc.push(userId);
+        }
+
+        return acc;
+    }, []);
+}
+
+export function compareReactions(a, b) {
+    if (a.count !== b.count) {
+        return b.count - a.count;
+    }
+
+    return a.name.localeCompare(b.name);
+}
+
+export function getReactionsByName(reactions = []) {
+    return reactions.reduce((acc, reaction) => {
+        const byName = acc[reaction.emoji_name] || [];
+        acc[reaction.emoji_name] = [...byName, reaction];
+
+        return acc;
+    }, {});
+}
+
+export function sortReactionsByName(reactionsByName = {}) {
+    return Object.entries(reactionsByName).
+        map(([name, reactions]) => ({name, reactions, count: reactions.length})).
+        sort(compareReactions);
+}
+
+export function sortReactions(reactionsByName = {}) {
+    return sortReactionsByName(reactionsByName).
+        reduce((acc, {reactions}) => {
+            reactions.forEach((r) => acc.push(r));
+            return acc;
+        }, []);
+}
+
+export function getSortedReactionsForHeader(reactionsByName = {}) {
+    const sortedReactionsForHeader = sortReactionsByName(reactionsByName);
+
+    const totalCount = sortedReactionsForHeader.reduce((acc, reaction) => {
+        return acc + reaction.count;
+    }, 0);
+
+    return [{name: ALL_EMOJIS, count: totalCount}, ...sortedReactionsForHeader];
+}

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -329,6 +329,7 @@
   "mobile.post.failed_title": "Unable to send your message",
   "mobile.post.retry": "Refresh",
   "mobile.posts_view.moreMsg": "More New Messages Above",
+  "mobile.reaction_list.title": "Reactions",
   "mobile.recent_mentions.empty_description": "Messages containing your username and other words that trigger mentions will appear here.",
   "mobile.recent_mentions.empty_title": "No Recent Mentions",
   "mobile.rename_channel.display_name_maxLength": "Channel name must be less than {maxLength, number} characters",


### PR DESCRIPTION
#### Summary
Add reaction list but this is different from the specs as it's lacking the animation.  Therefore, the reaction list is here on P1, and then the modal animation to follow in P2.

I'd like to get a first pass review first before providing unit tests.

Specs: https://projects.invisionapp.com/share/YJFC6W98KM4#/screens/293894143_Emoji_Reaction_List

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
- [x] Added or updated unit tests (TO FOLLOW)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 

#### Screenshots
[Latest]
Android: - https://youtu.be/qYyMoEZxXtU
<img width="355" alt="screen shot 2018-09-20 at 2 42 29 am" src="https://user-images.githubusercontent.com/5334504/45774275-260c2a00-bc7f-11e8-949e-eb60f8124c69.png">
<img width="353" alt="screen shot 2018-09-20 at 2 42 43 am" src="https://user-images.githubusercontent.com/5334504/45774295-2c020b00-bc7f-11e8-8b7c-2db478d006f2.png">

iPhone: - https://youtu.be/EMPLfsNNkzM
<img width="356" alt="screen shot 2018-09-20 at 2 36 17 am" src="https://user-images.githubusercontent.com/5334504/45774340-450abc00-bc7f-11e8-9f3a-125a7b4e5e5c.png">
<img width="350" alt="screen shot 2018-09-20 at 2 36 35 am" src="https://user-images.githubusercontent.com/5334504/45774356-4b993380-bc7f-11e8-82e0-4f8e33a06a9d.png">
<img width="610" alt="screen shot 2018-09-20 at 2 36 48 am" src="https://user-images.githubusercontent.com/5334504/45774367-505de780-bc7f-11e8-9fb5-adf8926be4a9.png">



