### PR TITLE
[MM-14044] Fix for "No internet connection" not showing up for a minute after connection loss

### DIFF
--- a/app/utils/network.js
+++ b/app/utils/network.js
@@ -10,13 +10,11 @@ import {Client4} from 'mattermost-redux/client';
 import mattermostBucket from 'app/mattermost_bucket';
 import LocalConfig from 'assets/config';
 
-const PING_TIMEOUT = 3000;
-
 let certificate = '';
 let previousState;
 export async function checkConnection(isConnected) {
-    if (!Client4.getBaseRoute().startsWith('http')) {
-        // If we don't have a server yet, return the default implementation
+    if (!isConnected || !Client4.getBaseRoute().startsWith('http')) {
+        // If we don't have a connection or have a server yet, return the default implementation
         return {hasInternet: isConnected, serverReachable: false};
     }
 
@@ -24,7 +22,6 @@ export async function checkConnection(isConnected) {
     const server = `${Client4.getBaseRoute()}/system/ping?time=${Date.now()}`;
 
     const config = {
-        timeout: PING_TIMEOUT,
         auto: true,
         waitsForConnectivity: true,
     };


### PR DESCRIPTION
#### Summary
In order to better support connection scenarios like VPN's connecting etc, a change was made that caused the "No internet connection" banner to not show up for a minute (native timeout value) after a connection is lost while waiting for confirmation from a ping of the MM server. This PR allows the "No internet connection" banner to show up immediately when a connection is actually down.

#### Ticket Link
[MM-14044](https://mattermost.atlassian.net/projects/MM/issues/MM-14044)

#### Checklist
n/a

#### Device Information
This PR was tested on: iPhone X Simulator (iOS 12.1), iPhone Xs (iOS 12.1.4)

#### Screenshots
n/a