### PR TITLE
[MM-14466] Fix channel mention when app is started from push notification

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -345,7 +345,7 @@ export function selectDefaultChannel(teamId) {
     };
 }
 
-export function handleSelectChannel(channelId) {
+export function handleSelectChannel(channelId, fromPushNotification = false) {
     return async (dispatch, getState) => {
         const state = getState();
         const channel = getChannel(state, channelId);
@@ -376,8 +376,8 @@ export function handleSelectChannel(channelId) {
             },
         ]));
 
-        dispatch(markChannelAsRead(channelId, sameChannel ? null : currentChannelId));
-        dispatch(markChannelAsViewed(channelId, sameChannel ? null : currentChannelId));
+        dispatch(markChannelAsRead(channelId, fromPushNotification || sameChannel ? null : currentChannelId));
+        dispatch(markChannelAsViewed(channelId, fromPushNotification || sameChannel ? null : currentChannelId));
     };
 }
 

--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -92,7 +92,7 @@ export function loadFromPushNotification(notification, startAppFromPushNotificat
         } else if (channelId !== currentChannelId) {
             // when the notification is from a channel other than the current channel
             dispatch(setChannelDisplayName(''));
-            dispatch(handleSelectChannel(channelId));
+            dispatch(handleSelectChannel(channelId, true));
         }
     };
 }


### PR DESCRIPTION
#### Summary
Fix channel mention when app is started from push notification by adding flag to `handleSelectChannel` that the call is from push notification.

#### Ticket Link
Jira ticket: [MM-14466](https://mattermost.atlassian.net/browse/MM-14466)

#### Device Information
This PR was tested on: [Android emulator and iOS simulator] 
