### PR TITLE
Reset isLoadingMoreTop flag when switching channels

### DIFF
--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -62,6 +62,10 @@ export default class ChannelPostList extends PureComponent {
             visiblePostIds = this.getVisiblePostIds(nextProps);
         }
 
+        if (this.props.channelId !== nextProps.channelId) {
+            this.isLoadingMoreTop = false;
+        }
+
         this.setState({visiblePostIds});
     }
 


### PR DESCRIPTION
#### Summary
When reaching the top of a channel and then switch to a different channel, it wasnt loading more posts as the flag was not being reset

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12527