### PR TITLE
[MM-13439] Change "X" to "Cancel" on Profile page

### DIFF
--- a/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
+++ b/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
@@ -34,6 +34,12 @@ exports[`edit_profile should match snapshot 1`] = `
           "calls": Array [
             Array [
               Object {
+                "leftButtons": Array [
+                  Object {
+                    "id": "close-settings",
+                    "title": undefined,
+                  },
+                ],
                 "rightButtons": Array [
                   Object {
                     "disabled": true,

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -72,6 +72,10 @@ export default class EditProfile extends PureComponent {
         intl: intlShape,
     };
 
+    leftButton = {
+        id: 'close-settings',
+    };
+
     rightButton = {
         id: 'update-profile',
         disabled: true,
@@ -83,10 +87,13 @@ export default class EditProfile extends PureComponent {
 
         const {email, first_name: firstName, last_name: lastName, nickname, position, username} = props.currentUser;
         const buttons = {
+            leftButtons: [this.leftButton],
             rightButtons: [this.rightButton],
         };
 
+        this.leftButton.title = context.intl.formatMessage({id: 'mobile.account.settings.cancel', defaultMessage: 'Cancel'});
         this.rightButton.title = context.intl.formatMessage({id: 'mobile.account.settings.save', defaultMessage: 'Save'});
+
         props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
         props.navigator.setButtons(buttons);
 

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -125,6 +125,7 @@
   "mobile.account_notifications.threads_start": "Threads that I start",
   "mobile.account_notifications.threads_start_participate": "Threads that I start or participate in",
   "mobile.account.settings.save": "Save",
+  "mobile.account.settings.cancel": "Cancel",
   "mobile.action_menu.select": "Select an option",
   "mobile.action_menu.submitted": "Submitted",
   "mobile.advanced_settings.clockDisplay": "Clock display",


### PR DESCRIPTION
#### Summary

Changes the left button in the edit profile page to Cancel instead of the default close icon.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10078

#### Checklist
- [x] Added or updated unit tests
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone XR Simulator, iPhone X, 12.1.3 

#### Screenshots

<img width="522" alt="screen shot 2019-01-24 at 12 02 27 am" src="https://user-images.githubusercontent.com/2381136/51655650-97305680-1f6b-11e9-9a93-5ac3b124df77.png">