### PR TITLE
MM-14238 Build unsigned x86_64 Android apk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,16 @@ unsigned-android: stop pre-build check-style prepare-android-build ## Build an u
 	@mv android/app/build/outputs/apk/unsigned/app-unsigned-unsigned.apk ./Mattermost-unsigned.apk
 	@ps -ef | grep -i "cli.js start" | grep -iv grep | awk '{print $$2}' | xargs kill -9
 
+unsigned-x86_64-android: stop pre-build check-style prepare-android-build ## Build an unsigned x86_64 version of the Android app
+	@if [ $(shell ps -ef | grep -i "cli.js start" | grep -civ grep) -eq 0 ]; then \
+		echo Starting React Native packager server; \
+		npm start & echo; \
+    fi
+	@echo "Building unsigned x86_64 Android app"
+	@cd fastlane && NODE_ENV=production bundle exec fastlane android unsigned_x86_64
+	@mv android/app/build/outputs/apk/unsigned/app-x86_64-unsigned-unsigned.apk ./Mattermost-x86_64-unsigned.apk
+	@ps -ef | grep -i "cli.js start" | grep -iv grep | awk '{print $$2}' | xargs kill -9
+
 test: | pre-run check-style ## Runs tests
 	@npm test
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,10 +138,10 @@ android {
     }
     splits {
         abi {
-            reset()
             enable enableSeparateBuildPerCPUArchitecture
-            universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86"
+            reset()
+            include "x86_64"
+            universalApk true  // If true, also generate a universal APK
         }
     }
     buildTypes {
@@ -164,8 +164,8 @@ android {
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
-            // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a":1, "x86":2]
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["x86_64":1]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -370,6 +370,42 @@ platform :android do
     )
   end
 
+  desc "Build unsigned x86_64 apk"
+  lane :unsigned_x86_64 do
+    unless configured
+      configure
+    end
+    enable_separate_build_per_CPU_arch
+    update_identifiers
+    replace_assets
+
+    gradle(
+        task: 'assemble',
+        build_type: 'Unsigned',
+        project_dir: 'android/'
+    )
+
+    disable_separate_build_per_CPU_arch
+  end
+
+  def enable_separate_build_per_CPU_arch()
+    # Set enableSeparateBuildPerCPUArchitecture to true
+    find_replace_string(
+          path_to_file: './android/app/build.gradle',
+          old_string: 'def enableSeparateBuildPerCPUArchitecture = false',
+          new_string: 'def enableSeparateBuildPerCPUArchitecture = true'
+      )
+  end
+
+  def disable_separate_build_per_CPU_arch()
+    # Set enableSeparateBuildPerCPUArchitecture to false
+    find_replace_string(
+          path_to_file: './android/app/build.gradle',
+          old_string: 'def enableSeparateBuildPerCPUArchitecture = true',
+          new_string: 'def enableSeparateBuildPerCPUArchitecture = false'
+      )
+  end
+
   lane :update_identifiers do
     # Set the name for the app
     app_name =  ENV['APP_NAME'] || 'Mattermost Beta'


### PR DESCRIPTION
#### Summary
Rainforest confirmed that the Android release build was able to successfully run on their VM/emulator.  This PR is not strictly necessary but submitted anyway in case it's needed in the future. 

RN builds for Rainforest QA.
- unsigned x86_64 Android apk for VM/emulator

*x86_64 based on https://help.rainforestqa.com/mobile-testing/android/test-native-android-apps-on-a-virtual-machine

Generated build - https://s3.amazonaws.com/x86-64/android-1.16.1/Mattermost-x86_64-unsigned.apk

To follow, auto-upload to S3 (if necessary)

#### Ticket Link
Jira ticket: [MM-14238](https://mattermost.atlassian.net/browse/MM-14238)

