### PR TITLE
LHS use getSortedFavoriteChannelIds instead of getFavoriteChannelIds

### DIFF
--- a/app/components/sidebars/main/channels_list/list/index.js
+++ b/app/components/sidebars/main/channels_list/list/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 
 import {General} from 'mattermost-redux/constants';
 import {
-    getFavoriteChannelIds,
+    getSortedFavoriteChannelIds,
     getSortedUnreadChannelIds,
     getOrderedChannelIds,
 } from 'mattermost-redux/selectors/entities/channels';
@@ -39,7 +39,7 @@ function mapStateToProps(state) {
     const isSystemAdmin = checkIsSystemAdmin(roles);
     const sidebarPrefs = getSidebarPreferences(state);
     const unreadChannelIds = getSortedUnreadChannelIds(state, null);
-    const favoriteChannelIds = getFavoriteChannelIds(state);
+    const favoriteChannelIds = getSortedFavoriteChannelIds(state);
     const orderedChannelIds = filterZeroUnreads(getOrderedChannelIds(
         state,
         null,


### PR DESCRIPTION
#### Summary
When a favorite channel had an unread message it was displayed in the unread section and not in the favorite section. BUT if there was only one favorite channel with unread messages it was also keeping the favorite section empty. The reason for this is that `getFavoriteChannelIds` does not filter the channels in the unread section but `getSortedFavoriteChannelIds` does.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13517
