### PR TITLE
MM-16228 Add compatibility for removal of ExperimentalEnablePostMetadata data flag from config

### DIFF
--- a/app/components/emoji/index.js
+++ b/app/components/emoji/index.js
@@ -33,7 +33,8 @@ function mapStateToProps(state, ownProps) {
             config.EnableCustomEmoji !== 'true' ||
             config.ExperimentalEnablePostMetadata === 'true' ||
             getCurrentUserId(state) === '' ||
-            !isMinimumServerVersion(Client4.getServerVersion(), 4, 7);
+            !isMinimumServerVersion(Client4.getServerVersion(), 4, 7) ||
+            isMinimumServerVersion(Client4.getServerVersion(), 5, 12);
     }
 
     return {


### PR DESCRIPTION
#### Summary
As `ExperimentalEnablePostMetadata` is defaulted to true we need to check for server version of 5.12 

#### Ticket Link
[MM-16228](https://mattermost.atlassian.net/browse/MM-16228)
