### PR TITLE
Draft channel indicator to ignore message with whitespaces only

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -78,7 +78,7 @@ function makeMapStateToProps() {
             fake: channel.fake,
             isChannelMuted: isChannelMuted(member),
             isMyUser,
-            hasDraft: Boolean(channelDraft.draft || channelDraft.files.length),
+            hasDraft: Boolean(channelDraft.draft.trim() || channelDraft.files.length),
             mentions: member ? member.mention_count : 0,
             shouldHideChannel,
             showUnreadForMsgs,


### PR DESCRIPTION
#### Summary
The draft indicator should not be present if the draft only contains whitespaces

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12337
