### PR TITLE
Prevent the app from crashing when file mime type is null

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
+++ b/android/app/src/main/java/com/mattermost/share/RealPathUtil.java
@@ -205,8 +205,12 @@ public class RealPathUtil {
     }
 
     public static String getMimeTypeFromUri(final Context context, final Uri uri) {
-        ContentResolver cR = context.getContentResolver();
-        return cR.getType(uri);
+        try {
+            ContentResolver cR = context.getContentResolver();
+            return cR.getType(uri);
+        } catch (Exception e) {
+            return "application/octet-stream";
+        }
     }
 
     public static void deleteTempFiles(final File dir) {

--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -165,12 +165,15 @@ public class ShareModule extends ReactContextBaseJavaModule {
                     map.putString("value", text);
 
                     type = RealPathUtil.getMimeTypeFromUri(currentActivity, uri);
-                    if (type.equals("image/*")) {
-                        type = "image/jpeg";
-                    } else if (type.equals("video/*")) {
-                        type = "video/mp4";
+                    if (type != null) {
+                        if (type.equals("image/*")) {
+                            type = "image/jpeg";
+                        } else if (type.equals("video/*")) {
+                            type = "video/mp4";
+                        }
+                    } else {
+                        type = "application/octet-stream";
                     }
-
                     map.putString("type", type);
                     items.pushMap(map);
                 }


### PR DESCRIPTION
#### Summary
Sometimes when sharing files it could be that the mime type returns null, this PR will prevent a crash when that happens.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14249