### PR TITLE
Add support for iPhone XR, XS and XS Max

### DIFF
--- a/app/components/safe_area_view/safe_area_view.ios.js
+++ b/app/components/safe_area_view/safe_area_view.ios.js
@@ -31,7 +31,7 @@ export default class SafeAreaIos extends PureComponent {
     constructor(props) {
         super(props);
 
-        this.isX = DeviceInfo.getModel() === 'iPhone X';
+        this.isX = DeviceInfo.getModel().includes('iPhone X');
 
         if (props.navigator) {
             props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14256,8 +14256,8 @@
       }
     },
     "react-native-device-info": {
-      "version": "github:enahum/react-native-device-info#3b1a676801215444b1758aa76b6f0fe0fc449650",
-      "from": "github:enahum/react-native-device-info#3b1a676801215444b1758aa76b6f0fe0fc449650"
+      "version": "github:enahum/react-native-device-info#f28e4ef36cd2e3d30f36ed96f2341591fc3f038f",
+      "from": "github:enahum/react-native-device-info#f28e4ef36cd2e3d30f36ed96f2341591fc3f038f"
     },
     "react-native-dismiss-keyboard": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-native-calendars": "github:enahum/react-native-calendars#b96954bf85126222b311b638fe458a8194f25bed",
     "react-native-circular-progress": "1.0.1",
     "react-native-cookies": "github:joeferraro/react-native-cookies#f11374745deba9f18f7b8a9bb4b0b2573026f522",
-    "react-native-device-info": "github:enahum/react-native-device-info#3b1a676801215444b1758aa76b6f0fe0fc449650",
+    "react-native-device-info": "github:enahum/react-native-device-info#f28e4ef36cd2e3d30f36ed96f2341591fc3f038f",
     "react-native-doc-viewer": "2.7.8",
     "react-native-document-picker": "2.1.0",
     "react-native-drawer-layout": "2.0.0",


### PR DESCRIPTION
#### Summary
The new set of iPhones XR, XS and XS Max were not being considered when setting the Safe Area this PR adds support for those devices

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12281
Closes: #2152 

#### Device Information
This PR was tested on: iOS 12 Simulator for XR, XS and XS Max
