### PR TITLE
Return if message is null

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
@@ -36,13 +36,17 @@ public class NotificationReplyBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            final CharSequence message = getReplyMessage(intent);
+            if (message == null) {
+                return;
+            }
+
             mContext = context;
             bundle = NotificationIntentAdapter.extractPendingNotificationDataFromIntent(intent);
             notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
             final ReactApplicationContext reactApplicationContext = new ReactApplicationContext(context);
             final int notificationId = intent.getIntExtra(CustomPushNotification.NOTIFICATION_ID, -1);
-            final CharSequence message = getReplyMessage(intent);
             final KeychainModule keychainModule = new KeychainModule(reactApplicationContext);
 
             keychainModule.getGenericPasswordForOptions(null, new ResolvePromise() {


### PR DESCRIPTION
#### Summary
I was unable to repro the crash, however, [getReplyMessage can return null](https://github.com/mattermost/mattermost-mobile/blob/a3bfaba64916e5081777055d77819bea909e66a8/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java#L157) so this change returns early if it is.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16422

#### Device Information
This PR was tested on:
* Emulator running Android 8.1
