### PR TITLE
[MM-14821] Avoid force casting items to URL

### DIFF
--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -175,10 +175,12 @@ class ShareViewController: SLComposeServiceViewController {
           dispatchGroup.enter()
           itemProvider.loadItem(forTypeIdentifier: kUTTypeMovie as String, options: nil, completionHandler: ({item, error in
             if error == nil {
-              let attachment = self.saveAttachment(url: item as! URL)
-              if (attachment != nil) {
-                attachment?.type = kUTTypeMovie as String
-                self.attachments.append(attachment!)
+              if let url = item as? URL {
+                let attachment = self.saveAttachment(url: url)
+                if (attachment != nil) {
+                  attachment?.type = kUTTypeMovie as String
+                  self.attachments.append(attachment!)
+                }
               }
             }
             self.dispatchGroup.leave()
@@ -187,10 +189,12 @@ class ShareViewController: SLComposeServiceViewController {
           dispatchGroup.enter()
           itemProvider.loadItem(forTypeIdentifier: kUTTypeImage as String, options: nil, completionHandler: ({item, error in
             if error == nil {
-              let attachment = self.saveAttachment(url: item as! URL)
-              if (attachment != nil) {
-                attachment?.type = kUTTypeImage as String
-                self.attachments.append(attachment!)
+              if let url = item as? URL {
+                let attachment = self.saveAttachment(url: url)
+                if (attachment != nil) {
+                  attachment?.type = kUTTypeImage as String
+                  self.attachments.append(attachment!)
+                }
               }
             }
             self.dispatchGroup.leave()
@@ -199,10 +203,12 @@ class ShareViewController: SLComposeServiceViewController {
           dispatchGroup.enter()
           itemProvider.loadItem(forTypeIdentifier: kUTTypeFileURL as String, options: nil, completionHandler: ({item, error in
             if error == nil {
-              let attachment = self.saveAttachment(url: item as! URL)
-              if (attachment != nil) {
-                attachment?.type = kUTTypeFileURL as String
-                self.attachments.append(attachment!)
+              if let url = item as? URL {
+                let attachment = self.saveAttachment(url: url)
+                if (attachment != nil) {
+                  attachment?.type = kUTTypeFileURL as String
+                  self.attachments.append(attachment!)
+                }
               }
             }
             self.dispatchGroup.leave()


### PR DESCRIPTION
#### Summary
Use the `as?` operator over `as!` to return nil and avoid a crash in the case where `item` is not a URL.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14821

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.1.4
