### PR TITLE
[MM-10380] Migrate Android from GCM to FCM

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -182,8 +182,17 @@ configurations.all {
             if (details.requested.name == 'android-jsc') {
                 details.useTarget group: details.requested.group, name: 'android-jsc-intl', version: 'r236355'
             }
-            if (details.requested.name == 'play-services-gcm') {
-                details.useTarget group: details.requested.group, name: details.requested.name, version: '16.0.0'
+            if (details.requested.name == 'play-services-base') {
+                details.useTarget group: details.requested.group, name: details.requested.name, version: '15.0.1'
+            }
+            if (details.requested.name == 'play-services-tasks') {
+                details.useTarget group: details.requested.group, name: details.requested.name, version: '15.0.1'
+            }
+            if (details.requested.name == 'play-services-stats') {
+                details.useTarget group: details.requested.group, name: details.requested.name, version: '15.0.1'
+            }
+            if (details.requested.name == 'play-services-basement') {
+                details.useTarget group: details.requested.group, name: details.requested.name, version: '15.0.1'
             }
         }
     }
@@ -232,3 +241,5 @@ task copyDownloadableDepsToLibs(type: Copy) {
     from configurations.compile
     into 'libs'
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2566,7 +2566,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2611,8 +2610,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",
@@ -11272,8 +11270,8 @@
       }
     },
     "react-native-notifications": {
-      "version": "github:enahum/react-native-notifications#aeb014b4d01db3d0afb091683c45e7ad7e572ea3",
-      "from": "github:enahum/react-native-notifications#aeb014b4d01db3d0afb091683c45e7ad7e572ea3",
+      "version": "github:enahum/react-native-notifications#ae66562fb9ad167cf8078def3588895049881859",
+      "from": "github:enahum/react-native-notifications#ae66562fb9ad167cf8078def3588895049881859",
       "requires": {
         "core-js": "^1.0.0",
         "uuid": "^2.0.3"
@@ -11281,12 +11279,12 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "uuid": {
           "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
@@ -12136,7 +12134,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -13332,7 +13330,7 @@
         },
         "ws": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
           "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-native-linear-gradient": "2.4.4",
     "react-native-local-auth": "github:enahum/react-native-local-auth#cc9ce2f468fbf7b431dfad3191a31aaa9227a6ab",
     "react-native-navigation": "1.1.492",
-    "react-native-notifications": "github:enahum/react-native-notifications#aeb014b4d01db3d0afb091683c45e7ad7e572ea3",
+    "react-native-notifications": "github:enahum/react-native-notifications#ae66562fb9ad167cf8078def3588895049881859",
     "react-native-passcode-status": "1.1.1",
     "react-native-permissions": "1.1.1",
     "react-native-recyclerview-list": "enahum/react-native-recyclerview-list.git#a2d26bc7b2623cae25e947ba3905f702434717bf",


### PR DESCRIPTION
#### Summary
This PR migrates Android to use FCM instead of GCM.

> As of April 10, 2018, Google has deprecated GCM. The GCM server and client APIs are deprecated and will be removed as soon as April 11, 2019. Migrate GCM apps to Firebase Cloud Messaging (FCM), which inherits the reliable and scalable GCM infrastructure, plus many new features. See the migration guide to learn more.

* If the server still uses GCM before April 11 2019 the apps with GCM and with this PR that includes FCM will receive notifications.
* If the server is updated to use FCM (see https://github.com/mattermost/mattermost-push-proxy/pull/38) the apps using GCM and FCM (with this PR) will receive notifications
* If the server still uses GCM after April 11 2019 the apps won't receive notifications at all.

The actual migration was done in this repo https://github.com/enahum/react-native-notifications/

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10380

#### Device Information
This PR was tested on: Tested on Android Pie, Oreo and Nougat with the app in all states, also tested the local notifications and the scheduled notifications. 
