### PR TITLE
Fix 'pre-buid' typo in build-android target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ build-ios: | stop pre-build check-style ## Builds the iOS app
 	@cd fastlane && BABEL_ENV=production NODE_ENV=production bundle exec fastlane ios build
 	@ps -ef | grep -i "cli.js start" | grep -iv grep | awk '{print $$2}' | xargs kill -9
 
-build-android: | stop pre-buid check-style prepare-android-build ## Build the Android app
+build-android: | stop pre-build check-style prepare-android-build ## Build the Android app
 	@if [ $(shell ps -ef | grep -i "cli.js start" | grep -civ grep) -eq 0 ]; then \
 		echo Starting React Native packager server; \
 		npm start & echo; \


### PR DESCRIPTION
The `build-android` target calls the `pre-build` target as `pre-buid`, resulting in build failure for the `build-android` target. This PR fixes the issue.

([PR #2272](https://github.com/mattermost/mattermost-mobile/pull/2272) did the same for a typo in the `build-pr` target.)
