### PR TITLE
MM-17562 scroll to new message line indicator on componentDidUpdate

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -133,9 +133,7 @@ export default class PostList extends PureComponent {
     };
 
     handleContentSizeChange = (contentWidth, contentHeight) => {
-        setTimeout(() => {
-            // this.scrollToInitialIndexIfNeeded(contentWidth, contentHeight);
-            this.setState({contentHeight});
+        this.setState({contentHeight}, () => {
             if (this.state.postListHeight && contentHeight < this.state.postListHeight && this.props.extraData) {
                 // We still have less than 1 screen of posts loaded with more to get, so load more
                 this.props.onLoadMoreUp();

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -124,6 +124,14 @@ export default class PostList extends PureComponent {
 
     componentWillUnmount() {
         EventEmitter.off('scroll-to-bottom', this.handleSetScrollToBottom);
+
+        if (this.animationFrameIndexFailed) {
+            cancelAnimationFrame(this.animationFrameIndexFailed);
+        }
+
+        if (this.animationFrameInitialIndex) {
+            cancelAnimationFrame(this.animationFrameInitialIndex);
+        }
     }
 
     handleClosePermalink = () => {
@@ -206,7 +214,7 @@ export default class PostList extends PureComponent {
     };
 
     handleScrollToIndexFailed = () => {
-        requestAnimationFrame(() => {
+        this.animationFrameIndexFailed = requestAnimationFrame(() => {
             if (this.props.initialIndex > 0 && this.state.contentHeight > 0) {
                 this.hasDoneInitialScroll = false;
                 this.scrollToInitialIndexIfNeeded(this.props.initialIndex);
@@ -296,7 +304,7 @@ export default class PostList extends PureComponent {
     scrollToInitialIndexIfNeeded = (index) => {
         if (!this.hasDoneInitialScroll && this.flatListRef?.current) {
             this.hasDoneInitialScroll = true;
-            requestAnimationFrame(() => {
+            this.animationFrameInitialIndex = requestAnimationFrame(() => {
                 this.flatListRef.current.scrollToIndex({
                     animated: false,
                     index,


### PR DESCRIPTION
#### Summary
After the crash fixes around `scrollToIndex` the app is no longer scrolling to the new message line  indicator, this was happening cause of a race condition.

In order to fix it, the decision to scroll to the new message line indicator happens when the component updates, scrolling to the line does not update the component once again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17562