### PR TITLE
Fix error text when intl object is not provided

### DIFF
--- a/app/components/error_text/error_text.js
+++ b/app/components/error_text/error_text.js
@@ -25,8 +25,8 @@ export default class ErrorText extends PureComponent {
 
         const style = getStyleSheet(theme);
 
-        if (error.hasOwnProperty('intl')) {
-            const {intl} = error;
+        const {intl} = error;
+        if (intl) {
             return (
                 <FormattedText
                     id={intl.id}


### PR DESCRIPTION
#### Summary
Fixes the screen going blank if when creating a channel errors out

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13150
