### PR TITLE
[MM-14698] Add CSRF Header in File Upload and Profile Image Set Operations

### DIFF
--- a/app/components/file_upload_preview/file_upload_item/file_upload_item.js
+++ b/app/components/file_upload_preview/file_upload_item/file_upload_item.js
@@ -119,6 +119,7 @@ export default class FileUploadItem extends PureComponent {
             Authorization: `Bearer ${Client4.getToken()}`,
             'X-Requested-With': 'XMLHttpRequest',
             'Content-Type': 'multipart/form-data',
+            'X-CSRF-Token': Client4.csrf,
         };
 
         const fileInfo = {

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -226,6 +226,7 @@ export default class EditProfile extends PureComponent {
             Authorization: `Bearer ${Client4.getToken()}`,
             'X-Requested-With': 'XMLHttpRequest',
             'Content-Type': 'multipart/form-data',
+            'X-CSRF-Token': Client4.csrf,
         };
 
         const fileInfo = {


### PR DESCRIPTION
#### Summary
This PR manually sets the `X-CSRF-Token` header for operations that do not rely on `Client4` for non-get HTTP requests to avoid missing token warning.

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-14698

#### Device Information
This PR was tested on: Android 9 Emulator