### PR TITLE
[MM-14081] Show MFA Prompt after Server returned error for login request

### DIFF
--- a/app/initial_state.js
+++ b/app/initial_state.js
@@ -123,10 +123,6 @@ const state = {
             },
         },
         users: {
-            checkMfa: {
-                status: 'not_started',
-                error: null,
-            },
             login: {
                 status: 'not_started',
                 error: null,

--- a/app/screens/login/index.js
+++ b/app/screens/login/index.js
@@ -8,17 +8,16 @@ import LoginActions from 'app/actions/views/login';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
-import {checkMfa, login} from 'mattermost-redux/actions/users';
+import {login} from 'mattermost-redux/actions/users';
 
 import Login from './login.js';
 
 function mapStateToProps(state) {
-    const {checkMfa: checkMfaRequest, login: loginRequest} = state.requests.users;
+    const {login: loginRequest} = state.requests.users;
     const config = getConfig(state);
     const license = getLicense(state);
     return {
         ...state.views.login,
-        checkMfaRequest,
         loginRequest,
         config,
         license,
@@ -30,7 +29,6 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             ...LoginActions,
-            checkMfa,
             login,
         }, dispatch),
     };

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -194,12 +194,12 @@ export default class Login extends PureComponent {
     signIn = () => {
         const {actions, loginId, loginRequest, password} = this.props;
         if (loginRequest.status !== RequestStatus.STARTED) {
-            actions.login(loginId.toLowerCase(), password).then(this.checkLoginResponse)
+            actions.login(loginId.toLowerCase(), password).then(this.checkLoginResponse);
         }
     };
 
     checkLoginResponse = (data) => {
-        if (data?.error?.server_error_id === "mfa.validate_token.authenticate.app_error") {
+        if (data?.error.server_error_id === 'mfa.validate_token.authenticate.app_error') { // eslint-disable-line camelcase
             this.goToMfa();
         }
     };

--- a/app/screens/mfa/mfa.js
+++ b/app/screens/mfa/mfa.js
@@ -24,6 +24,7 @@ import TextInputWithLocalizedPlaceholder from 'app/components/text_input_with_lo
 import {GlobalStyles} from 'app/styles';
 import {preventDoubleTap} from 'app/utils/tap';
 import {t} from 'app/utils/i18n';
+import {setMfaPreflightDone} from 'app/utils/security';
 
 export default class Mfa extends PureComponent {
     static propTypes = {
@@ -97,7 +98,7 @@ export default class Mfa extends PureComponent {
             });
             return;
         }
-
+        setMfaPreflightDone(true);
         this.props.actions.login(this.props.loginId, this.props.password, this.state.token);
     });
 

--- a/app/utils/security.js
+++ b/app/utils/security.js
@@ -5,6 +5,16 @@ import {Client4} from 'mattermost-redux/client';
 import CookieManager from 'react-native-cookies';
 import urlParse from 'url-parse';
 
+let mfaPreflightDone = false;
+
+export function setMfaPreflightDone(state) {
+    mfaPreflightDone = state;
+}
+
+export function getMfaPreflightDone() {
+    return mfaPreflightDone;
+}
+
 export function setCSRFFromCookie(url) {
     return new Promise((resolve) => {
         CookieManager.get(urlParse(url).origin, false).then((res) => {


### PR DESCRIPTION
#### Summary
This pull request is the mobile changes related to Server PR https://github.com/mattermost/mattermost-server/pull/10356 - It changes the current way how we determine if a user has MFA enabled or not. 

Previously a separate request was made with the user eMail to determine if MFA is turned or not, which resulted in a leak of the users MFA status without having any information but the users email. The new implementation will attempt to login without MFA, and if the server returns an MFA error show MFA form.

**To Do - Pointers appreciated:**
- Don't show error on first login request if MFA error is returned and MFA screen wasn't shown yet
- Remove ESLint line ignore (?)

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-14081

#### Device Information
This PR was tested on: Android 9.0 Emulator, Fedora 28
