### PR TITLE
[MM-10346] Set CSRF Token from Cookie after Login / on App load

### DIFF
--- a/app/actions/views/login.js
+++ b/app/actions/views/login.js
@@ -42,7 +42,7 @@ export function handleSuccessfulLogin() {
         const deviceToken = state.entities.general.deviceToken;
         const currentUserId = getCurrentUserId(state);
 
-        setCSRFFromCookie(url);
+        await setCSRFFromCookie(url);
         app.setAppCredentials(deviceToken, currentUserId, token, url);
 
         const enableTimezone = isTimezoneEnabled(state);

--- a/app/actions/views/login.js
+++ b/app/actions/views/login.js
@@ -12,6 +12,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {ViewTypes} from 'app/constants';
 import {app} from 'app/mattermost';
 import {getDeviceTimezone, isTimezoneEnabled} from 'app/utils/timezone';
+import {setCSRFFromCookie} from 'app/utils/security';
 
 export function handleLoginIdChanged(loginId) {
     return async (dispatch, getState) => {
@@ -41,6 +42,7 @@ export function handleSuccessfulLogin() {
         const deviceToken = state.entities.general.deviceToken;
         const currentUserId = getCurrentUserId(state);
 
+        setCSRFFromCookie(url);
         app.setAppCredentials(deviceToken, currentUserId, token, url);
 
         const enableTimezone = isTimezoneEnabled(state);

--- a/app/actions/views/login.test.js
+++ b/app/actions/views/login.test.js
@@ -17,6 +17,21 @@ jest.mock('app/mattermost', () => ({
     },
 }));
 
+jest.mock('react-native-cookies', () => ({
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    openURL: jest.fn(),
+    canOpenURL: jest.fn(),
+    getInitialURL: jest.fn(),
+    get: () => Promise.resolve(({
+        res: {
+            MMCSRF: {
+                value: 'the cookie',
+            },
+        },
+    })),
+}));
+
 const mockStore = configureStore([thunk]);
 
 describe('Actions.Views.Login', () => {

--- a/app/app.js
+++ b/app/app.js
@@ -17,6 +17,7 @@ import {getCurrentLocale} from 'app/selectors/i18n';
 import {getTranslations as getLocalTranslations} from 'app/i18n';
 import {store, handleManagedConfig} from 'app/mattermost';
 import avoidNativeBridge from 'app/utils/avoid_native_bridge';
+import {setCSRFFromCookie} from 'utils/security';
 
 const {Initialization} = NativeModules;
 
@@ -138,6 +139,7 @@ export default class App {
                         this.url = url;
                         Client4.setUrl(url);
                         Client4.setToken(token);
+                        setCSRFFromCookie(url);
                     } else {
                         this.waitForRehydration = true;
                     }

--- a/app/app.js
+++ b/app/app.js
@@ -139,7 +139,7 @@ export default class App {
                         this.url = url;
                         Client4.setUrl(url);
                         Client4.setToken(token);
-                        setCSRFFromCookie(url);
+                        await setCSRFFromCookie(url);
                     } else {
                         this.waitForRehydration = true;
                     }

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -143,6 +143,7 @@ const handleLogout = () => {
     // the Client online flag to true cause the network handler
     // is not available at this point
     Client4.setOnline(true);
+    Client4.setCSRF(null);
     store.dispatch(closeWebSocket(false));
 
     app.setAppStarted(true);

--- a/app/utils/security.js
+++ b/app/utils/security.js
@@ -6,10 +6,13 @@ import CookieManager from 'react-native-cookies';
 import urlParse from 'url-parse';
 
 export function setCSRFFromCookie(url) {
-    CookieManager.get(urlParse(url).origin, false).then((res) => {
-        const token = res.MMCSRF;
-        if (token) {
-            Client4.setCSRF(token?.value || token);
-        }
+    return new Promise((resolve) => {
+        CookieManager.get(urlParse(url).origin, false).then((res) => {
+            const token = res.MMCSRF;
+            if (token) {
+                Client4.setCSRF(token?.value || token);
+            }
+            resolve();
+        });
     });
 }

--- a/app/utils/security.js
+++ b/app/utils/security.js
@@ -9,7 +9,7 @@ export function setCSRFFromCookie(url) {
     CookieManager.get(urlParse(url).origin, false).then((res) => {
         const token = res.MMCSRF;
         if (token) {
-            Client4.setCSRF(res?.MMCSRF?.value || res?.MMCSRF);
+            Client4.setCSRF(token?.value || token);
         }
     });
 }

--- a/app/utils/security.js
+++ b/app/utils/security.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Client4} from 'mattermost-redux/client';
+import CookieManager from 'react-native-cookies';
+import urlParse from 'url-parse';
+
+export function setCSRFFromCookie(url) {
+    CookieManager.get(urlParse(url).origin, false).then((res) => {
+        const token = res.MMCSRF;
+        if (token) {
+            Client4.setCSRF(res?.MMCSRF?.value || res?.MMCSRF);
+        }
+    });
+}


### PR DESCRIPTION
#### Summary
This sets the CSRF token after login / after page load in the Client4, which is returned as part of the login flow from the server.

**Note:** This was tested on Android only, I would appreciate some testing on iOS.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10346

**Redux:** https://github.com/mattermost/mattermost-redux/pull/753
**Server:** https://github.com/mattermost/mattermost-server/pull/10067

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) 

#### Device Information
This PR was tested on: Android Emulator (9.0)
