### PR TITLE
MM-12348 Persist interactive menu choices past channel switch and share with thread view

### DIFF
--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -3,6 +3,7 @@
 
 import {Posts} from 'mattermost-redux/constants';
 import {PostTypes} from 'mattermost-redux/action_types';
+import {doPostAction} from 'mattermost-redux/actions/posts';
 
 import {ViewTypes} from 'app/constants';
 
@@ -48,5 +49,17 @@ export function setMenuActionSelector(dataSource, onSelect, options) {
             onSelect,
             options,
         },
+    };
+}
+
+export function selectAttachmentMenuAction(postId, actionId, dataSource, displayText, value) {
+    return async (dispatch) => {
+        dispatch({
+            type: ViewTypes.SUBMIT_ATTACHMENT_MENU_ACTION,
+            postId,
+            data: {displayText, value},
+        });
+
+        dispatch(doPostAction(postId, actionId, value));
     };
 }

--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -53,7 +53,7 @@ export function setMenuActionSelector(dataSource, onSelect, options) {
 }
 
 export function selectAttachmentMenuAction(postId, actionId, dataSource, displayText, value) {
-    return async (dispatch) => {
+    return (dispatch) => {
         dispatch({
             type: ViewTypes.SUBMIT_ATTACHMENT_MENU_ACTION,
             postId,

--- a/app/components/message_attachments/action_menu/action_menu.js
+++ b/app/components/message_attachments/action_menu/action_menu.js
@@ -15,7 +15,7 @@ import {ViewTypes} from 'app/constants';
 export default class ActionMenu extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            doPostAction: PropTypes.func.isRequired,
+            selectAttachmentMenuAction: PropTypes.func.isRequired,
             setMenuActionSelector: PropTypes.func.isRequired,
         }).isRequired,
         id: PropTypes.string.isRequired,
@@ -23,6 +23,7 @@ export default class ActionMenu extends PureComponent {
         dataSource: PropTypes.string,
         options: PropTypes.arrayOf(PropTypes.object),
         postId: PropTypes.string.isRequired,
+        selected: PropTypes.object,
         theme: PropTypes.object.isRequired,
         navigator: PropTypes.object,
     };
@@ -37,6 +38,17 @@ export default class ActionMenu extends PureComponent {
         this.state = {
             selectedText: null,
         };
+    }
+
+    static getDerivedStateFromProps(props, state) {
+        if (props.selected && props.selected !== state.selected) {
+            return {
+                selectedText: props.selected.displayText,
+                selected: props.selected,
+            };
+        }
+
+        return null;
     }
 
     handleSelect = (selected) => {
@@ -61,7 +73,7 @@ export default class ActionMenu extends PureComponent {
 
         this.setState({selectedText});
 
-        actions.doPostAction(postId, id, selectedValue);
+        actions.selectAttachmentMenuAction(postId, id, dataSource, selectedText, selectedValue);
     }
 
     goToMenuActionSelector = preventDoubleTap(() => {

--- a/app/components/message_attachments/action_menu/index.js
+++ b/app/components/message_attachments/action_menu/index.js
@@ -4,23 +4,23 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {doPostAction} from 'mattermost-redux/actions/posts';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {setMenuActionSelector} from 'app/actions/views/post';
+import {setMenuActionSelector, selectAttachmentMenuAction} from 'app/actions/views/post';
 
 import ActionMenu from './action_menu';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
     return {
         theme: getTheme(state),
+        selected: state.views.post.submittedMenuActions[ownProps.postId],
     };
 }
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            doPostAction,
+            selectAttachmentMenuAction,
             setMenuActionSelector,
         }, dispatch),
     };

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -73,6 +73,7 @@ const ViewTypes = keyMirror({
     SET_PROFILE_IMAGE_URI: null,
 
     SELECTED_ACTION_MENU: null,
+    SUBMIT_ATTACHMENT_MENU_ACTION: null,
 });
 
 export default {

--- a/app/reducers/views/post.js
+++ b/app/reducers/views/post.js
@@ -2,10 +2,11 @@
 // See LICENSE.txt for license information.
 
 import {combineReducers} from 'redux';
+import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ViewTypes} from 'app/constants';
 
-function menuAction(state = {}, action) {
+function selectedMenuAction(state = {}, action) {
     switch (action.type) {
     case ViewTypes.SELECTED_ACTION_MENU:
         return action.data;
@@ -15,6 +16,25 @@ function menuAction(state = {}, action) {
     }
 }
 
+function submittedMenuActions(state = {}, action) {
+    switch (action.type) {
+    case ViewTypes.SUBMIT_ATTACHMENT_MENU_ACTION: {
+        const nextState = {...state};
+        nextState[action.postId] = action.data;
+        return nextState;
+    }
+    case UserTypes.LOGOUT_SUCCESS:
+        return {};
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
-    menuAction,
+
+    // Currently selected menu action
+    selectedMenuAction,
+
+    // Submitted menu actions per post
+    submittedMenuActions,
 });

--- a/app/screens/menu_action_selector/index.js
+++ b/app/screens/menu_action_selector/index.js
@@ -16,7 +16,7 @@ import {ViewTypes} from 'app/constants';
 import MenuActionSelector from './menu_action_selector';
 
 function mapStateToProps(state) {
-    const menuAction = state.views.post.menuAction || {};
+    const menuAction = state.views.post.selectedMenuAction || {};
 
     let data;
     let loadMoreRequestStatus;


### PR DESCRIPTION
#### Summary
When choosing an option in the interactive menus, have the choice persist after channel switch and have threaded view and main channel view share choices. The web app does something similar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12348

#### Device Information
Android Galaxy S9
iOS Simulator