### PR TITLE
[MM-14918] Do not display package name in failed push notification reply message

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
@@ -133,7 +133,6 @@ public class NotificationReplyBroadcastReceiver extends BroadcastReceiver {
         Notification notification =
                 new Notification.Builder(mContext, CHANNEL_ID)
                         .setContentTitle("Message failed to send.")
-                        .setContentText(packageName)
                         .setSmallIcon(smallIconResId)
                         .build();
 


### PR DESCRIPTION
#### Summary
Removed package name from push notification content.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14918

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Android emulator running Android 9

#### Screenshots
![Screen Shot 2019-04-07 at 12 23 55 PM](https://user-images.githubusercontent.com/3208014/55688693-37253b80-5930-11e9-860a-0265f148323f.png)

