### PR TITLE
Add the onMessage handler when sso completes

### DIFF
--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -157,21 +157,20 @@ class SSO extends PureComponent {
 
     onNavigationStateChange = (navState) => {
         const {url} = navState;
-        const nextState = {};
+        const nextState = {
+            messagingEnabled: false,
+        };
         const parsed = urlParse(url);
 
         if (parsed.host.includes('.onelogin.com')) {
             nextState.jsCode = oneLoginFormScalingJS;
-        } else if (parsed.pathname === this.completedUrl && !parsed.query) {
+        } else if (parsed.pathname === this.completedUrl) {
             // To avoid `window.postMessage` conflicts in any of the SSO flows
-            // we enable the onMessage handler only When the webView navigates to the final SSO URL
-            // without including a query string in the url.
-            this.setState({messagingEnabled: true});
+            // we enable the onMessage handler only When the webView navigates to the final SSO URL.
+            nextState.messagingEnabled = true;
         }
 
-        if (Object.keys(nextState).length) {
-            this.setState(nextState);
-        }
+        this.setState(nextState);
     };
 
     onLoadEnd = (event) => {


### PR DESCRIPTION
#### Summary
Some OKTA deployments use `window.postMessage` internally to handle their own flow, maybe this is true with other SSO providers that we don't know about.

By adding the `onMessage` event handler we were hijacking the `postMessage` from OKTA thus it did not complete the flow needed.

With this PR we only set the `onMessage` handler when we've reached the final page for the login flow in the Mattermost server

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13570