### PR TITLE
[MM-14460] Do not save email interval preference on cancel on Android device

### DIFF
--- a/app/screens/settings/notification_settings_email/notification_settings_email.android.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.android.js
@@ -28,7 +28,7 @@ class NotificationSettingsEmailAndroid extends NotificationSettingsEmailBase {
 
     handleClose = () => {
         this.setState({
-            newInterval: this.state.interval,
+            newInterval: this.state.emailInterval,
             showEmailNotificationsModal: false,
         });
     }
@@ -47,11 +47,11 @@ class NotificationSettingsEmailAndroid extends NotificationSettingsEmailBase {
             sendEmailNotifications,
             theme,
         } = this.props;
-        const {interval} = this.state;
+        const {newInterval} = this.state;
         let i18nId;
         let i18nMessage;
         if (sendEmailNotifications) {
-            switch (interval) {
+            switch (newInterval) {
             case Preferences.INTERVAL_IMMEDIATE.toString():
                 i18nId = t('user.settings.notifications.email.immediately');
                 i18nMessage = 'Immediately';

--- a/app/screens/settings/notification_settings_email/notification_settings_email.android.test.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.android.test.js
@@ -12,6 +12,12 @@ import RadioButtonGroup from 'app/components/radio_button';
 
 import NotificationSettingsEmailAndroid from './notification_settings_email.android.js';
 
+jest.mock('Platform', () => {
+    const Platform = require.requireActual('Platform');
+    Platform.OS = 'android';
+    return Platform;
+});
+
 describe('NotificationSettingsEmailAndroid', () => {
     const baseProps = {
         currentUser: {id: 'current_user_id'},
@@ -138,5 +144,23 @@ describe('NotificationSettingsEmailAndroid', () => {
         wrapper.setState({showEmailNotificationsModal: false});
         wrapper.instance().showEmailModal();
         expect(wrapper.state('showEmailNotificationsModal')).toEqual(true);
+    });
+
+    test('should not save preference on back button on Android', () => {
+        const wrapper = shallowWithIntl(
+            <NotificationSettingsEmailAndroid {...baseProps}/>
+        );
+
+        const instance = wrapper.instance();
+        instance.saveEmailNotifyProps = jest.fn();
+
+        // should not save preference on back button on Android
+        // saving email preference on Android is done via Save button
+        instance.onNavigatorEvent({type: 'ScreenChangedEvent', id: 'willDisappear'});
+        expect(instance.saveEmailNotifyProps).toHaveBeenCalledTimes(0);
+
+        wrapper.setState({newInterval: '0'});
+        instance.onNavigatorEvent({type: 'ScreenChangedEvent', id: 'willDisappear'});
+        expect(instance.saveEmailNotifyProps).toHaveBeenCalledTimes(0);
     });
 });

--- a/app/screens/settings/notification_settings_email/notification_settings_email.ios.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.ios.js
@@ -28,7 +28,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
             siteName,
             theme,
         } = this.props;
-        const {interval} = this.state;
+        const {newInterval} = this.state;
         const style = getStyleSheet(theme);
 
         return (
@@ -53,7 +53,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                         action={this.setEmailNotifications}
                         actionType='select'
                         actionValue={Preferences.INTERVAL_IMMEDIATE.toString()}
-                        selected={interval === Preferences.INTERVAL_IMMEDIATE.toString()}
+                        selected={newInterval === Preferences.INTERVAL_IMMEDIATE.toString()}
                         theme={theme}
                     />
                     <View style={style.separator}/>
@@ -69,7 +69,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                             action={this.setEmailNotifications}
                             actionType='select'
                             actionValue={Preferences.INTERVAL_FIFTEEN_MINUTES.toString()}
-                            selected={interval === Preferences.INTERVAL_FIFTEEN_MINUTES.toString()}
+                            selected={newInterval === Preferences.INTERVAL_FIFTEEN_MINUTES.toString()}
                             theme={theme}
                         />
                         <View style={style.separator}/>
@@ -83,7 +83,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                             action={this.setEmailNotifications}
                             actionType='select'
                             actionValue={Preferences.INTERVAL_HOUR.toString()}
-                            selected={interval === Preferences.INTERVAL_HOUR.toString()}
+                            selected={newInterval === Preferences.INTERVAL_HOUR.toString()}
                             theme={theme}
                         />
                         <View style={style.separator}/>
@@ -99,7 +99,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                         action={this.setEmailNotifications}
                         actionType='select'
                         actionValue={Preferences.INTERVAL_NEVER.toString()}
-                        selected={interval === Preferences.INTERVAL_NEVER.toString()}
+                        selected={newInterval === Preferences.INTERVAL_NEVER.toString()}
                         theme={theme}
                     />
                 </View>

--- a/app/screens/settings/notification_settings_email/notification_settings_email.ios.test.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.ios.test.js
@@ -12,6 +12,12 @@ import SectionItem from 'app/screens/settings/section_item';
 
 import NotificationSettingsEmailIos from './notification_settings_email.ios.js';
 
+jest.mock('Platform', () => {
+    const Platform = require.requireActual('Platform');
+    Platform.OS = 'ios';
+    return Platform;
+});
+
 jest.mock('app/utils/theme', () => {
     const original = require.requireActual('app/utils/theme');
     return {
@@ -43,16 +49,23 @@ describe('NotificationSettingsEmailIos', () => {
         expect(wrapper.instance().renderEmailSection()).toMatchSnapshot();
     });
 
-    test('should call saveEmailNotifyProps on onNavigatorEvent', () => {
+    test('should save preference on back button only if email interval has changed', () => {
         const wrapper = shallow(
             <NotificationSettingsEmailIos {...baseProps}/>
         );
 
         const instance = wrapper.instance();
-        instance.saveEmailNotifyProps = jest.fn();
-        instance.onNavigatorEvent({type: 'ScreenChangedEvent', id: 'willDisappear'});
 
-        expect(instance.saveEmailNotifyProps).toHaveBeenCalledTimes(1);
+        // should not save preference if email interval has not changed.
+        instance.onNavigatorEvent({type: 'ScreenChangedEvent', id: 'willDisappear'});
+        expect(baseProps.actions.updateMe).toHaveBeenCalledTimes(0);
+        expect(baseProps.actions.savePreferences).toHaveBeenCalledTimes(0);
+
+        // should save preference if email interval has changed.
+        wrapper.setState({newInterval: '0'});
+        instance.onNavigatorEvent({type: 'ScreenChangedEvent', id: 'willDisappear'});
+        expect(baseProps.actions.updateMe).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.savePreferences).toHaveBeenCalledTimes(1);
     });
 
     test('should call actions.updateMe and actions.savePreferences on saveEmailNotifyProps', () => {


### PR DESCRIPTION
#### Summary
This ticket is related to Android but minor change is done to iOS as well.  Tested on both platforms.

On Android:
- do not save email interval preference on cancel
- remove duplicate call in saving email interval preference on back button since saving is handled already on pressed on save button.
- only save when there's actual change

On iOS:
- only save when there's actual change

#### Ticket Link
Jira ticket: [MM-14460](https://mattermost.atlassian.net/browse/MM-14460)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [Android emulator and iOS simulator] 