### PR TITLE
Revert "Fix "{yyyy} {name of copyright owner}" in LICENSE.txt"

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2015-present Mattermost, Inc. 
+Copyright 2016 Mattermost, Inc. 
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +188,7 @@ Copyright 2015-present Mattermost, Inc.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015-present Mattermost, Inc.
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I was let know this is a boilerplate and a part of Apache-2.0 APPENDIX part. So we should not change this.