### PR TITLE
Remove .npminstall and don't explicitly build mattermost-redux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OS := $(shell sh -c 'uname -s 2>/dev/null')
 BASE_ASSETS = $(shell find assets/base -type d) $(shell find assets/base -type f -name '*')
 OVERRIDE_ASSETS = $(shell find assets/override -type d 2> /dev/null) $(shell find assets/override -type f -name '*' 2> /dev/null)
 
-.npminstall: package.json
+node_modules: package.json
 	@if ! [ $(shell which npm 2> /dev/null) ]; then \
 		echo "npm is not installed https://npmjs.com"; \
 		exit 1; \
@@ -18,8 +18,6 @@ OVERRIDE_ASSETS = $(shell find assets/override -type d 2> /dev/null) $(shell fin
 
 	@echo Getting Javascript dependencies
 	@npm install
-
-	@touch $@
 
 .podinstall:
 ifeq ($(OS), Darwin)
@@ -43,9 +41,9 @@ dist/assets: $(BASE_ASSETS) $(OVERRIDE_ASSETS)
 	@echo "Generating app assets"
 	@node scripts/make-dist-assets.js
 
-pre-run: | .npminstall .podinstall dist/assets ## Installs dependencies and assets
+pre-run: | node_modules .podinstall dist/assets ## Installs dependencies and assets
 
-check-style: .npminstall ## Runs eslint
+check-style: node_modules ## Runs eslint
 	@echo Checking for style guide compliance
 	@npm run check
 
@@ -53,7 +51,6 @@ clean: ## Cleans dependencies, previous builds and temp files
 	@echo Cleaning started
 
 	@rm -rf node_modules
-	@rm -f .npminstall
 	@rm -f .podinstall
 	@rm -rf dist
 	@rm -rf ios/build
@@ -84,7 +81,6 @@ post-install:
 		sed $ -i'' -e "s|const ReactNative = require('ReactNative');|const ReactNative = require('ReactNative');`echo $\\\\\\r;`const Platform = require('Platform');|g" node_modules/react-native/Libraries/Lists/VirtualizedList.js; \
 	fi
 	@sed -i'' -e 's|transform: \[{scaleY: -1}\],|...Platform.select({android: {transform: \[{perspective: 1}, {scaleY: -1}\]}, ios: {transform: \[{scaleY: -1}\]}}),|g' node_modules/react-native/Libraries/Lists/VirtualizedList.js
-	@cd ./node_modules/mattermost-redux && npm run build
 
 start: | pre-run ## Starts the React Native packager server
 	@if [ $(shell ps -ef | grep -i "cli.js start" | grep -civ grep) -eq 0 ]; then \

--- a/package-lock.json
+++ b/package-lock.json
@@ -10465,8 +10465,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
-      "from": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
+      "version": "github:mattermost/mattermost-redux#a10b6c7f67a5163c15d029defbcd9bccf0eb0412",
+      "from": "github:mattermost/mattermost-redux#a10b6c7f67a5163c15d029defbcd9bccf0eb0412",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10465,8 +10465,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#c7aa1f1dc8dd67f9806b2cbb3a6103ff8a9c16fd",
-      "from": "github:mattermost/mattermost-redux#c7aa1f1dc8dd67f9806b2cbb3a6103ff8a9c16fd",
+      "version": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
+      "from": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "224109.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#c7aa1f1dc8dd67f9806b2cbb3a6103ff8a9c16fd",
+    "mattermost-redux": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
     "mime-db": "1.36.0",
     "moment-timezone": "0.5.21",
     "prop-types": "15.6.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "224109.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
+    "mattermost-redux": "github:mattermost/mattermost-redux#a10b6c7f67a5163c15d029defbcd9bccf0eb0412",
     "mime-db": "1.36.0",
     "moment-timezone": "0.5.21",
     "prop-types": "15.6.2",


### PR DESCRIPTION
I've always found the fact that you can't just `npm install mattermost/mattermost-redux` kind of annoying, but moving the build step to `prepublish` or `prepare` (both are very similar, but `prepare` happens after `prepublish`) instead of `prepublishOnly` so that it triggers automatically on `npm install` should fix that.

This also lets us remove the `.npminstall` files on each repo since we can just check if `node_modules` is up to date rather than creating a new file.

Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/1717
Redux PR: https://github.com/mattermost/mattermost-redux/pull/635