### PR TITLE
MM-14345: Changes the channelIsReadOnly prop to be associated to the …

### DIFF
--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import {createPost, removePost} from 'mattermost-redux/actions/posts';
 import {Posts} from 'mattermost-redux/constants';
-import {isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
+import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 import {getPost, makeGetCommentCountForPost, makeIsPostCommentMention} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getMyPreferences, getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -71,7 +71,7 @@ function makeMapStateToProps() {
         }
 
         return {
-            channelIsReadOnly: isCurrentChannelReadOnly(state),
+            channelIsReadOnly: isChannelReadOnlyById(state, post.channel_id),
             currentUserId,
             post,
             isFirstReply,


### PR DESCRIPTION
…post's channel rather than the current channel. Show the unpin regardless of whether a channel is read-only.

#### Summary
* Sets the `channelIsReadOnly` prop using the post's channel ID rather than the *current* channel. This will properly show and hide the "Pin to Channel" long-press option for specific posts in the "Flagged Posts" list.
* Allows flag/unflag long-press options regardless of whether the channel is readonly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14345

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
iPhone X, iOS 12.1 emulator.

#### Screenshots
![Simulator Screen Shot - iPhone X - 2019-03-18 at 13 08 00](https://user-images.githubusercontent.com/1149597/54548719-e9479400-497e-11e9-832b-2e3c37f468b9.png)
![Simulator Screen Shot - iPhone X - 2019-03-18 at 13 07 57](https://user-images.githubusercontent.com/1149597/54548720-e9479400-497e-11e9-8e34-a7321d19ffac.png)

