### PR TITLE
Do not show the option to copy post if there is no text

### DIFF
--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -132,6 +132,7 @@ export default class PostBody extends PureComponent {
             isPostEphemeral,
             isSystemMessage,
             managedConfig,
+            message,
             onCopyText,
             onPostDelete,
             onPostEdit,
@@ -149,7 +150,7 @@ export default class PostBody extends PureComponent {
                 });
             }
 
-            if (managedConfig.copyAndPasteProtection !== 'true') {
+            if (managedConfig.copyAndPasteProtection !== 'true' && message) {
                 actions.push({
                     text: formatMessage({id: 'mobile.post_info.copy_post', defaultMessage: 'Copy Post'}),
                     onPress: onCopyText,


### PR DESCRIPTION
#### Summary
In case the post does not have text we do not show the option to copy the post as there is nothing to copy

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12349
