### PR TITLE
DateHeader rendering bug fix

### DIFF
--- a/app/screens/flagged_posts/flagged_posts.js
+++ b/app/screens/flagged_posts/flagged_posts.js
@@ -12,7 +12,7 @@ import {
     View,
 } from 'react-native';
 
-import {isDateLine} from 'mattermost-redux/utils/post_list';
+import {isDateLine, getDateForDateLine} from 'mattermost-redux/utils/post_list';
 
 import ChannelLoader from 'app/components/channel_loader';
 import DateHeader from 'app/components/post_list/date_header';
@@ -163,7 +163,7 @@ export default class FlaggedPosts extends PureComponent {
         if (isDateLine(item)) {
             return (
                 <DateHeader
-                    dateLineString={item}
+                    date={getDateForDateLine(item)}
                     index={index}
                 />
             );

--- a/app/screens/pinned_posts/pinned_posts.js
+++ b/app/screens/pinned_posts/pinned_posts.js
@@ -12,7 +12,7 @@ import {
     View,
 } from 'react-native';
 
-import {isDateLine} from 'mattermost-redux/utils/post_list';
+import {isDateLine, getDateForDateLine} from 'mattermost-redux/utils/post_list';
 
 import ChannelLoader from 'app/components/channel_loader';
 import DateHeader from 'app/components/post_list/date_header';
@@ -165,7 +165,7 @@ export default class PinnedPosts extends PureComponent {
         if (isDateLine(item)) {
             return (
                 <DateHeader
-                    dateLineString={item}
+                    date={getDateForDateLine(item)}
                     index={index}
                 />
             );

--- a/app/screens/recent_mentions/recent_mentions.js
+++ b/app/screens/recent_mentions/recent_mentions.js
@@ -12,7 +12,7 @@ import {
     View,
 } from 'react-native';
 
-import {isDateLine} from 'mattermost-redux/utils/post_list';
+import {isDateLine, getDateForDateLine} from 'mattermost-redux/utils/post_list';
 
 import ChannelLoader from 'app/components/channel_loader';
 import DateHeader from 'app/components/post_list/date_header';
@@ -163,7 +163,7 @@ export default class RecentMentions extends PureComponent {
         if (isDateLine(item)) {
             return (
                 <DateHeader
-                    dateLineString={item}
+                    date={getDateForDateLine(item)}
                     index={index}
                 />
             );

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -15,7 +15,7 @@ import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 
 import {debounce} from 'mattermost-redux/actions/helpers';
 import {RequestStatus} from 'mattermost-redux/constants';
-import {isDateLine} from 'mattermost-redux/utils/post_list';
+import {isDateLine, getDateForDateLine} from 'mattermost-redux/utils/post_list';
 
 import Autocomplete from 'app/components/autocomplete';
 import KeyboardLayout from 'app/components/layout/keyboard_layout';
@@ -379,7 +379,7 @@ export default class Search extends PureComponent {
         if (isDateLine(item)) {
             return (
                 <DateHeader
-                    dateLineString={item}
+                    date={getDateForDateLine(item)}
                     index={index}
                 />
             );


### PR DESCRIPTION
#### Summary
After [#2693](https://github.com/mattermost/mattermost-mobile/pull/2693) merged to `master` branch, there's bug in the post search screen. `DateHeader` component doesn't render the date properly. Now, it looks like this.
![bug](https://postfiles.pstatic.net/MjAxOTA0MTZfMjAz/MDAxNTU1Mzk3NzMwMjI2.ZkGD7bp3cGQNKfHoNjmd0LnuoXtQA4dIUsvVvMxflcAg.e0WmYzo-U6FRX3WPF6TcrSeC0uVbOn_0AWsQ7052IZMg.PNG.ninanung/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7_2019-04-16_%EC%98%A4%ED%9B%84_3.54.11.png?type=w773)
So i fixed `app/screens/search.js` file to render the `DateHeader` normally.

#### Ticket Link
This PR has just 2 lines of code change, so there's no ticket but related to [#2693](https://github.com/mattermost/mattermost-mobile/pull/2693)

#### Checklist
None apply

#### Device Information
This PR was tested on: Samsung Galaxy Note 9, Android 9
Mattermost Server: v5.6.0
