### PR TITLE
MM-12560 Fix for infinite loading indicator for thread from search

### DIFF
--- a/app/components/post_list/post_list_base.js
+++ b/app/components/post_list/post_list_base.js
@@ -35,7 +35,7 @@ export default class PostListBase extends PureComponent {
         onPostPress: PropTypes.func,
         onRefresh: PropTypes.func,
         postIds: PropTypes.array.isRequired,
-        renderFooter: PropTypes.func,
+        renderFooter: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
         renderReplies: PropTypes.bool,
         serverURL: PropTypes.string.isRequired,
         shouldRenderReplyButton: PropTypes.bool,

--- a/app/screens/thread/__snapshots__/thread.test.js.snap
+++ b/app/screens/thread/__snapshots__/thread.test.js.snap
@@ -46,7 +46,13 @@ exports[`thread should match snapshot, has root post 1`] = `
           "post_id_2",
         ]
       }
-      renderFooter={[Function]}
+      renderFooter={
+        <Loading
+          color="grey"
+          size="large"
+          style={Object {}}
+        />
+      }
     />
     <Connect(PostTextbox)
       channelId="channel_id"
@@ -104,44 +110,105 @@ exports[`thread should match snapshot, no root post, loading 1`] = `
 `;
 
 exports[`thread should match snapshot, render footer 1`] = `
-<Loading
-  color="grey"
-  size="large"
-  style={Object {}}
+<Connect(PostList)
+  currentUserId="member_user_id"
+  indicateNewMessages={true}
+  navigator={
+    Object {
+      "dismissModal": [MockFunction],
+      "pop": [MockFunction],
+      "resetTo": [MockFunction],
+      "setTitle": [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "title": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+    }
+  }
+  postIds={
+    Array [
+      "root_id",
+      "post_id_1",
+      "post_id_2",
+    ]
+  }
+  renderFooter={
+    <Loading
+      color="grey"
+      size="large"
+      style={Object {}}
+    />
+  }
 />
 `;
 
-exports[`thread should match snapshot, render footer 2`] = `null`;
-
-exports[`thread should match snapshot, render footer 3`] = `
-<DeletedPost
-  theme={
+exports[`thread should match snapshot, render footer 2`] = `
+<Connect(PostList)
+  currentUserId="member_user_id"
+  indicateNewMessages={true}
+  lastViewedAt={0}
+  navigator={
     Object {
-      "awayIndicator": "#ffbc42",
-      "buttonBg": "#166de0",
-      "buttonColor": "#ffffff",
-      "centerChannelBg": "#ffffff",
-      "centerChannelColor": "#3d3c40",
-      "codeTheme": "github",
-      "dndIndicator": "#f74343",
-      "errorTextColor": "#fd5960",
-      "linkColor": "#2389d7",
-      "mentionBj": "#ffffff",
-      "mentionColor": "#145dbf",
-      "mentionHighlightBg": "#ffe577",
-      "mentionHighlightLink": "#166de0",
-      "newMessageSeparator": "#ff8800",
-      "onlineIndicator": "#06d6a0",
-      "sidebarBg": "#145dbf",
-      "sidebarHeaderBg": "#1153ab",
-      "sidebarHeaderTextColor": "#ffffff",
-      "sidebarText": "#ffffff",
-      "sidebarTextActiveBorder": "#579eff",
-      "sidebarTextActiveColor": "#ffffff",
-      "sidebarTextHoverBg": "#4578bf",
-      "sidebarUnreadText": "#ffffff",
-      "type": "Mattermost",
+      "dismissModal": [MockFunction],
+      "pop": [MockFunction],
+      "resetTo": [MockFunction],
+      "setTitle": [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "title": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
     }
   }
+  postIds={
+    Array [
+      "root_id",
+      "post_id_1",
+      "post_id_2",
+    ]
+  }
+  renderFooter={null}
 />
+`;
+
+exports[`thread should match snapshot, render footer 3`] = `
+<Connect(SafeAreaIos)
+  excludeHeader={true}
+  keyboardOffset={20}
+>
+  <Connect(StatusBar) />
+  <KeyboardLayout
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+        "flex": 1,
+      }
+    }
+  >
+    <Loading
+      color="grey"
+      size="large"
+      style={Object {}}
+    />
+  </KeyboardLayout>
+</Connect(SafeAreaIos)>
 `;

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -139,7 +139,7 @@ export default class Thread extends PureComponent {
         if (this.hasRootPost()) {
             content = (
                 <PostList
-                    renderFooter={this.renderFooter}
+                    renderFooter={this.renderFooter()}
                     indicateNewMessages={true}
                     postIds={postIds}
                     currentUserId={myMember.user_id}

--- a/app/screens/thread/thread.test.js
+++ b/app/screens/thread/thread.test.js
@@ -6,6 +6,7 @@ import {shallow} from 'enzyme';
 
 import Preferences from 'mattermost-redux/constants/preferences';
 import {General, RequestStatus} from 'mattermost-redux/constants';
+import PostList from 'app/components/post_list';
 
 import Thread from './thread.js';
 
@@ -89,15 +90,15 @@ describe('thread', () => {
         );
 
         // return loading
-        expect(wrapper.instance().renderFooter()).toMatchSnapshot();
+        expect(wrapper.find(PostList).getElement()).toMatchSnapshot();
 
         // return null
         wrapper.setProps({threadLoadingStatus: {status: RequestStatus.SUCCESS}});
-        expect(wrapper.instance().renderFooter()).toMatchSnapshot();
+        expect(wrapper.find(PostList).getElement()).toMatchSnapshot();
 
         // return deleted post
         const newPostIds = ['post_id_1', 'post_id_2'];
         wrapper.setProps({postIds: newPostIds});
-        expect(wrapper.instance().renderFooter()).toMatchSnapshot();
+        expect(wrapper.getElement()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Summary
Fixes infinite loader for thread view

Though the status for post loading changes props to postList does not change(As it is func reference and not a component or Obj) causing it not to render again.

Flatlist accepts react component too so changing this to accept component as it causes the render.

There should not cause any unnecessary render cycles as only initial state changes cause renders and after that this.renderFooter return null and `null === null`.
 
#### Ticket Link
[MM-12560](https://mattermost.atlassian.net/browse/MM-12560)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Screenshots
![oct-10-2018 19-04-07](https://user-images.githubusercontent.com/4973621/46742001-cb854d00-ccc3-11e8-8986-f13911dc3683.gif)
