### PR TITLE
Image cache token

### DIFF
--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -9,6 +9,7 @@ import {DeviceTypes} from 'app/constants';
 import mattermostBucket from 'app/mattermost_bucket';
 
 import LocalConfig from 'assets/config';
+import {Client4} from 'mattermost-redux/client';
 
 const {IMAGES_PATH} = DeviceTypes;
 
@@ -39,7 +40,9 @@ export default class ImageCacheManager {
                         certificate,
                     };
 
-                    this.downloadTask = await RNFetchBlob.config(options).fetch('GET', uri);
+                    this.downloadTask = await RNFetchBlob.config(options).fetch('GET', uri, {
+                        Authorization: `Bearer ${Client4.getToken()}`,
+                    });
                     if (this.downloadTask.respInfo.respType === 'text') {
                         throw new Error();
                     }

--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -41,7 +41,7 @@ export default class ImageCacheManager {
                     };
 
                     this.downloadTask = await RNFetchBlob.config(options).fetch('GET', uri, {
-                        Authorization: `Bearer ${Client4.getToken()}`,
+                        Authorization: uri.includes(Client4.getUrl()) ? `Bearer ${Client4.getToken()}` : '',
                     });
                     if (this.downloadTask.respInfo.respType === 'text') {
                         throw new Error();


### PR DESCRIPTION
#### Summary
This change ensures that the proper authentication token is sent when retrieving images uploaded by users within a chat window. While this doesn't seem to affect production builds, images will not download and YellowBox errors are shown when attempting to retrieve images in debug mode.

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-3761

#### Checklist

#### Device Information
This PR was tested on: Nexus 6 (Android), iPhone X (iOS)

#### Screenshots
![issue retrieving image from cache](https://user-images.githubusercontent.com/1859611/48011662-e0e47000-e0e5-11e8-8dc9-2a04d1af0890.png)

via @dseawel