### PR TITLE
image thumbnail not centered

### DIFF
--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -49,8 +49,8 @@ export default class FileAttachmentImage extends PureComponent {
         loading: false,
         resizeMode: 'cover',
         resizeMethod: 'resize',
-        wrapperHeight: 80,
-        wrapperWidth: 80,
+        wrapperHeight: 100,
+        wrapperWidth: 100,
     };
 
     constructor(props) {

--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -37,8 +37,6 @@ export default class FileAttachmentImage extends PureComponent {
         onCaptureRef: PropTypes.func,
         resizeMode: PropTypes.string,
         resizeMethod: PropTypes.string,
-        wrapperHeight: PropTypes.number,
-        wrapperWidth: PropTypes.number,
     };
 
     static defaultProps = {
@@ -49,8 +47,6 @@ export default class FileAttachmentImage extends PureComponent {
         loading: false,
         resizeMode: 'cover',
         resizeMethod: 'resize',
-        wrapperHeight: 100,
-        wrapperWidth: 100,
     };
 
     constructor(props) {
@@ -99,8 +95,6 @@ export default class FileAttachmentImage extends PureComponent {
             imageSize,
             resizeMethod,
             resizeMode,
-            wrapperHeight,
-            wrapperWidth,
         } = this.props;
 
         let height = imageHeight;
@@ -123,7 +117,7 @@ export default class FileAttachmentImage extends PureComponent {
         return (
             <View
                 ref={this.handleCaptureRef}
-                style={[style.fileImageWrapper, {height: wrapperHeight, width: wrapperWidth, overflow: 'hidden'}]}
+                style={style.fileImageWrapper}
             >
                 <ProgressiveImage
                     style={imageStyle}
@@ -145,6 +139,9 @@ const style = StyleSheet.create({
         justifyContent: 'center',
         borderBottomLeftRadius: 2,
         borderTopLeftRadius: 2,
+        height: 100,
+        width: 100,
+        overflow: 'hidden',
     },
     loaderContainer: {
         position: 'absolute',

--- a/app/components/file_upload_preview/file_upload_item/file_upload_item.js
+++ b/app/components/file_upload_preview/file_upload_item/file_upload_item.js
@@ -177,8 +177,6 @@ export default class FileUploadItem extends PureComponent {
                     file={file}
                     imageHeight={100}
                     imageWidth={100}
-                    wrapperHeight={100}
-                    wrapperWidth={100}
                 />
             );
         } else {


### PR DESCRIPTION
#### Summary
By setting the wrapper container height and width the same as the file upload previewer images now look centered

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12445

![image](https://user-images.githubusercontent.com/6757047/46378399-d6abfd80-c671-11e8-87db-8e8b174ca277.png)
