### PR TITLE
Fetch team channels on extension init

### DIFF
--- a/share_extension/android/actions/index.js
+++ b/share_extension/android/actions/index.js
@@ -3,17 +3,15 @@
 
 import {fetchMyChannelsAndMembers} from 'mattermost-redux/actions/channels';
 
+import {loadProfilesAndTeamMembersForDMSidebar} from 'app/actions/views/channel';
 import {ViewTypes} from 'app/constants';
 import {getDefaultChannelForTeam} from 'share_extension/android/selectors';
 
 export function getTeamChannels(teamId) {
     return async (dispatch, getState) => {
-        let defaultChannel = getDefaultChannelForTeam(getState(), teamId);
-
-        if (!defaultChannel) {
-            await fetchMyChannelsAndMembers(teamId)(dispatch, getState);
-            defaultChannel = getDefaultChannelForTeam(getState(), teamId);
-        }
+        await dispatch(fetchMyChannelsAndMembers(teamId));
+        dispatch(loadProfilesAndTeamMembersForDMSidebar(teamId));
+        const defaultChannel = getDefaultChannelForTeam(getState(), teamId);
 
         return defaultChannel.id;
     };

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -60,6 +60,9 @@ const MAX_MESSAGE_LENGTH = 4000;
 
 export default class ExtensionPost extends PureComponent {
     static propTypes = {
+        actions: PropTypes.shape({
+            getTeamChannels: PropTypes.func.isRequired,
+        }).isRequired,
         channelId: PropTypes.string.isRequired,
         currentUserId: PropTypes.string.isRequired,
         maxFileSize: PropTypes.number.isRequired,
@@ -265,12 +268,14 @@ export default class ExtensionPost extends PureComponent {
     };
 
     loadData = async (items) => {
-        const {maxFileSize, token, url} = this.props;
+        const {actions, maxFileSize, teamId, token, url} = this.props;
         if (token && url) {
             const text = [];
             const files = [];
             let totalSize = 0;
             let error;
+
+            actions.getTeamChannels(teamId);
 
             for (let i = 0; i < items.length; i++) {
                 const item = items[i];

--- a/share_extension/android/extension_post/index.js
+++ b/share_extension/android/extension_post/index.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getCurrentChannel, getDefaultChannel} from 'mattermost-redux/selectors/entities/channels';
@@ -8,6 +9,7 @@ import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
+import {getTeamChannels} from 'share_extension/android/actions';
 import {getAllowedServerMaxFileSize} from 'app/utils/file';
 
 import ExtensionPost from './extension_post';
@@ -17,12 +19,12 @@ function mapStateToProps(state) {
     const {credentials} = state.entities.general;
     const {token, url} = credentials;
     let channel = getCurrentChannel(state);
-    if (channel.delete_at !== 0) {
+    if (channel && channel.delete_at !== 0) {
         channel = getDefaultChannel(state);
     }
 
     return {
-        channelId: channel.id,
+        channelId: channel?.id,
         currentUserId: getCurrentUserId(state),
         maxFileSize: getAllowedServerMaxFileSize(config),
         teamId: getCurrentTeamId(state),
@@ -31,4 +33,12 @@ function mapStateToProps(state) {
     };
 }
 
-export default connect(mapStateToProps)(ExtensionPost);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getTeamChannels,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExtensionPost);

--- a/share_extension/android/index.js
+++ b/share_extension/android/index.js
@@ -36,17 +36,13 @@ export default class ShareApp extends PureComponent {
         const {dispatch, getState} = store;
         const state = getState();
         if (state.views.root.hydrationComplete) {
-            const {credentials} = state.entities.general;
             const {currentTeamId} = state.entities.teams;
 
             if (this.unsubscribeFromStore) {
                 this.unsubscribeFromStore();
             }
 
-            if (credentials.token && credentials.url) {
-                Client4.setToken(credentials.token);
-                Client4.setUrl(credentials.url);
-            }
+            this.setCredentialsForClient();
 
             dispatch(extensionSelectTeamId(currentTeamId));
 
@@ -55,6 +51,16 @@ export default class ShareApp extends PureComponent {
             }
         }
     };
+
+    setCredentialsForClient() {
+        const state = store.getState();
+        const {credentials} = state.entities.general;
+
+        if (credentials.token && credentials.url) {
+            Client4.setToken(credentials.token);
+            Client4.setUrl(credentials.url);
+        }
+    }
 
     render() {
         if (!this.state.init) {


### PR DESCRIPTION
#### Summary
Fetch the current team channels when the extension opens to ensure we have them in the store, also fetch the channels when switching teams regardless if the default channel is already loaded to keep the list up to date.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13029