### PR TITLE
[MM-17018] Handle null currentChannelMember

### DIFF
--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -96,7 +96,7 @@ function mapStateToProps(state) {
         currentChannelMemberCount,
         currentUserId,
         isChannelMuted: isChannelMuted(currentChannelMember),
-        ignoreChannelMentions: areChannelMentionsIgnored(currentChannelMember.notify_props, currentUser.notify_props),
+        ignoreChannelMentions: areChannelMentionsIgnored(currentChannelMember && currentChannelMember.notify_props, currentUser.notify_props),
         isCurrent,
         isFavorite,
         status,


### PR DESCRIPTION
#### Summary
Only access `notify_props` if `currentChannelMember` is not null.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17018

#### Checklist
- [x] All new/modified APIs include changes to [mattermost-redux PR 879](https://github.com/mattermost/mattermost-redux/pull/879)
