### PR TITLE
Set the file prefix in image_cache_manager

### DIFF
--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -82,14 +82,8 @@ export default class Emoji extends React.PureComponent {
     }
 
     setImageUrl = (imageUrl) => {
-        let prefix = '';
-        if (Platform.OS === 'android') {
-            prefix = 'file://';
-        }
-
-        const uri = `${prefix}${imageUrl}`;
         this.setState({
-            imageUrl: uri,
+            imageUrl,
         });
     };
 

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -5,7 +5,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     Keyboard,
-    Platform,
     ScrollView,
     StyleSheet,
     TouchableOpacity,
@@ -101,12 +100,7 @@ export default class FileAttachmentList extends Component {
                 }
 
                 if (cache) {
-                    let path = cache.path;
-                    if (Platform.OS === 'android') {
-                        path = `file://${path}`;
-                    }
-
-                    uri = path;
+                    uri = cache.path;
                 }
 
                 results.push({

--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -187,11 +187,7 @@ export default class MarkdownImage extends React.Component {
     };
 
     setImageUrl = (imageURL) => {
-        let uri = imageURL;
-
-        if (Platform.OS === 'android') {
-            uri = `file://${imageURL}`;
-        }
+        const uri = imageURL;
 
         this.setState({uri});
         this.loadImageSize(uri);

--- a/app/components/message_attachments/message_attachment.js
+++ b/app/components/message_attachments/message_attachment.js
@@ -267,13 +267,7 @@ export default class MessageAttachment extends PureComponent {
         }
     };
 
-    setImageUrl = (imageURL) => {
-        let imageUri = imageURL;
-
-        if (Platform.OS === 'android') {
-            imageUri = `file://${imageURL}`;
-        }
-
+    setImageUrl = (imageUri) => {
         Image.getSize(imageUri, (width, height) => {
             const dimensions = calculateDimensions(height, width, this.maxImageWidth);
             if (this.mounted) {

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {
     Image,
     Linking,
-    Platform,
     Text,
     TouchableOpacity,
     TouchableWithoutFeedback,
@@ -112,14 +111,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
     };
 
     getImageSize = (imageUrl) => {
-        let prefix = '';
-        if (Platform.OS === 'android') {
-            prefix = 'file://';
-        }
-
-        const uri = `${prefix}${imageUrl}`;
-
-        Image.getSize(uri, (width, height) => {
+        Image.getSize(imageUrl, (width, height) => {
             const dimensions = calculateDimensions(height, width, this.getViewPostWidth());
 
             if (this.mounted) {
@@ -127,7 +119,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
                     ...dimensions,
                     originalHeight: height,
                     originalWidth: width,
-                    imageUrl: uri,
+                    imageUrl,
                 });
             }
         }, () => null);

--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -254,13 +254,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
         const viewPortWidth = deviceSize - VIEWPORT_IMAGE_OFFSET - (isReplyPost ? VIEWPORT_IMAGE_REPLY_OFFSET : 0);
 
         if (link && path) {
-            let prefix = '';
-            if (Platform.OS === 'android') {
-                prefix = 'file://';
-            }
-
-            const uri = `${prefix}${path}`;
-            Image.getSize(uri, (width, height) => {
+            Image.getSize(path, (width, height) => {
                 if (!this.mounted) {
                     return;
                 }
@@ -282,7 +276,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
                     originalHeight: height,
                     originalWidth: width,
                     linkLoaded: true,
-                    uri,
+                    uri: path,
                 });
             }, () => this.setState({linkLoadError: true}));
         }

--- a/app/components/progressive_image/progressive_image.js
+++ b/app/components/progressive_image/progressive_image.js
@@ -81,26 +81,14 @@ export default class ProgressiveImage extends PureComponent {
 
     setImage = (uri) => {
         if (this.subscribedToCache) {
-            let path = uri;
-
-            if (Platform.OS === 'android') {
-                path = `file://${uri}`;
-            }
-
-            this.setState({uri: path});
+            this.setState({uri});
         }
     };
 
     setThumbnail = (thumb) => {
         if (this.subscribedToCache) {
             const {filename, imageUri} = this.props;
-            let path = thumb;
-
-            if (Platform.OS === 'android') {
-                path = `file://${thumb}`;
-            }
-
-            this.setState({thumb: path}, () => {
+            this.setState({thumb}, () => {
                 setTimeout(() => {
                     ImageCacheManager.cache(filename, imageUri, this.setImage);
                 }, 300);

--- a/app/components/team_icon/team_icon.js
+++ b/app/components/team_icon/team_icon.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 
 import {
     Image,
-    Platform,
     Text,
     View,
 } from 'react-native';
@@ -50,12 +49,7 @@ export default class TeamIcon extends React.PureComponent {
     }
 
     setImageURL = (teamIcon) => {
-        let prefix = '';
-        if (Platform.OS === 'android') {
-            prefix = 'file://';
-        }
-
-        this.setState({teamIcon: `${prefix}${teamIcon}`});
+        this.setState({teamIcon});
     };
 
     render() {


### PR DESCRIPTION
#### Summary
Set the `file://` prefix for android in one central place instead in every component that displays an image and should solve the unlink issue that is being reported on Sentry for Android

#### Ticket Link
