### PR TITLE
fix ios sso cookie bug when running on top-level domain

### DIFF
--- a/native_modules/RNCookieManagerIOS.m
+++ b/native_modules/RNCookieManagerIOS.m
@@ -134,7 +134,8 @@ RCT_EXPORT_METHOD(
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
                     NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
                     for(NSHTTPCookie *currentCookie in allCookies) {
-                        if([currentCookie.domain containsString:topLevelDomain]) {
+                        NSString *domainWithDot = [NSString stringWithFormat:@".%@", currentCookie.domain];
+                        if([currentCookie.domain containsString:topLevelDomain] || [domainWithDot containsString:topLevelDomain]) {
                             [cookies setObject:currentCookie.value forKey:currentCookie.name];
                         }
                     }


### PR DESCRIPTION
#### Summary
Fix iOS SSO when running on top-level domain (like example.com instead of www.example.com / chat.example.com)

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-mobile/issues/2722

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: ios / emulator, iphone x 

#### Screenshots
no ui changes
