### PR TITLE
MM-12424 Properly set softInputMode on Android

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationsLifecycleFacade.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationsLifecycleFacade.java
@@ -10,6 +10,7 @@ import android.content.IntentFilter;
 import android.os.Bundle;
 import android.util.Log;
 import android.util.ArraySet;
+import android.view.WindowManager;
 import android.view.WindowManager.LayoutParams;
 import android.content.res.Configuration;
 
@@ -69,8 +70,12 @@ public class NotificationsLifecycleFacade extends ActivityCallbacks implements A
             activity.getWindow().setFlags(LayoutParams.FLAG_SECURE,
                     LayoutParams.FLAG_SECURE);
         }
-        if (managedConfig!= null && managedConfig.size() > 0 && activity != null) {
+        if (managedConfig != null && managedConfig.size() > 0 && activity != null) {
             activity.registerReceiver(restrictionsReceiver, restrictionsFilter);
+        }
+
+        if (activity != null) {
+            activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         }
     }
 


### PR DESCRIPTION
Setting this value as per https://github.com/wix/react-native-navigation/blob/master/docs/android-specific-use-cases.md#adjusting-soft-input-mode. It was previously set through the AndroidManifest, but that's not used once we switch to the NavigationActivity used by that library.

Setting this causes the app content to shrink appropriately when the soft keyboard is visible.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12424

#### Device Information
This PR was tested on: Nexus 5 (Android 6.0)