### PR TITLE
MM-12347 Fix crash of app when accessing jumpTo

### DIFF
--- a/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
+++ b/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
@@ -217,6 +217,9 @@ class FilteredList extends Component {
                 nickname: u.nickname,
                 fullname: `${u.first_name} ${u.last_name}`,
                 delete_at: u.delete_at,
+
+                // need name key for DM's as we use it for sortChannelsByDisplayName with same display_name
+                name: displayName,
             };
         });
 


### PR DESCRIPTION
#### Summary
Adds a key `name` for sorting as DM's profiles will not have the key.
Redux utils function for sorting fails as it checks for name to sort if two display_names are equal
 
Reverts a minor change from https://github.com/mattermost/mattermost-mobile/commit/a6e15320d4110799c78c4a02b7600af6c1065c4a#diff-23e5d2f83331fd7fccf6be48c0aa6052L214

#### Ticket Link
[MM-12347](https://mattermost.atlassian.net/browse/MM-12347)

#### Device Information
This PR was tested on: [Ios emulator and android emulators] 
