### PR TITLE
[MM-15407] Add ability to upload compiled app to S3 via fastlane with S3 path as "<s3_bucket>/<version_number>/<build_number>/<file>.(apk | ipa | app.zip)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,7 @@ unsigned-ios: stop pre-build check-style ## Build an unsigned version of the iOS
 	@cd ios/ && xcodebuild -workspace Mattermost.xcworkspace/ -scheme Mattermost -sdk iphoneos -configuration Release -parallelizeTargets -resultBundlePath ../build-ios/result -derivedDataPath ../build-ios/ CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 	@cd build-ios/ && mkdir -p Payload && cp -R Build/Products/Release-iphoneos/Mattermost.app Payload/ && zip -r Mattermost-unsigned.ipa Payload/
 	@mv build-ios/Mattermost-unsigned.ipa .
+	@cd fastlane && NODE_ENV=production bundle exec fastlane upload_file_to_s3 file:Mattermost-unsigned.ipa
 	@rm -rf build-ios/
 	$(call stop_packager)
 
@@ -211,6 +212,7 @@ ios-sim-x86_64: stop pre-build check-style ## Build an unsigned x86_64 version o
 	@cd build-ios/Build/Products/Release-iphonesimulator/ && zip -r Mattermost-simulator-x86_64.app.zip Mattermost.app/
 	@mv build-ios/Build/Products/Release-iphonesimulator/Mattermost-simulator-x86_64.app.zip .
 	@rm -rf build-ios/
+	@cd fastlane && NODE_ENV=production bundle exec fastlane upload_file_to_s3 file:Mattermost-simulator-x86_64.app.zip
 	$(call stop_packager)
 
 unsigned-android: stop pre-build check-style prepare-android-build ## Build an unsigned version of the Android app
@@ -218,6 +220,7 @@ unsigned-android: stop pre-build check-style prepare-android-build ## Build an u
 	@echo "Building unsigned Android app"
 	@cd fastlane && NODE_ENV=production bundle exec fastlane android unsigned
 	@mv android/app/build/outputs/apk/unsigned/app-unsigned-unsigned.apk ./Mattermost-unsigned.apk
+	@cd fastlane && NODE_ENV=production bundle exec fastlane upload_file_to_s3 file:Mattermost-unsigned.apk os_type:Android
 	$(call stop_packager)
 
 test: | pre-run check-style ## Runs tests

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ unsigned-ios: stop pre-build check-style ## Build an unsigned version of the iOS
 	@cd ios/ && xcodebuild -workspace Mattermost.xcworkspace/ -scheme Mattermost -sdk iphoneos -configuration Release -parallelizeTargets -resultBundlePath ../build-ios/result -derivedDataPath ../build-ios/ CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 	@cd build-ios/ && mkdir -p Payload && cp -R Build/Products/Release-iphoneos/Mattermost.app Payload/ && zip -r Mattermost-unsigned.ipa Payload/
 	@mv build-ios/Mattermost-unsigned.ipa .
-	@cd fastlane && NODE_ENV=production bundle exec fastlane upload_file_to_s3 file:Mattermost-unsigned.ipa
+	@cd fastlane && bundle exec fastlane upload_file_to_s3 filename:Mattermost-unsigned.ipa os_type:iOS
 	@rm -rf build-ios/
 	$(call stop_packager)
 
@@ -212,7 +212,7 @@ ios-sim-x86_64: stop pre-build check-style ## Build an unsigned x86_64 version o
 	@cd build-ios/Build/Products/Release-iphonesimulator/ && zip -r Mattermost-simulator-x86_64.app.zip Mattermost.app/
 	@mv build-ios/Build/Products/Release-iphonesimulator/Mattermost-simulator-x86_64.app.zip .
 	@rm -rf build-ios/
-	@cd fastlane && NODE_ENV=production bundle exec fastlane upload_file_to_s3 file:Mattermost-simulator-x86_64.app.zip
+	@cd fastlane && bundle exec fastlane upload_file_to_s3 filename:Mattermost-simulator-x86_64.app.zip os_type:iOS
 	$(call stop_packager)
 
 unsigned-android: stop pre-build check-style prepare-android-build ## Build an unsigned version of the Android app
