### PR TITLE
Enable tapping on channels when jump to textfield is focused.

### DIFF
--- a/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
+++ b/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
@@ -9,6 +9,7 @@ import {
     Text,
     TouchableHighlight,
     View,
+    Platform,
 } from 'react-native';
 import {injectIntl, intlShape} from 'react-intl';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -396,7 +397,7 @@ class FilteredList extends Component {
                     renderItem={this.renderItem}
                     keyExtractor={(item) => item.id}
                     onViewableItemsChanged={this.updateUnreadIndicators}
-                    keyboardDismissMode='interactive'
+                    keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
                     keyboardShouldPersistTaps='always'
                     maxToRenderPerBatch={10}
                     viewabilityConfig={VIEWABILITY_CONFIG}

--- a/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
+++ b/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
@@ -399,6 +399,7 @@ class FilteredList extends Component {
                     keyboardDismissMode='on-drag'
                     maxToRenderPerBatch={10}
                     viewabilityConfig={VIEWABILITY_CONFIG}
+                    keyboardShouldPersistTaps='handled'
                 />
             </View>
         );

--- a/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
+++ b/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
@@ -396,10 +396,10 @@ class FilteredList extends Component {
                     renderItem={this.renderItem}
                     keyExtractor={(item) => item.id}
                     onViewableItemsChanged={this.updateUnreadIndicators}
-                    keyboardDismissMode='on-drag'
+                    keyboardDismissMode='interactive'
+                    keyboardShouldPersistTaps='always'
                     maxToRenderPerBatch={10}
                     viewabilityConfig={VIEWABILITY_CONFIG}
-                    keyboardShouldPersistTaps='handled'
                 />
             </View>
         );


### PR DESCRIPTION
#### Summary
This pull request enables tapping on channels while the "Jump to ..." field is in focus by specifying the correct property setting on the FlatList component. Previously, tapping on a channel only dismissed the keyboard and required tapping the channel again. The specified property also allows tapping off of channels to just dismiss the keyboard without loading a channel.

#### Ticket Link
[MM-13649](https://mattermost.atlassian.net/browse/MM-13649)

#### Checklist
n/a

#### Device Information
This PR was tested on: iPhone 7 Plus (iOS 12.1.3), iPhone X simulator (iOS 12.1),  Android Pixel 2 emulator (Android 8.1.0)

#### Screenshots
n/a
