### PR TITLE
MM-14741 Add default option to post action dropdown

### DIFF
--- a/app/components/message_attachments/action_menu/action_menu.js
+++ b/app/components/message_attachments/action_menu/action_menu.js
@@ -14,11 +14,35 @@ export default class ActionMenu extends PureComponent {
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
         dataSource: PropTypes.string,
+        defaultOption: PropTypes.string,
         options: PropTypes.arrayOf(PropTypes.object),
         postId: PropTypes.string.isRequired,
         selected: PropTypes.object,
         navigator: PropTypes.object,
     };
+
+    constructor(props) {
+        super(props);
+
+        let selected;
+        if (props.defaultOption && props.options) {
+            selected = props.options.find((option) => option.value === props.defaultOption);
+        }
+
+        this.state = {
+            selected,
+        };
+    }
+
+    static getDerivedStateFromProps(props, state) {
+        if (props.selected && props.selected !== state.selected) {
+            return {
+                selected: props.selected,
+            };
+        }
+
+        return null;
+    }
 
     handleSelect = (selected) => {
         if (!selected) {
@@ -38,10 +62,10 @@ export default class ActionMenu extends PureComponent {
         const {
             name,
             dataSource,
-            selected,
             options,
             navigator,
         } = this.props;
+        const {selected} = this.state;
 
         return (
             <AutocompleteSelector

--- a/app/components/message_attachments/action_menu/action_menu.test.js
+++ b/app/components/message_attachments/action_menu/action_menu.test.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {shallow} from 'enzyme';
+import React from 'react';
+
+import ActionMenu from './action_menu';
+
+describe('ActionMenu', () => {
+    const baseProps = {
+        postId: 'post1',
+        id: 'action1',
+        name: 'action',
+        options: [
+            {
+                text: 'One',
+                value: '1',
+            },
+            {
+                text: 'Two',
+                value: '2',
+            },
+        ],
+        actions: {
+            selectAttachmentMenuAction: jest.fn(),
+        },
+    };
+
+    test('should start with nothing selected when no default is selected', () => {
+        const wrapper = shallow(<ActionMenu {...baseProps}/>);
+
+        expect(wrapper.state('selected')).toBeUndefined();
+    });
+
+    test('should set selected based on default option', () => {
+        const props = {
+            ...baseProps,
+            defaultOption: '2',
+        };
+        const wrapper = shallow(<ActionMenu {...props}/>);
+
+        expect(wrapper.state('selected')).toBe(props.options[1]);
+    });
+
+    test('should start with previous value selected', () => {
+        const props = {
+            ...baseProps,
+            defaultOption: '2',
+            selected: baseProps.options[0],
+        };
+        const wrapper = shallow(<ActionMenu {...props}/>);
+
+        expect(wrapper.state('selected')).toBe(props.selected);
+    });
+});

--- a/app/components/message_attachments/attachment_actions.js
+++ b/app/components/message_attachments/attachment_actions.js
@@ -40,6 +40,7 @@ export default class AttachmentActions extends PureComponent {
                         id={action.id}
                         name={action.name}
                         dataSource={action.data_source}
+                        defaultOption={action.default_option}
                         options={action.options}
                         postId={postId}
                         navigator={navigator}


### PR DESCRIPTION
This PR is pretty straightforward. This value starts selected in the dropdown, allowing integrations to "save" a value which we wanted for the NPS plugin.

Server PR: https://github.com/mattermost/mattermost-server/pull/10659
Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/2677

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14741