### PR TITLE
MM-16859 Fix app crashing when sending invalid slash command

### DIFF
--- a/app/actions/views/command.js
+++ b/app/actions/views/command.js
@@ -30,7 +30,7 @@ export function executeCommand(message, channelId, rootId) {
 
         const {data, error} = await dispatch(executeCommandService(msg, args));
 
-        if (data.trigger_id) {
+        if (data?.trigger_id) { //eslint-disable-line camelcase
             dispatch({type: IntegrationTypes.RECEIVED_DIALOG_TRIGGER_ID, data: data.trigger_id});
         }
 


### PR DESCRIPTION
#### Summary
Fix app crashing when sending invalid slash command

Note: I think this happened in past few releases already (and not a recent regression) but would be nice for 1.21.

#### Ticket Link
Jira ticket: [MM-16859](https://mattermost.atlassian.net/browse/MM-16859)

#### Device Information
This PR was tested on: [iOS simulator and Android emulator] 

