### PR TITLE
[MM-17431] Remove flex for horizontalRule

### DIFF
--- a/app/screens/terms_of_service/__snapshots__/terms_of_service.test.js.snap
+++ b/app/screens/terms_of_service/__snapshots__/terms_of_service.test.js.snap
@@ -32,7 +32,6 @@ exports[`TermsOfService should enable/disable navigator buttons on setNavigatorB
           },
           "horizontalRule": Object {
             "backgroundColor": "#3d3c40",
-            "flex": 1,
             "height": 0.5,
             "marginVertical": 10,
           },
@@ -167,7 +166,6 @@ exports[`TermsOfService should enable/disable navigator buttons on setNavigatorB
           },
           "horizontalRule": Object {
             "backgroundColor": "#3d3c40",
-            "flex": 1,
             "height": 0.5,
             "marginVertical": 10,
           },
@@ -366,7 +364,6 @@ exports[`TermsOfService should match snapshot on enableNavigatorLogout 1`] = `
           },
           "horizontalRule": Object {
             "backgroundColor": "#3d3c40",
-            "flex": 1,
             "height": 0.5,
             "marginVertical": 10,
           },

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -103,7 +103,6 @@ export const getMarkdownBlockStyles = makeStyleSheetFromTheme((theme) => {
         horizontalRule: {
             backgroundColor: theme.centerChannelColor,
             height: StyleSheet.hairlineWidth,
-            flex: 1,
             marginVertical: 10,
         },
         quoteBlockIcon: {


### PR DESCRIPTION
#### Summary
While I did find this [react-native issue](https://github.com/facebook/react-native/issues/22927), removing `flex` displays the horizontal rule.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17431

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Pixel 2 emulator, Android 8.1

#### Screenshots
Pixel 2 emulator:
![Screenshot_1565236895](https://user-images.githubusercontent.com/3208014/62674460-4efce280-b957-11e9-9cc9-3b63e5d28368.png)

iOS:
![Simulator Screen Shot - iPhone X - 2019-08-07 at 21 11 50](https://user-images.githubusercontent.com/3208014/62674619-04c83100-b958-11e9-8c3b-431577e74801.png)


