### PR TITLE
Use numbered capture over named capture

### DIFF
--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -10,7 +10,7 @@ import {lookupMimeType} from 'mattermost-redux/utils/file_utils';
 import {DeviceTypes} from 'app/constants/';
 
 const EXTRACT_TYPE_REGEXP = /^\s*([^;\s]*)(?:;|\s|$)/;
-const CONTENT_DISPOSITION_REGEXP = /inline;filename=".*\.(?<ext>[a-z]+)";/i;
+const CONTENT_DISPOSITION_REGEXP = /inline;filename=".*\.([a-z]+)";/i;
 const {DOCUMENTS_PATH, IMAGES_PATH, VIDEOS_PATH} = DeviceTypes;
 const DEFAULT_SERVER_MAX_FILE_SIZE = 50 * 1024 * 1024;// 50 Mb
 
@@ -238,7 +238,7 @@ export function getLocalFilePathFromFile(dir, file) {
 
 export function getExtensionFromContentDisposition(contentDisposition) {
     const match = CONTENT_DISPOSITION_REGEXP.exec(contentDisposition);
-    let extension = match && match.groups.ext;
+    let extension = match && match[1];
     if (extension) {
         if (!Object.keys(types).length) {
             populateMaps();


### PR DESCRIPTION
#### Summary
The Jenkins build process was failing when encountering this regex:
`app/utils/file.js: Invalid regular expression: /inline;filename=".*\.(?<ext>[a-z]+)";/: Invalid group in file app/utils/file.js at 21:35`.
