### PR TITLE
MM-14055: Load the channel even if not joining.

### DIFF
--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -311,9 +311,9 @@ export default class Permalink extends PureComponent {
         if (!channelId) {
             const focusedPost = post.data && post.data.posts ? post.data.posts[focusedPostId] : null;
             focusChannelId = focusedPost ? focusedPost.channel_id : '';
-            if (focusChannelId && !this.props.myMembers[focusChannelId]) {
+            if (focusChannelId) {
                 const {data: channel} = await actions.getChannel(focusChannelId);
-                if (channel && channel.type === General.OPEN_CHANNEL) {
+                if (!this.props.myMembers[focusChannelId] && channel && channel.type === General.OPEN_CHANNEL) {
                     await actions.joinChannel(currentUserId, channel.team_id, channel.id);
                 }
             }


### PR DESCRIPTION
#### Summary
Load channel from server if it doesn't exist in Redux even if not joining.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14055

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
* iPhone X, iOS 12.1 (emulator)

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]