### PR TITLE
MM-14001 Don't mount PostBodyAdditionalContent for system messages

### DIFF
--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -236,7 +236,21 @@ export default class PostBody extends PureComponent {
     }
 
     renderPostAdditionalContent = (blockStyles, messageStyle, textStyles) => {
-        const {isReplyPost, message, navigator, onHashtagPress, onPermalinkPress, postId, postProps, metadata} = this.props;
+        const {
+            isReplyPost,
+            isSystemMessage,
+            message,
+            metadata,
+            navigator,
+            onHashtagPress,
+            onPermalinkPress,
+            postId,
+            postProps,
+        } = this.props;
+
+        if (isSystemMessage) {
+            return null;
+        }
 
         if (metadata && !metadata.embeds) {
             return null;

--- a/app/components/post_body/post_body.test.js
+++ b/app/components/post_body/post_body.test.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {Preferences} from 'mattermost-redux/constants';
+
+import PostBodyAdditionalContent from 'app/components/post_body_additional_content';
+import {shallowWithIntl} from 'test/intl-test-helper';
+
+import PostBody from './post_body.js';
+
+describe('PostBody', () => {
+    const baseProps = {
+        canDelete: true,
+        channelIsReadOnly: false,
+        deviceHeight: 1920,
+        fileIds: [],
+        hasBeenDeleted: false,
+        hasBeenEdited: false,
+        hasReactions: false,
+        highlight: false,
+        isFailed: false,
+        isFlagged: false,
+        isPending: false,
+        isPostAddChannelMember: false,
+        isPostEphemeral: false,
+        isReplyPost: false,
+        isSearchResult: false,
+        isSystemMessage: false,
+        managedConfig: {},
+        message: 'Hello, World!',
+        navigator: {},
+        onFailedPostPress: jest.fn(),
+        onHashtagPress: jest.fn(),
+        onPermalinkPress: jest.fn(),
+        onPress: jest.fn(),
+        postId: 'post',
+        postProps: {},
+        postType: '',
+        replyBarStyle: [],
+        showAddReaction: true,
+        showLongPost: true,
+        isEmojiOnly: false,
+        shouldRenderJumboEmoji: false,
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should mount additional content for non-system messages', () => {
+        const props = {
+            ...baseProps,
+            isSystemMessage: false,
+        };
+
+        const wrapper = shallowWithIntl(<PostBody {...props}/>);
+
+        expect(wrapper.find(PostBodyAdditionalContent).exists()).toBeTruthy();
+    });
+
+    test('should not mount additional content for system messages', () => {
+        const props = {
+            ...baseProps,
+            isSystemMessage: true,
+        };
+
+        const wrapper = shallowWithIntl(<PostBody {...props}/>);
+
+        expect(wrapper.find(PostBodyAdditionalContent).exists()).toBeFalsy();
+    });
+});


### PR DESCRIPTION
The web app has the `PostAttachmentOpenGraph` component not mount for system messages, but I didn't want to pass `isSystemMessage` all the way down to it. I also couldn't think of any cases where `PostBodyAdditionalContent` would be needed for a system message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14001

#### Checklist
- [Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator