### PR TITLE
 Android/iOS leave notifications until channel is read

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotificationDrawer.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotificationDrawer.java
@@ -1,0 +1,39 @@
+package com.mattermost.rnbeta;
+
+import android.content.Context;
+
+import com.wix.reactnativenotifications.core.AppLaunchHelper;
+import com.wix.reactnativenotifications.core.notificationdrawer.PushNotificationsDrawer;
+import com.wix.reactnativenotifications.core.notificationdrawer.IPushNotificationsDrawer;
+import com.wix.reactnativenotifications.core.notificationdrawer.INotificationsDrawerApplication;
+import com.wix.reactnativenotifications.helpers.PushNotificationHelper;
+import static com.wix.reactnativenotifications.Defs.LOGTAG;
+
+public class CustomPushNotificationDrawer extends PushNotificationsDrawer {
+    final protected Context mContext;
+    final protected AppLaunchHelper mAppLaunchHelper;
+
+   protected CustomPushNotificationDrawer(Context context, AppLaunchHelper appLaunchHelper) {
+        super(context, appLaunchHelper);
+        mContext = context;
+        mAppLaunchHelper = appLaunchHelper;
+    }
+
+    @Override
+    public void onAppInit() {
+    }
+
+    @Override
+    public void onAppVisible() {
+    }
+
+    @Override
+    public void onNotificationOpened() {
+    }
+
+    @Override
+    public void onCancelAllLocalNotifications() {
+        CustomPushNotification.clearAllNotifications(mContext);
+        cancelAllScheduledNotifications();
+    }
+}

--- a/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
@@ -34,6 +34,8 @@ import com.reactnativenavigation.NavigationApplication;
 import com.wix.reactnativenotifications.RNNotificationsPackage;
 import com.wix.reactnativenotifications.core.notification.INotificationsApplication;
 import com.wix.reactnativenotifications.core.notification.IPushNotification;
+import com.wix.reactnativenotifications.core.notificationdrawer.IPushNotificationsDrawer;
+import com.wix.reactnativenotifications.core.notificationdrawer.INotificationsDrawerApplication;
 import com.wix.reactnativenotifications.core.AppLaunchHelper;
 import com.wix.reactnativenotifications.core.AppLifecycleFacade;
 import com.wix.reactnativenotifications.core.JsIOHelper;
@@ -41,7 +43,7 @@ import com.wix.reactnativenotifications.core.JsIOHelper;
 import java.util.Arrays;
 import java.util.List;
 
-public class MainApplication extends NavigationApplication implements INotificationsApplication {
+public class MainApplication extends NavigationApplication implements INotificationsApplication, INotificationsDrawerApplication {
   public NotificationsLifecycleFacade notificationsLifecycleFacade;
   public Boolean sharedExtensionIsOpened = false;
   public Boolean replyFromPushNotification = false;
@@ -116,5 +118,10 @@ public class MainApplication extends NavigationApplication implements INotificat
             defaultAppLaunchHelper,
             new JsIOHelper()
     );
+  }
+
+  @Override
+  public IPushNotificationsDrawer getPushNotificationsDrawer(Context context, AppLaunchHelper defaultAppLaunchHelper) {
+    return new CustomPushNotificationDrawer(context, defaultAppLaunchHelper);
   }
 }

--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationPreferencesModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationPreferencesModule.java
@@ -1,12 +1,15 @@
 package com.mattermost.rnbeta;
 
 import android.app.Application;
+import android.app.Notification;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.database.Cursor;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.os.Bundle;
 import android.net.Uri;
