### PR TITLE
MM-13866 Never ending loader if app is un authenticated

### DIFF
--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -63,7 +63,7 @@ export default class ExtensionPost extends PureComponent {
         actions: PropTypes.shape({
             getTeamChannels: PropTypes.func.isRequired,
         }).isRequired,
-        channelId: PropTypes.string.isRequired,
+        channelId: PropTypes.string,
         currentUserId: PropTypes.string.isRequired,
         maxFileSize: PropTypes.number.isRequired,
         navigation: PropTypes.object.isRequired,
@@ -325,8 +325,9 @@ export default class ExtensionPost extends PureComponent {
                 });
             }
 
-            this.setState({error, files, value, hasPermission: true, totalSize, loaded: true});
+            this.setState({error, files, value, hasPermission: true, totalSize});
         }
+        this.setState({loaded: true});
     };
 
     onClose = (data) => {


### PR DESCRIPTION
#### Summary
`loaded` flag is used for showing loader and is only set to true if token and url are present. If app is unauthenticated then the flag never becomes true showing an infinite loader. 

Irrespective of token and url set flag to true at the end of function as async calls will also be completed.

#### Ticket Link
[MM-13866](https://mattermost.atlassian.net/browse/MM-13866)

#### Device Information
This PR was tested on: [Android emulator running 8.0] 

#### Screenshots
<img width="360" alt="screenshot 2019-01-31 at 3 05 58 am" src="https://user-images.githubusercontent.com/4973621/52014292-2d80f100-2505-11e9-9a7a-d0c3e0922a1c.png">
