### PR TITLE
MM-15442 Filtered list not showing bot account icon

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -33,7 +33,7 @@ function makeMapStateToProps() {
 
         if (channel.type === General.DM_CHANNEL) {
             if (ownProps.isSearchResult) {
-                isBot = channel.isBot ? channel.isBot : false;
+                isBot = Boolean(channel.isBot);
             } else {
                 const teammateId = getUserIdFromChannelName(currentUserId, channel.name);
                 const teammate = getUser(state, teammateId);

--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -33,7 +33,7 @@ function makeMapStateToProps() {
 
         if (channel.type === General.DM_CHANNEL) {
             if (ownProps.isSearchResult) {
-                isBot = channel.isBot;
+                isBot = channel.isBot ? channel.isBot : false;
             } else {
                 const teammateId = getUserIdFromChannelName(currentUserId, channel.name);
                 const teammate = getUser(state, teammateId);


### PR DESCRIPTION
#### Summary
A brief state between render cycles for channel items in the channel drawer can have channel.isBot undefined in a filtered list.  This PR handles the undefined state gracefully by returning false.

An alternative to using channel.isBot would be to use the existing several calls to state for channel and user, which would slow the filtered channel item.  If that is the desired approach (or another approach), I would be happy to follow that.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10821

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: IPhoneX 12.2 emulator

#### Screenshots
<img width="420" alt="Screen Shot 2019-05-11 at 10 37 42 AM" src="https://user-images.githubusercontent.com/2914443/57573199-d67a9a00-73d8-11e9-85fc-f2e20b64f0c0.png">