@@ -220,7 +220,7 @@ unsigned-android: stop pre-build check-style prepare-android-build ## Build an u
 	@echo "Building unsigned Android app"
 	@cd fastlane && NODE_ENV=production bundle exec fastlane android unsigned
 	@mv android/app/build/outputs/apk/unsigned/app-unsigned-unsigned.apk ./Mattermost-unsigned.apk
-	@cd fastlane && NODE_ENV=production bundle exec fastlane upload_file_to_s3 file:Mattermost-unsigned.apk os_type:Android
+	@cd fastlane && bundle exec fastlane upload_file_to_s3 filename:Mattermost-unsigned.apk os_type:Android
 	$(call stop_packager)
 
 test: | pre-run check-style ## Runs tests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -215,7 +215,7 @@ platform :ios do
     update_identifiers
     replace_assets
     build_ios
-    upload_ipa_to_s3
+    upload_file_to_s3({:os_type => "iOS"})
   end
 
   desc 'Build an unsigned ipa'
@@ -330,44 +330,6 @@ platform :ios do
     end
   end
 
-  desc 'Upload iOS Mattermost.ipa file to s3'
-  lane :upload_ipa_to_s3 do
-    ipa_path = lane_context[SharedValues::IPA_OUTPUT_PATH]
-
-    unless ENV['AWS_BUCKET_NAME'].nil? || ENV['AWS_BUCKET_NAME'].empty? || ENV['AWS_REGION'].nil? || ENV['AWS_REGION'].empty? || ipa_path.nil?
-      s3_region = ENV['AWS_REGION']
-      s3_bucket = ENV['AWS_BUCKET_NAME']
-      s3_folder = ''
-
-      if ENV['BRANCH_TO_BUILD'] == 'pr'
-        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{ENV['BRANCH_TO_BUILD']}"
-      else
-        version_number = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
-        build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
-        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
-      end
-
-      s3 = Aws::S3::Resource.new(region: s3_region)
-      ipa_obj = s3.bucket(s3_bucket).object("#{s3_folder}/Mattermost.ipa")
-      ipa_obj.upload_file("#{ipa_path}")
-
-      if ENV['BRANCH_TO_BUILD'] == 'pr'
-        plist_template = File.read('plist.erb')
-        plist_body = ERB.new(plist_template).result(binding)
-
-        plist_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{filename}.plist")
-        plist_obj.put(body: plist_body)
-
-        ios_plist_install_url = "itms-services://?action=download-manifest&url=https://#{s3_bucket}/#{s3_folder}/#{filename}.plist"
-
-        post_pr_message({:install_url => ios_plist_install_url})
-      end
-
-      UI.success("iOS app - S3 bucket @#{s3_bucket}, object @#{s3_folder}/Mattermost.ipa")
-      UI.success("iOS app - S3 public path: https://#{s3_bucket}/#{s3_folder}/Mattermost.ipa")
-    end
-  end
-
   error do |lane, exception|
     version = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
     build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
@@ -416,7 +378,8 @@ platform :android do
     replace_assets
     link_sentry_android
     build_android
-    upload_apk_to_s3
+    move_apk_to_root
+    upload_file_to_s3({:os_type => "Android"})
   end
 
   desc 'Build an unsigned apk'
@@ -516,39 +479,6 @@ platform :android do
     end
   end
 
-  desc 'Upload Android Mattermost.apk file to s3'
-  lane :upload_apk_to_s3 do
-    apk_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
-    unless ENV['AWS_BUCKET_NAME'].nil? || ENV['AWS_BUCKET_NAME'].empty? || ENV['AWS_REGION'].nil? || ENV['AWS_REGION'].empty? || apk_path.nil?
-      s3_region = ENV['AWS_REGION']
-      s3_bucket = ENV['AWS_BUCKET_NAME']
-      s3_folder = ENV['AWS_FOLDER_NAME']
-
-      if ENV['BRANCH_TO_BUILD'] == 'pr'
-        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{ENV['BRANCH_TO_BUILD']}"
-      else
-        version_number = android_get_version_name(gradle_file: './android/app/build.gradle')
-        build_number = android_get_version_code(gradle_file: './android/app/build.gradle')
-        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
-      end
-
-      s3 = Aws::S3::Resource.new(region: s3_region)
-      apk_obj = s3.bucket(s3_bucket).object("#{s3_folder}/Mattermost.apk")
-      apk_obj.upload_file("#{apk_path}")
-
-      if ENV['BRANCH_TO_BUILD'] == 'pr'
-        android_apk_install_path = "https://#{s3_bucket}/#{s3_folder}/Mattermost.apk"
-        post_pr_message({
-          :os_type => 'Android',
-          :install_url => android_apk_install_path
-        })
-      end
-
-      UI.success("Android app - S3 bucket @#{s3_bucket}, object @#{s3_folder}/Mattermost.apk")
-      UI.success("Android app - S3 public path: https://#{s3_bucket}/#{s3_folder}/Mattermost.apk")
-    end
-  end
-
   error do |lane, exception|
     build_number = android_get_version_code(
         gradle_file: './android/app/build.gradle'
@@ -577,6 +507,15 @@ platform :android do
         build_type: config_mode,
         project_dir: 'android/'
     )
