### PR TITLE
MM-14541 Fix search bar animation stutter in main search bar

### DIFF
--- a/app/components/search_bar/search_bar.android.js
+++ b/app/components/search_bar/search_bar.android.js
@@ -44,6 +44,7 @@ export default class SearchBarAndroid extends PureComponent {
         showArrow: PropTypes.bool,
         value: PropTypes.string,
         containerStyle: CustomPropTypes.Style,
+        leftComponent: PropTypes.element,
     };
 
     static defaultProps = {
@@ -63,6 +64,7 @@ export default class SearchBarAndroid extends PureComponent {
         onBlur: () => true,
         onSelectionChange: () => true,
         value: '',
+        leftComponent: null,
     };
 
     constructor(props) {
@@ -174,6 +176,7 @@ export default class SearchBarAndroid extends PureComponent {
                     backgroundColor && {backgroundColor},
                 ]}
             >
+                {!isFocused && this.props.leftComponent}
                 <View
                     style={[
                         styles.searchBar,

--- a/app/components/search_bar/search_bar.ios.js
+++ b/app/components/search_bar/search_bar.ios.js
@@ -36,6 +36,7 @@ export default class SearchBarIos extends PureComponent {
         inputBorderRadius: PropTypes.number,
         blurOnSubmit: PropTypes.bool,
         value: PropTypes.string,
+        leftComponent: PropTypes.element,
     };
 
     static defaultProps = {
@@ -46,6 +47,7 @@ export default class SearchBarIos extends PureComponent {
         onBlur: () => true,
         onSelectionChange: () => true,
         blurOnSubmit: true,
+        leftComponent: null,
     };
 
     cancel = () => {

--- a/app/components/search_bar/search_box.js
+++ b/app/components/search_bar/search_box.js
@@ -187,6 +187,7 @@ export default class Search extends Component {
             {
                 toValue: (text.length > 0) ? 1 : 0,
                 duration: 200,
+                useNativeDriver: true,
             }
         ).start();
 
@@ -212,6 +213,7 @@ export default class Search extends Component {
             {
                 toValue: 0,
                 duration: 200,
+                useNativeDriver: true,
             }
         ).start();
         this.focus();
@@ -243,57 +245,59 @@ export default class Search extends Component {
                         toValue: this.contentWidth - 70,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.inputFocusAnimated,
                     {
                         toValue: this.state.leftComponentWidth,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.leftComponentAnimated,
                     {
                         toValue: this.contentWidth,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.btnCancelAnimated,
                     {
                         toValue: this.state.leftComponentWidth ? 15 - this.state.leftComponentWidth : 10,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.inputFocusPlaceholderAnimated,
                     {
                         toValue: this.props.placeholderExpandedMargin,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.iconSearchAnimated,
                     {
                         toValue: this.props.searchIconExpandedMargin,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.iconDeleteAnimated,
                     {
                         toValue: (this.props.value.length > 0) ? 1 : 0,
                         duration: 200,
+                        useNativeDriver: true,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.shadowOpacityAnimated,
                     {
                         toValue: this.props.shadowOpacityExpanded,
                         duration: 200,
+                        useNativeDriver: true,
                     }
-                ).start(),
-            ]);
+                ),
+            ]).start();
             this.shadowHeight = this.props.shadowOffsetHeightExpanded;
             resolve();
         });
@@ -309,28 +313,28 @@ export default class Search extends Component {
                         toValue: this.contentWidth - this.state.leftComponentWidth - 10,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.inputFocusAnimated,
                     {
                         toValue: 0,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.leftComponentAnimated,
                     {
                         toValue: 0,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.btnCancelAnimated,
                     {
                         toValue: this.contentWidth,
                         duration: 200,
                     }
-                ).start(),
+                ),
                 ((this.props.keyboardShouldPersist === false) ?
                     Animated.timing(
                         this.inputFocusPlaceholderAnimated,
@@ -338,7 +342,7 @@ export default class Search extends Component {
                             toValue: this.props.placeholderCollapsedMargin,
                             duration: 200,
                         }
-                    ).start() : null),
+                    ) : null),
                 ((this.props.keyboardShouldPersist === false || isForceAnim === true) ?
                     Animated.timing(
                         this.iconSearchAnimated,
@@ -346,22 +350,24 @@ export default class Search extends Component {
                             toValue: this.props.searchIconCollapsedMargin + this.state.leftComponentWidth,
                             duration: 200,
                         }
-                    ).start() : null),
+                    ) : null),
                 Animated.timing(
                     this.iconDeleteAnimated,
                     {
                         toValue: 0,
                         duration: 200,
+                        useNativeDriver: true,
                     }
-                ).start(),
+                ),
                 Animated.timing(
                     this.shadowOpacityAnimated,
                     {
                         toValue: this.props.shadowOpacityCollapsed,
                         duration: 200,
+                        useNativeDriver: true,
                     }
-                ).start(),
-            ]);
+                ),
+            ]).start();
             this.shadowHeight = this.props.shadowOffsetHeightCollapsed;
             resolve();
         });

