### PR TITLE
MM-17100 setCSRFFromCookie with subpath support

### DIFF
--- a/app/utils/security.js
+++ b/app/utils/security.js
@@ -3,7 +3,6 @@
 
 import {Client4} from 'mattermost-redux/client';
 import CookieManager from 'react-native-cookies';
-import urlParse from 'url-parse';
 
 let mfaPreflightDone = false;
 
@@ -17,7 +16,7 @@ export function getMfaPreflightDone() {
 
 export function setCSRFFromCookie(url) {
     return new Promise((resolve) => {
-        CookieManager.get(urlParse(url).origin, false).then((res) => {
+        CookieManager.get(url, false).then((res) => {
             const token = res.MMCSRF;
             if (token) {
                 Client4.setCSRF(token?.value || token);


### PR DESCRIPTION
#### Summary
Using the full server url so Cookies are retrieved when a subpath is used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17100