### PR TITLE
[MM-15378] Update react-native-fetch-blob dependency to use okhttp3 v3.13.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -173,6 +173,11 @@ android {
             }
         }
     }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 repositories {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13392,8 +13392,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -13973,8 +13972,8 @@
       }
     },
     "rn-fetch-blob": {
-      "version": "github:mattermost/react-native-fetch-blob#1800697e2e3834e80f7e5fa84edb5aa43c161bbc",
-      "from": "github:mattermost/react-native-fetch-blob#1800697e2e3834e80f7e5fa84edb5aa43c161bbc",
+      "version": "github:mattermost/react-native-fetch-blob#4ba6980c29608ff8915c70b500b273a0c2fd47b5",
+      "from": "github:mattermost/react-native-fetch-blob#4ba6980c29608ff8915c70b500b273a0c2fd47b5",
       "requires": {
         "base-64": "0.1.0",
         "glob": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "redux-persist-transform-filter": "0.0.18",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "rn-fetch-blob": "github:mattermost/react-native-fetch-blob#1800697e2e3834e80f7e5fa84edb5aa43c161bbc",
+    "rn-fetch-blob": "github:mattermost/react-native-fetch-blob#4ba6980c29608ff8915c70b500b273a0c2fd47b5",
     "rn-placeholder": "github:mattermost/rn-placeholder#bfee66eb54f1f06d1425a0ad511a5e16559bf82c",
     "semver": "5.6.0",
     "shallow-equals": "1.0.0",


### PR DESCRIPTION
#### Summary
v3.13.1 includes support for non-ascii characters in the MultipartBody so now files with names that include non-ascii characters can be shared with the Android share extension.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15378

#### Device Information
This PR was tested on:
* Galaxy S7, Android 7.0
* iPhone 8, iOS 12.2
