### PR TITLE
Wait for VPN connection only when appconfig flag is set

### DIFF
--- a/app/utils/network.js
+++ b/app/utils/network.js
@@ -8,11 +8,12 @@ import RNFetchBlob from 'rn-fetch-blob';
 import {Client4} from 'mattermost-redux/client';
 
 import mattermostBucket from 'app/mattermost_bucket';
+import mattermostManaged from 'app/mattermost_managed';
 
 let certificate = '';
 let previousState;
 export async function checkConnection(isConnected) {
-    if (!isConnected || !Client4.getBaseRoute().startsWith('http')) {
+    if (!Client4.getBaseRoute().startsWith('http')) {
         // If we don't have a connection or have a server yet, return the default implementation
         return {hasInternet: isConnected, serverReachable: false};
     }
@@ -20,9 +21,28 @@ export async function checkConnection(isConnected) {
     // Ping the Mattermost server to detect if the we have network connection even if the websocket cannot connect
     const server = `${Client4.getBaseRoute()}/system/ping?time=${Date.now()}`;
 
+    let managedConfig;
+    let waitsForConnectivity = false;
+    let timeoutIntervalForResource = 30;
+
+    try {
+        managedConfig = await mattermostManaged.getConfig();
+    } catch {
+        // no managed config
+    }
+
+    if (managedConfig?.useVPN === 'true') {
+        waitsForConnectivity = true;
+    }
+
+    if (managedConfig?.timeoutVPN) {
+        timeoutIntervalForResource = parseInt(managedConfig.timeoutVPN, 10);
+    }
+
     const config = {
         auto: true,
-        waitsForConnectivity: true,
+        waitsForConnectivity,
+        timeoutIntervalForResource,
     };
 
     if (Platform.OS === 'ios' && certificate === '') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13188,8 +13188,8 @@
       }
     },
     "rn-fetch-blob": {
-      "version": "github:enahum/react-native-fetch-blob#e81b40d87e9e2ca39870d61a6e4c02b9a695aaad",
-      "from": "github:enahum/react-native-fetch-blob#e81b40d87e9e2ca39870d61a6e4c02b9a695aaad",
+      "version": "github:enahum/react-native-fetch-blob#5b19784992ef2a1fa00c3a4c71fb005d7789b05c",
+      "from": "github:enahum/react-native-fetch-blob#5b19784992ef2a1fa00c3a4c71fb005d7789b05c",
       "requires": {
         "base-64": "0.1.0",
         "glob": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "redux-persist-transform-filter": "0.0.18",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "rn-fetch-blob": "github:enahum/react-native-fetch-blob#e81b40d87e9e2ca39870d61a6e4c02b9a695aaad",
+    "rn-fetch-blob": "github:enahum/react-native-fetch-blob#5b19784992ef2a1fa00c3a4c71fb005d7789b05c",
     "rn-placeholder": "github:enahum/rn-placeholder#bfee66eb54f1f06d1425a0ad511a5e16559bf82c",
     "semver": "5.6.0",
     "shallow-equals": "1.0.0",


### PR DESCRIPTION
#### Summary
Previously we added a property to fetch `waitsForConnectivity` that only applied for the `ping` endpoint that indicated that the request should wait until the VPN connection was established.

The previous approach had some issues:
1. Users that did not need a VPN connection were force to wait for 60 seconds if their server wasn't using SSL and even 120 seconds if the server was down to get an error message.
2. Users under VPN had some other issues when the VPN was disconnected and they were already logged in as the flag only worked for the `ping` endpoint instead of every request, thus the app was behaving strangely.

This PR handles the flag for `waitsForConnectivity` and also includes a value for `timeout` with a couple of AppConfig settings (managed configuration through EMM providers) to indicate that every request should wait for the VPN connection to be establish and to set the value in seconds for the timeout.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14402

Note: Docs PR https://github.com/mattermost/docs/pull/2578