### PR TITLE
[MM-16532] Update jsc to intl version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -211,7 +211,7 @@ configurations.all {
 
 dependencies {
     // Make sure to put android-jsc at the top
-    implementation "org.webkit:android-jsc:r241213"
+    implementation "org.webkit:android-jsc-intl:r241213"
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"


### PR DESCRIPTION
#### Summary
`localCompare` was returning different values for Android and iOS. Updating to jsc-intl fixes this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16532

#### Device Information
This PR was tested on:
* Galaxy S7, Android 7.0
* iPhone 8, iOS 12.3
