### PR TITLE
Do not fetch image if file.id is not present

### DIFF
--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -115,7 +115,7 @@ export default class FileAttachmentImage extends PureComponent {
         const imageProps = {};
         if (file.localPath) {
             imageProps.defaultSource = {uri: file.localPath};
-        } else {
+        } else if (file.id) {
             imageProps.thumbnailUri = Client4.getFileThumbnailUrl(file.id);
             imageProps.imageUri = Client4.getFilePreviewUrl(file.id);
         }


### PR DESCRIPTION
#### Summary
We were trying to fetch the thumbnail and preview files for images even when no file.id was set, thus getting a warning, this PR prevents those requests from being made until the file.id is present