### PR TITLE
MM-12952 Avoid iOS autocorrect from overriding autocomplete values

### DIFF
--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -158,10 +158,12 @@ export default class ChannelMention extends PureComponent {
         if (isSearch) {
             const channelOrIn = mentionPart.includes('in:') ? 'in:' : 'channel:';
             completedDraft = mentionPart.replace(CHANNEL_MENTION_SEARCH_REGEX, `${channelOrIn} ${mention} `);
-        } else {
+        } else if (Platform.OS === 'ios') {
             // We are going to set a double ~ on iOS to prevent the auto correct from taking over and replacing it
             // with the wrong value, this is a hack but I could not found another way to solve it
             completedDraft = mentionPart.replace(CHANNEL_MENTION_REGEX, `~~${mention} `);
+        } else {
+            completedDraft = mentionPart.replace(CHANNEL_MENTION_REGEX, `~${mention} `);
         }
 
         if (value.length > cursorPosition) {

--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -5,6 +5,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     FlatList,
+    Platform,
     Text,
     TouchableOpacity,
     View,
@@ -133,13 +134,28 @@ export default class EmojiSuggestion extends Component {
             actions.addReactionToLatestPost(emoji, rootId);
             onChangeText('');
         } else {
-            let completedDraft = emojiPart.replace(EMOJI_REGEX_WITHOUT_PREFIX, `:${emoji}: `);
+            // We are going to set a double : on iOS to prevent the auto correct from taking over and replacing it
+            // with the wrong value, this is a hack but I could not found another way to solve it
+            let completedDraft;
+            if (Platform.OS === 'ios') {
+                completedDraft = emojiPart.replace(EMOJI_REGEX_WITHOUT_PREFIX, `::${emoji}: `);
+            } else {
+                completedDraft = emojiPart.replace(EMOJI_REGEX_WITHOUT_PREFIX, `:${emoji}: `);
+            }
 
             if (value.length > cursorPosition) {
                 completedDraft += value.substring(cursorPosition);
             }
 
             onChangeText(completedDraft);
+
+            if (Platform.OS === 'ios') {
+                // This is the second part of the hack were we replace the double : with just one
+                // after the auto correct vanished
+                setTimeout(() => {
+                    onChangeText(completedDraft.replace(`::${emoji}: `, `:${emoji}: `));
+                });
+            }
         }
 
         this.setState({

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion.js
@@ -5,6 +5,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     FlatList,
+    Platform,
 } from 'react-native';
 
 import {RequestStatus} from 'mattermost-redux/constants';
@@ -112,9 +113,22 @@ export default class SlashSuggestion extends Component {
     completeSuggestion = (command) => {
         const {onChangeText} = this.props;
 
-        const completedDraft = `/${command} `;
+        // We are going to set a double / on iOS to prevent the auto correct from taking over and replacing it
+        // with the wrong value, this is a hack but I could not found another way to solve it
+        let completedDraft = `/${command} `;
+        if (Platform.OS === 'ios') {
+            completedDraft = `//${command} `;
+        }
 
         onChangeText(completedDraft);
+
+        if (Platform.OS === 'ios') {
+            // This is the second part of the hack were we replace the double / with just one
+            // after the auto correct vanished
+            setTimeout(() => {
+                onChangeText(completedDraft.replace(`//${command} `, `/${command} `));
+            });
+        }
 
         this.setState({
             active: false,


### PR DESCRIPTION
#### Summary
As I said this is a super hacky solution that will replace the text twice on iOS just to avoid the autocorrect for overriding the values, this is the best way I was able to fix it after HH spent about a day trying to come up with a different solution

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12952
