### PR TITLE
[MM-14312] Fix intermittent crash when selecting a link

### DIFF
--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -30,6 +30,8 @@ export default class MarkdownLink extends PureComponent {
 
     static defaultProps = {
         onPermalinkPress: () => true,
+        serverURL: '',
+        siteURL: '',
     };
 
     static contextTypes = {

--- a/app/components/post_list/post_list_base.js
+++ b/app/components/post_list/post_list_base.js
@@ -53,6 +53,8 @@ export default class PostListBase extends PureComponent {
         onLoadMoreUp: () => true,
         renderFooter: () => null,
         refreshing: false,
+        serverURL: '',
+        siteURL: '',
     };
 
     componentWillMount() {

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -99,6 +99,10 @@ export function getScheme(url) {
 }
 
 export function matchDeepLink(url, serverURL, siteURL) {
+    if (!url || !serverURL || !siteURL) {
+        return null;
+    }
+
     const linkRoot = `(?:${escapeRegex(serverURL)}|${escapeRegex(siteURL)})?`;
 
     let match = new RegExp('^' + linkRoot + '\\/([^\\/]+)\\/channels\\/(\\S+)').exec(url);

--- a/app/utils/url.test.js
+++ b/app/utils/url.test.js
@@ -86,4 +86,26 @@ describe('UrlUtils', () => {
             expect(UrlUtils.stripTrailingSlashes(url)).toEqual(expected);
         });
     });
+
+    describe('matchDeepLink', () => {
+        const SITE_URL = 'http://localhost:8065';
+        const SERVER_URL = 'http://localhost:8065';
+        const tests = [
+            {name: 'should return null if all inputs are empty', input: {url: '', serverURL: '', siteURL: ''}, expected: null},
+            {name: 'should return null if any of the input is null', input: {url: '', serverURL: '', siteURL: null}, expected: null},
+            {name: 'should return null if any of the input is null', input: {url: '', serverURL: null, siteURL: ''}, expected: null},
+            {name: 'should return null if any of the input is null', input: {url: null, serverURL: '', siteURL: ''}, expected: null},
+            {name: 'should return null for not supported link', input: {url: 'https://mattermost.com', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: null},
+            {name: 'should match channel link', input: {url: SITE_URL + '/ad-1/channels/town-square', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: {channelName: 'town-square', teamName: 'ad-1', type: 'channel'}},
+            {name: 'should match permalink', input: {url: SITE_URL + '/ad-1/pl/qe93kkfd7783iqwuwfcwcxbsgy', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: {postId: 'qe93kkfd7783iqwuwfcwcxbsgy', teamName: 'ad-1', type: 'permalink'}},
+        ];
+
+        for (const test of tests) {
+            const {name, input, expected} = test;
+
+            it(name, () => {
+                expect(UrlUtils.matchDeepLink(input.url, input.serverURL, input.siteURL)).toEqual(expected);
+            });
+        }
+    });
 });


### PR DESCRIPTION
#### Summary
Fix intermittent crash when selecting a link.  The crash happen when it tries to do regex (replace) on undefined text.  Such text is either serverURL or siteURL which eventually resolves with the correct value.

Note that this fix is also to be backported to 1.16.

#### Ticket Link
Jira ticket: [MM-14312](https://mattermost.atlassian.net/browse/MM-14312)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [Android emulator and iOS simulator] 
