### PR TITLE
MM-15643 Fix race condition to prompt for passcode and

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -31,6 +31,7 @@ export default class App {
         // Usage: app.js
         this.shouldRelaunchWhenActive = false;
         this.inBackgroundSince = null;
+        this.previousAppState = null;
 
         // Usage: screen/entry.js
         this.startAppFromPushNotification = false;


### PR DESCRIPTION
detect if passcode has been removed while the app in the background

#### Summary
There was a race condition that set the value of `app.inBackgroundSince` in different appStates, the appState has 3 values: `active`, `background` and `inactive` while bringing the app from the background the `background` and `inactive` states are set thus the value of `app.inBackgroundSince` was being set more than once. Also we are now only prompting the user for a passcode when the appState transitions from `background` to `active`.

Also this PR is changing when we check if the passcode is set, before we were checking if the device is secure only when we needed to prompt the user for a passcode, meaning that we only checked for this when the app was in the background for 5 minutes or more. Now it is being checked every time the app becomes `active` to ensure the device has a passcode, and then we only prompt for the actual passcode after those 5 minutes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15643

