### PR TITLE
Fix AD/LDAP & SAML profile sync properties

### DIFF
--- a/app/screens/edit_profile/index.js
+++ b/app/screens/edit_profile/index.js
@@ -15,7 +15,7 @@ import EditProfile from './edit_profile';
 function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const {serverVersion} = state.entities.general;
-    const {service} = ownProps.currentUser;
+    const {auth_service: service} = ownProps.currentUser;
 
     const firstNameDisabled = (service === 'ldap' && config.LdapFirstNameAttributeSet === 'true') ||
         (service === 'saml' && config.SamlFirstNameAttributeSet === 'true');


### PR DESCRIPTION
#### Summary
The actual user property is `auth_service` instead of `service`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16239

HH: I think one review is enough