### PR TITLE
Properly check if link is an image when link is shortened

### DIFF
--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -489,7 +489,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
         }
 
         const isYouTube = isYoutubeLink(link);
-        const isImage = this.isImage();
+        const isImage = this.isImage(link);
         const isOpenGraph = Boolean(openGraphData);
 
         if (((isImage && !isOpenGraph) || isYouTube) && !linkLoadError) {


### PR DESCRIPTION
#### Summary
When post-metadata a shortened link was not displaying the image cause we checked if the link is an image but we were using the shortened one instead of the full location.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13356
