### PR TITLE
MM-13333 Fix minor alignment issue with reply thread indicator

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -383,9 +383,18 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         profilePictureContainer: {
             marginBottom: 5,
-            marginRight: 10,
             marginLeft: 12,
             marginTop: 10,
+
+            // to compensate STATUS_BUFFER in profile_picture component
+            ...Platform.select({
+                android: {
+                    marginRight: 11,
+                },
+                ios: {
+                    marginRight: 10,
+                },
+            }),
         },
         replyBar: {
             backgroundColor: theme.centerChannelColor,


### PR DESCRIPTION
#### Summary
Fix minor alignment issue with reply thread indicator
  * Add a pixel to margin right for profile_picture container
    to compensate status icon platform styles

Post with profile picture is always off by 1px in android not just the replyBar

#### Ticket Link
[MM-13333](https://mattermost.atlassian.net/browse/MM-13333)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [Android and IOS simulators] 

#### Screenshots
<img width="818" alt="screenshot 2018-12-13 at 3 03 33 am" src="https://user-images.githubusercontent.com/4973621/49900358-5a5d4400-fe84-11e8-81d6-d8937a7495e9.png">
