### PR TITLE
Fixed empty message attachment text

### DIFF
--- a/app/components/message_attachments/message_attachment.js
+++ b/app/components/message_attachments/message_attachment.js
@@ -99,7 +99,7 @@ export default class MessageAttachment extends PureComponent {
                         navigator={navigator}
                         onPermalinkPress={onPermalinkPress}
                         textStyles={textStyles}
-                        value={attachment.text}
+                        value={attachment.text || attachment.fallback}
                     />
                     <AttachmentFields
                         baseTextStyle={baseTextStyle}


### PR DESCRIPTION
#### Summary
Fixes an issue where message attachments were empty if text came through on fallback

#### Ticket Link
n/a

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone X (iOS), Nexus 6 (Android)

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
![image](https://user-images.githubusercontent.com/1859611/49242666-f7be6f80-f3d0-11e8-90dd-219ee8b06b7d.png)