### PR TITLE
MM-15428 Return empty object for native managed configuration when not set

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
@@ -56,10 +56,10 @@ public class MattermostManagedModule extends ReactContextBaseJavaModule {
                 Object result = Arguments.fromBundle(config);
                 promise.resolve(result);
             } else {
-                throw new Exception("The MDM vendor has not sent any Managed configuration");
+                promise.resolve(Arguments.createMap());
             }
         } catch (Exception e) {
-            promise.reject("no managed configuration", e);
+            promise.resolve(Arguments.createMap());
         }
     }
 }

--- a/app/components/at_mention/at_mention.js
+++ b/app/components/at_mention/at_mention.js
@@ -99,7 +99,7 @@ export default class AtMention extends React.PureComponent {
 
         const config = mattermostManaged.getCachedConfig();
 
-        if (config.copyAndPasteProtection !== 'true') {
+        if (config?.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});
             const actionText = formatMessage({id: 'mobile.mention.copy_mention', defaultMessage: 'Copy Mention'});
 

--- a/app/components/markdown/markdown_code_block/markdown_code_block.js
+++ b/app/components/markdown/markdown_code_block/markdown_code_block.js
@@ -84,7 +84,7 @@ export default class MarkdownCodeBlock extends React.PureComponent {
 
         const config = mattermostManaged.getCachedConfig();
 
-        if (config.copyAndPasteProtection !== 'true') {
+        if (config?.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});
             const actionText = formatMessage({id: 'mobile.markdown.code.copy_code', defaultMessage: 'Copy Code'});
             BottomSheet.showBottomSheetWithOptions({

--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -146,7 +146,7 @@ export default class MarkdownImage extends React.Component {
 
         const config = mattermostManaged.getCachedConfig();
 
-        if (config.copyAndPasteProtection !== 'true') {
+        if (config?.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});
             const actionText = formatMessage({id: 'mobile.markdown.link.copy_url', defaultMessage: 'Copy URL'});
             BottomSheet.showBottomSheetWithOptions({

--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -101,7 +101,7 @@ export default class MarkdownLink extends PureComponent {
 
         const config = mattermostManaged.getCachedConfig();
 
-        if (config.copyAndPasteProtection !== 'true') {
+        if (config?.copyAndPasteProtection !== 'true') {
             const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});
             const actionText = formatMessage({id: 'mobile.markdown.link.copy_url', defaultMessage: 'Copy URL'});
             BottomSheet.showBottomSheetWithOptions({

--- a/app/components/post_list/post_list.android.js
+++ b/app/components/post_list/post_list.android.js
@@ -19,7 +19,6 @@ export default class PostList extends PostListBase {
 
         this.state = {
             refreshing: false,
-            managedConfig: {},
             dataSource: new DataSource(props.postIds, this.keyExtractor),
         };
     }

--- a/app/components/post_list/post_list.ios.js
+++ b/app/components/post_list/post_list.ios.js
@@ -31,7 +31,6 @@ export default class PostList extends PostListBase {
         this.makeExtraData = makeExtraData();
 
         this.state = {
-            managedConfig: {},
             postListHeight: 0,
         };
     }

--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -8,7 +8,6 @@ const {BlurAppScreen, MattermostManaged} = NativeModules;
 const mattermostManagedEmitter = new NativeEventEmitter(MattermostManaged);
 
 const listeners = [];
-const emptyObject = {};
 let cachedConfig = {};
 
 export default {
@@ -39,7 +38,7 @@ export default {
     blurAppScreen: BlurAppScreen.enabled,
     getConfig: async () => {
         try {
-            cachedConfig = await MattermostManaged.getConfig() || emptyObject;
+            cachedConfig = await MattermostManaged.getConfig();
         } catch (error) {
             // do nothing...
         }

--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -96,7 +96,7 @@ function mapStateToProps(state, ownProps) {
         canAddReaction = false;
     }
 
-    if (!ownProps.isSystemMessage && ownProps.managedConfig.copyAndPasteProtection !== 'true' && post.message) {
+    if (!ownProps.isSystemMessage && ownProps.managedConfig?.copyAndPasteProtection !== 'true' && post.message) {
         canCopyText = true;
     }
 

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -112,14 +112,22 @@ static NSString * const feedbackKey = @"com.apple.feedback.managed";
 {
   NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:configurationKey];
   if (hasListeners) {
-    [self sendEventWithName:@"managedConfigDidChange" body:response];
+    @try {
+      [self sendEventWithName:@"managedConfigDidChange" body:response];
+    } @catch (NSException *exception) {
+      NSLog(@"Error sending event managedConfigDidChange to JS details=%@", exception.reason);
+    }
   }
 }
 
 - (void) remoteConfigChanged {
   NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:configurationKey];
   if (hasListeners) {
-    [self sendEventWithName:@"managedConfigDidChange" body:response];
+    @try {
+      [self sendEventWithName:@"managedConfigDidChange" body:response];
+    } @catch (NSException *exception) {
+      NSLog(@"Error sending event managedConfigDidChange to JS details=%@", exception.reason);
+    }
   }
 }
 
@@ -130,8 +138,7 @@ RCT_EXPORT_METHOD(getConfig:(RCTPromiseResolveBlock)resolve
     resolve(response);
   }
   else {
-    NSError *error = [NSError errorWithDomain:@"Mattermost Managed" code:-1 userInfo:nil];
-    reject(@"no managed configuration", @"The MDM vendor has not sent any Managed configuration", error);
+    resolve(@{});
   }
 }
 


### PR DESCRIPTION
#### Summary
Previous fix wasn't working as expected, in this PR we are returning an empty object from the native code when no managed configuration has been set and just in case we check for null or undefined before accessing the managed configuration object.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15428
