### PR TITLE
[MM-14389] Remove state.value and rely only on props.value for searchbar on Android

### DIFF
--- a/app/components/search_bar/search_bar.android.js
+++ b/app/components/search_bar/search_bar.android.js
@@ -68,20 +68,9 @@ export default class SearchBarAndroid extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {
-            value: props.value,
             isFocused: false,
             refocusInput: true,
         };
-    }
-
-    static getDerivedStateFromProps(nextProps, prevState) {
-        if (nextProps.value !== prevState.value) {
-            return {
-                value: nextProps.value,
-            };
-        }
-
-        return null;
     }
 
     cancel = () => {
@@ -107,7 +96,6 @@ export default class SearchBarAndroid extends PureComponent {
         InteractionManager.runAfterInteractions(() => {
             this.setState({
                 isFocused: false,
-                value: '',
             }, () => {
                 this.props.onCancelButtonPress();
             });
@@ -119,9 +107,7 @@ export default class SearchBarAndroid extends PureComponent {
     };
 
     onChangeText = (value) => {
-        this.setState({value}, () => {
-            this.props.onChangeText(value);
-        });
+        this.props.onChangeText(value);
     };
 
     onSelectionChange = (event) => {
@@ -219,7 +205,7 @@ export default class SearchBarAndroid extends PureComponent {
                         ref='input'
                         blurOnSubmit={blurOnSubmit}
                         refocusInput={this.state.refocusInput}
-                        value={this.state.value}
+                        value={this.props.value}
                         autoCapitalize={autoCapitalize}
                         autoCorrect={false}
                         returnKeyType={returnKeyType || 'search'}


### PR DESCRIPTION
#### Summary
Honestly, I cannot reproduced the issue of "extra text in search box after using autocomplete drop down - Android only".  Looks like easy to repro from Dylan but I couldn't have it even a single one out of many trials.

This PR eliminates the use of state.value and just rely on props.value for the searchbar on Android.  I'm guessing it's somewhat a race condition between the state and an update from props' value.  If not solving the issue, then this is a good first step in realizing the root cause.

#### Ticket Link
Jira ticket: [MM-14389](https://mattermost.atlassian.net/browse/MM-14389)

#### Device Information
This PR was tested on: [Android emulator] 

