### PR TITLE
Set the current user status as offline when the app loses connection

### DIFF
--- a/app/actions/views/user.js
+++ b/app/actions/views/user.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {UserTypes} from 'mattermost-redux/action_types';
+import {getStatus} from 'mattermost-redux/actions/users';
+import {General} from 'mattermost-redux/constants';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+export function setCurrentUserStatus(isOnline) {
+    return (dispatch, getState) => {
+        const currentUserId = getCurrentUserId(getState());
+
+        if (isOnline) {
+            return dispatch(getStatus(currentUserId));
+        }
+
+        return dispatch({
+            type: UserTypes.RECEIVED_STATUS,
+            data: {
+                user_id: currentUserId,
+                status: General.OFFLINE,
+            },
+        });
+    };
+}

--- a/app/actions/views/user.test.js
+++ b/app/actions/views/user.test.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import {UserTypes} from 'mattermost-redux/action_types';
+import {General} from 'mattermost-redux/constants';
+
+import {setCurrentUserStatus} from 'app/actions/views/user';
+
+const mockStore = configureStore([thunk]);
+
+jest.mock('mattermost-redux/actions/users', () => ({
+    getStatus: (...args) => ({type: 'MOCK_GET_STATUS', args}),
+}));
+
+describe('Actions.Views.User', () => {
+    let store;
+
+    beforeEach(() => {
+        store = mockStore({
+            entities: {
+                users: {
+                    currentUserId: 'current-user-id',
+                },
+            },
+        });
+    });
+
+    test('should set the current user as offline', async () => {
+        const action = {
+            type: UserTypes.RECEIVED_STATUS,
+            data: {
+                user_id: 'current-user-id',
+                status: General.OFFLINE,
+            },
+        };
+
+        await store.dispatch(setCurrentUserStatus(false));
+        expect(store.getActions()).toEqual([action]);
+    });
+
+    test('should fetch the current user status from the server', async () => {
+        const action = {
+            type: 'MOCK_GET_STATUS',
+            args: ['current-user-id'],
+        };
+
+        await store.dispatch(setCurrentUserStatus(true));
+        expect(store.getActions()).toEqual([action]);
+    });
+});

--- a/app/components/network_indicator/index.js
+++ b/app/components/network_indicator/index.js
@@ -9,6 +9,7 @@ import {init as initWebSocket, close as closeWebSocket} from 'mattermost-redux/a
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
 import {connection} from 'app/actions/device';
+import {setCurrentUserStatus} from 'app/actions/views/user';
 import {getConnection, isLandscape} from 'app/selectors/device';
 
 import NetworkIndicator from './network_indicator';
@@ -33,6 +34,7 @@ function mapDispatchToProps(dispatch) {
             connection,
             initWebSocket,
             logout,
+            setCurrentUserStatus,
             startPeriodicStatusUpdates,
             stopPeriodicStatusUpdates,
         }, dispatch),


### PR DESCRIPTION
#### Summary
When the user goes offline (either loses internet connection or cannot connect to the server) we set the current user status to offline and then we fetch the user's status from the server when the device regains connection to the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13082

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
