### PR TITLE
[MM-14151] Ensure data has url key before attempting upload

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -77,7 +77,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
         this.clear();
         getCurrentActivity().finish();
 
-        if (data != null) {
+        if (data != null && data.hasKey("url")) {
             ReadableArray files = data.getArray("files");
             String serverUrl = data.getString("url");
             String token = data.getString("token");


### PR DESCRIPTION
#### Summary
Proceed to extract URL from data and upload shared content only if data has the `url` key. This will prevent a crash from a NoSuchKeyException.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14151

#### Device Information
This PR was tested on:
* Samsung SM-G930V, Android 7.0
