### PR TITLE
Handle postIds null or undefined in channel_post_list

### DIFF
--- a/app/screens/channel/channel_post_list/__snapshots__/channel_post_list.test.js.snap
+++ b/app/screens/channel/channel_post_list/__snapshots__/channel_post_list.test.js.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChannelPostList should match snapshot 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <Connect(PostList)
+    channelId="current_channel_id"
+    currentUserId="current_user_id"
+    extraData={false}
+    indicateNewMessages={true}
+    lastViewedAt={1556753170812}
+    navigator={
+      Object {
+        "pop": [MockFunction],
+        "setButtons": [MockFunction],
+        "setOnNavigatorEvent": [MockFunction],
+      }
+    }
+    onLoadMoreUp={[Function]}
+    onPostPress={[Function]}
+    postIds={Array []}
+    refreshing={false}
+    renderFooter={[Function]}
+    renderReplies={true}
+  />
+  <Connect(AnnouncementBanner)
+    navigator={
+      Object {
+        "pop": [MockFunction],
+        "setButtons": [MockFunction],
+        "setOnNavigatorEvent": [MockFunction],
+      }
+    }
+  />
+  <Connect(RetryBarIndicator) />
+</View>
+`;
+
+exports[`ChannelPostList should match snapshot 2`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <Connect(PostList)
+    channelId="current_channel_id"
+    currentUserId="current_user_id"
+    extraData={false}
+    indicateNewMessages={true}
+    lastViewedAt={1556753170812}
+    navigator={
+      Object {
+        "pop": [MockFunction],
+        "setButtons": [MockFunction],
+        "setOnNavigatorEvent": [MockFunction],
+      }
+    }
+    onLoadMoreUp={[Function]}
+    onPostPress={[Function]}
+    postIds={Array []}
+    refreshing={false}
+    renderFooter={[Function]}
+    renderReplies={true}
+  />
+  <Connect(AnnouncementBanner)
+    navigator={
+      Object {
+        "pop": [MockFunction],
+        "setButtons": [MockFunction],
+        "setOnNavigatorEvent": [MockFunction],
+      }
+    }
+  />
+  <Connect(RetryBarIndicator) />
+</View>
+`;
+
+exports[`ChannelPostList should match snapshot 3`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <Connect(PostList)
+    channelId="current_channel_id"
+    currentUserId="current_user_id"
+    extraData={false}
+    indicateNewMessages={true}
+    lastViewedAt={1556753170812}
+    navigator={
+      Object {
+        "pop": [MockFunction],
+        "setButtons": [MockFunction],
+        "setOnNavigatorEvent": [MockFunction],
+      }
+    }
+    onLoadMoreUp={[Function]}
+    onPostPress={[Function]}
+    postIds={Array []}
+    refreshing={false}
+    renderFooter={[Function]}
+    renderReplies={true}
+  />
+  <Connect(AnnouncementBanner)
+    navigator={
+      Object {
+        "pop": [MockFunction],
+        "setButtons": [MockFunction],
+        "setOnNavigatorEvent": [MockFunction],
+      }
+    }
+  />
+  <Connect(RetryBarIndicator) />
+</View>
+`;

--- a/app/screens/channel/channel_post_list/__snapshots__/channel_post_list.test.js.snap
+++ b/app/screens/channel/channel_post_list/__snapshots__/channel_post_list.test.js.snap
@@ -13,7 +13,7 @@ exports[`ChannelPostList should match snapshot 1`] = `
     currentUserId="current_user_id"
     extraData={false}
     indicateNewMessages={true}
-    lastViewedAt={1556753170812}
+    lastViewedAt={12345}
     navigator={
       Object {
         "pop": [MockFunction],
@@ -54,7 +54,7 @@ exports[`ChannelPostList should match snapshot 2`] = `
     currentUserId="current_user_id"
     extraData={false}
     indicateNewMessages={true}
-    lastViewedAt={1556753170812}
+    lastViewedAt={12345}
     navigator={
       Object {
         "pop": [MockFunction],
@@ -95,7 +95,7 @@ exports[`ChannelPostList should match snapshot 3`] = `
     currentUserId="current_user_id"
     extraData={false}
     indicateNewMessages={true}
-    lastViewedAt={1556753170812}
+    lastViewedAt={12345}
     navigator={
       Object {
         "pop": [MockFunction],

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -35,7 +35,7 @@ export default class ChannelPostList extends PureComponent {
         lastViewedAt: PropTypes.number,
         loadMorePostsVisible: PropTypes.bool.isRequired,
         navigator: PropTypes.object,
-        postIds: PropTypes.array.isRequired,
+        postIds: PropTypes.array,
         postVisibility: PropTypes.number,
         refreshing: PropTypes.bool.isRequired,
         theme: PropTypes.object.isRequired,
@@ -43,6 +43,7 @@ export default class ChannelPostList extends PureComponent {
 
     static defaultProps = {
         postVisibility: ViewTypes.POST_VISIBILITY_CHUNK_SIZE,
+        postIds: [],
     };
 
     constructor(props) {
@@ -77,7 +78,7 @@ export default class ChannelPostList extends PureComponent {
     }
 
     getVisiblePostIds = (props) => {
-        return props.postIds.slice(0, props.postVisibility);
+        return props.postIds?.slice(0, props.postVisibility) || [];
     };
 
     goToThread = (post) => {
@@ -173,7 +174,7 @@ export default class ChannelPostList extends PureComponent {
         const {visiblePostIds} = this.state;
         let component;
 
-        if (!postIds.length && channelRefreshingFailed) {
+        if (!postIds?.length && channelRefreshingFailed) {
             component = (
                 <PostListRetry
                     retry={this.loadPostsRetry}

--- a/app/screens/channel/channel_post_list/channel_post_list.test.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.test.js
@@ -21,7 +21,7 @@ describe('ChannelPostList', () => {
         channelId: 'current_channel_id',
         channelRefreshingFailed: false,
         currentUserId: 'current_user_id',
-        lastViewedAt: Date.now(),
+        lastViewedAt: 12345,
         loadMorePostsVisible: false,
         postIds: [],
         postVisibility: 15,

--- a/app/screens/channel/channel_post_list/channel_post_list.test.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.test.js
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {Preferences} from 'mattermost-redux/constants';
+
+import ChannelPostList from './channel_post_list';
+
+describe('ChannelPostList', () => {
+    const baseProps = {
+        actions: {
+            loadPostsIfNecessaryWithRetry: jest.fn(),
+            loadThreadIfNecessary: jest.fn(),
+            increasePostVisibility: jest.fn(),
+            selectPost: jest.fn(),
+            recordLoadTime: jest.fn(),
+            refreshChannelWithRetry: jest.fn(),
+        },
+        channelId: 'current_channel_id',
+        channelRefreshingFailed: false,
+        currentUserId: 'current_user_id',
+        lastViewedAt: Date.now(),
+        loadMorePostsVisible: false,
+        postIds: [],
+        postVisibility: 15,
+        refreshing: false,
+        navigator: {
+            pop: jest.fn(),
+            setButtons: jest.fn(),
+            setOnNavigatorEvent: jest.fn(),
+        },
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should match snapshot', async () => {
+        const wrapper = shallow(
+            <ChannelPostList {...baseProps}/>,
+        );
+        expect(wrapper.getElement()).toMatchSnapshot();
+
+        wrapper.setProps({postIds: null});
+        expect(wrapper.getElement()).toMatchSnapshot();
+
+        wrapper.setProps({postIds: undefined});
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
This is only happening in **release-1.19**.

On Android for some reason at some point after logging in, the props passed to the `channel_post_list` is null thus the app crashes. By looking at the selector it should return an empty array but for some reason the first value received by the component is null.

This PR handles the case when the postIds prop is null or undefined to avoid the crash.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15402

Note: No need to cherry pick as this PR is directly against the release branch as this is not happening on master.