### PR TITLE
[MM-17401] Dispatch setDeviceToken after hydration

### DIFF
--- a/app/screens/entry/entry.js
+++ b/app/screens/entry/entry.js
@@ -63,6 +63,7 @@ export default class Entry extends PureComponent {
         initializeModules: PropTypes.func,
         actions: PropTypes.shape({
             autoUpdateTimezone: PropTypes.func.isRequired,
+            setDeviceToken: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -108,6 +109,7 @@ export default class Entry extends PureComponent {
         const {
             actions: {
                 autoUpdateTimezone,
+                setDeviceToken,
             },
             enableTimezone,
             deviceTimezone,
@@ -134,6 +136,10 @@ export default class Entry extends PureComponent {
 
             if (currentUserId) {
                 Client4.setUserId(currentUserId);
+            }
+
+            if (app.deviceToken) {
+                setDeviceToken(app.deviceToken);
             }
 
             this.setStartupThemes();

--- a/app/screens/entry/index.js
+++ b/app/screens/entry/index.js
@@ -3,6 +3,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
+import {setDeviceToken} from 'mattermost-redux/actions/general';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {isTimezoneEnabled} from 'mattermost-redux/selectors/entities/timezone';
@@ -30,6 +31,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             autoUpdateTimezone,
+            setDeviceToken,
         }, dispatch),
     };
 }


### PR DESCRIPTION
#### Summary
The call to dispatch `setDeviceToken` was previously made in `setAppCredentials` of the entry screen which was removed in [PR-3034](https://github.com/mattermost/mattermost-mobile/pull/3034). I'm just adding back the call to `setDeviceToken`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17401

#### Device Information
This PR was tested on:
* Galaxy S7, Android 8.1
