### PR TITLE
Fix edit profile image

### DIFF
--- a/app/components/attachment_button.js
+++ b/app/components/attachment_button.js
@@ -28,7 +28,8 @@ export default class AttachmentButton extends PureComponent {
         blurTextBox: PropTypes.func.isRequired,
         browseFileTypes: PropTypes.string,
         canBrowseFiles: PropTypes.bool,
-        canBrowseLibrary: PropTypes.bool,
+        canBrowsePhotoLibrary: PropTypes.bool,
+        canBrowseVideoLibrary: PropTypes.bool,
         canTakePhoto: PropTypes.bool,
         canTakeVideo: PropTypes.bool,
         children: PropTypes.node,
@@ -46,7 +47,8 @@ export default class AttachmentButton extends PureComponent {
     static defaultProps = {
         browseFileTypes: Platform.OS === 'ios' ? 'public.item' : '*/*',
         canBrowseFiles: true,
-        canBrowseLibrary: true,
+        canBrowsePhotoLibrary: true,
+        canBrowseVideoLibrary: true,
         canTakePhoto: true,
         canTakeVideo: true,
         maxFileCount: 5,
@@ -342,7 +344,8 @@ export default class AttachmentButton extends PureComponent {
     showFileAttachmentOptions = () => {
         const {
             canBrowseFiles,
-            canBrowseLibrary,
+            canBrowsePhotoLibrary,
+            canBrowseVideoLibrary,
             canTakePhoto,
             canTakeVideo,
             fileCount,
@@ -380,7 +383,7 @@ export default class AttachmentButton extends PureComponent {
             });
         }
 
-        if (canBrowseLibrary) {
+        if (canBrowsePhotoLibrary) {
             items.push({
                 action: () => this.handleFileAttachmentOption(this.attachFileFromLibrary),
                 text: {
@@ -389,17 +392,17 @@ export default class AttachmentButton extends PureComponent {
                 },
                 icon: 'photo',
             });
+        }
 
-            if (Platform.OS === 'android') {
-                items.push({
-                    action: () => this.handleFileAttachmentOption(this.attachVideoFromLibraryAndroid),
-                    text: {
-                        id: t('mobile.file_upload.video'),
-                        defaultMessage: 'Video Library',
-                    },
-                    icon: 'file-video-o',
-                });
-            }
+        if (canBrowseVideoLibrary && Platform.OS === 'android') {
+            items.push({
+                action: () => this.handleFileAttachmentOption(this.attachVideoFromLibraryAndroid),
+                text: {
+                    id: t('mobile.file_upload.video'),
+                    defaultMessage: 'Video Library',
+                },
+                icon: 'file-video-o',
+            });
         }
 
         if (canBrowseFiles) {

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -4,7 +4,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
-import {View} from 'react-native';
+import {Alert, View} from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 import {DocumentPickerUtil} from 'react-native-document-picker';
@@ -25,8 +25,9 @@ import ProfilePicture from 'app/components/profile_picture';
 import AttachmentButton from 'app/components/attachment_button';
 import mattermostBucket from 'app/mattermost_bucket';
 import LocalConfig from 'assets/config';
+import {getFormattedFileSize} from 'mattermost-redux/utils/file_utils';
 
-const MAX_SIZE = 20 * 1024;
+const MAX_SIZE = 20 * 1024 * 1024;
 const holders = {
     firstName: {
         id: t('user.settings.general.firstName'),
@@ -240,6 +241,19 @@ export default class EditProfile extends PureComponent {
                 break;
             }
         }
+    };
+
+    onShowFileSizeWarning = (filename) => {
+        const {formatMessage} = this.context.intl;
+        const fileSizeWarning = formatMessage({
+            id: 'file_upload.fileAbove',
+            defaultMessage: 'File above {max}MB cannot be uploaded: {filename}',
+        }, {
+            max: getFormattedFileSize({size: MAX_SIZE}),
+            filename,
+        });
+
+        Alert.alert(fileSizeWarning);
     };
 
     renderFirstNameSettings = () => {
@@ -492,11 +506,13 @@ export default class EditProfile extends PureComponent {
                                 blurTextBox={emptyFunction}
                                 browseFileTypes={DocumentPickerUtil.images()}
                                 canTakeVideo={false}
+                                canBrowseVideoLibrary={false}
                                 maxFileSize={MAX_SIZE}
                                 theme={theme}
                                 navigator={navigator}
                                 wrapper={true}
                                 uploadFiles={this.handleUploadProfileImage}
+                                onShowFileSizeWarning={this.onShowFileSizeWarning}
                             >
                                 <ProfilePicture
                                     userId={currentUser.id}


### PR DESCRIPTION
#### Summary
Three things got fixed with this PR:
1. File size was 20 Kb instead of 20 Mb
2. If the image to be set is larger than 20Mb now we show an alert box (instead of no feedback)
3. Disable video library for Android

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13365
