### PR TITLE
[MM-16294] Fix white transition screen displayed on app relaunch to Channel screen

### DIFF
--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -143,7 +143,7 @@ export default class ChannelSidebar extends Component {
     };
 
     handleShowDrawerContent = () => {
-        this.setState({show: true});
+        requestAnimationFrame(() => this.setState({show: true}));
     };
 
     closeChannelDrawer = () => {


### PR DESCRIPTION
#### Summary
The drawer contents were taking a while to render which affected the channel rendering.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16294

#### Device Information
This PR was tested on:
* Emulator, Android 9.0
* iPhone 8, iOS 12.3
