### PR TITLE
Match lineHeight used in ChannelInfoHeader to PostBody's

### DIFF
--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import {
     Text,
     View,
+    Platform,
 } from 'react-native';
 
 import ChannelIcon from 'app/components/channel_icon';
@@ -52,6 +53,9 @@ export default class ChannelInfoHeader extends React.PureComponent {
         const style = getStyleSheet(theme);
         const textStyles = getMarkdownTextStyles(theme);
         const blockStyles = getMarkdownBlockStyles(theme);
+        const baseTextStyle = Platform.OS === 'ios' ?
+            {...style.detail, lineHeight: 20} :
+            style.detail;
 
         return (
             <View style={style.container}>
@@ -84,7 +88,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
                         <Markdown
                             navigator={navigator}
                             onPermalinkPress={onPermalinkPress}
-                            baseTextStyle={style.detail}
+                            baseTextStyle={baseTextStyle}
                             textStyles={textStyles}
                             blockStyles={blockStyles}
                             value={purpose}
@@ -101,7 +105,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
                         <Markdown
                             navigator={navigator}
                             onPermalinkPress={onPermalinkPress}
-                            baseTextStyle={style.detail}
+                            baseTextStyle={baseTextStyle}
                             textStyles={textStyles}
                             blockStyles={blockStyles}
                             value={header}
@@ -160,7 +164,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         detail: {
             fontSize: 13,
             color: theme.centerChannelColor,
-            lineHeight: 20,
         },
         header: {
             fontSize: 13,

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -160,6 +160,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         detail: {
             fontSize: 13,
             color: theme.centerChannelColor,
+            lineHeight: 20,
         },
         header: {
             fontSize: 13,


### PR DESCRIPTION
#### Summary
The PostBody passes a [lineHeight](https://github.com/mattermost/mattermost-mobile/blob/MM-13650/app/components/post_body/post_body.js#L478) of 20 to the Markdown component. I do the same in ChannelInfoHeader for iOS so emojis in the channel's header and purpose sections render the same as in a post.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13650

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.2

#### Screenshots
iOS
<img width="375" alt="26258512-9401-4FA1-8C91-B777BD5FD2A8" src="https://user-images.githubusercontent.com/3208014/56329445-5e51e900-6138-11e9-875e-a30cf2c498f8.png">

Android
![Screenshot_20190417-180924](https://user-images.githubusercontent.com/3208014/56330225-00270500-613c-11e9-8388-2d87182b131d.png)



