### PR TITLE
[MM-10193] Enable to highlight CJK mention key

### DIFF
--- a/app/components/markdown/transform.js
+++ b/app/components/markdown/transform.js
@@ -7,6 +7,8 @@ import {escapeRegex} from 'app/utils/markdown';
 
 /* eslint-disable no-underscore-dangle */
 
+const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf\uac00-\ud7a3]/;
+
 // Combines adjacent text nodes into a single text node to make further transformation easier
 export function combineTextNodes(ast) {
     const walker = ast.walker();
@@ -315,7 +317,12 @@ export function getFirstMention(str, mentionKeys) {
         }
 
         const flags = mention.caseSensitive ? '' : 'i';
-        const pattern = new RegExp(`\\b${escapeRegex(mention.key)}_*\\b`, flags);
+        let pattern;
+        if (cjkPattern.test(mention.key)) {
+            pattern = new RegExp(`${escapeRegex(mention.key)}`, flags);
+        } else {
+            pattern = new RegExp(`\\b${escapeRegex(mention.key)}_*\\b`, flags);
+        }
 
         const match = pattern.exec(str);
         if (!match || match[0] === '') {

--- a/app/components/markdown/transform.test.js
+++ b/app/components/markdown/transform.test.js
@@ -2693,6 +2693,64 @@ describe('Components.Markdown.transform', () => {
                     }],
                 }],
             },
+        }, {
+            name: 'multibyte keyword',
+            input: '我爱吃番茄炒饭',
+            mentionKeys: [{key: '番茄'}],
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: '我爱吃',
+                    }, {
+                        type: 'mention_highlight',
+                        children: [{
+                            type: 'text',
+                            literal: '番茄',
+                        }],
+                    }, {
+                        type: 'text',
+                        literal: '炒饭',
+                    }],
+                }],
+            },
+        }, {
+            name: 'multiple multibyte keywords',
+            input: 'CJK is 中國日本한국.',
+            mentionKeys: [{key: '中國'}, {key: '日本'}, {key: '한국'}],
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'CJK is ',
+                    }, {
+                        type: 'mention_highlight',
+                        children: [{
+                            type: 'text',
+                            literal: '中國',
+                        }],
+                    }, {
+                        type: 'mention_highlight',
+                        children: [{
+                            type: 'text',
+                            literal: '日本',
+                        }],
+                    }, {
+                        type: 'mention_highlight',
+                        children: [{
+                            type: 'text',
+                            literal: '한국',
+                        }],
+                    }, {
+                        type: 'text',
+                        literal: '.',
+                    }],
+                }],
+            },
         }];
 
         for (const test of tests) {
@@ -2763,6 +2821,11 @@ describe('Components.Markdown.transform', () => {
             input: 'apple banana orange',
             mentionKeys: [{key: ''}],
             expected: {index: -1, mention: null},
+        }, {
+            name: 'multibyte key',
+            input: '좋은 하루 되세요.',
+            mentionKeys: [{key: '하루'}],
+            expected: {index: 3, mention: {key: '하루'}},
         }];
 
         for (const test of tests) {


### PR DESCRIPTION
#### Summary
Enable to highlight CJK mention key in sentense.

#### Ticket Link
[\[Help Wanted\] \[MM\-10193\] Words that trigger mentions does not support Chinese · Issue \#8642 · mattermost/mattermost\-server](https://github.com/mattermost/mattermost-server/issues/8642)
[\[MM\-10193\] Words that trigger mentions does not support Chinese \- Mattermost](https://mattermost.atlassian.net/browse/MM-10193)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS 11.2, iPhone X Simulator 

#### Screenshots
![simulator screen shot - iphone x - 2019-02-23 at 00 40 14](https://user-images.githubusercontent.com/1453749/53281487-92c6ab80-376c-11e9-8868-51cbd627fa28.png)
