### PR TITLE
 Get more search results only if value is set

### DIFF
--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -534,7 +534,9 @@ export default class Search extends PureComponent {
     });
 
     onEndReached = debounce(() => {
-        this.props.actions.getMorePostsForSearch();
+        if (this.state.value) {
+            this.props.actions.getMorePostsForSearch();
+        }
     }, 100);
 
     render() {


### PR DESCRIPTION
#### Summary
Only attempt to get more search results if the value is set. without it the search screen was trying to fetch more results when the screen loaded

Also updated mattermost-redux as the previous PR did not include the commit for `getMorePostsForSearch` action thus causing a crash