### PR TITLE
Add a threshold of 60px from the bottom to show new messages

### DIFF
--- a/app/components/post_list/post_list.ios.js
+++ b/app/components/post_list/post_list.ios.js
@@ -12,7 +12,14 @@ import PostListBase from './post_list_base';
 const INITIAL_BATCH_TO_RENDER = 15;
 const SCROLL_UP_MULTIPLIER = 3.5;
 const SCROLL_POSITION_CONFIG = {
+
+    // To avoid scrolling the list when new messages arrives
+    // if the user is not at the bottom
     minIndexForVisible: 0,
+
+    // If the user is at the bottom or 60px from the bottom
+    // auto scroll show the new message
+    autoscrollToTopThreshold: 60,
 };
 
 export default class PostList extends PostListBase {


### PR DESCRIPTION
#### Summary
on iOS the post list will not scroll or pop when new messages arrive not even when you were at the bottom, this PR adds a threshold so the post lists scrolls you to the new messages as they arrive if you are at the bottom or above the bottom by a max of 60px, above those 60px the list won't scroll
