### PR TITLE
MM-14959 iOS Share Extension channel search open by default

### DIFF
--- a/ios/MattermostShare/ChannelsViewController.swift
+++ b/ios/MattermostShare/ChannelsViewController.swift
@@ -15,15 +15,30 @@ class ChannelsViewController: UIViewController {
     return tableView
   }()
   
+  var navbarTitle: String? = "Channels"
   var channelDecks = [Section]()
   var filteredDecks: [Section]?
   weak var delegate: ChannelsViewControllerDelegate?
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    if #available(iOS 11.0, *) {
+      navigationItem.hidesSearchBarWhenScrolling = false
+    }
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    if #available(iOS 11.0, *) {
+      navigationItem.hidesSearchBarWhenScrolling = true
+    }
+  }
   
   override func viewDidLoad() {
     super.viewDidLoad()
     
     filteredDecks = channelDecks
-    title = "Channels"
+    title = navbarTitle
     configureSearchBar()
     view.addSubview(tableView)
   }
@@ -34,13 +49,17 @@ class ChannelsViewController: UIViewController {
     searchController.dimsBackgroundDuringPresentation = false
     searchController.searchBar.searchBarStyle = .minimal
     searchController.searchBar.autocapitalizationType = .none
+    searchController.searchBar.delegate = self
+
+    self.definesPresentationContext = true
     
     if #available(iOS 11.0, *) {
       // For iOS 11 and later, place the search bar in the navigation bar.
-      self.definesPresentationContext = true
       
-      // Make the search bar always visible.
-      navigationItem.hidesSearchBarWhenScrolling = true
+      // Give space at the top so provide a better look and feel
+      let offset = UIOffset(horizontal: 0.0, vertical: 6.0)
+      searchController.searchBar.searchFieldBackgroundPositionAdjustment = offset
+      
       
       navigationItem.searchController = searchController
     } else {
@@ -130,5 +149,27 @@ extension ChannelsViewController: UISearchBarDelegate {
   
   func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
     searchBar.showsCancelButton = true
+    
+    // Center the Cancel Button
+    if #available(iOS 11.0, *) {
+      searchBar.cancelButton?.titleEdgeInsets = UIEdgeInsets(top: 12.0, left: 0, bottom: 0, right: 0)
+    }
+  }
+}
+
+// get the cancel button of the Search Bar
+extension UISearchBar {
+  var cancelButton : UIButton? {
+    let topView: UIView = self.subviews[0] as UIView
+    
+    if let pvtClass = NSClassFromString("UINavigationButton") {
+      for v in topView.subviews {
+        if v.isKind(of: pvtClass) {
+          return v as? UIButton
+        }
+      }
+    }
+    
+    return nil
   }
 }

--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -121,6 +121,7 @@ class ShareViewController: SLComposeServiceViewController {
       channels.tapHandler = {
         let vc = ChannelsViewController()
         vc.channelDecks = channelDecks!
+        vc.navbarTitle = self.selectedTeam?.title
         vc.delegate = self
         self.pushConfigurationViewController(vc)
       }
@@ -161,6 +162,7 @@ class ShareViewController: SLComposeServiceViewController {
       if id == currentChannelId {
         item.selected = true
         selectedChannel = item
+        placeholder = "Write to \(item.title!)"
       }
       section.items.append(item)
     }

--- a/ios/MattermostShare/TeamsViewController.swift
+++ b/ios/MattermostShare/TeamsViewController.swift
@@ -17,7 +17,7 @@ class TeamsViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    title = "Teams"
+    title = "Team"
     view.addSubview(tableView)
   }
   


### PR DESCRIPTION
#### Summary
on iOS 11+ the way the search bar is displayed is as part of the Navigation bar instead of in the table header, the Search bar then looks trimmed in comparison, so in this PR we do a few things:

1. Show the Search bar when entering the select channel screen
2. Modify the Search Bar to add some padding at the top (this is done by adding an offset to the background and then moving the Cancel button down)
3. The title of the navigation bar to select the channel now shows the team display name instead of the word "Channels"
4. The title of the navigation bar to select the team is now singular (Team instead of Teams)
5. The placeholder to write text is now "Write to <Channel name>"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14959

