### PR TITLE
MM-15575 Make Entry mount properly after hydration

### DIFF
--- a/app/screens/entry/entry.js
+++ b/app/screens/entry/entry.js
@@ -75,6 +75,8 @@ export default class Entry extends PureComponent {
             launchLogin: false,
             launchChannel: false,
         };
+
+        this.unsubscribeFromStore = null;
     }
 
     componentDidMount() {
@@ -127,6 +129,7 @@ export default class Entry extends PureComponent {
     handleHydrationComplete = () => {
         if (this.unsubscribeFromStore) {
             this.unsubscribeFromStore();
+            this.unsubscribeFromStore = null;
         }
 
         this.autoUpdateTimezone();


### PR DESCRIPTION
Upgrading to RNN v2 seems to change the order of things on startup, so this makes the Entry screen handle rehydration properly regardless of when it happens

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15575

#### Device Information
This PR was tested on: iOS Simulator