### PR TITLE
[MM-13879] Add Edit profile button to RHS menu and own profile pop-over

### DIFF
--- a/app/components/sidebars/settings/settings_sidebar.js
+++ b/app/components/sidebars/settings/settings_sidebar.js
@@ -153,11 +153,12 @@ export default class SettingsDrawer extends PureComponent {
     goToEditProfile = preventDoubleTap(() => {
         const {currentUser} = this.props;
         const {formatMessage} = this.context.intl;
+        const commandType = 'ShowModal';
 
         this.openModal(
             'EditProfile',
             formatMessage({id: 'mobile.routes.edit_profile', defaultMessage: 'Edit Profile'}),
-            {currentUser}
+            {currentUser, commandType}
         );
     });
 

--- a/app/components/sidebars/settings/settings_sidebar.js
+++ b/app/components/sidebars/settings/settings_sidebar.js
@@ -186,7 +186,7 @@ export default class SettingsDrawer extends PureComponent {
         this.openModal(
             'UserProfile',
             formatMessage({id: 'mobile.routes.user_profile', defaultMessage: 'Profile'}),
-            {userId}
+            {userId, fromSettings: true}
         );
     });
 

--- a/app/components/sidebars/settings/settings_sidebar.js
+++ b/app/components/sidebars/settings/settings_sidebar.js
@@ -294,6 +294,15 @@ export default class SettingsDrawer extends PureComponent {
                         <View style={style.separator}/>
                         <View style={style.block}>
                             <DrawerItem
+                                defaultMessage='Edit Profile'
+                                i18nId='mobile.routes.edit_profile'
+                                iconName='ios-person'
+                                iconType='ion'
+                                onPress={this.goToEditProfile}
+                                separator={true}
+                                theme={theme}
+                            />
+                            <DrawerItem
                                 defaultMessage='Settings'
                                 i18nId='mobile.routes.settings'
                                 iconName='ios-options'

--- a/app/components/sidebars/settings/settings_sidebar.js
+++ b/app/components/sidebars/settings/settings_sidebar.js
@@ -179,6 +179,17 @@ export default class SettingsDrawer extends PureComponent {
         );
     });
 
