### PR TITLE
Remove the RN bridge from MattermostManaged

### DIFF
--- a/app/fetch_preconfig.js
+++ b/app/fetch_preconfig.js
@@ -21,7 +21,7 @@ const HEADER_TOKEN = 'Token';
 
 let managedConfig;
 
-mattermostManaged.addEventListener('fetch_managed_config', (config) => {
+mattermostManaged.addEventListener('managedConfigDidChange', (config) => {
     managedConfig = config;
 });
 

--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {NativeModules, DeviceEventEmitter} from 'react-native';
+import {NativeModules, NativeEventEmitter} from 'react-native';
 import LocalAuth from 'react-native-local-auth';
 import JailMonkey from 'jail-monkey';
 
@@ -11,7 +11,7 @@ let localConfig;
 
 export default {
     addEventListener: (name, callback) => {
-        const listener = DeviceEventEmitter.addListener(name, (config) => {
+        const listener = NativeEventEmitter.addListener(name, (config) => {
             localConfig = config;
             if (callback && typeof callback === 'function') {
                 callback(config);

--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -5,13 +5,14 @@ import LocalAuth from 'react-native-local-auth';
 import JailMonkey from 'jail-monkey';
 
 const {BlurAppScreen, MattermostManaged} = NativeModules;
+const mattermostManagedEmitter = new NativeEventEmitter(MattermostManaged);
 
 const listeners = [];
 let localConfig;
 
 export default {
     addEventListener: (name, callback) => {
-        const listener = NativeEventEmitter.addListener(name, (config) => {
+        const listener = mattermostManagedEmitter.addListener(name, (config) => {
             localConfig = config;
             if (callback && typeof callback === 'function') {
                 callback(config);

--- a/ios/Mattermost/MattermostManaged.h
+++ b/ios/Mattermost/MattermostManaged.h
@@ -7,9 +7,9 @@
 //
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-
-@interface MattermostManaged : NSObject <RCTBridgeModule>
+@interface MattermostManaged : RCTEventEmitter <RCTBridgeModule>
 - (NSUserDefaults *)bucketByName:(NSString*)name;
 + (void)sendConfigChangedEvent;
 

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -6,8 +6,6 @@
 // See License.txt for license information.
 //
 
-#import <React/RCTBridge.h>
-#import <React/RCTEventDispatcher.h>
 #import "RCTUITextView.h"
 #import "MattermostManaged.h"
 
@@ -20,23 +18,28 @@ RCT_EXPORT_MODULE();
   return YES;
 }
 
-@synthesize bridge = _bridge;
-
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [[NSNotificationCenter defaultCenter] removeObserver:NSUserDefaultsDidChangeNotification];
 }
 
-- (void)setBridge:(RCTBridge *)bridge
+- (NSArray<NSString *> *)supportedEvents
 {
-  _bridge = bridge;
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedConfigDidChange:) name:@"managedConfigDidChange" object:nil];
-  [[NSNotificationCenter defaultCenter] addObserverForName:NSUserDefaultsDidChangeNotification
-                                                    object:nil
-                                                     queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-                                                       [self remoteConfigChanged];
-                                                     }];
+  return @[@"managedConfigDidChange"];
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedConfigDidChange:) name:@"managedConfigDidChange" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserverForName:NSUserDefaultsDidChangeNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+                                                         [self remoteConfigChanged];
+                                                       }];
+  }
+  return self;
 }
 
 + (void)sendConfigChangedEvent {
@@ -55,12 +58,12 @@ static NSString * const feedbackKey = @"com.apple.feedback.managed";
 - (void)managedConfigDidChange:(NSNotification *)notification
 {
   NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:configurationKey];
-  [_bridge.eventDispatcher sendDeviceEventWithName:@"managedConfigDidChange" body:response];
+  [self sendEventWithName:@"managedConfigDidChange" body:response];
 }
 
 - (void) remoteConfigChanged {
   NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:configurationKey];
-  [_bridge.eventDispatcher sendDeviceEventWithName:@"managedConfigDidChange" body:response];
+  [self sendEventWithName:@"managedConfigDidChange" body:response];
 }
 
 RCT_EXPORT_METHOD(getConfig:(RCTPromiseResolveBlock)resolve

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -9,13 +9,23 @@
 #import "RCTUITextView.h"
 #import "MattermostManaged.h"
 
-@implementation MattermostManaged
+@implementation MattermostManaged {
+  bool hasListeners;
+}
 
 RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {
   return YES;
+}
+
+- (void)startObserving {
+  hasListeners = YES;
+}
+
+- (void)stopObserving {
+  hasListeners = NO;
 }
 
 - (void)dealloc
@@ -58,12 +68,16 @@ static NSString * const feedbackKey = @"com.apple.feedback.managed";
 - (void)managedConfigDidChange:(NSNotification *)notification
 {
   NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:configurationKey];
-  [self sendEventWithName:@"managedConfigDidChange" body:response];
+  if (hasListeners) {
+    [self sendEventWithName:@"managedConfigDidChange" body:response];
+  }
 }
 
 - (void) remoteConfigChanged {
   NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:configurationKey];
-  [self sendEventWithName:@"managedConfigDidChange" body:response];
+  if (hasListeners) {
+    [self sendEventWithName:@"managedConfigDidChange" body:response];
+  }
 }
 
 RCT_EXPORT_METHOD(getConfig:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
#### Summary
While checking some EMM configurations I realized that we were listening to the wrong event in the fetch_preconfig file, and improved the Native module by removing the bridge.

#### Ticket Link
N/A
