### PR TITLE
[MM-15401] Fix setting of extension when caching files

### DIFF
--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -5,7 +5,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     Keyboard,
-    Platform,
     ScrollView,
     StyleSheet,
 } from 'react-native';
@@ -13,9 +12,10 @@ import {
 import {Client4} from 'mattermost-redux/client';
 
 import {isDocument, isGif, isVideo} from 'app/utils/file';
-import {getCacheFile} from 'app/utils/image_cache_manager';
+import ImageCacheManager from 'app/utils/image_cache_manager';
 import {previewImageAtIndex} from 'app/utils/images';
 import {preventDoubleTap} from 'app/utils/tap';
+import {emptyFunction} from 'app/utils/general';
 
 import FileAttachment from './file_attachment';
 
@@ -99,18 +99,12 @@ export default class FileAttachmentList extends Component {
                 }
 
                 let uri;
-                let cache;
                 if (file.localPath) {
                     uri = file.localPath;
                 } else if (isGif(file)) {
-                    cache = await getCacheFile(file.name, Client4.getFileUrl(file.id)); // eslint-disable-line no-await-in-loop
+                    uri = await ImageCacheManager.cache(file.name, Client4.getFileUrl(file.id), emptyFunction); // eslint-disable-line no-await-in-loop
                 } else {
-                    cache = await getCacheFile(file.name, Client4.getFilePreviewUrl(file.id)); // eslint-disable-line no-await-in-loop
-                }
-
-                if (cache) {
-                    const prefix = Platform.OS === 'android' ? 'file://' : '';
-                    uri = `${prefix}${cache.path}`;
+                    uri = await ImageCacheManager.cache(file.name, Client4.getFilePreviewUrl(file.id), emptyFunction); // eslint-disable-line no-await-in-loop
                 }
 
                 results.push({

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -10,6 +10,7 @@ import {lookupMimeType} from 'mattermost-redux/utils/file_utils';
 import {DeviceTypes} from 'app/constants/';
 
 const EXTRACT_TYPE_REGEXP = /^\s*([^;\s]*)(?:;|\s|$)/;
+const CONTENT_DISPOSITION_REGEXP = /inline;filename=".*\.(?<ext>[a-z]+)";/i;
 const {DOCUMENTS_PATH, IMAGES_PATH, VIDEOS_PATH} = DeviceTypes;
 const DEFAULT_SERVER_MAX_FILE_SIZE = 50 * 1024 * 1024;// 50 Mb
 
@@ -233,4 +234,10 @@ export function getLocalFilePathFromFile(dir, file) {
     }
 
     return null;
+}
+
+export function getExtensionFromContentDisposition(contentDisposition) {
+    const match = CONTENT_DISPOSITION_REGEXP.exec(contentDisposition);
+
+    return match && match.groups.ext;
 }

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -238,6 +238,19 @@ export function getLocalFilePathFromFile(dir, file) {
 
 export function getExtensionFromContentDisposition(contentDisposition) {
     const match = CONTENT_DISPOSITION_REGEXP.exec(contentDisposition);
+    let extension = match && match.groups.ext;
+    if (extension) {
+        if (!Object.keys(types).length) {
+            populateMaps();
+        }
 
-    return match && match.groups.ext;
+        extension = extension.toLowerCase();
+        if (types[extension]) {
+            return extension;
+        }
+
+        return null;
+    }
+
+    return null;
 }

--- a/app/utils/file.test.js
+++ b/app/utils/file.test.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getExtensionFromContentDisposition} from 'app/utils/file';
+
+describe('getExtensionFromContentDisposition', () => {
+    it('should return the extracted the extension', () => {
+        const exts = [
+            'png',
+            'PNG',
+            'gif',
+            'GIF',
+            'bmp',
+            'BMP',
+            'jpg',
+            'JPG',
+            'jpeg',
+            'JPEG',
+        ];
+
+        exts.forEach((ext) => {
+            const contentDisposition = `inline;filename="test_image.${ext}"; filename*=UTF-8''test_image.${ext}"`;
+            const extension = getExtensionFromContentDisposition(contentDisposition);
+            expect(extension).toBe(ext);
+        });
+    });
+});

--- a/app/utils/file.test.js
+++ b/app/utils/file.test.js
@@ -21,7 +21,27 @@ describe('getExtensionFromContentDisposition', () => {
         exts.forEach((ext) => {
             const contentDisposition = `inline;filename="test_image.${ext}"; filename*=UTF-8''test_image.${ext}"`;
             const extension = getExtensionFromContentDisposition(contentDisposition);
-            expect(extension).toBe(ext);
+            expect(extension).toBe(ext.toLowerCase());
+        });
+    });
+
+    it('should return null for an invalid extension', () => {
+        const invalidExt = 'invalid';
+        const contentDisposition = `inline;filename="test_image.${invalidExt}"; filename*=UTF-8''test_image.${invalidExt}"`;
+        const extension = getExtensionFromContentDisposition(contentDisposition);
+        expect(extension).toBe(null);
+    });
+
+    it('should return null for no content disposition', () => {
+        const contentDispositions = [
+            undefined,
+            null,
+            '',
+        ];
+
+        contentDispositions.forEach((contentDisposition) => {
+            const extension = getExtensionFromContentDisposition(contentDisposition);
+            expect(extension).toBe(null);
         });
     });
 });

