### PR TITLE
[MM-13412 & MM-13711] Allow showing of all post options if possible to fit 75% of the screen height

### DIFF
--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -406,7 +406,7 @@ export default class PostOptions extends PureComponent {
                 <SlideUpPanel
                     allowStayMiddle={false}
                     ref={this.refSlideUpPanel}
-                    marginFromTop={marginFromTop}
+                    marginFromTop={marginFromTop > 0 ? marginFromTop : 0}
                     onRequestClose={this.close}
                     initialPosition={initialPosition}
                 >

--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -9,11 +9,9 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import SlideUpPanel from 'app/components/slide_up_panel';
 import {BOTTOM_MARGIN} from 'app/components/slide_up_panel/slide_up_panel';
-import DeviceTypes from 'app/constants/device';
 
+import {OPTION_HEIGHT, getInitialPosition} from './post_options_utils';
 import PostOption from './post_option';
-
-const OPTION_HEIGHT = 50;
 
 export default class PostOptions extends PureComponent {
     static propTypes = {
@@ -401,7 +399,7 @@ export default class PostOptions extends PureComponent {
         const {deviceHeight} = this.props;
         const options = this.getPostOptions();
         const marginFromTop = deviceHeight - BOTTOM_MARGIN - ((options.length + 1) * OPTION_HEIGHT);
-        const initialPosition = DeviceTypes.IS_IPHONE_X ? 280 : 305;
+        const initialPosition = getInitialPosition(deviceHeight, marginFromTop);
 
         return (
             <View style={style.container}>

--- a/app/screens/post_options/post_options_utils.js
+++ b/app/screens/post_options/post_options_utils.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const OPTION_HEIGHT = 50;
+const BOTTOM_HEIGHT = 18;
+export const MAX_INITIAL_POSITION_MULTIPLIER = 0.6;
+
+export function getInitialPosition(deviceHeight, marginFromTop) {
+    const computedSlidePanelHeight = deviceHeight - marginFromTop;
+    const maxInitialPosition = deviceHeight * MAX_INITIAL_POSITION_MULTIPLIER;
+
+    if (computedSlidePanelHeight <= maxInitialPosition) {
+        // Show all options to the user
+        return computedSlidePanelHeight;
+    }
+
+    const optionHeightWithBorder = OPTION_HEIGHT + 1;
+
+    // Partially show options to user with the first hidden option in mid appearance
+    // to indicate that are still option/s available on slide up
+    let adjustedInitialPosition = computedSlidePanelHeight - BOTTOM_HEIGHT - (optionHeightWithBorder / 2);
+    while (adjustedInitialPosition > maxInitialPosition) {
+        adjustedInitialPosition -= optionHeightWithBorder;
+    }
+
+    return adjustedInitialPosition;
+}

--- a/app/screens/post_options/post_options_utils.js
+++ b/app/screens/post_options/post_options_utils.js
@@ -3,7 +3,7 @@
 
 export const OPTION_HEIGHT = 50;
 const BOTTOM_HEIGHT = 18;
-export const MAX_INITIAL_POSITION_MULTIPLIER = 0.7;
+export const MAX_INITIAL_POSITION_MULTIPLIER = 0.75;
 
 export function getInitialPosition(deviceHeight, marginFromTop) {
     const computedSlidePanelHeight = deviceHeight - marginFromTop;

--- a/app/screens/post_options/post_options_utils.js
+++ b/app/screens/post_options/post_options_utils.js
@@ -3,7 +3,7 @@
 
 export const OPTION_HEIGHT = 50;
 const BOTTOM_HEIGHT = 18;
-export const MAX_INITIAL_POSITION_MULTIPLIER = 0.6;
+export const MAX_INITIAL_POSITION_MULTIPLIER = 0.7;
 
 export function getInitialPosition(deviceHeight, marginFromTop) {
     const computedSlidePanelHeight = deviceHeight - marginFromTop;

--- a/app/screens/post_options/post_options_utils.test.js
+++ b/app/screens/post_options/post_options_utils.test.js
@@ -15,8 +15,11 @@ describe('should match return value of getInitialPosition', () => {
             input: {deviceHeight: 600, marginFromTop: 50},
             output: 404.5,
         }, {
-            input: {deviceHeight: 1000, marginFromTop: 300},
-            output: 700,
+            input: {deviceHeight: 1000, marginFromTop: 250},
+            output: 750,
+        }, {
+            input: {deviceHeight: 1000, marginFromTop: 150},
+            output: 704.5,
         }, {
             input: {deviceHeight: 1000, marginFromTop: 400},
             output: 600,
@@ -31,7 +34,7 @@ describe('should match return value of getInitialPosition', () => {
             const initialPosition = getInitialPosition(input.deviceHeight, input.marginFromTop);
             expect(initialPosition).toEqual(output);
 
-            // should not exceed maximum initial position at 70% of screen height
+            // should not exceed maximum initial position at 75% of screen height
             expect(initialPosition).toBeLessThanOrEqual(maxInitialPosition);
         });
     }

--- a/app/screens/post_options/post_options_utils.test.js
+++ b/app/screens/post_options/post_options_utils.test.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getInitialPosition, MAX_INITIAL_POSITION_MULTIPLIER} from './post_options_utils';
+
+describe('should match return value of getInitialPosition', () => {
+    const testCases = [
+        {
+            input: {deviceHeight: 600, marginFromTop: 400},
+            output: 200,
+        }, {
+            input: {deviceHeight: 600, marginFromTop: 300},
+            output: 300,
+        }, {
+            input: {deviceHeight: 600, marginFromTop: 50},
+            output: 353.5,
+        }, {
+            input: {deviceHeight: 1000, marginFromTop: 300},
+            output: 554.5,
+        }, {
+            input: {deviceHeight: 1000, marginFromTop: 400},
+            output: 600,
+        },
+    ];
+
+    for (const testCase of testCases) {
+        const {input, output} = testCase;
+        const maxInitialPosition = input.deviceHeight * MAX_INITIAL_POSITION_MULTIPLIER;
+
+        test('should match initial position', () => {
+            const initialPosition = getInitialPosition(input.deviceHeight, input.marginFromTop);
+            expect(initialPosition).toEqual(output);
+
+            // should not exceed maximum initial position at 60% of screen height
+            expect(initialPosition).toBeLessThanOrEqual(maxInitialPosition);
+        });
+    }
+});

--- a/app/screens/post_options/post_options_utils.test.js
+++ b/app/screens/post_options/post_options_utils.test.js
@@ -13,10 +13,10 @@ describe('should match return value of getInitialPosition', () => {
             output: 300,
         }, {
             input: {deviceHeight: 600, marginFromTop: 50},
-            output: 353.5,
+            output: 404.5,
         }, {
             input: {deviceHeight: 1000, marginFromTop: 300},
-            output: 554.5,
+            output: 700,
         }, {
             input: {deviceHeight: 1000, marginFromTop: 400},
             output: 600,
@@ -31,7 +31,7 @@ describe('should match return value of getInitialPosition', () => {
             const initialPosition = getInitialPosition(input.deviceHeight, input.marginFromTop);
             expect(initialPosition).toEqual(output);
 
-            // should not exceed maximum initial position at 60% of screen height
+            // should not exceed maximum initial position at 70% of screen height
             expect(initialPosition).toBeLessThanOrEqual(maxInitialPosition);
         });
     }


### PR DESCRIPTION
#### Summary
- Allow showing of all post options if possible to fit 60% of the screen height
- If not, make the last viewable option partially show to indicate more options below on slide up

#### Ticket Link
Jira ticket: [MM-13412](https://mattermost.atlassian.net/browse/MM-13412)

Also added fix to: [MM-13711](https://mattermost.atlassian.net/browse/MM-13711)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

#### Screenshots
Small screen size, iPhone 5s - https://youtu.be/MsFR9mLG3YI
Big Screen size, iPhone x - https://youtu.be/_BfCrLw8acU

Small screen, Android Nexus 5 - https://youtu.be/QzxfNxaDOxA
Big screen, Android Nexus 5 - https://youtu.be/8Z-oy2-HtHo


