### PR TITLE
Fix crash when loading the permalink view

### DIFF
--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -100,7 +100,7 @@ export default class Permalink extends PureComponent {
             newState.channelNameState = nextProps.channelName;
         }
 
-        if (nextProps.postIds.length > 0 && nextProps.postIds !== prevState.postIdsState) {
+        if (nextProps.postIds && nextProps.postIds.length > 0 && nextProps.postIds !== prevState.postIdsState) {
             newState.postIdsState = nextProps.postIds;
         }
 


### PR DESCRIPTION
#### Summary
If postsIds is null this was causing a crash.

https://mattermost.atlassian.net/browse/MM-12658