### PR TITLE
Allow user to install mattermost on sd card

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme"
+      android:installLocation="auto"
       android:networkSecurityConfig="@xml/network_security_config"
     >
         <meta-data android:name="android.content.APP_RESTRICTIONS"


### PR DESCRIPTION

Please make sure you've read the [pull request](https://developers.mattermost.com/contribute/getting-started/contribution-checklist/) section of our [code contribution guidelines](https://developers.mattermost.com/contribute/getting-started/).

When filling in a section please remove the help text and the above text.

#### Summary
Cannot install Mattermost when there is no enough space in internal memory, So when add this line
android:installLocation="auto" 
to the manifest file user can install Mattermost on the sd card.
https://developer.android.com/guide/topics/data/install-location


#### Ticket Link
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: LG K8 - Android 6.0

#### Screenshots

