### PR TITLE
[MM-17016] Ensure Flatlist is mounted prior to calling scrollToIndex

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -292,8 +292,7 @@ export default class PostList extends PureComponent {
             height > 0 &&
             this.props.initialIndex > 0 &&
             !this.hasDoneInitialScroll &&
-            this.flatListRef &&
-            this.flatListRef.current
+            this.flatListRef?.current
         ) {
             requestAnimationFrame(() => {
                 this.flatListRef.current.scrollToIndex({

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -291,7 +291,9 @@ export default class PostList extends PureComponent {
             width > 0 &&
             height > 0 &&
             this.props.initialIndex > 0 &&
-            !this.hasDoneInitialScroll
+            !this.hasDoneInitialScroll &&
+            this.flatListRef &&
+            this.flatListRef.current
         ) {
             requestAnimationFrame(() => {
                 this.flatListRef.current.scrollToIndex({


### PR DESCRIPTION
#### Summary
Similar issue to https://github.com/mattermost/mattermost-mobile/pull/2925. Added a check to ensure that the ref's current is not null prior to calling scrollToIndex.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17016