### PR TITLE
[MM-16910] Set footerColor the same as navBarBackgroundColor

### DIFF
--- a/app/components/sidebars/main/__snapshots__/main_sidebar.test.js.snap
+++ b/app/components/sidebars/main/__snapshots__/main_sidebar.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChannelSidebar should match, full snapshot 1`] = `
+<DrawerLayout
+  drawerPosition="left"
+  drawerWidth={-30}
+  isTablet={false}
+  onDrawerClose={[Function]}
+  onDrawerOpen={[Function]}
+  renderNavigationView={[Function]}
+  useNativeAnimations={true}
+/>
+`;

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -378,7 +378,7 @@ export default class ChannelSidebar extends Component {
             <SafeAreaView
                 navBarBackgroundColor={theme.sidebarBg}
                 backgroundColor={theme.sidebarHeaderBg}
-                footerColor={theme.sidebarHeaderBg}
+                footerColor={theme.sidebarBg}
             >
                 <DrawerSwiper
                     ref={this.drawerSwiperRef}

--- a/app/components/sidebars/main/main_sidebar.test.js
+++ b/app/components/sidebars/main/main_sidebar.test.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import ChannelSidebar from './main_sidebar';
+
+jest.mock('react-intl');
+
+describe('ChannelSidebar', () => {
+    const baseProps = {
+        actions: {
+            getTeams: jest.fn(),
+            logChannelSwitch: jest.fn(),
+            makeDirectChannel: jest.fn(),
+            setChannelDisplayName: jest.fn(),
+            setChannelLoading: jest.fn(),
+        },
+        blurPostTextBox: jest.fn(),
+        currentTeamId: 'current-team-id',
+        currentUserId: 'current-user-id',
+        deviceWidth: 10,
+        isLandscape: false,
+        teamsCount: 2,
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should match, full snapshot', () => {
+        const wrapper = shallow(
+            <ChannelSidebar {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
Set `footerColor` the same as `navBarBackgroundColor`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16910

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone X simulator, iOS 12.2

#### Screenshots
![Simulator Screen Shot - iPhone X - 2019-07-19 at 15 46 24](https://user-images.githubusercontent.com/3208014/61570048-1dbb8180-aa3f-11e9-9c19-9905393d45b8.png)

![Simulator Screen Shot - iPhone X - 2019-07-19 at 15 47 19](https://user-images.githubusercontent.com/3208014/61570054-2613bc80-aa3f-11e9-801f-8e46ddd016e5.png)

![Simulator Screen Shot - iPhone X - 2019-07-19 at 15 47 35](https://user-images.githubusercontent.com/3208014/61570056-28761680-aa3f-11e9-9a97-fef03cb13198.png)

![Simulator Screen Shot - iPhone X - 2019-07-19 at 15 49 23](https://user-images.githubusercontent.com/3208014/61570058-2b710700-aa3f-11e9-9433-cb5c9c0a5f74.png)
