### PR TITLE
Fix server version for Android telemetry

### DIFF
--- a/app/telemetry/telemetry.android.js
+++ b/app/telemetry/telemetry.android.js
@@ -146,7 +146,7 @@ class Telemetry {
 
         const {config} = store.getState().entities.general;
         const deviceInfo = getDeviceInfo();
-        deviceInfo.serverVersion = config.Version;
+        deviceInfo.server_version = config.Version;
 
         saveToTelemetryServer({trace_events: metrics, device_info: deviceInfo});
 


### PR DESCRIPTION
#### Summary
Fix server version for Android telemetry.  `serverVersion` is successfully sent to metrics server but it failed to parse correctly since it's expected to be [server_version](https://github.com/mattermost/mattermost-metrics-server/blob/master/src/post_metric.js#L31).

#### Ticket Link
none
