### PR TITLE
Place the new message indicator at the top of the screen

### DIFF
--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -89,6 +89,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
 
         const bestImage = getNearestPoint(bestDimensions, data.images, 'width', 'height');
         const imageUrl = bestImage.secure_url || bestImage.url;
+
         let ogImage;
         if (imagesMetadata && imagesMetadata[imageUrl]) {
             ogImage = imagesMetadata[imageUrl];
@@ -96,6 +97,12 @@ export default class PostAttachmentOpenGraph extends PureComponent {
 
         if (!ogImage) {
             ogImage = data.images.find((i) => i.url === imageUrl || i.secure_url === imageUrl);
+        }
+
+        // Fallback when the ogImage does not have dimensions but there is a metaImage defined
+        const metaImages = imagesMetadata ? Object.values(imagesMetadata) : null;
+        if ((!ogImage?.width || !ogImage?.height) && metaImages?.length) {
+            ogImage = metaImages[0];
         }
 
         let dimensions = bestDimensions;
@@ -139,9 +146,16 @@ export default class PostAttachmentOpenGraph extends PureComponent {
             ogImage = openGraphData.images.find((i) => i.url === openGraphImageUrl || i.secure_url === openGraphImageUrl);
         }
 
+        // Fallback when the ogImage does not have dimensions but there is a metaImage defined
+        const metaImages = imagesMetadata ? Object.values(imagesMetadata) : null;
+        if ((!ogImage?.width || !ogImage?.height) && metaImages?.length) {
+            ogImage = metaImages[0];
+        }
+
         if (ogImage?.width && ogImage?.height) {
             this.setImageSize(imageUrl, ogImage.width, ogImage.height);
         } else {
+            // if we get to this point there can be a scroll pop
             Image.getSize(imageUrl, (width, height) => {
                 this.setImageSize(imageUrl, width, height);
             }, () => null);

--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -182,11 +182,12 @@ export default class PostBodyAdditionalContent extends PureComponent {
     };
 
     generateStaticEmbed = (isYouTube, isImage) => {
-        if (isYouTube || isImage) {
+        const {isReplyPost, link, metadata, navigator, openGraphData, showLinkPreviews, theme} = this.props;
+
+        if (isYouTube || (isImage && !openGraphData)) {
             return null;
         }
 
-        const {isReplyPost, link, metadata, navigator, openGraphData, showLinkPreviews, theme} = this.props;
         const attachments = this.getMessageAttachment();
         if (attachments) {
             return attachments;

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -294,11 +294,13 @@ export default class PostList extends PureComponent {
             this.props.initialIndex > 0 &&
             !this.hasDoneInitialScroll
         ) {
-            this.flatListRef.current.scrollToIndex({
-                animated: false,
-                index: this.props.initialIndex,
-                viewOffset: 50,
-                viewPosition: 0.5,
+            requestAnimationFrame(() => {
+                this.flatListRef.current.scrollToIndex({
+                    animated: false,
+                    index: this.props.initialIndex,
+                    viewOffset: 0,
+                    viewPosition: 1, // 0 is at bottom
+                });
             });
             this.hasDoneInitialScroll = true;
         }

--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -266,7 +266,11 @@ function postVisibility(state = {}, action) {
     }
     case ViewTypes.INCREASE_POST_VISIBILITY: {
         const nextState = {...state};
-        nextState[action.data] += action.amount;
+        if (nextState[action.data]) {
+            nextState[action.data] += action.amount;
+        } else {
+            nextState[action.data] = action.amount;
+        }
         return nextState;
     }
     case ViewTypes.RECEIVED_FOCUSED_POST: {

--- a/app/reducers/views/channel.test.js
+++ b/app/reducers/views/channel.test.js
@@ -1,0 +1,112 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import channelReducer from './channel';
+import {ViewTypes} from 'app/constants';
+
+describe('Reducers.channel', () => {
+    const initialState = {
+        displayName: '',
+        drafts: {},
+        loading: false,
+        refreshing: false,
+        postCountInChannel: {},
+        postVisibility: {},
+        loadingPosts: {},
+        lastGetPosts: {},
+        retryFailed: false,
+        loadMorePostsVisible: true,
+        lastChannelViewTime: {},
+        keepChannelIdAsUnread: null,
+    };
+
+    test('Initial state', () => {
+        const nextState = channelReducer(
+            {
+                displayName: '',
+                drafts: {},
+                loading: false,
+                refreshing: false,
+                postCountInChannel: {},
+                postVisibility: {},
+                loadingPosts: {},
+                lastGetPosts: {},
+                retryFailed: false,
+                loadMorePostsVisible: true,
+                lastChannelViewTime: {},
+                keepChannelIdAsUnread: null,
+            },
+            {}
+        );
+
+        expect(nextState).toEqual(initialState);
+    });
+
+    test('should set the postVisibility amount for a channel', () => {
+        const channelId = 'channel_id';
+        const amount = 15;
+        const nextState = channelReducer(
+            {
+                displayName: '',
+                drafts: {},
+                loading: false,
+                refreshing: false,
+                postCountInChannel: {},
+                postVisibility: {},
+                loadingPosts: {},
+                lastGetPosts: {},
+                retryFailed: false,
+                loadMorePostsVisible: true,
+                lastChannelViewTime: {},
+                keepChannelIdAsUnread: null,
+            },
+            {
+                type: ViewTypes.INCREASE_POST_VISIBILITY,
+                data: channelId,
+                amount,
+            }
+        );
+
+        expect(nextState).toEqual({
+            ...initialState,
+            postVisibility: {
+                [channelId]: amount,
+            },
+        });
+    });
+
+    test('should increase the postVisibility amount for a channel', () => {
+        const channelId = 'channel_id';
+        const amount = 15;
+        const nextState = channelReducer(
+            {
+                displayName: '',
+                drafts: {},
+                loading: false,
+                refreshing: false,
+                postCountInChannel: {},
+                postVisibility: {
+                    [channelId]: amount,
+                },
+                loadingPosts: {},
+                lastGetPosts: {},
+                retryFailed: false,
+                loadMorePostsVisible: true,
+                lastChannelViewTime: {},
+                keepChannelIdAsUnread: null,
+            },
+            {
+                type: ViewTypes.INCREASE_POST_VISIBILITY,
+                data: channelId,
+                amount,
+            }
+        );
+
+        expect(nextState).toEqual({
+            ...initialState,
+            postVisibility: {
+                [channelId]: 2 * amount,
+            },
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
This PR fixes the issue where new messages appeared below the keyboard when the new message indicator is present. We now place the new message indicator as far up in the list as possible but always visible.

Other fixes in this PR:
* Scroll pop in certain cases with open graph metadata where the image url does not match the images in the metadata
* Post visibility was set to 0 at times causing a refresh of the post list.