### PR TITLE
[MM-15885] Configure telemetry on build 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -376,8 +376,8 @@ platform :android do
   lane :build do
     unless configured
       configure
-      configure_telemetry_android
     end
+    configure_telemetry_android
     update_identifiers
     replace_assets
     link_sentry_android


### PR DESCRIPTION
#### Summary
This fixes the issue of Android mobile build for not collecting telemetry data due to telemetry config not properly setup.

The config is setup for `fastlane android build` but skip for `fastlane build` since on the first run of build, it's already configured.

Tested and it's collecting data.

#### Ticket Link
Jira ticket: [MM-15885](https://mattermost.atlassian.net/browse/MM-15885)

#### Device Information
This PR was tested on: [Android] 

