### PR TITLE
[MM-14887] Allow only jpeg, png, and bmp profile image uploads

### DIFF
--- a/app/components/__snapshots__/attachment_button.test.js.snap
+++ b/app/components/__snapshots__/attachment_button.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AttachmentButton should match snapshot 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  onPress={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "height": 34,
+      "justifyContent": "center",
+      "width": 45,
+    }
+  }
+>
+  <Icon
+    allowFontScaling={false}
+    color="rgba(61,60,64,0.9)"
+    name="md-add"
+    size={30}
+    style={
+      Object {
+        "marginTop": 2,
+      }
+    }
+  />
+</TouchableOpacity>
+`;

--- a/app/components/__snapshots__/profile_picture_button.test.js.snap
+++ b/app/components/__snapshots__/profile_picture_button.test.js.snap
@@ -53,5 +53,6 @@ exports[`profile_picture_button should match snapshot 1`] = `
     }
   }
   uploadFiles={[MockFunction]}
+  validMimeTypes={Array []}
 />
 `;

--- a/app/components/attachment_button.test.js
+++ b/app/components/attachment_button.test.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import AttachmentButton from './attachment_button';
+
+jest.mock('react-intl');
+
+describe('AttachmentButton', () => {
+    const baseProps = {
+        theme: Preferences.THEMES.default,
+        navigator: {},
+        blurTextBox: jest.fn(),
+        maxFileSize: 10,
+        uploadFiles: jest.fn(),
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <AttachmentButton {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should not upload file with invalid MIME type', () => {
+        const props = {
+            ...baseProps,
+            validMimeTypes: ['image/jpeg'],
+            onShowUnsupportedMimeTypeWarning: jest.fn(),
+        };
+
+        const wrapper = shallow(
+            <AttachmentButton {...props}/>
+        );
+
+        const file = {
+            type: 'image/gif',
+            fileSize: 10,
+            fileName: 'test',
+        };
+        wrapper.instance().uploadFiles([file]);
+        expect(props.onShowUnsupportedMimeTypeWarning).toHaveBeenCalled();
+        expect(props.uploadFiles).not.toHaveBeenCalled();
+    });
+
+    test('should upload file with valid MIME type', () => {
+        const props = {
+            ...baseProps,
+            validMimeTypes: ['image/jpeg'],
+            onShowUnsupportedMimeTypeWarning: jest.fn(),
+        };
+
+        const wrapper = shallow(
+            <AttachmentButton {...props}/>
+        );
+
+        const file = {
+            type: 'image/jpeg',
+            fileSize: 10,
+            fileName: 'test',
+        };
+        wrapper.instance().uploadFiles([file]);
+        expect(props.onShowUnsupportedMimeTypeWarning).not.toHaveBeenCalled();
+        expect(props.uploadFiles).toHaveBeenCalled();
+    });
+});

--- a/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
+++ b/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
@@ -74,6 +74,7 @@ exports[`edit_profile should match snapshot 1`] = `
       }
     }
     onShowFileSizeWarning={[Function]}
