### PR TITLE
[MM-13839] Remove possibility to change eMail within mobile app

### DIFF
--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -362,7 +362,7 @@ export default class EditProfile extends PureComponent {
         if (currentUser.auth_service === '') {
             helpText = formatMessage({
                 id: 'user.settings.general.emailCantUpdate',
-                defaultMessage: 'Email cannot be updated using the mobile app. Please use the web or desktop app.',
+                defaultMessage: 'Email cannot be updated within the mobile app. Please use the web or desktop app.',
             });
         } else {
             switch (currentUser.auth_service) {

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -354,21 +354,17 @@ export default class EditProfile extends PureComponent {
 
     renderEmailSettings = () => {
         const {formatMessage} = this.context.intl;
-        const {config, currentUser, theme} = this.props;
+        const {currentUser, theme} = this.props;
         const {email} = this.state;
 
         let helpText;
-        let disabled = false;
 
-        if (config.SendEmailNotifications !== 'true') {
-            disabled = true;
+        if (currentUser.auth_service === '') {
             helpText = formatMessage({
-                id: 'user.settings.general.emailHelp1',
-                defaultMessage: 'Email is used for sign-in, notifications, and password reset. Email requires verification if changed.',
+                id: 'user.settings.general.emailCantUpdate',
+                defaultMessage: 'Email cannot be updated using the mobile app. Please use the web or desktop app.',
             });
-        } else if (currentUser.auth_service !== '') {
-            disabled = true;
-
+        } else {
             switch (currentUser.auth_service) {
             case 'gitlab':
                 helpText = formatMessage({
@@ -406,7 +402,7 @@ export default class EditProfile extends PureComponent {
         return (
             <View>
                 <TextSetting
-                    disabled={disabled}
+                    disabled={true}
                     id='email'
                     label={holders.email}
                     disabledText={helpText}

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -362,7 +362,7 @@ export default class EditProfile extends PureComponent {
         if (currentUser.auth_service === '') {
             helpText = formatMessage({
                 id: 'user.settings.general.emailCantUpdate',
-                defaultMessage: 'Email cannot be updated within the mobile app. Please use the web or desktop app.',
+                defaultMessage: 'Email must be updated using a web client or desktop application.',
             });
         } else {
             switch (currentUser.auth_service) {

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -522,6 +522,7 @@
   "user.settings.display.normalClock": "12-hour clock (example: 4:00 PM)",
   "user.settings.display.preferTime": "Select how you prefer time displayed.",
   "user.settings.general.email": "Email",
+  "user.settings.general.emailCantUpdate": "Email cannot be updated within the mobile app. Please use the web or desktop app.",
   "user.settings.general.emailGitlabCantUpdate": "Login occurs through GitLab. Email cannot be updated. Email address used for notifications is {email}.",
   "user.settings.general.emailGoogleCantUpdate": "Login occurs through Google. Email cannot be updated. Email address used for notifications is {email}.",
   "user.settings.general.emailHelp1": "Email is used for sign-in, notifications, and password reset. Email requires verification if changed.",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -522,7 +522,7 @@
   "user.settings.display.normalClock": "12-hour clock (example: 4:00 PM)",
   "user.settings.display.preferTime": "Select how you prefer time displayed.",
   "user.settings.general.email": "Email",
-  "user.settings.general.emailCantUpdate": "Email cannot be updated within the mobile app. Please use the web or desktop app.",
+  "user.settings.general.emailCantUpdate": "Email must be updated using a web client or desktop application.",
   "user.settings.general.emailGitlabCantUpdate": "Login occurs through GitLab. Email cannot be updated. Email address used for notifications is {email}.",
   "user.settings.general.emailGoogleCantUpdate": "Login occurs through Google. Email cannot be updated. Email address used for notifications is {email}.",
   "user.settings.general.emailHelp1": "Email is used for sign-in, notifications, and password reset. Email requires verification if changed.",


### PR DESCRIPTION
#### Summary
This PR removes the possibility to change the eMail within the app, since with https://github.com/mattermost/mattermost-server/pull/10207 we will require the password being submitted as part of an eMail update request. 

CC @crspeller 

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-13839

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: Android Emulator (9.0)

#### Screenshots
![image](https://user-images.githubusercontent.com/5972329/52019244-7927a080-24ed-11e9-8d0d-5552dcabd889.png)

