### PR TITLE
[MM-14587] Fix channel mention badge and posts after opening the app from push notification (which was initially at closed state)

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -355,7 +355,12 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
         const member = getMyChannelMember(state, channelId);
 
         dispatch(setLoadMorePostsVisible(true));
-        dispatch(loadPostsIfNecessaryWithRetry(channelId));
+
+        // If the app is open from push notification, we already fetched the posts.
+        if (!fromPushNotification) {
+            dispatch(loadPostsIfNecessaryWithRetry(channelId));
+        }
+
         dispatch(batchActions([
             selectChannel(channelId),
             setChannelDisplayName(channel.display_name),
@@ -376,8 +381,13 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
             },
         ]));
 
-        dispatch(markChannelAsRead(channelId, fromPushNotification || sameChannel ? null : currentChannelId));
-        dispatch(markChannelAsViewed(channelId, fromPushNotification || sameChannel ? null : currentChannelId));
+        let markPreviousChannelId;
+        if (!fromPushNotification && !sameChannel) {
+            markPreviousChannelId = currentChannelId;
+        }
+
+        dispatch(markChannelAsRead(channelId, markPreviousChannelId));
+        dispatch(markChannelAsViewed(channelId, markPreviousChannelId));
     };
 }
 

--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -4,17 +4,14 @@
 import {GeneralTypes, PostTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {General} from 'mattermost-redux/constants';
-import {fetchMyChannelsAndMembers, markChannelAsRead, markChannelAsViewed} from 'mattermost-redux/actions/channels';
+import {fetchMyChannelsAndMembers} from 'mattermost-redux/actions/channels';
 import {getClientConfig, getDataRetentionPolicy, getLicenseConfig} from 'mattermost-redux/actions/general';
 import {getMyTeams, getMyTeamMembers, selectTeam} from 'mattermost-redux/actions/teams';
 
 import {ViewTypes} from 'app/constants';
 import {recordTime} from 'app/utils/segment';
 
-import {
-    handleSelectChannel,
-    setChannelDisplayName,
-} from 'app/actions/views/channel';
+import {handleSelectChannel} from 'app/actions/views/channel';
 
 export function startDataCleanup() {
     return async (dispatch, getState) => {
@@ -54,7 +51,7 @@ export function loadFromPushNotification(notification, startAppFromPushNotificat
         const state = getState();
         const {data} = notification;
         const {currentTeamId, teams, myMembers: myTeamMembers} = state.entities.teams;
-        const {currentChannelId, channels} = state.entities.channels;
+        const {channels} = state.entities.channels;
 
         let channelId = '';
         let teamId = currentTeamId;
@@ -86,14 +83,7 @@ export function loadFromPushNotification(notification, startAppFromPushNotificat
             dispatch(selectTeam({id: teamId}));
         }
 
-        if (channelId === currentChannelId && !startAppFromPushNotification) {
-            dispatch(markChannelAsRead(channelId, null, true));
-            dispatch(markChannelAsViewed(channelId));
-        } else if (channelId !== currentChannelId) {
-            // when the notification is from a channel other than the current channel
-            dispatch(setChannelDisplayName(''));
-            dispatch(handleSelectChannel(channelId, true));
-        }
+        dispatch(handleSelectChannel(channelId, startAppFromPushNotification));
     };
 }
 

--- a/app/fetch_preconfig.js
+++ b/app/fetch_preconfig.js
@@ -37,12 +37,14 @@ const handleRedirectProtocol = (url, response) => {
 };
 
 Client4.doFetchWithResponse = async (url, options) => {
-    if (!Client4.online) {
-        throw new ClientError(Client4.getUrl(), {
-            message: 'no internet connection',
-            url,
-        });
-    }
+    // Removing the check of this flag to be handled natively.
+    // In case Android presents the out of memory issue, consider uncommenting line 42-47.
+    // if (!Client4.online) {
+    //     throw new ClientError(Client4.getUrl(), {
+    //         message: 'no internet connection',
+    //         url,
+    //     });
+    // }
 
     const customHeaders = LocalConfig.CustomRequestHeaders;
     let waitsForConnectivity = false;

--- a/app/utils/push_notifications.js
+++ b/app/utils/push_notifications.js
@@ -50,7 +50,7 @@ const onRegisterDevice = (data) => {
 };
 
 const loadFromNotification = async (notification) => {
-    await store.dispatch(loadFromPushNotification(notification, app.startAppFromPushNotification));
+    await store.dispatch(loadFromPushNotification(notification, true));
     if (!app.startAppFromPushNotification) {
         EventEmitter.emit(ViewTypes.NOTIFICATION_TAPPED);
         PushNotifications.resetNotification();


### PR DESCRIPTION
#### Summary
Fix channel mention badge and posts after opening the app from push notification (which was initially at closed state)
- the `app.startAppFromPushNotification` is being set twice, first as `true` then `false` causing the post visibility to have `NaN` value and wiped out the posts which were initially rendered in a channel screen.
- clearing of mention badge is fixed by correctly identifying the case when to mark channel as read and viewed
- commented online check that potentially causing to stop API requests.  Such online check is actually handled natively but added a note just in case we encountered related out-of-memory issue on Android in the future.

@enahum Thank you very much for figuring this out and giving your full time.  I really appreciate it very much and sorry for asking for your time knowing that you're sick today.

#### Ticket Link
Jira ticket: [MM-14587](https://mattermost.atlassian.net/browse/MM-14587)

#### Device Information
This PR was tested on: [Android simulator] 
