### PR TITLE
MM-13897 preserve iOS push notifications when opening the app

### DIFF
--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -152,6 +152,8 @@ class PushNotification {
     clearChannelNotifications(channelId) {
         NotificationsIOS.getDeliveredNotifications((notifications) => {
             const ids = [];
+            let badgeCount = notifications.length;
+
             for (let i = 0; i < notifications.length; i++) {
                 const notification = notifications[i];
 
@@ -161,8 +163,11 @@ class PushNotification {
             }
 
             if (ids.length) {
+                badgeCount -= ids.length;
                 NotificationsIOS.removeDeliveredNotifications(ids);
             }
+
+            this.setApplicationIconBadgeNumber(badgeCount);
         });
     }
 }

--- a/app/screens/channel/channel.js
+++ b/app/screens/channel/channel.js
@@ -86,6 +86,10 @@ export default class Channel extends PureComponent {
         } else {
             this.props.actions.selectDefaultTeam();
         }
+
+        if (this.props.currentChannelId) {
+            PushNotifications.clearChannelNotifications(this.props.currentChannelId);
+        }
     }
 
     componentDidMount() {

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button.js
@@ -13,7 +13,6 @@ import {
 import Icon from 'react-native-vector-icons/Ionicons';
 
 import Badge from 'app/components/badge';
-import PushNotifications from 'app/push_notifications';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {preventDoubleTap} from 'app/utils/tap';
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
@@ -59,10 +58,6 @@ class ChannelDrawerButton extends PureComponent {
 
     componentDidMount() {
         EventEmitter.on('drawer_opacity', this.setOpacity);
-    }
-
-    componentDidUpdate() {
-        PushNotifications.setApplicationIconBadgeNumber(this.props.mentionCount);
     }
 
     componentWillUnmount() {

--- a/ios/Mattermost/AppDelegate.m
+++ b/ios/Mattermost/AppDelegate.m
@@ -115,7 +115,7 @@ NSString* const NotificationClearAction = @"clear";
     [self cleanNotificationsFromChannel:channelId andUpdateBadge:NO];
   } else if (state == UIApplicationStateInactive) {
     // When the notification is opened
-    [self cleanNotificationsFromChannel:channelId andUpdateBadge:YES];
+    [self cleanNotificationsFromChannel:channelId andUpdateBadge:NO];
   }
 
   [RNNotifications didReceiveRemoteNotification:userInfo];


### PR DESCRIPTION
#### Summary
Previously we were using the `ChannelDrawerButton` lifecycle to set the badge for the app icon, but if for any reason the `mentionCount` was **0** all the previous notifications got cleared.

Now instead we use the function that clears the notifications for a specific channel to calculate the the badge count based on the remaining notifications.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13897