### PR TITLE
MM-13421 Fix channel sidebar sometimes using old permissions

### DIFF
--- a/app/components/sidebars/main/channels_list/list/list.js
+++ b/app/components/sidebars/main/channels_list/list/list.js
@@ -82,8 +82,8 @@ export default class List extends PureComponent {
         }
     }
 
-    getSectionConfigByType = (sectionType) => {
-        const {canCreatePrivateChannels} = this.props;
+    getSectionConfigByType = (props, sectionType) => {
+        const {canCreatePrivateChannels} = props;
 
         switch (sectionType) {
         case SidebarSectionTypes.UNREADS:
@@ -142,7 +142,7 @@ export default class List extends PureComponent {
 
         return orderedChannelIds.map((s, i) => {
             return {
-                ...this.getSectionConfigByType(s.type),
+                ...this.getSectionConfigByType(props, s.type),
                 data: s.items,
                 topSeparator: i !== 0,
                 bottomSeparator: s.items.length > 0,


### PR DESCRIPTION
When receiving new props, `buildSections` is called with the new props, but it would then call `getSectionConfigByType` which just uses `this.props`, so it wouldn't know to apply newly received permissions right away.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13421

#### Device Information
This PR was tested on: iOS Simulator (iPhone X, iOS 12.1)