### PR TITLE
Fix build error on Hashtag component

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -15,7 +15,7 @@ import AtMention from 'app/components/at_mention';
 import ChannelLink from 'app/components/channel_link';
 import Emoji from 'app/components/emoji';
 import FormattedText from 'app/components/formatted_text';
-import Hashtag from 'app/components/hashtag';
+import Hashtag from 'app/components/markdown/hashtag';
 import CustomPropTypes from 'app/constants/custom_prop_types';
 import {blendColors, concatStyles, makeStyleSheetFromTheme} from 'app/utils/theme';
 import {getScheme} from 'app/utils/url';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5325,8 +5325,8 @@
       }
     },
     "commonmark-react-renderer": {
-      "version": "github:mattermost/commonmark-react-renderer#86fa63f898802953842526c2030f3b63c5d1ae7a",
-      "from": "github:mattermost/commonmark-react-renderer#86fa63f898802953842526c2030f3b63c5d1ae7a",
+      "version": "github:mattermost/commonmark-react-renderer#b560513b93357ee5fd33489fe311bc65d4658870",
+      "from": "github:mattermost/commonmark-react-renderer#b560513b93357ee5fd33489fe311bc65d4658870",
       "requires": {
         "in-publish": "^2.0.0",
         "lodash.assign": "^4.2.0",
@@ -12883,7 +12883,7 @@
     },
     "pretty-format": {
       "version": "4.3.1",
-      "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
       "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
     },
     "private": {
@@ -14842,7 +14842,7 @@
     },
     "sax": {
       "version": "1.1.6",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
     },
     "sc-auth": {
@@ -15989,7 +15989,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5325,8 +5325,8 @@
       }
     },
     "commonmark-react-renderer": {
-      "version": "github:mattermost/commonmark-react-renderer#b560513b93357ee5fd33489fe311bc65d4658870",
-      "from": "github:mattermost/commonmark-react-renderer#b560513b93357ee5fd33489fe311bc65d4658870",
+      "version": "github:mattermost/commonmark-react-renderer#86fa63f898802953842526c2030f3b63c5d1ae7a",
+      "from": "github:mattermost/commonmark-react-renderer#86fa63f898802953842526c2030f3b63c5d1ae7a",
       "requires": {
         "in-publish": "^2.0.0",
         "lodash.assign": "^4.2.0",
@@ -12883,7 +12883,7 @@
     },
     "pretty-format": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
       "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
     },
     "private": {
@@ -14842,7 +14842,7 @@
     },
     "sax": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
     },
     "sc-auth": {
@@ -15989,7 +15989,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }


### PR DESCRIPTION
#### Summary
Fix build error on Hashtag component

```
BUILDING MODULES FOR ios
error: bundling failed: Error: Unable to resolve module `app/components/hashtag` from `/Users/nnn/go/src/github.com/mattermost/mattermost-mobile/app/components/markdown/markdown.js`: Module `app/components/hashtag` does not exist in the Haste module map
```

#### Ticket Link
none
