### PR TITLE
[MM-14926] Clear foreground notifications from AsyncStorage on logout and server upgrade

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -225,8 +225,6 @@ class GlobalEventHandler {
         dispatch(setServerVersion(''));
         Client4.serverVersion = '';
 
-        PushNotifications.clearNotifications();
-
         const credentials = await getAppCredentials();
 
         if (credentials) {

--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -143,8 +143,7 @@ class GlobalEventHandler {
         deleteFileCache();
         removeAppCredentials();
 
-        PushNotifications.setApplicationIconBadgeNumber(0);
-        PushNotifications.cancelAllLocalNotifications(); // TODO: Only cancel the notification that belongs to this server
+        PushNotifications.clearNotifications();
 
         if (this.launchApp) {
             this.launchApp();
@@ -225,8 +224,8 @@ class GlobalEventHandler {
 
         dispatch(setServerVersion(''));
         Client4.serverVersion = '';
-        PushNotifications.setApplicationIconBadgeNumber(0);
-        PushNotifications.cancelAllLocalNotifications(); // TODO: Only cancel the notification that belongs to this server
+
+        PushNotifications.clearNotifications();
 
         const credentials = await getAppCredentials();
 

--- a/app/init/global_event_handler.test.js
+++ b/app/init/global_event_handler.test.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import PushNotification from 'app/push_notifications';
+
+import GlobalEventHandler from './global_event_handler';
+
+jest.mock('app/init/credentials', () => ({
+    getAppCredentials: jest.fn(),
+    removeAppCredentials: jest.fn(),
+}));
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({});
+GlobalEventHandler.store = store;
+
+// TODO: Add Android test as part of https://mattermost.atlassian.net/browse/MM-17110
+describe('GlobalEventHandler', () => {
+    it('should clear notifications when server upgrade is needed', () => {
+        const clearNotifications = jest.spyOn(PushNotification, 'clearNotifications');
+
+        GlobalEventHandler.serverUpgradeNeeded();
+        expect(clearNotifications).toHaveBeenCalled();
+    });
+
+    it('should clear notifications on logout', () => {
+        const clearNotifications = jest.spyOn(PushNotification, 'clearNotifications');
+
+        GlobalEventHandler.onLogout();
+        expect(clearNotifications).toHaveBeenCalled();
+    });
+});

--- a/app/init/global_event_handler.test.js
+++ b/app/init/global_event_handler.test.js
@@ -19,13 +19,6 @@ GlobalEventHandler.store = store;
 
 // TODO: Add Android test as part of https://mattermost.atlassian.net/browse/MM-17110
 describe('GlobalEventHandler', () => {
-    it('should clear notifications when server upgrade is needed', () => {
-        const clearNotifications = jest.spyOn(PushNotification, 'clearNotifications');
-
-        GlobalEventHandler.serverUpgradeNeeded();
-        expect(clearNotifications).toHaveBeenCalled();
-    });
-
     it('should clear notifications on logout', () => {
         const clearNotifications = jest.spyOn(PushNotification, 'clearNotifications');
 

--- a/app/push_notifications/push_notifications.android.js
+++ b/app/push_notifications/push_notifications.android.js
@@ -113,6 +113,16 @@ class PushNotification {
             NotificationPreferences.removeDeliveredNotifications(notificationForChannel.identifier, channelId);
         }
     }
+
+    clearForegroundNotifications = () => {
+        // TODO: Implement as part of https://mattermost.atlassian.net/browse/MM-17110
+    };
+
+    clearNotifications = () => {
+        this.setApplicationIconBadgeNumber(0);
+        this.cancelAllLocalNotifications(); // TODO: Only cancel the local notifications that belong to this server
+        this.clearForegroundNotifications(); // TODO: Only clear the foreground notifications that belong to this server
+    }
 }
 
 export default new PushNotification();

--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -210,6 +210,16 @@ class PushNotification {
         foregroundNotifications[channelId] += 1;
         await AsyncStorage.setItem(FOREGROUND_NOTIFICATIONS_KEY, JSON.stringify(foregroundNotifications));
     }
+
+    clearForegroundNotifications = () => {
+        AsyncStorage.removeItem(FOREGROUND_NOTIFICATIONS_KEY);
+    };
+
+    clearNotifications = () => {
+        this.setApplicationIconBadgeNumber(0);
+        this.cancelAllLocalNotifications(); // TODO: Only cancel the local notifications that belong to this server
+        this.clearForegroundNotifications(); // TODO: Only clear the foreground notifications that belong to this server
+    }
 }
 
 export default new PushNotification();

--- a/app/push_notifications/push_notifications.ios.test.js
+++ b/app/push_notifications/push_notifications.ios.test.js
@@ -24,6 +24,7 @@ jest.mock('react-native-notifications', () => {
         removeDeliveredNotifications: jest.fn((ids) => {
             deliveredNotifications = deliveredNotifications.filter((n) => !ids.includes(n.identifier));
         }),
+        cancelAllLocalNotifications: jest.fn(),
         NotificationAction: jest.fn(),
         NotificationCategory: jest.fn(),
     };
@@ -132,5 +133,18 @@ describe('PushNotification', () => {
             const badgeNumber = channel2DeliveredNotifications.lenth + channel2ForegroundNotifications.length;
             expect(setApplicationIconBadgeNumber).toHaveBeenCalledWith(badgeNumber);
         });
+    });
+
+    it('should clear all notifications', () => {
+        const setApplicationIconBadgeNumber = jest.spyOn(PushNotification, 'setApplicationIconBadgeNumber');
+        const cancelAllLocalNotifications = jest.spyOn(PushNotification, 'cancelAllLocalNotifications');
+        const clearForegroundNotifications = jest.spyOn(PushNotification, 'clearForegroundNotifications');
+
+        PushNotification.clearNotifications();
+        expect(setApplicationIconBadgeNumber).toHaveBeenCalledWith(0);
+        expect(NotificationsIOS.setBadgesCount).toHaveBeenCalledWith(0);
+        expect(cancelAllLocalNotifications).toHaveBeenCalled();
+        expect(NotificationsIOS.cancelAllLocalNotifications).toHaveBeenCalled();
+        expect(clearForegroundNotifications).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
#### Summary
This is a follow up to https://github.com/mattermost/mattermost-mobile/pull/3001.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14926

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.3

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
