### PR TITLE
[MM-14834] [MM-14835] Delay PostTextbox animation on iOS when clearing text

### DIFF
--- a/app/components/post_textbox/post_textbox.js
+++ b/app/components/post_textbox/post_textbox.js
@@ -380,23 +380,41 @@ export default class PostTextbox extends PureComponent {
                 }
             }
 
-            this.handleTextChange('');
-            this.changeDraft('');
-
-            // Shrink the input textbox since the layout events lag slightly
-            const nextState = {
-                contentHeight: INITIAL_HEIGHT,
-            };
-
-            // Fixes the issue where Android predictive text would prepend suggestions to the post draft when messages
-            // are typed successively without blurring the input
-            let callback;
-            if (Platform.OS === 'android') {
-                nextState.keyboardType = 'email-address';
-                callback = () => this.setState({keyboardType: 'default'});
+            if (Platform.OS === 'ios') {
+                // On iOS, if the PostTextbox height increases from its
+                // initial height (due to a multiline post or a post whose
+                // message wraps, for example), then when the text is cleared
+                // the PostTextbox height decrease will be animated. This
+                // animation in conjunction with the PostList animation as it
+                // receives the newly created post is causing issues in the iOS
+                // PostList component as it fails to properly react to its content
+                // size changes. While a proper fix is determined for the PostList
+                // component, a small delay in triggering the height decrease
+                // animation gives the PostList enough time to first handle content
+                // size changes from the new post.
+                setTimeout(() => {
+                    this.handleTextChange('');
+                }, 250);
+            } else {
+                this.handleTextChange('');
             }
 
-            this.setState(nextState, callback);
+            this.changeDraft('');
+
+            let callback;
+            if (Platform.OS === 'android') {
+                // Shrink the input textbox since the layout events lag slightly
+                const nextState = {
+                    contentHeight: INITIAL_HEIGHT,
+                };
+
+                // Fixes the issue where Android predictive text would prepend suggestions to the post draft when messages
+                // are typed successively without blurring the input
+                nextState.keyboardType = 'email-address';
+                callback = () => this.setState({keyboardType: 'default'});
+
+                this.setState(nextState, callback);
+            }
         }
     };
 


### PR DESCRIPTION
#### Summary
On iOS, if the PostTextbox height increases from its initial height (due to a multiline post or a post whose message wraps, for example), then when the text is cleared the PostTextbox height decrease will be animated. This animation in conjunction with the PostList animation as it receives the newly created post is causing issues in the iOS PostList component as it fails to properly react to its content size changes. While a proper fix is determined for the PostList component, a small delay in triggering the height decrease animation gives the PostList enough time to first handle content size changes from the new post.

There is a similar issue that was fixed by [PR-2730](https://github.com/mattermost/mattermost-mobile/pull/2730), however, I overlooked this problem when I removed `handleScrollToRecentPost` in that PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14834
https://mattermost.atlassian.net/browse/MM-14835

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.2

#### Screenshots
Before:
![before](https://user-images.githubusercontent.com/3208014/56711918-5ae2d280-66e1-11e9-9fef-7d7d3c836379.gif)

After:
![after](https://user-images.githubusercontent.com/3208014/56711919-5e765980-66e1-11e9-8e40-75a594d7788f.gif)
