### PR TITLE
MM-12467 Made borders between autocomplete items consistent

### DIFF
--- a/app/components/autocomplete/autocomplete_section_header.js
+++ b/app/components/autocomplete/autocomplete_section_header.js
@@ -39,8 +39,6 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             justifyContent: 'center',
             paddingLeft: 8,
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
-            borderTopWidth: 1,
-            borderTopColor: changeOpacity(theme.centerChannelColor, 0.2),
         },
         sectionText: {
             fontSize: 12,

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion.js
@@ -9,6 +9,7 @@ import {
 
 import {RequestStatus} from 'mattermost-redux/constants';
 
+import AutocompleteDivider from 'app/components/autocomplete/autocomplete_divider';
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import SlashSuggestionItem from './slash_suggestion_item';
@@ -152,6 +153,7 @@ export default class SlashSuggestion extends Component {
                 data={this.state.dataSource}
                 keyExtractor={this.keyExtractor}
                 renderItem={this.renderItem}
+                ItemSeparatorComponent={AutocompleteDivider}
                 pageSize={10}
                 initialListSize={10}
             />

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
@@ -53,8 +53,6 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             justifyContent: 'center',
             paddingHorizontal: 8,
             backgroundColor: theme.centerChannelBg,
-            borderTopWidth: 1,
-            borderTopColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderLeftWidth: 1,
             borderLeftColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderRightWidth: 1,


### PR DESCRIPTION
This removes the duplicate borders at the top of some lists and also removes the borders around the autocomplete section headers

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12467

<img width="393" alt="screen shot 2018-10-25 at 2 29 14 pm" src="https://user-images.githubusercontent.com/3277310/47521973-63596e00-d862-11e8-8956-fdab3bb8d7e3.png">
<img width="394" alt="screen shot 2018-10-25 at 2 29 20 pm" src="https://user-images.githubusercontent.com/3277310/47521977-648a9b00-d862-11e8-8ab4-66d36eee02c9.png">
