### PR TITLE
Refresh indicator fix

### DIFF
--- a/app/components/post_list/post_list.ios.js
+++ b/app/components/post_list/post_list.ios.js
@@ -93,11 +93,10 @@ export default class PostList extends PostListBase {
             channelId,
             highlightPostId,
             postIds,
+            refreshing,
         } = this.props;
 
-        const refreshControl = {
-            refreshing: false,
-        };
+        const refreshControl = {refreshing};
 
         if (channelId) {
             refreshControl.onRefresh = this.handleRefresh;

--- a/app/components/post_list/post_list_base.js
+++ b/app/components/post_list/post_list_base.js
@@ -37,6 +37,7 @@ export default class PostListBase extends PureComponent {
         onPostPress: PropTypes.func,
         onRefresh: PropTypes.func,
         postIds: PropTypes.array.isRequired,
+        refreshing: PropTypes.bool.isRequired,
         renderFooter: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
         renderReplies: PropTypes.bool,
         serverURL: PropTypes.string.isRequired,

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -37,6 +37,7 @@ export default class ChannelPostList extends PureComponent {
         navigator: PropTypes.object,
         postIds: PropTypes.array.isRequired,
         postVisibility: PropTypes.number,
+        refreshing: PropTypes.bool.isRequired,
         theme: PropTypes.object.isRequired,
     };
 
@@ -165,6 +166,7 @@ export default class ChannelPostList extends PureComponent {
             loadMorePostsVisible,
             navigator,
             postIds,
+            refreshing,
             theme,
         } = this.props;
 
@@ -193,6 +195,7 @@ export default class ChannelPostList extends PureComponent {
                     channelId={channelId}
                     navigator={navigator}
                     renderFooter={this.renderFooter}
+                    refreshing={refreshing}
                 />
             );
         }

--- a/app/screens/channel/channel_post_list/index.js
+++ b/app/screens/channel/channel_post_list/index.js
@@ -28,6 +28,7 @@ function mapStateToProps(state) {
         postVisibility: state.views.channel.postVisibility[channelId],
         lastViewedAt: getMyCurrentChannelMembership(state).last_viewed_at,
         loadMorePostsVisible: state.views.channel.loadMorePostsVisible,
+        refreshing: state.views.channel.refreshing,
         theme: getTheme(state),
     };
 }


### PR DESCRIPTION
#### Summary
This fixes an issue on iOS where the refresh indicator was not properly showing while a channel's posts are being refreshed

#### Ticket Link

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: Nexus 6 (Android), iPhone X (iOS)

#### Screenshots
![image](https://user-images.githubusercontent.com/1859611/48805319-adf0cd80-ecdc-11e8-95bd-b36bb90c51bf.png)