### PR TITLE
Update device info ref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15475,8 +15475,8 @@
       }
     },
     "react-native-device-info": {
-      "version": "github:mattermost/react-native-device-info#7acc6130cafe129a78b1e28d760db5c647aa82a0",
-      "from": "github:mattermost/react-native-device-info#7acc6130cafe129a78b1e28d760db5c647aa82a0"
+      "version": "github:mattermost/react-native-device-info#66d730b4f675038867ca389be7374714c2db63b2",
+      "from": "github:mattermost/react-native-device-info#66d730b4f675038867ca389be7374714c2db63b2"
     },
     "react-native-doc-viewer": {
       "version": "2.7.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-native-calendars": "github:mattermost/react-native-calendars#4937ec5a3bf7e86f9f35fcd85eb4aa6133f45b58",
     "react-native-circular-progress": "1.1.0",
     "react-native-cookies": "github:joeferraro/react-native-cookies#f11374745deba9f18f7b8a9bb4b0b2573026f522",
-    "react-native-device-info": "github:mattermost/react-native-device-info#7acc6130cafe129a78b1e28d760db5c647aa82a0",
+    "react-native-device-info": "github:mattermost/react-native-device-info#66d730b4f675038867ca389be7374714c2db63b2",
     "react-native-doc-viewer": "2.7.8",
     "react-native-document-picker": "2.3.0",
     "react-native-exception-handler": "2.10.7",


### PR DESCRIPTION
#### Summary
This PR updates device-info so that devices with screen sizes bigger than 7.9" are considered tablets instead of the previous 6.9", this solves the issues on moto g(7) devices where the manufacturer was reporting the wrong size.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16807
