### PR TITLE
Fix GCM senderId

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         <meta-data android:name="android.content.APP_RESTRICTIONS"
                    android:resource="@xml/app_restrictions" />
 
-        <meta-data android:name="com.wix.reactnativenotifications.gcmSenderId" android:value="184930218130\0"/>
+        <meta-data android:name="com.wix.reactnativenotifications.gcmSenderId" android:value="184930218130\"/>
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"


### PR DESCRIPTION
#### Summary
Based on this GH issue https://github.com/wix/react-native-notifications/issues/245 some Android devices were getting `INVALID_SENDER` cause of the `0` at the end thus not registering a deviceToken.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12236

#### Device Information
This PR was tested on: Android 7.1.1, 8.0 And 9.0  

#### Screenshots
9.0
![screenshot_1537918680](https://user-images.githubusercontent.com/6757047/46049272-dfe21b00-c103-11e8-93ca-1a9d14e98ded.png)

8.0
![screenshot_1537918845](https://user-images.githubusercontent.com/6757047/46049282-e7092900-c103-11e8-93e6-25684b5dc949.png)

7.1.1
![screenshot_1537919170](https://user-images.githubusercontent.com/6757047/46049325-0f912300-c104-11e8-83fb-fd1e4ac0bab0.png)

