### PR TITLE
Select server fix login options transition

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -107,15 +107,15 @@ export default class SelectServer extends PureComponent {
         if (this.state.connected && this.props.hasConfigAndLicense && !(prevState.connected && prevProps.hasConfigAndLicense)) {
             if (LocalConfig.EnableMobileClientUpgrade) {
                 this.props.actions.setLastUpgradeCheck();
-                const {currentVersion, minVersion, latestVersion} = prevProps;
+                const {currentVersion, minVersion, latestVersion} = this.props;
                 const upgradeType = checkUpgradeType(currentVersion, minVersion, latestVersion);
                 if (isUpgradeAvailable(upgradeType)) {
                     this.handleShowClientUpgrade(upgradeType);
                 } else {
-                    this.handleLoginOptions(prevProps);
+                    this.handleLoginOptions(this.props);
                 }
             } else {
-                this.handleLoginOptions(prevProps);
+                this.handleLoginOptions(this.props);
             }
         }
     }


### PR DESCRIPTION
#### Summary
The select server screeen in componentDidUpdate was passing the previous props to the login options handler instead of the current props, thus causing a race condition when the config or the license was not set.