### PR TITLE
[MM-14954] Set canFlag to false for system messages

### DIFF
--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -87,6 +87,7 @@ function mapStateToProps(state, ownProps) {
         canCopyPermalink = false;
         canEdit = false;
         canPin = false;
+        canFlag = false;
     }
     if (ownProps.hasBeenDeleted) {
         canDelete = false;


### PR DESCRIPTION
#### Summary
Set `canFlag` to false for system messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14954

#### Device Information
This PR was tested on:
* Samsung Galaxy S7, Android 7.0
* iPhone 8, iOS 12.2
