### PR TITLE
Allow user system CA's for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme"
+      android:networkSecurityConfig="@xml/network_security_config"
     >
         <meta-data android:name="android.content.APP_RESTRICTIONS"
                    android:resource="@xml/app_restrictions" />

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system" />
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
#### Summary
This will allow Android to establish a network connection with any server that uses a Self sign certificate that has the CA certificate installed on the device

More info [here](https://developer.android.com/training/articles/security-config)  and in this [blog post](https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html)

#### Ticket Link
Resolves #2139 
