### PR TITLE
[MM-14866] Fix app crash due to parseInt call on null and display test notification message

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -263,10 +263,12 @@ public class CustomPushNotification extends PushNotification {
                 .setGroupSummary(true)
                 .setStyle(messagingStyle)
                 .setSmallIcon(smallIconResId)
-                .setNumber(Integer.parseInt(badge))
                 .setVisibility(Notification.VISIBILITY_PRIVATE)
                 .setPriority(Notification.PRIORITY_HIGH)
                 .setAutoCancel(true);
+        if (badge != null) {
+            notification.setNumber(Integer.parseInt(badge));
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             notification.setBadgeIconType(Notification.BADGE_ICON_SMALL);

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -250,6 +250,7 @@ public class CustomPushNotification extends PushNotification {
             list = new ArrayList<Bundle>(bundleArray);
         } else {
             list = new ArrayList<Bundle>();
+            list.add(bundle);
         }
 
         for (Bundle data : list) {

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -230,7 +230,9 @@ public class CustomPushNotification extends PushNotification {
         }
 
         if (badge != null) {
-            CustomPushNotification.badgeCount = Integer.parseInt(badge);
+            int badgeCount = Integer.parseInt(badge);
+            CustomPushNotification.badgeCount = badgeCount;
+            notification.setNumber(badgeCount);
             ApplicationBadgeHelper.instance.setApplicationIconBadgeNumber(mContext.getApplicationContext(), CustomPushNotification.badgeCount);
         } else {
             // HERE ADD THE DOT INDICATOR STUFF
@@ -266,9 +268,6 @@ public class CustomPushNotification extends PushNotification {
                 .setVisibility(Notification.VISIBILITY_PRIVATE)
                 .setPriority(Notification.PRIORITY_HIGH)
                 .setAutoCancel(true);
-        if (badge != null) {
-            notification.setNumber(Integer.parseInt(badge));
-        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             notification.setBadgeIconType(Notification.BADGE_ICON_SMALL);


### PR DESCRIPTION
#### Summary
Call setNumber on notification only if badge is not null and add bundle to empty list so that test notification message is handled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14866

#### Device Information
This PR was tested on:
* Samsung Galaxy S7, Android 7.0

#### Screenshots
![Screenshot_20190402-123427](https://user-images.githubusercontent.com/3208014/55431474-7c6af700-5545-11e9-8e51-6f1b6f337bf8.png)

