### PR TITLE
Fix regression when sharing files with spaces in the filename

### DIFF
--- a/ios/UploadAttachments/UploadAttachments/UploadManager.swift
+++ b/ios/UploadAttachments/UploadAttachments/UploadManager.swift
@@ -9,6 +9,17 @@ import UIKit
         return Singleton.instance
     }
 
+    private func buildUploadURL(baseURL: String, channelId: String, fileName: String?) -> URL? {
+        let urlComponent = NSURLComponents(string: "\(baseURL)/api/v4/files")
+        let queryChannel = URLQueryItem(name: "channel_id", value: channelId)
+        let queryFile = URLQueryItem(name: "filename", value: fileName)
+
+        urlComponent?.path = "/api/v4/files"
+        urlComponent?.queryItems = [queryChannel, queryFile]
+        print("URL TO UPLOAD \(urlComponent?.string ?? "NOT DEFINED")")
+        return urlComponent?.url
+    }
+    
     public func uploadFiles(baseURL: String, token: String, channelId: String, message: String?, attachments: AttachmentArray<AttachmentItem>, callback: () -> Void) {
         let identifier = "mattermost-share-upload-\(UUID().uuidString)"
         UploadSessionManager.shared.createUploadSessionData(
@@ -24,7 +35,8 @@ import UIKit
 
             for index in 0..<attachments.count {
                 guard let item = attachments[index] else {return}
-                let url = URL(string: "\(baseURL)/api/v4/files?channel_id=\(channelId)&filename=\(item.fileName!)")
+
+                let url = buildUploadURL(baseURL: baseURL, channelId: channelId, fileName: item.fileName)
                 var uploadRequest = URLRequest(url: url!)
                 uploadRequest.httpMethod = "POST"
                 uploadRequest.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")


### PR DESCRIPTION
#### Summary
If the name of the filename contains spaces we need to url encoded it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14387
