### PR TITLE
[MM-15671] Allow updating of isLongPost after editing message

### DIFF
--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -115,9 +115,9 @@ export default class PostBody extends PureComponent {
         const {height} = event.nativeEvent.layout;
         const {showLongPost} = this.props;
 
-        if (!showLongPost && height >= this.state.maxHeight) {
+        if (!showLongPost) {
             this.setState({
-                isLongPost: true,
+                isLongPost: height >= this.state.maxHeight,
             });
         }
 


### PR DESCRIPTION
#### Summary
This change allows `isLongPost` to be set to false.
I wanted to add some tests like:
```
const longMessage = 'A really long message';
wrapper.setProps({message: longMessage});
expect(wrapper.state().isLongPost).toEqual(true);
expect(wrapper.find(ShowMoreButton).exists()).toEqual(true);

const shortMessage = 'A short message';
wrapper.setProps({message: shortMessage});
expect(wrapper.state().isLongPost).toEqual(false);
expect(wrapper.find(ShowMoreButton).exists()).toEqual(false);
```
but found that I needed to mount the PostBody component, however, I then get the error:
`It looks like you called mount() without a global document being loaded.`.
I could use some guidance with how to write the appropriate tests.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15671

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.2
* Galaxy S7, Android 7.0
