### PR TITLE
MM-11232 Fix table column width to better support wide tables 

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -364,9 +364,12 @@ export default class Markdown extends PureComponent {
         return rendered;
     };
 
-    renderTable = ({children}) => {
+    renderTable = ({children, numColumns}) => {
         return (
-            <MarkdownTable navigator={this.props.navigator}>
+            <MarkdownTable
+                navigator={this.props.navigator}
+                numColumns={numColumns}
+            >
                 {children}
             </MarkdownTable>
         );

--- a/app/components/markdown/markdown_table_cell/markdown_table_cell.js
+++ b/app/components/markdown/markdown_table_cell/markdown_table_cell.js
@@ -7,10 +7,13 @@ import {Text, View} from 'react-native';
 
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
+export const CELL_WIDTH = 100;
+
 export default class MarkdownTableCell extends React.PureComponent {
     static propTypes = {
         align: PropTypes.oneOf(['', 'left', 'center', 'right']),
         children: PropTypes.node,
+        isLastCell: PropTypes.bool,
         theme: PropTypes.object.isRequired,
     };
 
@@ -18,6 +21,9 @@ export default class MarkdownTableCell extends React.PureComponent {
         const style = getStyleSheet(this.props.theme);
 
         const cellStyle = [style.cell];
+        if (!this.props.isLastCell) {
+            cellStyle.push(style.cellRightBorder);
+        }
 
         let textStyle = null;
         if (this.props.align === 'center') {
@@ -40,11 +46,13 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         cell: {
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),
-            borderRightWidth: 1,
-            flex: 1,
+            width: CELL_WIDTH,
             justifyContent: 'flex-start',
             paddingHorizontal: 13,
             paddingVertical: 6,
+        },
+        cellRightBorder: {
+            borderRightWidth: 1,
         },
         alignCenter: {
             textAlign: 'center',

--- a/app/components/markdown/markdown_table_row/markdown_table_row.js
+++ b/app/components/markdown/markdown_table_row/markdown_table_row.js
@@ -22,16 +22,21 @@ export default class MarkdownTableRow extends React.PureComponent {
             rowStyle.push(style.rowBottomBorder);
         }
 
-        return <View style={rowStyle}>{this.props.children}</View>;
+        // Add an extra prop to the last cell so that it knows not to render a right border since the container
+        // will handle that
+        const children = React.Children.toArray(this.props.children);
+        children[children.length - 1] = React.cloneElement(children[children.length - 1], {
+            isLastCell: true,
+        });
+
+        return <View style={rowStyle}>{children}</View>;
     }
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         row: {
-            flex: 1,
             flexDirection: 'row',
-            justifyContent: 'flex-start',
         },
         rowBottomBorder: {
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),

--- a/app/screens/table/table.js
+++ b/app/screens/table/table.js
@@ -3,30 +3,19 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {ScrollView, StyleSheet} from 'react-native';
+import {ScrollView} from 'react-native';
 
 export default class Table extends React.PureComponent {
     static propTypes = {
         renderRows: PropTypes.func.isRequired,
+        tableWidth: PropTypes.number.isRequired,
     };
 
     render() {
         return (
-            <ScrollView
-                style={style.scrollContainer}
-                contentContainerStyle={style.container}
-            >
+            <ScrollView contentContainerStyle={{width: this.props.tableWidth}}>
                 {this.props.renderRows()}
             </ScrollView>
         );
     }
 }
-
-const style = StyleSheet.create({
-    scrollContainer: {
-        flex: 1,
-    },
-    container: {
-        flexDirection: 'row',
-    },
-});

--- a/app/screens/table/table.js
+++ b/app/screens/table/table.js
@@ -3,7 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {ScrollView} from 'react-native';
+import {
+    Platform,
+    ScrollView,
+} from 'react-native';
 
 export default class Table extends React.PureComponent {
     static propTypes = {
@@ -12,10 +15,27 @@ export default class Table extends React.PureComponent {
     };
 
     render() {
-        return (
-            <ScrollView contentContainerStyle={{width: this.props.tableWidth}}>
-                {this.props.renderRows()}
-            </ScrollView>
-        );
+        const content = this.props.renderRows();
+
+        let container;
+        if (Platform.OS === 'android') {
+            // On Android, ScrollViews can only handle one direction at once, so use two ScrollViews that go in
+            // different directions. This prevents diagonal scrolling, so only do it on Android when totally necessary.
+            container = (
+                <ScrollView>
+                    <ScrollView horizontal={true}>
+                        {content}
+                    </ScrollView>
+                </ScrollView>
+            );
+        } else {
+            container = (
+                <ScrollView contentContainerStyle={{width: this.props.tableWidth}}>
+                    {content}
+                </ScrollView>
+            );
+        }
+
+        return container;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2840,8 +2840,8 @@
       }
     },
     "commonmark-react-renderer": {
-      "version": "github:mattermost/commonmark-react-renderer#ea502501b1f2c31c6b3ff6d40eead2c808f40d42",
-      "from": "github:mattermost/commonmark-react-renderer#ea502501b1f2c31c6b3ff6d40eead2c808f40d42",
+      "version": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",
+      "from": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",
       "requires": {
         "in-publish": "^2.0.0",
         "lodash.assign": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@babel/runtime": "7.1.5",
     "analytics-react-native": "1.2.0",
     "commonmark": "github:mattermost/commonmark.js#d5a7a7bfb373778d3bfd4575962c10fb3f3909c6",
-    "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#ea502501b1f2c31c6b3ff6d40eead2c808f40d42",
+    "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",
     "deep-equal": "1.0.1",
     "fuse.js": "3.3.0",
     "intl": "1.2.5",


### PR DESCRIPTION
This makes it so that the columns in Markdown tables are a fixed width instead of fitting all columns into the available space so that tables with more columns be readable. A few things to note with this:
1. I'm unable to make the tables scroll horizontally in the post view as requested, but you can scroll horizontally once tapping on the table for the full view
2. When viewing the whole table, Android does not support diagonal scrolling so you can only scroll horizontally and then vertically. 
3. I've increased the max height of tables in the post list from 120 to 300 points

As part of this ticket, I've also made a small change to commonmark-react-renderer to make it so that the MarkdownTable component knows the number of rows and columns to be rendered. Those changes are here: https://github.com/mattermost/commonmark-react-renderer/commit/3a2ac19cab725ad28b170fdc1d397dddedcf87eb

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11232

#### Checklist
- Has UI changes

#### Device Information
This PR was tested on: iOS Simulator (iPhone X, iOS 12.1), Nexus 5 (Android 6.0)

#### Screenshots
New behaviour:
<img width="358" alt="screen shot 2018-12-13 at 6 15 07 pm" src="https://user-images.githubusercontent.com/3277310/50176261-ea5c1d00-02cc-11e9-8aba-698a76e82ba6.png">

Old behaviour:
<img width="372" alt="screen shot 2018-12-13 at 6 16 29 pm" src="https://user-images.githubusercontent.com/3277310/50176262-ec25e080-02cc-11e9-91e5-e42f13ff9b40.png">

