### PR TITLE
Fix Android previewer download option

### DIFF
--- a/app/screens/image_preview/downloader.android.js
+++ b/app/screens/image_preview/downloader.android.js
@@ -156,8 +156,12 @@ export default class Downloader extends PureComponent {
     render() {
         const {show} = this.props;
 
+        if (!show) {
+            return null;
+        }
+
         return (
-            <View style={[styles.wrapper, {opacity: show ? 1 : 0}]}>
+            <View style={styles.wrapper}>
                 <TouchableOpacity
                     style={styles.downloadButton}
                     onPress={this.handleDownload}

--- a/app/screens/image_preview/downloader.android.js
+++ b/app/screens/image_preview/downloader.android.js
@@ -22,8 +22,8 @@ import {emptyFunction} from 'app/utils/general';
 
 const {DOCUMENTS_PATH, VIDEOS_PATH} = DeviceTypes;
 const EXTERNAL_STORAGE_PERMISSION = 'android.permission.WRITE_EXTERNAL_STORAGE';
-const HEADER_HEIGHT = 64;
-const OPTION_LIST_WIDTH = 39;
+const HEADER_HEIGHT = 46;
+const OPTION_LIST_HEIGHT = 39;
 
 export default class Downloader extends PureComponent {
     static propTypes = {
@@ -157,7 +157,7 @@ export default class Downloader extends PureComponent {
         const {show} = this.props;
 
         return (
-            <View style={[styles.wrapper, {height: show ? OPTION_LIST_WIDTH : 0}]}>
+            <View style={[styles.wrapper, {opacity: show ? 1 : 0}]}>
                 <TouchableOpacity
                     style={styles.downloadButton}
                     onPress={this.handleDownload}
@@ -186,8 +186,10 @@ const styles = StyleSheet.create({
     wrapper: {
         position: 'absolute',
         backgroundColor: '#575757',
+        height: OPTION_LIST_HEIGHT,
         top: HEADER_HEIGHT,
         right: 0,
         width: 150,
+        marginRight: 5,
     },
 });


### PR DESCRIPTION
#### Summary
With the upgrade to RN 0.57 the download option was always showing as the container for it had a height of 0 and somehow that was causing the text to show up but not the container

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12289
