### PR TITLE
[MM-15379] Include null check on name from mattermost-redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,8 +13396,8 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#84748d22aebf07826c6938058e3da0f8d583d6f8",
-      "from": "github:mattermost/mattermost-redux#84748d22aebf07826c6938058e3da0f8d583d6f8",
+      "version": "github:mattermost/mattermost-redux#c93aa5fd83601ef226eb07d26e36a1ad65b5af95",
+      "from": "github:mattermost/mattermost-redux#c93aa5fd83601ef226eb07d26e36a1ad65b5af95",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.2.0",
     "jsc-android": "241213.2.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#84748d22aebf07826c6938058e3da0f8d583d6f8",
+    "mattermost-redux": "github:mattermost/mattermost-redux#c93aa5fd83601ef226eb07d26e36a1ad65b5af95",
     "mime-db": "1.40.0",
     "moment-timezone": "0.5.25",
     "prop-types": "15.7.2",


### PR DESCRIPTION
#### Summary
Now that the mobile repo has been updated for core-js 3 I can update the mattermost-redux commit hash to point to https://github.com/mattermost/mattermost-redux/commit/c93aa5fd83601ef226eb07d26e36a1ad65b5af95 which is built on top of the mattermost-redux update to core-js 3.

**Note: The commit hash on the cherry-pick to 1.22 needs to point to the 5.14 commit of my mattermost-redux change (https://github.com/mattermost/mattermost-redux/commit/482c5d4ecfe0818295d6e539eac102c935989b4b). I'm omitting the cherry pick approved label so I can do this manually.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15379