### PR TITLE
Keep connection as active when retrying teams

### DIFF
--- a/app/screens/error_teams_list/error_teams_list.js
+++ b/app/screens/error_teams_list/error_teams_list.js
@@ -67,13 +67,17 @@ export default class ErrorTeamsList extends PureComponent {
     };
 
     getUserInfo = async () => {
-        this.setState({loading: true});
-        this.props.actions.connection(true);
-        await this.props.actions.loadMe();
-        this.props.actions.connection(false);
-        this.setState({loading: false});
-        this.props.actions.selectDefaultTeam();
-        this.goToChannelView();
+        try {
+            this.setState({loading: true});
+            this.props.actions.connection(true);
+            await this.props.actions.loadMe();
+            this.props.actions.selectDefaultTeam();
+            this.goToChannelView();
+        } catch {
+            this.props.actions.connection(false);
+        } finally {
+            this.setState({loading: false});
+        }
     }
 
     onNavigatorEvent = (event) => {


### PR DESCRIPTION
#### Summary
When on the failed teams screen the user retried to get the teams we were setting the connection back to false thus every request made right after it was failing, here we only set the flag back as false if the action fails

#### Ticket Link
