### PR TITLE
MM-16070 Fix channel sidebar state while filtering

### DIFF
--- a/app/components/sidebars/main/channels_list/channels_list.js
+++ b/app/components/sidebars/main/channels_list/channels_list.js
@@ -49,11 +49,11 @@ export default class ChannelsList extends PureComponent {
         });
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (!nextProps.drawerOpened && this.props.drawerOpened) {
-            this.cancelSearch();
+    cancelSearch = () => {
+        if (this.refs.search_bar) {
+            this.refs.search_bar.cancel();
         }
-    }
+    };
 
     onSelectChannel = (channel, currentChannelId) => {
         if (channel.fake) {
@@ -62,9 +62,7 @@ export default class ChannelsList extends PureComponent {
             this.props.onSelectChannel(channel, currentChannelId);
         }
 
-        if (this.refs.search_bar) {
-            this.refs.search_bar.cancel();
-        }
+        this.cancelSearch();
     };
 
     onSearch = (term) => {
@@ -79,7 +77,7 @@ export default class ChannelsList extends PureComponent {
         this.props.onSearchStart();
     };
 
-    cancelSearch = () => {
+    onSearchCancel = () => {
         this.props.onSearchEnds();
         this.setState({searching: false});
         this.onSearch('');
@@ -142,7 +140,7 @@ export default class ChannelsList extends PureComponent {
                     titleCancelColor={theme.sidebarHeaderTextColor}
                     selectionColor={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
                     onSearchButtonPress={this.onSearch}
-                    onCancelButtonPress={this.cancelSearch}
+                    onCancelButtonPress={this.onSearchCancel}
                     onChangeText={this.onSearch}
                     onFocus={this.onSearchFocused}
                     searchIconCollapsedMargin={5}

--- a/app/components/sidebars/main/channels_list/index.js
+++ b/app/components/sidebars/main/channels_list/index.js
@@ -13,4 +13,4 @@ function mapStateToProps(state) {
     };
 }
 
-export default connect(mapStateToProps)(ChannelsList);
+export default connect(mapStateToProps, null, null, {forwardRef: true})(ChannelsList);

--- a/app/components/sidebars/main/drawer_swipper/drawer_swiper.js
+++ b/app/components/sidebars/main/drawer_swipper/drawer_swiper.js
@@ -59,7 +59,6 @@ export default class DrawerSwiper extends Component {
     showTeamsPage = () => {
         if (this.swiperRef?.current) {
             this.swiperRef.current.scrollToIndex(0, true);
-            this.swiperPageSelected(0);
         }
     };
 

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -63,6 +63,7 @@ export default class ChannelSidebar extends Component {
 
         this.swiperIndex = 1;
         this.drawerRef = React.createRef();
+        this.channelListRef = React.createRef();
         this.state = {
             show: false,
             openDrawerOffset,
@@ -142,6 +143,7 @@ export default class ChannelSidebar extends Component {
     handleDrawerClose = () => {
         this.setState({
             drawerOpened: false,
+            searching: false,
         });
         this.resetDrawer();
         Keyboard.dismiss();
@@ -283,6 +285,14 @@ export default class ChannelSidebar extends Component {
         if (this.drawerSwiper) {
             this.drawerSwiper.resetPage();
         }
+
+        if (this.drawerRef?.current) {
+            this.drawerRef.current.canClose = true;
+        }
+
+        if (this.channelListRef?.current) {
+            this.channelListRef.current.cancelSearch();
+        }
     };
 
     renderNavigationView = (drawerWidth) => {
@@ -334,6 +344,7 @@ export default class ChannelSidebar extends Component {
                 style={style.swiperContent}
             >
                 <ChannelsList
+                    ref={this.channelListRef}
                     navigator={navigator}
                     onSelectChannel={this.selectChannel}
                     onJoinChannel={this.joinChannel}

--- a/app/components/swiper.js
+++ b/app/components/swiper.js
@@ -182,9 +182,7 @@ export default class Swiper extends PureComponent {
         }
 
         this.scrollView.scrollTo({x: (index * this.props.width), animated});
-        if (index === 0) {
-            this.offset = 0;
-        }
+        this.updateIndex(this.props.width * index);
     };
 
     updateIndex = (offset) => {


### PR DESCRIPTION
#### Summary
When closing the sidebar when the teams were displayed it was causing very strange behaviors as the offset was not being re-calculated. Also you were able to close the sidebar while filtering and the search bar was not being reset.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16070