### PR TITLE
MM-13875 Fix user profile icon for a Webhook to follow the prop for use_user_icon

### DIFF
--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -23,8 +23,8 @@ function isConsecutivePost(state, ownProps) {
     let consecutivePost = false;
 
     if (previousPost) {
-        const postFromWebhook = Boolean(post.props && post.props.from_webhook);
-        const prevPostFromWebhook = Boolean(previousPost.props && previousPost.props.from_webhook);
+        const postFromWebhook = Boolean(post?.props?.from_webhook); // eslint-disable-line camelcase
+        const prevPostFromWebhook = Boolean(previousPost?.props?.from_webhook); // eslint-disable-line camelcase
         if (previousPost && previousPost.user_id === post.user_id &&
             post.create_at - previousPost.create_at <= Posts.POST_COLLAPSE_TIMEOUT &&
             !postFromWebhook && !prevPostFromWebhook &&

--- a/app/components/post_header/index.js
+++ b/app/components/post_header/index.js
@@ -36,12 +36,12 @@ function makeMapStateToProps() {
             createAt: post.create_at,
             displayName: displayUsername(user, teammateNameDisplay),
             enablePostUsernameOverride: config.EnablePostUsernameOverride === 'true',
-            fromWebHook: post.props && post.props.from_webhook === 'true',
+            fromWebHook: post?.props?.from_webhook === 'true', // eslint-disable-line camelcase
             militaryTime,
             isPendingOrFailedPost: isPostPendingOrFailed(post),
             isSystemMessage: isSystemMessage(post),
             fromAutoResponder: fromAutoResponder(post),
-            overrideUsername: post.props && post.props.override_username,
+            overrideUsername: post?.props?.override_username, // eslint-disable-line camelcase
             theme: getTheme(state),
             username: user.username,
             userTimezone,

--- a/app/components/post_profile_picture/index.js
+++ b/app/components/post_profile_picture/index.js
@@ -18,11 +18,11 @@ function mapStateToProps(state, ownProps) {
     const post = getPost(state, ownProps.postId);
 
     return {
-        enablePostIconOverride: config.EnablePostIconOverride === 'true',
-        fromWebHook: post.props && post.props.from_webhook === 'true',
+        enablePostIconOverride: config.EnablePostIconOverride === 'true' && post?.props?.use_user_icon === 'false', // eslint-disable-line camelcase
+        fromWebHook: post?.props?.from_webhook === 'true', // eslint-disable-line camelcase
         isSystemMessage: isSystemMessage(post),
         fromAutoResponder: fromAutoResponder(post),
-        overrideIconUrl: post.props && post.props.override_icon_url,
+        overrideIconUrl: post?.props?.override_icon_url, // eslint-disable-line camelcase
         userId: post.user_id,
         theme: getTheme(state),
     };

--- a/app/screens/notification/notification.js
+++ b/app/screens/notification/notification.js
@@ -72,7 +72,7 @@ export default class Notification extends PureComponent {
             />
         );
 
-        if (data.from_webhook && config.EnablePostIconOverride === 'true') {
+        if (data.from_webhook && config.EnablePostIconOverride === 'true' && data.use_user_icon !== 'true') {
             const wsIcon = data.override_icon_url ? {uri: data.override_icon_url} : webhookIcon;
             icon = (
                 <Image


### PR DESCRIPTION
#### Summary
When a Webhook is configured to use the user icon instead of the icon override but the server has the `EnablePostIconOverride` config set to true the icon used was the default icon instead. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13875
