### PR TITLE
Fix regression opening a channel from a push notification

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -378,7 +378,7 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
             dispatch(loadPostsIfNecessaryWithRetry(channelId));
         }
 
-        dispatch(batchActions([
+        const actions = [
             selectChannel(channelId),
             setChannelDisplayName(channel.display_name),
             {
@@ -391,18 +391,29 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
                 teamId: currentTeamId,
                 channelId,
             },
-            {
-                type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
-                data: channelId,
-                channel,
-                member,
-            },
-        ]));
+        ];
 
         let markPreviousChannelId;
         if (!fromPushNotification && !sameChannel) {
             markPreviousChannelId = currentChannelId;
+            actions.push({
+                type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
+                data: currentChannelId,
+                channel: getChannel(state, currentChannelId),
+                member: getMyChannelMember(state, currentChannelId),
+            });
         }
+
+        if (!fromPushNotification) {
+            actions.push({
+                type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
+                data: channelId,
+                channel,
+                member,
+            });
+        }
+
+        dispatch(batchActions(actions));
 
         dispatch(markChannelViewedAndRead(channelId, markPreviousChannelId));
     };

--- a/app/push_notifications/push_notifications.android.js
+++ b/app/push_notifications/push_notifications.android.js
@@ -4,6 +4,8 @@
 import {AppState, NativeModules} from 'react-native';
 import {NotificationsAndroid, PendingNotifications} from 'react-native-notifications';
 
+import ephemeralStore from 'app/store/ephemeral_store';
+
 const {NotificationPreferences} = NativeModules;
 
 class PushNotification {
@@ -65,6 +67,7 @@ class PushNotification {
                     if (notification) {
                         const data = notification.getData();
                         if (data) {
+                            ephemeralStore.appStartedFromPushNotification = true;
                             this.handleNotification(data, true);
                         }
                     }

--- a/app/utils/push_notifications.js
+++ b/app/utils/push_notifications.js
@@ -55,11 +55,6 @@ class PushNotificationUtils {
         let unsubscribeFromStore = null;
         let stopLoadingNotification = false;
 
-        // mark the app as started as soon as possible
-        if (!ephemeralStore.appStarted) {
-            ephemeralStore.appStartedFromPushNotification = true;
-        }
-
         const {data, foreground, message, userInfo, userInteraction} = deviceNotification;
         const notification = {
             data,


### PR DESCRIPTION
#### Summary
This PR fixes a current regression in master when opening the app from a push notification, the app is detecting the notification as being captured while the app is on the foreground and does not send the user to the right channel.

Also makes sure that when switching channels by tapping on a notification the new message indicator is properly displayed