### PR TITLE
MM-12880 Properly link the next sibling following a combined text node

### DIFF
--- a/app/components/markdown/transform.js
+++ b/app/components/markdown/transform.js
@@ -37,6 +37,10 @@ export function combineTextNodes(ast) {
                 node._parent._lastChild = node;
             }
         }
+
+        // Resume parsing after the current node since otherwise the walker would continue to parse any old text nodes
+        // that have been merged into this one
+        walker.resumeAt(node, false);
     }
 
     return ast;

--- a/app/components/markdown/transform.test.js
+++ b/app/components/markdown/transform.test.js
@@ -172,16 +172,57 @@ describe('Components.Markdown.transform', () => {
                     }],
                 }],
             },
+        }, {
+            name: 'MM-12880 merging text followed by non-text',
+            input: 'test: *italics*',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'test: ',
+                    }, {
+                        type: 'emph',
+                        children: [{
+                            type: 'text',
+                            literal: 'italics',
+                        }],
+                    }],
+                }],
+            },
+        }, {
+            name: 'MM-12880 merging text followed by image',
+            input: 'test: ![image](https://example.com/image)',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'test: ',
+                    }, {
+                        type: 'image',
+                        destination: 'https://example.com/image',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: 'image',
+                        }],
+                    }],
+                }],
+            },
         }];
 
         for (const test of tests) {
             it(test.name, () => {
-                const input = makeAst(test.input);
+                const input = typeof test.input === 'string' ? parser.parse(test.input) : makeAst(test.input);
                 const expected = makeAst(test.expected);
                 const actual = combineTextNodes(input);
 
                 assert.ok(verifyAst(actual));
-                assert.deepStrictEqual(actual, expected);
+                assert.deepStrictEqual(astToString(actual), astToString(expected));
+                assert.deepStrictEqual(stripUnusedFields(actual), stripUnusedFields(expected));
             });
         }
     });
@@ -2862,7 +2903,7 @@ function verifyAst(node) {
     }
 
     if (node.next && node.next.prev !== node) {
-        console.error('node is not linked properly to prev');
+        console.error('node is not linked properly to next');
         return false;
     }
 


### PR DESCRIPTION
Some background information: `combineTextNodes` is used because the Markdown parser sometimes breaks up a string of plain text into a multiple text nodes. Notably, a word followed by a colon and then a space like `test: ` is broken up into one node for each character by the autolinker.

The bug that was happening was that for text like `test: *italics*`, after running `combineTextNodes`, you'd end up with a Text node for `test: ` and an Emphasis node for the rest, but they wouldn't be correctly linked as siblings which would make the source tree invalid, sometimes causing other parts of the formatting to break. That was due to some behaviour that I had missed in the NodeWalker that's fixed by calling `walker.resumeAt` to reset the NodeWalker's internal state

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12880

#### Checklist
- Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: Nexus 5 (Android 6.0)