### PR TITLE
MM-11477 Wrap objects thrown by Client4 in a proper error type

### DIFF
--- a/app/fetch_preconfig.js
+++ b/app/fetch_preconfig.js
@@ -6,6 +6,7 @@ import RNFetchBlob from 'rn-fetch-blob';
 import urlParse from 'url-parse';
 
 import {Client4} from 'mattermost-redux/client';
+import {ClientError} from 'mattermost-redux/client/client4';
 
 import mattermostBucket from 'app/mattermost_bucket';
 import LocalConfig from 'assets/config';
@@ -30,10 +31,10 @@ const handleRedirectProtocol = (url, response) => {
 
 Client4.doFetchWithResponse = async (url, options) => {
     if (!Client4.online) {
-        throw {
+        throw new ClientError(this.getUrl(), {
             message: 'no internet connection',
             url,
-        };
+        });
     }
 
     const customHeaders = LocalConfig.CustomRequestHeaders;
@@ -62,21 +63,21 @@ Client4.doFetchWithResponse = async (url, options) => {
         data = await response.json();
     } catch (err) {
         if (response && response.resp && response.resp.data && response.resp.data.includes('SSL certificate')) {
-            throw {
+            throw new ClientError(this.getUrl(), {
                 message: 'You need to use a valid client certificate in order to connect to this Mattermost server',
                 status_code: 401,
                 url,
-            };
+            });
         }
 
-        throw {
+        throw new ClientError(this.getUrl(), {
             message: 'Received invalid response from the server.',
             intl: {
                 id: t('mobile.request.invalid_response'),
                 defaultMessage: 'Received invalid response from the server.',
             },
             url,
-        };
+        });
     }
 
     if (headers[HEADER_X_CLUSTER_ID] || headers[HEADER_X_CLUSTER_ID.toLowerCase()]) {
@@ -110,12 +111,12 @@ Client4.doFetchWithResponse = async (url, options) => {
         console.error(msg); // eslint-disable-line no-console
     }
 
-    throw {
+    throw new ClientError(this.getUrl(), {
         message: msg,
         server_error_id: data.id,
         status_code: data.status_code,
         url,
-    };
+    });
 };
 
 const initFetchConfig = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9802,8 +9802,8 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#549ba756de1f52f8321f0a66427c347019849bf6",
-      "from": "github:mattermost/mattermost-redux#549ba756de1f52f8321f0a66427c347019849bf6",
+      "version": "github:mattermost/mattermost-redux#9395b5287441a79c758edd0a7a5c0f6c188da0bf",
+      "from": "github:mattermost/mattermost-redux#9395b5287441a79c758edd0a7a5c0f6c188da0bf",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9802,8 +9802,8 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#b81ef9337c4e07bc4537a0e7862d0b7e09ffeff6",
-      "from": "github:mattermost/mattermost-redux#b81ef9337c4e07bc4537a0e7862d0b7e09ffeff6",
+      "version": "github:mattermost/mattermost-redux#549ba756de1f52f8321f0a66427c347019849bf6",
+      "from": "github:mattermost/mattermost-redux#549ba756de1f52f8321f0a66427c347019849bf6",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "224109.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#b81ef9337c4e07bc4537a0e7862d0b7e09ffeff6",
+    "mattermost-redux": "github:mattermost/mattermost-redux#549ba756de1f52f8321f0a66427c347019849bf6",
     "mime-db": "1.36.0",
     "moment-timezone": "0.5.21",
     "prop-types": "15.6.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "224109.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#549ba756de1f52f8321f0a66427c347019849bf6",
+    "mattermost-redux": "github:mattermost/mattermost-redux#9395b5287441a79c758edd0a7a5c0f6c188da0bf",
     "mime-db": "1.36.0",
     "moment-timezone": "0.5.21",
     "prop-types": "15.6.2",


### PR DESCRIPTION
This is another attempt at stopping the "non-error exceptions" that Sentry keeps getting because we're not catching the errors thrown by Client4 correctly, and Sentry doesn't provide any helpful debugging information unless you're throwing an actual Error object.

Waiting on redux changes from: https://github.com/mattermost/mattermost-redux/pull/704

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11477

#### Checklist
- Added or updated unit tests (required for all new features)