### PR TITLE
MM-12439 Hide warnings caused by React Native

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -10,6 +10,7 @@ import {
     Keyboard,
     NativeModules,
     Platform,
+    YellowBox,
 } from 'react-native';
 const {StatusBarManager, MattermostShare, Initialization} = NativeModules;
 
@@ -52,6 +53,9 @@ import App from './app';
 import './fetch_preconfig';
 
 const AUTHENTICATION_TIMEOUT = 5 * 60 * 1000;
+
+// Hide warnings caused by React Native (https://github.com/facebook/react-native/issues/20841)
+YellowBox.ignoreWarnings(['Require cycle: node_modules/react-native/Libraries/Network/fetch.js']);
 
 export const app = new App();
 export const store = configureStore(initialState);


### PR DESCRIPTION
The new version of RN reports a circular dependency in the fetch implementation that it provides. This will silence that until it's fixed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12439

#### Device Information
This PR was tested on: iOS Simulator (iPhone 5S, iOS 12), Nexus 5 (Android 6.0)