### PR TITLE
Fix Upload file size

### DIFF
--- a/app/components/attachment_button.js
+++ b/app/components/attachment_button.js
@@ -49,8 +49,8 @@ export default class AttachmentButton extends PureComponent {
     attachFileFromCamera = async (mediaType) => {
         const {formatMessage} = this.context.intl;
         const options = {
-            quality: 1,
-            videoQuality: 'high',
+            quality: 0.8,
+            videoQuality: 'low',
             noData: true,
             mediaType,
             storageOptions: {
@@ -90,7 +90,7 @@ export default class AttachmentButton extends PureComponent {
     attachFileFromLibrary = () => {
         const {formatMessage} = this.context.intl;
         const options = {
-            quality: 1,
+            quality: 0.8,
             noData: true,
             permissionDenied: {
                 title: formatMessage({
@@ -129,7 +129,7 @@ export default class AttachmentButton extends PureComponent {
     attachVideoFromLibraryAndroid = () => {
         const {formatMessage} = this.context.intl;
         const options = {
-            videoQuality: 'high',
+            videoQuality: 'low',
             mediaType: 'video',
             noData: true,
             permissionDenied: {

--- a/ios/MattermostShare/ShareViewController.m
+++ b/ios/MattermostShare/ShareViewController.m
@@ -185,7 +185,7 @@ typedef void (^ProviderCallback)(NSString *content, NSString *contentType, BOOL 
           }
           
           NSURL *tempFileURL = [tempContainerURL URLByAppendingPathComponent: fileName];
-          BOOL created = [UIImageJPEGRepresentation(image, 1) writeToFile:[tempFileURL path] atomically:YES];
+          BOOL created = [UIImageJPEGRepresentation(image, 0.8) writeToFile:[tempFileURL path] atomically:YES];
           if (created) {
             return callback([tempFileURL absoluteString], @"public.image", YES, nil);
           } else {
@@ -200,7 +200,7 @@ typedef void (^ProviderCallback)(NSString *content, NSString *contentType, BOOL 
             return callback(nil, nil, NO, nil);
           }
           NSURL *tempFileURL = [tempContainerURL URLByAppendingPathComponent: fileName];
-          BOOL created = [UIImageJPEGRepresentation(image, 0.95) writeToFile:[tempFileURL path] atomically:YES];
+          BOOL created = [UIImageJPEGRepresentation(image, 0.8) writeToFile:[tempFileURL path] atomically:YES];
           if (created) {
             return callback([tempFileURL absoluteString], @"public.image", YES, nil);
           } else {


### PR DESCRIPTION
#### Summary
By lowering the quality we ensure that the file size is definitely lower, the main issue here is that for images and videos the library actually process and re-encodes the image, so it is actually not the original file, I've looked to replace the library but did not find one that satisfies what we need. The share extension on iOS also does the same process by using `UIImageJPEGRepresentation` but the quality values were different than the one used the RN code now they are set at `0.8` in both places.

On the other hand the Share Extension for Android actually uses a copy of the original file, so sizes might in fact be different.

I also found this in another similar library that also process and re-encodes the images and videos

> Compress image with quality (from 0 to 1, where 1 is best quality). Values larger than 0.8 don't produce a noticeable quality increase in most images, while a value of 0.8 will reduce the file size by about half or less compared to a value of 1.

By setting the videoQuality to 'low' the video quality is good enough but the file size is considerably lower as you can see here
![image](https://user-images.githubusercontent.com/6757047/46807872-59534d80-cd41-11e8-9d70-ba40f487e606.png)

In fact the whole idea is to be able to upload images and videos with good quality and have them be as smaller in size as possible ;)

Note: Taking a photo and uploading the file and then upload the same file from the gallery should have the same fileSize even though the same image is processed twice.

Share Extension for iOS does not compress video files (so sharing the video file might have a larger filesize than attaching from within the app)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12555

#### Device Information
This PR was tested on: Android and iOS

#### Screenshots
![image](https://user-images.githubusercontent.com/6757047/46808177-15147d00-cd42-11e8-895e-c4317648eb1f.png)

![image](https://user-images.githubusercontent.com/6757047/46808190-1e054e80-cd42-11e8-887c-3eab5af4bd84.png)

