### PR TITLE
MM-13337 Fix EMM connections using VPN on-demand

### DIFF
--- a/app/fetch_preconfig.js
+++ b/app/fetch_preconfig.js
@@ -38,7 +38,15 @@ Client4.doFetchWithResponse = async (url, options) => {
     }
 
     const customHeaders = LocalConfig.CustomRequestHeaders;
-    let requestOptions = Client4.getOptions(options);
+    let waitsForConnectivity = false;
+    if (url.includes('/api/v4/system/ping')) {
+        waitsForConnectivity = true;
+    }
+    let requestOptions = {
+        ...Client4.getOptions(options),
+        waitsForConnectivity,
+    };
+
     if (customHeaders && Object.keys(customHeaders).length > 0) {
         requestOptions = {
             ...requestOptions,

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -321,6 +321,7 @@ export default class SelectServer extends PureComponent {
         });
 
         Client4.setUrl(url);
+        Client4.online = true;
         handleServerUrlChanged(url);
 
         let cancel = false;

--- a/app/utils/network.js
+++ b/app/utils/network.js
@@ -26,6 +26,7 @@ export async function checkConnection(isConnected) {
     const config = {
         timeout: PING_TIMEOUT,
         auto: true,
+        waitsForConnectivity: true,
     };
 
     if (Platform.OS === 'ios' && certificate === '') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12358,8 +12358,8 @@
       }
     },
     "rn-fetch-blob": {
-      "version": "github:enahum/react-native-fetch-blob#8fef0771d9ce921cb9cf66c696cb98356742d20d",
-      "from": "github:enahum/react-native-fetch-blob#8fef0771d9ce921cb9cf66c696cb98356742d20d",
+      "version": "github:enahum/react-native-fetch-blob#1f370ab3616101d4ffe919e0b58cbe4ef319ce5d",
+      "from": "github:enahum/react-native-fetch-blob#1f370ab3616101d4ffe919e0b58cbe4ef319ce5d",
       "requires": {
         "base-64": "0.1.0",
         "glob": "7.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12358,8 +12358,8 @@
       }
     },
     "rn-fetch-blob": {
-      "version": "github:enahum/react-native-fetch-blob#20d1c07ef34ba18be485a1f56cd2261158e93f69",
-      "from": "github:enahum/react-native-fetch-blob#20d1c07ef34ba18be485a1f56cd2261158e93f69",
+      "version": "github:enahum/react-native-fetch-blob#8fef0771d9ce921cb9cf66c696cb98356742d20d",
+      "from": "github:enahum/react-native-fetch-blob#8fef0771d9ce921cb9cf66c696cb98356742d20d",
       "requires": {
         "base-64": "0.1.0",
         "glob": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "redux-persist-transform-filter": "0.0.18",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "rn-fetch-blob": "github:enahum/react-native-fetch-blob#20d1c07ef34ba18be485a1f56cd2261158e93f69",
+    "rn-fetch-blob": "github:enahum/react-native-fetch-blob#8fef0771d9ce921cb9cf66c696cb98356742d20d",
     "rn-placeholder": "github:enahum/rn-placeholder#bfee66eb54f1f06d1425a0ad511a5e16559bf82c",
     "semver": "5.6.0",
     "shallow-equals": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "redux-persist-transform-filter": "0.0.18",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "rn-fetch-blob": "github:enahum/react-native-fetch-blob#8fef0771d9ce921cb9cf66c696cb98356742d20d",
+    "rn-fetch-blob": "github:enahum/react-native-fetch-blob#1f370ab3616101d4ffe919e0b58cbe4ef319ce5d",
     "rn-placeholder": "github:enahum/rn-placeholder#bfee66eb54f1f06d1425a0ad511a5e16559bf82c",
     "semver": "5.6.0",
     "shallow-equals": "1.0.0",


### PR DESCRIPTION
#### Summary
When iOS devices are enrolled with an EMM provider that has a setup to use an on-demand VPN in the actual VPN is not connected by the time the Mattermost app is opened, the first connection (ping) will always fail. This causes the users not to be able to connect to the server until the VPN is manually connected.

With this PR we added an option called [waitsForConnectivity](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/2908812-waitsforconnectivity?language=objc) only available in iOS 11+ that will wait until the VPN actually connects. The default timeout is **7 days** but I've changed it to be 10 seconds.

The actual fix that adds the above explain property is [here in our react-native-fetch-blob fork](https://github.com/enahum/react-native-fetch-blob/tree/8fef0771d9ce921cb9cf66c696cb98356742d20d)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13337

