### PR TITLE
do not wait for rehydration is credentials are false

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -142,6 +142,8 @@ export default class App {
                         this.waitForRehydration = true;
                     }
                 }
+            } else {
+                this.waitForRehydration = false;
             }
         } catch (error) {
             return null;


### PR DESCRIPTION
#### Summary
Sometimes after an initial login goes wrong the app was entering into an unrecoverable state as the credentials was falling back to `getGenericPassword` that returned false and we kept the app waitingForRehydration and by that moment rehydration already happened, thus the app remain in this never ending loading state even after restarting the app, by not waiting for rehydration if there is no credentials set app continues with the flow.

#### Ticket Link


