### PR TITLE
[MM-14669] Return null dimensions when height or width is falsy

### DIFF
--- a/app/constants/image.js
+++ b/app/constants/image.js
@@ -1,0 +1,5 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const IMAGE_MAX_HEIGHT = 350;
+export const IMAGE_MIN_DIMENSION = 50;

--- a/app/utils/images.js
+++ b/app/utils/images.js
@@ -1,9 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {
+    IMAGE_MAX_HEIGHT,
+    IMAGE_MIN_DIMENSION,
+} from 'app/constants/image';
+
 let previewComponents;
-const IMAGE_MAX_HEIGHT = 350;
-const IMAGE_MIN_DIMENSION = 50;
 
 export const calculateDimensions = (height, width, viewPortWidth = 0, viewPortHeight = 0) => {
     if (height === 0 || width === 0) {

--- a/app/utils/images.js
+++ b/app/utils/images.js
@@ -6,6 +6,13 @@ const IMAGE_MAX_HEIGHT = 350;
 const IMAGE_MIN_DIMENSION = 50;
 
 export const calculateDimensions = (height, width, viewPortWidth = 0, viewPortHeight = 0) => {
+    if (height === 0 || width === 0) {
+        return {
+            height: IMAGE_MIN_DIMENSION,
+            width: IMAGE_MIN_DIMENSION,
+        };
+    }
+
     const ratio = height / width;
     const heightRatio = width / height;
 

--- a/app/utils/images.js
+++ b/app/utils/images.js
@@ -9,10 +9,10 @@ import {
 let previewComponents;
 
 export const calculateDimensions = (height, width, viewPortWidth = 0, viewPortHeight = 0) => {
-    if (height === 0 || width === 0) {
+    if (!height || !width) {
         return {
-            height: IMAGE_MIN_DIMENSION,
-            width: IMAGE_MIN_DIMENSION,
+            height: null,
+            width: null,
         };
     }
 

--- a/app/utils/images.test.js
+++ b/app/utils/images.test.js
@@ -8,6 +8,18 @@ const IMAGE_MAX_HEIGHT = 350;
 const IMAGE_MIN_DIMENSION = 50;
 
 describe('Images calculateDimensions', () => {
+    it('image with 0 height should return 50x50', () => {
+        const {height, width} = calculateDimensions(0, 20, PORTRAIT_VIEWPORT);
+        expect(height).toEqual(IMAGE_MIN_DIMENSION);
+        expect(width).toEqual(IMAGE_MIN_DIMENSION);
+    });
+
+    it('image with 0 width should return 50x50', () => {
+        const {height, width} = calculateDimensions(20, 0, PORTRAIT_VIEWPORT);
+        expect(height).toEqual(IMAGE_MIN_DIMENSION);
+        expect(width).toEqual(IMAGE_MIN_DIMENSION);
+    });
+
     it('image smaller than 50x50 should return 50x50', () => {
         const {height, width} = calculateDimensions(20, 20, PORTRAIT_VIEWPORT);
         expect(height).toEqual(IMAGE_MIN_DIMENSION);

--- a/app/utils/images.test.js
+++ b/app/utils/images.test.js
@@ -10,16 +10,22 @@ import {
 const PORTRAIT_VIEWPORT = 315;
 
 describe('Images calculateDimensions', () => {
-    it('image with 0 height should return 50x50', () => {
-        const {height, width} = calculateDimensions(0, 20, PORTRAIT_VIEWPORT);
-        expect(height).toEqual(IMAGE_MIN_DIMENSION);
-        expect(width).toEqual(IMAGE_MIN_DIMENSION);
+    it('image with falsy height should return null height and width', () => {
+        const falsyHeights = [0, null, undefined, NaN, '', false];
+        falsyHeights.forEach((falsyHeight) => {
+            const {height, width} = calculateDimensions(falsyHeight, 20, PORTRAIT_VIEWPORT);
+            expect(height).toEqual(null);
+            expect(width).toEqual(null);
+        });
     });
 
-    it('image with 0 width should return 50x50', () => {
-        const {height, width} = calculateDimensions(20, 0, PORTRAIT_VIEWPORT);
-        expect(height).toEqual(IMAGE_MIN_DIMENSION);
-        expect(width).toEqual(IMAGE_MIN_DIMENSION);
+    it('image with falsy width should return null height and width', () => {
+        const falsyWidths = [0, null, undefined, NaN, '', false];
+        falsyWidths.forEach((falsyWidth) => {
+            const {height, width} = calculateDimensions(20, falsyWidth, PORTRAIT_VIEWPORT);
+            expect(height).toEqual(null);
+            expect(width).toEqual(null);
+        });
     });
 
     it('image smaller than 50x50 should return 50x50', () => {

--- a/app/utils/images.test.js
+++ b/app/utils/images.test.js
@@ -2,10 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {calculateDimensions} from 'app/utils/images';
+import {
+    IMAGE_MAX_HEIGHT,
+    IMAGE_MIN_DIMENSION,
+} from 'app/constants/image';
 
 const PORTRAIT_VIEWPORT = 315;
-const IMAGE_MAX_HEIGHT = 350;
-const IMAGE_MIN_DIMENSION = 50;
 
 describe('Images calculateDimensions', () => {
     it('image with 0 height should return 50x50', () => {


### PR DESCRIPTION
#### Summary
When a 0 height and/or width is passed to `calculateDimensions`, a `NaN` value can be returned for width and/or height. Passing this value to the Image component crashed the app. With this change we check for 0 height/width and return default dimensions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14669

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone XS emulator, iOS 12.1
* Samsung Galaxy S7, Android 7.0

#### Screenshots
iOS
<img width="403" alt="Screen Shot 2019-03-28 at 2 52 36 PM" src="https://user-images.githubusercontent.com/3208014/55195278-460a3200-5169-11e9-8750-b393edc76649.png">

Android
![Screenshot_20190328-144931](https://user-images.githubusercontent.com/3208014/55195290-50c4c700-5169-11e9-9283-83d95a6c497b.png)

