### PR TITLE
Fix crash when fresh install android when getting the fcm token

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -208,6 +208,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:percent:28.0.0'
+    implementation "com.google.firebase:firebase-messaging:17.3.0"
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation project(':react-native-document-picker')
     implementation project(':react-native-keychain')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.1'
-        classpath 'com.google.gms:google-services:3.2.0'
+        classpath 'com.google.gms:google-services:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/package-lock.json
+++ b/package-lock.json
@@ -11994,8 +11994,8 @@
       }
     },
     "react-native-notifications": {
-      "version": "github:enahum/react-native-notifications#ae66562fb9ad167cf8078def3588895049881859",
-      "from": "github:enahum/react-native-notifications#ae66562fb9ad167cf8078def3588895049881859",
+      "version": "github:enahum/react-native-notifications#fcfed22dfee7a02e43f4d8acc5cf6310fa18bd6a",
+      "from": "github:enahum/react-native-notifications#fcfed22dfee7a02e43f4d8acc5cf6310fa18bd6a",
       "requires": {
         "core-js": "^1.0.0",
         "uuid": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-native-linear-gradient": "2.5.3",
     "react-native-local-auth": "github:enahum/react-native-local-auth#cc9ce2f468fbf7b431dfad3191a31aaa9227a6ab",
     "react-native-navigation": "github:migbot/react-native-navigation#03c623c373f818827a463ca0fe90f86f56e71b2f",
-    "react-native-notifications": "github:enahum/react-native-notifications#ae66562fb9ad167cf8078def3588895049881859",
+    "react-native-notifications": "github:enahum/react-native-notifications#fcfed22dfee7a02e43f4d8acc5cf6310fa18bd6a",
     "react-native-passcode-status": "1.1.1",
     "react-native-permissions": "1.1.1",
     "react-native-recyclerview-list": "enahum/react-native-recyclerview-list.git#a2d26bc7b2623cae25e947ba3905f702434717bf",


### PR DESCRIPTION
#### Summary
The mobile app was crashing on Android after migrating to FCM, this PR updates the notification library as well as the google-services plugin to avoid that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14352
