### PR TITLE
Keep postlist scroll position on iOS and fix opengraph

### DIFF
--- a/app/components/post_body_additional_content/index.js
+++ b/app/components/post_body_additional_content/index.js
@@ -30,6 +30,16 @@ function makeGetFirstLink() {
     };
 }
 
+function getOpenGraphData(metadata, url) {
+    if (!metadata || !metadata.embeds) {
+        return null;
+    }
+
+    return metadata.embeds.find((embed) => {
+        return embed.type === 'opengraph' && embed.url === url ? embed.data : null;
+    });
+}
+
 function makeMapStateToProps() {
     const getFirstLink = makeGetFirstLink();
 
@@ -46,7 +56,7 @@ function makeMapStateToProps() {
             ...getDimensions(state),
             googleDeveloperKey: config.GoogleDeveloperKey,
             link,
-            openGraphData: getOpenGraphMetadataForUrl(state, link),
+            openGraphData: getOpenGraphMetadataForUrl(state, link) || getOpenGraphData(ownProps.metadata, link)?.data,
             showLinkPreviews: previewsEnabled && config.EnableLinkPreviews === 'true',
             theme: getTheme(state),
         };

--- a/app/components/post_list/post_list.ios.js
+++ b/app/components/post_list/post_list.ios.js
@@ -11,6 +11,9 @@ import PostListBase from './post_list_base';
 
 const INITIAL_BATCH_TO_RENDER = 15;
 const SCROLL_UP_MULTIPLIER = 3.5;
+const SCROLL_POSITION_CONFIG = {
+    minIndexForVisible: 0,
+};
 
 export default class PostList extends PostListBase {
     constructor(props) {
@@ -115,6 +118,7 @@ export default class PostList extends PostListBase {
                 inverted={true}
                 keyExtractor={this.keyExtractor}
                 ListFooterComponent={this.props.renderFooter}
+                maintainVisibleContentPosition={SCROLL_POSITION_CONFIG}
                 maxToRenderPerBatch={INITIAL_BATCH_TO_RENDER + 1}
                 onContentSizeChange={this.handleContentSizeChange}
                 onLayout={this.handleLayout}


### PR DESCRIPTION
#### Summary
* Added support to keep the postlist in place without scrolling when new content is available (iOS only)
* Using post metadata for opengraph as a fallback as I encounter a case where for some reason the metadata was not set in the reducer but it was still in the metadata object
