### PR TITLE
[MM-16389] Enable emojis for profile icons from webhooks

### DIFF
--- a/app/components/post_profile_picture/index.js
+++ b/app/components/post_profile_picture/index.js
@@ -20,6 +20,9 @@ function mapStateToProps(state, ownProps) {
     const post = ownProps.post;
     const user = getUser(state, post.user_id);
 
+    // if it's relative we assume it's a link to an emoji
+    const isEmoji = post?.props?.override_icon_url?.startsWith('/') || false; // eslint-disable-line camelcase
+
     const overrideIconURL = Client4.getAbsoluteUrl(post?.props?.override_icon_url); // eslint-disable-line camelcase
 
     return {
@@ -30,6 +33,7 @@ function mapStateToProps(state, ownProps) {
         overrideIconUrl: overrideIconURL,
         userId: post.user_id,
         isBot: (user ? user.is_bot : false),
+        isEmoji,
         theme: getTheme(state),
     };
 }

--- a/app/components/post_profile_picture/index.js
+++ b/app/components/post_profile_picture/index.js
@@ -30,7 +30,7 @@ function mapStateToProps(state, ownProps) {
         overrideIconUrl,
         userId: post.user_id,
         isBot: (user ? user.is_bot : false),
-        isEmoji: post?.props?.override_icon_emoji?.length > 0, // eslint-disable-line camelcase
+        isEmoji: Boolean(post?.props?.override_icon_emoji), // eslint-disable-line camelcase
         theme: getTheme(state),
     };
 }

--- a/app/components/post_profile_picture/index.js
+++ b/app/components/post_profile_picture/index.js
@@ -20,20 +20,17 @@ function mapStateToProps(state, ownProps) {
     const post = ownProps.post;
     const user = getUser(state, post.user_id);
 
-    // if it's relative we assume it's a link to an emoji
-    const isEmoji = post?.props?.override_icon_url?.startsWith('/') || false; // eslint-disable-line camelcase
-
-    const overrideIconURL = Client4.getAbsoluteUrl(post?.props?.override_icon_url); // eslint-disable-line camelcase
+    const overrideIconUrl = Client4.getAbsoluteUrl(post?.props?.override_icon_url); // eslint-disable-line camelcase
 
     return {
         enablePostIconOverride: config.EnablePostIconOverride === 'true' && post?.props?.use_user_icon !== 'true', // eslint-disable-line camelcase
         fromWebHook: post?.props?.from_webhook === 'true', // eslint-disable-line camelcase
         isSystemMessage: isSystemMessage(post),
         fromAutoResponder: fromAutoResponder(post),
-        overrideIconUrl: overrideIconURL,
+        overrideIconUrl,
         userId: post.user_id,
         isBot: (user ? user.is_bot : false),
-        isEmoji,
+        isEmoji: post?.props?.override_icon_emoji?.length > 0, // eslint-disable-line camelcase
         theme: getTheme(state),
     };
 }

