### PR TITLE
[MM 13720] Fix for "No internet connection" banner not always showing

### DIFF
--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -68,7 +68,7 @@ export default class NetworkIndicator extends PureComponent {
         super(props);
 
         this.state = {
-            opacity: 0
+            opacity: 0,
         };
 
         const navBar = this.getNavBarHeight(props.isLandscape);
@@ -183,7 +183,7 @@ export default class NetworkIndicator extends PureComponent {
         ]).start(() => {
             this.backgroundColor.setValue(0);
             this.setState({
-                opacity: 0
+                opacity: 0,
             });
         });
     };
@@ -256,10 +256,11 @@ export default class NetworkIndicator extends PureComponent {
             this.initializeWebSocket();
             startPeriodicStatusUpdates();
             this.firstRun = false;
+
             // if the state of the internet connection was previously known to be false,
             // don't exit connection handler in order for application to register it has
             // reconnected to the internet
-            if(this.hasInternet !== false){
+            if (this.hasInternet !== false) {
                 return;
             }
         }
@@ -327,7 +328,7 @@ export default class NetworkIndicator extends PureComponent {
 
     show = () => {
         this.setState({
-            opacity: 1
+            opacity: 1,
         });
 
         Animated.timing(

--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -67,9 +67,12 @@ export default class NetworkIndicator extends PureComponent {
     constructor(props) {
         super(props);
 
+        this.state = {
+            opacity: 0
+        };
+
         const navBar = this.getNavBarHeight(props.isLandscape);
         this.top = new Animated.Value(navBar - HEIGHT);
-        this.opacity = 0;
         this.clearNotificationTimeout = null;
 
         this.backgroundColor = new Animated.Value(0);
@@ -179,7 +182,9 @@ export default class NetworkIndicator extends PureComponent {
             ),
         ]).start(() => {
             this.backgroundColor.setValue(0);
-            this.opacity = 0;
+            this.setState({
+                opacity: 0
+            });
         });
     };
 
@@ -316,7 +321,9 @@ export default class NetworkIndicator extends PureComponent {
     };
 
     show = () => {
-        this.opacity = 1;
+        this.setState({
+            opacity: 1
+        });
 
         Animated.timing(
             this.top, {
@@ -376,7 +383,7 @@ export default class NetworkIndicator extends PureComponent {
         }
 
         return (
-            <Animated.View style={[styles.container, {top: this.top, backgroundColor: background, opacity: this.opacity}]}>
+            <Animated.View style={[styles.container, {top: this.top, backgroundColor: background, opacity: this.state.opacity}]}>
                 <Animated.View style={styles.wrapper}>
                     <FormattedText
                         defaultMessage={defaultMessage}

--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -256,7 +256,12 @@ export default class NetworkIndicator extends PureComponent {
             this.initializeWebSocket();
             startPeriodicStatusUpdates();
             this.firstRun = false;
-            return;
+            // if the state of the internet connection was previously known to be false,
+            // don't exit connection handler in order for application to register it has
+            // reconnected to the internet
+            if(this.hasInternet !== false){
+                return;
+            }
         }
 
         // Prevent for being called more than once.


### PR DESCRIPTION
#### Summary
Fixes the UI for the "No internet connection" banner not showing. Turns out the app was successfully detecting the connection toggling, however, the UI didn't show because a property (`opacity`) setting the opacity wasn't triggering render on the component and so remained hidden until the next render was triggered.

This PR converts the `opacity` properly into a component prop, allowing RN to detect changes and re-render the component as needed.

This PR also fixes a case where the app doesn't recognize the connection coming back if it was launched while the device is offline.

#### Ticket Link
[MM-13720](https://mattermost.atlassian.net/projects/MM/issues/MM-13720)

#### Checklist
n/a

#### Device Information
This PR was tested on: iPhone 7 Plus (iOS 12.1.3), iPhone X Simulator (iOS 12.1), Android Pixel 2 Emulator (Android 8.1.0)

#### Screenshots
n/a