### PR TITLE
Fix file upload not completing

### DIFF
--- a/app/components/file_upload_preview/file_upload_preview.js
+++ b/app/components/file_upload_preview/file_upload_preview.js
@@ -79,7 +79,6 @@ export default class FileUploadPreview extends PureComponent {
             files,
         } = this.props;
         const {fileSizeWarning, showFileMaxWarning} = this.state;
-
         if (
             !fileSizeWarning && !showFileMaxWarning &&
             (channelIsLoading || (!files.length && !filesUploadingForCurrentChannel))

--- a/app/components/file_upload_preview/index.js
+++ b/app/components/file_upload_preview/index.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {getDimensions} from 'app/selectors/device';
@@ -13,12 +14,14 @@ import FileUploadPreview from './file_upload_preview';
 function mapStateToProps(state, ownProps) {
     const {deviceHeight} = getDimensions(state);
     const currentDraft = ownProps.rootId ? getThreadDraft(state, ownProps.rootId) : getCurrentChannelDraft(state);
+    const channelId = getCurrentChannelId(state);
 
     return {
+        channelId,
         channelIsLoading: state.views.channel.loading,
         deviceHeight,
         files: currentDraft.files,
-        filesUploadingForCurrentChannel: checkForFileUploadingInChannel(state, ownProps.channelId, ownProps.rootId),
+        filesUploadingForCurrentChannel: checkForFileUploadingInChannel(state, channelId, ownProps.rootId),
         theme: getTheme(state),
     };
 }

--- a/app/components/post_textbox/post_textbox.android.js
+++ b/app/components/post_textbox/post_textbox.android.js
@@ -15,7 +15,6 @@ const AUTOCOMPLETE_MAX_HEIGHT = 200;
 export default class PostTextBoxAndroid extends PostTextBoxBase {
     render() {
         const {
-            channelId,
             deactivatedChannel,
             files,
             rootId,
@@ -31,7 +30,6 @@ export default class PostTextBoxAndroid extends PostTextBoxBase {
             <React.Fragment>
                 <Typing/>
                 <FileUploadPreview
-                    channelId={channelId}
                     files={files}
                     rootId={rootId}
                 />

--- a/app/screens/channel/channel.ios.js
+++ b/app/screens/channel/channel.ios.js
@@ -53,7 +53,7 @@ export default class ChannelIOS extends ChannelBase {
                         updateNativeScrollView={this.updateNativeScrollView}
                     />
                     <View nativeID={ACCESSORIES_CONTAINER_NATIVE_ID}>
-                        <FileUploadPreview channelId={currentChannelId}/>
+                        <FileUploadPreview/>
                         <Autocomplete
                             maxHeight={AUTOCOMPLETE_MAX_HEIGHT}
                             onChangeText={this.handleAutoComplete}

--- a/app/screens/thread/__snapshots__/thread.ios.test.js.snap
+++ b/app/screens/thread/__snapshots__/thread.ios.test.js.snap
@@ -56,7 +56,6 @@ exports[`thread should match snapshot, has root post 1`] = `
         nativeID="threadAccessoriesContainer"
       >
         <Connect(FileUploadPreview)
-          channelId="channel_id"
           rootId="root_id"
         />
         <ForwardRef(forwardConnectRef)

--- a/app/screens/thread/thread.ios.js
+++ b/app/screens/thread/thread.ios.js
@@ -54,7 +54,6 @@ export default class ThreadIOS extends ThreadBase {
                     />
                     <View nativeID={ACCESSORIES_CONTAINER_NATIVE_ID}>
                         <FileUploadPreview
-                            channelId={channelId}
                             rootId={rootId}
                         />
                         <Autocomplete


### PR DESCRIPTION
#### Summary
Previously this was partially fixed, but there was another issue with this, for some reason the channelId received in the `FileUploadPreview` component was referring to the previous channel thus the draft was always in **loading** state and never completed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15912
