### PR TITLE
Allow drawer pan responder when switching teams

### DIFF
--- a/app/components/sidebars/drawer_layout.js
+++ b/app/components/sidebars/drawer_layout.js
@@ -306,6 +306,7 @@ export default class DrawerLayout extends Component {
             if (this.props.onDrawerClose) {
                 telemetry.end(['channel:close_drawer']);
                 this.props.onDrawerClose();
+                this.canClose = true;
             }
 
             this._emitStateChanged(IDLE);


### PR DESCRIPTION
#### Summary
When switching a team the panResponder for the channel drawer was not responding as we were not updating the variable to allow the panResponder to capture the gesture to open the drawer again.

