### PR TITLE
Fix reaction list cutoff at end of list

### DIFF
--- a/app/components/slide_up_panel/slide_up_panel.js
+++ b/app/components/slide_up_panel/slide_up_panel.js
@@ -140,6 +140,7 @@ export default class SlideUpPanel extends PureComponent {
     onHeaderHandlerStateChange = ({nativeEvent}) => {
         if (nativeEvent.oldState === GestureState.BEGAN) {
             this.lastScrollY.setValue(0);
+            this.lastScrollYValue = 0;
         }
         this.onHandlerStateChange({nativeEvent});
     };
@@ -155,7 +156,7 @@ export default class SlideUpPanel extends PureComponent {
             const endOffsetY = lastSnap + translation;
             let destSnapPoint = this.snapPoints[0];
 
-            if (Math.abs(translationY) < 50) {
+            if (Math.abs(translationY) < 50 && allowStayMiddle) {
                 // Only drag the panel after moving 50 or more points
                 destSnapPoint = lastSnap;
             } else if (isGoingDown && !allowStayMiddle) {
@@ -184,6 +185,11 @@ export default class SlideUpPanel extends PureComponent {
                         useNativeDriver: true,
                     }).start(() => {
                         this.setState({lastSnap: destSnapPoint});
+
+                        // When dragging down the panel when is fully open reset the scrollView to the top
+                        if (isGoingDown && destSnapPoint !== this.snapPoints[0]) {
+                            this.scrollToTop();
+                        }
                     });
                 }
             } else {
@@ -284,6 +290,7 @@ export default class SlideUpPanel extends PureComponent {
                                         bounces={false}
                                         onScrollBeginDrag={this.onRegisterLastScroll}
                                         scrollEventThrottle={1}
+                                        style={{marginBottom: (this.props.marginFromTop + BOTTOM_MARGIN)}}
                                     >
                                         {children}
                                     </Animated.ScrollView>


### PR DESCRIPTION
#### Summary
Fixes:
1. On Android when there are so may different reaction s the you can scroll it's very hard to scroll back up from the bottom of the list without just closing the screen.
2. It seems like when there are so may different reactions that you have to scroll, the bottom record is not shown on Android. And, the bottom 1 and 1/2 emojis is missing on iOS


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12228