### PR TITLE
[MM-14837] Check for null activity in ShareModule before calling finish.

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -75,7 +75,10 @@ public class ShareModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void close(ReadableMap data) {
         this.clear();
-        getCurrentActivity().finish();
+        Activity currentActivity = getCurrentActivity();
+        if (currentActivity != null) {
+            currentActivity.finish();
+        }
 
         if (data != null && data.hasKey("url")) {
             ReadableArray files = data.getArray("files");


### PR DESCRIPTION
#### Summary
Check for null activity in ShareModule before calling finish.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14837

#### Device Information
This PR was tested on:
* Galaxy S7, Android 7.0 
