### PR TITLE
[MM-13074] Render text for non-existent emoji when post metadata is enabled

### DIFF
--- a/app/components/emoji/index.js
+++ b/app/components/emoji/index.js
@@ -10,11 +10,11 @@ import {Client4} from 'mattermost-redux/client';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
 import {EmojiIndicesByAlias, Emojis} from 'app/utils/emojis';
-import {doesMatchNamedEmoji} from 'app/utils/emoji_utils';
 
 import Emoji from './emoji';
 
 function mapStateToProps(state, ownProps) {
+    const config = getConfig(state);
     const emojiName = ownProps.emojiName;
     const customEmojis = getCustomEmojisByName(state);
 
@@ -30,8 +30,8 @@ function mapStateToProps(state, ownProps) {
         isCustomEmoji = true;
     } else {
         displayTextOnly = state.entities.emojis.nonExistentEmoji.has(emojiName) ||
-            (doesMatchNamedEmoji(`:${emojiName}:`) && !customEmojis.has(emojiName)) ||
-            getConfig(state).EnableCustomEmoji !== 'true' ||
+            config.EnableCustomEmoji !== 'true' ||
+            config.ExperimentalEnablePostMetadata === 'true' ||
             getCurrentUserId(state) === '' ||
             !isMinimumServerVersion(Client4.getServerVersion(), 4, 7);
     }


### PR DESCRIPTION
#### Summary
Render text for non-existent emoji when post metadata is enabled.

This is a proper fix for the original Jira issue of https://mattermost.atlassian.net/browse/MM-13074

#### Ticket Link
Jira ticket: [MM-13174](https://mattermost.atlassian.net/browse/MM-13174) & [MM-13074](https://mattermost.atlassian.net/browse/MM-13074)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

Server PR - https://github.com/mattermost/mattermost-server/pull/9970
