### PR TITLE
MM-14498 Generate random channel URL name from display names that don't clean into a usable name

### DIFF
--- a/app/actions/views/create_channel.js
+++ b/app/actions/views/create_channel.js
@@ -6,6 +6,17 @@ import {createChannel} from 'mattermost-redux/actions/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {cleanUpUrlable} from 'mattermost-redux/utils/channel_utils';
+import {generateId} from 'mattermost-redux/utils/helpers';
+
+export function generateChannelNameFromDisplayName(displayName) {
+    let name = cleanUpUrlable(displayName);
+
+    if (name === '') {
+        name = generateId();
+    }
+
+    return name;
+}
 
 export function handleCreateChannel(displayName, purpose, header, type) {
     return async (dispatch, getState) => {
@@ -14,7 +25,7 @@ export function handleCreateChannel(displayName, purpose, header, type) {
         const teamId = getCurrentTeamId(state);
         const channel = {
             team_id: teamId,
-            name: cleanUpUrlable(displayName),
+            name: generateChannelNameFromDisplayName(displayName),
             display_name: displayName,
             purpose,
             header,

--- a/app/actions/views/create_channel.test.js
+++ b/app/actions/views/create_channel.test.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {generateChannelNameFromDisplayName} from 'app/actions/views/create_channel';
+
+describe('Actions.Views.CreateChannel', () => {
+    describe('generateChannelNameFromDisplayName', () => {
+        test('should not change name', async () => {
+            expect(generateChannelNameFromDisplayName('abc')).toEqual('abc');
+        });
+
+        test('should generate name from non-latin characters', async () => {
+            expect(generateChannelNameFromDisplayName('熊本').length).toEqual(36);
+        });
+
+        test('should generate name from blank string', async () => {
+            expect(generateChannelNameFromDisplayName('').length).toEqual(36);
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Generate random channel URL name from display names that don't clean into a usable name. This will fix cases where non-latin characters are used in the display name but are not convertible to a usable channel name.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14498

#### Checklist
- [x] Added or updated unit tests (required for all new features)