--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -9,7 +9,10 @@ import RNFetchBlob from 'rn-fetch-blob';
 import {Client4} from 'mattermost-redux/client';
 
 import {DeviceTypes} from 'app/constants';
-import {getExtensionFromMime} from 'app/utils/file';
+import {
+    getExtensionFromMime,
+    getExtensionFromContentDisposition,
+} from 'app/utils/file';
 import mattermostBucket from 'app/mattermost_bucket';
 
 const {IMAGES_PATH} = DeviceTypes;
@@ -55,8 +58,13 @@ export default class ImageCacheManager {
                         throw new Error();
                     }
 
+                    const contentDisposition = this.downloadTask.respInfo.headers['Content-Disposition'];
                     const mimeType = this.downloadTask.respInfo.headers['Content-Type'];
-                    const ext = `.${getExtensionFromMime(mimeType) || getExtensionFromMime(DEFAULT_MIME_TYPE)}`;
+                    const ext = '.' +
+                        getExtensionFromContentDisposition(contentDisposition) ||
+                        getExtensionFromMime(mimeType) ||
+                        getExtensionFromMime(DEFAULT_MIME_TYPE);
+
                     if (path.endsWith(ext)) {
                         notifyAll(uri, `${prefix}${path}`);
                     } else {

--- a/app/utils/image_cache_manager.js
+++ b/app/utils/image_cache_manager.js
@@ -22,8 +22,6 @@ let siteUrl;
 export default class ImageCacheManager {
     static listeners = {};
 
-    static isDownloading = (uri) => Boolean(ImageCacheManager.listeners[uri]);
-
     static cache = async (filename, uri, listener) => {
         if (!listener) {
             console.warn('Unable to cache image when no listener is provided'); // eslint-disable-line no-console
@@ -33,7 +31,7 @@ export default class ImageCacheManager {
         const prefix = Platform.OS === 'android' ? 'file://' : '';
         let pathWithPrefix = `${prefix}${path}`;
 
-        if (ImageCacheManager.isDownloading(uri)) {
+        if (exports.isDownloading(uri)) {
             addListener(uri, listener);
         } else if (exists) {
             listener(pathWithPrefix);
@@ -131,6 +129,8 @@ export const getSiteUrl = () => {
 export const setSiteUrl = (url) => {
     siteUrl = url;
 };
+
+export const isDownloading = (uri) => Boolean(ImageCacheManager.listeners[uri]);
 
 const addListener = (uri, listener) => {
     if (!ImageCacheManager.listeners[uri]) {

--- a/app/utils/image_cache_manager.test.js
+++ b/app/utils/image_cache_manager.test.js
@@ -151,8 +151,9 @@ describe('ImageCacheManager.cache', () => {
         const ext = 'jpg';
         const headers = {'Content-Type': 'image/jpeg'};
         RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers}});
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // first call in getCacheFile
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // seconds call in cache using MIME type from header
+        fileUtils.getExtensionFromMime.
+            mockReturnValueOnce(ext). // first call in getCacheFile
+            mockReturnValueOnce(ext); // seconds call in cache using MIME type from header
 
         const fileName = '';
         const fileUri = 'https://file-uri';
@@ -166,9 +167,10 @@ describe('ImageCacheManager.cache', () => {
 
         const ext = 'png';
         RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers: {}}});
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // first call in getCacheFile
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(null); // second call in cache using MIME type from header
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // third call in cache using DEFAULT_MIME_TYPE
+        fileUtils.getExtensionFromMime.
+            mockReturnValueOnce(ext). // first call in getCacheFile
+            mockReturnValueOnce(null). // second call in cache using MIME type from header
+            mockReturnValueOnce(ext); // third call in cache using DEFAULT_MIME_TYPE
 
         const fileName = '';
         const fileUri = 'https://file-uri';
@@ -190,8 +192,9 @@ describe('ImageCacheManager.cache', () => {
             const ext = 'bmp';
             const headers = {'Content-Type': 'image/bmp'};
             RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers}});
-            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // first call in getCacheFile
-            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // second call in cache using MIME type from header
+            fileUtils.getExtensionFromMime.
+                mockReturnValueOnce(ext). // first call in getCacheFile
+                mockReturnValueOnce(ext); // second call in cache using MIME type from header
 
             const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
             expect(path.endsWith(`.${ext}`)).toEqual(true);

--- a/app/utils/image_cache_manager.test.js
+++ b/app/utils/image_cache_manager.test.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import RNFetchBlob from 'rn-fetch-blob';
+
+import ImageCacheManager from 'app/utils/image_cache_manager';
+
+RNFetchBlob.fs = {
+    exists: jest.fn(),
+    existsWithDiffExt: jest.fn(),
+};
+
+describe('ImageCacheManager.getCacheFile', () => {
+    it('should return a path with correct extension for a non-cached file using file name', async () => {
+        RNFetchBlob.fs.exists.mockReturnValue(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(null);
+
+        const extensions = ['.pdf', '.png', '.bmp', '.jpg', '.jpeg'];
+        const fileUri = 'https://file-uri';
+        for (const ext of extensions) {
+            const fileName = `file${ext}`;
+            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
+            const pathExt = path.substring(path.lastIndexOf('.'));
+
+            expect(exists).toEqual(false);
+            expect(pathExt).toEqual(ext);
+        }
+    });
+
+    it('should return a path with correct extension for a non-cached file using file uri', async () => {
+        RNFetchBlob.fs.exists.mockReturnValue(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(null);
+
+        const extensions = ['.pdf', '.png', '.bmp', '.jpg', '.jpeg'];
+        const fileName = '';
+        for (const ext of extensions) {
+            const fileUri = `https://file-uri/file${ext}`;
+            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
+            const pathExt = path.substring(path.lastIndexOf('.'));
+
+            expect(exists).toEqual(false);
+            expect(pathExt).toEqual(ext);
+        }
+    });
+
+    it('should return a path with correct extension for a cached file using file name', async () => {
+        RNFetchBlob.fs.exists.mockReturnValue(true);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(null);
+
+        const extensions = ['.pdf', '.png', '.bmp', '.jpg', '.jpeg'];
+        const fileUri = 'https://file-uri';
+        for (const ext of extensions) {
+            const fileName = `file${ext}`;
+            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
+            const pathExt = path.substring(path.lastIndexOf('.'));
+
+            expect(exists).toEqual(true);
+            expect(pathExt).toEqual(ext);
+        }
+    });
+
+    it('should return a path with correct extension for a cached file using file uri', async () => {
+        RNFetchBlob.fs.exists.mockReturnValue(true);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(null);
+
+        const extensions = ['.pdf', '.png', '.bmp', '.jpg', '.jpeg'];
+        const fileName = '';
+        for (const ext of extensions) {
+            const fileUri = `https://file-uri/file${ext}`;
+            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
+            const pathExt = path.substring(path.lastIndexOf('.'));
+
+            expect(exists).toEqual(true);
+            expect(pathExt).toEqual(ext);
+        }
+    });
+
+    it('should return a path with default extension for a file and uri without an extension', async () => {
+        RNFetchBlob.fs.exists.mockReturnValue(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(null);
+
+        const defaultExt = '.png';
+        const fileNames = ['', 'file'];
+        const fileUris = ['', 'https://file-uri/file'];
+        for (const fileName of fileNames) {
+            for (const fileUri of fileUris) {
+                const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
+                const pathExt = path.substring(path.lastIndexOf('.'));
+
+                expect(exists).toEqual(false);
+                expect(pathExt).toEqual(defaultExt);
+            }
+        }
+    });
+
+    it('should return a path with a different extension for a file cached with the different extension', async () => {
+        const pathWithDiffExt = '/path/to/file.jpeg';
+        RNFetchBlob.fs.exists.mockReturnValue(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(pathWithDiffExt);
+
+        const fileNamesUris = [
+            {fileName: '', fileUri: 'https://file-uri/file.png'},
+            {fileName: 'file.png', fileUri: ''},
+        ];
+
+        for (const {fileName, fileUri} of fileNamesUris) {
+            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
+            expect(exists).toEqual(true);
+            expect(path).toEqual(pathWithDiffExt);
+        }
+    });
+});

--- a/app/utils/image_cache_manager.test.js
+++ b/app/utils/image_cache_manager.test.js
@@ -2,14 +2,15 @@
 // See LICENSE.txt for license information.
 import RNFetchBlob from 'rn-fetch-blob';
 
-import ImageCacheManager from 'app/utils/image_cache_manager';
+import ImageCacheManager, {getCacheFile} from 'app/utils/image_cache_manager';
+import {emptyFunction} from 'app/utils/general';
+import * as fileUtils from 'app/utils/file';
+import mattermostBucket from 'app/mattermost_bucket';
 
-RNFetchBlob.fs = {
-    exists: jest.fn(),
-    existsWithDiffExt: jest.fn(),
-};
+fileUtils.getExtensionFromMime = jest.fn();
+mattermostBucket.config = jest.fn().mockReturnValue({});
 
-describe('ImageCacheManager.getCacheFile', () => {
+describe('getCacheFile', () => {
     it('should return a path with correct extension for a non-cached file using file name', async () => {
         RNFetchBlob.fs.exists.mockReturnValue(false);
         RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(null);
@@ -18,11 +19,10 @@ describe('ImageCacheManager.getCacheFile', () => {
         const fileUri = 'https://file-uri';
         for (const ext of extensions) {
             const fileName = `file${ext}`;
-            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
-            const pathExt = path.substring(path.lastIndexOf('.'));
+            const {exists, path} = await getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
 
             expect(exists).toEqual(false);
-            expect(pathExt).toEqual(ext);
+            expect(path.endsWith(ext)).toEqual(true);
         }
     });
 
@@ -34,11 +34,10 @@ describe('ImageCacheManager.getCacheFile', () => {
         const fileName = '';
         for (const ext of extensions) {
             const fileUri = `https://file-uri/file${ext}`;
-            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
-            const pathExt = path.substring(path.lastIndexOf('.'));
+            const {exists, path} = await getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
 
             expect(exists).toEqual(false);
-            expect(pathExt).toEqual(ext);
+            expect(path.endsWith(ext)).toEqual(true);
         }
     });
 
@@ -50,11 +49,10 @@ describe('ImageCacheManager.getCacheFile', () => {
         const fileUri = 'https://file-uri';
         for (const ext of extensions) {
             const fileName = `file${ext}`;
-            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
-            const pathExt = path.substring(path.lastIndexOf('.'));
+            const {exists, path} = await getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
 
             expect(exists).toEqual(true);
-            expect(pathExt).toEqual(ext);
+            expect(path.endsWith(ext)).toEqual(true);
         }
     });
 
@@ -66,11 +64,10 @@ describe('ImageCacheManager.getCacheFile', () => {
         const fileName = '';
         for (const ext of extensions) {
             const fileUri = `https://file-uri/file${ext}`;
-            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
-            const pathExt = path.substring(path.lastIndexOf('.'));
+            const {exists, path} = await getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
 
             expect(exists).toEqual(true);
-            expect(pathExt).toEqual(ext);
+            expect(path.endsWith(ext)).toEqual(true);
         }
     });
 
@@ -78,16 +75,17 @@ describe('ImageCacheManager.getCacheFile', () => {
         RNFetchBlob.fs.exists.mockReturnValue(false);
         RNFetchBlob.fs.existsWithDiffExt.mockReturnValue(null);
 
-        const defaultExt = '.png';
+        const defaultExt = 'png';
+        fileUtils.getExtensionFromMime.mockReturnValue(defaultExt);
+
         const fileNames = ['', 'file'];
         const fileUris = ['', 'https://file-uri/file'];
         for (const fileName of fileNames) {
             for (const fileUri of fileUris) {
-                const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
-                const pathExt = path.substring(path.lastIndexOf('.'));
+                const {exists, path} = await getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
 
                 expect(exists).toEqual(false);
-                expect(pathExt).toEqual(defaultExt);
+                expect(path.endsWith(`.${defaultExt}`)).toEqual(true);
             }
         }
     });
@@ -103,9 +101,191 @@ describe('ImageCacheManager.getCacheFile', () => {
         ];
 
         for (const {fileName, fileUri} of fileNamesUris) {
-            const {exists, path} = await ImageCacheManager.getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
+            const {exists, path} = await getCacheFile(fileName, fileUri); // eslint-disable-line no-await-in-loop
             expect(exists).toEqual(true);
             expect(path).toEqual(pathWithDiffExt);
         }
+    });
+});
+
+describe('ImageCacheManager.cache', () => {
+    RNFetchBlob.config.mockReturnValue(RNFetchBlob);
+    ImageCacheManager.isDownloading = jest.fn();
+
+    beforeEach(() => {
+        ImageCacheManager.listeners = {};
+    });
+
+    it('should cache a file from an http uri', async () => {
+        const fileName = '';
+        const fileUris = ['http://file-uri', 'https://file-uri'];
+        for (const fileUri of fileUris) {
+            RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+            RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+            RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers: {}}});
+
+            const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+            expect(path).not.toEqual(null);
+        }
+    });
+
+    it('should get the extension from the content disposition', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+        const ext = '.bmp';
+        const headers = {'Content-Disposition': `inline;filename="file${ext}"; filename*=UTF-8''file${ext}`};
+        RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers}});
+
+        const fileName = '';
+        const fileUri = 'https://file-uri';
+        const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+        expect(path.endsWith(ext)).toEqual(true);
+    });
+
+    it('should get the extension from the content type', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+        const ext = 'jpg';
+        const headers = {'Content-Type': 'image/jpeg'};
+        RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers}});
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in getCacheFile
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in cache using MIME type from header
+
+        const fileName = '';
+        const fileUri = 'https://file-uri';
+        const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+        expect(path.endsWith(`.${ext}`)).toEqual(true);
+    });
+
+    it('should default to .png', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+        const ext = 'png';
+        RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers: {}}});
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in getCacheFile
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(null); // first call in cache using MIME type from header
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // second call in cache using DEFAULT_MIME_TYPE
+
+        const fileName = '';
+        const fileUri = 'https://file-uri';
+        const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+        expect(path.endsWith(`.${ext}`)).toEqual(true);
+    });
+
+    it('should move file if path extension and extracted extension don\'t match', async () => {
+        const oldExt = 'png';
+        const fileNameUris = [
+            {fileName: '', fileUri: `https://file-uri/file.${oldExt}`},
+            {fileName: `file${oldExt}`, fileUri: `https://file-uri/file.${oldExt}`},
+        ];
+
+        for (const {fileName, fileUri} of fileNameUris) {
+            RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+            RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+            const ext = 'bmp';
+            const headers = {'Content-Type': 'image/bmp'};
+            RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers}});
+            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in getCacheFile
+            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in cache using MIME type from header
+
+            const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+            expect(path.endsWith(`.${ext}`)).toEqual(true);
+
+            const oldPath = path.replace(ext, oldExt);
+            expect(RNFetchBlob.fs.mv).toHaveBeenCalledWith(oldPath, path);
+        }
+    });
+
+    it('should return cached file when it exists', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(true);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+        const ext = '.png';
+        const fileName = `file${ext}`;
+        const fileUri = `http://file-uri/file${ext}`;
+        const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+        expect(path.endsWith(ext)).toEqual(true);
+    });
+
+    it('should not cache the file when respInfo.respType === "text"', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+        RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: 'text', headers: {}}});
+
+        const fileName = '';
+        const fileUri = 'https://file-uri';
+        const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+        expect(path).toEqual(null);
+        expect(RNFetchBlob.fs.unlink).toHaveBeenCalled();
+    });
+
+    it('should add the listener if it is downloading', async () => {
+        ImageCacheManager.isDownloading = jest.fn().mockReturnValueOnce(true);
+
+        const fileName = 'file.png';
+        const fileUri = 'http://file-uri/file.png';
+        await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
+
+        const expectedListeners = {[fileUri]: [emptyFunction]};
+        expect(ImageCacheManager.listeners).toMatchObject(expectedListeners);
+    });
+
+    it('should call listener with path if file exists', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(true);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+        const fileName = 'file.png';
+        const fileUri = 'http://file-uri/file.png';
+        const listener = jest.fn();
+        const path = await ImageCacheManager.cache(fileName, fileUri, listener); // eslint-disable-line no-await-in-loop
+
+        expect(ImageCacheManager.listeners).toMatchObject({});
+        expect(listener).toHaveBeenCalledWith(path);
+    });
+
+    it('should call all listeners with path after downloading file then remove listeners', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+        RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers: {}}});
+
+        // Ensure isDownloading returns false so that we can proceed to
+        // download the file even if there are existing listeners.
+        ImageCacheManager.isDownloading.mockReturnValueOnce(false);
+
+        const fileName = 'file.png';
+        const fileUri = 'http://file-uri/file.png';
+        const existingListener = jest.fn();
+        ImageCacheManager.listeners = {[fileUri]: [existingListener]};
+        const newListener = jest.fn();
+        const path = await ImageCacheManager.cache(fileName, fileUri, newListener); // eslint-disable-line no-await-in-loop
+
+        expect(ImageCacheManager.listeners).toMatchObject({});
+        expect(existingListener).toHaveBeenCalledWith(path);
+        expect(newListener).toHaveBeenCalledWith(path);
+    });
+
+    it('should call all listeners with the local file', async () => {
+        RNFetchBlob.fs.exists.mockReturnValueOnce(false);
+        RNFetchBlob.fs.existsWithDiffExt.mockReturnValueOnce(null);
+
+        // Ensure isDownloading returns false so that we can proceed to
+        // download the file even if there are existing listeners.
+        ImageCacheManager.isDownloading.mockReturnValueOnce(false);
+
+        const fileName = 'file.png';
+        const fileUri = 'file://file-uri/file.png';
+        const existingListener = jest.fn();
+        ImageCacheManager.listeners = {[fileUri]: [existingListener]};
+        const newListener = jest.fn();
+        await ImageCacheManager.cache(fileName, fileUri, newListener); // eslint-disable-line no-await-in-loop
+
+        expect(ImageCacheManager.listeners).toMatchObject({});
+        expect(existingListener).toHaveBeenCalledWith(fileUri);
+        expect(newListener).toHaveBeenCalledWith(fileUri);
     });
 });

