### PR TITLE
Fix copy markdown link

### DIFF
--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -108,7 +108,7 @@ export default class MarkdownLink extends PureComponent {
         }
     };
 
-    handleCopyURL = () => {
+    handleLinkCopy = () => {
         Clipboard.setString(this.props.href);
     };
 


### PR DESCRIPTION
#### Summary
Copying a link from Md was crashing the app