### PR TITLE
[MM-8404] Channel notification setting for disabling channel mentions (#MM-8404)

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -325,7 +325,7 @@ export default class ChannelInfo extends PureComponent {
         const {updateChannelNotifyProps} = actions;
 
         const opts = {
-            ignore_channel_mentions: ignoreChannelMentions ? 'ignore_channel_mentions_off' : 'ignore_channel_mentions_on',
+            ignore_channel_mentions: ignoreChannelMentions ? Preferences.IGNORE_CHANNEL_MENTIONS_OFF : Preferences.IGNORE_CHANNEL_MENTIONS_ON,
         };
 
         this.setState({ignoreChannelMentions: !ignoreChannelMentions});

--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -11,7 +11,7 @@ import {
     View,
 } from 'react-native';
 
-import {General} from 'mattermost-redux/constants';
+import {General, Users} from 'mattermost-redux/constants';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import StatusBar from 'app/components/status_bar';
@@ -325,7 +325,7 @@ export default class ChannelInfo extends PureComponent {
         const {updateChannelNotifyProps} = actions;
 
         const opts = {
-            ignore_channel_mentions: ignoreChannelMentions ? Preferences.IGNORE_CHANNEL_MENTIONS_OFF : Preferences.IGNORE_CHANNEL_MENTIONS_ON,
+            ignore_channel_mentions: ignoreChannelMentions ? Users.IGNORE_CHANNEL_MENTIONS_OFF : Users.IGNORE_CHANNEL_MENTIONS_ON,
         };
 
         this.setState({ignoreChannelMentions: !ignoreChannelMentions});

--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -56,6 +56,7 @@ export default class ChannelInfo extends PureComponent {
         isFavorite: PropTypes.bool.isRequired,
         canManageUsers: PropTypes.bool.isRequired,
         canEditChannel: PropTypes.bool.isRequired,
+        ignoreChannelMentions: PropTypes.bool.isRequired,
     };
 
     static contextTypes = {
@@ -68,6 +69,7 @@ export default class ChannelInfo extends PureComponent {
         this.state = {
             isFavorite: props.isFavorite,
             isMuted: props.isChannelMuted,
+            ignoreChannelMentions: props.ignoreChannelMentions,
         };
     }
 
@@ -91,7 +93,12 @@ export default class ChannelInfo extends PureComponent {
             isMuted = nextProps.isChannelMuted;
         }
 
-        this.setState({isFavorite, isMuted});
+        let ignoreChannelMentions = this.state.ignoreChannelMentions;
+        if (ignoreChannelMentions !== nextProps.ignoreChannelMentions) {
+            ignoreChannelMentions = nextProps.ignoreChannelMentions;
+        }
+
+        this.setState({isFavorite, isMuted, ignoreChannelMentions});
     }
 
     close = (redirect = true) => {
@@ -313,6 +320,18 @@ export default class ChannelInfo extends PureComponent {
         updateChannelNotifyProps(currentUserId, currentChannel.id, opts);
     };
 
+    handleIgnoreChannelMentions = () => {
+        const {actions, currentChannel, currentUserId, ignoreChannelMentions} = this.props;
+        const {updateChannelNotifyProps} = actions;
+
+        const opts = {
+            ignore_channel_mentions: ignoreChannelMentions ? 'ignore_channel_mentions_off' : 'ignore_channel_mentions_on',
+        };
+
+        this.setState({ignoreChannelMentions: !ignoreChannelMentions});
+        updateChannelNotifyProps(currentUserId, currentChannel.id, opts);
+    }
+
     showPermalinkView = (postId) => {
         const {actions, navigator} = this.props;
 
@@ -405,6 +424,16 @@ export default class ChannelInfo extends PureComponent {
                     detail={this.state.isMuted}
                     icon='bell-slash-o'
                     textId={t('channel_notifications.muteChannel.settings')}
+                    togglable={true}
+                    theme={theme}
+                />
+                <View style={style.separator}/>
+                <ChannelInfoRow
+                    action={this.handleIgnoreChannelMentions}
+                    defaultMessage='Ignore @channel, @here, @all'
+                    detail={this.state.ignoreChannelMentions}
+                    icon='at'
+                    textId={t('channel_notifications.ignoreChannelMentions.settings')}
                     togglable={true}
                     theme={theme}
                 />

--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -25,7 +25,7 @@ import {
     isCurrentChannelReadOnly,
 } from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getUser, getStatusForUserId, getCurrentUserRoles} from 'mattermost-redux/selectors/entities/users';
-import {getUserIdFromChannelName, isChannelMuted, showDeleteOption, showManagementOptions} from 'mattermost-redux/utils/channel_utils';
+import {areChannelMentionsIgnored, getUserIdFromChannelName, isChannelMuted, showDeleteOption, showManagementOptions} from 'mattermost-redux/utils/channel_utils';
 import {isAdmin as checkIsAdmin, isChannelAdmin as checkIsChannelAdmin, isSystemAdmin as checkIsSystemAdmin} from 'mattermost-redux/utils/user_utils';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
@@ -55,6 +55,7 @@ function mapStateToProps(state) {
     const isFavorite = favoriteChannels && favoriteChannels.indexOf(currentChannel.id) > -1;
     const roles = getCurrentUserRoles(state);
     const canManageUsers = currentChannel.hasOwnProperty('id') ? canManageChannelMembers(state) : false;
+    const currentUser = getUser(state, currentUserId);
 
     let status;
     if (currentChannel.type === General.DM_CHANNEL) {
@@ -79,6 +80,7 @@ function mapStateToProps(state) {
         currentChannelMemberCount,
         currentUserId,
         isChannelMuted: isChannelMuted(currentChannelMember),
+        ignoreChannelMentions: areChannelMentionsIgnored(currentChannelMember.notify_props, currentUser.notify_props),
         isCurrent,
         isFavorite,
         status,

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -34,6 +34,7 @@
   "channel_modal.purpose": "Purpose",
   "channel_modal.purposeEx": "E.g.: \"A channel to file bugs and improvements\"",
   "channel_notifications.muteChannel.settings": "Mute channel",
+  "channel_notifications.ignoreChannelMentions.settings": "Ignore @channel, @here, @all",
   "combined_system_message.added_to_channel.many_expanded": "{users} and {lastUser} were **added to the channel** by {actor}.",
   "combined_system_message.added_to_channel.one": "{firstUser} **added to the channel** by {actor}.",
   "combined_system_message.added_to_channel.one_you": "You were **added to the channel** by {actor}.",


### PR DESCRIPTION
#### Summary
Channel notification setting for disabling channel mentions

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9505

#### Checklist
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (https://github.com/mattermost/mattermost-redux/pull/697)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: Nexus 9, Android 8

#### Screenshots
https://lh3.google.com/u/0/d/1eUx8pWFHB2FAnopfXzQQoAmnaOy_63gp=w1920-h978
