### PR TITLE
[MM-17512] Fix theme thumbnail width

### DIFF
--- a/app/screens/settings/theme/theme_tile.js
+++ b/app/screens/settings/theme/theme_tile.js
@@ -12,8 +12,6 @@ import {
 
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
 
-const {width: deviceWidth, height: deviceHeight} = Dimensions.get('window');
-
 const checkmark = require('assets/images/themes/check.png');
 
 const tilePadding = 8;
@@ -38,7 +36,8 @@ const ThemeTile = (props) => {
     );
 
     const tilesPerLine = isLandscape || isTablet ? 4 : 2;
-    const fullWidth = isLandscape ? deviceHeight - 40 : deviceWidth;
+    const {width: deviceWidth} = Dimensions.get('window');
+    const fullWidth = isLandscape ? deviceWidth - 40 : deviceWidth;
     const layoutStyle = {
         container: {
             width: (fullWidth / tilesPerLine) - tilePadding,


### PR DESCRIPTION
#### Summary
Get the device width inside the component and use it to calculate the thumbnail width.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17512

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.3
* Emulator, Android 8.1

#### Screenshots
iOS:
![Simulator Screen Shot - iPhone X - 2019-08-07 at 21 32 19](https://user-images.githubusercontent.com/3208014/62675326-6e960a00-b95b-11e9-9ded-52bc36ff6a9c.png)
![Simulator Screen Shot - iPhone X - 2019-08-07 at 21 32 17](https://user-images.githubusercontent.com/3208014/62675328-7190fa80-b95b-11e9-99b6-c309a88b2f51.png)

Android:
![Screenshot_1565239111](https://user-images.githubusercontent.com/3208014/62675402-c5034880-b95b-11e9-8ad4-cfba3cc84625.png)
![Screenshot_1565239107](https://user-images.githubusercontent.com/3208014/62675406-c7fe3900-b95b-11e9-8b92-61cd478468d3.png)


