### PR TITLE
Added config flag for controlling attachment downloads on mobile

### DIFF
--- a/app/components/file_attachment_list/index.js
+++ b/app/components/file_attachment_list/index.js
@@ -11,14 +11,17 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {loadFilesForPostIfNecessary} from 'app/actions/views/channel';
 import {getDimensions} from 'app/selectors/device';
 
+import LocalConfig from 'assets/config';
+
 import FileAttachmentList from './file_attachment_list';
 
 function makeMapStateToProps() {
     const getFilesForPost = makeGetFilesForPost();
+
     return function mapStateToProps(state, ownProps) {
         return {
             ...getDimensions(state),
-            canDownloadFiles: canDownloadFilesOnMobile(state),
+            canDownloadFiles: canDownloadFilesOnMobile(state) && LocalConfig.EnableAttachmentDownloads,
             files: getFilesForPost(state, ownProps.postId),
             theme: getTheme(state),
         };

--- a/app/screens/image_preview/index.js
+++ b/app/screens/image_preview/index.js
@@ -8,11 +8,12 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {canDownloadFilesOnMobile} from 'mattermost-redux/selectors/entities/general';
 
 import ImagePreview from './image_preview';
+import LocalConfig from 'assets/config';
 
 function mapStateToProps(state) {
     return {
         ...getDimensions(state),
-        canDownloadFiles: canDownloadFilesOnMobile(state),
+        canDownloadFiles: canDownloadFilesOnMobile(state) && LocalConfig.EnableAttachmentDownloads,
         theme: getTheme(state),
     };
 }

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -41,5 +41,7 @@
 
     "ShowSentryDebugOptions": false,
 
-    "CustomRequestHeaders": {}
+    "CustomRequestHeaders": {},
+    
+    "EnableAttachmentDownloads": true
 }


### PR DESCRIPTION
#### Summary
Added config flag for controlling attachment downloads on mobile

#### Device Information
This PR was tested on: OnePlus 6 (Android 9), iPhone X (iOS 12)
