### PR TITLE
Fix when message have multiple actions

### DIFF
--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -52,12 +52,17 @@ export function setMenuActionSelector(dataSource, onSelect, options) {
     };
 }
 
-export function selectAttachmentMenuAction(postId, actionId, dataSource, displayText, value) {
+export function selectAttachmentMenuAction(postId, actionId, displayText, value) {
     return (dispatch) => {
         dispatch({
             type: ViewTypes.SUBMIT_ATTACHMENT_MENU_ACTION,
             postId,
-            data: {displayText, value},
+            data: {
+                [actionId]: {
+                    displayText,
+                    value,
+                },
+            },
         });
 
         dispatch(doPostAction(postId, actionId, value));

--- a/app/components/message_attachments/action_menu/index.js
+++ b/app/components/message_attachments/action_menu/index.js
@@ -4,16 +4,20 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {getTeammateNameDisplaySetting, getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {setMenuActionSelector, selectAttachmentMenuAction} from 'app/actions/views/post';
 
 import ActionMenu from './action_menu';
 
 function mapStateToProps(state, ownProps) {
+    const actions = state.views.post.submittedMenuActions[ownProps.postId];
+    const selected = actions ? actions[ownProps.id] : null;
+
     return {
+        selected,
+        teammateNameDisplay: getTeammateNameDisplaySetting(state),
         theme: getTheme(state),
-        selected: state.views.post.submittedMenuActions[ownProps.postId],
     };
 }
 

--- a/app/components/message_attachments/action_menu/index.js
+++ b/app/components/message_attachments/action_menu/index.js
@@ -12,7 +12,7 @@ import ActionMenu from './action_menu';
 
 function mapStateToProps(state, ownProps) {
     const actions = state.views.post.submittedMenuActions[ownProps.postId];
-    const selected = actions ? actions[ownProps.id] : null;
+    const selected = actions?.[ownProps.id];
 
     return {
         selected,

--- a/app/components/message_attachments/message_attachment.js
+++ b/app/components/message_attachments/message_attachment.js
@@ -114,7 +114,7 @@ export default class MessageAttachment extends PureComponent {
         });
 
         return (
-            <View style={style.actionsContainer}>
+            <View style={style.bodyContainer}>
                 {content}
             </View>
         );
@@ -545,11 +545,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderRadius: 2,
             marginTop: 5,
             padding: 5,
-        },
-        actionsContainer: {
-            flex: 1,
-            flexDirection: 'row',
-            flexWrap: 'wrap',
         },
     };
 });

--- a/app/reducers/views/post.js
+++ b/app/reducers/views/post.js
@@ -20,7 +20,15 @@ function submittedMenuActions(state = {}, action) {
     switch (action.type) {
     case ViewTypes.SUBMIT_ATTACHMENT_MENU_ACTION: {
         const nextState = {...state};
-        nextState[action.postId] = action.data;
+        if (nextState[action.postId]) {
+            nextState[action.postId] = {
+                ...nextState[action.postId],
+                ...action.data,
+            };
+        } else {
+            nextState[action.postId] = action.data;
+        }
+
         return nextState;
     }
     case UserTypes.LOGOUT_SUCCESS:


### PR DESCRIPTION
#### Summary
When a message attachment had multiple actions there were a few issues:
1. The actions did not wrap properly so I changed it to be vertically align instead of horizontal
2. The reducer was taking into account only one selection per post so all the actions had the same selection
3. the tappable area was on the text and the chevron icon instead of the whole button
4. When the datasource is `users` the result was not following the Teammate display name setting

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12977

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 

#### Screenshots
![image](https://user-images.githubusercontent.com/6757047/48291093-e7f7df00-e453-11e8-82a4-a23366cdcb52.png)

