### PR TITLE
[MM-14834] [MM-14835] Increase Typing animation duration and remove handleScrollToRecentPost

### DIFF
--- a/app/components/post_list/post_list.ios.js
+++ b/app/components/post_list/post_list.ios.js
@@ -4,10 +4,7 @@
 import React from 'react';
 import {FlatList, StyleSheet} from 'react-native';
 
-import {debounce} from 'mattermost-redux/actions/helpers';
-
 import {ListTypes} from 'app/constants';
-import {THREAD} from 'app/constants/screen';
 import {makeExtraData} from 'app/utils/list_view';
 
 import PostListBase from './post_list_base';
@@ -62,8 +59,8 @@ export default class PostList extends PostListBase {
 
     handleScroll = (event) => {
         const pageOffsetY = event.nativeEvent.contentOffset.y;
-        const contentHeight = event.nativeEvent.contentSize.height;
         if (pageOffsetY > 0) {
+            const contentHeight = event.nativeEvent.contentSize.height;
             const direction = (this.contentOffsetY < pageOffsetY) ?
                 ListTypes.VISIBILITY_SCROLL_UP :
                 ListTypes.VISIBILITY_SCROLL_DOWN;
@@ -75,25 +72,8 @@ export default class PostList extends PostListBase {
             ) {
                 this.props.onLoadMoreUp();
             }
-        } else if (pageOffsetY < 0) {
-            if (this.state.postListHeight > contentHeight || this.props.location === THREAD) {
-                // Posting a message like multiline or jumbo emojis causes the FlatList component for iOS
-                // to render RefreshControl component and remain the space as is when it's unmounted,
-                // leaving a whitespace of ~64 units of height between input box and post list.
-                // This condition explicitly pull down the list to recent post when pageOffsetY is less than zero,
-                // and the height of the layout is greater than its content or is on a thread screen.
-                this.handleScrollToRecentPost();
-            }
         }
     };
-
-    handleScrollToRecentPost = debounce(() => {
-        this.refs.list.scrollToIndex({
-            animated: true,
-            index: 0,
-            viewPosition: 1,
-        });
-    }, 100);
 
     handleScrollToIndexFailed = () => {
         requestAnimationFrame(() => {

--- a/app/components/post_textbox/components/typing/typing.js
+++ b/app/components/post_textbox/components/typing/typing.js
@@ -32,11 +32,13 @@ export default class Typing extends PureComponent {
     }
 
     animateTyping = (show = false) => {
-        const height = show ? 20 : 0;
+        const [height, duration] = show ?
+            [20, 200] :
+            [0, 400];
 
         Animated.timing(this.state.typingHeight, {
             toValue: height,
-            duration: 200,
+            duration,
         }).start();
     }
 


### PR DESCRIPTION
#### Summary
There were some app crashes caused by `handleScrollToRecentPost` scrolling to an index that was out of range. While I wasn't able to reproduce that scenario, I found that the cause of the blank space issue described in [MM-14017](https://mattermost.atlassian.net/browse/MM-14017) was the Typing component height animation being too quick when it's set back to 0. By increasing the duration a bit, the FlatList has enough time to handle the content size change resulting from a new post arrival before handling the change caused by the Typing component height change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14834

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.2

#### Screenshots
Before:
![before](https://user-images.githubusercontent.com/3208014/56446530-04782d00-62b8-11e9-960f-424ab573e1ea.gif)

After:
![after](https://user-images.githubusercontent.com/3208014/56446534-08a44a80-62b8-11e9-8167-50584b7c2bc6.gif)

