### PR TITLE
[MM-14589] Fix relative URL permalink

### DIFF
--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -97,7 +97,7 @@ export function getScheme(url) {
 }
 
 export function matchPermalink(link, rootURL) {
-    if (!link || !rootURL) {
+    if (!link) {
         return null;
     }
 


### PR DESCRIPTION
#### Summary
Fix relative URL permalink by removing null/empty check to `rootURL` of `matchPermalink` and continue to return matched relative URL. 

This only happened on release-1.17 but not on master.

#### Ticket Link
Jira ticket: [MM-14589](https://mattermost.atlassian.net/browse/MM-14589)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 
