### PR TITLE
Use of cached managed config in components

### DIFF
--- a/app/components/at_mention/at_mention.js
+++ b/app/components/at_mention/at_mention.js
@@ -97,9 +97,9 @@ export default class AtMention extends React.PureComponent {
     handleLongPress = async () => {
         const {formatMessage} = this.context.intl;
 
-        const config = await mattermostManaged.getLocalConfig();
+        const config = mattermostManaged.getCachedConfig();
 
-        if (config.copyAndPasteProtection !== 'false') {
+        if (config.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});
             const actionText = formatMessage({id: 'mobile.mention.copy_mention', defaultMessage: 'Copy Mention'});
 

--- a/app/components/markdown/markdown_code_block/markdown_code_block.js
+++ b/app/components/markdown/markdown_code_block/markdown_code_block.js
@@ -82,7 +82,7 @@ export default class MarkdownCodeBlock extends React.PureComponent {
     handleLongPress = async () => {
         const {formatMessage} = this.context.intl;
 
-        const config = await mattermostManaged.getLocalConfig();
+        const config = mattermostManaged.getCachedConfig();
 
         if (config.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});

--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -140,7 +140,7 @@ export default class MarkdownImage extends React.Component {
     handleLinkLongPress = async () => {
         const {formatMessage} = this.context.intl;
 
-        const config = await mattermostManaged.getLocalConfig();
+        const config = mattermostManaged.getCachedConfig();
 
         if (config.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});

--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -99,7 +99,7 @@ export default class MarkdownLink extends PureComponent {
     handleLongPress = async () => {
         const {formatMessage} = this.context.intl;
 
-        const config = await mattermostManaged.getLocalConfig();
+        const config = mattermostManaged.getCachedConfig();
 
         if (config.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});

--- a/app/components/post_list/post_list_base.js
+++ b/app/components/post_list/post_list_base.js
@@ -58,25 +58,11 @@ export default class PostListBase extends PureComponent {
         siteURL: '',
     };
 
-    componentWillMount() {
-        this.listenerId = mattermostManaged.addEventListener('managedConfigDidChange', this.setManagedConfig);
-    }
-
-    componentDidMount() {
-        this.mounted = true;
-        this.setManagedConfig();
-    }
-
     componentDidUpdate() {
         if (this.props.deepLinkURL) {
             this.handleDeepLink(this.props.deepLinkURL);
             this.props.actions.setDeepLinkURL('');
         }
-    }
-
-    componentWillUnmount() {
-        this.mounted = false;
-        mattermostManaged.removeEventListener(this.listenerId);
     }
 
     handleClosePermalink = () => {
@@ -163,7 +149,7 @@ export default class PostListBase extends PureComponent {
             highlightPinnedOrFlagged: this.props.highlightPinnedOrFlagged,
             isSearchResult: this.props.isSearchResult,
             location: this.props.location,
-            managedConfig: this.state.managedConfig,
+            managedConfig: mattermostManaged.getCachedConfig(),
             navigator: this.props.navigator,
             onHashtagPress: this.props.onHashtagPress,
             onPermalinkPress: this.handlePermalinkPress,
@@ -190,19 +176,6 @@ export default class PostListBase extends PureComponent {
                 {...postProps}
             />
         );
-    };
-
-    setManagedConfig = async (config) => {
-        let nextConfig = config;
-        if (!nextConfig) {
-            nextConfig = await mattermostManaged.getLocalConfig();
-        }
-
-        if (this.mounted) {
-            this.setState({
-                managedConfig: nextConfig,
-            });
-        }
     };
 
     showPermalinkView = (postId) => {

--- a/app/mattermost_managed/mattermost-managed.android.js
+++ b/app/mattermost_managed/mattermost-managed.android.js
@@ -8,12 +8,12 @@ import JailMonkey from 'jail-monkey';
 const {MattermostManaged} = NativeModules;
 
 const listeners = [];
-let localConfig;
+let cachedConfig = {};
 
 export default {
     addEventListener: (name, callback) => {
         const listener = DeviceEventEmitter.addListener(name, (config) => {
-            localConfig = config;
+            cachedConfig = config;
             if (callback && typeof callback === 'function') {
                 callback(config);
             }
@@ -36,17 +36,17 @@ export default {
     },
     authenticate: LocalAuth.auth,
     blurAppScreen: MattermostManaged.blurAppScreen,
-    getConfig: MattermostManaged.getConfig,
-    getLocalConfig: async () => {
-        if (!localConfig) {
-            try {
-                localConfig = await MattermostManaged.getConfig();
-            } catch (error) {
-                // do nothing...
-            }
+    getConfig: async () => {
+        try {
+            cachedConfig = await MattermostManaged.getConfig();
+        } catch (error) {
+            // do nothing...
         }
 
-        return localConfig || {};
+        return cachedConfig;
+    },
+    getCachedConfig: () => {
+        return cachedConfig;
     },
     isDeviceSecure: async () => {
         try {

--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -8,12 +8,12 @@ const {BlurAppScreen, MattermostManaged} = NativeModules;
 const mattermostManagedEmitter = new NativeEventEmitter(MattermostManaged);
 
 const listeners = [];
-let localConfig;
+let cachedConfig = {};
 
 export default {
     addEventListener: (name, callback) => {
         const listener = mattermostManagedEmitter.addListener(name, (config) => {
-            localConfig = config;
+            cachedConfig = config;
             if (callback && typeof callback === 'function') {
                 callback(config);
             }
@@ -36,17 +36,17 @@ export default {
     },
     authenticate: LocalAuth.authenticate,
     blurAppScreen: BlurAppScreen.enabled,
-    getConfig: MattermostManaged.getConfig,
-    getLocalConfig: async () => {
-        if (!localConfig) {
-            try {
-                localConfig = await MattermostManaged.getConfig();
-            } catch (error) {
-                // do nothing...
-            }
+    getConfig: async () => {
+        try {
+            cachedConfig = await MattermostManaged.getConfig();
+        } catch (error) {
+            // do nothing...
         }
 
-        return localConfig || {};
+        return cachedConfig;
+    },
+    getCachedConfig: () => {
+        return cachedConfig;
     },
     isDeviceSecure: async () => {
         try {

--- a/app/screens/flagged_posts/flagged_posts.js
+++ b/app/screens/flagged_posts/flagged_posts.js
@@ -57,22 +57,6 @@ export default class FlaggedPosts extends PureComponent {
         props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
         props.actions.clearSearch();
         props.actions.getFlaggedPosts();
-
-        this.state = {
-            managedConfig: {},
-        };
-    }
-
-    componentWillMount() {
-        this.listenerId = mattermostManaged.addEventListener('managedConfigDidChange', this.setManagedConfig);
-    }
-
-    componentDidMount() {
-        this.setManagedConfig();
-    }
-
-    componentWillUnmount() {
-        mattermostManaged.removeEventListener(this.listenerId);
     }
 
     goToThread = (post) => {
@@ -159,7 +143,7 @@ export default class FlaggedPosts extends PureComponent {
 
     renderPost = ({item, index}) => {
         const {postIds, theme} = this.props;
-        const {managedConfig} = this.state;
+
         if (isDateLine(item)) {
             return (
                 <DateHeader
@@ -186,7 +170,7 @@ export default class FlaggedPosts extends PureComponent {
                     navigator={this.props.navigator}
                     onHashtagPress={this.handleHashtagPress}
                     onPermalinkPress={this.handlePermalinkPress}
-                    managedConfig={managedConfig}
+                    managedConfig={mattermostManaged.getCachedConfig()}
                     showFullDate={false}
                     skipFlaggedHeader={true}
                     skipPinnedHeader={true}
@@ -194,17 +178,6 @@ export default class FlaggedPosts extends PureComponent {
                 {separator}
             </View>
         );
-    };
-
-    setManagedConfig = async (config) => {
-        let nextConfig = config;
-        if (!nextConfig) {
-            nextConfig = await mattermostManaged.getLocalConfig();
-        }
-
-        this.setState({
-            managedConfig: nextConfig,
-        });
     };
 
     showPermalinkView = (postId, isPermalink) => {

--- a/app/screens/pinned_posts/pinned_posts.js
+++ b/app/screens/pinned_posts/pinned_posts.js
@@ -56,25 +56,12 @@ export default class PinnedPosts extends PureComponent {
         super(props);
 
         props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
-
-        this.state = {
-            managedConfig: {},
-        };
-    }
-
-    componentWillMount() {
-        this.listenerId = mattermostManaged.addEventListener('managedConfigDidChange', this.setManagedConfig);
     }
 
     componentDidMount() {
         const {actions, currentChannelId} = this.props;
-        this.setManagedConfig();
         actions.clearSearch();
         actions.getPinnedPosts(currentChannelId);
-    }
-
-    componentWillUnmount() {
-        mattermostManaged.removeEventListener(this.listenerId);
     }
 
     goToThread = (post) => {
@@ -161,7 +148,6 @@ export default class PinnedPosts extends PureComponent {
 
     renderPost = ({item, index}) => {
         const {postIds, theme} = this.props;
-        const {managedConfig} = this.state;
         if (isDateLine(item)) {
             return (
                 <DateHeader
@@ -187,7 +173,7 @@ export default class PinnedPosts extends PureComponent {
                     navigator={this.props.navigator}
                     onHashtagPress={this.handleHashtagPress}
                     onPermalinkPress={this.handlePermalinkPress}
-                    managedConfig={managedConfig}
+                    managedConfig={mattermostManaged.getCachedConfig()}
                     showFullDate={false}
                     skipFlaggedHeader={false}
                     skipPinnedHeader={true}
@@ -195,17 +181,6 @@ export default class PinnedPosts extends PureComponent {
                 {separator}
             </React.Fragment>
         );
-    };
-
-    setManagedConfig = async (config) => {
-        let nextConfig = config;
-        if (!nextConfig) {
-            nextConfig = await mattermostManaged.getLocalConfig();
-        }
-
-        this.setState({
-            managedConfig: nextConfig,
-        });
     };
 
     showPermalinkView = (postId, isPermalink) => {

--- a/app/screens/recent_mentions/recent_mentions.js
+++ b/app/screens/recent_mentions/recent_mentions.js
@@ -57,22 +57,6 @@ export default class RecentMentions extends PureComponent {
         props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
         props.actions.clearSearch();
         props.actions.getRecentMentions();
-
-        this.state = {
-            managedConfig: {},
-        };
-    }
-
-    componentWillMount() {
-        this.listenerId = mattermostManaged.addEventListener('managedConfigDidChange', this.setManagedConfig);
-    }
-
-    componentDidMount() {
-        this.setManagedConfig();
-    }
-
-    componentWillUnmount() {
-        mattermostManaged.removeEventListener(this.listenerId);
     }
 
     goToThread = (post) => {
@@ -159,7 +143,7 @@ export default class RecentMentions extends PureComponent {
 
     renderPost = ({item, index}) => {
         const {postIds, theme} = this.props;
-        const {managedConfig} = this.state;
+
         if (isDateLine(item)) {
             return (
                 <DateHeader
@@ -185,24 +169,13 @@ export default class RecentMentions extends PureComponent {
                     navigator={this.props.navigator}
                     onHashtagPress={this.handleHashtagPress}
                     onPermalinkPress={this.handlePermalinkPress}
-                    managedConfig={managedConfig}
+                    managedConfig={mattermostManaged.getCachedConfig()}
                     showFullDate={false}
                     skipPinnedHeader={true}
                 />
                 {separator}
             </View>
         );
-    };
-
-    setManagedConfig = async (config) => {
-        let nextConfig = config;
-        if (!nextConfig) {
-            nextConfig = await mattermostManaged.getLocalConfig();
-        }
-
-        this.setState({
-            managedConfig: nextConfig,
-        });
     };
 
     showPermalinkView = (postId, isPermalink) => {

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -92,18 +92,11 @@ export default class Search extends PureComponent {
             channelName: '',
             cursorPosition: 0,
             value: props.initialValue,
-            managedConfig: {},
             recent: props.recent,
         };
     }
 
-    componentWillMount() {
-        this.listenerId = mattermostManaged.addEventListener('managedConfigDidChange', this.setManagedConfig);
-    }
-
     componentDidMount() {
-        this.setManagedConfig();
-
         if (this.props.initialValue) {
             this.search(this.props.initialValue);
         }
@@ -145,10 +138,6 @@ export default class Search extends PureComponent {
                 }
             }, 250);
         }
-    }
-
-    componentWillUnmount() {
-        mattermostManaged.removeEventListener(this.listenerId);
     }
 
     archivedIndicator = (postID, style) => {
@@ -365,7 +354,6 @@ export default class Search extends PureComponent {
 
     renderPost = ({item, index}) => {
         const {postIds, theme} = this.props;
-        const {managedConfig} = this.state;
         const style = getStyleFromTheme(theme);
 
         if (item.id) {
@@ -402,7 +390,7 @@ export default class Search extends PureComponent {
                     navigator={this.props.navigator}
                     onHashtagPress={this.handleHashtagPress}
                     onPermalinkPress={this.handlePermalinkPress}
-                    managedConfig={managedConfig}
+                    managedConfig={mattermostManaged.getCachedConfig()}
                     skipPinnedHeader={true}
                 />
                 {separator}
@@ -456,17 +444,6 @@ export default class Search extends PureComponent {
 
     retry = () => {
         this.search(this.state.value.trim());
-    };
-
-    setManagedConfig = async (config) => {
-        let nextConfig = config;
-        if (!nextConfig) {
-            nextConfig = await mattermostManaged.getLocalConfig();
-        }
-
-        this.setState({
-            managedConfig: nextConfig,
-        });
     };
 
     showPermalinkView = (postId, isPermalink) => {


### PR DESCRIPTION
#### Summary
Some customers using EMM providers reported that the managed configuration was not being applied in some cases, and this was caused by the managed configuration being accessed asynchronously and not updated properly in the components.

This PR address the issue by having the managed configuration accessing a cached version of it.

This goes into the 1.19 release but two other PR's needs to be cherry-picked at the same time:
* #2741
* #2754

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15380
