### PR TITLE
MM-16829 Fix for sso with server subpaths

### DIFF
--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -175,7 +175,7 @@ class SSO extends PureComponent {
     onLoadEnd = (event) => {
         const url = event.nativeEvent.url;
         if (url.includes(this.completedUrl)) {
-            CookieManager.get(urlParse(url).origin, this.useWebkit).then((res) => {
+            CookieManager.get(this.props.serverUrl, this.useWebkit).then((res) => {
                 const token = res.MMAUTHTOKEN;
 
                 if (token) {


### PR DESCRIPTION
#### Summary
With https://github.com/mattermost/mattermost-server/pull/10493 we are supporting cookies for different subpaths so mobile needs to look for cookies in subpaths instead or root urls.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16829

#### Device Information
Android and IOS emulators

