### PR TITLE
MM-14470 Android - App does not launch on deep link click when app is backgrou…

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
@@ -1,7 +1,10 @@
 package com.mattermost.rnbeta;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+
 import com.reactnativenavigation.controllers.SplashActivity;
 
 public class MainActivity extends SplashActivity {
@@ -18,10 +21,15 @@ public class MainActivity extends SplashActivity {
          * 5. Causing an unnecessary app restart
          * 6. This solution short-circuits the restart
          */
-        if (!isTaskRoot()) {
+
+        if (!isTaskRoot() && !intentHasDeepLink(getIntent())) {
             finish();
             return;
         }
+    }
+
+    public Boolean intentHasDeepLink(Intent intent) {
+        return intent != null && intent.getData() != null;
     }
 
     @Override

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -477,6 +477,14 @@ if (startedSharedExtension || fromPushNotification) {
     });
 }
 
+if (Platform.OS === 'android') {
+    new NativeEventsReceiver().appLaunched(() => {
+        if (app.appStarted) {
+            launchChannel();
+        }
+    });
+}
+
 if (!app.appStarted) {
     launchEntry();
 }


### PR DESCRIPTION
#### Summary
(Android only) Fixes an issue where, when the app is backgrounded (not closed) and a valid deep link is clicked, the app will not launch and immediately show the user to the post or channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14470

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: Nexus 6 (Android)