### PR TITLE
Update mmjstool commit with fix on newline to end of file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13746,8 +13746,8 @@
       }
     },
     "mmjstool": {
-    "version": "github:mattermost/mattermost-utilities#b55348242168df75da500fd813d4105c44eaea08",
-      "from": "github:mattermost/mattermost-utilities",
+      "version": "github:mattermost/mattermost-utilities#b55348242168df75da500fd813d4105c44eaea08",
+      "from": "github:mattermost/mattermost-utilities#b55348242168df75da500fd813d4105c44eaea08",
       "dev": true,
       "requires": {
         "estree-walk": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13746,7 +13746,7 @@
       }
     },
     "mmjstool": {
-      "version": "github:mattermost/mattermost-utilities#a87adfc21fba93e93265cfe12e11714b39fd3ea3",
+    "version": "github:mattermost/mattermost-utilities#b55348242168df75da500fd813d4105c44eaea08",
       "from": "github:mattermost/mattermost-utilities",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "jest-enzyme": "7.0.2",
     "jsdom-global": "3.0.2",
     "metro-react-native-babel-preset": "0.54.0",
-    "mmjstool": "github:mattermost/mattermost-utilities",
+    "mmjstool": "github:mattermost/mattermost-utilities#b55348242168df75da500fd813d4105c44eaea08",
     "nyc": "14.1.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "16.8.6",


### PR DESCRIPTION
#### Summary
PR build fails on `make i18n-extract-ci` due to mmjstool not adding `\n` when generating en.json.
This PR updates mmjstool to latest commit with fix on newline to end of file.

Actual fix is at https://github.com/mattermost/mattermost-utilities/commit/89543752e9c3b7fe4ad41d3af3821d3923198c20

#### Ticket Link
none
