### PR TITLE
MM-15050 Reminder message (`/remind`) do not show message text on mobile.

### DIFF
--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -241,6 +241,7 @@ export default class PostBody extends PureComponent {
 
     renderPostAdditionalContent = (blockStyles, messageStyle, textStyles) => {
         const {
+            isPostEphemeral,
             isReplyPost,
             isSystemMessage,
             message,
@@ -252,7 +253,7 @@ export default class PostBody extends PureComponent {
             postProps,
         } = this.props;
 
-        if (isSystemMessage) {
+        if (isSystemMessage && !isPostEphemeral) {
             return null;
         }
 


### PR DESCRIPTION
#### Summary
This change address a bug where Reminder ephemeral posts (using the `/remind` command) did not show message text.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15050

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone X (iOS), Nexus 6 (Android)