### PR TITLE
[MM-14699] Determine cached image's file extension from MIME type

### DIFF
--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -22,6 +22,11 @@ export default class Emoji extends React.PureComponent {
         emojiName: PropTypes.string.isRequired,
 
         /*
+         * Emoji mime type.
+         */
+        mimeType: PropTypes.string.isRequired,
+
+        /*
          * Image URL for the emoji.
          */
         imageUrl: PropTypes.string.isRequired,
@@ -56,15 +61,15 @@ export default class Emoji extends React.PureComponent {
     }
 
     componentWillMount() {
-        const {displayTextOnly, emojiName, imageUrl} = this.props;
+        const {displayTextOnly, emojiName, imageUrl, mimeType} = this.props;
         this.mounted = true;
         if (!displayTextOnly && imageUrl) {
-            ImageCacheManager.cache(`emoji-${emojiName}`, imageUrl, this.setImageUrl);
+            ImageCacheManager.cache(`emoji-${emojiName}`, imageUrl, this.setImageUrl, mimeType);
         }
     }
 
     componentWillReceiveProps(nextProps) {
-        const {displayTextOnly, emojiName, imageUrl} = nextProps;
+        const {displayTextOnly, emojiName, imageUrl, mimeType} = nextProps;
         if (emojiName !== this.props.emojiName) {
             this.setState({
                 imageUrl: null,
@@ -73,7 +78,7 @@ export default class Emoji extends React.PureComponent {
 
         if (!displayTextOnly && imageUrl &&
                 imageUrl !== this.props.imageUrl) {
-            ImageCacheManager.cache(`emoji-${emojiName}`, imageUrl, this.setImageUrl);
+            ImageCacheManager.cache(`emoji-${emojiName}`, imageUrl, this.setImageUrl, mimeType);
         }
     }
 

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -49,6 +49,7 @@ export default class Emoji extends React.PureComponent {
         customEmojis: new Map(),
         literal: '',
         imageUrl: '',
+        mimeType: '',
         isCustomEmoji: false,
     };
 

--- a/app/components/emoji/index.js
+++ b/app/components/emoji/index.js
@@ -25,11 +25,11 @@ function mapStateToProps(state, ownProps) {
     let displayTextOnly = false;
     if (EmojiIndicesByAlias.has(emojiName)) {
         const emoji = Emojis[EmojiIndicesByAlias.get(emojiName)];
-        mimeType = emoji.mimeType;
+        mimeType = emoji.mime_type;
         imageUrl = Client4.getSystemEmojiImageUrl(emoji.filename);
     } else if (customEmojis.has(emojiName)) {
         const emoji = customEmojis.get(emojiName);
-        mimeType = emoji.mimeType;
+        mimeType = emoji.mime_type;
         imageUrl = Client4.getCustomEmojiImageUrl(emoji.id);
         isCustomEmoji = true;
     } else {

--- a/app/components/emoji/index.js
+++ b/app/components/emoji/index.js
@@ -10,6 +10,7 @@ import {Client4} from 'mattermost-redux/client';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
 import {EmojiIndicesByAlias, Emojis} from 'app/utils/emojis';
+import {DEFAULT_MIME_TYPE} from 'app/constants/emoji';
 
 import Emoji from './emoji';
 
@@ -18,14 +19,17 @@ function mapStateToProps(state, ownProps) {
     const emojiName = ownProps.emojiName;
     const customEmojis = getCustomEmojisByName(state);
 
+    let mimeType = DEFAULT_MIME_TYPE;
     let imageUrl = '';
     let isCustomEmoji = false;
     let displayTextOnly = false;
     if (EmojiIndicesByAlias.has(emojiName)) {
         const emoji = Emojis[EmojiIndicesByAlias.get(emojiName)];
+        mimeType = emoji.mimeType;
         imageUrl = Client4.getSystemEmojiImageUrl(emoji.filename);
     } else if (customEmojis.has(emojiName)) {
         const emoji = customEmojis.get(emojiName);
+        mimeType = emoji.mimeType;
         imageUrl = Client4.getCustomEmojiImageUrl(emoji.id);
         isCustomEmoji = true;
     } else {
@@ -37,6 +41,7 @@ function mapStateToProps(state, ownProps) {
     }
 
     return {
+        mimeType,
         imageUrl,
         isCustomEmoji,
         displayTextOnly,

--- a/app/constants/emoji.js
+++ b/app/constants/emoji.js
@@ -2,3 +2,10 @@
 // See LICENSE.txt for license information.
 
 export const ALL_EMOJIS = 'all_emojis';
+
+export const DEFAULT_MIME_TYPE = 'image/png';
+
+export const mimeTypeExtensions = {
+    'image/png': '.png',
+    'image/gif': '.gif',
+};

--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -23,7 +23,7 @@ export default class ImageCacheManager {
             console.warn('Unable to cache image when no listener is provided'); // eslint-disable-line no-console
         }
 
-        const {path, exists} = await getCacheFile(filename, mimeType, uri);
+        const {path, exists} = await getCacheFile(filename, uri, mimeType);
         const prefix = Platform.OS === 'android' ? 'file://' : '';
         if (isDownloading(uri)) {
             addListener(uri, listener);
@@ -69,7 +69,7 @@ export default class ImageCacheManager {
     };
 }
 
-export const getCacheFile = async (name, mimeType, uri) => {
+export const getCacheFile = async (name, uri, mimeType = DEFAULT_MIME_TYPE) => {
     const filename = name || uri.substring(uri.lastIndexOf('/'), uri.indexOf('?') === -1 ? uri.length : uri.indexOf('?'));
     let ext;
     if (filename.indexOf('.') === -1) {

--- a/app/utils/image_cache_manager.test.js
+++ b/app/utils/image_cache_manager.test.js
@@ -15,7 +15,7 @@ describe('getCacheFile', () => {
         const mimeType = 'application/octet-stream';
         const uri = '';
 
-        const {path} = await getCacheFile(name, mimeType, uri);
+        const {path} = await getCacheFile(name, uri, mimeType);
         expect(path).toMatch(/\.png$/);
     });
 
@@ -24,7 +24,7 @@ describe('getCacheFile', () => {
         const mimeType = 'image/png';
         const uri = '';
 
-        const {path} = await getCacheFile(name, mimeType, uri);
+        const {path} = await getCacheFile(name, uri, mimeType);
         expect(path).toMatch(/\.png$/);
     });
 
@@ -33,7 +33,7 @@ describe('getCacheFile', () => {
         const mimeType = 'image/gif';
         const uri = '';
 
-        const {path} = await getCacheFile(name, mimeType, uri);
+        const {path} = await getCacheFile(name, uri, mimeType);
         expect(path).toMatch(/\.gif$/);
     });
 
@@ -42,7 +42,7 @@ describe('getCacheFile', () => {
         const mimeType = '';
         const uri = 'file://uri.png';
 
-        const {path} = await getCacheFile(name, mimeType, uri);
+        const {path} = await getCacheFile(name, uri, mimeType);
         expect(path).toMatch(/\.png$/);
     });
 
@@ -51,7 +51,7 @@ describe('getCacheFile', () => {
         const mimeType = '';
         const uri = 'file://uri.gif';
 
-        const {path} = await getCacheFile(name, mimeType, uri);
+        const {path} = await getCacheFile(name, uri, mimeType);
         expect(path).toMatch(/\.gif$/);
     });
 });

--- a/app/utils/image_cache_manager.test.js
+++ b/app/utils/image_cache_manager.test.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getCacheFile} from 'app/utils/image_cache_manager';
+
+jest.mock('rn-fetch-blob', () => ({
+    fs: {
+        exists: jest.fn().mockReturnValue(false),
+    },
+}));
+
+describe('getCacheFile', () => {
+    it('should have a path with default extension .png for unknown mime type', async () => {
+        const name = 'emoji-name';
+        const mimeType = 'application/octet-stream';
+        const uri = '';
+
+        const {path} = await getCacheFile(name, mimeType, uri);
+        expect(path).toMatch(/\.png$/);
+    });
+
+    it('should have a path with extension .png for mime type image/png', async () => {
+        const name = 'emoji-name';
+        const mimeType = 'image/png';
+        const uri = '';
+
+        const {path} = await getCacheFile(name, mimeType, uri);
+        expect(path).toMatch(/\.png$/);
+    });
+
+    it('should have a path with extension .gif for mime type image/gif', async () => {
+        const name = 'emoji-name';
+        const mimeType = 'image/gif';
+        const uri = '';
+
+        const {path} = await getCacheFile(name, mimeType, uri);
+        expect(path).toMatch(/\.gif$/);
+    });
+
+    it('should have a path with extension .png extracted from uri', async () => {
+        const name = '';
+        const mimeType = '';
+        const uri = 'file://uri.png';
+
+        const {path} = await getCacheFile(name, mimeType, uri);
+        expect(path).toMatch(/\.png$/);
+    });
+
+    it('should have a path with extension .gif extracted from uri', async () => {
+        const name = '';
+        const mimeType = '';
+        const uri = 'file://uri.gif';
+
+        const {path} = await getCacheFile(name, mimeType, uri);
+        expect(path).toMatch(/\.gif$/);
+    });
+});


### PR DESCRIPTION
#### Summary
See [PR-10528](https://github.com/mattermost/mattermost-server/pull/10528) for mattermost-server changes.

With the custom emoji's MIME type, we can now create a file path with the correct extension prior to requesting the custom emoji image from the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14699

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux/pull/801)

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.1.4
* Samsung Galaxy S7, Android 7.0
