### PR TITLE
[MM-14192] Render hyperlinks in Message Attachment title

### DIFF
--- a/app/components/message_attachments/attachment_title.js
+++ b/app/components/message_attachments/attachment_title.js
@@ -60,7 +60,8 @@ export default class AttachmentTitle extends PureComponent {
                     navigator={navigator}
                     theme={theme}
                     value={value}
-                    baseTextStyle={[style.title, Boolean(link) && style.link]}
+                    baseTextStyle={style.title}
+                    textStyles={{link: style.link}}
                 />
             );
         }


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
This PR makes it possible to render hyperlinks in Message Attachment title.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-14192) | Fixes [GitHub issue #10292](https://github.com/mattermost/mattermost-server/issues/10292)

#### Checklist
N/A

#### Device Information
This PR was tested on: iPhone X with iOS 12.1, Nexus 5X with Android 9.0

#### Screenshots
![iphone](https://user-images.githubusercontent.com/45372453/53691509-c793bd80-3d7f-11e9-9aab-da36bd5ce24b.png)
![android](https://user-images.githubusercontent.com/45372453/53691510-cb274480-3d7f-11e9-9113-e215c8fa1fe8.png)
