### PR TITLE
MM-17630 add Navigation bar to terms of service modal

### DIFF
--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -176,15 +176,23 @@ export default class ChannelBase extends PureComponent {
     };
 
     showTermsOfServiceModal = async () => {
+        const {intl} = this.context;
         const {actions, theme} = this.props;
         const closeButton = await MaterialIcon.getImageSource('close', 20, theme.sidebarHeaderTextColor);
         const screen = 'TermsOfService';
-        const passProps = {
-            closeButton,
-        };
+        const passProps = {closeButton};
+        const title = intl.formatMessage({id: 'mobile.tos_link', defaultMessage: 'Terms of Service'});
         const options = {
             layout: {
                 backgroundColor: theme.centerChannelBg,
+            },
+            topBar: {
+                visible: true,
+                height: null,
+                title: {
+                    color: theme.sidebarHeaderTextColor,
+                    text: title,
+                },
             },
         };
 


### PR DESCRIPTION
#### Summary
With the changes to the navigation library the Terms of Service modal had no Navigation bar set, and the buttons to agree with the terms was not being displayed

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17630

#### Screenshots
![image](https://user-images.githubusercontent.com/6757047/62798654-cee89100-baac-11e9-8539-cff96ca01e18.png)

