### PR TITLE
MM-16239 disable fields according to SAML or LDAP

### DIFF
--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -88,9 +88,12 @@ export default class EditProfile extends PureComponent {
             removeProfileImage: PropTypes.func.isRequired,
             updateUser: PropTypes.func.isRequired,
         }).isRequired,
-        config: PropTypes.object.isRequired,
         currentUser: PropTypes.object.isRequired,
+        firstNameDisabled: PropTypes.bool.isRequired,
+        lastNameDisabled: PropTypes.bool.isRequired,
         navigator: PropTypes.object.isRequired,
+        nicknameDisabled: PropTypes.bool.isRequired,
+        positionDisabled: PropTypes.bool.isRequired,
         theme: PropTypes.object.isRequired,
         commandType: PropTypes.string.isRequired,
     };
@@ -316,16 +319,12 @@ export default class EditProfile extends PureComponent {
 
     renderFirstNameSettings = () => {
         const {formatMessage} = this.context.intl;
-        const {config, currentUser, theme} = this.props;
+        const {firstNameDisabled, theme} = this.props;
         const {firstName} = this.state;
-
-        const {auth_service: service} = currentUser;
-        const disabled = (service === 'ldap' && config.LdapFristNameAttributeSet === 'true') ||
-            (service === 'saml' && config.SamlFirstNameAttributeSet === 'true');
 
         return (
             <TextSetting
-                disabled={disabled}
+                disabled={firstNameDisabled}
                 id='firstName'
                 label={holders.firstName}
                 disabledText={formatMessage({
@@ -341,17 +340,13 @@ export default class EditProfile extends PureComponent {
 
     renderLastNameSettings = () => {
         const {formatMessage} = this.context.intl;
-        const {config, currentUser, theme} = this.props;
+        const {lastNameDisabled, theme} = this.props;
         const {lastName} = this.state;
-
-        const {auth_service: service} = currentUser;
-        const disabled = (service === 'ldap' && config.LdapLastNameAttributeSet === 'true') ||
-            (service === 'saml' && config.SamlLastNameAttributeSet === 'true');
 
         return (
             <View>
                 <TextSetting
-                    disabled={disabled}
+                    disabled={lastNameDisabled}
                     id='lastName'
                     label={holders.lastName}
                     disabledText={formatMessage({
@@ -453,16 +448,12 @@ export default class EditProfile extends PureComponent {
 
     renderNicknameSettings = () => {
         const {formatMessage} = this.context.intl;
-        const {config, currentUser, theme} = this.props;
+        const {nicknameDisabled, theme} = this.props;
         const {nickname} = this.state;
-
-        const {auth_service: service} = currentUser;
-        const disabled = (service === 'ldap' && config.LdapNicknameAttributeSet === 'true') ||
-            (service === 'saml' && config.SamlNicknameAttributeSet === 'true');
 
         return (
             <TextSetting
-                disabled={disabled}
+                disabled={nicknameDisabled}
                 id='nickname'
                 label={holders.nickname}
                 disabledText={formatMessage({
@@ -479,15 +470,12 @@ export default class EditProfile extends PureComponent {
 
     renderPositionSettings = () => {
         const {formatMessage} = this.context.intl;
-        const {config, currentUser, theme} = this.props;
+        const {positionDisabled, theme} = this.props;
         const {position} = this.state;
-
-        const {auth_service: service} = currentUser;
-        const disabled = (service === 'ldap' || service === 'saml') && config.PositionAttribute === 'true';
 
         return (
             <TextSetting
-                disabled={disabled}
+                disabled={positionDisabled}
                 id='position'
                 label={holders.position}
                 disabledText={formatMessage({

--- a/app/screens/edit_profile/edit_profile.test.js
+++ b/app/screens/edit_profile/edit_profile.test.js
@@ -32,9 +32,10 @@ describe('edit_profile', () => {
 
     const baseProps = {
         actions,
-        config: {
-            ShowEmailAddress: true,
-        },
+        firstNameDisabled: true,
+        lastNameDisabled: true,
+        nicknameDisabled: true,
+        positionDisabled: true,
         theme: Preferences.THEMES.default,
         navigator,
         currentUser: {

--- a/app/screens/edit_profile/index.js
+++ b/app/screens/edit_profile/index.js
@@ -17,7 +17,7 @@ function mapStateToProps(state, ownProps) {
     const {serverVersion} = state.entities.general;
     const {service} = ownProps.currentUser;
 
-    const firstNameDisabled = (service === 'ldap' && config.LdapFristNameAttributeSet === 'true') ||
+    const firstNameDisabled = (service === 'ldap' && config.LdapFirstNameAttributeSet === 'true') ||
         (service === 'saml' && config.SamlFirstNameAttributeSet === 'true');
 
     const lastNameDisabled = (service === 'ldap' && config.LdapLastNameAttributeSet === 'true') ||

--- a/app/screens/edit_profile/index.js
+++ b/app/screens/edit_profile/index.js
@@ -6,14 +6,39 @@ import {bindActionCreators} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
 import {setProfileImageUri, removeProfileImage, updateUser} from 'app/actions/views/edit_profile';
 
 import EditProfile from './edit_profile';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
+    const config = getConfig(state);
+    const {serverVersion} = state.entities.general;
+    const {service} = ownProps.currentUser;
+
+    const firstNameDisabled = (service === 'ldap' && config.LdapFristNameAttributeSet === 'true') ||
+        (service === 'saml' && config.SamlFirstNameAttributeSet === 'true');
+
+    const lastNameDisabled = (service === 'ldap' && config.LdapLastNameAttributeSet === 'true') ||
+        (service === 'saml' && config.SamlLastNameAttributeSet === 'true');
+
+    const nicknameDisabled = (service === 'ldap' && config.LdapNicknameAttributeSet === 'true') ||
+        (service === 'saml' && config.SamlNicknameAttributeSet === 'true');
+
+    let positionDisabled = false;
+    if (isMinimumServerVersion(serverVersion, 5, 12)) {
+        positionDisabled = (service === 'ldap' && config.LdapPositionAttributeSet === 'true') ||
+            (service === 'saml' && config.SamlPositionAttributeSet === 'true');
+    } else {
+        positionDisabled = (service === 'ldap' || service === 'saml') && config.PositionAttribute === 'true';
+    }
+
     return {
-        config: getConfig(state),
+        firstNameDisabled,
+        lastNameDisabled,
+        nicknameDisabled,
+        positionDisabled,
         theme: getTheme(state),
     };
 }


### PR DESCRIPTION
#### Summary
In 5.12 there were some configuration changes for the position, this PR will take those into account but also keeps backwards compatibility with previous server versions.

In this PR I've also removed the need of the config prop and we are checking if the fields are editable or not in the connector.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16239