### PR TITLE
[MM-17001] Check initialIndex in callback

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -201,10 +201,8 @@ export default class PostList extends PureComponent {
     };
 
     handleScrollToIndexFailed = () => {
-        requestAnimationFrame(() => {
-            this.hasDoneInitialScroll = false;
-            this.scrollToInitialIndexIfNeeded(1, 1);
-        });
+        this.hasDoneInitialScroll = false;
+        this.scrollToInitialIndexIfNeeded(1, 1);
     };
 
     handleSetScrollToBottom = () => {
@@ -290,11 +288,10 @@ export default class PostList extends PureComponent {
         if (
             width > 0 &&
             height > 0 &&
-            this.props.initialIndex > 0 &&
             !this.hasDoneInitialScroll
         ) {
             requestAnimationFrame(() => {
-                if (this.flatListRef?.current) {
+                if (this.props.initialIndex > 0 && this.flatListRef?.current) {
                     this.flatListRef.current.scrollToIndex({
                         animated: false,
                         index: this.props.initialIndex,


### PR DESCRIPTION
#### Summary
While the `initialIndex` was > 0 prior to the `requestAnimationFrame` call, it was -1 inside the callback so I moved the check inside the callback. I was able to repro this consistently by scrolling on a channel, switching channels, and then re-running the app in XCode.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17001

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.3