### PR TITLE
iOS clear notifications from a specific channel when clear PN

### DIFF
--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -150,9 +150,8 @@ class PushNotification {
     }
 
     clearChannelNotifications(channelId) {
-        const ids = [];
-
         NotificationsIOS.getDeliveredNotifications((notifications) => {
+            const ids = [];
             for (let i = 0; i < notifications.length; i++) {
                 const notification = notifications[i];
 

--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -137,7 +137,8 @@ class PushNotification {
     }
 
     setApplicationIconBadgeNumber(number) {
-        NotificationsIOS.setBadgesCount(number);
+        const count = number < 0 ? 0 : number;
+        NotificationsIOS.setBadgesCount(count);
     }
 
     getNotification() {
@@ -146,6 +147,24 @@ class PushNotification {
 
     resetNotification() {
         this.deviceNotification = null;
+    }
+
+    clearChannelNotifications(channelId) {
+        const ids = [];
+
+        NotificationsIOS.getDeliveredNotifications((notifications) => {
+            for (let i = 0; i < notifications.length; i++) {
+                const notification = notifications[i];
+
+                if (notification.userInfo.channel_id === channelId) {
+                    ids.push(notification.identifier);
+                }
+            }
+
+            if (ids.length) {
+                NotificationsIOS.removeDeliveredNotifications(ids);
+            }
+        });
     }
 }
 

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -60,11 +60,12 @@ class ChannelDrawerButton extends PureComponent {
 
     componentDidMount() {
         EventEmitter.on('drawer_opacity', this.setOpacity);
-        PushNotifications.setApplicationIconBadgeNumber(this.props.mentionCount);
     }
 
     componentWillReceiveProps(nextProps) {
-        PushNotifications.setApplicationIconBadgeNumber(nextProps.mentionCount);
+        if (nextProps.mentionCount !== this.props.mentionCount) {
+            PushNotifications.setApplicationIconBadgeNumber(nextProps.mentionCount);
+        }
     }
 
     componentWillUnmount() {

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -62,9 +62,9 @@ class ChannelDrawerButton extends PureComponent {
         EventEmitter.on('drawer_opacity', this.setOpacity);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.mentionCount !== this.props.mentionCount) {
-            PushNotifications.setApplicationIconBadgeNumber(nextProps.mentionCount);
+    componentDidUpdate(prevProps) {
+        if (prevProps.mentionCount !== this.props.mentionCount) {
+            PushNotifications.setApplicationIconBadgeNumber(this.props.mentionCount);
         }
     }
 

--- a/ios/Mattermost/AppDelegate.m
+++ b/ios/Mattermost/AppDelegate.m
@@ -79,7 +79,6 @@ NSString* const NotificationClearAction = @"clear";
       NSMutableArray<NSString *> *notificationIds = [NSMutableArray new];
       
       for (UNNotification *prevNotification in notifications) {
-        //            [formattedNotifications addObject:RCTFormatUNNotification(notification)];
         UNNotificationRequest *notificationRequest = [prevNotification request];
         UNNotificationContent *notificationContent = [notificationRequest content];
         NSString *identifier = [notificationRequest identifier];

--- a/ios/Mattermost/AppDelegate.m
+++ b/ios/Mattermost/AppDelegate.m
@@ -20,8 +20,11 @@
 #import "RCCManager.h"
 #import "RNNotifications.h"
 #import "SessionManager.h"
+#import <UserNotifications/UserNotifications.h>
 
 @implementation AppDelegate
+
+NSString* const NotificationClearAction = @"clear";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
@@ -69,9 +72,55 @@
   [RNNotifications didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
+-(void)cleanNotificationsFromChannel:(NSString *)channelId andUpdateBadge:(BOOL)updateBadge {
+  if ([UNUserNotificationCenter class]) {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
+      NSMutableArray<NSString *> *notificationIds = [NSMutableArray new];
+      
+      for (UNNotification *prevNotification in notifications) {
+        //            [formattedNotifications addObject:RCTFormatUNNotification(notification)];
+        UNNotificationRequest *notificationRequest = [prevNotification request];
+        UNNotificationContent *notificationContent = [notificationRequest content];
+        NSString *identifier = [notificationRequest identifier];
+        NSString* cId = [[notificationContent userInfo] objectForKey:@"channel_id"];
+
+        if ([cId isEqualToString: channelId]) {
+          [notificationIds addObject:identifier];
+        }
+      }
+
+      [center removeDeliveredNotificationsWithIdentifiers:notificationIds];
+      NSInteger removed = (NSInteger)[notificationIds count] + 1;
+      if (removed > 0 && updateBadge) {
+        NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
+        NSInteger count = badge - removed;
+        if (count > 0) {
+          [[UIApplication sharedApplication] setApplicationIconBadgeNumber:count];
+        } else {
+          [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+        }
+      }
+    }];
+  }
+}
+
 // Required for the notification event.
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-  [RNNotifications didReceiveRemoteNotification:notification];
+-(void)application:(UIApplication *)application didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler {
+  UIApplicationState state = [UIApplication sharedApplication].applicationState;
+  NSString* action = [userInfo objectForKey:@"type"];
+  NSString* channelId = [userInfo objectForKey:@"channel_id"];
+  
+  if (action && [action isEqualToString: NotificationClearAction]) {
+    // If received a notification that a channel was read, remove all notifications from that channel (only with app in foreground/background)
+    [self cleanNotificationsFromChannel:channelId andUpdateBadge:NO];
+  } else if (state == UIApplicationStateInactive) {
+    // When the notification is opened
+    [self cleanNotificationsFromChannel:channelId andUpdateBadge:YES];
+  }
+
+  [RNNotifications didReceiveRemoteNotification:userInfo];
+  completionHandler(UIBackgroundFetchResultNoData);
 }
 
 // Required for the localNotification event.

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -112,6 +112,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
#### Summary
on iOS when the device receives a Clear push notification or when switching to a channel in the app that has notifications and even when bringing the app from the background it will remove all the push notifications that belong to that channel from the *NotificationCenter*.

Caveats: 
* If the app is fully closed (was killed) the OS won't deliver the notification to the app to be processed and will be processed by the OS thus the clear notification **won't** remove the notifications from the *NotificationCenter*. from the apple's doc:

> Discussion
Use this method to process incoming remote notifications for your app. Unlike the application:didReceiveRemoteNotification: method, which is called only when your app is running in the foreground, the system calls this method when your app is running in the foreground or background. In addition, if you enabled the remote notifications background mode, the system launches your app (or wakes it from the suspended state) and puts it in the background state when a remote notification arrives. However, the system does not automatically launch your app if the user has force-quit it. In that situation, the user must relaunch your app or restart the device before the system attempts to launch your app automatically again.

* Replying to a notification will cause the badge count to get out of sync:
When replying the badge count decreases by one and leaves the rest of the notifications for that channel intact BUT it marks the channel as read so the next push notification will have a badge number with the total of unread mentions that by this point exclude the previous ones in that channel. (the same will happen if we don't mark the channel as read, the proper way to fix this is to have read indication per posts)

------
This PR should be tested and for that the changes in the push proxy needs to be deployed

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12534

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Include changes to [mattermost-push-proxy](https://github.com/mattermost/mattermost-push-proxy) (https://github.com/mattermost/mattermost-push-proxy/pull/36)

#### Device Information
This PR was tested on: iOS 12