### PR TITLE
[MM-13955] Add lastPostIndex props to Thread and Permalink, and add markers for those screens

### DIFF
--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -102,7 +102,8 @@ export default class PostBody extends PureComponent {
         telemetry.end([
             'channel:switch_initial',
             'channel:switch_loaded',
-            'posts:list_update',
+            'post_list:permalink',
+            'post_list:thread',
             'team:switch',
             'start:overall',
         ]);

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -105,8 +105,6 @@ export default class PostList extends PureComponent {
             this.handleDeepLink(this.props.deepLinkURL);
             this.props.actions.setDeepLinkURL('');
         }
-
-        telemetry.start(['posts:list_update']);
     }
 
     componentWillUnmount() {
@@ -147,6 +145,7 @@ export default class PostList extends PureComponent {
     };
 
     handlePermalinkPress = (postId, teamName) => {
+        telemetry.start(['post_list:permalink']);
         const {actions, onPermalinkPress} = this.props;
 
         if (onPermalinkPress) {

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -17,6 +17,7 @@ import PostListRetry from 'app/components/post_list_retry';
 import RetryBarIndicator from 'app/components/retry_bar_indicator';
 import {ViewTypes} from 'app/constants';
 import tracker from 'app/utils/time_tracker';
+import telemetry from 'app/telemetry';
 
 let ChannelIntro = null;
 let LoadMorePosts = null;
@@ -87,6 +88,7 @@ export default class ChannelPostList extends PureComponent {
     };
 
     goToThread = (post) => {
+        telemetry.start(['post_list:thread']);
         const {actions, channelId, navigator, theme} = this.props;
         const rootId = (post.root_id || post.id);
 

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -4,6 +4,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
+    Platform,
     Text,
     TouchableOpacity,
     View,
@@ -15,6 +16,7 @@ import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 
 import {General} from 'mattermost-redux/constants';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
+import {getLastPostIndex} from 'mattermost-redux/utils/post_list';
 
 import FormattedText from 'app/components/formatted_text';
 import Loading from 'app/components/loading';
@@ -393,6 +395,7 @@ export default class Permalink extends PureComponent {
                     onPermalinkPress={this.handlePermalinkPress}
                     onPostPress={this.goToThread}
                     postIds={postIdsState}
+                    lastPostIndex={Platform.OS === 'android' ? getLastPostIndex(postIdsState) : -1}
                     currentUserId={currentUserId}
                     lastViewedAt={0}
                     navigator={navigator}

--- a/app/screens/thread/__snapshots__/thread.test.js.snap
+++ b/app/screens/thread/__snapshots__/thread.test.js.snap
@@ -17,6 +17,7 @@ exports[`thread should match snapshot, has root post 1`] = `
     <Connect(PostList)
       currentUserId="member_user_id"
       indicateNewMessages={false}
+      lastPostIndex={-1}
       location="thread"
       navigator={
         Object {
@@ -114,6 +115,7 @@ exports[`thread should match snapshot, render footer 1`] = `
 <Connect(PostList)
   currentUserId="member_user_id"
   indicateNewMessages={false}
+  lastPostIndex={-1}
   location="thread"
   navigator={
     Object {
@@ -158,6 +160,7 @@ exports[`thread should match snapshot, render footer 2`] = `
 <Connect(PostList)
   currentUserId="member_user_id"
   indicateNewMessages={false}
+  lastPostIndex={-1}
   lastViewedAt={0}
   location="thread"
   navigator={

--- a/app/screens/thread/thread.js
+++ b/app/screens/thread/thread.js
@@ -5,7 +5,9 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {Platform} from 'react-native';
 import {intlShape} from 'react-intl';
+
 import {General, RequestStatus} from 'mattermost-redux/constants';
+import {getLastPostIndex} from 'mattermost-redux/utils/post_list';
 
 import {THREAD} from 'app/constants/screen';
 
@@ -147,6 +149,7 @@ export default class Thread extends PureComponent {
                     renderFooter={this.renderFooter()}
                     indicateNewMessages={false}
                     postIds={postIds}
+                    lastPostIndex={Platform.OS === 'android' ? getLastPostIndex(postIds) : -1}
                     currentUserId={myMember && myMember.user_id}
                     lastViewedAt={this.state.lastViewedAt}
                     navigator={navigator}

--- a/app/telemetry/telemetry_utils.js
+++ b/app/telemetry/telemetry_utils.js
@@ -39,7 +39,8 @@ const presetTID = {
     'channel:close_drawer': 9,
     'channel:open_drawer': 10,
     'posts:loading': 11,
-    'posts:list_update': 12,
+    'post_list:thread': 12,
+    'post_list:permalink': 13,
 };
 
 export function setTraceRecord({


### PR DESCRIPTION
#### Summary
- Addressed the missing props warning at Thread and Permalink views by adding `lastPostIndex` props into Thread and Permalink screens.
- While at it, added markers in opening Thread and Permalink screens from channel's post list instead of just adding default props (`-1`).  Note that there are other several ways to get into the said screens (e.g. from flag, pinned posts screens, etc) which is not covered by the said markers.
- Other: remove `posts:list_update` marker as it's found to be giving inconsistent result (having a false long time period in case of new post added but the "last post" did not re-render).  It's placed for extra monitoring only, will revisit in the future if such marker is found to be helpful.

#### Ticket Link
GitHub issue: https://github.com/mattermost/mattermost-mobile/pull/2719#discussion_r282257787
Jira ticket: [MM-13955](https://mattermost.atlassian.net/browse/MM-13955)

#### Device Information
This PR was tested on: [Android emulator, iOS simulator (no effect)] 
