### PR TITLE
[MM 15552] Determine number of placeholder rows from height

### DIFF
--- a/app/components/channel_loader/__snapshots__/channel_loader.test.js.snap
+++ b/app/components/channel_loader/__snapshots__/channel_loader.test.js.snap
@@ -1,0 +1,383 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChannelLoader should match snapshot 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      undefined,
+      Object {
+        "backgroundColor": "#ffffff",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginVertical": 10,
+          "paddingLeft": 12,
+          "paddingRight": 20,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+      ]
+    }
+  >
+    <ImageContent
+      animate="fade"
+      color="rgba(61,60,64,0.2)"
+      firstLineWidth="80%"
+      hasRadius={true}
+      lineNumber={3}
+      lineSpacing={5}
+      size={32}
+      textSize={14}
+    />
+  </View>
+</View>
+`;

--- a/app/components/channel_loader/channel_loader.test.js
+++ b/app/components/channel_loader/channel_loader.test.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import ChannelLoader from './channel_loader';
+
+jest.mock('rn-placeholder', () => ({
+    ImageContent: () => {},
+}));
+
+describe('ChannelLoader', () => {
+    const baseProps = {
+        channelIsLoading: true,
+        theme: Preferences.THEMES.default,
+        actions: {
+            handleSelectChannel: jest.fn(),
+            setChannelLoading: jest.fn(),
+        }
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<ChannelLoader {...baseProps}/>);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/app/components/channel_loader/channel_loader.test.js
+++ b/app/components/channel_loader/channel_loader.test.js
@@ -19,7 +19,7 @@ describe('ChannelLoader', () => {
         actions: {
             handleSelectChannel: jest.fn(),
             setChannelLoading: jest.fn(),
-        }
+        },
     };
 
     test('should match snapshot', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16796,8 +16796,8 @@
       "dev": true
     },
     "rn-placeholder": {
-      "version": "github:mattermost/rn-placeholder#0389b32e0c7e2f88ea21b4bd978b5834fb09ab1d",
-      "from": "github:mattermost/rn-placeholder#0389b32e0c7e2f88ea21b4bd978b5834fb09ab1d",
+      "version": "github:mattermost/rn-placeholder#02c629c65d0123a2eee623ada0fd17186415d3c3",
+      "from": "github:mattermost/rn-placeholder#02c629c65d0123a2eee623ada0fd17186415d3c3",
       "requires": {
         "prop-types": "15.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "rn-fetch-blob": "github:mattermost/react-native-fetch-blob#d5a1efb3166f3d42e4f316b4be99da82fdc159b4",
-    "rn-placeholder": "github:mattermost/rn-placeholder#0389b32e0c7e2f88ea21b4bd978b5834fb09ab1d",
+    "rn-placeholder": "github:mattermost/rn-placeholder#02c629c65d0123a2eee623ada0fd17186415d3c3",
     "semver": "6.0.0",
     "shallow-equals": "1.0.0",
     "tinycolor2": "1.4.1",


### PR DESCRIPTION
#### Summary
We previously defaulted to six placeholder rows in portrait view and four for landscape. These changes allow for the number of rows to be calculated from height. I've also removed the `top` adjustment per feedback from Andrew. I've tested the loader on entry, channel loading, flagged and recent screens and all look good.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15552

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Pixel C emulator, Android 9.0
* Galaxy S7, Android 7.0
* iPad Pro (11 inch), iOS 12.2
* iPad Pro (10.5 inch) simulator, iOS 12.2
* iPhone X simulator, iOS 12.2
* iPhone 8, iOS 12.2

#### Screenshots
Pixel C, channel loading, portrait
![PixelC_Channel_Portrait](https://user-images.githubusercontent.com/3208014/58267274-255cf380-7d38-11e9-8f61-839bdbd02c7a.png)

iPad Pro (10.5 inch), channel loading, portrait
![iPad10 5_Channel_Portrait](https://user-images.githubusercontent.com/3208014/58267439-7d93f580-7d38-11e9-9b79-7f80dad77f05.png)
