### PR TITLE
Post Menu initial position to show one option cut off

### DIFF
--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -9,6 +9,7 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import SlideUpPanel from 'app/components/slide_up_panel';
 import {BOTTOM_MARGIN} from 'app/components/slide_up_panel/slide_up_panel';
+import DeviceTypes from 'app/constants/device';
 
 import PostOption from './post_option';
 
@@ -387,6 +388,7 @@ export default class PostOptions extends PureComponent {
         const {deviceHeight} = this.props;
         const options = this.getPostOptions();
         const marginFromTop = deviceHeight - BOTTOM_MARGIN - ((options.length + 1) * OPTION_HEIGHT);
+        const initialPosition = DeviceTypes.IS_IPHONE_X ? 280 : 305;
 
         return (
             <View style={style.container}>
@@ -395,7 +397,7 @@ export default class PostOptions extends PureComponent {
                     ref={this.refSlideUpPanel}
                     marginFromTop={marginFromTop}
                     onRequestClose={this.close}
-                    initialPosition={290}
+                    initialPosition={initialPosition}
                 >
                     {options}
                 </SlideUpPanel>


### PR DESCRIPTION
#### Summary
on iPhone X family the initial position will be set at 280 and the rest of iOS and Android will be at 305 so one option is cutoff at the end of the option list to indicate that there are more options to be shown

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13366
