### PR TITLE
[MM-15378] Upgrade okhttp3 to allow for non-ascii chars in filename when using MultipartBody

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -114,6 +114,11 @@ android {
         pickFirst 'lib/arm64-v8a/libjsc.so'
     }
 
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     defaultConfig {
         applicationId "com.mattermost.rnbeta"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -210,6 +215,7 @@ dependencies {
     implementation 'com.android.support:percent:28.0.0'
     implementation "com.google.firebase:firebase-messaging:17.3.0"
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.squareup.okhttp3:okhttp:3.13.1"
     implementation project(':react-native-document-picker')
     implementation project(':react-native-keychain')
     implementation project(':react-native-doc-viewer')


### PR DESCRIPTION
#### Summary
Non-ascii chars is now supported in [v3.13.1](https://github.com/square/okhttp/issues/4439#issuecomment-460993154)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15378

#### Device Information
This PR was tested on:
* Samsung S7, Android 7.0
* iPhone 8, iOS 12.2 (verified RNFetchBlob uploads were unaffected)
