### PR TITLE
Fixed typo in i18nId

### DIFF
--- a/app/screens/settings/advanced_settings/advanced_settings.js
+++ b/app/screens/settings/advanced_settings/advanced_settings.js
@@ -176,7 +176,7 @@ class AdvancedSettings extends PureComponent {
                     <View style={style.divider}/>
                     <SettingsItem
                         defaultMessage='Delete File Cache'
-                        i18nId='mobile.advanced_settings.clear_downloads'
+                        i18nId='mobile.advanced_settings.delete_file_cache'
                         iconName='md-trash'
                         iconType='ion'
                         onPress={this.clearDownloadCache}


### PR DESCRIPTION
There are should be `mobile.advanced_settings.delete_file_cache` instead of `mobile.advanced_settings.clear_downloads`.
