### PR TITLE
Docker based Android build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ npm-debug.log
 .npminstall
 yarn-error.log
 .yarninstall
+.npm
 
 # BUCK
 buck-out/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 .PHONY: build build-ios build-android unsigned-ios unsigned-android
 .PHONY: build-pr can-build-pr prepare-pr
 .PHONY: test help
+.PHONY: fastlane
 
 POD := $(shell which pod 2> /dev/null)
 OS := $(shell sh -c 'uname -s 2>/dev/null')
@@ -20,6 +21,15 @@ node_modules: package.json
 
 	@echo Getting Javascript dependencies
 	@npm install
+
+fastlane:
+	@if ! [ $(shell which bundle 2> /dev/null) ]; then \
+		echo "bundle is not installed https://bundler.io"; \
+		exit 1; \
+	fi
+
+	@echo Installing fastlane
+	@cd fastlane && bundle install
 
 npm-ci: package.json
 	@if ! [ $(shell which npm 2> /dev/null) ]; then \
@@ -54,7 +64,7 @@ dist/assets: $(BASE_ASSETS) $(OVERRIDE_ASSETS)
 
 pre-run: | node_modules .podinstall dist/assets ## Installs dependencies and assets
 
-pre-build: | npm-ci .podinstall dist/assets ## Install dependencies and assets before building
+pre-build: | npm-ci fastlane .podinstall dist/assets ## Install dependencies and assets before building
 
 check-style: node_modules ## Runs eslint
 	@echo Checking for style guide compliance

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,61 @@
+FROM node:8-slim
+
+ENV ANDROID_SDK_TOOLS_VERSION   4333796
+ENV ANDROID_HOME                /opt/android
+ENV WATCHMAN_VERSION            4.9.0
+ENV PATH                        $ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$PATH
+
+RUN apt-get update && apt-get install -y \
+    wget \
+    unzip \
+    git \
+    procps \
+    # required by make build-android
+    bundler \
+    # required by fastlane
+    zlib1g-dev
+
+# Android SDK
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
+RUN mkdir -p /usr/share/man/man1 && apt-get install -y default-jre default-jdk
+RUN mkdir -p ${ANDROID_HOME} && cd ${ANDROID_HOME} && \
+    wget -q https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip && \
+    unzip sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip && \
+    rm -rf sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip
+RUN cd ${ANDROID_HOME}/tools && yes | ./bin/sdkmanager \
+    "build-tools;23.0.3" \
+    "build-tools;25.0.3" \
+    "build-tools;26.0.1" \
+    "emulator" \
+    "platform-tools" \
+    "extras;google;google_play_services"
+
+# Watchman
+RUN apt-get install -y \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    python-setuptools \
+    python-dev \
+    pkg-config \
+    g++ \
+    make
+RUN git clone https://github.com/facebook/watchman.git
+RUN cd watchman && \
+    git checkout v${WATCHMAN_VERSION} && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j $(nproc) && \
+    make install && \
+    cd .. && rm -rf watchman
+
+# react-native-cli
+RUN npm -g install react-native-cli
+
+# fastlane requires the en_us.UTF-8 locale
+RUN apt-get install -y locales-all locales
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8


### PR DESCRIPTION
#### Summary

Introduces a new - and simpler - way to build the Android app based on a Docker container.
The *only* required dependency is Docker. Everything else is installed in the provided Dockerfile.

The first step (has to be done only once) is to build the container image:

```bash
docker build docker -t mattermost-mobile
```

When the container image is built, the Android app can be built with a one liner:

```bash
docker run --rm -it -v $PWD:$PWD -w $PWD mattermost-mobile make build-android
```

To keep the NPM cache between builds to make the build process faster, one can use:

```bash
docker run --rm -it -v $PWD:$PWD -w $PWD -e NPM_CONFIG_CACHE=${PWD}/.npm mattermost-mobile make build-android
```

#### Ticket Link

NA

#### Checklist

- [X] Has *no* UI changes
- [X] Does *not* Includes text changes and localization file updates

#### Device Information

This PR was tested on:

* Ubuntu 18.04 64bit
* Docker version 18.09.0, build 4d60db4

It "should" work on other Docker-available platforms, such as Windows and OSX.

#### Screenshots

NA