+  end
+
+  def move_apk_to_root
+    app_name =  ENV['APP_NAME'] || 'Mattermost Beta'
+    apk_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+
+    unless apk_path.nil?
+      sh "mv #{apk_path} \"../#{app_name}.apk\""
+    end
   end
 
   def link_sentry_android
@@ -642,7 +581,6 @@ def send_message_to_mattermost(options)
 end
 
 def submit_to_store
-  app_name =  ENV['APP_NAME'] || 'Mattermost Beta'
   apk_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
   ipa_path = lane_context[SharedValues::IPA_OUTPUT_PATH]
 
@@ -666,7 +604,7 @@ def submit_to_store
 
     # Send a build message to Mattermost
     pretext = '#### New Android released ready to be published'
-    msg = 'release has been cut and is on the Beta track ready to be published.\nDownload link: #{public_link}'
+    msg = 'Release has been cut and is on the Beta track ready to be published.\nDownload link: #{public_link}'
 
     if ENV['BETA_BUILD'] == 'true'
       pretext = '#### New Android beta published to Google Play'
@@ -699,11 +637,11 @@ def submit_to_store
 
     # Send a build message to Mattermost
     pretext = '#### New iOS released ready to be published'
-    msg = 'Release has been cut and is on TestFlight ready to be published.\nDownload link: #{public_link}'
+    msg = "Release has been cut and is on TestFlight ready to be published.\nDownload link: #{public_link}"
 
     if ENV['BETA_BUILD'] == 'true'
       pretext = '#### New iOS beta published to TestFlight'
-      msg = 'Sign up as a beta tester [here](https://testflight.apple.com/join/Q7Rx7K9P).\nDownload link: #{public_link}'
+      msg = "Sign up as a beta tester [here](https://testflight.apple.com/join/Q7Rx7K9P).\nDownload link: #{public_link}"
     end
 
     send_message_to_mattermost({
@@ -717,54 +655,88 @@ def submit_to_store
                                    :success => true,
                                })
   end
-
-  unless apk_path.nil?
-    sh "mv #{apk_path} \"../#{app_name}.apk\""
-  end
 end
 
-def post_pr_message(options)
+def qa_build_message(options)
   abbreviated_commit_hash = last_git_commit[:abbreviated_commit_hash]
+  os_type = options[:os_type]
   install_url = options[:install_url]
 
   unless ENV['MATTERMOST_WEBHOOK_URL'].nil? || ENV['MATTERMOST_WEBHOOK_URL'].empty?
-    if options[:os_type] == 'Android'
+    os_type = options[:os_type]
+
+    if os_type == 'Android'
       msg = "QA build [#{abbreviated_commit_hash}](https://github.com/mattermost/mattermost-mobile/commit/#{abbreviated_commit_hash}) — [Android APK Link](#{install_url})"
       mattermost(message: msg, username: 'Fastlane', icon_url: 'https://lh3.ggpht.com/XL0CrI8skkxnboGct-duyg-bZ_MxJDTrjczyjdU8OP2PM1dmj7SP4jL1K8JQeMIB3AM=w300')
-    else
+    elsif os_type == 'iOS'
       msg = "QA build [#{abbreviated_commit_hash}](https://github.com/mattermost/mattermost-mobile/commit/#{abbreviated_commit_hash}) — [iOS pList Link](#{install_url})"
       mattermost(message: msg, username: 'Fastlane', icon_url: 'https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iOS/move-to-ios-icon.png')
     end
