### PR TITLE
Handling nulls in getMyChannelMember

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -24,7 +24,7 @@ function makeMapStateToProps() {
 
     return (state, ownProps) => {
         const channel = ownProps.channel || getChannel(state, {id: ownProps.channelId});
-        const member = getMyChannelMember(state, channel.id) || {};
+        const member = getMyChannelMember(state, channel.id);
         const currentUserId = getCurrentUserId(state);
         const channelDraft = getDraftForChannel(state, channel.id);
 

--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -24,7 +24,7 @@ function makeMapStateToProps() {
 
     return (state, ownProps) => {
         const channel = ownProps.channel || getChannel(state, {id: ownProps.channelId});
-        const member = getMyChannelMember(state, channel.id);
+        const member = getMyChannelMember(state, channel.id) || {};
         const currentUserId = getCurrentUserId(state);
         const channelDraft = getDraftForChannel(state, channel.id);
 

--- a/app/screens/channel_peek/index.js
+++ b/app/screens/channel_peek/index.js
@@ -15,13 +15,13 @@ import ChannelPeek from './channel_peek';
 
 function mapStateToProps(state, ownProps) {
     const channelId = ownProps.channelId;
-    const myMember = getMyChannelMember(state, channelId) || {};
+    const myMember = getMyChannelMember(state, channelId);
 
     return {
         channelId,
         currentUserId: getCurrentUserId(state),
         postIds: getPostIdsInChannel(state, channelId),
-        lastViewedAt: myMember.last_viewed_at,
+        lastViewedAt: myMember && myMember.last_viewed_at,
         theme: getTheme(state),
     };
 }

--- a/app/screens/channel_peek/index.js
+++ b/app/screens/channel_peek/index.js
@@ -15,12 +15,13 @@ import ChannelPeek from './channel_peek';
 
 function mapStateToProps(state, ownProps) {
     const channelId = ownProps.channelId;
+    const myMember = getMyChannelMember(state, channelId) || {};
 
     return {
         channelId,
         currentUserId: getCurrentUserId(state),
         postIds: getPostIdsInChannel(state, channelId),
-        lastViewedAt: getMyChannelMember(state, channelId).last_viewed_at,
+        lastViewedAt: myMember.last_viewed_at,
         theme: getTheme(state),
     };
 }


### PR DESCRIPTION
#### Summary
As part of the migration to flow the getMyChannelMember will return `null`
instead of `{}`. This PR handle that properly.

The mattermost-redux change was made here: mattermost/mattermost-redux#749