### PR TITLE
MM-13666 Detect post as emoji only if not a codeblock

### DIFF
--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -46,7 +46,7 @@ function isEmoticon(text) {
 }
 
 export function hasEmojisOnly(message, customEmojis) {
-    if (!message || message.length === 0 || /^\s{4}/.test(message)) {
+    if (!message || message.length === 0 || (/^\s{4}/).test(message)) {
         return {isEmojiOnly: false, shouldRenderJumboEmoji: false};
     }
 

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -46,7 +46,7 @@ function isEmoticon(text) {
 }
 
 export function hasEmojisOnly(message, customEmojis) {
-    if (!message || message.length === 0 || message.search(/\S|$/) > 3) {
+    if (!message || message.length === 0 || /^\s{4}/.test(message)) {
         return {isEmojiOnly: false, shouldRenderJumboEmoji: false};
     }
 

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -46,7 +46,7 @@ function isEmoticon(text) {
 }
 
 export function hasEmojisOnly(message, customEmojis) {
-    if (!message || message.length === 0) {
+    if (!message || message.length === 0 || message.search(/\S|$/) > 3) {
         return {isEmojiOnly: false, shouldRenderJumboEmoji: false};
     }
 

--- a/app/utils/emoji_utils.test.js
+++ b/app/utils/emoji_utils.test.js
@@ -60,6 +60,10 @@ describe('hasEmojisOnly with named emojis', () => {
         name: 'Mixed valid and invalid named emojis',
         message: '   :smile:  invalid  :heart:   ',
         expected: {isEmojiOnly: false, shouldRenderJumboEmoji: false},
+    }, {
+        name: 'This should render a codeblock instead',
+        message: '    :D',
+        expected: {isEmojiOnly: false, shouldRenderJumboEmoji: false},
     }];
 
     const customEmojis = new Map([['valid_custom', 0]]);


### PR DESCRIPTION
#### Summary
If the post begins with 4 or more spaces treat is as a regular Markdown and not Emoji Only markdown

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13666

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
