### PR TITLE
MM-13846 Alert boxes to follow UX Guidelines

### DIFF
--- a/app/components/attachment_button.js
+++ b/app/components/attachment_button.js
@@ -61,10 +61,10 @@ export default class AttachmentButton extends PureComponent {
     };
 
     attachPhotoFromCamera = () => {
-        return this.attachFileFromCamera('photo');
+        return this.attachFileFromCamera('photo', 'camera');
     };
 
-    attachFileFromCamera = async (mediaType) => {
+    attachFileFromCamera = async (mediaType, source) => {
         const {formatMessage} = this.context.intl;
         const options = {
             quality: 0.8,
@@ -92,7 +92,7 @@ export default class AttachmentButton extends PureComponent {
             },
         };
 
-        const hasPhotoPermission = await this.hasPhotoPermission();
+        const hasPhotoPermission = await this.hasPhotoPermission(source);
 
         if (hasPhotoPermission) {
             ImagePicker.launchCamera(options, (response) => {
@@ -141,7 +141,7 @@ export default class AttachmentButton extends PureComponent {
     };
 
     attachVideoFromCamera = () => {
-        return this.attachFileFromCamera('video');
+        return this.attachFileFromCamera('video', 'camera');
     };
 
     attachVideoFromLibraryAndroid = () => {
@@ -206,11 +206,11 @@ export default class AttachmentButton extends PureComponent {
         }
     };
 
-    hasPhotoPermission = async () => {
+    hasPhotoPermission = async (source) => {
         if (Platform.OS === 'ios') {
             const {formatMessage} = this.context.intl;
             let permissionRequest;
-            const hasPermissionToStorage = await Permissions.check('photo');
+            const hasPermissionToStorage = await Permissions.check(source || 'photo');
 
             switch (hasPermissionToStorage) {
             case PermissionTypes.UNDETERMINED:
@@ -295,13 +295,13 @@ export default class AttachmentButton extends PureComponent {
                         defaultMessage: 'To upload images from your Android device, please change your permission settings.',
                     }),
                     [
-                        grantOption,
                         {
                             text: formatMessage({
                                 id: 'mobile.android.permission_denied_dismiss',
                                 defaultMessage: 'Dismiss',
                             }),
                         },
+                        grantOption,
                     ]
                 );
                 return false;

--- a/app/screens/terms_of_service/terms_of_service.js
+++ b/app/screens/terms_of_service/terms_of_service.js
@@ -186,7 +186,7 @@ export default class TermsOfService extends PureComponent {
                         siteName,
                     }),
                     [{
-                        text: intl.formatMessage({id: 'mobile.terms_of_service.alert_ok', defaultMessage: 'Ok'}),
+                        text: intl.formatMessage({id: 'mobile.terms_of_service.alert_ok', defaultMessage: 'OK'}),
                         onPress: this.closeTermsAndLogout,
                     }],
                 );
@@ -221,11 +221,12 @@ export default class TermsOfService extends PureComponent {
                     defaultMessage: 'Unable to complete the request. If this issue persists, contact your System Administrator.',
                 }),
                 [{
+                    text: intl.formatMessage({id: 'mobile.terms_of_service.alert_cancel', defaultMessage: 'Cancel'}),
+                    style: 'cancel',
+                    onPress: this.closeTermsAndLogout,
+                }, {
                     text: intl.formatMessage({id: 'mobile.terms_of_service.alert_retry', defaultMessage: 'Try Again'}),
                     onPress: retry,
-                }, {
-                    text: intl.formatMessage({id: 'mobile.terms_of_service.alert_cancel', defaultMessage: 'Cancel'}),
-                    onPress: this.closeTermsAndLogout,
                 }],
             );
         }

--- a/app/utils/status.js
+++ b/app/utils/status.js
@@ -39,6 +39,7 @@ export function confirmOutOfOfficeDisabled(intl, status, updateStatus) {
         }, {status: translatedStatus}),
         [{
             text: intl.formatMessage({id: 'mobile.reset_status.alert_cancel', defaultMessage: 'Cancel'}),
+            style: 'cancel',
         }, {
             text: intl.formatMessage({id: 'mobile.reset_status.alert_ok', defaultMessage: 'OK'}),
             onPress: () => updateStatus(status),


### PR DESCRIPTION
#### Summary
Based on [Android Material Design](https://material.io/design/components/dialogs.html#anatomy) and [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/views/alerts/)

Alert boxes should have the most common action to take by the user to the right and if a cancel option is available it should always be at the left

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13846

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