+  else
+    UI.success("PR Built for #{os_type}: #{install_url}")
   end
 end
 
 desc 'Upload file to s3'
 lane :upload_file_to_s3 do |options|
-  file = options[:file]
   os_type = options[:os_type]
+  filename = options[:filename]
+  filename_plist = ""
+
+  if filename.nil? || filename.empty?
+    UI.message("Filename empty")
+    app_name =  ENV['APP_NAME'] || 'Mattermost Beta'
+    if os_type == 'Android'
+      filename = "#{app_name}.apk"
+    elsif os_type == 'iOS'
+      filename = "#{app_name}.ipa"
+      filename_plist = "#{app_name}.plist"
+    end
+  end
+  
 
   build_folder_path = Dir[File.expand_path('..')].first
-  file_path = "#{build_folder_path}/#{file}"
+  file_path = "#{build_folder_path}/#{filename}"
 
   unless ENV['AWS_BUCKET_NAME'].nil? || ENV['AWS_BUCKET_NAME'].empty? || ENV['AWS_REGION'].nil? || ENV['AWS_REGION'].empty? || file_path.nil?
     s3_region = ENV['AWS_REGION']
     s3_bucket = ENV['AWS_BUCKET_NAME']
+    s3_folder = ''
 
-    if os_type == 'Android'
-      version_number = android_get_version_name(gradle_file: './android/app/build.gradle')
-      build_number = android_get_version_code(gradle_file: './android/app/build.gradle')
+    if ENV['BRANCH_TO_BUILD'] == 'pr'
+      s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{ENV['BRANCH_TO_BUILD']}"
     else
-      version_number = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
-      build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
+      if os_type == 'Android'
+        version_number = android_get_version_name(gradle_file: './android/app/build.gradle')
+        build_number = android_get_version_code(gradle_file: './android/app/build.gradle')
+      else
+        version_number = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
+        build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
+      end
+
+      s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
     end
 
-    s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
-
     s3 = Aws::S3::Resource.new(region: s3_region)
-    file_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{file}")
+    file_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{filename}")
     file_obj.upload_file("#{file_path}")
 
-    UI.success("S3 bucket @#{s3_bucket}, object @#{s3_folder}/#{file}")
-    UI.success("S3 public path: https://#{s3_bucket}/#{s3_folder}/#{file}")
+    if ENV['BRANCH_TO_BUILD'] == 'pr'
+      plist_template = File.read('plist.erb')
+      plist_body = ERB.new(plist_template).result(binding)
+
+      plist_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{filename_plist}")
+      plist_obj.put(body: plist_body)
+
+      ios_plist_install_url = "itms-services://?action=download-manifest&url=https://#{s3_bucket}/#{s3_folder}/#{filename}.plist"
+
+      qa_build_message({
+        :os_type => os_type,
+        :install_url => ios_plist_install_url
+      })
+    end
+
+    UI.success("S3 bucket @#{s3_bucket}, object @#{s3_folder}/#{filename}")
+    UI.success("S3 public path: https://#{s3_bucket}/#{s3_folder}/#{filename}")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,8 +44,6 @@ end
 after_all do |lane|
   if lane.to_s == 'build'
     submit_to_store
-  elsif lane.to_s == 'build_pr'
-    upload_to_s3
   end
 
   if ENV['RESET_GIT_BRANCH'] == 'true'
@@ -217,6 +215,7 @@ platform :ios do
     update_identifiers
     replace_assets
     build_ios
+    upload_ipa_to_s3
   end
 
   desc 'Build an unsigned ipa'
@@ -331,6 +330,44 @@ platform :ios do
     end
   end
 
