### PR TITLE
MM-14960 Use the correct icon set for channel types

### DIFF
--- a/app/components/channel_icon.js
+++ b/app/components/channel_icon.js
@@ -8,9 +8,10 @@ import {
     Text,
     View,
 } from 'react-native';
-import Icon from 'react-native-vector-icons/FontAwesome5';
 
 import {General} from 'mattermost-redux/constants';
+
+import Icon from 'app/components/vector_icon';
 
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
@@ -85,6 +86,7 @@ export default class ChannelIcon extends React.PureComponent {
                 <Icon
                     name='archive'
                     style={[style.icon, unreadIcon, activeIcon, {fontSize: size}]}
+                    type='fontawesome'
                 />
             );
         } else if (isBot) {
@@ -92,6 +94,7 @@ export default class ChannelIcon extends React.PureComponent {
                 <Icon
                     name='robot'
                     style={[style.icon, unreadIcon, activeIcon, {fontSize: size}, style.iconBot]}
+                    type='fontawesome5'
                 />
             );
         } else if (hasDraft) {
@@ -99,6 +102,7 @@ export default class ChannelIcon extends React.PureComponent {
                 <Icon
                     name='pencil'
                     style={[style.icon, unreadIcon, activeIcon, {fontSize: size}]}
+                    type='fontawesome'
                 />
             );
         } else if (type === General.OPEN_CHANNEL) {
@@ -106,6 +110,7 @@ export default class ChannelIcon extends React.PureComponent {
                 <Icon
                     name='globe'
                     style={[style.icon, unreadIcon, activeIcon, {fontSize: size}]}
+                    type='fontawesome'
                 />
             );
         } else if (type === General.PRIVATE_CHANNEL) {
@@ -113,6 +118,7 @@ export default class ChannelIcon extends React.PureComponent {
                 <Icon
                     name='lock'
                     style={[style.icon, unreadIcon, activeIcon, {fontSize: size}]}
+                    type='fontawesome'
                 />
             );
         } else if (type === General.GM_CHANNEL) {

--- a/app/components/vector_icon.js
+++ b/app/components/vector_icon.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import {Text} from 'react-native';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
+import FontAwesome5Icon from 'react-native-vector-icons/FontAwesome5';
 import FoundationIcon from 'react-native-vector-icons/Foundation';
 import IonIcon from 'react-native-vector-icons/Ionicons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -28,6 +29,14 @@ export default class VectorIcon extends PureComponent {
         case 'fontawesome':
             return (
                 <FontAwesomeIcon
+                    name={name}
+                    style={style}
+                    size={size}
+                />
+            );
+        case 'fontawesome5':
+            return (
+                <FontAwesome5Icon
                     name={name}
                     style={style}
                     size={size}


### PR DESCRIPTION
#### Summary
The PR that introduced support for bot accounts #2669 changed the icons from `FontAwesome` to `FontAwesome5` causing the icons to change, this PR reverts to use the same `FontAwesome` for previous icons to avoid changes in the UI and includes support for `FontAwesome5` for the new bot account type

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14960