+    goToUserProfile = preventDoubleTap(() => {
+        const userId = this.props.currentUser.id;
+        const {formatMessage} = this.context.intl;
+
+        this.openModal(
+            'UserProfile',
+            formatMessage({id: 'mobile.routes.user_profile', defaultMessage: 'Profile'}),
+            {userId}
+        );
+    });
+
     goToSettings = preventDoubleTap(() => {
         const {intl} = this.context;
 
@@ -258,7 +269,7 @@ export default class SettingsDrawer extends PureComponent {
                         contentContainerStyle={style.wrapper}
                     >
                         <UserInfo
-                            onPress={this.goToEditProfile}
+                            onPress={this.goToUserProfile}
                             user={currentUser}
                         />
                         <View style={style.block}>

--- a/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
+++ b/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
@@ -34,12 +34,6 @@ exports[`edit_profile should match snapshot 1`] = `
           "calls": Array [
             Array [
               Object {
-                "leftButtons": Array [
-                  Object {
-                    "id": "close-settings",
-                    "title": undefined,
-                  },
-                ],
                 "rightButtons": Array [
                   Object {
                     "disabled": true,

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -92,6 +92,7 @@ export default class EditProfile extends PureComponent {
         currentUser: PropTypes.object.isRequired,
         navigator: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
+        commandType: PropTypes.string.isRequired,
     };
 
     static contextTypes = {

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -98,10 +98,6 @@ export default class EditProfile extends PureComponent {
         intl: intlShape,
     };
 
-    leftButton = {
-        id: 'close-settings',
-    };
-
     rightButton = {
         id: 'update-profile',
         disabled: true,
@@ -113,11 +109,8 @@ export default class EditProfile extends PureComponent {
 
         const {email, first_name: firstName, last_name: lastName, nickname, position, username} = props.currentUser;
         const buttons = {
-            leftButtons: [this.leftButton],
             rightButtons: [this.rightButton],
         };
-
-        this.leftButton.title = context.intl.formatMessage({id: t('mobile.account.settings.cancel'), defaultMessage: 'Cancel'});
         this.rightButton.title = context.intl.formatMessage({id: t('mobile.account.settings.save'), defaultMessage: 'Save'});
 
         props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
@@ -164,9 +157,13 @@ export default class EditProfile extends PureComponent {
     };
 
     close = () => {
-        this.props.navigator.dismissModal({
-            animationType: 'slide-down',
-        });
+        if (this.props.commandType === 'Push') {
+            this.props.navigator.pop();
+        } else {
+            this.props.navigator.dismissModal({
+                animationType: 'slide-down',
+            });
+        }
     };
 
     emitCanUpdateAccount = (enabled) => {

--- a/app/screens/edit_profile/edit_profile.test.js
+++ b/app/screens/edit_profile/edit_profile.test.js
@@ -45,7 +45,7 @@ describe('edit_profile', () => {
             nickname: 'Dragon',
             position: 'position',
         },
-        commandType: 'showModal',
+        commandType: 'ShowModal',
     };
 
     test('should match snapshot', async () => {

--- a/app/screens/edit_profile/edit_profile.test.js
+++ b/app/screens/edit_profile/edit_profile.test.js
@@ -45,6 +45,7 @@ describe('edit_profile', () => {
             nickname: 'Dragon',
             position: 'position',
         },
+        commandType: 'showModal',
     };
 
     test('should match snapshot', async () => {

--- a/app/screens/user_profile/index.js
+++ b/app/screens/user_profile/index.js
@@ -12,6 +12,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import Preferences from 'mattermost-redux/constants/preferences';
 import {loadBot} from 'mattermost-redux/actions/bots';
 import {getBotAccounts} from 'mattermost-redux/selectors/entities/bots';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {isTimezoneEnabled} from 'app/utils/timezone';
 
@@ -33,6 +34,7 @@ function mapStateToProps(state, ownProps) {
         enableTimezone,
         militaryTime,
         theme: getTheme(state),
+        isMyUser: getCurrentUserId(state) === ownProps.userId,
     };
 }
 

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -219,6 +219,7 @@ export default class UserProfile extends PureComponent {
     goToEditProfile = () => {
         const {user: currentUser} = this.props;
         const {formatMessage} = this.context.intl;
+        const commandType = 'Push';
 
         const {navigator, theme} = this.props;
         const options = {
@@ -226,7 +227,7 @@ export default class UserProfile extends PureComponent {
             title: formatMessage({id: 'mobile.routes.edit_profile', defaultMessage: 'Edit Profile'}),
             animated: true,
             backButtonTitle: '',
-            passProps: {currentUser},
+            passProps: {currentUser, commandType},
             navigatorStyle: {
                 navBarTextColor: theme.sidebarHeaderTextColor,
                 navBarBackgroundColor: theme.sidebarHeaderBg,

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -43,6 +43,7 @@ export default class UserProfile extends PureComponent {
         militaryTime: PropTypes.bool.isRequired,
         enableTimezone: PropTypes.bool.isRequired,
         isMyUser: PropTypes.bool.isRequired,
+        fromSettings: PropTypes.bool,
     };
 
     static contextTypes = {
@@ -83,6 +84,13 @@ export default class UserProfile extends PureComponent {
 
     close = () => {
         const {navigator, theme} = this.props;
+
+        if (this.props.fromSettings) {
+            this.props.navigator.dismissModal({
+                animationType: 'slide-down',
+            });
+            return;
+        }
 
         navigator.resetTo({
             screen: 'Channel',
@@ -227,7 +235,9 @@ export default class UserProfile extends PureComponent {
             },
         };
 
-        navigator.push(options);
+        requestAnimationFrame(() => {
+            navigator.push(options);
+        });
     };
 
     onNavigatorEvent = (event) => {

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -86,7 +86,7 @@ export default class UserProfile extends PureComponent {
         const {navigator, theme} = this.props;
 
         if (this.props.fromSettings) {
-            this.props.navigator.dismissModal({
+            navigator.dismissModal({
                 animationType: 'slide-down',
             });
             return;

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -42,11 +42,32 @@ export default class UserProfile extends PureComponent {
         bot: PropTypes.object,
         militaryTime: PropTypes.bool.isRequired,
         enableTimezone: PropTypes.bool.isRequired,
+        isMyUser: PropTypes.bool.isRequired,
     };
 
     static contextTypes = {
         intl: intlShape.isRequired,
     };
+
+    rightButton = {
+        id: 'edit-profile',
+        showAsAction: 'always',
+    };
+
+    constructor(props, context) {
+        super(props);
+
+        if (props.isMyUser) {
+            this.rightButton.title = context.intl.formatMessage({id: 'mobile.routes.user_profile.edit', defaultMessage: 'Edit'});
+
+            const buttons = {
+                rightButtons: [this.rightButton],
+            };
+
+            props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
+            props.navigator.setButtons(buttons);
+        }
+    }
 
     componentWillReceiveProps(nextProps) {
         if (this.props.theme !== nextProps.theme) {
@@ -185,6 +206,41 @@ export default class UserProfile extends PureComponent {
             hydrated = hydrated.replace(/{username}/, username);
             Linking.openURL(hydrated);
         };
+    };
+
+    goToEditProfile = () => {
+        const {user: currentUser} = this.props;
+        const {formatMessage} = this.context.intl;
+
+        const {navigator, theme} = this.props;
+        const options = {
+            screen: 'EditProfile',
+            title: formatMessage({id: 'mobile.routes.edit_profile', defaultMessage: 'Edit Profile'}),
+            animated: true,
+            backButtonTitle: '',
+            passProps: {currentUser},
+            navigatorStyle: {
+                navBarTextColor: theme.sidebarHeaderTextColor,
+                navBarBackgroundColor: theme.sidebarHeaderBg,
+                navBarButtonColor: theme.sidebarHeaderTextColor,
+                screenBackgroundColor: theme.centerChannelBg,
+            },
+        };
+
+        navigator.push(options);
+    };
+
+    onNavigatorEvent = (event) => {
+        if (event.type === 'NavBarButtonPress') {
+            switch (event.id) {
+            case this.rightButton.id:
+                this.goToEditProfile();
+                break;
+            case 'close-settings':
+                this.close();
+                break;
+            }
+        }
     };
 
     renderAdditionalOptions = () => {

--- a/app/screens/user_profile/user_profile.test.js
+++ b/app/screens/user_profile/user_profile.test.js
@@ -36,6 +36,7 @@ describe('user_profile', () => {
         theme: Preferences.THEMES.default,
         enableTimezone: false,
         militaryTime: false,
+        isMyUser: false,
     };
 
     const user = {

--- a/app/screens/user_profile/user_profile.test.js
+++ b/app/screens/user_profile/user_profile.test.js
@@ -110,7 +110,7 @@ describe('user_profile', () => {
         }, 16);
     });
 
-    test('should call goToEditProfile', async () => {
+    test('should call goToEditProfile', () => {
         const props = {
             ...baseProps,
             navigator: {
@@ -130,7 +130,7 @@ describe('user_profile', () => {
         wrapper.instance().onNavigatorEvent(event);
         setTimeout(() => {
             expect(props.navigator.push).toHaveBeenCalledTimes(1);
-        }, 16);
+        }, 0);
     });
 
     test('should close', async () => {

--- a/app/screens/user_profile/user_profile.test.js
+++ b/app/screens/user_profile/user_profile.test.js
@@ -31,6 +31,8 @@ describe('user_profile', () => {
         teammateNameDisplay: 'username',
         navigator: {
             resetTo: jest.fn(),
+            push: jest.fn(),
+            dismissModal: jest.fn(),
         },
         teams: [],
         theme: Preferences.THEMES.default,
@@ -84,5 +86,71 @@ describe('user_profile', () => {
                 theme={baseProps.theme}
             />
         )).toEqual(true);
+    });
+
+    test('should push EditProfile', async () => {
+        const props = {
+            ...baseProps,
+            navigator: {
+                push: jest.fn(),
+            },
+        };
+
+        const wrapper = shallow(
+            <UserProfile
+                {...props}
+                user={user}
+            />,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        wrapper.instance().goToEditProfile();
+        setTimeout(() => {
+            expect(props.navigator.push).toHaveBeenCalledTimes(1);
+        }, 16);
+    });
+
+    test('should call goToEditProfile', async () => {
+        const props = {
+            ...baseProps,
+            navigator: {
+                push: jest.fn(),
+            },
+        };
+
+        const wrapper = shallow(
+            <UserProfile
+                {...props}
+                user={user}
+            />,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        const event = {type: 'NavBarButtonPress', id: wrapper.instance().rightButton.id};
+        wrapper.instance().onNavigatorEvent(event);
+        setTimeout(() => {
+            expect(props.navigator.push).toHaveBeenCalledTimes(1);
+        }, 16);
+    });
+
+    test('should close', async () => {
+        const props = {...baseProps, fromSettings: true};
+
+        const wrapper = shallow(
+            <UserProfile
+                {...props}
+                user={user}
+            />,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        const event = {type: 'NavBarButtonPress', id: 'close-settings'};
+        wrapper.instance().onNavigatorEvent(event);
+        expect(props.navigator.dismissModal).toHaveBeenCalledTimes(1);
+
+        props.fromSettings = false;
+        wrapper.setProps({...props});
+        wrapper.instance().onNavigatorEvent(event);
+        expect(props.navigator.resetTo).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
#### Summary
- Add "Edit Profile" button above the "Settings" option in the right panel menu
- Make user info of right panel menu opens the users own profile
- Add an Edit button in the header of the users own profile pop-over
- Have changes on navigation codes to support `showModal` and `push`

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10624

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
- Nexus 5X, Android 8.1.0
- iOS Simulator 11.4 (iPhone XS)

#### Screenshots
iOS
![Simulator Screen Shot - iPhone X - 2019-05-25 at 04 21 16](https://user-images.githubusercontent.com/2460345/58351788-c799ea00-7ea4-11e9-9475-68a381c8d009.png)
![Simulator Screen Shot - iPhone X - 2019-05-25 at 04 21 28](https://user-images.githubusercontent.com/2460345/58351790-c799ea00-7ea4-11e9-9f75-6687fd81dbb2.png)
![Simulator Screen Shot - iPhone X - 2019-05-25 at 04 21 35](https://user-images.githubusercontent.com/2460345/58351792-c799ea00-7ea4-11e9-9fa1-b2b8bdde898c.png)

Android
![Screenshot_20190525-042416](https://user-images.githubusercontent.com/2460345/58351938-21021900-7ea5-11e9-9aa6-1d49ec21e857.png)
![Screenshot_20190525-042424](https://user-images.githubusercontent.com/2460345/58351939-21021900-7ea5-11e9-99aa-3cf1c6773aae.png)
![Screenshot_20190525-042428](https://user-images.githubusercontent.com/2460345/58351940-219aaf80-7ea5-11e9-9ad6-51fa3792bc21.png)
