### PR TITLE
MM-13525 Fix alignment of jewel on channel drawer icon

### DIFF
--- a/app/components/__snapshots__/badge.test.js.snap
+++ b/app/components/__snapshots__/badge.test.js.snap
@@ -30,6 +30,7 @@ exports[`Badge should match snapshot 1`] = `
         "alignItems": "center",
         "flex": 1,
         "justifyContent": "center",
+        "marginBottom": -1,
       }
     }
   >

--- a/app/components/__snapshots__/badge.test.js.snap
+++ b/app/components/__snapshots__/badge.test.js.snap
@@ -45,7 +45,6 @@ exports[`Badge should match snapshot 1`] = `
             "color": "#145dbf",
             "fontSize": 10,
           },
-          Object {},
         ]
       }
     >

--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -96,13 +96,26 @@ export default class Badge extends PureComponent {
 
     renderText = () => {
         const {count} = this.props;
-        let text = count.toString();
-        const extra = {};
+        let unreadCount = null;
+        let unreadIndicator = null;
         if (count < 0) {
-            text = '•';
-
-            //the extra margin is to align to the center?
-            extra.marginBottom = 1;
+            unreadIndicator = (
+                <View
+                    style={[styles.text, this.props.countStyle]}
+                    onLayout={this.onLayout}
+                >
+                    <View style={[styles.unreadIndicator, {backgroundColor: this.props.countStyle.color}]}/>
+                </View>
+            );
+        } else {
+            unreadCount = (
+                <Text
+                    style={[styles.text, this.props.countStyle]}
+                    onLayout={this.onLayout}
+                >
+                    {count.toString()}
+                </Text>
+            );
         }
         return (
             <View
@@ -110,12 +123,8 @@ export default class Badge extends PureComponent {
                 style={[styles.badge, this.props.style, {opacity: 0}]}
             >
                 <View style={styles.wrapper}>
-                    <Text
-                        style={[styles.text, this.props.countStyle, extra]}
-                        onLayout={this.onLayout}
-                    >
-                        {text}
-                    </Text>
+                    {unreadCount}
+                    {unreadIndicator}
                 </View>
             </View>
         );
@@ -157,5 +166,14 @@ const styles = StyleSheet.create({
     text: {
         fontSize: 14,
         color: 'white',
+    },
+    unreadIndicator: {
+        height: 4,
+        width: 4,
+        backgroundColor: '#444',
+        position: 'absolute',
+        top: -1,
+        left: -2,
+        borderRadius: 4,
     },
 });

--- a/app/components/badge.js
+++ b/app/components/badge.js
@@ -162,6 +162,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         flex: 1,
         justifyContent: 'center',
+        marginBottom: -1,
     },
     text: {
         fontSize: 14,
@@ -171,9 +172,6 @@ const styles = StyleSheet.create({
         height: 4,
         width: 4,
         backgroundColor: '#444',
-        position: 'absolute',
-        top: -1,
-        left: -2,
         borderRadius: 4,
     },
 });

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {
     PanResponder,
-    Platform,
     TouchableOpacity,
     View,
 } from 'react-native';
@@ -133,8 +132,10 @@ class ChannelDrawerButton extends PureComponent {
                 style={style.container}
             >
                 <View style={[style.wrapper, {opacity: this.state.opacity}]}>
-                    {icon}
-                    {badge}
+                    <View>
+                        {icon}
+                        {badge}
+                    </View>
                 </View>
             </TouchableOpacity>
         );
@@ -159,22 +160,19 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             borderRadius: 10,
             borderWidth: 1,
             flexDirection: 'row',
-            left: 3,
+            left: -13,
             padding: 3,
             position: 'absolute',
             right: 0,
-            ...Platform.select({
-                android: {
-                    top: 10,
-                },
-                ios: {
-                    top: 5,
-                },
-            }),
+            top: -4,
+            justifyContent: 'center',
+            alignItems: 'center',
         },
         mention: {
             color: theme.mentionColor,
             fontSize: 10,
+            textAlign: 'center',
+            lineHeight: 12,
         },
     };
 });


### PR DESCRIPTION
#### Summary
Fixes the mention and unread jewel alignment on IOS tablets.
 
Badge component and unread components needs to be wrapped with a `</view>`  to keep styles relative to each other

#### Ticket Link
[MM-13525](https://mattermost.atlassian.net/browse/MM-13525)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: [Mobile and tablets emulators of both android and IOS] 

#### Screenshots

<img width="721" alt="screenshot 2018-12-21 at 2 32 53 pm" src="https://user-images.githubusercontent.com/4973621/50335141-6609d400-0530-11e9-9885-54dbb37e22c1.png">
<img width="450" alt="screenshot 2018-12-21 at 2 32 38 pm" src="https://user-images.githubusercontent.com/4973621/50335142-6609d400-0530-11e9-984d-457e7aae0e0c.png">
<img width="947" alt="screenshot 2018-12-21 at 2 28 23 pm" src="https://user-images.githubusercontent.com/4973621/50335143-6609d400-0530-11e9-80aa-5a6ef246a9d5.png">
<img width="645" alt="screenshot 2018-12-21 at 2 28 15 pm" src="https://user-images.githubusercontent.com/4973621/50335144-66a26a80-0530-11e9-8abe-48a48d82bac7.png">
<img width="933" alt="screenshot 2018-12-21 at 2 19 51 pm" src="https://user-images.githubusercontent.com/4973621/50335146-66a26a80-0530-11e9-9c74-7a5d383e17d6.png">
<img width="421" alt="screenshot 2018-12-21 at 2 19 39 pm" src="https://user-images.githubusercontent.com/4973621/50335148-66a26a80-0530-11e9-836e-244fa4a13a87.png">
<img width="1075" alt="screenshot 2018-12-21 at 2 15 38 pm" src="https://user-images.githubusercontent.com/4973621/50335149-673b0100-0530-11e9-96b6-3a19445c9097.png">
<img width="834" alt="screenshot 2018-12-21 at 2 15 29 pm" src="https://user-images.githubusercontent.com/4973621/50335150-673b0100-0530-11e9-830a-7b7e8436a22e.png">

