### PR TITLE
MM-15059: Restict the permissions for guests

### DIFF
--- a/app/components/sidebars/main/channels_list/list/index.js
+++ b/app/components/sidebars/main/channels_list/list/index.js
@@ -15,7 +15,9 @@ import {getTheme, getFavoritesPreferences, getSidebarPreferences} from 'mattermo
 import {showCreateOption} from 'mattermost-redux/utils/channel_utils';
 import {memoizeResult} from 'mattermost-redux/utils/helpers';
 import {isAdmin as checkIsAdmin, isSystemAdmin as checkIsSystemAdmin} from 'mattermost-redux/utils/user_utils';
-import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getLicense, hasNewPermissions} from 'mattermost-redux/selectors/entities/general';
+import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
+import Permissions from 'mattermost-redux/constants/permissions';
 
 import {SidebarSectionTypes} from 'app/constants/view';
 
@@ -49,7 +51,16 @@ function mapStateToProps(state) {
         sidebarPrefs.favorite_at_top === 'true' && favoriteChannelIds.length,
     ));
 
+    let canJoinPublicChannels = true;
+    if (hasNewPermissions(state)) {
+        canJoinPublicChannels = haveITeamPermission(state, {
+            team: currentTeamId,
+            permission: Permissions.JOIN_PUBLIC_CHANNELS,
+        });
+    }
+
     return {
+        canJoinPublicChannels,
         canCreatePrivateChannels: showCreateOption(
             state,
             config,

--- a/app/components/sidebars/main/channels_list/list/list.js
+++ b/app/components/sidebars/main/channels_list/list/list.js
@@ -32,6 +32,7 @@ let UnreadIndicator = null;
 
 export default class List extends PureComponent {
     static propTypes = {
+        canJoinPublicChannels: PropTypes.bool.isRequired,
         canCreatePrivateChannels: PropTypes.bool.isRequired,
         favoriteChannelIds: PropTypes.array.isRequired,
         navigator: PropTypes.object,
@@ -85,7 +86,7 @@ export default class List extends PureComponent {
     }
 
     getSectionConfigByType = (props, sectionType) => {
-        const {canCreatePrivateChannels} = props;
+        const {canCreatePrivateChannels, canJoinPublicChannels} = props;
 
         switch (sectionType) {
         case SidebarSectionTypes.UNREADS:
@@ -100,7 +101,7 @@ export default class List extends PureComponent {
             };
         case SidebarSectionTypes.PUBLIC:
             return {
-                action: this.goToMoreChannels,
+                action: canJoinPublicChannels ? this.goToMoreChannels : null,
                 id: t('sidebar.channels'),
                 defaultMessage: 'PUBLIC CHANNELS',
             };


### PR DESCRIPTION
#### Summary
Restict the permissions for guests (in this case is only need to remove the create public channel icon)

#### Ticket Link
[MM-15059](https://mattermost.atlassian.net/browse/MM-15059)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates