### PR TITLE
MM-14459 Ensure hydrationComplete is set to true

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -91,7 +91,7 @@ const initializeModules = () => {
     EventEmitter.on(NavigationTypes.RESTART_APP, restartApp);
     EventEmitter.on(General.SERVER_VERSION_CHANGED, handleServerVersionChanged);
     EventEmitter.on(General.CONFIG_CHANGED, handleConfigChanged);
-    EventEmitter.on(General.SWITCH_TO_DEFAULT_CHANNEL, handleSwithToDefaultChannel);
+    EventEmitter.on(General.SWITCH_TO_DEFAULT_CHANNEL, handleSwitchToDefaultChannel);
     Dimensions.addEventListener('change', handleOrientationChange);
     mattermostManaged.addEventListener('managedConfigDidChange', () => {
         handleManagedConfig(true);
@@ -338,7 +338,7 @@ const handleAuthentication = async (vendor) => {
     return true;
 };
 
-const handleSwithToDefaultChannel = (teamId) => {
+const handleSwitchToDefaultChannel = (teamId) => {
     store.dispatch(selectDefaultChannel(teamId));
 };
 

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -145,7 +145,6 @@ export default function configureAppStore(initialState) {
             const persistor = persistStore(store, {storage: AsyncStorage, ...options}, () => {
                 store.dispatch({
                     type: General.STORE_REHYDRATION_COMPLETE,
-                    complete: true,
                 });
             });
 
@@ -205,6 +204,9 @@ export default function configureAppStore(initialState) {
                             data: initialState,
                         },
                         {
+                            type: General.STORE_REHYDRATION_COMPLETE,
+                        },
+                        {
                             type: ViewTypes.SERVER_URL_CHANGED,
                             serverUrl: state.entities.general.credentials.url || state.views.selectServer.serverUrl,
                         },
@@ -255,6 +257,9 @@ export default function configureAppStore(initialState) {
                         {
                             type: GeneralTypes.RECEIVED_SERVER_VERSION,
                             data: state.entities.general.serverVersion,
+                        },
+                        {
+                            type: General.STORE_REHYDRATION_COMPLETE,
                         },
                     ], 'BATCH_FOR_RESTART'));
 

--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -166,6 +166,9 @@ function resetStateForNewVersion(action) {
             thread: {
                 drafts: threadDrafts,
             },
+            root: {
+                hydrationComplete: true,
+            },
             selectServer,
             recentEmojis,
         },


### PR DESCRIPTION
#### Summary
When opening a notification the first thing that happens is we check if the `hydrationComplete` is true to ensure that the redux store has been loaded and we have access to its data.

When sending the app to the background we perform a cleanup of the redux state to try and avoid memory pressure (that can cause performance degradation). When this happens sometimes the `hydrationComplete` under `views.root` was reset and the original value is set to **false**.

Also when resetting the `Cache and Documents data` the same state is set to its original value which is **false**

This PR corrects that by ensuring in both cases that `hydrationComplete` remains as **true**

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14459
