### PR TITLE
Fix for LHS populating you next to current user

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
+++ b/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
@@ -94,14 +94,356 @@ exports[`ChannelItem should match snapshot 1`] = `
               },
             ]
           }
-        />
+        >
+          display_name
+        </Component>
       </Component>
     </Component>
   </TouchableHighlight>
 </AnimatedComponent>
 `;
 
-exports[`ChannelItem should match snapshot for deactivated user 1`] = `null`;
+exports[`ChannelItem should match snapshot for current user i.e currentUser (you) 1`] = `
+<AnimatedComponent>
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    onLongPress={[Function]}
+    onPress={[Function]}
+    underlayColor="rgba(69,120,191,0.5)"
+  >
+    <Component
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 44,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Component
+        style={
+          Object {
+            "backgroundColor": "#579eff",
+            "width": 5,
+          }
+        }
+      />
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "paddingLeft": 16,
+            },
+            Object {
+              "backgroundColor": "rgba(255,255,255,0.1)",
+              "paddingLeft": 11,
+            },
+          ]
+        }
+      >
+        <ChannelIcon
+          channelId="channel_id"
+          hasDraft={false}
+          isActive={true}
+          isArchived={false}
+          isInfo={false}
+          isUnread={true}
+          membersCount={1}
+          size={16}
+          status="online"
+          theme={
+            Object {
+              "awayIndicator": "#ffbc42",
+              "buttonBg": "#166de0",
+              "buttonColor": "#ffffff",
+              "centerChannelBg": "#ffffff",
+              "centerChannelColor": "#3d3c40",
+              "codeTheme": "github",
+              "dndIndicator": "#f74343",
+              "errorTextColor": "#fd5960",
+              "linkColor": "#2389d7",
+              "mentionBj": "#ffffff",
+              "mentionColor": "#145dbf",
+              "mentionHighlightBg": "#ffe577",
+              "mentionHighlightLink": "#166de0",
+              "newMessageSeparator": "#ff8800",
+              "onlineIndicator": "#06d6a0",
+              "sidebarBg": "#145dbf",
+              "sidebarHeaderBg": "#1153ab",
+              "sidebarHeaderTextColor": "#ffffff",
+              "sidebarText": "#ffffff",
+              "sidebarTextActiveBorder": "#579eff",
+              "sidebarTextActiveColor": "#ffffff",
+              "sidebarTextHoverBg": "#4578bf",
+              "sidebarUnreadText": "#ffffff",
+              "type": "Mattermost",
+            }
+          }
+          type="D"
+        />
+        <Component
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "rgba(255,255,255,0.4)",
+                "flex": 1,
+                "fontSize": 14,
+                "fontWeight": "600",
+                "height": "100%",
+                "lineHeight": 44,
+                "paddingRight": 40,
+                "textAlignVertical": "center",
+              },
+              Object {
+                "color": "#ffffff",
+              },
+            ]
+          }
+        >
+          {displayName} (you)
+        </Component>
+      </Component>
+    </Component>
+  </TouchableHighlight>
+</AnimatedComponent>
+`;
+
+exports[`ChannelItem should match snapshot for current user i.e currentUser (you) when isSearchResult 1`] = `
+<AnimatedComponent>
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    onLongPress={[Function]}
+    onPress={[Function]}
+    underlayColor="rgba(69,120,191,0.5)"
+  >
+    <Component
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 44,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Component
+        style={
+          Object {
+            "backgroundColor": "#579eff",
+            "width": 5,
+          }
+        }
+      />
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "paddingLeft": 16,
+            },
+            Object {
+              "backgroundColor": "rgba(255,255,255,0.1)",
+              "paddingLeft": 11,
+            },
+          ]
+        }
+      >
+        <ChannelIcon
+          channelId="channel_id"
+          hasDraft={false}
+          isActive={true}
+          isArchived={false}
+          isInfo={false}
+          isUnread={true}
+          membersCount={1}
+          size={16}
+          status="online"
+          theme={
+            Object {
+              "awayIndicator": "#ffbc42",
+              "buttonBg": "#166de0",
+              "buttonColor": "#ffffff",
+              "centerChannelBg": "#ffffff",
+              "centerChannelColor": "#3d3c40",
+              "codeTheme": "github",
+              "dndIndicator": "#f74343",
+              "errorTextColor": "#fd5960",
+              "linkColor": "#2389d7",
+              "mentionBj": "#ffffff",
+              "mentionColor": "#145dbf",
+              "mentionHighlightBg": "#ffe577",
+              "mentionHighlightLink": "#166de0",
+              "newMessageSeparator": "#ff8800",
+              "onlineIndicator": "#06d6a0",
+              "sidebarBg": "#145dbf",
+              "sidebarHeaderBg": "#1153ab",
+              "sidebarHeaderTextColor": "#ffffff",
+              "sidebarText": "#ffffff",
+              "sidebarTextActiveBorder": "#579eff",
+              "sidebarTextActiveColor": "#ffffff",
+              "sidebarTextHoverBg": "#4578bf",
+              "sidebarUnreadText": "#ffffff",
+              "type": "Mattermost",
+            }
+          }
+          type="D"
+        />
+        <Component
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "rgba(255,255,255,0.4)",
+                "flex": 1,
+                "fontSize": 14,
+                "fontWeight": "600",
+                "height": "100%",
+                "lineHeight": 44,
+                "paddingRight": 40,
+                "textAlignVertical": "center",
+              },
+              Object {
+                "color": "#ffffff",
+              },
+            ]
+          }
+        >
+          {displayName} (you)
+        </Component>
+      </Component>
+    </Component>
+  </TouchableHighlight>
+</AnimatedComponent>
+`;
+
+exports[`ChannelItem should match snapshot for deactivated user and is currentChannel 1`] = `
+<AnimatedComponent>
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    onLongPress={[Function]}
+    onPress={[Function]}
+    underlayColor="rgba(69,120,191,0.5)"
+  >
+    <Component
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 44,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Component
+        style={
+          Object {
+            "backgroundColor": "#579eff",
+            "width": 5,
+          }
+        }
+      />
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "paddingLeft": 16,
+            },
+            Object {
+              "backgroundColor": "rgba(255,255,255,0.1)",
+              "paddingLeft": 11,
+            },
+          ]
+        }
+      >
+        <ChannelIcon
+          channelId="channel_id"
+          hasDraft={false}
+          isActive={true}
+          isArchived={true}
+          isInfo={false}
+          isUnread={true}
+          membersCount={1}
+          size={16}
+          status="online"
+          theme={
+            Object {
+              "awayIndicator": "#ffbc42",
+              "buttonBg": "#166de0",
+              "buttonColor": "#ffffff",
+              "centerChannelBg": "#ffffff",
+              "centerChannelColor": "#3d3c40",
+              "codeTheme": "github",
+              "dndIndicator": "#f74343",
+              "errorTextColor": "#fd5960",
+              "linkColor": "#2389d7",
+              "mentionBj": "#ffffff",
+              "mentionColor": "#145dbf",
+              "mentionHighlightBg": "#ffe577",
+              "mentionHighlightLink": "#166de0",
+              "newMessageSeparator": "#ff8800",
+              "onlineIndicator": "#06d6a0",
+              "sidebarBg": "#145dbf",
+              "sidebarHeaderBg": "#1153ab",
+              "sidebarHeaderTextColor": "#ffffff",
+              "sidebarText": "#ffffff",
+              "sidebarTextActiveBorder": "#579eff",
+              "sidebarTextActiveColor": "#ffffff",
+              "sidebarTextHoverBg": "#4578bf",
+              "sidebarUnreadText": "#ffffff",
+              "type": "Mattermost",
+            }
+          }
+          type="D"
+        />
+        <Component
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "rgba(255,255,255,0.4)",
+                "flex": 1,
+                "fontSize": 14,
+                "fontWeight": "600",
+                "height": "100%",
+                "lineHeight": 44,
+                "paddingRight": 40,
+                "textAlignVertical": "center",
+              },
+              Object {
+                "color": "#ffffff",
+              },
+            ]
+          }
+        >
+          display_name
+        </Component>
+      </Component>
+    </Component>
+  </TouchableHighlight>
+</AnimatedComponent>
+`;
 
 exports[`ChannelItem should match snapshot for deactivated user and is searchResult 1`] = `
 <AnimatedComponent>
@@ -197,126 +539,20 @@ exports[`ChannelItem should match snapshot for deactivated user and is searchRes
               },
             ]
           }
