### PR TITLE
File image attachments sometimes do not open the image preview

### DIFF
--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -23,6 +23,7 @@ export default class FileAttachment extends PureComponent {
         canDownloadFiles: PropTypes.bool.isRequired,
         deviceWidth: PropTypes.number.isRequired,
         file: PropTypes.object.isRequired,
+        id: PropTypes.string.isRequired,
         index: PropTypes.number.isRequired,
         onCaptureRef: PropTypes.func,
         onLongPress: PropTypes.func,
@@ -102,6 +103,7 @@ export default class FileAttachment extends PureComponent {
         if ((data && data.has_preview_image) || file.loading || isGif(data)) {
             fileAttachmentComponent = (
                 <TouchableOpacity
+                    key={`${this.props.id}${file.loading}`}
                     onPress={this.handlePreviewPress}
                     onLongPress={onLongPress}
                 >

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -133,6 +133,7 @@ export default class FileAttachmentList extends Component {
                     canDownloadFiles={canDownloadFiles}
                     deviceWidth={deviceWidth}
                     file={{loading: true}}
+                    id={id}
                     index={idx}
                     theme={this.props.theme}
                 />
@@ -151,6 +152,7 @@ export default class FileAttachmentList extends Component {
                     canDownloadFiles={canDownloadFiles}
                     deviceWidth={deviceWidth}
                     file={f}
+                    id={file.id}
                     index={idx}
                     navigator={navigator}
                     onCaptureRef={this.handleCaptureRef}


### PR DESCRIPTION
#### Summary
This change addresses a bug where image preview was not working specifically for new images or after resetting cache. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13237

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone X (iOS), Nexus 6 (Android)