### PR TITLE
MM-16467 Fix iOS layout when playing a youtube video in landscape

### DIFF
--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -10,9 +10,12 @@ import {
     Platform,
     StyleSheet,
     TouchableOpacity,
+    StatusBar,
 } from 'react-native';
 import {YouTubeStandaloneAndroid, YouTubeStandaloneIOS} from 'react-native-youtube';
 import {intlShape} from 'react-intl';
+
+import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {TABLET_WIDTH} from 'app/components/sidebars/drawer_layout';
 import PostAttachmentImage from 'app/components/post_attachment_image';
@@ -442,6 +445,7 @@ export default class PostBodyAdditionalContent extends PureComponent {
         if (Platform.OS === 'ios') {
             YouTubeStandaloneIOS.
                 playVideo(videoId, startTime).
+                then(this.playYouTubeVideoEnded).
                 catch(this.playYouTubeVideoError);
         } else {
             const {googleDeveloperKey} = this.props;
@@ -456,6 +460,13 @@ export default class PostBodyAdditionalContent extends PureComponent {
             } else {
                 Linking.openURL(link);
             }
+        }
+    };
+
+    playYouTubeVideoEnded = () => {
+        if (Platform.OS === 'ios') {
+            StatusBar.setHidden(false);
+            EventEmitter.emit('update_safe_area_view');
         }
     };
 

--- a/app/components/safe_area_view/safe_area_view.ios.js
+++ b/app/components/safe_area_view/safe_area_view.ios.js
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import {Dimensions, Keyboard, NativeModules, View} from 'react-native';
 import SafeArea from 'react-native-safe-area';
 
+import EventEmitter from 'mattermost-redux/utils/event_emitter';
+
 import {DeviceTypes} from 'app/constants';
 import mattermostManaged from 'app/mattermost_managed';
 
@@ -57,6 +59,7 @@ export default class SafeAreaIos extends PureComponent {
 
     componentDidMount() {
         Dimensions.addEventListener('change', this.getSafeAreaInsets);
+        EventEmitter.on('update_safe_area_view', this.getSafeAreaInsets);
         this.keyboardDidShowListener = Keyboard.addListener('keyboardWillShow', this.keyboardWillShow);
         this.keyboardDidHideListener = Keyboard.addListener('keyboardWillHide', this.keyboardWillHide);
         this.getStatusBarHeight();
@@ -65,6 +68,7 @@ export default class SafeAreaIos extends PureComponent {
     componentWillUnmount() {
         this.mounted = false;
         Dimensions.removeEventListener('change', this.getSafeAreaInsets);
+        EventEmitter.off('update_safe_area_view', this.getSafeAreaInsets);
         this.keyboardDidShowListener.remove();
         this.keyboardDidHideListener.remove();
         this.mounted = false;


### PR DESCRIPTION
#### Summary
on iOS devices that have a SafeAreaView (aka X series) when opening the a youtube video and rotating the device to landscape and then back to portrait was not setting the right safe area view as the status bar gets hidden by the YouTube player.

To fix it once the YouTube Video finish playback and the player is removed, we are now setting the StatusBar as visible and then emit an event to re-calculate the safe area view.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16467
