### PR TITLE
[MM-14296] Fix default email notification interval from never to immediate

### DIFF
--- a/app/screens/settings/notification_settings_email/index.js
+++ b/app/screens/settings/notification_settings_email/index.js
@@ -25,8 +25,8 @@ function mapStateToProps(state) {
         state,
         Preferences.CATEGORY_NOTIFICATIONS,
         Preferences.EMAIL_INTERVAL,
-        Preferences.INTERVAL_NEVER.toString(),
-    ) || '0';
+        Preferences.INTERVAL_IMMEDIATE.toString(),
+    );
 
     return {
         enableEmailBatching,


### PR DESCRIPTION
#### Summary
Fix default email notification interval from never to immediate.

Main issue on ticket being out of sync between RN and desktop app was fixed by https://github.com/mattermost/mattermost-webapp/pull/2416.  This is just a follow up PR to correct the dafault value.

#### Ticket Link
Jira ticket: [MM-14296](https://mattermost.atlassian.net/browse/MM-14296)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [iOS, Android simulators] 
