### PR TITLE
[MM-16456] Ensure Flatlist is mounted prior to calling scrollToOffset

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -281,7 +281,9 @@ export default class PostList extends PureComponent {
 
     scrollToBottom = () => {
         setTimeout(() => {
-            this.flatListRef.current?.scrollToOffset({offset: 0, animated: true});
+            if (this.flatListRef && this.flatListRef.current) {
+                this.flatListRef.current.scrollToOffset({offset: 0, animated: true});
+            }
         }, 250);
     };
 

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -281,7 +281,7 @@ export default class PostList extends PureComponent {
 
     scrollToBottom = () => {
         setTimeout(() => {
-            this.flatListRef.current.scrollToOffset({offset: 0, animated: true});
+            this.flatListRef.current?.scrollToOffset({offset: 0, animated: true});
         }, 250);
     };
 


### PR DESCRIPTION
#### Summary
[When the ref attribute is used on a custom class component, the ref object receives the mounted instance of the component as its current.](https://reactjs.org/docs/refs-and-the-dom.html#accessing-refs) In this case, `Flatlist` might be unmounted once the setTimeout timer expires.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16456
