### PR TITLE
[MM-17040] User popToRoot over resetToChannel

### DIFF
--- a/app/screens/user_profile/index.js
+++ b/app/screens/user_profile/index.js
@@ -18,8 +18,9 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {
     setButtons,
     dismissModal,
-    resetToChannel,
     goToScreen,
+    dismissAllModals,
+    popToRoot,
 } from 'app/actions/navigation';
 
 import UserProfile from './user_profile';
@@ -52,8 +53,9 @@ function mapDispatchToProps(dispatch) {
             loadBot,
             setButtons,
             dismissModal,
-            resetToChannel,
             goToScreen,
+            dismissAllModals,
+            popToRoot,
         }, dispatch),
     };
 }

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -35,8 +35,9 @@ export default class UserProfile extends PureComponent {
             loadBot: PropTypes.func.isRequired,
             setButtons: PropTypes.func.isRequired,
             dismissModal: PropTypes.func.isRequired,
-            resetToChannel: PropTypes.func.isRequired,
             goToScreen: PropTypes.func.isRequired,
+            dismissAllModals: PropTypes.func.isRequired,
+            popToRoot: PropTypes.func.isRequired,
         }).isRequired,
         componentId: PropTypes.string,
         config: PropTypes.object.isRequired,
@@ -100,17 +101,15 @@ export default class UserProfile extends PureComponent {
     }
 
     close = () => {
-        const {actions, fromSettings} = this.props;
+        const {actions, fromSettings, componentId} = this.props;
 
         if (fromSettings) {
             actions.dismissModal();
             return;
         }
 
-        const passProps = {
-            disableTermsModal: true,
-        };
-        actions.resetToChannel(passProps);
+        actions.dismissAllModals();
+        actions.popToRoot(componentId);
     };
 
     getDisplayName = () => {

--- a/app/screens/user_profile/user_profile.test.js
+++ b/app/screens/user_profile/user_profile.test.js
@@ -24,8 +24,9 @@ describe('user_profile', () => {
         loadBot: jest.fn(),
         setButtons: jest.fn(),
         dismissModal: jest.fn(),
-        resetToChannel: jest.fn(),
         goToScreen: jest.fn(),
+        dismissAllModals: jest.fn(),
+        popToRoot: jest.fn(),
     };
     const baseProps = {
         actions,
@@ -144,6 +145,8 @@ describe('user_profile', () => {
         props.fromSettings = false;
         wrapper.setProps({...props});
         wrapper.instance().navigationButtonPressed(event);
-        expect(props.actions.resetToChannel).toHaveBeenCalledTimes(1);
+        expect(props.actions.dismissAllModals).toHaveBeenCalledTimes(1);
+        expect(props.actions.popToRoot).toHaveBeenCalledTimes(1);
+        expect(props.actions.popToRoot).toHaveBeenCalledWith(props.componentId);
     });
 });


### PR DESCRIPTION
#### Summary
Using `popToRoot` over `resetToChannel` avoid a white screen when transitioning to the channel screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17040

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Emulator, Android 9.0
* iPhone 8, iOS 12.3
