### PR TITLE
Fix android crash on Android O & P after upgrading target to 28

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <!-- Trust preinstalled CAs -->
             <certificates src="system" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -15557,8 +15557,8 @@
       }
     },
     "react-native-notifications": {
-      "version": "github:mattermost/react-native-notifications#f6d32b55ecda9f6a6765437c21b075e13ac64141",
-      "from": "github:mattermost/react-native-notifications#f6d32b55ecda9f6a6765437c21b075e13ac64141",
+      "version": "github:mattermost/react-native-notifications#1b7ec8513606b42237ab4674de9dacb4d1935e38",
+      "from": "github:mattermost/react-native-notifications#1b7ec8513606b42237ab4674de9dacb4d1935e38",
       "requires": {
         "core-js": "^1.0.0",
         "uuid": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-linear-gradient": "2.5.4",
     "react-native-local-auth": "github:mattermost/react-native-local-auth#cc9ce2f468fbf7b431dfad3191a31aaa9227a6ab",
     "react-native-navigation": "github:migbot/react-native-navigation#03c623c373f818827a463ca0fe90f86f56e71b2f",
-    "react-native-notifications": "github:mattermost/react-native-notifications#f6d32b55ecda9f6a6765437c21b075e13ac64141",
+    "react-native-notifications": "github:mattermost/react-native-notifications#1b7ec8513606b42237ab4674de9dacb4d1935e38",
     "react-native-passcode-status": "1.1.1",
     "react-native-permissions": "1.1.1",
     "react-native-safe-area": "0.5.1",


### PR DESCRIPTION
#### Summary
After updating the `targetSdkVersion` to 28 as required by Google Play the react-native-notifications package was causing a security exception as `uses-permission android:name="android.permission.FOREGROUND_SERVICE" />` is now required, also the `startForeground` service that receives a notification now needs to set a notification channel, both of this issues were addressed in the library fork here https://github.com/mattermost/react-native-notifications/commit/1b7ec8513606b42237ab4674de9dacb4d1935e38

Also included the `cleartextTrafficPermitted` in the `network_security_config` to allow http requests instead of only allowing https.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16855
