### PR TITLE
MM-13594 Fix other users status changes

### DIFF
--- a/app/actions/views/user.js
+++ b/app/actions/views/user.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import {getStatus} from 'mattermost-redux/actions/users';
+import {getStatus, getStatusesByIds, startPeriodicStatusUpdates} from 'mattermost-redux/actions/users';
 import {General} from 'mattermost-redux/constants';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
@@ -21,5 +21,18 @@ export function setCurrentUserStatus(isOnline) {
                 status: General.OFFLINE,
             },
         });
+    };
+}
+
+export function initUserStatuses() {
+    return (dispatch, getState) => {
+        const {statuses} = getState().entities.users || {};
+        const userIds = Object.keys(statuses);
+
+        if (userIds.length) {
+            dispatch(getStatusesByIds(userIds));
+        }
+
+        dispatch(startPeriodicStatusUpdates());
     };
 }

--- a/app/actions/views/user.test.js
+++ b/app/actions/views/user.test.js
@@ -7,12 +7,14 @@ import thunk from 'redux-thunk';
 import {UserTypes} from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
 
-import {setCurrentUserStatus} from 'app/actions/views/user';
+import {initUserStatuses, setCurrentUserStatus} from 'app/actions/views/user';
 
 const mockStore = configureStore([thunk]);
 
 jest.mock('mattermost-redux/actions/users', () => ({
     getStatus: (...args) => ({type: 'MOCK_GET_STATUS', args}),
+    getStatusesByIds: (...args) => ({type: 'MOCK_GET_STATUS_BY_IDS', args}),
+    startPeriodicStatusUpdates: () => ({type: 'MOCK_PERIODIC_STATUS_UPDATES'}),
 }));
 
 describe('Actions.Views.User', () => {
@@ -23,6 +25,11 @@ describe('Actions.Views.User', () => {
             entities: {
                 users: {
                     currentUserId: 'current-user-id',
+                    statuses: {
+                        'current-user-id': 'online',
+                        'another-user-id1': 'away',
+                        'another-user-id2': 'dnd',
+                    },
                 },
             },
         });
@@ -49,5 +56,16 @@ describe('Actions.Views.User', () => {
 
         await store.dispatch(setCurrentUserStatus(true));
         expect(store.getActions()).toEqual([action]);
+    });
+
+    test('should initialize the periodic status updates and get the current user statuses', () => {
+        const actionStatusByIds = {
+            type: 'MOCK_GET_STATUS_BY_IDS',
+            args: [['current-user-id', 'another-user-id1', 'another-user-id2']],
+        };
+        const actionPeriodicUpdates = {type: 'MOCK_PERIODIC_STATUS_UPDATES'};
+
+        store.dispatch(initUserStatuses());
+        expect(store.getActions()).toEqual([actionStatusByIds, actionPeriodicUpdates]);
     });
 });

--- a/app/components/network_indicator/index.js
+++ b/app/components/network_indicator/index.js
@@ -4,12 +4,15 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates, logout} from 'mattermost-redux/actions/users';
+import {stopPeriodicStatusUpdates, logout} from 'mattermost-redux/actions/users';
 import {init as initWebSocket, close as closeWebSocket} from 'mattermost-redux/actions/websocket';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
 import {connection} from 'app/actions/device';
-import {setCurrentUserStatus} from 'app/actions/views/user';
+import {
+    initUserStatuses as startPeriodicStatusUpdates,
+    setCurrentUserStatus,
+} from 'app/actions/views/user';
 import {getConnection, isLandscape} from 'app/selectors/device';
 
 import NetworkIndicator from './network_indicator';

--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -243,12 +243,13 @@ export default class NetworkIndicator extends PureComponent {
     };
 
     handleConnectionChange = ({hasInternet, serverReachable}) => {
-        const {connection} = this.props.actions;
+        const {connection, startPeriodicStatusUpdates} = this.props.actions;
 
         // On first run always initialize the WebSocket
         // if we have internet connection
         if (hasInternet && this.firstRun) {
             this.initializeWebSocket();
+            startPeriodicStatusUpdates();
             this.firstRun = false;
             return;
         }


### PR DESCRIPTION
#### Summary
on first run the `startPeriodicStatusUpdates` action was not being called, also changed it for a local action that will fetch the current status of the users when called before starting the periodic updates

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13594

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
