### PR TITLE
Set the correct channel display name when switching teams

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -19,7 +19,7 @@ import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getTeamMembersByIds} from 'mattermost-redux/actions/teams';
 import {getProfilesInChannel} from 'mattermost-redux/actions/users';
 import {General, Preferences} from 'mattermost-redux/constants';
-import {getCurrentChannelId, getMyChannelMember} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getCurrentChannelId, getMyChannelMember} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId, getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 
 import {
@@ -314,7 +314,6 @@ export function selectPenultimateChannel(teamId) {
             (lastChannel.team_id === teamId || isDMVisible || isGMVisible)
         ) {
             dispatch(setChannelLoading(true));
-            dispatch(setChannelDisplayName(lastChannel.display_name));
             dispatch(handleSelectChannel(lastChannelId));
             return;
         }
@@ -341,7 +340,6 @@ export function selectDefaultChannel(teamId) {
         }
 
         if (channelId) {
-            dispatch(setChannelDisplayName(''));
             dispatch(handleSelectChannel(channelId));
         }
     };
@@ -350,6 +348,7 @@ export function selectDefaultChannel(teamId) {
 export function handleSelectChannel(channelId) {
     return async (dispatch, getState) => {
         const state = getState();
+        const channel = getChannel(state, channelId);
         const currentTeamId = getCurrentTeamId(state);
         const currentChannelId = getCurrentChannelId(state);
         const sameChannel = channelId === currentChannelId;
@@ -359,6 +358,7 @@ export function handleSelectChannel(channelId) {
         dispatch(loadPostsIfNecessaryWithRetry(channelId));
         dispatch(batchActions([
             selectChannel(channelId),
+            setChannelDisplayName(channel.display_name),
             {
                 type: ViewTypes.SET_INITIAL_POST_VISIBILITY,
                 data: channelId,
@@ -389,7 +389,6 @@ export function handleSelectChannelByName(channelName, teamName) {
         const {data: channel} = await dispatch(getChannelByNameAndTeamName(teamName || currentTeamName, channelName));
         const currentChannelId = getCurrentChannelId(state);
         if (channel && currentChannelId !== channel.id) {
-            dispatch(setChannelDisplayName(channel.display_name));
             dispatch(handleSelectChannel(channel.id));
         }
     };

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -164,14 +164,7 @@ export default class ChannelSidebar extends Component {
     };
 
     selectChannel = (channel, currentChannelId, closeDrawer = true) => {
-        const {
-            actions,
-        } = this.props;
-
-        const {
-            setChannelLoading,
-            setChannelDisplayName,
-        } = actions;
+        const {setChannelLoading} = this.props.actions;
 
         tracker.channelSwitch = Date.now();
 
@@ -195,7 +188,6 @@ export default class ChannelSidebar extends Component {
             return;
         }
 
-        setChannelDisplayName(channel.display_name);
         EventEmitter.emit('switch_channel', channel, currentChannelId);
     };
 


### PR DESCRIPTION
#### Summary
Fixes a regression when switching teams was not updating the channel name in the channel screen

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14376