-        />
+        >
+          display_name
+        </Component>
       </Component>
     </Component>
   </TouchableHighlight>
 </AnimatedComponent>
 `;
 
-exports[`ChannelItem should match snapshot if channel is archived 1`] = `null`;
+exports[`ChannelItem should match snapshot for deactivated user and not searchResults or currentChannel 1`] = `null`;
 
-exports[`ChannelItem should match snapshot if channel is archived and is currentChannel 1`] = `
-<AnimatedComponent>
-  <TouchableHighlight
-    activeOpacity={0.85}
-    delayPressOut={100}
-    onLongPress={[Function]}
-    onPress={[Function]}
-    underlayColor="rgba(69,120,191,0.5)"
-  >
-    <Component
-      style={
-        Array [
-          Object {
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 44,
-          },
-          undefined,
-        ]
-      }
-    >
-      <Component
-        style={
-          Object {
-            "backgroundColor": "#579eff",
-            "width": 5,
-          }
-        }
-      />
-      <Component
-        style={
-          Array [
-            Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "row",
-              "paddingLeft": 16,
-            },
-            Object {
-              "backgroundColor": "rgba(255,255,255,0.1)",
-              "paddingLeft": 11,
-            },
-          ]
-        }
-      >
-        <ChannelIcon
-          channelId="channel_id"
-          hasDraft={false}
-          isActive={true}
-          isArchived={true}
-          isInfo={false}
-          isUnread={true}
-          membersCount={1}
-          size={16}
-          status="online"
-          theme={
-            Object {
-              "awayIndicator": "#ffbc42",
-              "buttonBg": "#166de0",
-              "buttonColor": "#ffffff",
-              "centerChannelBg": "#ffffff",
-              "centerChannelColor": "#3d3c40",
-              "codeTheme": "github",
-              "dndIndicator": "#f74343",
-              "errorTextColor": "#fd5960",
-              "linkColor": "#2389d7",
-              "mentionBj": "#ffffff",
-              "mentionColor": "#145dbf",
-              "mentionHighlightBg": "#ffe577",
-              "mentionHighlightLink": "#166de0",
-              "newMessageSeparator": "#ff8800",
-              "onlineIndicator": "#06d6a0",
-              "sidebarBg": "#145dbf",
-              "sidebarHeaderBg": "#1153ab",
-              "sidebarHeaderTextColor": "#ffffff",
-              "sidebarText": "#ffffff",
-              "sidebarTextActiveBorder": "#579eff",
-              "sidebarTextActiveColor": "#ffffff",
-              "sidebarTextHoverBg": "#4578bf",
-              "sidebarUnreadText": "#ffffff",
-              "type": "Mattermost",
-            }
-          }
-          type="O"
-        />
-        <Component
-          ellipsizeMode="tail"
-          numberOfLines={1}
-          style={
-            Array [
-              Object {
-                "color": "rgba(255,255,255,0.4)",
-                "flex": 1,
-                "fontSize": 14,
-                "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
-                "paddingRight": 40,
-                "textAlignVertical": "center",
-              },
-              Object {
-                "color": "#ffffff",
-              },
-            ]
-          }
-        />
-      </Component>
-    </Component>
-  </TouchableHighlight>
-</AnimatedComponent>
-`;
+exports[`ChannelItem should match snapshot for no displayName 1`] = `null`;
+
+exports[`ChannelItem should match snapshot for showUnreadForMsgs 1`] = `null`;
 
 exports[`ChannelItem should match snapshot with draft 1`] = `
 <AnimatedComponent>
