### PR TITLE
[MM-15022] Ensure the correct value for channelIsLoading is used

### DIFF
--- a/app/components/channel_loader/index.js
+++ b/app/components/channel_loader/index.js
@@ -11,8 +11,12 @@ import {handleSelectChannel, setChannelLoading} from 'app/actions/views/channel'
 import ChannelLoader from './channel_loader';
 
 function mapStateToProps(state, ownProps) {
+    const channelIsLoading = ownProps.hasOwnProperty('channelIsLoading') ?
+        ownProps.channelIsLoading :
+        state.views.channel.loading;
+
     return {
-        channelIsLoading: ownProps.channelIsLoading || state.views.channel.loading,
+        channelIsLoading,
         theme: getTheme(state),
     };
 }


### PR DESCRIPTION
#### Summary
This change avoids the situation where the `state.views.channel.loading` value is used if `ownProps.channelIsLoading` is false. This may or may not be a contributing issue to MM-15022.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15022

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.2
