### PR TITLE
MM-13041: Not show direct channels without display name

### DIFF
--- a/app/components/autocomplete/channel_mention_item/channel_mention_item.js
+++ b/app/components/autocomplete/channel_mention_item/channel_mention_item.js
@@ -24,9 +24,7 @@ export default class ChannelMentionItem extends PureComponent {
 
     completeMention = () => {
         const {onPress, displayName, name, type} = this.props;
-        if (type === General.DM_CHANNEL) {
-            onPress('@' + displayName.replace(/ /g, ''));
-        } else if (type === General.DM_CHANNEL) {
+        if (type === General.DM_CHANNEL || type === General.GM_CHANNEL) {
             onPress('@' + displayName.replace(/ /g, ''));
         } else {
             onPress(name);
@@ -45,6 +43,9 @@ export default class ChannelMentionItem extends PureComponent {
         const style = getStyleFromTheme(theme);
 
         if (type === General.DM_CHANNEL || type === General.GM_CHANNEL) {
+            if (!displayName) {
+                return null;
+            }
             return (
                 <TouchableOpacity
                     key={channelId}


### PR DESCRIPTION
#### Summary
Direct message channels have no display name, except for search
autocompleted results. If we don't have display name, we don't show it
in the autocomplete results (until we receive from the autocomplete API
response).

Besides I fixed a problem with autocompletion of group message channels.

#### Ticket Link
[MM-13041](https://mattermost.atlassian.net/browse/MM-13041)

#### Device Information
This PR was tested on: [One Plus 5, Android 8.1]