### PR TITLE
Fix Android image preview

### DIFF
--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -5,6 +5,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     Keyboard,
+    Platform,
     ScrollView,
     StyleSheet,
     TouchableOpacity,
@@ -100,7 +101,8 @@ export default class FileAttachmentList extends Component {
                 }
 
                 if (cache) {
-                    uri = cache.path;
+                    const prefix = Platform.OS === 'android' ? 'file://' : '';
+                    uri = `${prefix}${cache.path}`;
                 }
 
                 results.push({


### PR DESCRIPTION
#### Summary
Image preview is not working on Android cause the images need the `file://` prefix