--- a/app/utils/image_cache_manager.test.js
+++ b/app/utils/image_cache_manager.test.js
@@ -8,7 +8,6 @@ import * as fileUtils from 'app/utils/file';
 import mattermostBucket from 'app/mattermost_bucket';
 
 fileUtils.getExtensionFromMime = jest.fn();
-mattermostBucket.config = jest.fn().mockReturnValue({});
 
 describe('getCacheFile', () => {
     it('should return a path with correct extension for a non-cached file using file name', async () => {
@@ -109,8 +108,10 @@ describe('getCacheFile', () => {
 });
 
 describe('ImageCacheManager.cache', () => {
+    const imageCacheManagerUtils = require('app/utils/image_cache_manager');
+    imageCacheManagerUtils.isDownloading = jest.fn();
     RNFetchBlob.config.mockReturnValue(RNFetchBlob);
-    ImageCacheManager.isDownloading = jest.fn();
+    mattermostBucket.getPreference = jest.fn().mockReturnValue({});
 
     beforeEach(() => {
         ImageCacheManager.listeners = {};
@@ -150,8 +151,8 @@ describe('ImageCacheManager.cache', () => {
         const ext = 'jpg';
         const headers = {'Content-Type': 'image/jpeg'};
         RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers}});
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in getCacheFile
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in cache using MIME type from header
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // first call in getCacheFile
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // seconds call in cache using MIME type from header
 
         const fileName = '';
         const fileUri = 'https://file-uri';
@@ -165,9 +166,9 @@ describe('ImageCacheManager.cache', () => {
 
         const ext = 'png';
         RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers: {}}});
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in getCacheFile
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(null); // first call in cache using MIME type from header
-        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // second call in cache using DEFAULT_MIME_TYPE
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // first call in getCacheFile
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(null); // second call in cache using MIME type from header
+        fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // third call in cache using DEFAULT_MIME_TYPE
 
         const fileName = '';
         const fileUri = 'https://file-uri';
@@ -189,8 +190,8 @@ describe('ImageCacheManager.cache', () => {
             const ext = 'bmp';
             const headers = {'Content-Type': 'image/bmp'};
             RNFetchBlob.fetch.mockReturnValueOnce({respInfo: {respType: '', headers}});
-            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in getCacheFile
-            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // call in cache using MIME type from header
+            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // first call in getCacheFile
+            fileUtils.getExtensionFromMime.mockReturnValueOnce(ext); // second call in cache using MIME type from header
 
             const path = await ImageCacheManager.cache(fileName, fileUri, emptyFunction); // eslint-disable-line no-await-in-loop
             expect(path.endsWith(`.${ext}`)).toEqual(true);
@@ -225,7 +226,7 @@ describe('ImageCacheManager.cache', () => {
     });
 
     it('should add the listener if it is downloading', async () => {
-        ImageCacheManager.isDownloading = jest.fn().mockReturnValueOnce(true);
+        imageCacheManagerUtils.isDownloading.mockReturnValueOnce(true);
 
         const fileName = 'file.png';
         const fileUri = 'http://file-uri/file.png';
@@ -255,7 +256,7 @@ describe('ImageCacheManager.cache', () => {
 
         // Ensure isDownloading returns false so that we can proceed to
         // download the file even if there are existing listeners.
-        ImageCacheManager.isDownloading.mockReturnValueOnce(false);
+        imageCacheManagerUtils.isDownloading.mockReturnValueOnce(false);
 
         const fileName = 'file.png';
         const fileUri = 'http://file-uri/file.png';
@@ -275,7 +276,7 @@ describe('ImageCacheManager.cache', () => {
 
         // Ensure isDownloading returns false so that we can proceed to
         // download the file even if there are existing listeners.
-        ImageCacheManager.isDownloading.mockReturnValueOnce(false);
+        imageCacheManagerUtils.isDownloading.mockReturnValueOnce(false);
 
         const fileName = 'file.png';
         const fileUri = 'file://file-uri/file.png';

--- a/test/setup.js
+++ b/test/setup.js
@@ -82,7 +82,13 @@ jest.mock('rn-fetch-blob', () => ({
             DocumentDir: () => jest.fn(),
             CacheDir: () => jest.fn(),
         },
+        exists: jest.fn(),
+        existsWithDiffExt: jest.fn(),
+        unlink: jest.fn(),
+        mv: jest.fn(),
     },
+    fetch: jest.fn(),
+    config: jest.fn(),
 }));
 
 jest.mock('rn-fetch-blob/fs', () => ({
@@ -90,6 +96,10 @@ jest.mock('rn-fetch-blob/fs', () => ({
         DocumentDir: () => jest.fn(),
         CacheDir: () => jest.fn(),
     },
+    exists: jest.fn(),
+    existsWithDiffExt: jest.fn(),
+    unlink: jest.fn(),
+    mv: jest.fn(),
 }));
 
 global.requestAnimationFrame = (callback) => {


### PR DESCRIPTION
#### Summary
When receiving a post with a file attachment, the `FileAttachmentList` component calls `getCacheFile` which returns a path with the correct extension extracted from the file name. This path is passed down the props to be used in the `Gallery` component when the user taps on the file attachment. Shortly after, the `FileAttachmentImage` component calls `ImageCacheManager.cache` which fetches the file from the server. The server returns an incorrect MIME type (a separate issue will be opened for this) in the response headers so the file is rewritten to a new path with an extension determined from that incorrect MIME type. When the user taps on the file attachment, the path provided to the Gallery component no longer exists so the error component is rendered.

This PR adds changes to determine the file extension from the server response in the following order:
1. From the header's `Content-Disposition` else
2. From the header's `Content-Type` else
3. From a default MIME type of `image/png`

The `FileAttachmentList` component has also been updated to call `ImageCacheManager.cache` instead of `getCacheFile` so that only one path for a particular file is ever passed around. It also avoids having the `FileAttachmentList` component determine the full path from `Platform.OS`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15401

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.2
* Samsung S7, Android 7.0
