### PR TITLE
Hide Favorite channel section when there are not favorite channels

### DIFF
--- a/app/components/sidebars/main/channels_list/list/index.js
+++ b/app/components/sidebars/main/channels_list/list/index.js
@@ -46,7 +46,7 @@ function mapStateToProps(state) {
         sidebarPrefs.grouping,
         sidebarPrefs.sorting,
         sidebarPrefs.unreads_at_top === 'true',
-        sidebarPrefs.favorite_at_top === 'true',
+        sidebarPrefs.favorite_at_top === 'true' && favoriteChannelIds.length,
     ));
 
     return {


### PR DESCRIPTION
#### Summary
Check if there are favorite channels before showing the section in the channel sidebar

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13395