### PR TITLE
Exclude the SafeAreaHeader in Select Server screen

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -416,7 +416,10 @@ export default class SelectServer extends PureComponent {
         }
 
         return (
-            <SafeAreaView useLandscapeMargin={true}>
+            <SafeAreaView
+                excludeHeader={true}
+                useLandscapeMargin={true}
+            >
                 <KeyboardAvoidingView
                     behavior='padding'
                     style={style.container}


### PR DESCRIPTION
#### Summary
Fixes the header in the select server screen

previous
![image](https://user-images.githubusercontent.com/6757047/62792596-a311df00-ba9d-11e9-8f77-ec74bbf009c5.png)

after this fix
![image](https://user-images.githubusercontent.com/6757047/62792615-aad18380-ba9d-11e9-9668-19fa55df34cb.png)
