### PR TITLE
Fix opening documents on Android

### DIFF
--- a/app/components/file_attachment_list/file_attachment_document.js
+++ b/app/components/file_attachment_list/file_attachment_document.js
@@ -236,7 +236,7 @@ export default class FileAttachmentDocument extends PureComponent {
                 OpenFile.openDoc([{
                     url: `${prefix}${path}`,
                     fileNameOptional: file.caption,
-                    fileName: data.name,
+                    fileName: encodeURI(data.name.split('.').slice(0, -1).join('.')),
                     fileType: data.extension,
                     cache: false,
                 }], (error) => {


### PR DESCRIPTION
#### Summary
The library that we use to open documents implements `MimeTypeMap.getFileExtensionFromUrl(url)` on Android to detect the file extension which in some cases it fails.

As to why `MimeTypeMap.getFileExtensionFromUrl(url)` fails? It's expecting a properly formatted URL String, which if the filename has spaces or any other weird character it will just fail. so we will first encode it using URLEncoder.

Also the underlying library is concatenating the `fileName` and `fileExtension` so we are now removing the extension from the filename

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13355

#### Device Information
This PR was tested on: Android & iOS