### PR TITLE
Show an alert box when the team could not be joined

### DIFF
--- a/app/screens/select_team/index.js
+++ b/app/screens/select_team/index.js
@@ -31,7 +31,6 @@ function mapStateToProps(state) {
         teamsRequest: state.requests.teams.getTeams,
         teams: Object.values(getJoinableTeams(state)).sort(sortTeams),
         currentChannelId: getCurrentChannelId(state),
-        joinTeamRequest: state.requests.teams.joinTeam,
     };
 }
 

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -51,7 +51,6 @@ export default class SelectTeam extends PureComponent {
         }).isRequired,
         currentChannelId: PropTypes.string,
         currentUrl: PropTypes.string.isRequired,
-        joinTeamRequest: PropTypes.object.isRequired,
         navigator: PropTypes.object,
         userWithoutTeams: PropTypes.bool,
         teams: PropTypes.array.isRequired,
@@ -80,11 +79,6 @@ export default class SelectTeam extends PureComponent {
 
         if (this.props.teams !== nextProps.teams) {
             this.buildData(nextProps);
-        }
-
-        if (this.props.joinTeamRequest.status !== RequestStatus.FAILURE &&
-            nextProps.joinTeamRequest.status === RequestStatus.FAILURE) {
-            Alert.alert('', nextProps.joinTeamRequest.error.message);
         }
     }
 
@@ -160,8 +154,9 @@ export default class SelectTeam extends PureComponent {
             markChannelAsRead(currentChannelId);
         }
 
-        const success = await joinTeam(team.invite_id, team.id);
-        if (!success) {
+        const {error} = await joinTeam(team.invite_id, team.id);
+        if (error) {
+            Alert.alert(error.message);
             this.setState({joining: false});
             return;
         }

--- a/app/screens/select_team/select_team.test.js
+++ b/app/screens/select_team/select_team.test.js
@@ -36,7 +36,6 @@ describe('SelectTeam', () => {
         actions,
         currentChannelId: 'someId',
         currentUrl: 'test',
-        joinTeamRequest: {},
         navigator: {
             setOnNavigatorEvent: jest.fn(),
         },


### PR DESCRIPTION
#### Summary
When joining a team failed, the app was "showing" the alert box but also errors out as after the request failed it continue to switch to the selected team even after it was unable to join.

We now await for the response and only if it succeeded we send the user to the channel screen, if not we just present the user with an alert box displaying the reason why it failed. 

Note: The actual bug described in the ticket no longer reproduces on server version 5.6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9220
