### PR TITLE
Do not show a loading spinner if thread has root post loaded

### DIFF
--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -126,7 +126,7 @@ class Thread extends PureComponent {
         } = this.props;
         const style = getStyle(theme);
         let content;
-        if (this.props.threadLoadingStatus.status === RequestStatus.STARTED) {
+        if (this.props.threadLoadingStatus.status === RequestStatus.STARTED && !this.hasRootPost()) {
             content = (
                 <Loading/>
             );

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -131,6 +131,7 @@ class Thread extends PureComponent {
         } = this.props;
         const style = getStyle(theme);
         let content;
+        let postTextBox;
         if (this.hasRootPost()) {
             content = (
                 <PostList
@@ -142,13 +143,7 @@ class Thread extends PureComponent {
                     navigator={navigator}
                 />
             );
-        } else {
-            content = (
-                <Loading/>
-            );
-        }
-        let postTextBox;
-        if (this.hasRootPost()) {
+
             postTextBox = (
                 <PostTextbox
                     channelIsArchived={channelIsArchived}
@@ -157,6 +152,10 @@ class Thread extends PureComponent {
                     navigator={navigator}
                     onCloseChannel={this.onCloseChannel}
                 />
+            );
+        } else {
+            content = (
+                <Loading/>
             );
         }
 

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -86,16 +86,21 @@ class Thread extends PureComponent {
 
     hasRootPost = () => {
         return this.props.postIds.includes(this.props.rootId);
-    }
+    };
 
     renderFooter = () => {
         if (!this.hasRootPost() && this.props.threadLoadingStatus.status !== RequestStatus.STARTED) {
             return (
                 <DeletedPost theme={this.props.theme}/>
             );
+        } else if (this.props.threadLoadingStatus.status === RequestStatus.STARTED) {
+            return (
+                <Loading/>
+            );
         }
+
         return null;
-    }
+    };
 
     onCloseChannel = () => {
         this.props.navigator.resetTo({
@@ -112,7 +117,7 @@ class Thread extends PureComponent {
                 screenBackgroundColor: 'transparent',
             },
         });
-    }
+    };
 
     render() {
         const {
@@ -126,11 +131,7 @@ class Thread extends PureComponent {
         } = this.props;
         const style = getStyle(theme);
         let content;
-        if (this.props.threadLoadingStatus.status === RequestStatus.STARTED && !this.hasRootPost()) {
-            content = (
-                <Loading/>
-            );
-        } else {
+        if (this.hasRootPost()) {
             content = (
                 <PostList
                     renderFooter={this.renderFooter}
@@ -141,9 +142,13 @@ class Thread extends PureComponent {
                     navigator={navigator}
                 />
             );
+        } else {
+            content = (
+                <Loading/>
+            );
         }
         let postTextBox;
-        if (this.hasRootPost() && this.props.threadLoadingStatus.status !== RequestStatus.STARTED) {
+        if (this.hasRootPost()) {
             postTextBox = (
                 <PostTextbox
                     channelIsArchived={channelIsArchived}


### PR DESCRIPTION
#### Summary
If the thread screen already had the root post we still waited until the request finished, that slowed viewing the thread even if there was no need for it