### PR TITLE
[MM-14751] Take group_constrained into account when adding users to channels

### DIFF
--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -33,7 +33,7 @@ export default class ChannelAddMembers extends PureComponent {
             handleAddChannelMembers: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
         }).isRequired,
-        currentChannelId: PropTypes.string.isRequired,
+        currentChannel: PropTypes.object.isRequired,
         currentTeamId: PropTypes.string.isRequired,
         currentUserId: PropTypes.string.isRequired,
         profilesNotInChannel: PropTypes.array.isRequired,
@@ -112,11 +112,12 @@ export default class ChannelAddMembers extends PureComponent {
         const {loading, term} = this.state;
         if (this.next && !loading && !term) {
             this.setState({loading: true}, () => {
-                const {actions, currentChannelId, currentTeamId} = this.props;
+                const {actions, currentChannel, currentTeamId} = this.props;
 
                 actions.getProfilesNotInChannel(
                     currentTeamId,
-                    currentChannelId,
+                    currentChannel.id,
+                    currentChannel.group_constrained,
                     this.page + 1,
                     General.PROFILE_CHUNK_SIZE
                 ).then(this.onProfilesLoaded);
@@ -126,7 +127,7 @@ export default class ChannelAddMembers extends PureComponent {
 
     handleAddMembersPress = () => {
         const {formatMessage} = this.context.intl;
-        const {actions, currentChannelId} = this.props;
+        const {actions, currentChannel} = this.props;
         const {selectedIds, adding} = this.state;
         const membersToAdd = Object.keys(selectedIds).filter((id) => selectedIds[id]);
 
@@ -145,7 +146,7 @@ export default class ChannelAddMembers extends PureComponent {
         if (!adding) {
             this.enableAddOption(false);
             this.setState({adding: true}, async () => {
-                const result = await actions.handleAddChannelMembers(currentChannelId, membersToAdd);
+                const result = await actions.handleAddChannelMembers(currentChannel.id, membersToAdd);
 
                 if (result.error) {
                     alertErrorIfInvalidPermissions(result);
@@ -258,8 +259,8 @@ export default class ChannelAddMembers extends PureComponent {
     };
 
     searchProfiles = (term) => {
-        const {actions, currentChannelId, currentTeamId} = this.props;
-        const options = {not_in_channel_id: currentChannelId, team_id: currentTeamId};
+        const {actions, currentChannel, currentTeamId} = this.props;
+        const options = {not_in_channel_id: currentChannel.id, team_id: currentTeamId, group_constrained: currentChannel.group_constrained};
         this.setState({loading: true});
 
         actions.searchProfiles(term.toLowerCase(), options).then(({data}) => {

--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -33,12 +33,17 @@ export default class ChannelAddMembers extends PureComponent {
             handleAddChannelMembers: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
         }).isRequired,
-        currentChannel: PropTypes.object.isRequired,
+        currentChannelId: PropTypes.string.isRequired,
+        currentChannelGroupConstrained: PropTypes.bool,
         currentTeamId: PropTypes.string.isRequired,
         currentUserId: PropTypes.string.isRequired,
         profilesNotInChannel: PropTypes.array.isRequired,
         navigator: PropTypes.object,
         theme: PropTypes.object.isRequired,
+    };
+
+    static defaultProps = {
+        currentChannelGroupConstrained: false,
     };
 
     static contextTypes = {
@@ -112,12 +117,12 @@ export default class ChannelAddMembers extends PureComponent {
         const {loading, term} = this.state;
         if (this.next && !loading && !term) {
             this.setState({loading: true}, () => {
-                const {actions, currentChannel, currentTeamId} = this.props;
+                const {actions, currentChannelId, currentChannelGroupConstrained, currentTeamId} = this.props;
 
                 actions.getProfilesNotInChannel(
                     currentTeamId,
-                    currentChannel.id,
-                    currentChannel.group_constrained,
+                    currentChannelId,
+                    currentChannelGroupConstrained,
                     this.page + 1,
                     General.PROFILE_CHUNK_SIZE
                 ).then(this.onProfilesLoaded);
@@ -127,7 +132,7 @@ export default class ChannelAddMembers extends PureComponent {
 
     handleAddMembersPress = () => {
         const {formatMessage} = this.context.intl;
-        const {actions, currentChannel} = this.props;
+        const {actions, currentChannelId} = this.props;
         const {selectedIds, adding} = this.state;
         const membersToAdd = Object.keys(selectedIds).filter((id) => selectedIds[id]);
 
@@ -146,7 +151,7 @@ export default class ChannelAddMembers extends PureComponent {
         if (!adding) {
             this.enableAddOption(false);
             this.setState({adding: true}, async () => {
-                const result = await actions.handleAddChannelMembers(currentChannel.id, membersToAdd);
+                const result = await actions.handleAddChannelMembers(currentChannelId, membersToAdd);
 
                 if (result.error) {
                     alertErrorIfInvalidPermissions(result);
@@ -259,8 +264,8 @@ export default class ChannelAddMembers extends PureComponent {
     };
 
     searchProfiles = (term) => {
-        const {actions, currentChannel, currentTeamId} = this.props;
-        const options = {not_in_channel_id: currentChannel.id, team_id: currentTeamId, group_constrained: currentChannel.group_constrained};
+        const {actions, currentChannelId, currentChannelGroupConstrained, currentTeamId} = this.props;
+        const options = {not_in_channel_id: currentChannelId, team_id: currentTeamId, group_constrained: currentChannelGroupConstrained};
         this.setState({loading: true});
 
         actions.searchProfiles(term.toLowerCase(), options).then(({data}) => {

--- a/app/screens/channel_add_members/channel_add_members.test.js
+++ b/app/screens/channel_add_members/channel_add_members.test.js
@@ -17,7 +17,7 @@ describe('ChannelAddMembers', () => {
             handleAddChannelMembers: jest.fn().mockResolvedValue({}),
             searchProfiles: jest.fn().mockResolvedValue({data: []}),
         },
-        currentChannel: {id: 'current_channel_id'},
+        currentChannelId: 'current_channel_id',
         currentTeamId: 'current_team_id',
         currentUserId: 'current_user_id',
         profilesNotInChannel: [],

--- a/app/screens/channel_add_members/channel_add_members.test.js
+++ b/app/screens/channel_add_members/channel_add_members.test.js
@@ -17,7 +17,7 @@ describe('ChannelAddMembers', () => {
             handleAddChannelMembers: jest.fn().mockResolvedValue({}),
             searchProfiles: jest.fn().mockResolvedValue({data: []}),
         },
-        currentChannelId: 'current_channel_id',
+        currentChannel: {id: 'current_channel_id'},
         currentTeamId: 'current_team_id',
         currentUserId: 'current_user_id',
         profilesNotInChannel: [],

--- a/app/screens/channel_add_members/index.js
+++ b/app/screens/channel_add_members/index.js
@@ -16,8 +16,11 @@ import {handleAddChannelMembers} from 'app/actions/views/channel_add_members';
 import ChannelAddMembers from './channel_add_members';
 
 function mapStateToProps(state) {
+    const currentChannel = getCurrentChannel(state);
+
     return {
-        currentChannel: getCurrentChannel(state),
+        currentChannelId: currentChannel.id,
+        currentChannelGroupConstrained: currentChannel.group_constrained,
         currentTeamId: getCurrentTeamId(state),
         currentUserId: getCurrentUserId(state),
         profilesNotInChannel: getProfilesNotInCurrentChannel(state),

--- a/app/screens/channel_add_members/index.js
+++ b/app/screens/channel_add_members/index.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 
 import {getTeamStats} from 'mattermost-redux/actions/teams';
 import {getProfilesNotInChannel, searchProfiles} from 'mattermost-redux/actions/users';
-import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getProfilesNotInCurrentChannel} from 'mattermost-redux/selectors/entities/users';
@@ -17,7 +17,7 @@ import ChannelAddMembers from './channel_add_members';
 
 function mapStateToProps(state) {
     return {
-        currentChannelId: getCurrentChannelId(state),
+        currentChannel: getCurrentChannel(state),
         currentTeamId: getCurrentTeamId(state),
         currentUserId: getCurrentUserId(state),
         profilesNotInChannel: getProfilesNotInCurrentChannel(state),

--- a/package-lock.json
+++ b/package-lock.json
@@ -13184,8 +13184,8 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#57061465c52c27bc25f646b1de8c85915aa62415",
-      "from": "github:mattermost/mattermost-redux#57061465c52c27bc25f646b1de8c85915aa62415",
+      "version": "github:mattermost/mattermost-redux#429ac99932207fa21441d05482e36a0597c80515",
+      "from": "github:mattermost/mattermost-redux#429ac99932207fa21441d05482e36a0597c80515",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.2.0",
     "jsc-android": "241213.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#57061465c52c27bc25f646b1de8c85915aa62415",
+    "mattermost-redux": "github:mattermost/mattermost-redux#429ac99932207fa21441d05482e36a0597c80515",
     "mime-db": "1.40.0",
     "moment-timezone": "0.5.25",
     "prop-types": "15.7.2",


### PR DESCRIPTION
#### Summary
Uses team and channel `group_constrained` property when loading users to add to channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14751

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)

#### Device Information
This PR was tested on: [Android Emulator for Pixel 2XL, with Android 9] 
