### PR TITLE
MM-13361 Set Open Teams icons background to white

### DIFF
--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -317,7 +317,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 18,
         },
         imageContainer: {
-            backgroundColor: theme.centerChannelBg,
+            backgroundColor: '#FFF',
         },
         noTeam: {
             color: theme.centerChannelColor,


### PR DESCRIPTION
#### Summary
Make the background image of the Team Icon white in the Join other teams screen to be consistent with the webapp

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13361
