### PR TITLE
MM-13428 Opening channels with unreads has loading indicator placed above unread messages line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8381,8 +8381,8 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#8faa9faf1b46e788a6fd3a43679c92c6fa4f84fb",
-      "from": "github:mattermost/mattermost-redux#8faa9faf1b46e788a6fd3a43679c92c6fa4f84fb",
+      "version": "github:mattermost/mattermost-redux#a8d240b0d464d1e467a04bb9bacac710342e9c8a",
+      "from": "github:mattermost/mattermost-redux#a8d240b0d464d1e467a04bb9bacac710342e9c8a",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "intl": "1.2.5",
     "jail-monkey": "1.0.0",
     "jsc-android": "236355.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#8faa9faf1b46e788a6fd3a43679c92c6fa4f84fb",
+    "mattermost-redux": "github:mattermost/mattermost-redux#a8d240b0d464d1e467a04bb9bacac710342e9c8a",
     "mime-db": "1.37.0",
     "moment-timezone": "0.5.23",
     "prop-types": "15.6.2",


### PR DESCRIPTION
#### Summary
Uses https://github.com/mattermost/mattermost-redux/pull/735 hash for fixing Opening channels with unreads has loading indicator placed above unread messages line

#### Ticket Link
[MM-13428](https://mattermost.atlassian.net/browse/MM-13428)
