### PR TITLE
MM-13654: Removes pin and delete longpress options from posts in arch…

### DIFF
--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -41,6 +41,8 @@ function mapStateToProps(state, ownProps) {
     let canAddReaction = true;
     let canEdit = false;
     let canEditUntil = -1;
+    let canDelete = true;
+    let canPin = true;
 
     if (hasNewPermissions(state)) {
         canAddReaction = haveIChannelPermission(state, {
@@ -52,6 +54,8 @@ function mapStateToProps(state, ownProps) {
 
     if (channelIsArchived) {
         canAddReaction = false;
+        canDelete = false;
+        canPin = false;
     } else {
         canEdit = canEditPost(state, config, license, currentTeamId, currentChannelId, currentUserId, post);
         if (canEdit && license.IsLicensed === 'true' &&
@@ -66,6 +70,8 @@ function mapStateToProps(state, ownProps) {
         canAddReaction,
         canEdit,
         canEditUntil,
+        canDelete,
+        canPin,
         currentTeamUrl: getCurrentTeamUrl(state),
         isMyPost: currentUserId === post.user_id,
         post,

--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -29,6 +29,7 @@ export default class PostOptions extends PureComponent {
         additionalOption: PropTypes.object,
         canAddReaction: PropTypes.bool,
         canDelete: PropTypes.bool,
+        canPin: PropTypes.bool,
         canEdit: PropTypes.bool,
         canEditUntil: PropTypes.number.isRequired,
         channelIsReadOnly: PropTypes.bool,
@@ -210,12 +211,18 @@ export default class PostOptions extends PureComponent {
         const actions = [
             this.getEditOption(),
             this.getFlagOption(),
-            this.getPinOption(),
             this.getAddReactionOption(),
             this.getCopyPermalink(),
             this.getCopyText(),
-            this.getDeleteOption(),
         ];
+
+        const {canDelete, canPin} = this.props;
+        if (canDelete) {
+            actions.push(this.getDeleteOption());
+        }
+        if (canPin) {
+            actions.push(this.getPinOption());
+        }
 
         return actions.filter((a) => a !== null);
     };

--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -217,11 +217,11 @@ export default class PostOptions extends PureComponent {
         ];
 
         const {canDelete, canPin} = this.props;
+        if (canPin) {
+            actions.splice(2, 0, this.getPinOption());
+        }
         if (canDelete) {
             actions.push(this.getDeleteOption());
-        }
-        if (canPin) {
-            actions.push(this.getPinOption());
         }
 
         return actions.filter((a) => a !== null);
@@ -231,12 +231,18 @@ export default class PostOptions extends PureComponent {
         const actions = [
             this.getFlagOption(),
             this.getAddReactionOption(),
-            this.getPinOption(),
             this.getCopyPermalink(),
             this.getCopyText(),
             this.getEditOption(),
-            this.getDeleteOption(),
         ];
+
+        const {canDelete, canPin} = this.props;
+        if (canPin) {
+            actions.splice(2, 0, this.getPinOption());
+        }
+        if (canDelete) {
+            actions.push(this.getDeleteOption());
+        }
 
         return actions.filter((a) => a !== null);
     };


### PR DESCRIPTION
#### Summary
Removes pin and delete longpress options from posts in archived channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13654

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
* iPhone X, iOS 12.1 emulator

#### Screenshots
![simulator screen shot - iphone x - 2019-01-08 at 10 33 53](https://user-images.githubusercontent.com/1149597/50840639-f28a0400-1330-11e9-82b2-986e23b6e273.png)
![simulator screen shot - iphone x - 2019-01-08 at 10 34 01](https://user-images.githubusercontent.com/1149597/50840640-f28a0400-1330-11e9-8fa8-204f644b41d7.png)
