### PR TITLE
[MM-15084] Pass cookie for post actions

### DIFF
--- a/app/components/message_attachments/action_button/action_button.js
+++ b/app/components/message_attachments/action_button/action_button.js
@@ -12,17 +12,18 @@ import ActionButtonText from './action_button_text';
 export default class ActionButton extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            doPostAction: PropTypes.func.isRequired,
+            doPostActionWithCookie: PropTypes.func.isRequired,
         }).isRequired,
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
         postId: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
+        cookie: PropTypes.string.isRequired,
     };
 
     handleActionPress = preventDoubleTap(() => {
-        const {actions, id, postId} = this.props;
-        actions.doPostAction(postId, id);
+        const {actions, id, postId, cookie} = this.props;
+        actions.doPostActionWithCookie(postId, id, cookie);
     }, 4000);
 
     render() {

--- a/app/components/message_attachments/action_button/index.js
+++ b/app/components/message_attachments/action_button/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {doPostAction} from 'mattermost-redux/actions/posts';
+import {doPostActionWithCookie} from 'mattermost-redux/actions/posts';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import ActionButton from './action_button';
@@ -18,7 +18,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            doPostAction,
+            doPostActionWithCookie,
         }, dispatch),
     };
 }

--- a/app/components/message_attachments/attachment_actions.js
+++ b/app/components/message_attachments/attachment_actions.js
@@ -53,6 +53,7 @@ export default class AttachmentActions extends PureComponent {
                     <ActionButton
                         key={action.id}
                         id={action.id}
+                        cookie={action.cookie}
                         name={action.name}
                         postId={postId}
                     />


### PR DESCRIPTION
#### Summary

This PR fixes an issue where post actions would fail because the cookie associated with the action is not being used. `doPostActionWithCookie` is now used instead of `doPostAction`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-15084

#### Checklist

- [ ] Added or updated unit tests (required for all new features)

#### Device Information

This PR was tested on: [Google Pixel 2, Android 8.1.0] 
