### PR TITLE
Fix uploading iOS videos

### DIFF
--- a/app/components/attachment_button.js
+++ b/app/components/attachment_button.js
@@ -300,7 +300,8 @@ export default class AttachmentButton extends PureComponent {
     uploadFiles = async (files) => {
         const file = files[0];
         if (!file.fileSize | !file.fileName) {
-            const fileInfo = await RNFetchBlob.fs.stat(file.path);
+            const path = (file.path || file.uri).replace('file://', '');
+            const fileInfo = await RNFetchBlob.fs.stat(path);
             file.fileSize = fileInfo.size;
             file.fileName = fileInfo.filename;
         }


### PR DESCRIPTION
#### Summary
on iOS the ImagePicker does not set the `path` on the returned response like for Android but an `uri` this PR handles that so it upload the video files correctly on both platforms

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12663