### PR TITLE
MM-13431 Fix load more posts

### DIFF
--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -65,6 +65,9 @@ const ViewTypes = keyMirror({
     LOADING_POSTS: null,
     SET_LOAD_MORE_POSTS_VISIBLE: null,
 
+    SET_INITIAL_POST_COUNT: null,
+    INCREASE_POST_COUNT: null,
+
     RECEIVED_POSTS_FOR_CHANNEL_AT_TIME: null,
 
     SET_LAST_UPGRADE_CHECK: null,

--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -278,6 +278,25 @@ function postVisibility(state = {}, action) {
     }
 }
 
+function postCountInChannel(state = {}, action) {
+    switch (action.type) {
+    case ViewTypes.SET_INITIAL_POST_COUNT: {
+        const {channelId, count} = action.data;
+        const nextState = {...state};
+        nextState[channelId] = count;
+        return nextState;
+    }
+    case ViewTypes.INCREASE_POST_COUNT: {
+        const {channelId, count} = action.data;
+        const nextState = {...state};
+        nextState[channelId] += count;
+        return nextState;
+    }
+    default:
+        return state;
+    }
+}
+
 function loadingPosts(state = {}, action) {
     switch (action.type) {
     case ViewTypes.LOADING_POSTS: {
@@ -318,6 +337,7 @@ export default combineReducers({
     drafts,
     loading,
     refreshing,
+    postCountInChannel,
     postVisibility,
     loadingPosts,
     lastGetPosts,


### PR DESCRIPTION
#### Summary
Load more posts of a channel by determining the amount of posts shown regardless of how many are in the store.

We were loading more posts into the channel if the amount of posts that we had in `postsInChannel` was <= to the desired amount of posts that we wanted to show, BUT sometimes we had more posts in `postsInChannel` and they can actually be out of order, here we add a new reducer to keep track of the actual amount of loaded posts that we have for a channel and then if we need more from the server those get loaded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13431
