### PR TITLE
Add support for Elixir syntax highlighting

### DIFF
--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -128,6 +128,7 @@ const languages = {
     diff: 'Diff',
     django: 'Django',
     dockerfile: 'Dockerfile',
+    elixir: 'Elixir',
     erlang: 'Erlang',
     fortran: 'Fortran',
     fsharp: 'F#',


### PR DESCRIPTION
see https://github.com/mattermost/mattermost-webapp/pull/2056

#### Summary
This PR attempts to add support for syntax highlighting of Elixir code and supports https://github.com/mattermost/mattermost-webapp/pull/2056

#### Ticket Link
N/A 

#### Checklist
- [ ] Added or updated unit tests (required for all new features) <- no matching/similar tests found

#### Device Information
N/A

#### Screenshots
N/A
