### PR TITLE
[MM-14871] Fix extraction of sender name for push notifications

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -236,7 +236,7 @@ public class CustomPushNotification extends PushNotification {
             // HERE ADD THE DOT INDICATOR STUFF
         }
 
-        Notification.MessagingStyle messagingStyle = new Notification.MessagingStyle("");
+        Notification.MessagingStyle messagingStyle = new Notification.MessagingStyle("You");
         if (title != null && !title.startsWith("@")) {
             messagingStyle
                     .setConversationTitle(title);
@@ -366,7 +366,7 @@ public class CustomPushNotification extends PushNotification {
             return senderName;
         }
 
-        return "";
+        return " ";
     }
 
     private String removeSenderFromMessage(String message) {

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import com.wix.reactnativenotifications.core.notification.PushNotification;
 import com.wix.reactnativenotifications.core.NotificationIntentAdapter;
@@ -47,6 +49,7 @@ public class CustomPushNotification extends PushNotification {
     private static AppLifecycleFacade lifecycleFacade;
     private static Context context;
     private static int badgeCount = 0;
+    private static Pattern senderNamePattern = Pattern.compile("^(@[a-z0-9\\.\\-_]+):.*$", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     public CustomPushNotification(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
@@ -361,7 +364,12 @@ public class CustomPushNotification extends PushNotification {
             return channelName;
         }
 
-        return message.split(":")[0];
+        Matcher m = senderNamePattern.matcher(message);
+        if (m.find()) {
+            return m.group(1);
+        }
+
+        return "";
     }
 
     private String removeSenderFromMessage(String message) {

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -25,8 +25,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 import com.wix.reactnativenotifications.core.notification.PushNotification;
 import com.wix.reactnativenotifications.core.NotificationIntentAdapter;
@@ -49,7 +47,6 @@ public class CustomPushNotification extends PushNotification {
     private static AppLifecycleFacade lifecycleFacade;
     private static Context context;
     private static int badgeCount = 0;
-    private static Pattern senderNamePattern = Pattern.compile("^(@[a-z0-9\\.\\-_]+):.*$", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     public CustomPushNotification(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
@@ -239,7 +236,7 @@ public class CustomPushNotification extends PushNotification {
             // HERE ADD THE DOT INDICATOR STUFF
         }
 
-        Notification.MessagingStyle messagingStyle = new Notification.MessagingStyle("You");
+        Notification.MessagingStyle messagingStyle = new Notification.MessagingStyle("");
         if (title != null && !title.startsWith("@")) {
             messagingStyle
                     .setConversationTitle(title);
@@ -364,9 +361,9 @@ public class CustomPushNotification extends PushNotification {
             return channelName;
         }
 
-        Matcher m = senderNamePattern.matcher(message);
-        if (m.find()) {
-            return m.group(1);
+        String senderName = message.split(":")[0];
+        if (senderName != message) {
+            return senderName;
         }
 
         return "";


### PR DESCRIPTION
#### Summary
Previously, the sender name was set by taking the first result from splitting the message on `:`. Since generic messages do not contain a `:`, the message itself was being set as the sender name.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14871

#### Device Information
This PR was tested on:
* Samsung Galaxy S7, Android 7.0
* Emulator, Android 9
