### PR TITLE
[MM-13171] Make circular badge on jewel for single-digit mention

### DIFF
--- a/app/components/__snapshots__/badge.test.js.snap
+++ b/app/components/__snapshots__/badge.test.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Badge should match snapshot 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#444",
+        "borderRadius": 20,
+        "height": 20,
+        "padding": 12,
+        "paddingBottom": 3,
+        "paddingTop": 3,
+        "position": "absolute",
+        "right": 30,
+        "top": 2,
+      },
+      Object {
+        "backgroundColor": "#ffffff",
+      },
+      Object {
+        "opacity": 0,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
+      }
+    }
+  >
+    <Text
+      onLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "color": "white",
+            "fontSize": 14,
+          },
+          Object {
+            "color": "#145dbf",
+            "fontSize": 10,
+          },
+          Object {},
+        ]
+      }
+    >
+      1
+    </Text>
+  </View>
+</View>
+`;

--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -15,8 +15,8 @@ import {
 export default class Badge extends PureComponent {
     static defaultProps = {
         extraPaddingHorizontal: 10,
-        minHeight: 0,
-        minWidth: 0,
+        minHeight: 20,
+        minWidth: 20,
     };
 
     static propTypes = {
@@ -81,7 +81,7 @@ export default class Badge extends PureComponent {
             } else {
                 width = e.nativeEvent.layout.width + this.props.extraPaddingHorizontal;
             }
-            width = Math.max(width + 10, this.props.minWidth);
+            width = Math.max(this.props.count < 10 ? width : width + 10, this.props.minWidth);
             const borderRadius = width / 2;
             this.setNativeProps({
                 style: {
@@ -105,12 +105,19 @@ export default class Badge extends PureComponent {
             extra.marginBottom = 1;
         }
         return (
-            <Text
-                style={[styles.text, this.props.countStyle, extra]}
-                onLayout={this.onLayout}
+            <View
+                ref='badgeContainer'
+                style={[styles.badge, this.props.style, {opacity: 0}]}
             >
-                {text}
-            </Text>
+                <View style={styles.wrapper}>
+                    <Text
+                        style={[styles.text, this.props.countStyle, extra]}
+                        onLayout={this.onLayout}
+                    >
+                        {text}
+                    </Text>
+                </View>
+            </View>
         );
     };
 
@@ -124,14 +131,7 @@ export default class Badge extends PureComponent {
                 {...this.panResponder.panHandlers}
                 onPress={this.handlePress}
             >
-                <View
-                    ref='badgeContainer'
-                    style={[styles.badge, this.props.style, {opacity: 0}]}
-                >
-                    <View style={styles.wrapper}>
-                        {this.renderText()}
-                    </View>
-                </View>
+                {this.renderText()}
             </TouchableWithoutFeedback>
         );
     }

--- a/app/components/badge.test.js
+++ b/app/components/badge.test.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {Text, TouchableWithoutFeedback} from 'react-native';
+import {shallow} from 'enzyme';
+
+import Badge from './badge';
+
+describe('Badge', () => {
+    const baseProps = {
+        count: 1,
+        countStyle: {color: '#145dbf', fontSize: 10},
+        style: {backgroundColor: '#ffffff'},
+        onPress: jest.fn(),
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <Badge {...baseProps}/>
+        );
+
+        expect(wrapper.instance().renderText()).toMatchSnapshot();
+        expect(wrapper.find(TouchableWithoutFeedback).exists()).toEqual(true);
+        expect(wrapper.find(Text).first().props().children).toContain('1');
+    });
+});

--- a/app/components/sidebars/main/channels_list/channel_item/channel_item.js
+++ b/app/components/sidebars/main/channels_list/channel_item/channel_item.js
@@ -162,8 +162,6 @@ export default class ChannelItem extends PureComponent {
                     style={style.badge}
                     countStyle={style.mention}
                     count={mentions}
-                    minHeight={20}
-                    minWidth={20}
                     onPress={this.onPress}
                 />
             );

--- a/app/components/sidebars/main/channels_list/switch_teams_button/switch_teams_button.js
+++ b/app/components/sidebars/main/channels_list/switch_teams_button/switch_teams_button.js
@@ -53,8 +53,6 @@ export default class SwitchTeamsButton extends React.PureComponent {
                 style={styles.badge}
                 countStyle={styles.mention}
                 count={mentionCount}
-                minHeight={20}
-                minWidth={20}
             />
         );
 

--- a/app/components/sidebars/main/teams_list/teams_list_item/teams_list_item.js
+++ b/app/components/sidebars/main/teams_list/teams_list_item/teams_list_item.js
@@ -62,8 +62,6 @@ export default class TeamsListItem extends React.PureComponent {
                 style={styles.badge}
                 countStyle={styles.mention}
                 count={mentionCount}
-                minHeight={20}
-                minWidth={20}
             />
         );
 

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -113,8 +113,6 @@ class ChannelDrawerButton extends PureComponent {
                     style={style.badge}
                     countStyle={style.mention}
                     count={badgeCount}
-                    minHeight={20}
-                    minWidth={20}
                     onPress={this.handlePress}
                 />
             );


### PR DESCRIPTION
#### Summary
Make circular badge on jewel for single-digit mention

#### Ticket Link
Jira ticket: [MM-13171](https://mattermost.atlassian.net/browse/MM-13171)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
Screen recording - https://youtu.be/sXRYsXdPFk0.  The incremental changes in mention count of emoji channel there was due to continuous posting of at-mention by other user on a browser.

iOS screenshots:
<img width="354" alt="screen shot 2018-12-06 at 3 30 01 pm" src="https://user-images.githubusercontent.com/5334504/49571326-e5fe3e80-f973-11e8-8b5e-628ce3b1952e.png">
<img width="350" alt="screen shot 2018-12-06 at 3 30 10 pm" src="https://user-images.githubusercontent.com/5334504/49571334-ebf41f80-f973-11e8-84e9-3fd5b659d124.png">
<img width="356" alt="screen shot 2018-12-06 at 3 30 18 pm" src="https://user-images.githubusercontent.com/5334504/49571338-ee567980-f973-11e8-8bfd-19fe6fff680b.png">


Android screenshots:
<img width="351" alt="screen shot 2018-12-06 at 3 27 54 pm" src="https://user-images.githubusercontent.com/5334504/49571293-d5e65f00-f973-11e8-90d7-0f0a5e0d8031.png">
<img width="354" alt="screen shot 2018-12-06 at 3 28 50 pm" src="https://user-images.githubusercontent.com/5334504/49571313-de3e9a00-f973-11e8-96d3-b91e753eec77.png">
<img width="360" alt="screen shot 2018-12-06 at 3 28 59 pm" src="https://user-images.githubusercontent.com/5334504/49571321-e1398a80-f973-11e8-9342-ba22fb2cae22.png">

