### PR TITLE
Show broken image for inline images without dimensions

### DIFF
--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -114,6 +114,11 @@ export default class MarkdownImage extends React.Component {
             return;
         }
 
+        if (!width || !height) {
+            this.setState({failed: true});
+            return;
+        }
+
         this.setState({
             failed: false,
             originalHeight: height,


### PR DESCRIPTION
#### Summary
When an image does not have dimensions like an SVG we'll show a broken image instead.

Note: As of today we do not have support to render svg images

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16091
