### PR TITLE
Ios accessibility fixes

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
+++ b/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
@@ -81,14 +81,12 @@ exports[`ChannelItem should match snapshot 1`] = `
           style={
             Array [
               Object {
+                "alignSelf": "center",
                 "color": "rgba(255,255,255,0.4)",
                 "flex": 1,
                 "fontSize": 14,
                 "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
                 "paddingRight": 10,
-                "textAlignVertical": "center",
               },
               Object {
                 "color": "#ffffff",
@@ -196,14 +194,12 @@ exports[`ChannelItem should match snapshot for current user i.e currentUser (you
           style={
             Array [
               Object {
+                "alignSelf": "center",
                 "color": "rgba(255,255,255,0.4)",
                 "flex": 1,
                 "fontSize": 14,
                 "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
                 "paddingRight": 10,
-                "textAlignVertical": "center",
               },
               Object {
                 "color": "#ffffff",
@@ -311,14 +307,12 @@ exports[`ChannelItem should match snapshot for current user i.e currentUser (you
           style={
             Array [
               Object {
+                "alignSelf": "center",
                 "color": "rgba(255,255,255,0.4)",
                 "flex": 1,
                 "fontSize": 14,
                 "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
                 "paddingRight": 10,
-                "textAlignVertical": "center",
               },
               Object {
                 "color": "#ffffff",
@@ -426,14 +420,12 @@ exports[`ChannelItem should match snapshot for deactivated user and is currentCh
           style={
             Array [
               Object {
+                "alignSelf": "center",
                 "color": "rgba(255,255,255,0.4)",
                 "flex": 1,
                 "fontSize": 14,
                 "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
                 "paddingRight": 10,
-                "textAlignVertical": "center",
               },
               Object {
                 "color": "#ffffff",
@@ -530,14 +522,12 @@ exports[`ChannelItem should match snapshot for deactivated user and is searchRes
           style={
             Array [
               Object {
+                "alignSelf": "center",
                 "color": "rgba(255,255,255,0.4)",
                 "flex": 1,
                 "fontSize": 14,
                 "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
                 "paddingRight": 10,
-                "textAlignVertical": "center",
               },
               Object {
                 "color": "#ffffff",
@@ -640,14 +630,12 @@ exports[`ChannelItem should match snapshot with draft 1`] = `
           style={
             Array [
               Object {
+                "alignSelf": "center",
                 "color": "rgba(255,255,255,0.4)",
                 "flex": 1,
                 "fontSize": 14,
                 "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
                 "paddingRight": 10,
-                "textAlignVertical": "center",
               },
               Object {
                 "color": "#ffffff",
@@ -746,14 +734,12 @@ exports[`ChannelItem should match snapshot with mentions and muted 1`] = `
           style={
             Array [
               Object {
+                "alignSelf": "center",
                 "color": "rgba(255,255,255,0.4)",
                 "flex": 1,
                 "fontSize": 14,
                 "fontWeight": "600",
-                "height": "100%",
-                "lineHeight": 44,
                 "paddingRight": 10,
-                "textAlignVertical": "center",
               },
               Object {
                 "color": "#ffffff",

--- a/app/components/sidebars/main/channels_list/channel_item/channel_item.js
+++ b/app/components/sidebars/main/channels_list/channel_item/channel_item.js
@@ -242,10 +242,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 14,
             fontWeight: '600',
             paddingRight: 10,
-            height: '100%',
             flex: 1,
-            textAlignVertical: 'center',
-            lineHeight: 44,
+            alignSelf: 'center',
         },
         textActive: {
             color: theme.sidebarTextActiveColor,

--- a/app/screens/settings/settings_item/style.ios.js
+++ b/app/screens/settings/settings_item/style.ios.js
@@ -40,7 +40,7 @@ export default makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             flex: 1,
             fontSize: 17,
-            lineHeight: 43,
+            alignSelf: 'center',
         },
         arrowContainer: {
             justifyContent: 'center',


### PR DESCRIPTION
#### Summary
This change fixes an issue where iOS users who utilize "Larger Text" option (see "Settings" App > Accessibility > Larger Text) cannot see text in the LHS menu and all settings screens. There are lots of other places that need to be adapted to large text, but this gets around some of the major issues.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15771

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone X (iOS), Moto G6 (Android)

#### Screenshots
- LH Menu issue
![Simulator Screen Shot - iPhone X - 2019-05-28 at 10 38 04](https://user-images.githubusercontent.com/1859611/58508247-4028d100-8159-11e9-8e75-61b569a8077e.png)

- Settings Screens
![Simulator Screen Shot - iPhone X - 2019-05-28 at 11 41 15](https://user-images.githubusercontent.com/1859611/58508293-546cce00-8159-11e9-9d3b-36fd4f00d31d.png)