### PR TITLE
Fix at-mention autocomplete causing a logout

### DIFF
--- a/app/components/autocomplete/at_mention/index.js
+++ b/app/components/autocomplete/at_mention/index.js
@@ -5,8 +5,9 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {autocompleteUsers} from 'mattermost-redux/actions/users';
-import {getCurrentChannelId, getDefaultChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel, getDefaultChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {
     filterMembersInChannel,
@@ -14,13 +15,14 @@ import {
     filterMembersInCurrentTeam,
     getMatchTermForAtMention,
 } from 'app/selectors/autocomplete';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import {isDirectOrGroupChannel} from 'app/utils/channels';
 
 import AtMention from './at_mention';
 
 function mapStateToProps(state, ownProps) {
     const {cursorPosition, isSearch} = ownProps;
-    const currentChannelId = getCurrentChannelId(state);
+    const currentChannel = getCurrentChannel(state);
 
     const value = ownProps.value.substring(0, cursorPosition);
     const matchTerm = getMatchTermForAtMention(value, isSearch);
@@ -36,8 +38,8 @@ function mapStateToProps(state, ownProps) {
     }
 
     return {
-        currentChannelId,
-        currentTeamId: getCurrentTeamId(state),
+        currentChannelId: currentChannel.id,
+        currentTeamId: (currentChannel && !isDirectOrGroupChannel(currentChannel)) || isSearch ? getCurrentTeamId(state) : '',
         defaultChannel: getDefaultChannel(state),
         matchTerm,
         teamMembers,

--- a/app/utils/channels.js
+++ b/app/utils/channels.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Preferences} from 'mattermost-redux/constants';
+import {General, Preferences} from 'mattermost-redux/constants';
 import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
 
 export function isDirectChannelVisible(userId, myPreferences, channel) {
@@ -13,4 +13,9 @@ export function isDirectChannelVisible(userId, myPreferences, channel) {
 export function isGroupChannelVisible(myPreferences, channel) {
     const gm = myPreferences[`${Preferences.CATEGORY_GROUP_CHANNEL_SHOW}--${channel.id}`];
     return gm && gm.value === 'true';
+}
+
+export function isDirectOrGroupChannel(channel) {
+    const {type} = channel;
+    return type === General.DM_CHANNEL || type === General.GM_CHANNEL;
 }


### PR DESCRIPTION
#### Summary
Performing an at-mention autocomplete in a DM channel was forcing a logout mainly because of this PR https://github.com/mattermost/mattermost-server/pull/9481  I did file a bug https://mattermost.atlassian.net/browse/MM-12519 cause it should return 403 instead of 401

This PR then fixes the issue by sending a blank teamId if the current channel is a DM or a GM unless the autocomplete is being used in the search screen

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12517