### PR TITLE
[MM-16426] Update react-native-device-info and fix status value

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -26,7 +26,7 @@
       ],
       "services": {
         "analytics_service": {
-          "status": 0
+          "status": 2
         },
         "appinvite_service": {
           "status": 1,
@@ -57,7 +57,7 @@
       ],
       "services": {
         "analytics_service": {
-          "status": 0
+          "status": 2
         },
         "appinvite_service": {
           "status": 1,
@@ -88,7 +88,7 @@
       ],
       "services": {
         "analytics_service": {
-          "status": 0
+          "status": 2
         },
         "appinvite_service": {
           "status": 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13144,6 +13144,7 @@
         "harmony-reflect": "1.6.1",
         "isomorphic-fetch": "2.2.1",
         "mime-db": "1.40.0",
+        "moment-timezone": "0.5.25",
         "redux": "4.0.1",
         "redux-action-buffer": "1.2.0",
         "redux-batched-actions": "0.4.1",
@@ -15453,8 +15454,8 @@
       }
     },
     "react-native-device-info": {
-      "version": "github:mattermost/react-native-device-info#5be3656f4e0ca5c3544618e5df3e9a498f183483",
-      "from": "github:mattermost/react-native-device-info#5be3656f4e0ca5c3544618e5df3e9a498f183483"
+      "version": "github:mattermost/react-native-device-info#7acc6130cafe129a78b1e28d760db5c647aa82a0",
+      "from": "github:mattermost/react-native-device-info#7acc6130cafe129a78b1e28d760db5c647aa82a0"
     },
     "react-native-doc-viewer": {
       "version": "2.7.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-native-calendars": "github:mattermost/react-native-calendars#4937ec5a3bf7e86f9f35fcd85eb4aa6133f45b58",
     "react-native-circular-progress": "1.1.0",
     "react-native-cookies": "github:joeferraro/react-native-cookies#f11374745deba9f18f7b8a9bb4b0b2573026f522",
-    "react-native-device-info": "github:mattermost/react-native-device-info#5be3656f4e0ca5c3544618e5df3e9a498f183483",
+    "react-native-device-info": "github:mattermost/react-native-device-info#7acc6130cafe129a78b1e28d760db5c647aa82a0",
     "react-native-doc-viewer": "2.7.8",
     "react-native-document-picker": "2.3.0",
     "react-native-exception-handler": "2.10.7",


### PR DESCRIPTION
#### Summary
For the react-native-device-info change see this [PR](https://github.com/react-native-community/react-native-device-info/pull/693)
For the status value change, 0 is an invalid value; it should be 2.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16426

#### Device Information
This PR was tested on:
* Android emulator
