### PR TITLE
[MM-10281] Support for Android split screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mattermost.rnbeta">
+    package="com.mattermost.rnbeta"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -42,8 +43,9 @@
                android:enabled="true"
                android:exported="false" />
         <activity
+                tools:replace="android:configChanges"
                 android:name="com.reactnativenavigation.controllers.NavigationActivity"
-                android:configChanges="keyboard|keyboardHidden|orientation|screenSize"/>
+                android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|density"/>
         <activity
                 android:name="com.mattermost.share.ShareActivity"
                 android:configChanges="keyboard|keyboardHidden|orientation|screenSize"

--- a/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
@@ -2,7 +2,10 @@ package com.mattermost.rnbeta;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import com.facebook.react.common.LifecycleState;
 import com.reactnativenavigation.controllers.SplashActivity;
+import com.reactnativenavigation.NavigationApplication;
+import com.reactnativenavigation.react.ReactGateway;
 
 public class MainActivity extends SplashActivity {
     @Override
@@ -22,6 +25,18 @@ public class MainActivity extends SplashActivity {
             finish();
             return;
         }
+    }
+
+    @Override
+    protected void onResume() {
+        ReactGateway reactGateway = NavigationApplication.instance.getReactGateway();
+        if (reactGateway.hasStartedCreatingContext() 
+            && reactGateway.getReactInstanceManager().getLifecycleState() == LifecycleState.BEFORE_CREATE) {
+            System.exit(0);
+            return;
+        }
+        
+        super.onResume();
     }
 
     @Override


### PR DESCRIPTION
#### Summary
- I've changed AndroidManifest.xml to modify configChanges of NavigationActivity. It seems to be onDestroy called when the app goes into the split mode, which leads to destroying of react context. Adding "smallestScreenSize|density" to configChanges prevents this.
- Also, I've observed there is a weird situation that react context is started but its lifecycle state is BEFORE_CREATE. This can be reproduced by closing the popup windowed app in Samsung devices. Calling System.exit(0) will fix this by restarting the whole application.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10186

#### Device Information
This PR was tested on: 
- Galaxy S10, Android 9.0.0
- Nexus 5X, Android 8.1.0