### PR TITLE
Set refreshing default value

### DIFF
--- a/app/components/post_list/post_list_base.js
+++ b/app/components/post_list/post_list_base.js
@@ -49,6 +49,7 @@ export default class PostListBase extends PureComponent {
     static defaultProps = {
         onLoadMoreUp: () => true,
         renderFooter: () => null,
+        refreshing: false,
     };
 
     componentWillMount() {


### PR DESCRIPTION
#### Summary
In some cases `refreshing` is undefined causing a crash when trying to set the `onRefresh` property to the FlatList