### PR TITLE
[MM-14923] Add channel_id to failed push notification reply

### DIFF
--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -96,13 +96,13 @@ class PushNotification {
     }
 
     localNotification(notification) {
-        const deviceNotification = {
+        this.deviceNotification = {
             alertBody: notification.message,
             alertAction: '',
             userInfo: notification.userInfo,
         };
 
-        NotificationsIOS.localNotification(deviceNotification);
+        NotificationsIOS.localNotification(this.deviceNotification);
     }
 
     cancelAllLocalNotifications() {

--- a/app/utils/push_notifications.js
+++ b/app/utils/push_notifications.js
@@ -140,9 +140,9 @@ class PushNotificationUtils {
                     userInfo: {
                         localNotification: true,
                         localTest: true,
+                        channel_id: data.channel_id,
                     },
                 });
-                console.warn('Failed to send reply to push notification', result.error); // eslint-disable-line no-console
                 completed();
                 return;
             }
@@ -190,6 +190,10 @@ class PushNotificationUtils {
         };
 
         unsubscribeFromStore = this.store.subscribe(waitForHydration);
+    }
+
+    getNotification = () => {
+        return PushNotifications.getNotification();
     }
 }
 

--- a/app/utils/push_notifications.test.js
+++ b/app/utils/push_notifications.test.js
@@ -1,0 +1,63 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import {PostTypes} from 'mattermost-redux/action_types';
+
+import PushNotificationUtils from './push_notifications';
+
+jest.mock('app/init/credentials', () => ({
+    getAppCredentials: jest.fn().mockReturnValue({
+        username: 'device-token,current-user-id',
+        password: 'token,url',
+    }),
+    getCurrentServerUrl: jest.fn().mockReturnValue('url'),
+}));
+
+jest.mock('app/actions/views/root', () => ({
+    createPostForNotificationReply: jest.fn().mockImplementation(() => {
+        return () => ({error: 'error'});
+    }),
+}));
+
+jest.mock('app/selectors/i18n', () => ({
+    getCurrentLocale: jest.fn().mockReturnValue('en'),
+}));
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({});
+PushNotificationUtils.configure(store);
+
+jest.mock('react-native-notifications', () => {
+    return {
+        requestPermissions: jest.fn(),
+        addEventListener: jest.fn(),
+        NotificationAction: jest.fn(),
+        NotificationCategory: jest.fn(),
+        consumeBackgroundQueue: jest.fn(),
+        localNotification: jest.fn(),
+    };
+});
+
+describe('PushNotifications', () => {
+    it('should add channel_id to failed push notification reply', async () => {
+        let notification = PushNotificationUtils.getNotification();
+        expect(notification).toBe(null);
+
+        const channelID = 'channel-id';
+        const data = {channel_id: channelID};
+        const text = 'text';
+        const badge = 1;
+        const completed = () => {};
+        await PushNotificationUtils.onPushNotificationReply(data, text, badge, completed);
+
+        const storeActions = store.getActions();
+        const receivedChannel = storeActions.some((action) => action.type === PostTypes.RECEIVED_POST);
+        expect(receivedChannel).toBe(false);
+
+        notification = PushNotificationUtils.getNotification();
+        expect(notification.userInfo.channel_id).toBe(channelID);
+    });
+});

--- a/app/utils/push_notifications.test.js
+++ b/app/utils/push_notifications.test.js
@@ -26,10 +26,6 @@ jest.mock('app/selectors/i18n', () => ({
     getCurrentLocale: jest.fn().mockReturnValue('en'),
 }));
 
-const mockStore = configureMockStore([thunk]);
-const store = mockStore({});
-PushNotificationUtils.configure(store);
-
 jest.mock('react-native-notifications', () => {
     return {
         requestPermissions: jest.fn(),
@@ -40,6 +36,10 @@ jest.mock('react-native-notifications', () => {
         localNotification: jest.fn(),
     };
 });
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({});
+PushNotificationUtils.configure(store);
 
 describe('PushNotifications', () => {
     it('should add channel_id to failed push notification reply', async () => {
@@ -54,8 +54,8 @@ describe('PushNotifications', () => {
         await PushNotificationUtils.onPushNotificationReply(data, text, badge, completed);
 
         const storeActions = store.getActions();
-        const receivedChannel = storeActions.some((action) => action.type === PostTypes.RECEIVED_POST);
-        expect(receivedChannel).toBe(false);
+        const receivedPost = storeActions.some((action) => action.type === PostTypes.RECEIVED_POST);
+        expect(receivedPost).toBe(false);
 
         notification = PushNotificationUtils.getNotification();
         expect(notification.userInfo.channel_id).toBe(channelID);


### PR DESCRIPTION
#### Summary
Adding channel_id to the failed push notification reply ensures that it is cleared when `clearChannelNotifications` is called. The test for `clearChannelNotifications` is part of [PR 3001](https://github.com/mattermost/mattermost-mobile/pull/3001).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14923

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.3