### PR TITLE
Do not disconnect WebSocket when NetworkIndicator on componentWillUnmount

### DIFF
--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -112,14 +112,8 @@ export default class NetworkIndicator extends PureComponent {
     componentWillUnmount() {
         this.mounted = false;
 
-        const {closeWebSocket, stopPeriodicStatusUpdates} = this.props.actions;
-
         this.networkListener.removeEventListener();
-
         AppState.removeEventListener('change', this.handleAppStateChange);
-
-        closeWebSocket();
-        stopPeriodicStatusUpdates();
 
         clearTimeout(this.connectionRetryTimeout);
     }


### PR DESCRIPTION
#### Summary
The `NetworkIndicator` component gets unmounted when switching teams as the channel screen changes the rendered content but we don't need nor want to disconnect the websocket then.

WebSocket init and disconnection will still occur when network changes or app state changes
