### PR TITLE
MM-14461: make @-mentions (and searches) case insensitive

### DIFF
--- a/app/selectors/autocomplete.js
+++ b/app/selectors/autocomplete.js
@@ -27,7 +27,7 @@ export const getMatchTermForAtMention = (() => {
             lastValue = value;
             lastIsSearch = isSearch;
             if (match) {
-                lastMatchTerm = isSearch ? match[1] : match[2];
+                lastMatchTerm = (isSearch ? match[1] : match[2]).toLowerCase();
             } else {
                 lastMatchTerm = null;
             }

--- a/app/selectors/autocomplete.test.js
+++ b/app/selectors/autocomplete.test.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import {
+    getMatchTermForAtMention,
+} from 'app/selectors/autocomplete';
+
+/* eslint-disable max-nested-callbacks */
+
+describe('Selectors.Autocomplete', () => {
+    describe('getMatchTermForAtMention', () => {
+        describe('match non-search at mentions', () => {
+            const testCases = [
+                ['@', ''],
+                ['@a', 'a'],
+                ['@match', 'match'],
+                ['@Username', 'username'],
+                ['@USERNAME', 'username'],
+                ['not a match', null],
+            ];
+
+            testCases.forEach((testCase) => {
+                it(testCase[0], () => {
+                    const value = testCase[0];
+                    const isSearch = false;
+                    const expected = testCase[1];
+                    const actual = getMatchTermForAtMention(value, isSearch);
+
+                    assert.equal(expected, actual);
+                });
+            });
+        });
+
+        describe('match search at mentions', () => {
+            const testCases = [
+                ['from:', ''],
+                ['from:a', 'a'],
+                ['from:match', 'match'],
+                ['from:not a match', null],
+                ['from:Username', 'username'],
+                ['from:USERNAME', 'username'],
+                ['from: space', 'space'],
+            ];
+
+            testCases.forEach((testCase) => {
+                it(testCase[0], () => {
+                    const value = testCase[0];
+                    const isSearch = true;
+                    const expected = testCase[1];
+                    const actual = getMatchTermForAtMention(value, isSearch);
+
+                    assert.equal(expected, actual);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Invoke `toLowerCase()` on the match result, matching the webapp behaviour re: same.

We /could/ also do this on the server, but there are local at-mention autocompletes as well and they need the same `toLowerCase()` logic anyway.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14461

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
![image](https://user-images.githubusercontent.com/1023171/54207404-7c308c00-44b0-11e9-949b-8eddbcb90c7f.png)
![image](https://user-images.githubusercontent.com/1023171/54207431-85b9f400-44b0-11e9-9242-163536d6cdf5.png)

