### PR TITLE
MM-13722 Reset application badge when there are no more mentions

### DIFF
--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -62,10 +62,8 @@ class ChannelDrawerButton extends PureComponent {
         EventEmitter.on('drawer_opacity', this.setOpacity);
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.mentionCount !== this.props.mentionCount) {
-            PushNotifications.setApplicationIconBadgeNumber(this.props.mentionCount);
-        }
+    componentDidUpdate() {
+        PushNotifications.setApplicationIconBadgeNumber(this.props.mentionCount);
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
#### Summary
This fixes an edge case when a new notification is received and the app is opened directly from the home icon instead of the notification.

Now the application badge is being set every time the mention count changes, when the mention count is equals to 0 the badge gets cleared along with every notification in the notification manager

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13722
