### PR TITLE
[MM-16078] Allow excluding archived channels in getChannelsBySections

### DIFF
--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -384,7 +384,7 @@ class ShareViewController: SLComposeServiceViewController {
       return nil
     }
     
-    let channelsInTeamBySections = store.getChannelsBySections(forTeamId) as NSDictionary
+    let channelsInTeamBySections = store.getChannelsBySections(forTeamId, excludeArchived: true) as NSDictionary
     channelDecks.append(buildChannelSection(
       channels: channelsInTeamBySections.object(forKey: "public") as! NSArray,
       currentChannelId: selectedChannel?.id ?? currentChannel?.object(forKey: "id") as! String,

--- a/ios/UploadAttachments/UploadAttachments/StoreManager.h
+++ b/ios/UploadAttachments/UploadAttachments/StoreManager.h
@@ -7,7 +7,7 @@
 
 +(instancetype)shared;
 -(NSDictionary *)getChannelById:(NSString *)channelId;
--(NSDictionary *)getChannelsBySections:(NSString *)forTeamId;
+-(NSDictionary *)getChannelsBySections:(NSString *)forTeamId excludeArchived:(BOOL)excludeArchived;
 -(NSDictionary *)getCurrentChannel;
 -(NSString *)getCurrentChannelId;
 -(NSString *)getCurrentTeamId;

--- a/ios/UploadAttachments/UploadAttachments/StoreManager.m
+++ b/ios/UploadAttachments/UploadAttachments/StoreManager.m
@@ -31,7 +31,7 @@
   return channel;
 }
 
--(NSDictionary *)getChannelsBySections:(NSString *)forTeamId {
+-(NSDictionary *)getChannelsBySections:(NSString *)forTeamId excludeArchived:(BOOL)excludeArchived {
   NSDictionary *channelsStore = [self.entities objectForKey:@"channels"];
   NSString *currentUserId = [self getCurrentUserId];
   NSString *currentChannelId = [self getCurrentChannelId];
@@ -44,6 +44,12 @@
   
   for (NSString * key in channels) {
     NSMutableDictionary *channel = [[channels objectForKey:key] mutableCopy];
+
+    NSNumber *deleteAt = [channel objectForKey:@"delete_at"];
+    if (excludeArchived && ![deleteAt isEqualToNumber:@0]) {
+      continue;
+    }
+
     NSString *team_id = [channel objectForKey:@"team_id"];
     NSString *channelType = [channel objectForKey:@"type"];
     BOOL isDM = [channelType isEqualToString:@"D"];


### PR DESCRIPTION
#### Summary
This change filters out archived channels if excludeArchived is true.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16078

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.3.1
