### PR TITLE
[MM-17597] Increase ReplyIcon dimensions

### DIFF
--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -256,8 +256,8 @@ export default class PostHeader extends PureComponent {
                         style={style.replyIconContainer}
                     >
                         <ReplyIcon
-                            height={15}
-                            width={15}
+                            height={16}
+                            width={16}
                             color={theme.linkColor}
                         />
                         {!isSearchResult &&


### PR DESCRIPTION
#### Summary
Increasing the ReplyIcon's width and height fixes the cutoff issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17597

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Emulator, Android 8.1
* iPhone 8+, iOS 12.2

#### Screenshots
Android:
![android_reply1](https://user-images.githubusercontent.com/3208014/62749658-0b1ae380-ba12-11e9-8ac4-bdefc16ff50b.png)
![android_reply2](https://user-images.githubusercontent.com/3208014/62749662-0e15d400-ba12-11e9-844d-eb8e3e618f60.png)

iOS:
![ios_reply1](https://user-images.githubusercontent.com/3208014/62749668-1241f180-ba12-11e9-9b5e-7829ff42f906.png)
![ios_reply2](https://user-images.githubusercontent.com/3208014/62749670-140bb500-ba12-11e9-8dda-c08b12801010.png)

