### PR TITLE
Improve channel switch

### DIFF
--- a/app/actions/views/create_channel.js
+++ b/app/actions/views/create_channel.js
@@ -21,10 +21,10 @@ export function handleCreateChannel(displayName, purpose, header, type) {
             type,
         };
 
-        const {data} = await createChannel(channel, currentUserId)(dispatch, getState);
+        const {data} = await dispatch(createChannel(channel, currentUserId));
         if (data && data.id) {
             dispatch(setChannelDisplayName(displayName));
-            handleSelectChannel(data.id)(dispatch, getState);
+            dispatch(handleSelectChannel(data.id));
         }
     };
 }

--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -93,7 +93,7 @@ export function loadFromPushNotification(notification) {
             // when the notification is from a channel other than the current channel
             dispatch(markChannelAsRead(channelId, currentChannelId, false));
             dispatch(setChannelDisplayName(''));
-            dispatch(handleSelectChannel(channelId));
+            dispatch(handleSelectChannel(channelId, false));
         }
     };
 }

--- a/app/components/channel_link/channel_link.js
+++ b/app/components/channel_link/channel_link.js
@@ -17,8 +17,7 @@ export default class ChannelLink extends React.PureComponent {
         textStyle: CustomPropTypes.Style,
         channelsByName: PropTypes.object.isRequired,
         actions: PropTypes.shape({
-            handleSelectChannel: PropTypes.func.isRequired,
-            setChannelDisplayName: PropTypes.func.isRequired,
+            switchToChannel: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -40,8 +39,7 @@ export default class ChannelLink extends React.PureComponent {
     }
 
     handlePress = () => {
-        this.props.actions.setChannelDisplayName(this.state.channel.display_name);
-        this.props.actions.handleSelectChannel(this.state.channel.id);
+        this.props.actions.switchToChannel(this.state.channel.id, this.state.channel.display_name);
 
         if (this.props.onChannelLinkPress) {
             this.props.onChannelLinkPress(this.state.channel);

--- a/app/components/channel_link/channel_link.test.js
+++ b/app/components/channel_link/channel_link.test.js
@@ -19,8 +19,7 @@ describe('ChannelLink', () => {
         textStyle: {color: '#3d3c40', fontSize: 15, lineHeight: 20},
         channelsByName,
         actions: {
-            handleSelectChannel: jest.fn(),
-            setChannelDisplayName: jest.fn(),
+            switchToChannel: jest.fn(),
         },
     };
 
@@ -65,10 +64,8 @@ describe('ChannelLink', () => {
         const channel = channelsByName.firstChannel;
         wrapper.setState({channel});
         wrapper.instance().handlePress();
-        expect(baseProps.actions.handleSelectChannel).toHaveBeenCalledTimes(1);
-        expect(baseProps.actions.handleSelectChannel).toBeCalledWith(channel.id);
-        expect(baseProps.actions.setChannelDisplayName).toHaveBeenCalledTimes(1);
-        expect(baseProps.actions.setChannelDisplayName).toBeCalledWith(channel.display_name);
+        expect(baseProps.actions.switchToChannel).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.switchToChannel).toBeCalledWith(channel.id, channel.display_name);
         expect(baseProps.onChannelLinkPress).toHaveBeenCalledTimes(1);
         expect(baseProps.onChannelLinkPress).toBeCalledWith(channel);
     });

--- a/app/components/channel_link/index.js
+++ b/app/components/channel_link/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 
-import {handleSelectChannel, setChannelDisplayName} from 'app/actions/views/channel';
+import {switchToChannel} from 'app/actions/views/channel';
 
 import ChannelLink from './channel_link';
 
@@ -19,8 +19,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            handleSelectChannel,
-            setChannelDisplayName,
+            switchToChannel,
         }, dispatch),
     };
 }

--- a/app/components/channel_loader/channel_loader.js
+++ b/app/components/channel_loader/channel_loader.js
@@ -9,19 +9,11 @@ import {
 } from 'react-native';
 import Placeholder from 'rn-placeholder';
 
-import EventEmitter from 'mattermost-redux/utils/event_emitter';
-
 import CustomPropTypes from 'app/constants/custom_prop_types';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 export default class ChannelLoader extends PureComponent {
     static propTypes = {
-        actions: PropTypes.shape({
-            handleSelectChannel: PropTypes.func.isRequired,
-            markChannelAsViewed: PropTypes.func.isRequired,
-            markChannelAsRead: PropTypes.func.isRequired,
-            setChannelLoading: PropTypes.func.isRequired,
-        }).isRequired,
         backgroundColor: PropTypes.string,
         channelIsLoading: PropTypes.bool.isRequired,
         maxRows: PropTypes.number,
@@ -32,55 +24,6 @@ export default class ChannelLoader extends PureComponent {
     static defaultProps = {
         maxRows: 6,
     };
-
-    state = {
-        switch: false,
-    };
-
-    static getDerivedStateFromProps(nextProps, prevState) {
-        if (!nextProps.channelIsLoading && prevState.switch) {
-            return {
-                switch: false,
-                channel: null,
-                currentChannelId: null,
-            };
-        }
-
-        return null;
-    }
-
-    componentDidMount() {
-        EventEmitter.on('switch_channel', this.handleChannelSwitch);
-    }
-
-    componentWillUnmount() {
-        EventEmitter.off('switch_channel', this.handleChannelSwitch);
-    }
-
-    componentDidUpdate() {
-        if (this.state.switch) {
-            const {
-                handleSelectChannel,
-                markChannelAsRead,
-                markChannelAsViewed,
-                setChannelLoading,
-            } = this.props.actions;
-
-            const {channel, currentChannelId} = this.state;
-
-            setTimeout(() => {
-                handleSelectChannel(channel.id);
-
-                // mark the channel as viewed after all the frame has flushed
-                markChannelAsRead(channel.id, currentChannelId);
-                if (channel.id !== currentChannelId) {
-                    markChannelAsViewed(currentChannelId);
-                }
-
-                setChannelLoading(false);
-            }, 250);
-        }
-    }
 
     buildSections({key, style, bg, color}) {
         return (
@@ -101,14 +44,6 @@ export default class ChannelLoader extends PureComponent {
             </View>
         );
     }
-
-    handleChannelSwitch = (channel, currentChannelId) => {
-        if (channel.id === currentChannelId) {
-            this.props.actions.setChannelLoading(false);
-        } else {
-            this.setState({switch: true, channel, currentChannelId});
-        }
-    };
 
     render() {
         const {channelIsLoading, maxRows, style: styleProp, theme} = this.props;

--- a/app/components/channel_loader/index.js
+++ b/app/components/channel_loader/index.js
@@ -1,32 +1,18 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {markChannelAsRead, markChannelAsViewed} from 'mattermost-redux/actions/channels';
+import {getPostIdsInCurrentChannel} from 'mattermost-redux/selectors/entities/posts';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-
-import {handleSelectChannel, setChannelLoading} from 'app/actions/views/channel';
 
 import ChannelLoader from './channel_loader';
 
 function mapStateToProps(state, ownProps) {
     return {
-        channelIsLoading: ownProps.channelIsLoading || state.views.channel.loading,
+        channelIsLoading: ownProps.channelIsLoading || (state.views.channel.loading && !getPostIdsInCurrentChannel(state).length),
         theme: getTheme(state),
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            handleSelectChannel,
-            markChannelAsRead,
-            setChannelLoading,
-            markChannelAsViewed,
-        }, dispatch),
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ChannelLoader);
+export default connect(mapStateToProps, null)(ChannelLoader);

--- a/app/components/post_profile_picture/post_profile_picture.js
+++ b/app/components/post_profile_picture/post_profile_picture.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Image, TouchableOpacity, View} from 'react-native';
+import {Image, TouchableOpacity} from 'react-native';
 
 import AppIcon from 'app/components/app_icon';
 import ProfilePicture from 'app/components/profile_picture';
@@ -41,13 +41,11 @@ export default class PostProfilePicture extends PureComponent {
 
         if (isSystemMessage && !fromAutoResponder) {
             return (
-                <View>
-                    <AppIcon
-                        color={theme.centerChannelColor}
-                        height={ViewTypes.PROFILE_PICTURE_SIZE}
-                        width={ViewTypes.PROFILE_PICTURE_SIZE}
-                    />
-                </View>
+                <AppIcon
+                    color={theme.centerChannelColor}
+                    height={ViewTypes.PROFILE_PICTURE_SIZE}
+                    width={ViewTypes.PROFILE_PICTURE_SIZE}
+                />
             );
         }
 
@@ -55,16 +53,14 @@ export default class PostProfilePicture extends PureComponent {
             const icon = overrideIconUrl ? {uri: overrideIconUrl} : webhookIcon;
 
             return (
-                <View>
-                    <Image
-                        source={icon}
-                        style={{
-                            height: ViewTypes.PROFILE_PICTURE_SIZE,
-                            width: ViewTypes.PROFILE_PICTURE_SIZE,
-                            borderRadius: ViewTypes.PROFILE_PICTURE_SIZE / 2,
-                        }}
-                    />
-                </View>
+                <Image
+                    source={icon}
+                    style={{
+                        height: ViewTypes.PROFILE_PICTURE_SIZE,
+                        width: ViewTypes.PROFILE_PICTURE_SIZE,
+                        borderRadius: ViewTypes.PROFILE_PICTURE_SIZE / 2,
+                    }}
+                />
             );
         }
 

--- a/app/components/sidebars/drawer_layout.js
+++ b/app/components/sidebars/drawer_layout.js
@@ -232,6 +232,7 @@ export default class DrawerLayout extends Component {
             restSpeedThreshold: 0.1,
             useNativeDriver: this.props.useNativeAnimations,
             ...options,
+            isInteraction: false,
         }).start(() => {
             if (this.props.onDrawerOpen) {
                 this.props.onDrawerOpen();

--- a/app/components/sidebars/main/index.js
+++ b/app/components/sidebars/main/index.js
@@ -9,7 +9,7 @@ import {getTeams} from 'mattermost-redux/actions/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId, getMyTeamsCount} from 'mattermost-redux/selectors/entities/teams';
 
-import {setChannelDisplayName, setChannelLoading} from 'app/actions/views/channel';
+import {setChannelDisplayName, switchToChannel} from 'app/actions/views/channel';
 import {makeDirectChannel} from 'app/actions/views/more_dms';
 import {isLandscape, isTablet, getDimensions} from 'app/selectors/device';
 
@@ -36,7 +36,7 @@ function mapDispatchToProps(dispatch) {
             joinChannel,
             makeDirectChannel,
             setChannelDisplayName,
-            setChannelLoading,
+            switchToChannel,
         }, dispatch),
     };
 }

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -32,7 +32,7 @@ export default class ChannelSidebar extends Component {
             getTeams: PropTypes.func.isRequired,
             makeDirectChannel: PropTypes.func.isRequired,
             setChannelDisplayName: PropTypes.func.isRequired,
-            setChannelLoading: PropTypes.func.isRequired,
+            switchToChannel: PropTypes.func.isRequired,
         }).isRequired,
         blurPostTextBox: PropTypes.func.isRequired,
         children: PropTypes.node,
@@ -165,20 +165,10 @@ export default class ChannelSidebar extends Component {
 
     selectChannel = (channel, currentChannelId, closeDrawer = true) => {
         const {
-            actions,
-        } = this.props;
-
-        const {
-            setChannelLoading,
-            setChannelDisplayName,
-        } = actions;
+            switchToChannel,
+        } = this.props.actions;
 
         tracker.channelSwitch = Date.now();
-
-        if (closeDrawer) {
-            this.closeChannelDrawer();
-            setChannelLoading(channel.id !== currentChannelId);
-        }
 
         if (!channel) {
             const utils = require('app/utils/general');
@@ -191,12 +181,18 @@ export default class ChannelSidebar extends Component {
             const erroMessage = {};
 
             utils.alertErrorWithFallback(intl, erroMessage, unableToJoinMessage);
-            setChannelLoading(false);
             return;
         }
 
-        setChannelDisplayName(channel.display_name);
-        EventEmitter.emit('switch_channel', channel, currentChannelId);
+        if (closeDrawer) {
+            this.closeChannelDrawer();
+        }
+
+        requestAnimationFrame(() => {
+            if (currentChannelId !== channel.id) {
+                switchToChannel(channel.id, channel.display_name);
+            }
+        });
     };
 
     joinChannel = (channel, currentChannelId) => {

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -42,11 +42,11 @@ const {
 } = ViewTypes;
 
 let ClientUpgradeListener;
-
 export default class Channel extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
             loadChannelsIfNecessary: PropTypes.func.isRequired,
+            loadPostsIfNecessaryWithRetry: PropTypes.func.isRequired,
             loadProfilesAndTeamMembersForDMSidebar: PropTypes.func.isRequired,
             selectDefaultTeam: PropTypes.func.isRequired,
             selectInitialChannel: PropTypes.func.isRequired,
@@ -81,6 +81,10 @@ export default class Channel extends PureComponent {
     componentWillMount() {
         EventEmitter.on('leave_team', this.handleLeaveTeam);
 
+        if (this.props.currentChannelId) {
+            this.props.actions.loadPostsIfNecessaryWithRetry(this.props.currentChannelId);
+        }
+
         if (this.props.currentTeamId) {
             this.loadChannels(this.props.currentTeamId);
         } else {
@@ -108,7 +112,7 @@ export default class Channel extends PureComponent {
         }
 
         if (nextProps.currentTeamId && this.props.currentTeamId !== nextProps.currentTeamId) {
-            this.loadChannels(nextProps.currentTeamId);
+            this.loadChannels(nextProps.currentTeamId, true);
         }
 
         if (nextProps.currentChannelId !== this.props.currentChannelId &&
@@ -234,7 +238,7 @@ export default class Channel extends PureComponent {
         this.props.actions.selectDefaultTeam();
     };
 
-    loadChannels = (teamId) => {
+    loadChannels = (teamId, shouldLoadPosts = false) => {
         const {
             loadChannelsIfNecessary,
             loadProfilesAndTeamMembersForDMSidebar,
@@ -243,9 +247,7 @@ export default class Channel extends PureComponent {
 
         loadChannelsIfNecessary(teamId).then(() => {
             loadProfilesAndTeamMembersForDMSidebar(teamId);
-            selectInitialChannel(teamId);
-        }).catch(() => {
-            selectInitialChannel(teamId);
+            selectInitialChannel(teamId, shouldLoadPosts);
         });
     };
 

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -14,7 +14,6 @@ import PostList from 'app/components/post_list';
 import PostListRetry from 'app/components/post_list_retry';
 import RetryBarIndicator from 'app/components/retry_bar_indicator';
 import {ViewTypes} from 'app/constants';
-import tracker from 'app/utils/time_tracker';
 
 let ChannelIntro = null;
 let LoadMorePosts = null;
@@ -26,7 +25,6 @@ export default class ChannelPostList extends PureComponent {
             loadThreadIfNecessary: PropTypes.func.isRequired,
             increasePostVisibility: PropTypes.func.isRequired,
             selectPost: PropTypes.func.isRequired,
-            recordLoadTime: PropTypes.func.isRequired,
             refreshChannelWithRetry: PropTypes.func.isRequired,
         }).isRequired,
         channelId: PropTypes.string.isRequired,
@@ -68,12 +66,6 @@ export default class ChannelPostList extends PureComponent {
         }
 
         this.setState({visiblePostIds});
-    }
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.channelId !== this.props.channelId && tracker.channelSwitch) {
-            this.props.actions.recordLoadTime('Switch Channel', 'channelSwitch');
-        }
     }
 
     getVisiblePostIds = (props) => {

--- a/app/screens/channel/channel_post_list/index.js
+++ b/app/screens/channel/channel_post_list/index.js
@@ -11,7 +11,6 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {loadPostsIfNecessaryWithRetry, loadThreadIfNecessary, increasePostVisibility, refreshChannelWithRetry} from 'app/actions/views/channel';
-import {recordLoadTime} from 'app/actions/views/root';
 
 import ChannelPostList from './channel_post_list';
 
@@ -40,7 +39,6 @@ function mapDispatchToProps(dispatch) {
             loadThreadIfNecessary,
             increasePostVisibility,
             selectPost,
-            recordLoadTime,
             refreshChannelWithRetry,
         }, dispatch),
     };

--- a/app/screens/channel/index.js
+++ b/app/screens/channel/index.js
@@ -13,6 +13,7 @@ import {shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/user
 
 import {
     loadChannelsIfNecessary,
+    loadPostsIfNecessaryWithRetry,
     loadProfilesAndTeamMembersForDMSidebar,
     selectInitialChannel,
 } from 'app/actions/views/channel';
@@ -41,6 +42,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             connection,
             loadChannelsIfNecessary,
+            loadPostsIfNecessaryWithRetry,
             loadProfilesAndTeamMembersForDMSidebar,
             logout,
             selectDefaultTeam,

--- a/app/screens/more_channels/index.js
+++ b/app/screens/more_channels/index.js
@@ -13,7 +13,7 @@ import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {showCreateOption} from 'mattermost-redux/utils/channel_utils';
 import {isAdmin, isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
-import {handleSelectChannel, setChannelDisplayName} from 'app/actions/views/channel';
+import {switchToChannel} from 'app/actions/views/channel';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
@@ -48,11 +48,10 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            handleSelectChannel,
             joinChannel,
             getChannels,
             searchChannels,
-            setChannelDisplayName,
+            switchToChannel,
         }, dispatch),
     };
 }

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -23,11 +23,10 @@ import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/ut
 export default class MoreChannels extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            handleSelectChannel: PropTypes.func.isRequired,
             joinChannel: PropTypes.func.isRequired,
             getChannels: PropTypes.func.isRequired,
             searchChannels: PropTypes.func.isRequired,
-            setChannelDisplayName: PropTypes.func.isRequired,
+            switchToChannel: PropTypes.func.isRequired,
         }).isRequired,
         canCreateChannels: PropTypes.bool.isRequired,
         channels: PropTypes.array,
@@ -197,12 +196,8 @@ export default class MoreChannels extends PureComponent {
             this.headerButtons(true);
             this.setState({adding: false});
         } else {
-            if (channel) {
-                actions.setChannelDisplayName(channel.display_name);
-            } else {
-                actions.setChannelDisplayName('');
-            }
-            await actions.handleSelectChannel(id);
+            const displayName = channel ? channel.display_name : '';
+            await actions.switchToChannel(id, displayName);
 
             EventEmitter.emit('close_channel_drawer');
             requestAnimationFrame(() => {

--- a/app/screens/more_channels/more_channels.test.js
+++ b/app/screens/more_channels/more_channels.test.js
@@ -19,11 +19,11 @@ describe('MoreChannels', () => {
     };
 
     const actions = {
-        handleSelectChannel: jest.fn(),
+        switchToChannel: jest.fn(),
         joinChannel: jest.fn(),
         getChannels: jest.fn().mockResolvedValue({data: [{id: 'id2', name: 'name2', display_name: 'display_name2'}]}),
+        removeHiddenDefaultChannel: jest.fn(),
         searchChannels: jest.fn(),
-        setChannelDisplayName: jest.fn(),
     };
 
     const baseProps = {

--- a/app/screens/permalink/index.js
+++ b/app/screens/permalink/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {getChannel as getChannelAction, joinChannel, markChannelAsRead, markChannelAsViewed} from 'mattermost-redux/actions/channels';
+import {getChannel as getChannelAction, joinChannel} from 'mattermost-redux/actions/channels';
 import {getPostsAfter, getPostsBefore, getPostThread, selectPost} from 'mattermost-redux/actions/posts';
 import {makeGetChannel, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetPostIdsAroundPost, getPost} from 'mattermost-redux/selectors/entities/posts';
@@ -12,12 +12,7 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {
-    handleSelectChannel,
-    loadThreadIfNecessary,
-    setChannelDisplayName,
-    setChannelLoading,
-} from 'app/actions/views/channel';
+import {loadThreadIfNecessary, switchToChannel} from 'app/actions/views/channel';
 import {showSearchModal} from 'app/actions/views/search';
 import {handleTeamChange} from 'app/actions/views/select_team';
 
@@ -64,16 +59,12 @@ function mapDispatchToProps(dispatch) {
             getPostsBefore,
             getPostThread,
             getChannel: getChannelAction,
-            handleSelectChannel,
             handleTeamChange,
             joinChannel,
             loadThreadIfNecessary,
-            markChannelAsRead,
-            markChannelAsViewed,
             selectPost,
-            setChannelDisplayName,
-            setChannelLoading,
             showSearchModal,
+            switchToChannel,
         }, dispatch),
     };
 }

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -4,7 +4,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    InteractionManager,
     Text,
     TouchableOpacity,
     View,
@@ -49,15 +48,11 @@ export default class Permalink extends PureComponent {
             getPostsBefore: PropTypes.func.isRequired,
             getPostThread: PropTypes.func.isRequired,
             getChannel: PropTypes.func.isRequired,
-            handleSelectChannel: PropTypes.func.isRequired,
             handleTeamChange: PropTypes.func.isRequired,
             joinChannel: PropTypes.func.isRequired,
             loadThreadIfNecessary: PropTypes.func.isRequired,
-            markChannelAsRead: PropTypes.func.isRequired,
-            markChannelAsViewed: PropTypes.func.isRequired,
             selectPost: PropTypes.func.isRequired,
-            setChannelDisplayName: PropTypes.func.isRequired,
-            setChannelLoading: PropTypes.func.isRequired,
+            switchToChannel: PropTypes.func.isRequired,
         }).isRequired,
         channelId: PropTypes.string,
         channelIsArchived: PropTypes.bool,
@@ -229,14 +224,7 @@ export default class Permalink extends PureComponent {
         if (channelId) {
             const {actions, channelTeamId, currentTeamId, navigator, onClose, theme} = this.props;
             const currentChannelId = this.props.channelId;
-            const {
-                handleSelectChannel,
-                handleTeamChange,
-                markChannelAsRead,
-                setChannelLoading,
-                setChannelDisplayName,
-                markChannelAsViewed,
-            } = actions;
+            const {handleTeamChange, switchToChannel} = actions;
 
             actions.selectPost('');
 
@@ -269,16 +257,7 @@ export default class Permalink extends PureComponent {
                 handleTeamChange(channelTeamId, false);
             }
 
-            setChannelLoading(channelId !== currentChannelId);
-            setChannelDisplayName(channelDisplayName);
-            handleSelectChannel(channelId);
-
-            InteractionManager.runAfterInteractions(async () => {
-                markChannelAsRead(channelId, currentChannelId);
-                if (channelId !== currentChannelId) {
-                    markChannelAsViewed(currentChannelId);
-                }
-            });
+            switchToChannel(channelId, channelDisplayName);
         }
     };
 

--- a/app/screens/permalink/permalink.test.js
+++ b/app/screens/permalink/permalink.test.js
@@ -24,15 +24,11 @@ describe('Permalink', () => {
         getPostsBefore: jest.fn(),
         getPostThread: jest.fn(),
         getChannel: jest.fn(),
-        handleSelectChannel: jest.fn(),
         handleTeamChange: jest.fn(),
         joinChannel: jest.fn(),
         loadThreadIfNecessary: jest.fn(),
-        markChannelAsRead: jest.fn(),
-        markChannelAsViewed: jest.fn(),
         selectPost: jest.fn(),
-        setChannelDisplayName: jest.fn(),
-        setChannelLoading: jest.fn(),
+        switchToChannel: jest.fn(),
     };
 
     const baseProps = {


### PR DESCRIPTION
#### Summary
Improving channel switch by:
1. on first load
    * Load posts if the currentChannelId is defined as soon as possible
    * Fix an issue that was causing the app to loadChannels for the team twice
2. load posts on handleChannelSwitch only when needed
3. created switchToChannel action that loads posts and switches to a channel as soon as possible
4. Channel loader only displays if the channel to be switched to does not have any posts

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12780