### PR TITLE
Automated cherry pick of #3022

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -291,16 +291,17 @@ export default class PostList extends PureComponent {
             width > 0 &&
             height > 0 &&
             this.props.initialIndex > 0 &&
-            !this.hasDoneInitialScroll &&
-            this.flatListRef?.current
+            !this.hasDoneInitialScroll
         ) {
             requestAnimationFrame(() => {
-                this.flatListRef.current.scrollToIndex({
-                    animated: false,
-                    index: this.props.initialIndex,
-                    viewOffset: 0,
-                    viewPosition: 1, // 0 is at bottom
-                });
+                if (this.flatListRef?.current) {
+                    this.flatListRef.current.scrollToIndex({
+                        animated: false,
+                        index: this.props.initialIndex,
+                        viewOffset: 0,
+                        viewPosition: 1, // 0 is at bottom
+                    });
+                }
             });
             this.hasDoneInitialScroll = true;
         }


### PR DESCRIPTION
Cherry pick of #3022 on release-1.22.

- #3022: Call scrollToIndex only if flatListRef.current is not null

/cc  @migbot