### PR TITLE
Clicking username in read-only allows sending message

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -263,7 +263,8 @@ export default class Post extends PureComponent {
 
         const style = getStyleSheet(theme);
         const isReplyPost = this.isReplyPost();
-        const onUsernamePress = Config.ExperimentalUsernamePressIsMention ? this.autofillUserMention : this.viewUserProfile;
+        const onUsernamePress =
+            Config.ExperimentalUsernamePressIsMention && !channelIsReadOnly ? this.autofillUserMention : this.viewUserProfile;
         const mergeMessage = consecutivePost && !hasComments;
         const highlightFlagged = isFlagged && !skipFlaggedHeader;
         const hightlightPinned = post.is_pinned && !skipPinnedHeader;


### PR DESCRIPTION
#### Summary
This change addresses an issue where users viewing a read-only channel could press a user's name and the username would appear in the post textbox allowing the user to send a post. This applies to environments where config key `ExperimentalUsernamePressIsMention` is set to `true`. Instead of mentioning the user in the post textbox, pressing a user's name in a read-only channel will fallback to opening the user's profile detail screen.

#### Ticket Link
N/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone X (iOS), Nexus 6 (Android)