### PR TITLE
[MM-12149] Add border to image of link preview and not allow such image width to exceed the view port width

### DIFF
--- a/app/components/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
+++ b/app/components/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
@@ -6,7 +6,8 @@ exports[`PostAttachmentOpenGraph should match snapshot, without image and descri
 <Component
   style={
     Object {
-      "borderColor": "rgba(170,170,170,0.2)",
+      "borderColor": "rgba(61,60,64,0.2)",
+      "borderRadius": 3,
       "borderWidth": 1,
       "flex": 1,
       "marginTop": 10,
@@ -26,7 +27,7 @@ exports[`PostAttachmentOpenGraph should match snapshot, without image and descri
       numberOfLines={1}
       style={
         Object {
-          "color": "rgba(170,170,170,0.5)",
+          "color": "rgba(61,60,64,0.5)",
           "fontSize": 12,
           "marginBottom": 10,
         }
@@ -58,7 +59,7 @@ exports[`PostAttachmentOpenGraph should match snapshot, without image and descri
         style={
           Array [
             Object {
-              "color": undefined,
+              "color": "#2389d7",
               "fontSize": 14,
               "marginBottom": 10,
             },
@@ -90,7 +91,7 @@ exports[`PostAttachmentOpenGraph should match state and snapshot, on renderDescr
     numberOfLines={5}
     style={
       Object {
-        "color": "rgba(170,170,170,0.7)",
+        "color": "rgba(61,60,64,0.7)",
         "fontSize": 13,
         "marginBottom": 10,
       }
@@ -108,6 +109,10 @@ exports[`PostAttachmentOpenGraph should match state and snapshot, on renderImage
   style={
     Object {
       "alignItems": "center",
+      "borderColor": "rgba(61,60,64,0.2)",
+      "borderRadius": 3,
+      "borderWidth": 1,
+      "marginTop": 5,
     }
   }
 >
@@ -116,7 +121,7 @@ exports[`PostAttachmentOpenGraph should match state and snapshot, on renderImage
     style={
       Object {
         "height": 150,
-        "width": 312,
+        "width": 307,
       }
     }
   >
@@ -129,7 +134,7 @@ exports[`PostAttachmentOpenGraph should match state and snapshot, on renderImage
           },
           Object {
             "height": 150,
-            "width": 312,
+            "width": 307,
           },
         ]
       }

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -19,7 +19,7 @@ import {getNearestPoint} from 'app/utils/opengraph';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 const MAX_IMAGE_HEIGHT = 150;
-const VIEWPORT_IMAGE_OFFSET = 88;
+const VIEWPORT_IMAGE_OFFSET = 93;
 const VIEWPORT_IMAGE_REPLY_OFFSET = 13;
 
 export default class PostAttachmentOpenGraph extends PureComponent {
@@ -216,7 +216,6 @@ export default class PostAttachmentOpenGraph extends PureComponent {
                     style={{width, height}}
                 >
                     <Image
-                        ref='image'
                         style={[style.image, {width, height}]}
                         source={source}
                         resizeMode='contain'
@@ -273,6 +272,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderWidth: 1,
+            borderRadius: 3,
             marginTop: 10,
             padding: 10,
         },
@@ -300,6 +300,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         imageContainer: {
             alignItems: 'center',
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderWidth: 1,
+            borderRadius: 3,
+            marginTop: 5,
         },
         image: {
             borderRadius: 3,

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.test.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.test.js
@@ -9,6 +9,8 @@ import {
     TouchableOpacity,
 } from 'react-native';
 
+import Preferences from 'mattermost-redux/constants/preferences';
+
 import PostAttachmentOpenGraph from './post_attachment_opengraph';
 
 describe('PostAttachmentOpenGraph', () => {
@@ -26,9 +28,7 @@ describe('PostAttachmentOpenGraph', () => {
         isReplyPost: false,
         link: 'https://mattermost.com/',
         navigator: {},
-        theme: {
-            centerChannelColor: '#aaa',
-        },
+        theme: Preferences.THEMES.default,
     };
 
     test('should match snapshot, without image and description', () => {

--- a/app/utils/images.js
+++ b/app/utils/images.js
@@ -28,7 +28,10 @@ export const calculateDimensions = (height, width, viewPortWidth = 0, viewPortHe
     ) {
         imageHeight = viewPortHeight || IMAGE_MAX_HEIGHT;
         imageWidth = imageHeight * heightRatio;
-    } else if (imageHeight < IMAGE_MIN_DIMENSION) {
+    } else if (
+        imageHeight < IMAGE_MIN_DIMENSION &&
+        IMAGE_MIN_DIMENSION * heightRatio <= viewPortWidth
+    ) {
         imageHeight = IMAGE_MIN_DIMENSION;
         imageWidth = imageHeight * heightRatio;
     }

--- a/app/utils/images.test.js
+++ b/app/utils/images.test.js
@@ -56,4 +56,10 @@ describe('Images calculateDimensions', () => {
         const {height} = calculateDimensions(1920, 1080, PORTRAIT_VIEWPORT, 340);
         expect(height).toEqual(340);
     });
+
+    it('images with height below 50 but setting to 50 will make the width exceed the view port width should remain as is', () => {
+        const {height, width} = calculateDimensions(45, 310, PORTRAIT_VIEWPORT);
+        expect(height).toEqual(45);
+        expect(width).toEqual(310);
+    });
 });


### PR DESCRIPTION
#### Summary
With all white PNG image from link preview and theme of white background, the image is hidden and makes a significant space on link preview.

Discussion on pre-release: https://pre-release.mattermost.com/core/pl/ytqicfj99tngf8dd6wq5ugcmkr

Solution is to add border to image of link preview.

This PR also includes:
- not allowing such image width to exceed the view port width
- set border radius of 3 pixel to link and image preview containers

#### Ticket Link
Jira ticket: [MM-12149](https://mattermost.atlassian.net/browse/MM-12149)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
![screen shot 2018-09-29 at 12 42 22 am](https://user-images.githubusercontent.com/5334504/46222308-73c11a80-c382-11e8-9925-81cda7559c60.png)

![screen shot 2018-09-29 at 12 42 38 am](https://user-images.githubusercontent.com/5334504/46222333-876c8100-c382-11e8-9ec4-c16dfe23108a.png)


![screen shot 2018-09-29 at 12 41 25 am](https://user-images.githubusercontent.com/5334504/46222273-58560f80-c382-11e8-90fb-30a27dccb228.png)

![screen shot 2018-09-29 at 1 14 56 am](https://user-images.githubusercontent.com/5334504/46223145-1da1a680-c385-11e8-9224-0557390e30e7.png)
