### PR TITLE
[MM-12622] Add opacity of 0.3 to circle stroke of offline status

### DIFF
--- a/app/components/user_status/__snapshots__/user_status.test.js.snap
+++ b/app/components/user_status/__snapshots__/user_status.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserStatus should match snapshot, away status 1`] = `
+<Component
+  source={
+    Object {
+      "testUri": "../../../dist/assets/images/status/away.png",
+    }
+  }
+  style={
+    Object {
+      "height": 32,
+      "tintColor": "#ffbc42",
+      "width": 32,
+    }
+  }
+/>
+`;
+
+exports[`UserStatus should match snapshot, dnd status 1`] = `
+<Component
+  source={
+    Object {
+      "testUri": "../../../dist/assets/images/status/dnd.png",
+    }
+  }
+  style={
+    Object {
+      "height": 32,
+      "tintColor": "#f74343",
+      "width": 32,
+    }
+  }
+/>
+`;
+
+exports[`UserStatus should match snapshot, online status 1`] = `
+<Component
+  source={
+    Object {
+      "testUri": "../../../dist/assets/images/status/online.png",
+    }
+  }
+  style={
+    Object {
+      "height": 32,
+      "tintColor": "#06d6a0",
+      "width": 32,
+    }
+  }
+/>
+`;
+
+exports[`UserStatus should match snapshot, should default to offline status 1`] = `
+<Component
+  source={
+    Object {
+      "testUri": "../../../dist/assets/images/status/offline.png",
+    }
+  }
+  style={
+    Object {
+      "height": 32,
+      "tintColor": "rgba(61,60,64,0.3)",
+      "width": 32,
+    }
+  }
+/>
+`;

--- a/app/components/user_status/user_status.js
+++ b/app/components/user_status/user_status.js
@@ -6,6 +6,9 @@ import {Image} from 'react-native';
 import PropTypes from 'prop-types';
 
 import {General} from 'mattermost-redux/constants';
+
+import {changeOpacity} from 'app/utils/theme';
+
 import away from 'assets/images/status/away.png';
 import dnd from 'assets/images/status/dnd.png';
 import offline from 'assets/images/status/offline.png';
@@ -47,7 +50,7 @@ export default class UserStatus extends PureComponent {
             iconColor = theme.onlineIndicator;
             break;
         default:
-            iconColor = theme.centerChannelColor;
+            iconColor = changeOpacity(theme.centerChannelColor, 0.3);
             break;
         }
 

--- a/app/components/user_status/user_status.test.js
+++ b/app/components/user_status/user_status.test.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {General} from 'mattermost-redux/constants';
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import UserStatus from './user_status';
+
+describe('UserStatus', () => {
+    const baseProps = {
+        size: 32,
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should match snapshot, should default to offline status', () => {
+        const wrapper = shallow(
+            <UserStatus {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should match snapshot, away status', () => {
+        const wrapper = shallow(
+            <UserStatus
+                {...baseProps}
+                status={General.AWAY}
+            />
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should match snapshot, dnd status', () => {
+        const wrapper = shallow(
+            <UserStatus
+                {...baseProps}
+                status={General.DND}
+            />
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should match snapshot, online status', () => {
+        const wrapper = shallow(
+            <UserStatus
+                {...baseProps}
+                status={General.ONLINE}
+            />
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
Add opacity of 0.3 to circle stroke of offline status.

@enahum Please confirm if we can make it for release-1.13.

#### Ticket Link
Jira ticket: [MM-12622](https://mattermost.atlassian.net/browse/MM-12622)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
iPhone:
![screen shot 2018-10-09 at 4 19 09 pm](https://user-images.githubusercontent.com/5334504/46655806-28f39e00-cbdf-11e8-8a4e-39740d3aa0fa.png)

Android:
![screen shot 2018-10-09 at 4 19 38 pm](https://user-images.githubusercontent.com/5334504/46655815-2ee97f00-cbdf-11e8-8746-404ce22a175b.png)