--- a/app/components/sidebars/main/channels_list/channels_list.js
+++ b/app/components/sidebars/main/channels_list/channels_list.js
@@ -145,6 +145,11 @@ export default class ChannelsList extends PureComponent {
                     onChangeText={this.onSearch}
                     onFocus={this.onSearchFocused}
                     value={term}
+                    leftComponent={(
+                        <SwitchTeamsButton
+                            onShowTeams={onShowTeams}
+                        />
+                    )}
                 />
             </View>
         );
@@ -155,12 +160,6 @@ export default class ChannelsList extends PureComponent {
             >
                 <View style={styles.statusBar}>
                     <View style={styles.headerContainer}>
-                        <View style={styles.switchContainer}>
-                            <SwitchTeamsButton
-                                searching={searching}
-                                onShowTeams={onShowTeams}
-                            />
-                        </View>
                         {title}
                     </View>
                 </View>

--- a/app/components/sidebars/main/channels_list/switch_teams_button/switch_teams_button.js
+++ b/app/components/sidebars/main/channels_list/switch_teams_button/switch_teams_button.js
@@ -18,7 +18,6 @@ import TeamIcon from 'app/components/team_icon';
 export default class SwitchTeamsButton extends React.PureComponent {
     static propTypes = {
         currentTeamId: PropTypes.string,
-        searching: PropTypes.bool.isRequired,
         onShowTeams: PropTypes.func.isRequired,
         mentionCount: PropTypes.number.isRequired,
         teamsCount: PropTypes.number.isRequired,
@@ -33,7 +32,6 @@ export default class SwitchTeamsButton extends React.PureComponent {
         const {
             currentTeamId,
             mentionCount,
-            searching,
             teamsCount,
             theme,
         } = this.props;
@@ -42,7 +40,7 @@ export default class SwitchTeamsButton extends React.PureComponent {
             return null;
         }
 
-        if (searching || teamsCount < 2) {
+        if (teamsCount < 2) {
             return null;
         }
 

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -63,6 +63,7 @@ export default class ChannelSidebar extends Component {
             show: false,
             openDrawerOffset,
             drawerOpened: false,
+            searching: false,
         };
     }
 
@@ -92,9 +93,9 @@ export default class ChannelSidebar extends Component {
 
     shouldComponentUpdate(nextProps, nextState) {
         const {currentTeamId, deviceWidth, isLandscape, teamsCount} = this.props;
-        const {openDrawerOffset} = this.state;
+        const {openDrawerOffset, show, searching} = this.state;
 
-        if (nextState.openDrawerOffset !== openDrawerOffset || nextState.show !== this.state.show) {
+        if (nextState.openDrawerOffset !== openDrawerOffset || nextState.show !== show || nextState.searching !== searching) {
             return true;
         }
 
@@ -258,20 +259,11 @@ export default class ChannelSidebar extends Component {
     };
 
     onSearchEnds = () => {
-        //hack to update the drawer when the offset changes
-        const {isLandscape, isTablet} = this.props;
-
-        let openDrawerOffset = DRAWER_INITIAL_OFFSET;
-        if (isLandscape || isTablet) {
-            openDrawerOffset = DRAWER_LANDSCAPE_OFFSET;
-        }
-        if (this.refs.drawer) {
-            this.refs.drawer.canClose = true;
-        }
-        this.setState({openDrawerOffset});
+        this.setState({searching: false});
     };
 
     onSearchStart = () => {
+        this.setState({searching: true});
         if (this.refs.drawer) {
             this.refs.drawer.canClose = false;
         }
@@ -299,6 +291,7 @@ export default class ChannelSidebar extends Component {
         const {
             show,
             openDrawerOffset,
+            searching,
         } = this.state;
 
         if (!show) {
@@ -306,7 +299,7 @@ export default class ChannelSidebar extends Component {
         }
 
         const multipleTeams = teamsCount > 1;
-        const showTeams = openDrawerOffset !== 0 && multipleTeams;
+        const showTeams = !searching && multipleTeams;
         if (this.drawerSwiper) {
             if (multipleTeams) {
                 this.drawerSwiper.getWrappedInstance().runOnLayout();

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -263,10 +263,10 @@ export default class ChannelSidebar extends Component {
     };
 
     onSearchStart = () => {
-        this.setState({searching: true});
         if (this.refs.drawer) {
             this.refs.drawer.canClose = false;
         }
+        this.setState({searching: true});
     };
 
     showTeams = () => {

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -275,7 +275,6 @@ export default class ChannelSidebar extends Component {
         if (this.refs.drawer) {
             this.refs.drawer.canClose = false;
         }
-        this.setState({openDrawerOffset: 0});
     };
 
     showTeams = () => {

--- a/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
+++ b/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
@@ -23,6 +23,7 @@ exports[`MoreChannels should match snapshot 1`] = `
             "fontSize": 15,
           }
         }
+        leftComponent={null}
         onBlur={[Function]}
         onCancelButtonPress={[Function]}
         onChangeText={[Function]}

--- a/app/screens/selector_screen/__snapshots__/selector_screen.test.js.snap
+++ b/app/screens/selector_screen/__snapshots__/selector_screen.test.js.snap
@@ -30,6 +30,7 @@ exports[`SelectorScreen should match snapshot for channels 1`] = `
           "fontSize": 15,
         }
       }
+      leftComponent={null}
       onBlur={[Function]}
       onCancelButtonPress={[Function]}
       onChangeText={[Function]}
@@ -117,6 +118,7 @@ exports[`SelectorScreen should match snapshot for channels 2`] = `
           "fontSize": 15,
         }
       }
+      leftComponent={null}
       onBlur={[Function]}
       onCancelButtonPress={[Function]}
       onChangeText={[Function]}
@@ -204,6 +206,7 @@ exports[`SelectorScreen should match snapshot for explicit options 1`] = `
           "fontSize": 15,
         }
       }
+      leftComponent={null}
       onBlur={[Function]}
       onCancelButtonPress={[Function]}
       onChangeText={[Function]}
@@ -298,6 +301,7 @@ exports[`SelectorScreen should match snapshot for searching 1`] = `
           "fontSize": 15,
         }
       }
+      leftComponent={null}
       onBlur={[Function]}
       onCancelButtonPress={[Function]}
       onChangeText={[Function]}
@@ -385,6 +389,7 @@ exports[`SelectorScreen should match snapshot for users 1`] = `
           "fontSize": 15,
         }
       }
+      leftComponent={null}
       onBlur={[Function]}
       onCancelButtonPress={[Function]}
       onChangeText={[Function]}
@@ -472,6 +477,7 @@ exports[`SelectorScreen should match snapshot for users 2`] = `
           "fontSize": 15,
         }
       }
+      leftComponent={null}
       onBlur={[Function]}
       onCancelButtonPress={[Function]}
       onChangeText={[Function]}


### PR DESCRIPTION
#### Summary
There are two scenarios where the search bar animation stutters in the main side bar for iOS:

1. When the drawer is expanded on focus of the search box and then shrunk on cancel of the search.
2. When the SwitchTeamsButton goes in and out of view on focus of the search box.

This PR removes the expansion of the drawer as well as passes the SwitchTeamsButton to SearchBox via a new prop, `leftComponent`, so that the SwitchTeamsButton animation can be handled along with the search bar animations.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14541

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.1.4
* Samsung Galaxy S7, Android 7.0

#### Screenshots
Before:
iOS
![before](https://user-images.githubusercontent.com/3208014/55017031-20d0c480-4fad-11e9-83a7-7e8c2bf1bdb3.png)
Android
![before_android](https://user-images.githubusercontent.com/3208014/55017947-14e60200-4faf-11e9-97cf-63845f2a8550.png)

After:
iOS
![after](https://user-images.githubusercontent.com/3208014/55017050-2cbc8680-4fad-11e9-88af-a37e055c35a1.png)
Android
![after_android](https://user-images.githubusercontent.com/3208014/55017967-1fa09700-4faf-11e9-88cc-4f691ef8e425.png)
