### PR TITLE
MM-16823 Fix "Freeze" after deleting cache

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -415,9 +415,9 @@ const launchChannel = (skipMetrics = false) => {
                 statusBarHideWithNavBar: false,
                 screenBackgroundColor: 'transparent',
             },
-            passProps: {
-                skipMetrics,
-            },
+        },
+        passProps: {
+            skipMetrics,
         },
         appStyle: {
             orientation: 'auto',


### PR DESCRIPTION
#### Summary
Deleting the cache was not properly restarting the app in the Channel Screen as the properties passed to the `Navigation.startSingleScreenApp` were wrong.

PR: Direct against the release branch as master is not affected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16823