### PR TITLE
MM-12424 Remove unused props from KeyboardLayout and simplify methods

### DIFF
--- a/app/components/layout/keyboard_layout/index.js
+++ b/app/components/layout/keyboard_layout/index.js
@@ -1,19 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {connect} from 'react-redux';
-
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-
-import {getStatusBarHeight} from 'app/selectors/device';
-
 import KeyboardLayout from './keyboard_layout';
 
-function mapStateToProps(state) {
-    return {
-        statusBarHeight: getStatusBarHeight(state),
-        theme: getTheme(state),
-    };
-}
-
-export default connect(mapStateToProps)(KeyboardLayout);
+export default KeyboardLayout;

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -395,6 +395,7 @@ export default class Channel extends PureComponent {
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         postList: {
+            backgroundColor: theme.centerChannelBg,
             flex: 1,
         },
         loading: {

--- a/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
+++ b/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MoreChannels should match snapshot 1`] = `
-<Connect(KeyboardLayout)>
+<KeyboardLayout>
   <Connect(StatusBar) />
   <React.Fragment>
     <Component
@@ -75,5 +75,5 @@ exports[`MoreChannels should match snapshot 1`] = `
       }
     />
   </React.Fragment>
-</Connect(KeyboardLayout)>
+</KeyboardLayout>
 `;

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -165,11 +165,7 @@ class Thread extends PureComponent {
                 keyboardOffset={20}
             >
                 <StatusBar/>
-                <KeyboardLayout
-                    behavior='padding'
-                    style={style.container}
-                    keyboardVerticalOffset={65}
-                >
+                <KeyboardLayout style={style.container}>
                     {content}
                     {postTextBox}
                 </KeyboardLayout>


### PR DESCRIPTION
This is some extra work done along with https://github.com/mattermost/mattermost-mobile/pull/2201. Of the removed props:
- `statusBarHeight` wasn't actually used
- `theme` was only used to add a background colour which was already set everywhere except for the Thread screen which was attempting to set it through a `style` prop that didn't work previously
- `behavior` and `keyboardVerticalOffset` were being passed from the Thread screen, but they didn't do anything. They were left over from using RN's built-in KeyboardAvoidingView

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12424

#### Checklist
- Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator (iPhone 5s, iOS 12), Nexus 5 (Android 6.0)