### PR TITLE
Use defaultProps to ensure postIds prop exists for ChannelPeek

### DIFF
--- a/app/screens/channel_peek/channel_peek.js
+++ b/app/screens/channel_peek/channel_peek.js
@@ -23,6 +23,7 @@ export default class ChannelPeek extends PureComponent {
     };
 
     static defaultProps = {
+        postIds: [],
         postVisibility: 15,
     };
 


### PR DESCRIPTION
This is because https://github.com/mattermost/mattermost-redux/pull/645 means that this selector will no longer return a default array