+    onShowUnsupportedMimeTypeWarning={[Function]}
     removeProfileImage={[Function]}
     theme={
       Object {
@@ -104,6 +105,13 @@ exports[`edit_profile should match snapshot 1`] = `
       }
     }
     uploadFiles={[Function]}
+    validMimeTypes={
+      Array [
+        "image/jpeg",
+        "image/png",
+        "image/bmp",
+      ]
+    }
     wrapper={true}
   >
     <Connect(ProfilePicture)

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -28,6 +28,11 @@ import mattermostBucket from 'app/mattermost_bucket';
 import {getFormattedFileSize} from 'mattermost-redux/utils/file_utils';
 
 const MAX_SIZE = 20 * 1024 * 1024;
+const VALID_MIME_TYPES = [
+    'image/jpeg',
+    'image/png',
+    'image/bmp',
+];
 const holders = {
     firstName: {
         id: t('user.settings.general.firstName'),
@@ -278,6 +283,18 @@ export default class EditProfile extends PureComponent {
         Alert.alert(fileSizeWarning);
     };
 
+    onShowUnsupportedMimeTypeWarning = () => {
+        const {formatMessage} = this.context.intl;
+        const fileTypeWarning = formatMessage({
+            id: 'mobile.file_upload.unsupportedMimeType',
+            defaultMessage: 'Only files of the following MIME type can be uploaded: {mimeTypes}',
+        }, {
+            mimeTypes: VALID_MIME_TYPES.join('\n'),
+        });
+
+        Alert.alert('', fileTypeWarning);
+    };
+
     renderFirstNameSettings = () => {
         const {formatMessage} = this.context.intl;
         const {config, currentUser, theme} = this.props;
@@ -500,6 +517,8 @@ export default class EditProfile extends PureComponent {
                     uploadFiles={this.handleUploadProfileImage}
                     removeProfileImage={this.handleRemoveProfileImage}
                     onShowFileSizeWarning={this.onShowFileSizeWarning}
+                    onShowUnsupportedMimeTypeWarning={this.onShowUnsupportedMimeTypeWarning}
+                    validMimeTypes={VALID_MIME_TYPES}
                 >
                     <ProfilePicture
                         userId={currentUser.id}

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -252,6 +252,7 @@
   "mobile.file_upload.library": "Photo Library",
   "mobile.file_upload.max_warning": "Uploads limited to 5 files maximum.",
   "mobile.file_upload.video": "Video Library",
+  "mobile.file_upload.unsupportedMimeType": "Only files of the following MIME type can be uploaded:\n{mimeTypes}",
   "mobile.flagged_posts.empty_description": "Flags are a way to mark messages for follow up. Your flags are personal, and cannot be seen by other users.",
   "mobile.flagged_posts.empty_title": "No Flagged Posts",
   "mobile.help.title": "Help",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1615,7 +1615,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "ansi-gray": {
@@ -2688,7 +2688,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2733,8 +2732,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",
@@ -2925,7 +2923,7 @@
     },
     "combined-stream": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -3070,7 +3068,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "fbjs": {
@@ -3100,7 +3098,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "fbjs": {
@@ -4229,7 +4227,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         }
@@ -4361,8 +4359,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4380,13 +4377,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4399,18 +4394,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4513,8 +4505,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4524,7 +4515,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4537,20 +4527,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4567,7 +4554,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4640,8 +4626,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4651,7 +4636,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4727,8 +4711,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4758,7 +4741,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4776,7 +4758,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4815,13 +4796,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5483,7 +5462,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -8975,7 +8954,7 @@
     },
     "kind-of": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
       "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
     },
     "klaw": {
@@ -9259,8 +9238,8 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#664ce79fd6db7c474b34d50ebe4afd62b9643f65",
-      "from": "github:mattermost/mattermost-redux#664ce79fd6db7c474b34d50ebe4afd62b9643f65",
+      "version": "github:mattermost/mattermost-redux#ea818389dc3d27a5dc9f0f7588928febc773c4d6",
+      "from": "github:mattermost/mattermost-redux#ea818389dc3d27a5dc9f0f7588928febc773c4d6",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "2.0.0",
@@ -11254,7 +11233,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         }
       }
@@ -12159,7 +12138,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "fbjs": {
@@ -12359,8 +12338,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
@@ -12646,8 +12624,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -15102,7 +15079,7 @@
     },
     "uuid": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
       "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.0.0",
     "jsc-android": "236355.1.1",
-    "mattermost-redux": "github:mattermost/mattermost-redux#664ce79fd6db7c474b34d50ebe4afd62b9643f65",
+    "mattermost-redux": "github:mattermost/mattermost-redux#ea818389dc3d27a5dc9f0f7588928febc773c4d6",
     "mime-db": "1.38.0",
     "moment-timezone": "0.5.23",
     "prop-types": "15.7.2",


### PR DESCRIPTION
#### Summary
This is the same as [PR-2715](https://github.com/mattermost/mattermost-mobile/pull/2715) but for release-1.19. The mattermost-redux commit hash is for the latest release-5.11 commit.
