### PR TITLE
MM-10273 Always focus search input when first opening

### DIFF
--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -102,13 +102,13 @@ export default class Search extends PureComponent {
 
         if (this.props.initialValue) {
             this.search(this.props.initialValue);
-        } else {
-            setTimeout(() => {
-                if (this.refs.searchBar) {
-                    this.refs.searchBar.focus();
-                }
-            }, 150);
         }
+
+        setTimeout(() => {
+            if (this.refs.searchBar) {
+                this.refs.searchBar.focus();
+            }
+        }, 150);
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
This fixes the issue with hashtag search where the cancel button isn't visible until the search bar gains focus. Ideally, we wouldn't need to focus the search box since that takes up a large part of the screen, but the cancel button being visible is heavily attached to that box receiving focus, and changing that would require some significant changes that I don't think I can have done for feature complete tomorrow.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10273

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator, Nexus 5