### PR TITLE
Don't show preview if remove_link_preview is set to true

### DIFF
--- a/app/components/post_body_additional_content/index.js
+++ b/app/components/post_body_additional_content/index.js
@@ -51,7 +51,7 @@ function makeMapStateToProps() {
         // We are checking both here until we bump the server requirement for the mobile apps.
         const previewsEnabled = (getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, `${ViewTypes.FEATURE_TOGGLE_PREFIX}${ViewTypes.EMBED_PREVIEW}`) ||
             getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, true));
-        
+
         const removeLinkPreview = ownProps.postProps.remove_link_preview === 'true';
 
         let openGraphData = getOpenGraphMetadataForUrl(state, link);

--- a/app/components/post_body_additional_content/index.js
+++ b/app/components/post_body_additional_content/index.js
@@ -49,8 +49,10 @@ function makeMapStateToProps() {
 
         // Link previews used to be an advanced settings until server version 4.4 when it was changed to be a display setting.
         // We are checking both here until we bump the server requirement for the mobile apps.
-        const previewsEnabled = getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, `${ViewTypes.FEATURE_TOGGLE_PREFIX}${ViewTypes.EMBED_PREVIEW}`) ||
-            getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, true);
+        const previewsEnabled = (getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, `${ViewTypes.FEATURE_TOGGLE_PREFIX}${ViewTypes.EMBED_PREVIEW}`) ||
+            getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, true));
+        
+        const removeLinkPreview = ownProps.postProps.remove_link_preview === 'true';
 
         let openGraphData = getOpenGraphMetadataForUrl(state, link);
         if (!openGraphData) {
@@ -63,7 +65,7 @@ function makeMapStateToProps() {
             googleDeveloperKey: config.GoogleDeveloperKey,
             link,
             openGraphData,
-            showLinkPreviews: previewsEnabled && config.EnableLinkPreviews === 'true',
+            showLinkPreviews: previewsEnabled && config.EnableLinkPreviews === 'true' && !removeLinkPreview,
             theme: getTheme(state),
         };
     };


### PR DESCRIPTION
#### Summary
Checks if `remove_link_preview` is set to `true`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16468

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
Not possible.