### PR TITLE
Use native transitions for sidebar

### DIFF
--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -382,6 +382,7 @@ export default class ChannelSidebar extends Component {
                 onDrawerClose={this.handleDrawerClose}
                 onDrawerOpen={this.handleDrawerOpen}
                 drawerWidth={deviceWidth - openDrawerOffset}
+                useNativeAnimations={true}
             >
                 {children}
             </DrawerLayout>

--- a/app/components/sidebars/settings/settings_sidebar.js
+++ b/app/components/sidebars/settings/settings_sidebar.js
@@ -358,6 +358,7 @@ export default class SettingsDrawer extends PureComponent {
                 onDrawerOpen={this.handleDrawerOpen}
                 drawerPosition='right'
                 drawerWidth={deviceWidth - DRAWER_INITIAL_OFFSET}
+                useNativeAnimations={true}
             >
                 {children}
             </DrawerLayout>


### PR DESCRIPTION
#### Summary
Uses native transitions for sidebar
Library does have nativeTranstion prop 
https://github.com/react-native-community/react-native-drawer-layout/blob/69d70f00585bc8ccbaeb824f88aa3f205bd0922e/src/DrawerLayout.js#L36

But sets to false by default. 
https://github.com/react-native-community/react-native-drawer-layout/blob/69d70f00585bc8ccbaeb824f88aa3f205bd0922e/src/DrawerLayout.js#L73

So passing down true here

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [Android and Ios emulators] 

#### Screenshots
Should have better results on real environment with traffic

Before
![oct-19-2018 00-46-26](https://user-images.githubusercontent.com/4973621/47179113-d599f200-d33a-11e8-918d-a9a5dbf38444.gif)
After
![oct-19-2018 00-45-08](https://user-images.githubusercontent.com/4973621/47179114-d599f200-d33a-11e8-91d1-88d922bdca0d.gif)


