### PR TITLE
Fix Options modal on iOS

### DIFF
--- a/app/screens/options_modal/options_modal.js
+++ b/app/screens/options_modal/options_modal.js
@@ -5,6 +5,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
     Animated,
+    Platform,
     StyleSheet,
     TouchableWithoutFeedback,
     View,
@@ -74,7 +75,11 @@ export default class OptionsModal extends PureComponent {
     };
 
     onItemPress = () => {
-        this.close();
+        if (Platform.OS === 'android') {
+            this.close();
+        } else {
+            this.props.actions.dismissModal();
+        }
     };
 
     render() {


### PR DESCRIPTION
#### Summary
For some reason iOS needs us to dismiss the modal before running the animation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17090