### PR TITLE
[MM-14078] Use forked react-native-navigation with v1 patch for NullPointerException

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11999,9 +11999,8 @@
       "from": "github:enahum/react-native-local-auth#cc9ce2f468fbf7b431dfad3191a31aaa9227a6ab"
     },
     "react-native-navigation": {
-      "version": "1.1.492",
-      "resolved": "https://registry.npmjs.org/react-native-navigation/-/react-native-navigation-1.1.492.tgz",
-      "integrity": "sha512-K75pFkJtbq0SDADkfSHkSHv6j0JzzAIPCJap78pP4VbPHDztT73uXe61aqyGHff8iQt6YnMoWH+uF9RIhTQykw==",
+      "version": "github:migbot/react-native-navigation#03c623c373f818827a463ca0fe90f86f56e71b2f",
+      "from": "github:migbot/react-native-navigation#03c623c373f818827a463ca0fe90f86f56e71b2f",
       "requires": {
         "lodash": "4.x.x"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native-keychain": "3.1.1",
     "react-native-linear-gradient": "2.5.3",
     "react-native-local-auth": "github:enahum/react-native-local-auth#cc9ce2f468fbf7b431dfad3191a31aaa9227a6ab",
-    "react-native-navigation": "1.1.492",
+    "react-native-navigation": "github:migbot/react-native-navigation#03c623c373f818827a463ca0fe90f86f56e71b2f",
     "react-native-notifications": "github:enahum/react-native-notifications#ae66562fb9ad167cf8078def3588895049881859",
     "react-native-passcode-status": "1.1.1",
     "react-native-permissions": "1.1.1",


### PR DESCRIPTION
#### Summary
We're seeing Android crashes due to a NullPointerException being thrown when [getReactEventEmitter()](https://github.com/wix/react-native-navigation/blob/v1/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java#L95) returns null. A patch is included in a fork of the library that recreates the event emitter if it is null prior to emitting the app launched event (commits [71c064](https://github.com/migbot/react-native-navigation/commit/71c06483c9a5a6f36911abf02456c3763f3a085a) and [03c623](https://github.com/migbot/react-native-navigation/commit/03c623c373f818827a463ca0fe90f86f56e71b2f))

#### Ticket Link
[MM-14078](https://mattermost.atlassian.net/browse/MM-14078)

#### Device Information
This PR was tested on:
Samsung SM-G930V, Android 7.0
