### PR TITLE
MM-16392 Split view support & hide sidebar on tablets

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,7 +44,8 @@
                android:exported="false" />
         <activity
                 android:name="com.reactnativenavigation.controllers.NavigationActivity"
-                android:configChanges="keyboard|keyboardHidden|orientation|screenSize"/>
+                android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+                android:resizeableActivity="true"/>
         <activity
                 android:name="com.mattermost.share.ShareActivity"
                 android:configChanges="keyboard|keyboardHidden|orientation|screenSize"

--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.WritableMap;
 
 public class MattermostManagedModule extends ReactContextBaseJavaModule {
     private static MattermostManagedModule instance;
@@ -71,6 +72,19 @@ public class MattermostManagedModule extends ReactContextBaseJavaModule {
         getReactApplicationContext().startActivity(new Intent(android.provider.Settings.ACTION_SECURITY_SETTINGS));
         getCurrentActivity().finish();
         System.exit(0);
+    }
+
+    @ReactMethod
+    public void isRunningInSplitView(final Promise promise) {
+        WritableMap result = Arguments.createMap();
+        Activity current = getCurrentActivity();
+        if (current != null) {
+            result.putBoolean("isSplitView", current.isInMultiWindowMode());
+        } else {
+            result.putBoolean("isSplitView", false);
+        }
+
+        promise.resolve(result);
     }
 
     @ReactMethod

--- a/app/app.js
+++ b/app/app.js
@@ -198,10 +198,11 @@ export default class App {
         const username = `${deviceToken}, ${currentUserId}`;
         const password = `${token},${url}`;
 
+        this.token = token;
+        this.url = url;
+
         if (this.waitForRehydration) {
             this.waitForRehydration = false;
-            this.token = token;
-            this.url = url;
         }
 
         // Only save to keychain if the url and token are set

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -5,6 +5,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     BackHandler,
+    Dimensions,
     Keyboard,
     StyleSheet,
     View,
@@ -17,6 +18,7 @@ import EventEmitter from 'mattermost-redux/utils/event_emitter';
 import SafeAreaView from 'app/components/safe_area_view';
 import DrawerLayout, {TABLET_WIDTH} from 'app/components/sidebars/drawer_layout';
 import {DeviceTypes} from 'app/constants';
+import mattermostManaged from 'app/mattermost_managed';
 import tracker from 'app/utils/time_tracker';
 import {t} from 'app/utils/i18n';
 
@@ -69,15 +71,19 @@ export default class ChannelSidebar extends Component {
             openDrawerOffset,
             drawerOpened: false,
             searching: false,
+            isSplitView: false,
         };
     }
 
     componentDidMount() {
+        this.mounted = true;
         this.props.actions.getTeams();
+        this.handleDimensions();
         EventEmitter.on('close_channel_drawer', this.closeChannelDrawer);
         EventEmitter.on('renderDrawer', this.handleShowDrawerContent);
         EventEmitter.on(WebsocketEvents.CHANNEL_UPDATED, this.handleUpdateTitle);
         BackHandler.addEventListener('hardwareBackPress', this.handleAndroidBack);
+        Dimensions.addEventListener('change', this.handleDimensions);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -97,7 +103,7 @@ export default class ChannelSidebar extends Component {
 
     shouldComponentUpdate(nextProps, nextState) {
         const {currentTeamId, deviceWidth, isLandscape, teamsCount} = this.props;
-        const {openDrawerOffset, show, searching} = this.state;
+        const {openDrawerOffset, isSplitView, show, searching} = this.state;
 
         if (nextState.openDrawerOffset !== openDrawerOffset || nextState.show !== show || nextState.searching !== searching) {
             return true;
@@ -105,14 +111,17 @@ export default class ChannelSidebar extends Component {
 
         return nextProps.currentTeamId !== currentTeamId ||
             nextProps.isLandscape !== isLandscape || nextProps.deviceWidth !== deviceWidth ||
-            nextProps.teamsCount !== teamsCount;
+            nextProps.teamsCount !== teamsCount ||
+            nextState.isSplitView !== isSplitView;
     }
 
     componentWillUnmount() {
+        this.mounted = false;
         EventEmitter.off('close_channel_drawer', this.closeChannelDrawer);
         EventEmitter.off(WebsocketEvents.CHANNEL_UPDATED, this.handleUpdateTitle);
         EventEmitter.off('renderDrawer', this.handleShowDrawerContent);
         BackHandler.removeEventListener('hardwareBackPress', this.handleAndroidBack);
+        Dimensions.addEventListener('change', this.handleDimensions);
     }
 
     handleAndroidBack = () => {
@@ -122,6 +131,15 @@ export default class ChannelSidebar extends Component {
         }
 
         return false;
+    };
+
+    handleDimensions = () => {
+        if (DeviceTypes.IS_TABLET && this.mounted) {
+            mattermostManaged.isRunningInSplitView().then((result) => {
+                const isSplitView = Boolean(result.isSplitView);
+                this.setState({isSplitView});
+            });
+        }
     };
 
     handleShowDrawerContent = () => {
@@ -380,6 +398,7 @@ export default class ChannelSidebar extends Component {
     render() {
         const {children, deviceWidth} = this.props;
         const {openDrawerOffset} = this.state;
+        const isTablet = DeviceTypes.IS_TABLET && !this.state.isSplitView;
         const drawerWidth = DeviceTypes.IS_TABLET ? TABLET_WIDTH : (deviceWidth - openDrawerOffset);
 
         return (
@@ -390,7 +409,7 @@ export default class ChannelSidebar extends Component {
                 onDrawerOpen={this.handleDrawerOpen}
                 drawerWidth={drawerWidth}
                 useNativeAnimations={true}
-                isTablet={DeviceTypes.IS_TABLET}
+                isTablet={isTablet}
             >
                 {children}
             </DrawerLayout>

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -405,7 +405,7 @@ const launchSelectServer = () => {
     });
 };
 
-const launchChannel = () => {
+const launchChannel = (skipMetrics = false) => {
     Navigation.startSingleScreenApp({
         screen: {
             screen: 'Channel',
@@ -414,6 +414,9 @@ const launchChannel = () => {
                 statusBarHidden: false,
                 statusBarHideWithNavBar: false,
                 screenBackgroundColor: 'transparent',
+            },
+            passProps: {
+                skipMetrics,
             },
         },
         appStyle: {
@@ -513,14 +516,19 @@ const fromPushNotification = Platform.OS === 'android' && Initialization.replyFr
 if (startedSharedExtension || fromPushNotification) {
     // Hold on launching Entry screen
     app.setAppStarted(true);
-
-    // Listen for when the user opens the app
-    new NativeEventsReceiver().appLaunched(() => {
-        app.setAppStarted(false);
-        launchEntry();
-    });
 }
 
 if (!app.appStarted) {
     launchEntry();
 }
+
+new NativeEventsReceiver().appLaunched(() => {
+    if (startedSharedExtension || fromPushNotification) {
+        app.setAppStarted(false);
+        launchEntry();
+    } else if (app.token && app.url) {
+        launchChannel(true);
+    } else {
+        launchSelectServer();
+    }
+});

--- a/app/mattermost_managed/mattermost-managed.android.js
+++ b/app/mattermost_managed/mattermost-managed.android.js
@@ -36,6 +36,7 @@ export default {
     },
     authenticate: LocalAuth.auth,
     blurAppScreen: MattermostManaged.blurAppScreen,
+    isRunningInSplitView: MattermostManaged.isRunningInSplitView,
     getConfig: async () => {
         try {
             cachedConfig = await MattermostManaged.getConfig();

--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -52,6 +52,7 @@ export default {
         return cachedConfig;
     },
     hasSafeAreaInsets: MattermostManaged.hasSafeAreaInsets,
+    isRunningInSplitView: MattermostManaged.isRunningInSplitView,
     isDeviceSecure: async () => {
         try {
             return await LocalAuth.isDeviceSecure();

--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -48,6 +48,7 @@ export default class ChannelBase extends PureComponent {
         theme: PropTypes.object.isRequired,
         showTermsOfService: PropTypes.bool,
         disableTermsModal: PropTypes.bool,
+        skipMetrics: PropTypes.bool,
     };
 
     static contextTypes = {
@@ -88,7 +89,7 @@ export default class ChannelBase extends PureComponent {
     }
 
     componentDidMount() {
-        if (tracker.initialLoad) {
+        if (tracker.initialLoad && !this.props.skipMetrics) {
             this.props.actions.recordLoadTime('Start time', 'initialLoad');
         }
 
@@ -98,7 +99,9 @@ export default class ChannelBase extends PureComponent {
 
         EventEmitter.emit('renderDrawer');
 
-        telemetry.end(['start:channel_screen']);
+        if (!this.props.skipMetrics) {
+            telemetry.end(['start:channel_screen']);
+        }
     }
 
     componentWillReceiveProps(nextProps) {

--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.js
@@ -3,9 +3,10 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Platform, View} from 'react-native';
+import {Dimensions, Platform, View} from 'react-native';
 
 import {DeviceTypes, ViewTypes} from 'app/constants';
+import mattermostManaged from 'app/mattermost_managed';
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import ChannelDrawerButton from './channel_drawer_button';
@@ -29,6 +30,30 @@ export default class ChannelNavBar extends PureComponent {
         openSettingsDrawer: PropTypes.func.isRequired,
         onPress: PropTypes.func.isRequired,
         theme: PropTypes.object.isRequired,
+    };
+
+    state = {
+        isSplitView: false,
+    };
+
+    componentDidMount() {
+        this.mounted = true;
+        this.handleDimensions();
+        Dimensions.addEventListener('change', this.handleDimensions);
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
+        Dimensions.removeEventListener('change', this.handleDimensions);
+    }
+
+    handleDimensions = () => {
+        if (DeviceTypes.IS_TABLET && this.mounted) {
+            mattermostManaged.isRunningInSplitView().then((result) => {
+                const isSplitView = Boolean(result.isSplitView);
+                this.setState({isSplitView});
+            });
+        }
     };
 
     render() {
@@ -60,7 +85,7 @@ export default class ChannelNavBar extends PureComponent {
         }
 
         let drawerButtonVisible = false;
-        if (!DeviceTypes.IS_TABLET) {
+        if (!DeviceTypes.IS_TABLET || this.state.isSplitView) {
             drawerButtonVisible = true;
         }
 

--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		7F581D35221ED5C60099E66B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F581D34221ED5C60099E66B /* NotificationService.swift */; };
 		7F581D39221ED5C60099E66B /* NotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 7F581D32221ED5C60099E66B /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7F581F78221EEA7C0099E66B /* libUploadAttachments.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FABE04522137F2A00D0F595 /* libUploadAttachments.a */; };
+		7F5BA34722B99B7B005B05D3 /* Mattermost+RCTUITextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F5BA34622B99B7B005B05D3 /* Mattermost+RCTUITextView.m */; };
 		7F5CA9A0208FE3B9004F91CE /* libRNDocumentPicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F5CA991208FE38F004F91CE /* libRNDocumentPicker.a */; };
 		7F642DF02093533300F3165E /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F642DED2093530B00F3165E /* libRNDeviceInfo.a */; };
 		7F72F2EE2211220500F98FFF /* GenericPreview.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7F72F2ED2211220500F98FFF /* GenericPreview.xib */; };
@@ -819,6 +820,8 @@
 		7F581D34221ED5C60099E66B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		7F581D36221ED5C60099E66B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7F581F77221EEA5A0099E66B /* NotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationService.entitlements; sourceTree = "<group>"; };
+		7F5BA34522B99B7B005B05D3 /* Mattermost+RCTUITextView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Mattermost+RCTUITextView.h"; path = "Mattermost/Mattermost+RCTUITextView.h"; sourceTree = "<group>"; };
+		7F5BA34622B99B7B005B05D3 /* Mattermost+RCTUITextView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "Mattermost+RCTUITextView.m"; path = "Mattermost/Mattermost+RCTUITextView.m"; sourceTree = "<group>"; };
 		7F5CA956208FE38F004F91CE /* RNDocumentPicker.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNDocumentPicker.xcodeproj; path = "../node_modules/react-native-document-picker/ios/RNDocumentPicker.xcodeproj"; sourceTree = "<group>"; };
 		7F63D27B1E6C957C001FAE12 /* RCTPushNotification.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTPushNotification.xcodeproj; path = "../node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj"; sourceTree = "<group>"; };
 		7F63D2C21E6DD98A001FAE12 /* Mattermost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Mattermost.entitlements; path = Mattermost/Mattermost.entitlements; sourceTree = "<group>"; };
@@ -1112,6 +1115,8 @@
 				7FEB109C1F61019C0039A015 /* UIImage+ImageEffects.m */,
 				7F151D40221B069200FAD8F3 /* 0155-keys.png */,
 				7F292AA51E8ABB1100A450A3 /* splash.png */,
+				7F5BA34522B99B7B005B05D3 /* Mattermost+RCTUITextView.h */,
+				7F5BA34622B99B7B005B05D3 /* Mattermost+RCTUITextView.m */,
 			);
 			name = Mattermost;
 			sourceTree = "<group>";
@@ -2618,6 +2623,7 @@
 				7FEB10981F6101710039A015 /* BlurAppScreen.m in Sources */,
 				7FEB109D1F61019C0039A015 /* MattermostManaged.m in Sources */,
 				7F240ACD220D460300637665 /* MattermostBucketModule.m in Sources */,
+				7F5BA34722B99B7B005B05D3 /* Mattermost+RCTUITextView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Mattermost/Mattermost+RCTUITextView.h
+++ b/ios/Mattermost/Mattermost+RCTUITextView.h
@@ -1,0 +1,17 @@
+//
+//  Mattermost+RCTUITextView.h
+//  Mattermost
+//
+//  Created by Elias Nahum on 6/18/19.
+//  Copyright © 2019 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Mattermost_RCTUITextView : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Mattermost/Mattermost+RCTUITextView.m
+++ b/ios/Mattermost/Mattermost+RCTUITextView.m
@@ -1,0 +1,36 @@
+//
+//  Mattermost+RCTUITextView.m
+//  Mattermost
+//
+//  Created by Elias Nahum on 6/18/19.
+//  Copyright © 2019 Facebook. All rights reserved.
+//
+
+#import "Mattermost+RCTUITextView.h"
+#import "RCTUITextView.h"
+
+@implementation Mattermost_RCTUITextView
+
+@end
+
+@implementation RCTUITextView (DisableCopyPaste)
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+  NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"com.apple.configuration.managed"];
+  if(response) {
+    NSString *copyPasteProtection = response[@"copyAndPasteProtection"];
+    BOOL prevent = action == @selector(paste:) ||
+    action == @selector(copy:) ||
+    action == @selector(cut:) ||
+    action == @selector(_share:);
+    
+    if ([copyPasteProtection isEqual: @"true"] && prevent) {
+      return NO;
+    }
+  }
+  
+  return [super canPerformAction:action withSender:sender];
+}
+
+@end

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -6,7 +6,6 @@
 // See License.txt for license information.
 //
 
-#import "RCTUITextView.h"
 #import "MattermostManaged.h"
 #import <UploadAttachments/MMMConstants.h>
 
@@ -152,31 +151,19 @@ RCT_EXPORT_METHOD(getConfig:(RCTPromiseResolveBlock)resolve
   }
 }
 
+RCT_EXPORT_METHOD(isRunningInSplitView:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  BOOL isRunningInFullScreen = CGRectEqualToRect(
+                                                 [UIApplication sharedApplication].delegate.window.frame,
+                                                 [UIApplication sharedApplication].delegate.window.screen.bounds);
+  resolve(@{
+            @"isSplitView": @(!isRunningInFullScreen)
+            });
+}
+
 RCT_EXPORT_METHOD(quitApp)
 {
   exit(0);
-}
-
-@end
-
-@implementation RCTUITextView (DisableCopyPaste)
-
-- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
-{
-  NSDictionary *response = [[NSUserDefaults standardUserDefaults] dictionaryForKey:configurationKey];
-  if(response) {
-    NSString *copyPasteProtection = response[@"copyAndPasteProtection"];
-    BOOL prevent = action == @selector(paste:) ||
-    action == @selector(copy:) ||
-    action == @selector(cut:) ||
-    action == @selector(_share:);
-
-    if ([copyPasteProtection isEqual: @"true"] && prevent) {
-      return NO;
-    }
-  }
-
-  return [super canPerformAction:action withSender:sender];
 }
 
 @end


### PR DESCRIPTION
#### Summary
Now when the app is opened on a tablet with split screen the drawer will not be present at all times but it will behave like it does on phones allowing more real state to display the messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16392

#### Device Information
This PR was tested on: iPad Pro 11" and Android Tablet running Pie
