### PR TITLE
[MM-15695] Move i18n check from shared pipelines to makefile as i18n-extract-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build-ios
 *.zip
 server.PID
 mattermost.keystore
+tmp/
 
 # OSX
 #

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: pre-run pre-build clean
 .PHONY: check-style
+.PHONY: i18n-extract-ci
 .PHONY: start stop
 .PHONY: run run-ios run-android
 .PHONY: build build-ios build-android unsigned-ios unsigned-android ios-sim-x86_64
@@ -172,20 +173,20 @@ run-android: | check-device-android pre-run prepare-android-build ## Runs the ap
 		fi; \
     fi
 
-build: | stop pre-build check-style ## Builds the app for Android & iOS
+build: | stop pre-build check-style i18n-extract-ci ## Builds the app for Android & iOS
 	$(call start_packager)
 	@echo "Building App"
 	@cd fastlane && BABEL_ENV=production NODE_ENV=production bundle exec fastlane build
 	$(call stop_packager)
 
 
-build-ios: | stop pre-build check-style ## Builds the iOS app
+build-ios: | stop pre-build check-style i18n-extract-ci ## Builds the iOS app
 	$(call start_packager)
 	@echo "Building iOS app"
 	@cd fastlane && BABEL_ENV=production NODE_ENV=production bundle exec fastlane ios build
 	$(call stop_packager)
 
-build-android: | stop pre-build check-style prepare-android-build ## Build the Android app
+build-android: | stop pre-build check-style i18n-extract-ci prepare-android-build ## Build the Android app
 	$(call start_packager)
 	@echo "Building Android app"
 	@cd fastlane && BABEL_ENV=production NODE_ENV=production bundle exec fastlane android build
@@ -226,7 +227,7 @@ unsigned-android: stop pre-build check-style prepare-android-build ## Build an u
 test: | pre-run check-style ## Runs tests
 	@npm test
 
-build-pr: | can-build-pr stop pre-build check-style ## Build a PR from the mattermost-mobile repo
+build-pr: | can-build-pr stop pre-build check-style i18n-extract-ci ## Build a PR from the mattermost-mobile repo
 	$(call start_packager)
 	@echo "Building App from PR ${PR_ID}"
 	@cd fastlane && BABEL_ENV=production NODE_ENV=production bundle exec fastlane build_pr pr:PR-${PR_ID}
@@ -240,6 +241,14 @@ can-build-pr:
 
 i18n-extract: ## Extract strings for translation from the source code
 	npm run mmjstool -- i18n extract-mobile
+
+i18n-extract-ci:
+	mkdir -p tmp
+	cp assets/base/i18n/en.json tmp/en.json
+	mkdir -p tmp/fake-webapp-dir/i18n/
+	echo '{}' > tmp/fake-webapp-dir/i18n/en.json
+	npm run mmjstool -- i18n extract-mobile --webapp-dir tmp/fake-webapp-dir --mobile-dir .
+	diff tmp/en.json assets/base/i18n/en.json
 
 ## Help documentation https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,7 @@ i18n-extract-ci:
 	echo '{}' > tmp/fake-webapp-dir/i18n/en.json
 	npm run mmjstool -- i18n extract-mobile --webapp-dir tmp/fake-webapp-dir --mobile-dir .
 	diff tmp/en.json assets/base/i18n/en.json
+	rm -rf tmp
 
 ## Help documentation https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:


### PR DESCRIPTION
#### Summary
Move i18n check from shared pipelines to makefile as i18n-extract-ci.

Related PR - https://github.com/mattermost/mattermost-shared-pipelines/pull/14

#### Ticket Link
Jira ticket: [MM-15695](https://mattermost.atlassian.net/browse/MM-15695)