+import android.service.notification.StatusBarNotification;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.NativeModule;
@@ -104,5 +107,30 @@ public class NotificationPreferencesModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setShouldBlink(boolean blink) {
         mNotificationPreference.setShouldBlink(blink);
+    }
+
+    @ReactMethod
+    public void getDeliveredNotifications(final Promise promise) {
+        Context context = mApplication.getApplicationContext();
+        final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        StatusBarNotification[] statusBarNotifications = notificationManager.getActiveNotifications();
+        WritableArray result = Arguments.createArray();
+        for (StatusBarNotification sbn:statusBarNotifications) {
+            WritableMap map = Arguments.createMap();
+            Notification n = sbn.getNotification();
+            Bundle bundle = n.extras;
+            int identifier = sbn.getId();
+            String channelId = bundle.getString("channel_id");
+            map.putInt("identifier", identifier);
+            map.putString("channel_id", channelId);
+            result.pushMap(map);
+        }
+        promise.resolve(result);
+    }
+
+    @ReactMethod
+    public void removeDeliveredNotifications(int identifier, String channelId) {
+        Context context = mApplication.getApplicationContext();
+        CustomPushNotification.clearNotification(context, identifier, channelId);
     }
 }

--- a/app/components/network_indicator/index.js
+++ b/app/components/network_indicator/index.js
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 
 import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates, logout} from 'mattermost-redux/actions/users';
 import {init as initWebSocket, close as closeWebSocket} from 'mattermost-redux/actions/websocket';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
 import {connection} from 'app/actions/device';
 import {getConnection, isLandscape} from 'app/selectors/device';
