### PR TITLE
[MM-14887] Include all png, jpeg, and bmp MIME types

### DIFF
--- a/app/components/attachment_button.test.js
+++ b/app/components/attachment_button.test.js
@@ -6,6 +6,7 @@ import {shallow} from 'enzyme';
 
 import Preferences from 'mattermost-redux/constants/preferences';
 
+import {VALID_MIME_TYPES} from 'app/screens/edit_profile/edit_profile';
 import AttachmentButton from './attachment_button';
 
 jest.mock('react-intl');
@@ -30,7 +31,7 @@ describe('AttachmentButton', () => {
     test('should not upload file with invalid MIME type', () => {
         const props = {
             ...baseProps,
-            validMimeTypes: ['image/jpeg'],
+            validMimeTypes: VALID_MIME_TYPES,
             onShowUnsupportedMimeTypeWarning: jest.fn(),
         };
 
@@ -51,7 +52,7 @@ describe('AttachmentButton', () => {
     test('should upload file with valid MIME type', () => {
         const props = {
             ...baseProps,
-            validMimeTypes: ['image/jpeg'],
+            validMimeTypes: VALID_MIME_TYPES,
             onShowUnsupportedMimeTypeWarning: jest.fn(),
         };
 
@@ -60,12 +61,14 @@ describe('AttachmentButton', () => {
         );
 
         const file = {
-            type: 'image/jpeg',
             fileSize: 10,
             fileName: 'test',
         };
-        wrapper.instance().uploadFiles([file]);
-        expect(props.onShowUnsupportedMimeTypeWarning).not.toHaveBeenCalled();
-        expect(props.uploadFiles).toHaveBeenCalled();
+        VALID_MIME_TYPES.forEach((mimeType) => {
+            file.type = mimeType;
+            wrapper.instance().uploadFiles([file]);
+            expect(props.onShowUnsupportedMimeTypeWarning).not.toHaveBeenCalled();
+            expect(props.uploadFiles).toHaveBeenCalled();
+        });
     });
 });

--- a/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
+++ b/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
@@ -108,8 +108,29 @@ exports[`edit_profile should match snapshot 1`] = `
     validMimeTypes={
       Array [
         "image/jpeg",
+        "image/jpeg",
+        "image/jpg",
+        "image/jp_",
+        "application/jpg",
+        "application/x-jpg",
+        "image/pjpeg",
+        "image/pipeg",
+        "image/vnd.swiftview-jpeg",
+        "image/x-xbitmap",
         "image/png",
+        "application/png",
+        "application/x-png",
         "image/bmp",
+        "image/x-bmp",
+        "image/x-bitmap",
+        "image/x-xbitmap",
+        "image/x-win-bitmap",
+        "image/x-windows-bmp",
+        "image/ms-bmp",
+        "image/x-ms-bmp",
+        "application/bmp",
+        "application/x-bmp",
+        "application/x-win-bitmap",
       ]
     }
     wrapper={true}

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -28,10 +28,31 @@ import mattermostBucket from 'app/mattermost_bucket';
 import {getFormattedFileSize} from 'mattermost-redux/utils/file_utils';
 
 const MAX_SIZE = 20 * 1024 * 1024;
-const VALID_MIME_TYPES = [
+export const VALID_MIME_TYPES = [
     'image/jpeg',
+    'image/jpeg',
+    'image/jpg',
+    'image/jp_',
+    'application/jpg',
+    'application/x-jpg',
+    'image/pjpeg',
+    'image/pipeg',
+    'image/vnd.swiftview-jpeg',
+    'image/x-xbitmap',
     'image/png',
+    'application/png',
+    'application/x-png',
     'image/bmp',
+    'image/x-bmp',
+    'image/x-bitmap',
+    'image/x-xbitmap',
+    'image/x-win-bitmap',
+    'image/x-windows-bmp',
+    'image/ms-bmp',
+    'image/x-ms-bmp',
+    'application/bmp',
+    'application/x-bmp',
+    'application/x-win-bitmap',
 ];
 const holders = {
     firstName: {


### PR DESCRIPTION
#### Summary
Ogi found that some BMP images received a warning due to the image having a MIME type of `x-ms-bmp`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14887

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
* iPhone 8, iOS 12.2
* Galaxy S7, Android 7.0
