### PR TITLE
MM-10273 Fix 3 character hashtags not being rendered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5126,8 +5126,8 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "commonmark": {
-      "version": "github:mattermost/commonmark.js#971456e6d3f07b14effac73718d1de768586876a",
-      "from": "github:mattermost/commonmark.js#971456e6d3f07b14effac73718d1de768586876a",
+      "version": "github:mattermost/commonmark.js#95999d98559338f0249ffb3ab72984b48eccea42",
+      "from": "github:mattermost/commonmark.js#95999d9",
       "requires": {
         "entities": "~ 1.1.1",
         "mdurl": "~ 1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@babel/polyfill": "7.0.0",
     "@babel/runtime": "7.0.0",
     "analytics-react-native": "1.2.0",
-    "commonmark": "github:mattermost/commonmark.js#971456e6d3f07b14effac73718d1de768586876a",
+    "commonmark": "github:mattermost/commonmark.js#95999d9",
     "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#b560513b93357ee5fd33489fe311bc65d4658870",
     "deep-equal": "1.0.1",
     "fuse.js": "3.2.1",


### PR DESCRIPTION
The code I added to commonmark.js to check the minimum length of hashtags was using a `> 3` instead of a `>= 3` for valid hashtags

Commonmark changes here: https://github.com/mattermost/commonmark.js/commit/95999d98559338f0249ffb3ab72984b48eccea42

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10273

#### Checklist
- Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator
