### PR TITLE
Instantly show autocomplete channels

### DIFF
--- a/app/components/autocomplete/autocomplete_section_header.js
+++ b/app/components/autocomplete/autocomplete_section_header.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import {ActivityIndicator, View} from 'react-native';
 
 import FormattedText from 'app/components/formatted_text';
 import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
@@ -12,11 +12,12 @@ export default class AutocompleteSectionHeader extends PureComponent {
     static propTypes = {
         defaultMessage: PropTypes.string.isRequired,
         id: PropTypes.string.isRequired,
+        loading: PropTypes.bool,
         theme: PropTypes.object.isRequired,
     };
 
     render() {
-        const {defaultMessage, id, theme} = this.props;
+        const {defaultMessage, id, loading, theme} = this.props;
         const style = getStyleFromTheme(theme);
 
         return (
@@ -27,6 +28,7 @@ export default class AutocompleteSectionHeader extends PureComponent {
                         defaultMessage={defaultMessage}
                         style={style.sectionText}
                     />
+                    {loading && <ActivityIndicator size='small'/>}
                 </View>
             </View>
         );
@@ -37,13 +39,17 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         section: {
             justifyContent: 'center',
-            paddingLeft: 8,
+            paddingHorizontal: 8,
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
+            borderTopWidth: 1,
+            borderTopColor: changeOpacity(theme.centerChannelColor, 0.2),
+            flexDirection: 'row',
         },
         sectionText: {
             fontSize: 12,
             color: changeOpacity(theme.centerChannelColor, 0.7),
             paddingVertical: 7,
+            flex: 1,
         },
         sectionWrapper: {
             backgroundColor: theme.centerChannelBg,

--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -82,21 +82,17 @@ export default class ChannelMention extends PureComponent {
         }
 
         if (matchTerm !== this.props.matchTerm) {
-            // if the term changed and we haven't made the request do that first
             const {currentTeamId} = this.props;
             this.runSearch(currentTeamId, matchTerm);
-            return;
         }
 
-        if (requestStatus !== RequestStatus.STARTED &&
-            (myChannels !== this.props.myChannels || otherChannels !== this.props.otherChannels ||
-                privateChannels !== this.props.privateChannels || publicChannels !== this.props.publicChannels ||
-                directAndGroupMessages !== this.props.directAndGroupMessages ||
-                myMembers !== this.props.myMembers || deletedPublicChannels !== this.props.deletedPublicChannels)) {
-            // if the request is complete and the term is not null we show the autocomplete
+        if (matchTerm === '' || (myChannels !== this.props.myChannels || otherChannels !== this.props.otherChannels ||
+        privateChannels !== this.props.privateChannels || publicChannels !== this.props.publicChannels ||
+        directAndGroupMessages !== this.props.directAndGroupMessages ||
+        myMembers !== this.props.myMembers || deletedPublicChannels !== this.props.deletedPublicChannels)) {
             const sections = [];
             if (isSearch) {
-                if (publicChannels.length) {
+                if (publicChannels.length || requestStatus === RequestStatus.STARTED) {
                     sections.push({
                         id: t('suggestion.search.public'),
                         defaultMessage: 'Public Channels',
@@ -105,7 +101,7 @@ export default class ChannelMention extends PureComponent {
                     });
                 }
 
-                if (privateChannels.length) {
+                if (privateChannels.length || requestStatus === RequestStatus.STARTED) {
                     sections.push({
                         id: t('suggestion.search.private'),
                         defaultMessage: 'Private Channels',
@@ -132,7 +128,7 @@ export default class ChannelMention extends PureComponent {
                     });
                 }
 
-                if (otherChannels.length) {
+                if (otherChannels.length || requestStatus === RequestStatus.STARTED) {
                     sections.push({
                         id: t('suggestion.mention.morechannels'),
                         defaultMessage: 'Other Channels',
@@ -145,7 +141,6 @@ export default class ChannelMention extends PureComponent {
             this.setState({
                 sections,
             });
-
             this.props.onResultCountChange(sections.reduce((total, section) => total + section.data.length, 0));
         }
     }
@@ -179,6 +174,7 @@ export default class ChannelMention extends PureComponent {
             <AutocompleteSectionHeader
                 id={section.id}
                 defaultMessage={section.defaultMessage}
+                loading={this.props.requestStatus === RequestStatus.STARTED}
                 theme={this.props.theme}
             />
         );

--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -125,6 +125,7 @@ export default class ChannelMention extends PureComponent {
                         defaultMessage: 'My Channels',
                         data: myChannels,
                         key: 'myChannels',
+                        hideLoadingIndicator: true,
                     });
                 }
 
@@ -174,7 +175,7 @@ export default class ChannelMention extends PureComponent {
             <AutocompleteSectionHeader
                 id={section.id}
                 defaultMessage={section.defaultMessage}
-                loading={this.props.requestStatus === RequestStatus.STARTED}
+                loading={!section.hideLoadingIndicator && this.props.requestStatus === RequestStatus.STARTED}
                 theme={this.props.theme}
             />
         );

--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -92,21 +92,23 @@ export default class ChannelMention extends PureComponent {
         myMembers !== this.props.myMembers || deletedPublicChannels !== this.props.deletedPublicChannels)) {
             const sections = [];
             if (isSearch) {
-                if (publicChannels.length || requestStatus === RequestStatus.STARTED) {
+                if (publicChannels.length) {
                     sections.push({
                         id: t('suggestion.search.public'),
                         defaultMessage: 'Public Channels',
                         data: publicChannels.filter((cId) => myMembers[cId]),
                         key: 'publicChannels',
+                        hideLoadingIndicator: true,
                     });
                 }
 
-                if (privateChannels.length || requestStatus === RequestStatus.STARTED) {
+                if (privateChannels.length) {
                     sections.push({
                         id: t('suggestion.search.private'),
                         defaultMessage: 'Private Channels',
                         data: privateChannels,
                         key: 'privateChannels',
+                        hideLoadingIndicator: true,
                     });
                 }
 


### PR DESCRIPTION
#### Summary
When using the channel autocomplete there is a delay before showing the autocomplete channels component. The delay occurs because the component is waiting for the search channels request to complete. It is most noticeable on a slow network or when there are thousands of channels. This PR changes the behavior of the channel autocomplete component to instantly show what is currently in the state while showing a loading indicator at the right of the autocomplete section header while the request is in flight.

![instant-autocomplete](https://user-images.githubusercontent.com/5090577/46221483-2f8e3580-c302-11e8-852b-36d06c4f56b4.gif)

