### PR TITLE
MM-13364 Fix text too light on dark themes in TextSetting widget

### DIFF
--- a/app/components/widgets/settings/text_setting.js
+++ b/app/components/widgets/settings/text_setting.js
@@ -185,7 +185,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderBottomWidth: 1,
             borderTopColor: changeOpacity(theme.centerChannelColor, 0.1),
             borderBottomColor: changeOpacity(theme.centerChannelColor, 0.1),
-            backgroundColor: '#fff',
+            backgroundColor: theme.centerChannelBg,
         },
         input: {
             ...input,


### PR DESCRIPTION
#### Summary
Use the theme channelColorBg instead of white cause the text was not visible on Darker Themes.

@jwilander I wonder if we should actually pass props for the backgroundColor and text Color for this component, I wasn't able to test it in the dialog screen, but if that screen is white this won't look good. Thoughts?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13364
