### PR TITLE
[MM 13934] Prevent blank mention keys from crashing the app

### DIFF
--- a/app/components/markdown/transform.js
+++ b/app/components/markdown/transform.js
@@ -314,7 +314,7 @@ export function getFirstMention(str, mentionKeys) {
         const pattern = new RegExp(`\\b${escapeRegex(mention.key)}_*\\b`, flags);
 
         const match = pattern.exec(str);
-        if (!match) {
+        if (!match || match[0] === '') {
             continue;
         }
 

--- a/app/components/markdown/transform.js
+++ b/app/components/markdown/transform.js
@@ -310,6 +310,10 @@ export function getFirstMention(str, mentionKeys) {
     let firstMentionIndex = -1;
 
     for (const mention of mentionKeys) {
+        if (mention.key === '') {
+            continue;
+        }
+
         const flags = mention.caseSensitive ? '' : 'i';
         const pattern = new RegExp(`\\b${escapeRegex(mention.key)}_*\\b`, flags);
 

--- a/app/components/markdown/transform.js
+++ b/app/components/markdown/transform.js
@@ -310,7 +310,7 @@ export function getFirstMention(str, mentionKeys) {
     let firstMentionIndex = -1;
 
     for (const mention of mentionKeys) {
-        if (mention.key === '') {
+        if (mention.key.trim() === '') {
             continue;
         }
 

--- a/app/components/markdown/transform.test.js
+++ b/app/components/markdown/transform.test.js
@@ -2758,6 +2758,11 @@ describe('Components.Markdown.transform', () => {
             input: 'apple banana orange',
             mentionKeys: [{key: '*\\3_.'}],
             expected: {index: -1, mention: null},
+        }, {
+            name: 'no blank mention keys',
+            input: 'apple banana orange',
+            mentionKeys: [{key: ''}],
+            expected: {index: -1, mention: null},
         }];
 
         for (const test of tests) {


### PR DESCRIPTION
#### Summary
A blank mention key would cause the app to try to match, via regex, the boundary of every word character for every post for the current channel. This PR prevents blank matches from being considered as valid mentions, preventing the app from trying to make every word boundary character into a match and crashing in the process.

#### Ticket Link
[MM-13934](https://mattermost.atlassian.net/projects/MM/issues/MM-13934)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iPhone X Simulator (iOS 12.1)
