### PR TITLE
Fix can download file for documents in preview screen

### DIFF
--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -216,7 +216,7 @@ export default class ImagePreview extends PureComponent {
     };
 
     renderAttachmentDocument = (file) => {
-        const {theme, navigator} = this.props;
+        const {canDownloadFiles, theme, navigator} = this.props;
 
         return (
             <View style={[style.flex, style.center]}>
@@ -224,6 +224,7 @@ export default class ImagePreview extends PureComponent {
                     ref={(ref) => {
                         this.documents[this.state.index] = ref;
                     }}
+                    canDownloadFiles={canDownloadFiles}
                     file={file}
                     theme={theme}
                     navigator={navigator}


### PR DESCRIPTION
#### Summary
Missing prop was causing the alert box saying that downloads has been disable to popup even if downloads are enabled in the image preview screen

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12253