### PR TITLE
Fix config fetch loop when HA config mismatch

### DIFF
--- a/app/fetch_preconfig.js
+++ b/app/fetch_preconfig.js
@@ -6,15 +6,12 @@ import RNFetchBlob from 'rn-fetch-blob';
 import urlParse from 'url-parse';
 
 import {Client4} from 'mattermost-redux/client';
-import {General} from 'mattermost-redux/constants';
-import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import mattermostBucket from 'app/mattermost_bucket';
 import LocalConfig from 'assets/config';
 
 import {t} from 'app/utils/i18n';
 
-const HEADER_X_VERSION_ID = 'X-Version-Id';
 const HEADER_X_CLUSTER_ID = 'X-Cluster-Id';
 const HEADER_TOKEN = 'Token';
 
@@ -65,17 +62,6 @@ Client4.doFetchWithResponse = async (url, options) => {
                 defaultMessage: 'Received invalid response from the server.',
             },
         };
-    }
-
-    // Need to only accept version in the header from requests that are not cached
-    // to avoid getting an old version from a cached response
-    if ((headers[HEADER_X_VERSION_ID] || headers[HEADER_X_VERSION_ID.toLowerCase()]) &&
-        (!headers['Cache-Control'] && !headers['cache-control'])) {
-        const serverVersion = headers[HEADER_X_VERSION_ID] || headers[HEADER_X_VERSION_ID.toLowerCase()];
-        if (serverVersion && this.serverVersion !== serverVersion) {
-            this.serverVersion = serverVersion;
-            EventEmitter.emit(General.SERVER_VERSION_CHANGED, serverVersion);
-        }
     }
 
     if (headers[HEADER_X_CLUSTER_ID] || headers[HEADER_X_CLUSTER_ID.toLowerCase()]) {


### PR DESCRIPTION
#### Summary
This PR fixes an issue that brings the app totally unusable when the server is configured in HA mode and there is a mismatch in the config between the servers involved.

Example:
appserver1: `5.3.0.master.733.6f44e8089aa43c309e7d38e7bcbdccfa.true`
appserver2: `5.3.0.master.733.e1684f7a33feead334cceb4aadf11790.true`

What was causing the issue is that for every request the header `X-Version-Id` would be different then the client was requesting the config and license again and again in a constant loop cause an event was being emitted blocking almost completely the UI.

Now the config is requested at the following cases:
* Entering a server URL
* When the WS connects
* When the WS event for the config or license change is triggered


This was being reported by an E20 customer and I got that behavior for the first time ever connected to pre-release