### PR TITLE
[MM-12390] Fix blank space on link preview when no site name

### DIFF
--- a/app/components/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
+++ b/app/components/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
@@ -76,6 +76,59 @@ exports[`PostAttachmentOpenGraph should match snapshot, without image and descri
 </Component>
 `;
 
+exports[`PostAttachmentOpenGraph should match snapshot, without site_name 1`] = `
+<Component
+  style={
+    Object {
+      "borderColor": "rgba(61,60,64,0.2)",
+      "borderRadius": 3,
+      "borderWidth": 1,
+      "flex": 1,
+      "marginTop": 10,
+      "padding": 10,
+    }
+  }
+>
+  <Component
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <Component
+        ellipsizeMode="tail"
+        numberOfLines={3}
+        style={
+          Array [
+            Object {
+              "color": "#2389d7",
+              "fontSize": 14,
+              "marginBottom": 10,
+            },
+            Object {
+              "marginRight": 0,
+            },
+          ]
+        }
+      >
+        Title
+      </Component>
+    </TouchableOpacity>
+  </Component>
+</Component>
+`;
+
 exports[`PostAttachmentOpenGraph should match state and snapshot, on renderDescription 1`] = `null`;
 
 exports[`PostAttachmentOpenGraph should match state and snapshot, on renderDescription 2`] = `

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -234,8 +234,9 @@ export default class PostAttachmentOpenGraph extends PureComponent {
 
         const style = getStyleSheet(theme);
 
-        return (
-            <View style={style.container}>
+        let siteTitle;
+        if (openGraphData.site_name) {
+            siteTitle = (
                 <View style={style.flex}>
                     <Text
                         style={style.siteTitle}
@@ -245,6 +246,12 @@ export default class PostAttachmentOpenGraph extends PureComponent {
                         {openGraphData.site_name}
                     </Text>
                 </View>
+            );
+        }
+
+        return (
+            <View style={style.container}>
+                {siteTitle}
                 <View style={style.wrapper}>
                     <TouchableOpacity
                         style={style.flex}

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.test.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.test.js
@@ -44,6 +44,20 @@ describe('PostAttachmentOpenGraph', () => {
         expect(wrapper.find(TouchableOpacity).exists()).toEqual(true);
     });
 
+    test('should match snapshot, without site_name', () => {
+        const newOpenGraphData = {
+            title: 'Title',
+            url: 'https://mattermost.com/',
+        };
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph
+                {...baseProps}
+                openGraphData={newOpenGraphData}
+            />
+        );
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
     test('should match state and snapshot, on renderImage', () => {
         const wrapper = shallow(
             <PostAttachmentOpenGraph {...baseProps}/>


### PR DESCRIPTION
#### Summary
Fix blank space on link preview when no site name.

Note that this PR is submitted on top of https://github.com/mattermost/mattermost-mobile/pull/2189 just to prevent merge conflict on unit testing.  Will rebase once that PR is merged.

Also, no milestone is set yet since I'm not sure if this should be part of 1.13.

#### Ticket Link
Jira ticket: [MM-12390](https://mattermost.atlassian.net/browse/MM-12390)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
![screen shot 2018-09-29 at 2 07 23 am](https://user-images.githubusercontent.com/5334504/46225799-f18a2380-c38c-11e8-9a1f-45bbd9150c42.png)

