### PR TITLE
[MM-14917] RN Android: Push notification settings are only saved when closing settings page

### DIFF
--- a/app/screens/settings/notification_settings_mobile/index.js
+++ b/app/screens/settings/notification_settings_mobile/index.js
@@ -16,7 +16,7 @@ function mapStateToProps(state) {
     const config = getConfig(state);
     const theme = getTheme(state);
     const updateMeRequest = state.requests.users.updateMe;
-    const currentUser = getCurrentUser(state) || {};
+    const currentUser = getCurrentUser(state);
 
     return {
         config,

--- a/app/screens/settings/notification_settings_mobile/index.js
+++ b/app/screens/settings/notification_settings_mobile/index.js
@@ -6,10 +6,11 @@ import {connect} from 'react-redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
 import {updateMe} from 'mattermost-redux/actions/users';
 
 import NotificationSettingsMobile from './notification_settings_mobile';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 function mapStateToProps(state) {
     const config = getConfig(state);

--- a/app/screens/settings/notification_settings_mobile/index.js
+++ b/app/screens/settings/notification_settings_mobile/index.js
@@ -1,19 +1,36 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {updateMe} from 'mattermost-redux/actions/users';
 
 import NotificationSettingsMobile from './notification_settings_mobile';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 function mapStateToProps(state) {
+    const config = getConfig(state);
+    const theme = getTheme(state);
+    const updateMeRequest = state.requests.users.updateMe;
+    const currentUser = getCurrentUser(state) || {};
+
     return {
-        config: getConfig(state),
-        theme: getTheme(state),
+        config,
+        theme,
+        updateMeRequest,
+        currentUser,
     };
 }
 
-export default connect(mapStateToProps)(NotificationSettingsMobile);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            updateMe,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NotificationSettingsMobile);

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
@@ -22,7 +22,7 @@ import SectionItem from 'app/screens/settings/section_item';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import NotificationSettingsMobileBase from './notification_settings_mobile_base';
-import {getNotificationProps} from '../../../utils/notify_props';
+import {getNotificationProps} from 'app/utils/notify_props';
 import deepEqual from 'deep-equal';
 import {RequestStatus} from 'mattermost-redux/constants';
 import PropTypes from 'prop-types';

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
@@ -35,6 +35,10 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
         updateMeRequest: PropTypes.object.isRequired,
     }
 
+    static defaultProps = {
+        currentUser: {}
+    }
+
     cancelMobilePushModal = () => {
         this.setState({
             newPush: this.state.push,

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
@@ -36,7 +36,7 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
     }
 
     static defaultProps = {
-        currentUser: {}
+        currentUser: {},
     }
 
     cancelMobilePushModal = () => {

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
@@ -13,6 +13,11 @@ import {
     View,
 } from 'react-native';
 
+import deepEqual from 'deep-equal';
+import PropTypes from 'prop-types';
+
+import {RequestStatus} from 'mattermost-redux/constants';
+
 import FormattedText from 'app/components/formatted_text';
 import RadioButtonGroup from 'app/components/radio_button';
 import NotificationPreferences from 'app/notification_preferences';
@@ -20,12 +25,9 @@ import PushNotifications from 'app/push_notifications';
 import StatusBar from 'app/components/status_bar';
 import SectionItem from 'app/screens/settings/section_item';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+import {getNotificationProps} from 'app/utils/notify_props';
 
 import NotificationSettingsMobileBase from './notification_settings_mobile_base';
-import {getNotificationProps} from 'app/utils/notify_props';
-import deepEqual from 'deep-equal';
-import {RequestStatus} from 'mattermost-redux/constants';
-import PropTypes from 'prop-types';
 
 class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
     static propTypes = {

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile_base.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile_base.js
@@ -11,6 +11,9 @@ import {setNavigatorStyles} from 'app/utils/theme';
 
 export default class NotificationSettingsMobileBase extends PureComponent {
     static propTypes = {
+        actions: PropTypes.shape({
+            updateMe: PropTypes.func.isRequired,
+        }),
         config: PropTypes.object.isRequired,
         currentUser: PropTypes.object.isRequired,
         intl: intlShape.isRequired,
@@ -89,12 +92,12 @@ export default class NotificationSettingsMobileBase extends PureComponent {
         }
     };
 
-    setMobilePush = (push) => {
-        this.setState({push});
+    setMobilePush = (push, callback) => {
+        this.setState({push}, callback);
     };
 
-    setMobilePushStatus = (value) => {
-        this.setState({push_status: value});
+    setMobilePushStatus = (value, callback) => {
+        this.setState({push_status: value}, callback);
     };
 
     saveUserNotifyProps = () => {


### PR DESCRIPTION
#### Summary
This pull request should avoid the user notification settings from being saved only after pressing back on notifications settings screen. The expected behavior is that the data should be saved right after pressing the save button on notification/notification status options dialog.

#### Ticket Link
Fixes mattermost/mattermost-server#10582
#### Device Information
This PR was tested on: Xiaomi Mi A1 (Android 9) and on iPhone XS emulator

