### PR TITLE
[MM-14316] Call NotificationsLifecycleFacade callbacks in ShareActivity

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/ShareActivity.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareActivity.java
@@ -17,4 +17,28 @@ public class ShareActivity extends ReactActivity {
         MainApplication app = (MainApplication) this.getApplication();
         app.sharedExtensionIsOpened = true;
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        MainApplication.instance.getActivityCallbacks().onActivityResumed(this);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        MainApplication.instance.getActivityCallbacks().onActivityPaused(this);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        MainApplication.instance.getActivityCallbacks().onActivityStopped(this);
+    }
+
+    @Override
+    protected void onDestroy() {
+        MainApplication.instance.getActivityCallbacks().onActivityDestroyed(this);
+        super.onDestroy();
+    }
 }


### PR DESCRIPTION
#### Summary
This allows for the visibility of the app to be set correctly as the ShareActivity moves between lifecycles and ensures that push notifications work in the share extension as they do in the main app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14316

#### Device Information
This PR was tested on:
* Samsung SM-G930V, Android 7.0
