### PR TITLE
[MM-17157] Check if ackId is nil first

### DIFF
--- a/ios/UploadAttachments/UploadAttachments/UploadSession.swift
+++ b/ios/UploadAttachments/UploadAttachments/UploadSession.swift
@@ -125,14 +125,14 @@ import os.log
     }
     
     public func notificationReceipt(notificationId: Any?, receivedAt: Int, type: Any?) {
-        let store = StoreManager.shared() as StoreManager
-        let entities = store.getEntities(true)
-        if (entities != nil) {
-            let serverURL = store.getServerUrl()
-            let sessionToken = store.getToken()
-            let urlString = "\(serverURL!)/api/v4/notifications/ack"
-            
-            if (notificationId != nil) {
+        if (notificationId != nil) {
+            let store = StoreManager.shared() as StoreManager
+            let entities = store.getEntities(true)
+            if (entities != nil) {
+                let serverURL = store.getServerUrl()
+                let sessionToken = store.getToken()
+                let urlString = "\(serverURL!)/api/v4/notifications/ack"
+
                 let jsonObject: [String: Any] = [
                     "id": notificationId as Any,
                     "received_at": receivedAt,


### PR DESCRIPTION
#### Summary
I'm unable to repro the crash, however, the exception in `notificationReceipt` is only happening with server versions 5.11 and below which don't include `ack_id` in the notification payload. I've added a null check for that ack id prior to running the body of the function.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17157
