### PR TITLE
Fix iOS Share Extension crashes

### DIFF
--- a/share_extension/ios/extension.js
+++ b/share_extension/ios/extension.js
@@ -38,7 +38,7 @@ export default class SharedApp extends PureComponent {
         };
 
         mattermostBucket.readFromFile('entities', props.appGroupId).then((value) => {
-            this.entities = value || initialState;
+            this.entities = value || initialState.entities;
             this.setState({init: true});
         });
     }


### PR DESCRIPTION
#### Summary

If `AppGroupId` was not set correct, iOS share extension crashes.

mattermost-mobile/share_extension/ios/extension.js
```
mattermostBucket.readFromFile('entities', props.appGroupId).then((value) => {
            this.entities = value || initialState;
            this.setState({init: true});
});
```

`this.entities = value || initialState;`
 must be 
`this.entities = value || initialState.entities;`

![extension](https://user-images.githubusercontent.com/1047661/46682307-c7075880-cc1f-11e8-8e6c-09c853fe1ef3.png)



#### Environment Information

- Device Name: all iOS device
- OS Version: Test on iOS 12
- Mattermost App Version: 1.12.0 

