### PR TITLE
Fix pop thread screen when deleting the root post

### DIFF
--- a/app/actions/navigation.js
+++ b/app/actions/navigation.js
@@ -166,11 +166,14 @@ export function goToScreen(name, title, passProps = {}, options = {}) {
     };
 }
 
-export function popTopScreen() {
+export function popTopScreen(screenId) {
     return () => {
-        const componentId = EphemeralStore.getNavigationTopComponentId();
-
-        Navigation.pop(componentId);
+        if (screenId) {
+            Navigation.pop(screenId);
+        } else {
+            const componentId = EphemeralStore.getNavigationTopComponentId();
+            Navigation.pop(componentId);
+        }
     };
 }
 

--- a/app/screens/thread/thread_base.js
+++ b/app/screens/thread/thread_base.js
@@ -88,7 +88,8 @@ export default class ThreadBase extends PureComponent {
     }
 
     close = () => {
-        this.props.actions.popTopScreen();
+        const {actions, componentId} = this.props;
+        actions.popTopScreen(componentId);
     };
 
     handleAutoComplete = (value) => {


### PR DESCRIPTION
#### Summary
Fixes a race condition when trying to pop the thread view once the root post is deleted. The fix is done by passing the componentId that we want the Navigator to pop

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17633