+  desc 'Upload iOS Mattermost.ipa file to s3'
+  lane :upload_ipa_to_s3 do
+    ipa_path = lane_context[SharedValues::IPA_OUTPUT_PATH]
+
+    unless ENV['AWS_BUCKET_NAME'].nil? || ENV['AWS_BUCKET_NAME'].empty? || ENV['AWS_REGION'].nil? || ENV['AWS_REGION'].empty? || ipa_path.nil?
+      s3_region = ENV['AWS_REGION']
+      s3_bucket = ENV['AWS_BUCKET_NAME']
+      s3_folder = ''
+
+      if ENV['BRANCH_TO_BUILD'] == 'pr'
+        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{ENV['BRANCH_TO_BUILD']}"
+      else
+        version_number = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
+        build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
+        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
+      end
+
+      s3 = Aws::S3::Resource.new(region: s3_region)
+      ipa_obj = s3.bucket(s3_bucket).object("#{s3_folder}/Mattermost.ipa")
+      ipa_obj.upload_file("#{ipa_path}")
+
+      if ENV['BRANCH_TO_BUILD'] == 'pr'
+        plist_template = File.read('plist.erb')
+        plist_body = ERB.new(plist_template).result(binding)
+
+        plist_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{filename}.plist")
+        plist_obj.put(body: plist_body)
+
+        ios_plist_install_url = "itms-services://?action=download-manifest&url=https://#{s3_bucket}/#{s3_folder}/#{filename}.plist"
+
+        post_pr_message({:install_url => ios_plist_install_url})
+      end
+
+      UI.success("iOS app - S3 bucket @#{s3_bucket}, object @#{s3_folder}/Mattermost.ipa")
+      UI.success("iOS app - S3 public path: https://#{s3_bucket}/#{s3_folder}/Mattermost.ipa")
+    end
+  end
+
   error do |lane, exception|
     version = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
     build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
@@ -379,6 +416,7 @@ platform :android do
     replace_assets
     link_sentry_android
     build_android
+    upload_apk_to_s3
   end
 
   desc 'Build an unsigned apk'
@@ -475,6 +513,39 @@ platform :android do
     if ENV['REPLACE_ASSETS'] == 'true'
       sh 'cp -R ../dist/assets/release/icons/android/* ../android/app/src/main/res/'
       sh 'cp -R ../dist/assets/release/splash_screen/android/* ../android/app/src/main/res/'
+    end
+  end
+
+  desc 'Upload Android Mattermost.apk file to s3'
+  lane :upload_apk_to_s3 do
+    apk_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+    unless ENV['AWS_BUCKET_NAME'].nil? || ENV['AWS_BUCKET_NAME'].empty? || ENV['AWS_REGION'].nil? || ENV['AWS_REGION'].empty? || apk_path.nil?
+      s3_region = ENV['AWS_REGION']
+      s3_bucket = ENV['AWS_BUCKET_NAME']
+      s3_folder = ENV['AWS_FOLDER_NAME']
+
+      if ENV['BRANCH_TO_BUILD'] == 'pr'
+        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{ENV['BRANCH_TO_BUILD']}"
+      else
+        version_number = android_get_version_name(gradle_file: './android/app/build.gradle')
+        build_number = android_get_version_code(gradle_file: './android/app/build.gradle')
+        s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
+      end
+
+      s3 = Aws::S3::Resource.new(region: s3_region)
+      apk_obj = s3.bucket(s3_bucket).object("#{s3_folder}/Mattermost.apk")
+      apk_obj.upload_file("#{apk_path}")
+
+      if ENV['BRANCH_TO_BUILD'] == 'pr'
+        android_apk_install_path = "https://#{s3_bucket}/#{s3_folder}/Mattermost.apk"
+        post_pr_message({
+          :os_type => 'Android',
+          :install_url => android_apk_install_path
+        })
+      end
+
+      UI.success("Android app - S3 bucket @#{s3_bucket}, object @#{s3_folder}/Mattermost.apk")
+      UI.success("Android app - S3 public path: https://#{s3_bucket}/#{s3_folder}/Mattermost.apk")
     end
   end
 
@@ -575,6 +646,9 @@ def submit_to_store
   apk_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
   ipa_path = lane_context[SharedValues::IPA_OUTPUT_PATH]
 
+  s3_region = ENV['AWS_REGION']
+  s3_bucket = ENV['AWS_BUCKET_NAME']
+
   # Submit to Google Play if required
   if !apk_path.nil? && ENV['SUBMIT_ANDROID_TO_GOOGLE_PLAY'] == 'true'
     UI.success("apk file #{apk_path}")
@@ -584,20 +658,19 @@ def submit_to_store
         apk: apk_path
     )
 
