### PR TITLE
MM-13535/MM-13538 Fixes for duplicate text on message attachments and empty space

### DIFF
--- a/app/components/message_attachments/attachment_fields.js
+++ b/app/components/message_attachments/attachment_fields.js
@@ -66,16 +66,18 @@ export default class AttachmentFields extends PureComponent {
                     style={style.flex}
                     key={`attachment__field-${i}__${nrTables}`}
                 >
-                    <View
-                        style={style.headingContainer}
-                        key={`attachment__field-caption-${i}__${nrTables}`}
-                    >
-                        <View>
-                            <Text style={style.heading}>
-                                {field.title}
-                            </Text>
+                    {Boolean(field.title) && (
+                        <View
+                            style={style.headingContainer}
+                            key={`attachment__field-caption-${i}__${nrTables}`}
+                        >
+                            <View>
+                                <Text style={style.heading}>
+                                    {field.title}
+                                </Text>
+                            </View>
                         </View>
-                    </View>
+                    )}
                     <View
                         style={style.flex}
                         key={`attachment__field-${i}__${nrTables}`}

--- a/app/components/message_attachments/message_attachment.js
+++ b/app/components/message_attachments/message_attachment.js
@@ -97,7 +97,7 @@ export default class MessageAttachment extends PureComponent {
                         navigator={navigator}
                         onPermalinkPress={onPermalinkPress}
                         textStyles={textStyles}
-                        value={attachment.text || attachment.fallback}
+                        value={attachment.text}
                     />
                     <AttachmentFields
                         baseTextStyle={baseTextStyle}


### PR DESCRIPTION
#### Summary
This change fixes both (1) an issue where text was duplicated on message attachments  and (2) an empty space above the message would appear when the attachment did not have a "title" field

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13535
https://mattermost.atlassian.net/browse/MM-13538

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone X (iOS), Nexus 6 (Android)

#### Screenshots
![dupe attachement message](https://user-images.githubusercontent.com/1859611/49950742-02433380-febe-11e8-9ff7-46d7954d1a5a.png)