### PR TITLE
MM-13859 set the auth token when fetching images from the server

### DIFF
--- a/app/store/index.js
+++ b/app/store/index.js
@@ -8,12 +8,14 @@ import {createTransform, persistStore} from 'redux-persist';
 
 import {ErrorTypes, GeneralTypes} from 'mattermost-redux/action_types';
 import {General, RequestStatus} from 'mattermost-redux/constants';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import configureStore from 'mattermost-redux/store';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {NavigationTypes, ViewTypes} from 'app/constants';
 import appReducer from 'app/reducers';
 import {throttle} from 'app/utils/general';
+import {getSiteUrl, setSiteUrl} from 'app/utils/image_cache_manager';
 import {createSentryMiddleware} from 'app/utils/sentry/middleware';
 
 import mattermostBucket from 'app/mattermost_bucket';
@@ -187,6 +189,12 @@ export default function configureAppStore(initialState) {
             // check to see if the logout request was successful
             store.subscribe(async () => {
                 const state = store.getState();
+                const config = getConfig(state);
+
+                if (config?.SiteURL && getSiteUrl() !== config?.SiteURL) {
+                    setSiteUrl(config.SiteURL);
+                }
+
                 if ((state.requests.users.logout.status === RequestStatus.SUCCESS || state.requests.users.logout.status === RequestStatus.FAILURE) && !purging) {
                     purging = true;
 
@@ -211,6 +219,7 @@ export default function configureAppStore(initialState) {
                     mattermostBucket.removePreference('cert', Config.AppGroupId);
                     mattermostBucket.removePreference('emm', Config.AppGroupId);
                     mattermostBucket.removeFile('entities', Config.AppGroupId);
+                    setSiteUrl(null);
 
                     setTimeout(() => {
                         purging = false;

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -191,7 +191,7 @@ export default function configureAppStore(initialState) {
                 const state = store.getState();
                 const config = getConfig(state);
 
-                if (config?.SiteURL && getSiteUrl() !== config?.SiteURL) {
+                if (getSiteUrl() !== config?.SiteURL) {
                     setSiteUrl(config.SiteURL);
                 }
 

--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -6,7 +6,11 @@
 import {Platform} from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 
+import {Client4} from 'mattermost-redux/client';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
 import {DeviceTypes} from 'app/constants';
+import {store} from 'app/mattermost';
 import mattermostBucket from 'app/mattermost_bucket';
 
 import LocalConfig from 'assets/config';
@@ -41,7 +45,14 @@ export default class ImageCacheManager {
                         certificate,
                     };
 
-                    this.downloadTask = await RNFetchBlob.config(options).fetch('GET', uri);
+                    const serverConfig = getConfig(store.getState());
+                    const headers = {};
+                    if (uri.includes(Client4.getUrl()) || uri.includes(serverConfig.SiteURL)) {
+                        headers.Authorization = `Bearer ${Client4.getToken()}`;
+                        headers['X-Requested-With'] = 'XMLHttpRequest';
+                    }
+
+                    this.downloadTask = await RNFetchBlob.config(options).fetch('GET', uri, headers);
                     if (this.downloadTask.respInfo.respType === 'text') {
                         throw new Error();
                     }

--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -7,15 +7,14 @@ import {Platform} from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 
 import {Client4} from 'mattermost-redux/client';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {DeviceTypes} from 'app/constants';
-import {store} from 'app/mattermost';
 import mattermostBucket from 'app/mattermost_bucket';
 
 import LocalConfig from 'assets/config';
 
 const {IMAGES_PATH} = DeviceTypes;
+let siteUrl;
 
 export default class ImageCacheManager {
     static listeners = {};
@@ -45,9 +44,9 @@ export default class ImageCacheManager {
                         certificate,
                     };
 
-                    const serverConfig = getConfig(store.getState());
+                    // const serverConfig = getConfig(store.getState());
                     const headers = {};
-                    if (uri.includes(Client4.getUrl()) || uri.includes(serverConfig.SiteURL)) {
+                    if (uri.includes(Client4.getUrl()) || uri.includes(siteUrl)) {
                         headers.Authorization = `Bearer ${Client4.getToken()}`;
                         headers['X-Requested-With'] = 'XMLHttpRequest';
                     }
@@ -88,6 +87,14 @@ export const getCacheFile = async (name, uri) => {
 
     const exists = await RNFetchBlob.fs.exists(path);
     return {exists, path};
+};
+
+export const getSiteUrl = () => {
+    return siteUrl;
+};
+
+export const setSiteUrl = (url) => {
+    siteUrl = url;
 };
 
 const isDownloading = (uri) => Boolean(ImageCacheManager.listeners[uri]);

--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -44,7 +44,6 @@ export default class ImageCacheManager {
                         certificate,
                     };
 
-                    // const serverConfig = getConfig(store.getState());
                     const headers = {};
                     if (uri.includes(Client4.getUrl()) || uri.includes(siteUrl)) {
                         headers.Authorization = `Bearer ${Client4.getToken()}`;


### PR DESCRIPTION
#### Summary
The endpoint fetch images through the push proxy needs to be Authorized either by using the cookie or the Authorization header. The image proxy uses the **SiteURL** config setting to set the base URL of the image. In our community/daily deployment the *SiteURL* is set to `https://community.mattermost.com` so when connecting the mobile app to `community-daily` the Cookie will not be use to Authenticate the request thus we need to make sure we set the header correctly to allow the request. This could happen in other deployments if they use the same strategy that we have in community/daily.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13859