### PR TITLE
Fix assigning credentials during app init

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -6,6 +6,7 @@ import {Linking, NativeModules, Platform, Text} from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import {setGenericPassword, getGenericPassword, resetGenericPassword} from 'react-native-keychain';
 
+import {setDeviceToken} from 'mattermost-redux/actions/general';
 import {loadMe} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
@@ -127,10 +128,12 @@ export default class App {
 
                     // if for any case the url and the token aren't valid proceed with re-hydration
                     if (url && url !== 'undefined' && token && token !== 'undefined') {
-                        this.deviceToken = deviceToken;
+                        const {dispatch} = store;
+
                         this.currentUserId = currentUserId;
                         this.token = token;
                         this.url = url;
+                        dispatch(setDeviceToken(deviceToken));
                         Client4.setUrl(url);
                         Client4.setToken(token);
                         await setCSRFFromCookie(url);

--- a/app/screens/entry/entry.js
+++ b/app/screens/entry/entry.js
@@ -21,7 +21,6 @@ import {
 } from 'app/mattermost';
 import {ViewTypes} from 'app/constants';
 import PushNotifications from 'app/push_notifications';
-import {stripTrailingSlashes} from 'app/utils/url';
 import {wrapWithContextProvider} from 'app/utils/wrap_context_provider';
 
 import ChannelLoader from 'app/components/channel_loader';
@@ -64,7 +63,6 @@ export default class Entry extends PureComponent {
         initializeModules: PropTypes.func,
         actions: PropTypes.shape({
             autoUpdateTimezone: PropTypes.func.isRequired,
-            setDeviceToken: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -148,33 +146,18 @@ export default class Entry extends PureComponent {
     };
 
     setAppCredentials = () => {
-        const {
-            actions: {
-                setDeviceToken,
-            },
-        } = this.props;
         const {getState} = store;
         const state = getState();
 
-        const {credentials} = state.entities.general;
         const {currentUserId} = state.entities.users;
 
-        if (app.deviceToken) {
-            setDeviceToken(app.deviceToken);
-        }
-
-        if (credentials.token && credentials.url) {
-            Client4.setToken(credentials.token);
-            Client4.setUrl(stripTrailingSlashes(credentials.url));
-        } else if (app.waitForRehydration) {
+        if (app.waitForRehydration) {
             app.waitForRehydration = false;
         }
 
         if (currentUserId) {
             Client4.setUserId(currentUserId);
         }
-
-        app.setAppCredentials(app.deviceToken, currentUserId, credentials.token, credentials.url);
     };
 
     setStartupThemes = () => {

--- a/app/screens/entry/entry.js
+++ b/app/screens/entry/entry.js
@@ -126,7 +126,16 @@ export default class Entry extends PureComponent {
                 autoUpdateTimezone(deviceTimezone);
             }
 
-            this.setAppCredentials();
+            const {currentUserId} = state.entities.users;
+
+            if (app.waitForRehydration) {
+                app.waitForRehydration = false;
+            }
+
+            if (currentUserId) {
+                Client4.setUserId(currentUserId);
+            }
+
             this.setStartupThemes();
             this.handleNotification();
             this.loadSystemEmojis();
@@ -143,21 +152,6 @@ export default class Entry extends PureComponent {
     configurePushNotifications = () => {
         const configureNotifications = lazyLoadPushNotifications();
         configureNotifications();
-    };
-
-    setAppCredentials = () => {
-        const {getState} = store;
-        const state = getState();
-
-        const {currentUserId} = state.entities.users;
-
-        if (app.waitForRehydration) {
-            app.waitForRehydration = false;
-        }
-
-        if (currentUserId) {
-            Client4.setUserId(currentUserId);
-        }
     };
 
     setStartupThemes = () => {

--- a/app/screens/entry/index.js
+++ b/app/screens/entry/index.js
@@ -3,7 +3,6 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {setDeviceToken} from 'mattermost-redux/actions/general';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {isTimezoneEnabled} from 'mattermost-redux/selectors/entities/timezone';
@@ -31,7 +30,6 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             autoUpdateTimezone,
-            setDeviceToken,
         }, dispatch),
     };
 }


### PR DESCRIPTION
#### Summary
on Android there was a race condition setting the user credentials, when this happened we were trying to set the credentials stored in the redux store. At this point we removed the session token from the redux store so it was being set to `undefined` then when the app makes the decision to show the server url screen or the channel screen then the server screen was shown as there was **no** session token at this point.

With this PR we are removing the second call to `setAppCredentials` so only the credentials stored in the keyChain are used.

**IMPORTANT:** This only applies to 1.21 as 1.22 does not do this after the entry refactor.

After this PR is merged we need to cut a dot release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17220