--- a/app/components/post_profile_picture/index.js
+++ b/app/components/post_profile_picture/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {Client4} from 'mattermost-redux/client';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -19,12 +20,14 @@ function mapStateToProps(state, ownProps) {
     const post = ownProps.post;
     const user = getUser(state, post.user_id);
 
+    const overrideIconURL = Client4.getAbsoluteUrl(post?.props?.override_icon_url); // eslint-disable-line camelcase
+
     return {
         enablePostIconOverride: config.EnablePostIconOverride === 'true' && post?.props?.use_user_icon !== 'true', // eslint-disable-line camelcase
         fromWebHook: post?.props?.from_webhook === 'true', // eslint-disable-line camelcase
         isSystemMessage: isSystemMessage(post),
         fromAutoResponder: fromAutoResponder(post),
-        overrideIconUrl: post?.props?.override_icon_url, // eslint-disable-line camelcase
+        overrideIconUrl: overrideIconURL,
         userId: post.user_id,
         isBot: (user ? user.is_bot : false),
         theme: getTheme(state),

--- a/app/components/post_profile_picture/post_profile_picture.js
+++ b/app/components/post_profile_picture/post_profile_picture.js
@@ -22,6 +22,7 @@ export default class PostProfilePicture extends PureComponent {
         theme: PropTypes.object,
         userId: PropTypes.string,
         isBot: PropTypes.bool,
+        isEmoji: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -39,6 +40,7 @@ export default class PostProfilePicture extends PureComponent {
             theme,
             userId,
             isBot,
+            isEmoji,
         } = this.props;
 
         if (isSystemMessage && !fromAutoResponder && !isBot) {
@@ -55,16 +57,26 @@ export default class PostProfilePicture extends PureComponent {
 
         if (fromWebHook && enablePostIconOverride) {
             const icon = overrideIconUrl ? {uri: overrideIconUrl} : webhookIcon;
-            const borderRadius = icon === webhookIcon ? ViewTypes.PROFILE_PICTURE_SIZE / 2 : 0;
+            const frameSize = ViewTypes.PROFILE_PICTURE_SIZE;
+            const pictureSize = (isEmoji ? ViewTypes.PROFILE_PICTURE_EMOJI_SIZE : ViewTypes.PROFILE_PICTURE_SIZE);
+            const borderRadius = ViewTypes.PROFILE_PICTURE_SIZE / 2;
 
             return (
-                <View>
+                <View
+                    style={{
+                        borderRadius,
+                        overflow: 'hidden',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        height: frameSize,
+                        width: frameSize,
+                    }}
+                >
                     <Image
                         source={icon}
                         style={{
-                            height: ViewTypes.PROFILE_PICTURE_SIZE,
-                            width: ViewTypes.PROFILE_PICTURE_SIZE,
-                            borderRadius,
+                            height: pictureSize,
+                            width: pictureSize,
                         }}
                     />
                 </View>

--- a/app/components/post_profile_picture/post_profile_picture.js
+++ b/app/components/post_profile_picture/post_profile_picture.js
@@ -55,6 +55,7 @@ export default class PostProfilePicture extends PureComponent {
 
         if (fromWebHook && enablePostIconOverride) {
             const icon = overrideIconUrl ? {uri: overrideIconUrl} : webhookIcon;
+            const borderRadius = icon === webhookIcon ? ViewTypes.PROFILE_PICTURE_SIZE / 2 : 0;
 
             return (
                 <View>
@@ -63,7 +64,7 @@ export default class PostProfilePicture extends PureComponent {
                         style={{
                             height: ViewTypes.PROFILE_PICTURE_SIZE,
                             width: ViewTypes.PROFILE_PICTURE_SIZE,
-                            borderRadius: ViewTypes.PROFILE_PICTURE_SIZE / 2,
+                            borderRadius,
                         }}
                     />
                 </View>

--- a/app/components/post_profile_picture/post_profile_picture.js
+++ b/app/components/post_profile_picture/post_profile_picture.js
@@ -58,8 +58,8 @@ export default class PostProfilePicture extends PureComponent {
         if (fromWebHook && enablePostIconOverride) {
             const icon = overrideIconUrl ? {uri: overrideIconUrl} : webhookIcon;
             const frameSize = ViewTypes.PROFILE_PICTURE_SIZE;
-            const pictureSize = (isEmoji ? ViewTypes.PROFILE_PICTURE_EMOJI_SIZE : ViewTypes.PROFILE_PICTURE_SIZE);
-            const borderRadius = ViewTypes.PROFILE_PICTURE_SIZE / 2;
+            const pictureSize = isEmoji ? ViewTypes.PROFILE_PICTURE_EMOJI_SIZE : ViewTypes.PROFILE_PICTURE_SIZE;
+            const borderRadius = isEmoji ? 0 : ViewTypes.PROFILE_PICTURE_SIZE / 2;
 
             return (
                 <View

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -114,6 +114,7 @@ export default {
     IOSX_TOP_PORTRAIT: 88,
     STATUS_BAR_HEIGHT: 20,
     PROFILE_PICTURE_SIZE: 32,
+    PROFILE_PICTURE_EMOJI_SIZE: 28,
     DATA_SOURCE_USERS: 'users',
     DATA_SOURCE_CHANNELS: 'channels',
     NotificationLevels,

--- a/app/screens/notification/notification.js
+++ b/app/screens/notification/notification.js
@@ -17,6 +17,7 @@ import FormattedText from 'app/components/formatted_text';
 import ProfilePicture from 'app/components/profile_picture';
 import {changeOpacity} from 'app/utils/theme';
 
+import {Client4} from 'mattermost-redux/client';
 import {isDirectChannel} from 'mattermost-redux/utils/channel_utils';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
@@ -73,7 +74,8 @@ export default class Notification extends PureComponent {
         );
 
         if (data.from_webhook && config.EnablePostIconOverride === 'true' && data.use_user_icon !== 'true') {
-            const wsIcon = data.override_icon_url ? {uri: data.override_icon_url} : webhookIcon;
+            const overrideIconURL = Client4.getAbsoluteUrl(data.override_icon_url); // eslint-disable-line camelcase
+            const wsIcon = data.override_icon_url ? {uri: overrideIconURL} : webhookIcon;
             icon = (
                 <Image
                     source={wsIcon}


### PR DESCRIPTION
#### Summary
An `icon_emoji` parameter was added to incoming webhook requests, that overrides the profile icon and the `icon_url` parameter.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16389

#### Checklist

- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (https://github.com/mattermost/mattermost-redux/pull/876
- [x] Has UI changes

#### Device Information
This PR was tested on:
 - Android Emulator (29)

Related PRs:
- https://github.com/mattermost/mattermost-server/pull/11586
- https://github.com/mattermost/mattermost-webapp/pull/3074
- https://github.com/mattermost/docs/pull/2832
- https://github.com/mattermost/mattermost-developer-documentation/pull/321