### PR TITLE
Fix edit post

### DIFF
--- a/app/components/text_input_with_localized_placeholder.js
+++ b/app/components/text_input_with_localized_placeholder.js
@@ -3,13 +3,16 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {injectIntl, intlShape} from 'react-intl';
+import {intlShape} from 'react-intl';
 import {TextInput} from 'react-native';
 
-class TextInputWithLocalizedPlaceholder extends PureComponent {
+export default class TextInputWithLocalizedPlaceholder extends PureComponent {
     static propTypes = {
         ...TextInput.propTypes,
         placeholder: PropTypes.object.isRequired,
+    };
+
+    static contextTypes = {
         intl: intlShape.isRequired,
     };
 
@@ -22,10 +25,11 @@ class TextInputWithLocalizedPlaceholder extends PureComponent {
     };
 
     render() {
-        const {intl, placeholder, ...otherProps} = this.props;
+        const {formatMessage} = this.context.intl;
+        const {placeholder, ...otherProps} = this.props;
         let placeholderString = '';
         if (placeholder.id) {
-            placeholderString = intl.formatMessage(placeholder);
+            placeholderString = formatMessage(placeholder);
         }
 
         return (
@@ -38,5 +42,3 @@ class TextInputWithLocalizedPlaceholder extends PureComponent {
         );
     }
 }
-
-export default injectIntl(TextInputWithLocalizedPlaceholder, {withRef: true});

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -108,7 +108,7 @@ export default class EditPost extends PureComponent {
     };
 
     focus = () => {
-        this.messageInput.refs.wrappedInstance.focus();
+        this.messageInput.focus();
     };
 
     messageRef = (ref) => {


### PR DESCRIPTION
#### Summary
it seems that with the update of react-intl injectIntl with ref no longer works or works in a different way, changing the class to be returned by default and using intl in the context fixes the issue.
