### PR TITLE
MM-13366 Post menu doesn't hint at more options below the fold

### DIFF
--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -395,7 +395,7 @@ export default class PostOptions extends PureComponent {
                     ref={this.refSlideUpPanel}
                     marginFromTop={marginFromTop}
                     onRequestClose={this.close}
-                    initialPosition={325}
+                    initialPosition={290}
                 >
                     {options}
                 </SlideUpPanel>


### PR DESCRIPTION
#### Summary
The post menu will now open with an initial position of 290 instead of 325 so the post menu hints that there are more options if the panel is dragged

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13366
