### PR TITLE
Don't show confusing versioning message in "Check for Updates" screen…

### DIFF
--- a/app/components/client_upgrade_listener/client_upgrade_listener.js
+++ b/app/components/client_upgrade_listener/client_upgrade_listener.js
@@ -14,8 +14,8 @@ import {intlShape} from 'react-intl';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import FormattedText from 'app/components/formatted_text';
-import {DeviceTypes, UpgradeTypes} from 'app/constants';
-import checkUpgradeType from 'app/utils/client_upgrade';
+import {DeviceTypes} from 'app/constants';
+import {checkUpgradeType, isUpgradeAvailable} from 'app/utils/client_upgrade';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 const {View: AnimatedView} = Animated;
@@ -70,7 +70,7 @@ export default class ClientUpgradeListener extends PureComponent {
         if (versionMismatch && (forceUpgrade || Date.now() - lastUpgradeCheck > UPDATE_TIMEOUT)) {
             this.checkUpgrade(minVersion, latestVersion, nextProps.isLandscape);
         } else if (this.props.isLandscape !== nextProps.isLandscape &&
-            this.state.upgradeType !== UpgradeTypes.NO_UPGRADE && DeviceTypes.IS_IPHONE_X) {
+            isUpgradeAvailable(this.state.upgradeType) && DeviceTypes.IS_IPHONE_X) {
             const newTop = nextProps.isLandscape ? 45 : 100;
             this.setState({top: new Animated.Value(newTop)});
         }
@@ -83,7 +83,7 @@ export default class ClientUpgradeListener extends PureComponent {
 
         this.setState({upgradeType});
 
-        if (upgradeType === UpgradeTypes.NO_UPGRADE) {
+        if (!isUpgradeAvailable(upgradeType)) {
             return;
         }
 
@@ -166,7 +166,7 @@ export default class ClientUpgradeListener extends PureComponent {
     };
 
     render() {
-        if (this.state.upgradeType === UpgradeTypes.NO_UPGRADE) {
+        if (!isUpgradeAvailable(this.state.upgradeType)) {
             return null;
         }
 

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -7,6 +7,7 @@ export const UpgradeTypes = {
     CAN_UPGRADE: 'can_upgrade',
     MUST_UPGRADE: 'must_upgrade',
     NO_UPGRADE: 'no_upgrade',
+    IS_BETA: 'is_beta',
 };
 
 export const SidebarSectionTypes = {

--- a/app/screens/client_upgrade/client_upgrade.js
+++ b/app/screens/client_upgrade/client_upgrade.js
@@ -17,7 +17,7 @@ import FormattedText from 'app/components/formatted_text';
 import StatusBar from 'app/components/status_bar';
 import {UpgradeTypes} from 'app/constants';
 import logo from 'assets/images/logo.png';
-import checkUpgradeType from 'app/utils/client_upgrade';
+import {checkUpgradeType, isUpgradeAvailable} from 'app/utils/client_upgrade';
 import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/utils/theme';
 
 export default class ClientUpgrade extends PureComponent {
@@ -203,6 +203,7 @@ export default class ClientUpgrade extends PureComponent {
             break;
         default:
         case UpgradeTypes.NO_UPGRADE:
+        case UpgradeTypes.IS_BETA:
             messageComponent = this.renderNoUpgrade();
             break;
         }
@@ -210,14 +211,16 @@ export default class ClientUpgrade extends PureComponent {
         return (
             <View style={styles.messageContainer}>
                 {messageComponent}
-                <FormattedText
-                    id='mobile.client_upgrade.current_version'
-                    defaultMessage='Lastest Version: {version}'
-                    style={styles.messageSubtitle}
-                    values={{
-                        version: latestVersion,
-                    }}
-                />
+                {upgradeType !== UpgradeTypes.IS_BETA && (
+                    <FormattedText
+                        id='mobile.client_upgrade.current_version'
+                        defaultMessage='Lastest Version: {version}'
+                        style={styles.messageSubtitle}
+                        values={{
+                            version: latestVersion,
+                        }}
+                    />
+                )}
                 <FormattedText
                     id='mobile.client_upgrade.latest_version'
                     defaultMessage='Your Version: {version}'
@@ -226,7 +229,7 @@ export default class ClientUpgrade extends PureComponent {
                         version: currentVersion,
                     }}
                 />
-                {upgradeType !== UpgradeTypes.NO_UPGRADE &&
+                {isUpgradeAvailable(this.state.upgradeType) &&
                     <View>
                         <TouchableOpacity
                             onPress={this.handleDownload}

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -25,12 +25,11 @@ import {Client4} from 'mattermost-redux/client';
 
 import ErrorText from 'app/components/error_text';
 import FormattedText from 'app/components/formatted_text';
-import {UpgradeTypes} from 'app/constants';
 import fetchConfig from 'app/fetch_preconfig';
 import mattermostBucket from 'app/mattermost_bucket';
 import PushNotifications from 'app/push_notifications';
 import {GlobalStyles} from 'app/styles';
-import checkUpgradeType from 'app/utils/client_upgrade';
+import {checkUpgradeType, isUpgradeAvailable} from 'app/utils/client_upgrade';
 import {isValidUrl, stripTrailingSlashes} from 'app/utils/url';
 import {preventDoubleTap} from 'app/utils/tap';
 import tracker from 'app/utils/time_tracker';
@@ -102,10 +101,10 @@ export default class SelectServer extends PureComponent {
                 this.props.actions.setLastUpgradeCheck();
                 const {currentVersion, minVersion, latestVersion} = nextProps;
                 const upgradeType = checkUpgradeType(currentVersion, minVersion, latestVersion);
-                if (upgradeType === UpgradeTypes.NO_UPGRADE) {
-                    this.handleLoginOptions(nextProps);
-                } else {
+                if (isUpgradeAvailable(upgradeType)) {
                     this.handleShowClientUpgrade(upgradeType);
+                } else {
+                    this.handleLoginOptions(nextProps);
                 }
             } else {
                 this.handleLoginOptions(nextProps);

--- a/app/utils/client_upgrade.js
+++ b/app/utils/client_upgrade.js
@@ -6,11 +6,13 @@ import {UpgradeTypes} from 'app/constants';
 
 import LocalConfig from 'assets/config';
 
-export default function checkUpgradeType(currentVersion, minVersion, latestVersion, logError) {
+export function checkUpgradeType(currentVersion, minVersion, latestVersion, logError) {
     let upgradeType = UpgradeTypes.NO_UPGRADE;
 
     try {
-        if (minVersion && semver.lt(currentVersion, minVersion)) {
+        if (semver.gt(currentVersion, latestVersion)) {
+            upgradeType = UpgradeTypes.IS_BETA;
+        } else if (minVersion && semver.lt(currentVersion, minVersion)) {
             upgradeType = UpgradeTypes.MUST_UPGRADE;
         } else if (latestVersion && semver.lt(currentVersion, latestVersion)) {
             if (LocalConfig.EnableForceMobileClientUpgrade) {
@@ -24,4 +26,11 @@ export default function checkUpgradeType(currentVersion, minVersion, latestVersi
     }
 
     return upgradeType;
+}
+
+export function isUpgradeAvailable(upgradeType) {
+    return [
+        UpgradeTypes.CAN_UPGRADE,
+        UpgradeTypes.MUST_UPGRADE,
+    ].includes(upgradeType);
 }


### PR DESCRIPTION
#### Summary
This change addresses a User Experience related issue where the "Check for Updates" screen shows a confusing message indicating that your installed version is higher than the latest available version. This occurs when a user has installed a testing or pre-release version of the app or in instances where the mobile app is updated and released and the server/platform config has not yet updated to reflect the latest mobile release. In these cases the "Latest Version" will no longer be shown on the "Check for Updates" screen.

#### Ticket Link
N/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: Nexus 6 (Android), iPhone X (iOS)

#### Screenshots
![confusingreleasemessage](https://user-images.githubusercontent.com/20302757/52372317-80830880-2a1d-11e9-8020-287917eef486.png)