### PR TITLE
[MM-14312] Fix intermittent crash when selecting a link

### DIFF
--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -26,6 +26,8 @@ export default class MarkdownLink extends PureComponent {
 
     static defaultProps = {
         onPermalinkPress: () => true,
+        serverURL: '',
+        siteURL: '',
     };
 
     static contextTypes = {

--- a/app/components/post_list/post_list_base.js
+++ b/app/components/post_list/post_list_base.js
@@ -51,6 +51,8 @@ export default class PostListBase extends PureComponent {
         onLoadMoreUp: () => true,
         renderFooter: () => null,
         refreshing: false,
+        serverURL: '',
+        siteURL: '',
     };
 
     componentWillMount() {

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -97,6 +97,10 @@ export function getScheme(url) {
 }
 
 export function matchPermalink(link, rootURL) {
+    if (!link || !rootURL) {
+        return null;
+    }
+
     return new RegExp('^' + escapeRegex(rootURL) + '\\/([^\\/]+)\\/pl\\/(\\w+)').exec(link);
 }
 

--- a/app/utils/url.test.js
+++ b/app/utils/url.test.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import assert from 'assert';
+
 import * as UrlUtils from 'app/utils/url';
 
 /* eslint-disable max-nested-callbacks */
@@ -85,5 +87,32 @@ describe('UrlUtils', () => {
             const expected = 'https://www.youtube.com/watch?v=zrFWrmPgfzc&feature=youtu.be';
             expect(UrlUtils.stripTrailingSlashes(url)).toEqual(expected);
         });
+    });
+
+    describe('matchPermalink', () => {
+        const ROOT_URL = 'http://localhost:8065';
+
+        const tests = [
+            {name: 'should return null if all inputs are empty', input: {link: '', rootURL: ''}, expected: null},
+            {name: 'should return null if any of the inputs is null', input: {link: '', rootURL: null}, expected: null},
+            {name: 'should return null if any of the inputs is null', input: {link: null, rootURL: ''}, expected: null},
+            {name: 'should return null for not supported link', input: {link: 'https://mattermost.com', rootURL: ROOT_URL}, expected: null},
+            {name: 'should match permalink', input: {link: ROOT_URL + '/ad-1/pl/qe93kkfd7783iqwuwfcwcxbsgy', rootURL: ROOT_URL}, expected: ['http://localhost:8065/ad-1/pl/qe93kkfd7783iqwuwfcwcxbsgy', 'ad-1', 'qe93kkfd7783iqwuwfcwcxbsgy']},
+        ];
+
+        for (const test of tests) {
+            const {name, input, expected} = test;
+
+            it(name, () => {
+                const actual = UrlUtils.matchPermalink(input.link, input.rootURL);
+                if (actual) {
+                    assert.equal(actual[0], expected[0]);
+                    assert.equal(actual[1], expected[1]);
+                    assert.equal(actual[2], expected[2]);
+                } else {
+                    assert.equal(actual, expected);
+                }
+            });
+        }
     });
 });


### PR DESCRIPTION
#### Summary
Backported to 1.17 with the original fix of https://github.com/mattermost/mattermost-mobile/pull/2620 on master.

matchDeepLink on master
matchPermalink on release-1.17

#### Ticket Link
Jira ticket: [MM-14312](https://mattermost.atlassian.net/browse/MM-14312)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [iOS simulator, Android emulator] 

