### PR TITLE
MM-12199 Add a check for loading on threads

### DIFF
--- a/app/screens/thread/index.js
+++ b/app/screens/thread/index.js
@@ -28,6 +28,7 @@ function makeMapStateToProps() {
             postIds: getPostIdsForThread(state, ownProps.rootId),
             theme: getTheme(state),
             channelIsArchived: channel ? channel.delete_at !== 0 : false,
+            threadLoadingStatus: state.requests.posts.getPostThread,
         };
     };
 }


### PR DESCRIPTION
#### Summary
As rootId might not be in the state there is a flicker initially showing a data retention message. 

#### Ticket Link
(https://mattermost.atlassian.net/browse/MM-12199)[MM-12199]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [Emulators] 