### PR TITLE
MM-13958/MM-13959 Make postsInChannel into a sparse array

### DIFF
--- a/app/screens/flagged_posts/flagged_posts.js
+++ b/app/screens/flagged_posts/flagged_posts.js
@@ -80,7 +80,7 @@ export default class FlaggedPosts extends PureComponent {
         const rootId = (post.root_id || post.id);
 
         Keyboard.dismiss();
-        actions.loadThreadIfNecessary(rootId, channelId);
+        actions.loadThreadIfNecessary(rootId);
         actions.selectPost(rootId);
 
         const options = {

--- a/app/screens/long_post/long_post.js
+++ b/app/screens/long_post/long_post.js
@@ -76,7 +76,7 @@ export default class LongPost extends PureComponent {
         const channelId = post.channel_id;
         const rootId = (post.root_id || post.id);
 
-        actions.loadThreadIfNecessary(rootId, channelId);
+        actions.loadThreadIfNecessary(rootId);
         actions.selectPost(rootId);
 
         const options = {

--- a/app/screens/permalink/index.js
+++ b/app/screens/permalink/index.js
@@ -5,7 +5,11 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getChannel as getChannelAction, joinChannel} from 'mattermost-redux/actions/channels';
-import {getPostsAfter, getPostsBefore, getPostThread, selectPost} from 'mattermost-redux/actions/posts';
+import {
+    getPostsAround,
+    getPostThread,
+    selectPost,
+} from 'mattermost-redux/actions/posts';
 import {makeGetChannel, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetPostIdsAroundPost, getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -60,8 +64,7 @@ function makeMapStateToProps() {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getPostsAfter,
-            getPostsBefore,
+            getPostsAround,
             getPostThread,
             getChannel: getChannelAction,
             handleSelectChannel,

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -44,8 +44,7 @@ Animatable.initializeRegistryWithDefinitions({
 export default class Permalink extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            getPostsAfter: PropTypes.func.isRequired,
-            getPostsBefore: PropTypes.func.isRequired,
+            getPostsAround: PropTypes.func.isRequired,
             getPostThread: PropTypes.func.isRequired,
             getChannel: PropTypes.func.isRequired,
             handleSelectChannel: PropTypes.func.isRequired,
@@ -167,7 +166,7 @@ export default class Permalink extends PureComponent {
         const channelId = post.channel_id;
         const rootId = (post.root_id || post.id);
 
-        actions.loadThreadIfNecessary(rootId, channelId);
+        actions.loadThreadIfNecessary(rootId);
         actions.selectPost(rootId);
 
         const options = {
@@ -307,10 +306,7 @@ export default class Permalink extends PureComponent {
             }
         }
 
-        await Promise.all([
-            actions.getPostsBefore(focusChannelId, focusedPostId, 0, 10),
-            actions.getPostsAfter(focusChannelId, focusedPostId, 0, 10),
-        ]);
+        await actions.getPostsAround(focusChannelId, focusedPostId, 10);
 
         if (this.mounted) {
             this.setState({loading: false});

--- a/app/screens/permalink/permalink.test.js
+++ b/app/screens/permalink/permalink.test.js
@@ -20,8 +20,7 @@ describe('Permalink', () => {
     };
 
     const actions = {
-        getPostsAfter: jest.fn(),
-        getPostsBefore: jest.fn(),
+        getPostsAround: jest.fn(),
         getPostThread: jest.fn(),
         getChannel: jest.fn(),
         handleSelectChannel: jest.fn(),

--- a/app/screens/pinned_posts/pinned_posts.js
+++ b/app/screens/pinned_posts/pinned_posts.js
@@ -82,7 +82,7 @@ export default class PinnedPosts extends PureComponent {
         const rootId = (post.root_id || post.id);
 
         Keyboard.dismiss();
-        actions.loadThreadIfNecessary(rootId, channelId);
+        actions.loadThreadIfNecessary(rootId);
         actions.selectPost(rootId);
 
         const options = {

--- a/app/screens/recent_mentions/recent_mentions.js
+++ b/app/screens/recent_mentions/recent_mentions.js
@@ -80,7 +80,7 @@ export default class RecentMentions extends PureComponent {
         const rootId = (post.root_id || post.id);
 
         Keyboard.dismiss();
-        actions.loadThreadIfNecessary(rootId, channelId);
+        actions.loadThreadIfNecessary(rootId);
         actions.selectPost(rootId);
 
         const options = {

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -188,7 +188,7 @@ export default class Search extends PureComponent {
         const rootId = (post.root_id || post.id);
 
         Keyboard.dismiss();
-        actions.loadThreadIfNecessary(rootId, channelId);
+        actions.loadThreadIfNecessary(rootId);
         actions.selectPost(rootId);
 
         const options = {

--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -30,7 +30,7 @@ export function messageRetention(store) {
             // and apply data retention on those posts if applies
             let nextAction;
             try {
-                nextAction = cleanupState(action);
+                nextAction = cleanUpState(action);
             } catch (e) {
                 // Sometimes, the payload is incomplete so log the error to Sentry and skip the cleanup
                 console.warn(e); // eslint-disable-line no-console
@@ -40,7 +40,7 @@ export function messageRetention(store) {
 
             return next(nextAction);
         } else if (action.type === ViewTypes.DATA_CLEANUP) {
-            const nextAction = cleanupState(action, true);
+            const nextAction = cleanUpState(action, true);
             return next(nextAction);
         }
 
@@ -191,7 +191,7 @@ function getLastChannelForTeam(payload) {
     return lastChannelForTeam;
 }
 
-function cleanupState(action, keepCurrent = false) {
+export function cleanUpState(action, keepCurrent = false) {
     const {payload: resetPayload} = resetStateForNewVersion(action);
     const {payload} = action;
     const {currentChannelId} = payload.entities.channels;
@@ -219,27 +219,13 @@ function cleanupState(action, keepCurrent = false) {
         retentionPeriod = resetPayload.entities.general.dataRetentionPolicy.message_retention_cutoff;
     }
 
-    const postIdsToKeep = Object.values(lastChannelForTeam).reduce((array, channelIds) => {
-        const ids = channelIds.reduce((result, id) => {
-            // we need to check that the channel id is not already included
-            // the reason it can be included is cause at least one of the last channels viewed
-            // in a team can be a DM or GM and the id can be duplicate
-            if (!nextEntities.posts.postsInChannel[id] && payload.entities.posts.postsInChannel[id]) {
-                let postIds;
-                if (keepCurrent && currentChannelId === id) {
-                    postIds = payload.entities.posts.postsInChannel[id];
-                } else {
-                    postIds = payload.entities.posts.postsInChannel[id].slice(0, 60);
-                }
-                nextEntities.posts.postsInChannel[id] = postIds;
-                return result.concat(postIds);
-            }
+    const postIdsToKeep = [];
 
-            return result;
-        }, []);
-        return array.concat(ids);
-    }, []);
+    // Keep the last 60 posts in each recently viewed channel
+    nextEntities.posts.postsInChannel = cleanUpPostsInChannel(payload.entities.posts.postsInChannel, lastChannelForTeam, keepCurrent ? currentChannelId : '');
+    postIdsToKeep.push(...getAllFromPostsInChannel(nextEntities.posts.postsInChannel));
 
+    // Keep any posts that appear in search resutls
     let searchResults = [];
     let flaggedPosts = [];
     if (payload.entities.search) {
@@ -261,21 +247,22 @@ function cleanupState(action, keepCurrent = false) {
 
         if (post) {
             if (retentionPeriod && post.create_at < retentionPeriod) {
-                const postsInChannel = nextEntities.posts.postsInChannel[post.channel_id] || [];
-                const index = postsInChannel.indexOf(postId);
-                if (index !== -1) {
-                    postsInChannel.splice(index, 1);
-                }
+                // This post has been removed by data retention, so don't keep it
+                removeFromPostsInChannel(nextEntities.posts.postsInChannel, post.channel_id, postId);
+
                 return;
             }
 
+            // Keep the post
             nextEntities.posts.posts[postId] = post;
 
+            // And its reactions
             const reaction = payload.entities.posts.reactions[postId];
             if (reaction) {
                 nextEntities.posts.reactions[postId] = reaction;
             }
 
+            // And its files
             const fileIds = payload.entities.files.fileIdsByPostId[postId];
             if (fileIds) {
                 nextEntities.files.fileIdsByPostId[postId] = fileIds;
@@ -284,44 +271,28 @@ function cleanupState(action, keepCurrent = false) {
                 });
             }
 
+            // And its comments
             const postsInThread = payload.entities.posts.postsInThread[postId];
             if (postsInThread) {
                 nextEntities.posts.postsInThread[postId] = postsInThread;
             }
-        } else {
-            // If the post is not in the store we need to remove it from the postsInChannel
-            const channelIds = Object.keys(nextEntities.posts.postsInChannel);
-            for (let i = 0; i < channelIds.length; i++) {
-                const channelId = channelIds[i];
-                const posts = nextEntities.posts.postsInChannel[channelId];
-                const index = posts.indexOf(postId);
-                if (index !== -1) {
-                    posts.splice(index, 1);
-                    break;
-                }
-            }
         }
     });
 
-    // remove any pending posts that hasn't failed
+    // Remove any pending posts that haven't failed
     if (payload.entities.posts && payload.entities.posts.pendingPostIds && payload.entities.posts.pendingPostIds.length) {
         const nextPendingPostIds = [...payload.entities.posts.pendingPostIds];
         payload.entities.posts.pendingPostIds.forEach((id) => {
             const posts = nextEntities.posts.posts;
             const post = posts[id];
 
-            if (post) {
-                const postsInChannel = [...nextEntities.posts.postsInChannel[post.channel_id]] || [];
-                if (!post.failed) {
-                    Reflect.deleteProperty(posts, id);
-                    const index = postsInChannel.indexOf(id);
-                    if (index !== -1) {
-                        postsInChannel.splice(index, 1);
-                        nextEntities.posts.postsInChannel[post.channel_id] = postsInChannel;
-                    }
-                    removePendingPost(nextPendingPostIds, id);
-                }
-            } else {
+            if (post && !post.failed) {
+                Reflect.deleteProperty(posts, id);
+
+                removeFromPostsInChannel(nextEntities.posts.postsInChannel, post.channel_id, id);
+
+                removePendingPost(nextPendingPostIds, id);
+            } else if (!post) {
                 removePendingPost(nextPendingPostIds, id);
             }
         });
@@ -363,6 +334,78 @@ function cleanupState(action, keepCurrent = false) {
         payload: nextState,
         error: action.error,
     };
+}
+
+// cleanUpPostsInChannel returns a copy of postsInChannel where only the most recent posts in each channel are kept
+export function cleanUpPostsInChannel(postsInChannel, lastChannelForTeam, currentChannelId, recentPostCount = 60) {
+    const nextPostsInChannel = {};
+
+    for (const channelIds of Object.values(lastChannelForTeam)) {
+        for (const channelId of channelIds) {
+            if (nextPostsInChannel[channelId]) {
+                // This is a DM or GM channel that we've already seen on another team
+                continue;
+            }
+
+            const postsForChannel = postsInChannel[channelId];
+
+            if (!postsForChannel) {
+                // We don't have anything to keep for this channel
+                continue;
+            }
+
+            let nextPostsForChannel;
+
+            if (channelId === currentChannelId) {
+                // Keep all of the posts for this channel
+                nextPostsForChannel = postsForChannel;
+            } else {
+                // Only keep the most recent posts for this channel
+                const recentBlock = postsForChannel.find((block) => block.recent);
+
+                if (!recentBlock) {
+                    // We don't have recent posts for this channel
+                    continue;
+                }
+
+                nextPostsForChannel = [{
+                    ...recentBlock,
+                    order: recentBlock.order.slice(0, recentPostCount),
+                }];
+            }
+
+            nextPostsInChannel[channelId] = nextPostsForChannel;
+        }
+    }
+
+    return nextPostsInChannel;
+}
+
+// getAllFromPostsInChannel returns an array of all post IDs found in postsInChannel
+export function getAllFromPostsInChannel(postsInChannel) {
+    const postIds = [];
+
+    for (const postsForChannel of Object.values(postsInChannel)) {
+        for (const block of postsForChannel) {
+            postIds.push(...block.order);
+        }
+    }
+
+    return postIds;
+}
+
+function removeFromPostsInChannel(postsInChannel, channelId, postId) {
+    const postsForChannel = postsInChannel[channelId];
+
+    if (!postsForChannel) {
+        return;
+    }
+
+    // Since this has already gone through cleanUpPostsInChannel, we know that there can only be one block to look at
+    const index = postsForChannel[0].order.indexOf(postId);
+    if (index !== -1) {
+        postsForChannel[0].order.splice(index, 1);
+    }
 }
 
 function removePendingPost(pendingPostIds, id) {

--- a/app/store/middleware.test.js
+++ b/app/store/middleware.test.js
@@ -6,50 +6,401 @@
 import assert from 'assert';
 
 import {ViewTypes} from 'app/constants';
-import {messageRetention} from 'app/store/middleware';
+import {
+    cleanUpPostsInChannel,
+    cleanUpState,
+    getAllFromPostsInChannel,
+    messageRetention,
+} from 'app/store/middleware';
 
-describe('store/middleware', () => {
-    describe('messageRetention', () => {
-        describe('should chain the same incoming action type', () => {
-            const actions = [
-                {
-                    type: 'persist/REHYDRATE',
-                    payload: {
-                        views: {
-                            team: {
-                            },
+describe('messageRetention', () => {
+    describe('should chain the same incoming action type', () => {
+        const actions = [
+            {
+                type: 'persist/REHYDRATE',
+                payload: {
+                    views: {
+                        team: {
                         },
                     },
                 },
-                {
-                    type: ViewTypes.DATA_CLEANUP,
-                    payload: {
-                        entities: {
-                            channels: {
-                            },
-                            posts: {
-                            },
+            },
+            {
+                type: ViewTypes.DATA_CLEANUP,
+                payload: {
+                    entities: {
+                        channels: {
                         },
-                        views: {
-                            team: {
-                            },
+                        posts: {
+                        },
+                    },
+                    views: {
+                        team: {
                         },
                     },
                 },
-                {
-                    type: 'other',
-                },
-            ];
+            },
+            {
+                type: 'other',
+            },
+        ];
 
-            actions.forEach((action) => {
-                it(`for action type ${action.type}`, () => {
-                    const store = {};
-                    const next = (a) => a;
+        actions.forEach((action) => {
+            it(`for action type ${action.type}`, () => {
+                const store = {};
+                const next = (a) => a;
 
-                    const nextAction = messageRetention(store)(next)(action);
-                    assert.equal(action.type, nextAction.type);
-                });
+                const nextAction = messageRetention(store)(next)(action);
+                assert.equal(action.type, nextAction.type);
             });
         });
+    });
+});
+
+describe('cleanUpState', () => {
+    test('should remove post because of data retention', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                files: {
+                    fileIdsByPostId: {},
+                },
+                general: {
+                    dataRetentionPolicy: {
+                        message_deletion_enabled: true,
+                        message_retention_cutoff: 1000,
+                    },
+                },
+                posts: {
+                    posts: {
+                        post1: {id: 'post1', channel_id: 'channel1', create_at: 1000},
+                        post2: {id: 'post2', channel_id: 'channel1', create_at: 999},
+                    },
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['post1', 'post2'], recent: true},
+                        ],
+                    },
+                    postsInThread: {},
+                    reactions: {},
+                },
+            },
+            views: {
+                team: {
+                    lastChannelForTeam: {
+                        team1: ['channel1'],
+                    },
+                },
+            },
+        };
+
+        const result = cleanUpState({payload: state});
+
+        expect(result.payload.entities.posts.posts.post1).toBeDefined();
+        expect(result.payload.entities.posts.posts.post2).toBeUndefined();
+        expect(result.payload.entities.posts.postsInChannel.channel1).toEqual([{order: ['post1'], recent: true}]);
+    });
+
+    test('should keep failed pending post', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                files: {
+                    fileIdsByPostId: {},
+                },
+                posts: {
+                    pendingPostIds: ['pending'],
+                    posts: {
+                        pending: {id: 'pending', pending_post_id: 'pending', channel_id: 'channel1', failed: true},
+                        post1: {id: 'post1', channel_id: 'channel1'},
+                        post2: {id: 'post2', channel_id: 'channel1'},
+                    },
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['pending', 'post1', 'post2'], recent: true},
+                        ],
+                    },
+                    postsInThread: {},
+                    reactions: {},
+                },
+            },
+            views: {
+                team: {
+                    lastChannelForTeam: {
+                        team1: ['channel1'],
+                    },
+                },
+            },
+        };
+
+        const result = cleanUpState({payload: state});
+
+        expect(result.payload.entities.posts.pendingPostIds).toEqual(['pending']);
+        expect(result.payload.entities.posts.posts.pending).toBeDefined();
+        expect(result.payload.entities.posts.postsInChannel.channel1).toEqual([{order: ['pending', 'post1', 'post2'], recent: true}]);
+    });
+
+    test('should remove non-failed pending post', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                files: {
+                    fileIdsByPostId: {},
+                },
+                posts: {
+                    pendingPostIds: ['pending'],
+                    posts: {
+                        pending: {id: 'pending', pending_post_id: 'pending', channel_id: 'channel1'},
+                        post1: {id: 'post1', channel_id: 'channel1'},
+                        post2: {id: 'post2', channel_id: 'channel1'},
+                    },
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['pending', 'post1', 'post2'], recent: true},
+                        ],
+                    },
+                    postsInThread: {},
+                    reactions: {},
+                },
+            },
+            views: {
+                team: {
+                    lastChannelForTeam: {
+                        team1: ['channel1'],
+                    },
+                },
+            },
+        };
+
+        const result = cleanUpState({payload: state});
+
+        expect(result.payload.entities.posts.pendingPostIds).toEqual([]);
+        expect(result.payload.entities.posts.posts.pending).toBeUndefined();
+        expect(result.payload.entities.posts.postsInChannel.channel1).toEqual([{order: ['post1', 'post2'], recent: true}]);
+    });
+
+    test('should remove non-existent pending post', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                files: {
+                    fileIdsByPostId: {},
+                },
+                posts: {
+                    pendingPostIds: ['pending'],
+                    posts: {
+                        post1: {id: 'post1', channel_id: 'channel1'},
+                        post2: {id: 'post2', channel_id: 'channel1'},
+                    },
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['post1', 'post2'], recent: true},
+                        ],
+                    },
+                    postsInThread: {},
+                    reactions: {},
+                },
+            },
+            views: {
+                team: {
+                    lastChannelForTeam: {
+                        team1: ['channel1'],
+                    },
+                },
+            },
+        };
+
+        const result = cleanUpState({payload: state});
+
+        expect(result.payload.entities.posts.pendingPostIds).toEqual([]);
+        expect(result.payload.entities.posts.postsInChannel.channel1).toEqual([{order: ['post1', 'post2'], recent: true}]);
+    });
+});
+
+describe('cleanUpPostsInChannel', () => {
+    test('should only keep posts for recently viewed channels', () => {
+        const postsInChannel = {
+            channel1: [
+                {order: ['a', 'b'], recent: true},
+            ],
+            channel2: [
+                {order: ['c', 'd'], recent: true},
+            ],
+        };
+        const lastChannelForTeam = {
+            team1: ['channel1'],
+        };
+
+        const nextPostsInChannel = cleanUpPostsInChannel(postsInChannel, lastChannelForTeam);
+
+        expect(nextPostsInChannel).toEqual({
+            channel1: [
+                {order: ['a', 'b'], recent: true},
+            ],
+        });
+    });
+
+    test('should keep posts for recently viewed channels across multiple teams', () => {
+        const postsInChannel = {
+            channel1: [
+                {order: ['a', 'b'], recent: true},
+            ],
+            channel2: [
+                {order: ['c', 'd'], recent: true},
+            ],
+        };
+        const lastChannelForTeam = {
+            team1: ['channel1'],
+            team2: ['channel2'],
+        };
+
+        const nextPostsInChannel = cleanUpPostsInChannel(postsInChannel, lastChannelForTeam);
+
+        expect(nextPostsInChannel).toEqual({
+            channel1: [
+                {order: ['a', 'b'], recent: true},
+            ],
+            channel2: [
+                {order: ['c', 'd'], recent: true},
+            ],
+        });
+    });
+
+    test('should only keep the last X posts in each channel', () => {
+        const postsInChannel = {
+            channel1: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+            ],
+            channel2: [
+                {order: ['e', 'f', 'g', 'h'], recent: true},
+            ],
+        };
+        const lastChannelForTeam = {
+            team1: ['channel1', 'channel2'],
+        };
+
+        const nextPostsInChannel = cleanUpPostsInChannel(postsInChannel, lastChannelForTeam, '', 2);
+
+        expect(nextPostsInChannel).toEqual({
+            channel1: [
+                {order: ['a', 'b'], recent: true},
+            ],
+            channel2: [
+                {order: ['e', 'f'], recent: true},
+            ],
+        });
+    });
+
+    test('should only keep the most recent posts in a channel', () => {
+        const postsInChannel = {
+            channel1: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+                {order: ['e', 'f', 'g', 'h']},
+            ],
+        };
+        const lastChannelForTeam = {
+            team1: ['channel1'],
+        };
+
+        const nextPostsInChannel = cleanUpPostsInChannel(postsInChannel, lastChannelForTeam, '');
+
+        expect(nextPostsInChannel).toEqual({
+            channel1: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+            ],
+        });
+    });
+
+    test('should keep all posts in the current channel, if specified', () => {
+        const postsInChannel = {
+            channel1: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+            ],
+            channel2: [
+                {order: ['e', 'f', 'g', 'h'], recent: true},
+            ],
+        };
+        const lastChannelForTeam = {
+            team1: ['channel1', 'channel2'],
+        };
+
+        const nextPostsInChannel = cleanUpPostsInChannel(postsInChannel, lastChannelForTeam, 'channel2', 2);
+
+        expect(nextPostsInChannel).toEqual({
+            channel1: [
+                {order: ['a', 'b'], recent: true},
+            ],
+            channel2: [
+                {order: ['e', 'f', 'g', 'h'], recent: true},
+            ],
+        });
+    });
+
+    test('should not error when a DM/GM channel appears on multiple teams', () => {
+        const postsInChannel = {
+            dmChannel: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+            ],
+        };
+        const lastChannelForTeam = {
+            team1: ['dmChannel'],
+            team2: ['dmChannel'],
+        };
+
+        const nextPostsInChannel = cleanUpPostsInChannel(postsInChannel, lastChannelForTeam);
+
+        expect(nextPostsInChannel).toEqual({
+            dmChannel: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+            ],
+        });
+    });
+
+    test('should not error when a recent channel is missing', () => {
+        const postsInChannel = {
+            channel1: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+            ],
+        };
+        const lastChannelForTeam = {
+            team1: ['channel1', 'channel2'],
+        };
+
+        const nextPostsInChannel = cleanUpPostsInChannel(postsInChannel, lastChannelForTeam);
+
+        expect(nextPostsInChannel).toEqual({
+            channel1: [
+                {order: ['a', 'b', 'c', 'd'], recent: true},
+            ],
+        });
+    });
+});
+
+describe('getAllFromPostsInChannel', () => {
+    test('should return every post ID', () => {
+        const postsInChannel = {
+            channel1: [
+                {order: ['a', 'b']},
+                {order: ['c', 'd']},
+            ],
+            channel2: [
+                {order: ['e', 'f']},
+            ],
+            channel3: [
+                {order: ['g', 'h']},
+            ],
+        };
+
+        const postIds = getAllFromPostsInChannel(postsInChannel);
+
+        expect(postIds).toMatchObject(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9043,8 +9043,8 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#24aefb2f5365a4e9f5cf70e95c43738a7e94cfda",
-      "from": "github:mattermost/mattermost-redux#24aefb2f5365a4e9f5cf70e95c43738a7e94cfda",
+      "version": "github:mattermost/mattermost-redux#357c7eee8f86f6f1edca100b2cf7f003068dd353",
+      "from": "github:mattermost/mattermost-redux#357c7eee8f86f6f1edca100b2cf7f003068dd353",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.0.0",
     "jsc-android": "236355.1.1",
-    "mattermost-redux": "github:mattermost/mattermost-redux#24aefb2f5365a4e9f5cf70e95c43738a7e94cfda",
+    "mattermost-redux": "github:mattermost/mattermost-redux#357c7eee8f86f6f1edca100b2cf7f003068dd353",
     "mime-db": "1.38.0",
     "moment-timezone": "0.5.23",
     "prop-types": "15.7.2",


### PR DESCRIPTION
The two major changes here are:
1. As in the web app changes, `increasePostVisibility` now uses `getPostsBefore` and `getPostsAfter` instead of paging. @enahum I had to comment out some of that logic used for bi-directional scrolling because it doesn't actually work with `postVisibility`.
2. I had to refactor some of the cleanup middleware so that I could properly test that it still works with the new `postInChannel`

See https://github.com/mattermost/mattermost-redux/pull/781 for more details.

Redux PR: https://github.com/mattermost/mattermost-redux/pull/781
Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/2411

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13958
https://mattermost.atlassian.net/browse/MM-13959

#### Checklist
- Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator
