### PR TITLE
MM-12959: Fix autocomplete archived channels visibility

### DIFF
--- a/app/selectors/autocomplete.js
+++ b/app/selectors/autocomplete.js
@@ -4,6 +4,7 @@
 import {createSelector} from 'reselect';
 
 import {General} from 'mattermost-redux/constants';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getMyChannels, getOtherChannels} from 'mattermost-redux/selectors/entities/channels';
 import {
     getCurrentUser, getCurrentUserId, getProfilesInCurrentChannel,
@@ -184,7 +185,8 @@ export const filterPublicChannels = createSelector(
     getOtherChannels,
     getCurrentLocale,
     (state, matchTerm) => matchTerm,
-    (myChannels, otherChannels, locale, matchTerm) => {
+    getConfig,
+    (myChannels, otherChannels, locale, matchTerm, config) => {
         if (matchTerm === null) {
             return null;
         }
@@ -203,6 +205,11 @@ export const filterPublicChannels = createSelector(
             }).concat(otherChannels);
         }
 
+        const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
+        if (!viewArchivedChannels) {
+            channels = channels.filter((c) => c.delete_at === 0);
+        }
+
         return channels.sort(sortChannelsByDisplayName.bind(null, locale)).map((c) => c.id);
     }
 );
@@ -210,7 +217,8 @@ export const filterPublicChannels = createSelector(
 export const filterPrivateChannels = createSelector(
     getMyChannels,
     (state, matchTerm) => matchTerm,
-    (myChannels, matchTerm) => {
+    getConfig,
+    (myChannels, matchTerm, config) => {
         if (matchTerm === null) {
             return null;
         }
@@ -225,6 +233,11 @@ export const filterPrivateChannels = createSelector(
             channels = myChannels.filter((c) => {
                 return c.type === General.PRIVATE_CHANNEL;
             });
+        }
+
+        const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
+        if (!viewArchivedChannels) {
+            channels = channels.filter((c) => c.delete_at === 0);
         }
 
         return channels.map((c) => c.id);


### PR DESCRIPTION
#### Summary
Fix autocomplete archived channels visibility (and update properly on
websocket events).

#### Ticket Link
[MM-12959](https://mattermost.atlassian.net/browse/MM-12959)

#### Device Information
This PR was tested on: [OnePlus 5, Android 8.1]