### PR TITLE
[MM-14017] Fix whitespace between input box and post list on iOS

### DIFF
--- a/app/components/post_list/post_list.ios.js
+++ b/app/components/post_list/post_list.ios.js
@@ -91,7 +91,7 @@ export default class PostList extends PostListBase {
         this.refs.list.scrollToIndex({
             animated: true,
             index: 0,
-            viewPosition: 0.5,
+            viewPosition: 1,
         });
     }, 100);
 
@@ -112,7 +112,7 @@ export default class PostList extends PostListBase {
             this.refs.list.scrollToIndex({
                 animated: false,
                 index: this.props.initialIndex,
-                viewPosition: 1,
+                viewPosition: 0.5,
             });
             this.hasDoneInitialScroll = true;
         }

--- a/app/components/post_list/post_list.ios.js
+++ b/app/components/post_list/post_list.ios.js
@@ -7,6 +7,7 @@ import {FlatList, StyleSheet} from 'react-native';
 import {debounce} from 'mattermost-redux/actions/helpers';
 
 import {ListTypes} from 'app/constants';
+import {THREAD} from 'app/constants/screen';
 import {makeExtraData} from 'app/utils/list_view';
 
 import PostListBase from './post_list_base';
@@ -75,7 +76,7 @@ export default class PostList extends PostListBase {
                 this.props.onLoadMoreUp();
             }
         } else if (pageOffsetY < 0) {
-            if (this.state.postListHeight > contentHeight || this.props.location === 'thread') {
+            if (this.state.postListHeight > contentHeight || this.props.location === THREAD) {
                 // Posting a message like multiline or jumbo emojis causes the FlatList component for iOS
                 // to render RefreshControl component and remain the space as is when it's unmounted,
                 // leaving a whitespace of ~64 units of height between input box and post list.
@@ -111,7 +112,7 @@ export default class PostList extends PostListBase {
             this.refs.list.scrollToIndex({
                 animated: false,
                 index: this.props.initialIndex,
-                viewPosition: 0.5,
+                viewPosition: 1,
             });
             this.hasDoneInitialScroll = true;
         }

--- a/app/components/post_list/post_list_base.js
+++ b/app/components/post_list/post_list_base.js
@@ -46,6 +46,7 @@ export default class PostListBase extends PureComponent {
         shouldRenderReplyButton: PropTypes.bool,
         siteURL: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
+        location: PropTypes.string,
     };
 
     static defaultProps = {

--- a/app/constants/screen.js
+++ b/app/constants/screen.js
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const THREAD = 'thread';

--- a/app/screens/thread/__snapshots__/thread.test.js.snap
+++ b/app/screens/thread/__snapshots__/thread.test.js.snap
@@ -17,6 +17,7 @@ exports[`thread should match snapshot, has root post 1`] = `
     <Connect(PostList)
       currentUserId="member_user_id"
       indicateNewMessages={false}
+      location="thread"
       navigator={
         Object {
           "dismissModal": [MockFunction],
@@ -113,6 +114,7 @@ exports[`thread should match snapshot, render footer 1`] = `
 <Connect(PostList)
   currentUserId="member_user_id"
   indicateNewMessages={false}
+  location="thread"
   navigator={
     Object {
       "dismissModal": [MockFunction],
@@ -157,6 +159,7 @@ exports[`thread should match snapshot, render footer 2`] = `
   currentUserId="member_user_id"
   indicateNewMessages={false}
   lastViewedAt={0}
+  location="thread"
   navigator={
     Object {
       "dismissModal": [MockFunction],

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -148,6 +148,7 @@ export default class Thread extends PureComponent {
                     currentUserId={myMember && myMember.user_id}
                     lastViewedAt={this.state.lastViewedAt}
                     navigator={navigator}
+                    location='thread'
                 />
             );
 

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -7,6 +7,8 @@ import {Platform} from 'react-native';
 import {intlShape} from 'react-intl';
 import {General, RequestStatus} from 'mattermost-redux/constants';
 
+import {THREAD} from 'app/constants/screen';
+
 import Loading from 'app/components/loading';
 import KeyboardLayout from 'app/components/layout/keyboard_layout';
 import PostList from 'app/components/post_list';
@@ -148,7 +150,7 @@ export default class Thread extends PureComponent {
                     currentUserId={myMember && myMember.user_id}
                     lastViewedAt={this.state.lastViewedAt}
                     navigator={navigator}
-                    location='thread'
+                    location={THREAD}
                 />
             );
 


### PR DESCRIPTION
#### Summary
The issue is isolated only on iOS but not on Android.  It's happening both on channel and thread screen when the height of the layout is greater than the content - (in short, the entire screen is not filled up by posts).

Posting a message like multiline or jumbo emojis causes the FlatList component for iOS to render RefreshControl component and remain the space as is when it's unmounted, leaving a whitespace of ~64 units of height between input box and post list.  I don't have a minimal repro steps but looks like it's a bug with the react-native's FlatList component.

![screen shot 2019-02-19 at 8 45 43 pm](https://user-images.githubusercontent.com/5334504/53016314-4f2c2300-3488-11e9-9f16-35e27ad0cd0a.png)

The fix explicitly pull down the list to recent post when pageOffsetY is less than zero, and the height of the layout is greater than its content or is on a thread screen.  Might not be a good solution but this fixes the issue.

#### Ticket Link
Jira ticket: [MM-14017](https://mattermost.atlassian.net/browse/MM-14017)

#### Checklist
- [x] Added or updated unit tests (required for all new features

#### Device Information
This PR was tested on: [iOS SE/X simulator, Android emulator - just to verify)] 