@@ -17,6 +18,7 @@ function mapStateToProps(state) {
     const websocketStatus = websocket.status;
 
     return {
+        currentChannelId: getCurrentChannelId(state),
         isLandscape: isLandscape(state),
         isOnline: getConnection(state),
         websocketErrorCount: websocket.error,

--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -194,7 +194,7 @@ export default class NetworkIndicator extends PureComponent {
 
         this.handleWebSocket(active);
 
-        if (Platform.OS === 'ios' && active && currentChannelId) {
+        if (active && currentChannelId) {
             PushNotifications.clearChannelNotifications(currentChannelId);
         }
     };

--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -19,6 +19,7 @@ import IonIcon from 'react-native-vector-icons/Ionicons';
 import FormattedText from 'app/components/formatted_text';
 import {DeviceTypes, ViewTypes} from 'app/constants';
 import mattermostBucket from 'app/mattermost_bucket';
+import PushNotifications from 'app/push_notifications';
 import networkConnectionListener, {checkConnection} from 'app/utils/network';
 import {t} from 'app/utils/i18n';
 import LocalConfig from 'assets/config';
@@ -48,6 +49,7 @@ export default class NetworkIndicator extends PureComponent {
             startPeriodicStatusUpdates: PropTypes.func.isRequired,
             stopPeriodicStatusUpdates: PropTypes.func.isRequired,
         }).isRequired,
+        currentChannelId: PropTypes.string,
         isLandscape: PropTypes.bool,
         isOnline: PropTypes.bool,
         websocketErrorCount: PropTypes.number,
@@ -187,7 +189,14 @@ export default class NetworkIndicator extends PureComponent {
     };
 
     handleAppStateChange = async (appState) => {
-        this.handleWebSocket(appState === 'active');
+        const {currentChannelId} = this.props;
+        const active = appState === 'active';
+
+        this.handleWebSocket(active);
+
+        if (Platform.OS === 'ios' && active && currentChannelId) {
+            PushNotifications.clearChannelNotifications(currentChannelId);
+        }
     };
 
     handleConnectionChange = (isConnected) => {
@@ -209,7 +218,7 @@ export default class NetworkIndicator extends PureComponent {
                 this.connect();
             }
         }, CONNECTION_RETRY_TIMEOUT);
-    }
+    };
 
     initializeWebSocket = async () => {
         const {formatMessage} = this.context.intl;

--- a/app/push_notifications/push_notifications.android.js
+++ b/app/push_notifications/push_notifications.android.js
@@ -1,11 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {AppRegistry, AppState} from 'react-native';
+import {AppRegistry, AppState, NativeModules} from 'react-native';
 import {NotificationsAndroid, PendingNotifications} from 'react-native-notifications';
 import Notification from 'react-native-notifications/notification.android';
 
 import {emptyFunction} from 'app/utils/general';
+
+const {NotificationPreferences} = NativeModules;
 
 class PushNotification {
     constructor() {
@@ -119,6 +121,14 @@ class PushNotification {
 
     resetNotification() {
         this.deviceNotification = null;
+    }
+
+    async clearChannelNotifications(channelId) {
+        const notifications = await NotificationPreferences.getDeliveredNotifications();
+        const notificationForChannel = notifications.find((n) => n.channel_id === channelId);
+        if (notificationForChannel) {
+            NotificationPreferences.removeDeliveredNotifications(notificationForChannel.identifier, channelId);
+        }
     }
 }
 

--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -137,7 +137,8 @@ class PushNotification {
     }
 
     setApplicationIconBadgeNumber(number) {
-        NotificationsIOS.setBadgesCount(number);
+        const count = number < 0 ? 0 : number;
+        NotificationsIOS.setBadgesCount(count);
     }
 
     getNotification() {
@@ -146,6 +147,23 @@ class PushNotification {
 
     resetNotification() {
         this.deviceNotification = null;
+    }
+
+    clearChannelNotifications(channelId) {
+        NotificationsIOS.getDeliveredNotifications((notifications) => {
+            const ids = [];
+            for (let i = 0; i < notifications.length; i++) {
+                const notification = notifications[i];
+
+                if (notification.userInfo.channel_id === channelId) {
+                    ids.push(notification.identifier);
+                }
+            }
+
+            if (ids.length) {
+                NotificationsIOS.removeDeliveredNotifications(ids);
+            }
+        });
     }
 }
 

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -111,8 +111,7 @@ export default class Channel extends PureComponent {
         }
 
         if (nextProps.currentChannelId !== this.props.currentChannelId &&
-            nextProps.currentTeamId === this.props.currentTeamId &&
-            Platform.OS === 'ios') {
+            nextProps.currentTeamId === this.props.currentTeamId) {
             PushNotifications.clearChannelNotifications(nextProps.currentChannelId);
         }
 

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -25,6 +25,7 @@ import StatusBar from 'app/components/status_bar';
 import {DeviceTypes, ViewTypes} from 'app/constants';
 import {preventDoubleTap} from 'app/utils/tap';
 import PostTextbox from 'app/components/post_textbox';
+import PushNotifications from 'app/push_notifications';
 import tracker from 'app/utils/time_tracker';
 import LocalConfig from 'assets/config';
 
@@ -107,6 +108,12 @@ export default class Channel extends PureComponent {
 
         if (nextProps.currentTeamId && this.props.currentTeamId !== nextProps.currentTeamId) {
             this.loadChannels(nextProps.currentTeamId);
+        }
+
+        if (nextProps.currentChannelId !== this.props.currentChannelId &&
+            nextProps.currentTeamId === this.props.currentTeamId &&
+            Platform.OS === 'ios') {
+            PushNotifications.clearChannelNotifications(nextProps.currentChannelId);
         }
 
         if (LocalConfig.EnableMobileClientUpgrade && !ClientUpgradeListener) {
@@ -294,7 +301,6 @@ export default class Channel extends PureComponent {
 
         const loaderDimensions = this.channelLoaderDimensions();
 
-        // console.warn('height', height, Date.now())
         return (
             <MainSidebar
                 ref={this.channelSidebarRef}
@@ -308,7 +314,7 @@ export default class Channel extends PureComponent {
                 >
                     <SafeAreaView navigator={navigator}>
                         <StatusBar/>
-                        <NetworkIndicator/>
+                        <NetworkIndicator currentChannelId={currentChannelId}/>
                         <ChannelNavBar
                             navigator={navigator}
                             openChannelDrawer={this.openChannelSidebar}

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -313,7 +313,7 @@ export default class Channel extends PureComponent {
                 >
                     <SafeAreaView navigator={navigator}>
                         <StatusBar/>
-                        <NetworkIndicator currentChannelId={currentChannelId}/>
+                        <NetworkIndicator/>
                         <ChannelNavBar
                             navigator={navigator}
                             openChannelDrawer={this.openChannelSidebar}

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -60,11 +60,12 @@ class ChannelDrawerButton extends PureComponent {
 
     componentDidMount() {
         EventEmitter.on('drawer_opacity', this.setOpacity);
-        PushNotifications.setApplicationIconBadgeNumber(this.props.mentionCount);
     }
 
-    componentWillReceiveProps(nextProps) {
-        PushNotifications.setApplicationIconBadgeNumber(nextProps.mentionCount);
+    componentDidUpdate(prevProps) {
+        if (prevProps.mentionCount !== this.props.mentionCount) {
+            PushNotifications.setApplicationIconBadgeNumber(this.props.mentionCount);
+        }
     }
 
     componentWillUnmount() {

--- a/ios/Mattermost/AppDelegate.m
+++ b/ios/Mattermost/AppDelegate.m
@@ -20,8 +20,11 @@
 #import "RCCManager.h"
 #import "RNNotifications.h"
 #import "SessionManager.h"
+#import <UserNotifications/UserNotifications.h>
 
 @implementation AppDelegate
+
+NSString* const NotificationClearAction = @"clear";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
@@ -69,9 +72,54 @@
   [RNNotifications didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
+-(void)cleanNotificationsFromChannel:(NSString *)channelId andUpdateBadge:(BOOL)updateBadge {
+  if ([UNUserNotificationCenter class]) {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
+      NSMutableArray<NSString *> *notificationIds = [NSMutableArray new];
+
+      for (UNNotification *prevNotification in notifications) {
+        UNNotificationRequest *notificationRequest = [prevNotification request];
+        UNNotificationContent *notificationContent = [notificationRequest content];
+        NSString *identifier = [notificationRequest identifier];
+        NSString* cId = [[notificationContent userInfo] objectForKey:@"channel_id"];
+
+        if ([cId isEqualToString: channelId]) {
+          [notificationIds addObject:identifier];
+        }
+      }
+
+      [center removeDeliveredNotificationsWithIdentifiers:notificationIds];
+      NSInteger removed = (NSInteger)[notificationIds count] + 1;
+      if (removed > 0 && updateBadge) {
+        NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
+        NSInteger count = badge - removed;
+        if (count > 0) {
+          [[UIApplication sharedApplication] setApplicationIconBadgeNumber:count];
+        } else {
+          [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+        }
+      }
+    }];
+  }
+}
+
 // Required for the notification event.
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-  [RNNotifications didReceiveRemoteNotification:notification];
+-(void)application:(UIApplication *)application didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler {
+  UIApplicationState state = [UIApplication sharedApplication].applicationState;
+  NSString* action = [userInfo objectForKey:@"type"];
+  NSString* channelId = [userInfo objectForKey:@"channel_id"];
+
+  if (action && [action isEqualToString: NotificationClearAction]) {
+    // If received a notification that a channel was read, remove all notifications from that channel (only with app in foreground/background)
+    [self cleanNotificationsFromChannel:channelId andUpdateBadge:NO];
+  } else if (state == UIApplicationStateInactive) {
+    // When the notification is opened
+    [self cleanNotificationsFromChannel:channelId andUpdateBadge:YES];
+  }
+
+  [RNNotifications didReceiveRemoteNotification:userInfo];
+  completionHandler(UIBackgroundFetchResultNoData);
 }
 
 // Required for the localNotification event.

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -112,6 +112,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
#### Summary
This PR improves Android push notifications by:
* Opening the app does not clear the push notifications
* If multiple notifications only the notification that was selected gets cleared when opening the app the rest remain in the notification center
* If there is a notification for a channel in the notification center, using the app to switch to that channel removes the notification from the device
* Notifications get cleared when the channel is read in desktop/browser

See #2292 for more details on iOS

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12542