-    build_number = android_get_version_code(
-        gradle_file: './android/app/build.gradle'
-    )
-    version_number = android_get_version_name(
-        gradle_file: './android/app/build.gradle'
-    )
+    version_number = android_get_version_name(gradle_file: './android/app/build.gradle')
+    build_number = android_get_version_code(gradle_file: './android/app/build.gradle')
+
+    s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
+    public_link = "https://#{s3_bucket}/#{s3_folder}/Mattermost.apk"
 
     # Send a build message to Mattermost
     pretext = '#### New Android released ready to be published'
-    msg = 'release has been cut and is on the Beta track ready to be published.'
+    msg = 'release has been cut and is on the Beta track ready to be published.\nDownload link: #{public_link}'
 
     if ENV['BETA_BUILD'] == 'true'
       pretext = '#### New Android beta published to Google Play'
-      msg = 'Sign up as a beta tester [here](https://play.google.com/apps/testing/com.mattermost.rnbeta)'
+      msg = 'Sign up as a beta tester [here](https://play.google.com/apps/testing/com.mattermost.rnbeta).\nDownload link: #{public_link}'
     end
 
     send_message_to_mattermost({
@@ -618,17 +691,20 @@ def submit_to_store
 
     pilot
 
+    version_number = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
+    build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
+
+    s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
+    public_link = "https://#{s3_bucket}/#{s3_folder}/Mattermost.ipa"
+
     # Send a build message to Mattermost
     pretext = '#### New iOS released ready to be published'
-    msg = 'release has been cut and is on TestFlight ready to be published.'
+    msg = 'Release has been cut and is on TestFlight ready to be published.\nDownload link: #{public_link}'
 
     if ENV['BETA_BUILD'] == 'true'
       pretext = '#### New iOS beta published to TestFlight'
-      msg = 'Sign up as a beta tester [here](https://testflight.apple.com/join/Q7Rx7K9P)'
+      msg = 'Sign up as a beta tester [here](https://testflight.apple.com/join/Q7Rx7K9P).\nDownload link: #{public_link}'
     end
-
-    version = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
-    build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
 
     send_message_to_mattermost({
                                    :version_number => version_number,
@@ -647,50 +723,48 @@ def submit_to_store
   end
 end
 
-def upload_to_s3
-  unless ENV['AWS_BUCKET_NAME'].nil? || ENV['AWS_BUCKET_NAME'].empty? || ENV['AWS_REGION'].nil? || ENV['AWS_REGION'].empty?
-    apk_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
-    ipa_path = lane_context[SharedValues::IPA_OUTPUT_PATH]
+def post_pr_message(options)
+  abbreviated_commit_hash = last_git_commit[:abbreviated_commit_hash]
+  install_url = options[:install_url]
+
+  unless ENV['MATTERMOST_WEBHOOK_URL'].nil? || ENV['MATTERMOST_WEBHOOK_URL'].empty?
+    if options[:os_type] == 'Android'
+      msg = "QA build [#{abbreviated_commit_hash}](https://github.com/mattermost/mattermost-mobile/commit/#{abbreviated_commit_hash}) — [Android APK Link](#{install_url})"
+      mattermost(message: msg, username: 'Fastlane', icon_url: 'https://lh3.ggpht.com/XL0CrI8skkxnboGct-duyg-bZ_MxJDTrjczyjdU8OP2PM1dmj7SP4jL1K8JQeMIB3AM=w300')
+    else
+      msg = "QA build [#{abbreviated_commit_hash}](https://github.com/mattermost/mattermost-mobile/commit/#{abbreviated_commit_hash}) — [iOS pList Link](#{install_url})"
+      mattermost(message: msg, username: 'Fastlane', icon_url: 'https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iOS/move-to-ios-icon.png')
+    end
+  end
+end
+
+desc 'Upload file to s3'
+lane :upload_file_to_s3 do |options|
+  file = options[:file]
+  os_type = options[:os_type]
+
+  build_folder_path = Dir[File.expand_path('..')].first
+  file_path = "#{build_folder_path}/#{file}"
+
+  unless ENV['AWS_BUCKET_NAME'].nil? || ENV['AWS_BUCKET_NAME'].empty? || ENV['AWS_REGION'].nil? || ENV['AWS_REGION'].empty? || file_path.nil?
     s3_region = ENV['AWS_REGION']
-    s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{ENV['BRANCH_TO_BUILD']}"
     s3_bucket = ENV['AWS_BUCKET_NAME']
+
+    if os_type == 'Android'
+      version_number = android_get_version_name(gradle_file: './android/app/build.gradle')
+      build_number = android_get_version_code(gradle_file: './android/app/build.gradle')
+    else
+      version_number = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
+      build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
+    end
+
+    s3_folder = "#{ENV['AWS_FOLDER_NAME']}/#{version_number}/#{build_number}"
+
     s3 = Aws::S3::Resource.new(region: s3_region)
-    abbreviated_commit_hash = last_git_commit[:abbreviated_commit_hash]
-    filename = ENV['BRANCH_TO_BUILD']
+    file_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{file}")
+    file_obj.upload_file("#{file_path}")
 
-    unless apk_path.nil?
-      apk_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{filename}.apk")
-      apk_obj.upload_file("#{apk_path}")
-
-      android_install_path = "https://#{s3_bucket}/#{s3_folder}/#{filename}.apk"
-
-      if ENV['MATTERMOST_WEBHOOK_URL'] && !ENV['MATTERMOST_WEBHOOK_URL'].nil? && !ENV['MATTERMOST_WEBHOOK_URL'].empty?
-        msg = "QA build [#{abbreviated_commit_hash}](https://github.com/mattermost/mattermost-mobile/commit/#{abbreviated_commit_hash}) — [Android APK Link](#{android_install_path})"
-        mattermost(message: msg, username: 'Fastlane', icon_url: 'https://lh3.ggpht.com/XL0CrI8skkxnboGct-duyg-bZ_MxJDTrjczyjdU8OP2PM1dmj7SP4jL1K8JQeMIB3AM=w300')
-      else
-        UI.success("PR Built for Android: #{android_install_path}")
-      end
-    end
-
-    unless ipa_path.nil?
-      current_build_number = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
-      plist_template = File.read('plist.erb')
-      plist_body = ERB.new(plist_template).result(binding)
-
-      plist_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{filename}.plist")
-      plist_obj.put(body: plist_body)
-
-      ipa_obj = s3.bucket(s3_bucket).object("#{s3_folder}/#{filename}.ipa")
-      ipa_obj.upload_file("#{ipa_path}")
-
-      ios_install_url = "itms-services://?action=download-manifest&url=https://#{s3_bucket}/#{s3_folder}/#{filename}.plist"
-
-      unless ENV['MATTERMOST_WEBHOOK_URL'].nil? || ENV['MATTERMOST_WEBHOOK_URL'].empty?
-        msg = "QA build [#{abbreviated_commit_hash}](https://github.com/mattermost/mattermost-mobile/commit/#{abbreviated_commit_hash}) — [iOS pList Link](#{ios_install_url})"
-        mattermost(message: msg, username: 'Fastlane', icon_url: 'https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iOS/move-to-ios-icon.png')
-      else
-        UI.success("PR Built for iOS: #{ios_install_url}")
-      end
-    end
+    UI.success("S3 bucket @#{s3_bucket}, object @#{s3_folder}/#{file}")
+    UI.success("S3 public path: https://#{s3_bucket}/#{s3_folder}/#{file}")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -604,7 +604,7 @@ def submit_to_store
 
     # Send a build message to Mattermost
     pretext = '#### New Android released ready to be published'
-    msg = 'Release has been cut and is on the Beta track ready to be published.\nDownload link: #{public_link}'
+    msg = "Release has been cut and is on the Beta track ready to be published.\nDownload link: #{public_link}"
 
     if ENV['BETA_BUILD'] == 'true'
       pretext = '#### New Android beta published to Google Play'


### PR DESCRIPTION
#### Summary
Add ability to upload compiled app to S3 via fastlane.  The path in S3 is `<s3_bucket>/<version_number>/<build_number>/<file>.(apk | ipa | app.zip)`.

Note: 
- Will update shared pipelines and both should be merged at the same period.
- Safe to merge once release-1.20 is branched out.  Propose to test in action for first v1.20 build.

#### Ticket Link
Jira ticket: [MM-15407](https://mattermost.atlassian.net/browse/MM-15407)

#### Device Information
This PR was tested on: [Android and iOS build of `build`, `unsigned` and `simulator`].  Was not tested against PR, will monitor 
