### PR TITLE
MM-15284 Disable allowBackup on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
     <application
       android:name=".MainApplication"
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
Disables backing up the Android app using ADB. Android has it enabled by default and it seems like RN may have enabled it by default at some point, but it's considered a good practice to disable it to prevent people from misusing it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15284

#### Device Information
Moto G6 (Android 8)