### PR TITLE
Fix previewing doc files more than once on Android

### DIFF
--- a/app/components/file_attachment_list/file_attachment_document.js
+++ b/app/components/file_attachment_list/file_attachment_document.js
@@ -267,12 +267,18 @@ export default class FileAttachmentDocument extends PureComponent {
                                 }),
                             }]
                         );
-                        this.setStatusBarColor();
+                        this.onDonePreviewingFile();
                         RNFetchBlob.fs.unlink(path);
                     }
 
                     this.setState({downloading: false, progress: 0});
                 });
+
+                // Android does not trigger the event for DoneButtonEvent
+                // so we'll wait 4 seconds before enabling the tap for open the preview again
+                if (Platform.OS === 'android') {
+                    setTimeout(this.onDonePreviewingFile, 4000);
+                }
             }
         }, delay);
     };


### PR DESCRIPTION
#### Summary
After the initial fix android was not previewing a document file more than once. the reason for it is because the library that we use do not have a handler for `DoneButtonEvent` so we are going to wait for 4 seconds before enabling the option.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13665