### PR TITLE
MM-15643 Better close app when checking for pin code

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
@@ -68,7 +68,14 @@ public class MattermostManagedModule extends ReactContextBaseJavaModule {
     @ReactMethod
     // Close the current activity and open the security settings.
     public void goToSecuritySettings() {
-        getCurrentActivity().finish();
         getReactApplicationContext().startActivity(new Intent(android.provider.Settings.ACTION_SECURITY_SETTINGS));
+        getCurrentActivity().finish();
+        System.exit(0);
+    }
+
+    @ReactMethod
+    public void quitApp() {
+        getCurrentActivity().finish();
+        System.exit(0);
     }
 }

--- a/app/mattermost_managed/mattermost-managed.android.js
+++ b/app/mattermost_managed/mattermost-managed.android.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {BackHandler, NativeModules, DeviceEventEmitter} from 'react-native';
+import {NativeModules, DeviceEventEmitter} from 'react-native';
 import LocalAuth from 'react-native-local-auth';
 import JailMonkey from 'jail-monkey';
 
@@ -63,5 +63,5 @@ export default {
 
         return JailMonkey.trustFall();
     },
-    quitApp: BackHandler.exitApp,
+    quitApp: MattermostManaged.quitApp,
 };


### PR DESCRIPTION
As discussed on Zoom, adding `System.exit(0)` properly terminates the app so that react-native-navigation re-initializes it when the app is reopened

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15643

#### Device Information
This PR was tested on: Moto G6 (Android 8)