### PR TITLE
[MM-14105] Long-press menu cannot be dragged up when rotating device to landscape while menu is open

### DIFF
--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -429,6 +429,7 @@ export default class PostOptions extends PureComponent {
                     marginFromTop={marginFromTop > 0 ? marginFromTop : 0}
                     onRequestClose={this.close}
                     initialPosition={initialPosition}
+                    key={marginFromTop}
                 >
                     {options}
                 </SlideUpPanel>


### PR DESCRIPTION
#### Summary
- As `SlideUpPanel` calculates `initialPosition` only in constructor, rotating device will not cause re-caculation of `initialPosition`.
- Adding `marginFromTop` as a key to `SlideUpPanel` can fix this problem in simplest way.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10275

#### Device Information
This PR was tested on
- Samsung Galaxy S10 (Android 9.0)
- iOS Simulator (iPhone XS, iOS 12.2)

