### PR TITLE
[MM-13824] add one_you strings for better translatability

### DIFF
--- a/app/components/combined_system_message/combined_system_message.js
+++ b/app/components/combined_system_message/combined_system_message.js
@@ -25,6 +25,10 @@ const postTypeMessage = {
             id: t('combined_system_message.joined_channel.one'),
             defaultMessage: '{firstUser} **joined the channel**.',
         },
+        one_you: {
+            id: t('combined_system_message.joined_channel.one_you'),
+            defaultMessage: 'You **joined the channel**.',
+        },
         two: {
             id: t('combined_system_message.joined_channel.two'),
             defaultMessage: '{firstUser} and {secondUser} **joined the channel**.',
@@ -75,6 +79,10 @@ const postTypeMessage = {
             id: t('combined_system_message.left_channel.one'),
             defaultMessage: '{firstUser} **left the channel**.',
         },
+        one_you: {
+            id: t('combined_system_message.left_channel.one_you'),
+            defaultMessage: 'You **left the channel**.',
+        },
         two: {
             id: t('combined_system_message.left_channel.two'),
             defaultMessage: '{firstUser} and {secondUser} **left the channel**.',
@@ -88,6 +96,10 @@ const postTypeMessage = {
         one: {
             id: t('combined_system_message.joined_team.one'),
             defaultMessage: '{firstUser} **joined the team**.',
+        },
+        one_you: {
+            id: t('combined_system_message.joined_team.one_you'),
+            defaultMessage: 'You **joined the team**.',
         },
         two: {
             id: t('combined_system_message.joined_team.two'),
@@ -138,6 +150,10 @@ const postTypeMessage = {
         one: {
             id: t('combined_system_message.left_team.one'),
             defaultMessage: '{firstUser} **left the team**.',
+        },
+        one_you: {
+            id: t('combined_system_message.left_team.one_you'),
+            defaultMessage: 'You **left the team**.',
         },
         two: {
             id: t('combined_system_message.left_team.two'),


### PR DESCRIPTION
#### Summary
Adds new strings for team/channel related messages for better translatability.
Proper translation to the german language  was impossible before.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10335
[MM-13824]

#### Checklist
- [x] Includes text changes and localization file updates