### PR TITLE
MM-16858 Fix app crash after typing

### DIFF
--- a/app/actions/views/typing.js
+++ b/app/actions/views/typing.js
@@ -5,7 +5,7 @@ import {userTyping as wsUserTyping} from 'mattermost-redux/actions/websocket';
 
 export function userTyping(channelId, rootId) {
     return async (dispatch, getState) => {
-        const {websocket} = getState().device;
+        const {websocket} = getState();
         if (websocket.connected) {
             wsUserTyping(channelId, rootId)(dispatch, getState);
         }


### PR DESCRIPTION
#### Summary
Fix by correctly accessing websocket state - introduced by the recent change https://github.com/mattermost/mattermost-mobile/commit/0ff6dba3c86e88b53fcee19d12e82cd4601ed862

Issue is on master only.

#### Ticket Link
Jira ticket - [MM-16858](https://mattermost.atlassian.net/browse/MM-16858)

#### Device Information
This PR was tested on: [Android simulator and iOS emulator] 