### PR TITLE
[MM-15483] Allow flagging/unflagging of read-only channel posts

### DIFF
--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -29,7 +29,7 @@ import {getDimensions} from 'app/selectors/device';
 
 import PostOptions from './post_options';
 
-function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state, ownProps) {
     const post = ownProps.post;
     const channel = getChannel(state, post.channel_id) || {};
     const config = getConfig(state);
@@ -74,10 +74,6 @@ function mapStateToProps(state, ownProps) {
         ) {
             canEditUntil = post.create_at + (config.PostEditTimeLimit * 1000);
         }
-    }
-
-    if (ownProps.channelIsReadOnly) {
-        canFlag = false;
     }
 
     if (ownProps.isSystemMessage) {

--- a/app/screens/post_options/index.test.js
+++ b/app/screens/post_options/index.test.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {mapStateToProps} from './index';
+
+import * as channelSelectors from 'mattermost-redux/selectors/entities/channels';
+import * as generalSelectors from 'mattermost-redux/selectors/entities/general';
+import * as userSelectors from 'mattermost-redux/selectors/entities/users';
+import * as commonSelectors from 'mattermost-redux/selectors/entities/common';
+import * as teamSelectors from 'mattermost-redux/selectors/entities/teams';
+import * as deviceSelectors from 'app/selectors/device';
+import * as preferencesSelectors from 'mattermost-redux/selectors/entities/preferences';
+
+channelSelectors.getChannel = jest.fn();
+channelSelectors.getCurrentChannelId = jest.fn();
+generalSelectors.getConfig = jest.fn();
+generalSelectors.getLicense = jest.fn();
+generalSelectors.hasNewPermissions = jest.fn();
+userSelectors.getCurrentUserId = jest.fn();
+commonSelectors.getCurrentUserId = jest.fn();
+commonSelectors.getCurrentChannelId = jest.fn();
+teamSelectors.getCurrentTeamId = jest.fn();
+teamSelectors.getCurrentTeamUrl = jest.fn();
+deviceSelectors.getDimensions = jest.fn();
+preferencesSelectors.getTheme = jest.fn();
+
+describe('mapStateToProps', () => {
+    const baseState = {};
+    const baseOwnProps = {
+        post: {},
+    };
+
+    test('canFlag is false for system messages', () => {
+        const ownProps = {
+            ...baseOwnProps,
+            isSystemMessage: true,
+        };
+
+        const props = mapStateToProps(baseState, ownProps);
+        expect(props.canFlag).toBe(false);
+    });
+
+    test('canFlag is true for non-system messages', () => {
+        const ownProps = {
+            ...baseOwnProps,
+            isSystemMessage: false,
+        };
+
+        const props = mapStateToProps(baseState, ownProps);
+        expect(props.canFlag).toBe(true);
+    });
+});


### PR DESCRIPTION
#### Summary
Allow flagging/unflagging of read-only channel posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15483

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Galaxy S7, Android 7.0
* iPhone 8, iOS 12.2