@@ -411,6 +647,137 @@ exports[`ChannelItem should match snapshot with draft 1`] = `
                 "color": "#ffffff",
               },
             ]
+          }
+        >
+          display_name
+        </Component>
+      </Component>
+    </Component>
+  </TouchableHighlight>
+</AnimatedComponent>
+`;
+
+exports[`ChannelItem should match snapshot with mentions and muted 1`] = `
+<AnimatedComponent>
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    onLongPress={[Function]}
+    onPress={[Function]}
+    underlayColor="rgba(69,120,191,0.5)"
+  >
+    <Component
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 44,
+          },
+          Object {
+            "opacity": 0.5,
+          },
+        ]
+      }
+    >
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "paddingLeft": 16,
+            },
+            undefined,
+          ]
+        }
+      >
+        <ChannelIcon
+          channelId="channel_id"
+          hasDraft={false}
+          isActive={false}
+          isArchived={false}
+          isInfo={false}
+          isUnread={true}
+          membersCount={1}
+          size={16}
+          status="online"
+          theme={
+            Object {
+              "awayIndicator": "#ffbc42",
+              "buttonBg": "#166de0",
+              "buttonColor": "#ffffff",
+              "centerChannelBg": "#ffffff",
+              "centerChannelColor": "#3d3c40",
+              "codeTheme": "github",
+              "dndIndicator": "#f74343",
+              "errorTextColor": "#fd5960",
+              "linkColor": "#2389d7",
+              "mentionBj": "#ffffff",
+              "mentionColor": "#145dbf",
+              "mentionHighlightBg": "#ffe577",
+              "mentionHighlightLink": "#166de0",
+              "newMessageSeparator": "#ff8800",
+              "onlineIndicator": "#06d6a0",
+              "sidebarBg": "#145dbf",
+              "sidebarHeaderBg": "#1153ab",
+              "sidebarHeaderTextColor": "#ffffff",
+              "sidebarText": "#ffffff",
+              "sidebarTextActiveBorder": "#579eff",
+              "sidebarTextActiveColor": "#ffffff",
+              "sidebarTextHoverBg": "#4578bf",
+              "sidebarUnreadText": "#ffffff",
+              "type": "Mattermost",
+            }
+          }
+          type="O"
+        />
+        <Component
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "rgba(255,255,255,0.4)",
+                "flex": 1,
+                "fontSize": 14,
+                "fontWeight": "600",
+                "height": "100%",
+                "lineHeight": 44,
+                "paddingRight": 40,
+                "textAlignVertical": "center",
+              },
+              Object {
+                "color": "#ffffff",
+              },
+            ]
+          }
+        >
+          display_name
+        </Component>
+        <Badge
+          count={1}
+          countStyle={
+            Object {
+              "color": "#145dbf",
+              "fontSize": 10,
+            }
+          }
+          extraPaddingHorizontal={10}
+          minHeight={20}
+          minWidth={20}
+          onPress={[Function]}
+          style={
+            Object {
+              "backgroundColor": undefined,
+              "borderColor": "#1153ab",
+              "borderRadius": 10,
+              "borderWidth": 1,
+              "padding": 3,
+              "position": "relative",
+              "right": 16,
+            }
           }
         />
       </Component>

--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -33,9 +33,10 @@ function makeMapStateToProps() {
         const isArchived = channel.delete_at > 0;
 
         if (channel.type === General.DM_CHANNEL) {
-            isMyUser = channel.id === currentUserId;
-
-            if (!ownProps.isSearchResult) {
+            if (ownProps.isSearchResult) {
+                isMyUser = channel.id === currentUserId;
+            } else {
+                isMyUser = channel.teammate_id === currentUserId;
                 const teammate = getUser(state, channel.teammate_id);
                 const teammateNameDisplay = getTeammateNameDisplaySetting(state);
                 displayName = displayUsername(teammate, teammateNameDisplay, false);

--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -28,15 +28,10 @@ function makeMapStateToProps() {
         const currentUserId = getCurrentUserId(state);
         const channelDraft = getDraftForChannel(state, channel.id);
 
-        let isMyUser = false;
         let displayName = channel.display_name;
-        const isArchived = channel.delete_at > 0;
 
         if (channel.type === General.DM_CHANNEL) {
-            if (ownProps.isSearchResult) {
-                isMyUser = channel.id === currentUserId;
-            } else {
-                isMyUser = channel.teammate_id === currentUserId;
+            if (!ownProps.isSearchResult) {
                 const teammate = getUser(state, channel.teammate_id);
                 const teammateNameDisplay = getTeammateNameDisplaySetting(state);
                 displayName = displayUsername(teammate, teammateNameDisplay, false);
@@ -70,18 +65,14 @@ function makeMapStateToProps() {
             channel,
             currentChannelId,
             displayName,
-            fake: channel.fake,
             isChannelMuted: isChannelMuted(member),
-            isMyUser,
+            currentUserId,
             hasDraft: Boolean(channelDraft.draft.trim() || channelDraft.files.length),
             mentions: member ? member.mention_count : 0,
             shouldHideChannel,
             showUnreadForMsgs,
-            status: channel.status,
             theme: getTheme(state),
-            type: channel.type,
             unreadMsgs,
-            isArchived,
         };
     };
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -67,3 +67,7 @@ jest.mock('rn-fetch-blob/fs', () => ({
         CacheDir: () => jest.fn(),
     },
 }));
+
+global.requestAnimationFrame = (callback) => {
+    setTimeout(callback, 0);
+};


### PR DESCRIPTION
#### Summary
Fix for populating (you) in LHS for currenUser
1. From search result currentUser id will be in channel.id
2. If in LHS currentUser id will be in channel.teammate_id
 
#### Ticket
[MM-12676](https://mattermost.atlassian.net/browse/MM-12676)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes


#### Screenshots
<img width="343" alt="screen shot 2018-10-13 at 3 10 13 am" src="https://user-images.githubusercontent.com/4973621/46895341-96305900-ce95-11e8-8a36-d13a4f41c138.png">
<img width="379" alt="screen shot 2018-10-13 at 3 10 22 am" src="https://user-images.githubusercontent.com/4973621/46895400-d55eaa00-ce95-11e8-9e18-dd3e54086990.png">
