### PR TITLE
[MM-13954] Fix prop type for post reactions

### DIFF
--- a/app/screens/reaction_list/reaction_list.js
+++ b/app/screens/reaction_list/reaction_list.js
@@ -29,7 +29,7 @@ export default class ReactionList extends PureComponent {
             getMissingProfilesByIds: PropTypes.func.isRequired,
         }).isRequired,
         navigator: PropTypes.object,
-        reactions: PropTypes.array.isRequired,
+        reactions: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
         teammateNameDisplay: PropTypes.string,
         userProfiles: PropTypes.array,

--- a/app/screens/reaction_list/reaction_list.test.js
+++ b/app/screens/reaction_list/reaction_list.test.js
@@ -18,7 +18,7 @@ describe('ReactionList', () => {
         },
         allUserIds: ['user_id_1', 'user_id_2'],
         navigator: {setOnNavigatorEvent: jest.fn()},
-        reactions: [{emoji_name: 'smile', user_id: 'user_id_1'}, {emoji_name: '+1', user_id: 'user_id_2'}],
+        reactions: {'user_id_1-smile': {emoji_name: 'smile', user_id: 'user_id_1'}, 'user_id_2-+1': {emoji_name: '+1', user_id: 'user_id_2'}},
         theme: Preferences.THEMES.default,
         teammateNameDisplay: 'username',
         userProfiles: [{id: 'user_id_1', username: 'username_1'}, {id: 'user_id_2', username: 'username_2'}],


### PR DESCRIPTION
#### Summary
Fixes the prop type for a post's reactions. There's a related change in [mattermost-redux](https://github.com/mattermost/mattermost-redux/pull/778) but it is not required to update the mattermost-redux dependency in `package.json`. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13954

#### Checklist
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux): [PR 778](https://github.com/mattermost/mattermost-redux/pull/778)

#### Device Information
This PR was tested on:
* Samsung Galaxy S7, Android 7.0
* iPhone 8, iOS 12.1.4
