### PR TITLE
Removed @babel/polyfill

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -7,42 +7,6 @@ NOTICES:
 This document includes a list of open source components used in Mattermost Mobile, including those that have been modified.
 
 --------
-## @babel/polyfill
-
-This product contains 'polyfill' by Sebastian McKenzie.
-
-Provides polyfills necessary for a full ES2015+ environment
-
-* HOMEPAGE:
-  * https://babeljs.io/
-
-* LICENSE: MIT
-
-MIT License
-
-Copyright (c) 2014-present Sebastian McKenzie and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
 ## @babel/runtime
 
 This product contains 'runtime' by Sebastian McKenzie.

--- a/app/app.js
+++ b/app/app.js
@@ -52,14 +52,6 @@ export default class App {
         this.token = null;
         this.url = null;
 
-        // Load polyfill for iOS 9
-        if (Platform.OS === 'ios') {
-            const majorVersionIOS = parseInt(Platform.Version, 10);
-            if (majorVersionIOS < 10) {
-                require('@babel/polyfill');
-            }
-        }
-
         // Usage deeplinking
         Linking.addEventListener('url', this.handleDeepLink);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,22 +1043,6 @@
         "regexpu-core": "^4.1.3"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha1-bFS5ZPca0n7d3FZ9Bl5X6H7X+n0=",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
-      }
-    },
     "@babel/preset-env": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "license": "Apache 2.0",
   "private": true,
   "dependencies": {
-    "@babel/polyfill": "7.2.5",
     "@babel/runtime": "7.3.1",
     "analytics-react-native": "1.2.0",
     "commonmark": "github:mattermost/commonmark.js#6c3136c18ae8bb7842f8491d160f370a334fd903",


### PR DESCRIPTION
#### Summary
Minimum iOS version is 10.3, so @babel/polyfill and check for iOS version < 10.x are no longer needed
