### PR TITLE
MM-15428 Fix iOS when managed config is not set

### DIFF
--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -8,6 +8,7 @@ const {BlurAppScreen, MattermostManaged} = NativeModules;
 const mattermostManagedEmitter = new NativeEventEmitter(MattermostManaged);
 
 const listeners = [];
+const emptyObject = {};
 let cachedConfig = {};
 
 export default {
@@ -38,7 +39,7 @@ export default {
     blurAppScreen: BlurAppScreen.enabled,
     getConfig: async () => {
         try {
-            cachedConfig = await MattermostManaged.getConfig();
+            cachedConfig = await MattermostManaged.getConfig() || emptyObject;
         } catch (error) {
             // do nothing...
         }


### PR DESCRIPTION
#### Summary
the iOS managed configuration is set as undefined when not set, this PR makes it so instead of undefined an empty object is used to avoid a crash.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15428
