### PR TITLE
[MM-14527] Fix email setting to "Never" when first saved (hitting back button on iOS) without actually changing the selection

### DIFF
--- a/app/screens/settings/notification_settings_email/notification_settings_email.android.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.android.js
@@ -180,7 +180,7 @@ class NotificationSettingsEmailAndroid extends NotificationSettingsEmailBase {
                             {sendEmailNotifications &&
                             <RadioButtonGroup
                                 name='emailSettings'
-                                onSelect={this.setEmailNotifications}
+                                onSelect={this.setEmailInterval}
                                 options={emailOptions}
                             />
                             }

--- a/app/screens/settings/notification_settings_email/notification_settings_email.android.test.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.android.test.js
@@ -56,20 +56,20 @@ describe('NotificationSettingsEmailAndroid', () => {
         expect(wrapper.instance().renderEmailNotificationsModal(style)).toMatchSnapshot();
     });
 
-    test('should match state on setEmailNotifications', () => {
+    test('should match state on setEmailInterval', () => {
         const wrapper = shallowWithIntl(
             <NotificationSettingsEmailAndroid {...baseProps}/>
         );
 
-        wrapper.setState({email: 'false', interval: '0'});
-        wrapper.instance().setEmailNotifications('30');
-        expect(wrapper.state({email: 'true', interval: '30'}));
+        wrapper.setState({interval: '0'});
+        wrapper.instance().setEmailInterval('30');
+        expect(wrapper.state({interval: '30'}));
 
-        wrapper.instance().setEmailNotifications('0');
-        expect(wrapper.state({email: 'false', interval: '0'}));
+        wrapper.instance().setEmailInterval('0');
+        expect(wrapper.state({interval: '0'}));
 
-        wrapper.instance().setEmailNotifications('3600');
-        expect(wrapper.state({email: 'true', interval: '3600'}));
+        wrapper.instance().setEmailInterval('3600');
+        expect(wrapper.state({interval: '3600'}));
     });
 
     test('should match state on select of RadioButtonGroup', () => {

--- a/app/screens/settings/notification_settings_email/notification_settings_email.ios.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.ios.js
@@ -50,7 +50,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                                 defaultMessage='Immediately'
                             />
                         )}
-                        action={this.setEmailNotifications}
+                        action={this.setEmailInterval}
                         actionType='select'
                         actionValue={Preferences.INTERVAL_IMMEDIATE.toString()}
                         selected={newInterval === Preferences.INTERVAL_IMMEDIATE.toString()}
@@ -66,7 +66,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                                     defaultMessage='Every 15 minutes'
                                 />
                             )}
-                            action={this.setEmailNotifications}
+                            action={this.setEmailInterval}
                             actionType='select'
                             actionValue={Preferences.INTERVAL_FIFTEEN_MINUTES.toString()}
                             selected={newInterval === Preferences.INTERVAL_FIFTEEN_MINUTES.toString()}
@@ -80,7 +80,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                                     defaultMessage='Every hour'
                                 />
                             )}
-                            action={this.setEmailNotifications}
+                            action={this.setEmailInterval}
                             actionType='select'
                             actionValue={Preferences.INTERVAL_HOUR.toString()}
                             selected={newInterval === Preferences.INTERVAL_HOUR.toString()}
@@ -96,7 +96,7 @@ class NotificationSettingsEmailIos extends NotificationSettingsEmailBase {
                                 defaultMessage='Never'
                             />
                         )}
-                        action={this.setEmailNotifications}
+                        action={this.setEmailInterval}
                         actionType='select'
                         actionValue={Preferences.INTERVAL_NEVER.toString()}
                         selected={newInterval === Preferences.INTERVAL_NEVER.toString()}

--- a/app/screens/settings/notification_settings_email/notification_settings_email.ios.test.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email.ios.test.js
@@ -86,20 +86,20 @@ describe('NotificationSettingsEmailIos', () => {
         expect(savePreferences).toBeCalledWith('current_user_id', [{category: 'notifications', name: 'email_interval', user_id: 'current_user_id', value: 30}]);
     });
 
-    test('should match state on setEmailNotifications', () => {
+    test('should match state on setEmailInterval', () => {
         const wrapper = shallow(
             <NotificationSettingsEmailIos {...baseProps}/>
         );
 
-        wrapper.setState({email: 'false', interval: '0'});
-        wrapper.instance().setEmailNotifications('30');
-        expect(wrapper.state({email: 'true', interval: '30'}));
+        wrapper.setState({interval: '0'});
+        wrapper.instance().setEmailInterval('30');
+        expect(wrapper.state({interval: '30'}));
 
-        wrapper.instance().setEmailNotifications('0');
-        expect(wrapper.state({email: 'false', interval: '0'}));
+        wrapper.instance().setEmailInterval('0');
+        expect(wrapper.state({interval: '0'}));
 
-        wrapper.instance().setEmailNotifications('3600');
-        expect(wrapper.state({email: 'true', interval: '3600'}));
+        wrapper.instance().setEmailInterval('3600');
+        expect(wrapper.state({interval: '3600'}));
     });
 
     test('should match state on action of SectionItem', () => {

--- a/app/screens/settings/notification_settings_email/notification_settings_email_base.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email_base.js
@@ -84,25 +84,25 @@ export default class NotificationSettingsEmailBase extends PureComponent {
         }
     };
 
-    setEmailNotifications = (value) => {
-        const {sendEmailNotifications} = this.props;
-
-        let email = 'false';
-        if (sendEmailNotifications && value !== Preferences.INTERVAL_NEVER.toString()) {
-            email = 'true';
-        }
-
-        this.setState({
-            email,
-            newInterval: value,
-        });
+    setEmailInterval = (value) => {
+        this.setState({newInterval: value});
     };
 
     saveEmailNotifyProps = () => {
-        const {actions, currentUser} = this.props;
-        const {email, emailInterval, newInterval} = this.state;
+        const {emailInterval, newInterval} = this.state;
 
         if (emailInterval !== newInterval) {
+            const {
+                actions,
+                currentUser,
+                sendEmailNotifications,
+            } = this.props;
+
+            let email = 'false';
+            if (sendEmailNotifications && newInterval !== Preferences.INTERVAL_NEVER.toString()) {
+                email = 'true';
+            }
+
             const notifyProps = getNotificationProps(currentUser);
             actions.updateMe({notify_props: {...notifyProps, email}});
 


### PR DESCRIPTION
#### Summary
Fix email setting of being set to "Never" when first saved (hitting back button on iOS) without actually changing the selection.

#### Ticket Link
Jira ticket: [MM-14527](https://mattermost.atlassian.net/browse/MM-14527)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 
