### PR TITLE
Capture video in high quality

### DIFF
--- a/app/components/attachment_button.js
+++ b/app/components/attachment_button.js
@@ -54,7 +54,7 @@ export default class AttachmentButton extends PureComponent {
         const {formatMessage} = this.context.intl;
         const options = {
             quality: 0.8,
-            videoQuality: 'low',
+            videoQuality: 'high',
             noData: true,
             mediaType,
             storageOptions: {
@@ -133,7 +133,7 @@ export default class AttachmentButton extends PureComponent {
     attachVideoFromLibraryAndroid = () => {
         const {formatMessage} = this.context.intl;
         const options = {
-            videoQuality: 'low',
+            videoQuality: 'high',
             mediaType: 'video',
             noData: true,
             permissionDenied: {


### PR DESCRIPTION
#### Summary
When changing the quality to reduce the file size videos had a low quality when being recorded directly, this ensures that they are recorded in high quality.

One thing to note is that recording a new video an uploading it directly will have a larger file size than the same video when selected from the image library, the reason is that the underlaying library do not apply the same conversion to the files.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12246
