### PR TITLE
MM-17693 Android fix close settings screen

### DIFF
--- a/app/actions/navigation.js
+++ b/app/actions/navigation.js
@@ -363,15 +363,21 @@ export function dismissOverlay(componentId) {
     };
 }
 
-export function applyTheme(componentId) {
+export function applyTheme(componentId, skipBackButtonStyle = false) {
     return (dispatch, getState) => {
         const theme = getTheme(getState());
 
+        let backButton = {
+            color: theme.sidebarHeaderTextColor,
+        };
+
+        if (skipBackButtonStyle && Platform.OS === 'android') {
+            backButton = null;
+        }
+
         Navigation.mergeOptions(componentId, {
             topBar: {
-                backButton: {
-                    color: theme.sidebarHeaderTextColor,
-                },
+                backButton,
                 background: {
                     color: theme.sidebarHeaderBg,
                 },

--- a/app/screens/settings/advanced_settings/advanced_settings.js
+++ b/app/screens/settings/advanced_settings/advanced_settings.js
@@ -28,6 +28,7 @@ import Config from 'assets/config';
 class AdvancedSettings extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
+            dismissAllModals: PropTypes.func.isRequired,
             purgeOfflineStore: PropTypes.func.isRequired,
         }).isRequired,
         intl: intlShape.isRequired,
@@ -74,6 +75,10 @@ class AdvancedSettings extends PureComponent {
         await deleteFileCache();
         this.setState({cacheSize: 0, cacheSizedFetched: true});
         actions.purgeOfflineStore();
+
+        if (Platform.OS === 'android') {
+            actions.dismissAllModals();
+        }
     });
 
     renderCacheFileSize = () => {

--- a/app/screens/settings/advanced_settings/index.js
+++ b/app/screens/settings/advanced_settings/index.js
@@ -4,6 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
+import {dismissAllModals} from 'app/actions/navigation';
 import {purgeOfflineStore} from 'app/actions/views/root';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {isLandscape} from 'app/selectors/device';
@@ -19,6 +20,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            dismissAllModals,
             purgeOfflineStore,
         }, dispatch),
     };

--- a/app/screens/settings/general/settings.js
+++ b/app/screens/settings/general/settings.js
@@ -54,7 +54,7 @@ class Settings extends PureComponent {
 
     componentDidAppear() {
         const {actions, componentId} = this.props;
-        actions.applyTheme(componentId);
+        actions.applyTheme(componentId, true);
     }
 
     navigationButtonPressed({buttonId}) {

--- a/app/screens/settings/notification_settings_mentions_keywords/__snapshots__/notification_settings_mentions_keywords.test.js.snap
+++ b/app/screens/settings/notification_settings_mentions_keywords/__snapshots__/notification_settings_mentions_keywords.test.js.snap
@@ -39,6 +39,7 @@ NotificationSettingsMentionsKeywords {
       "textComponent": "span",
       "timeZone": null,
     },
+    "isLandscape": false,
     "keywords": "",
     "onBack": [MockFunction],
     "theme": Object {
@@ -125,6 +126,7 @@ NotificationSettingsMentionsKeywords {
             "timeZone": null,
           }
         }
+        isLandscape={false}
         keywords=""
         onBack={[MockFunction]}
         theme={
@@ -211,23 +213,28 @@ NotificationSettingsMentionsKeywords {
               placeholderTextColor="rgba(61,60,64,0.4)"
               returnKeyType="done"
               style={
-                Object {
-                  "color": "#3d3c40",
-                  "fontSize": 15,
-                  "height": 150,
-                  "paddingHorizontal": 15,
-                  "paddingVertical": 10,
-                }
+                Array [
+                  Object {
+                    "color": "#3d3c40",
+                    "fontSize": 15,
+                    "height": 150,
+                    "paddingVertical": 10,
+                  },
+                  null,
+                ]
               }
               value=""
             />
           </View>
           <View
             style={
-              Object {
-                "marginTop": 10,
-                "paddingHorizontal": 15,
-              }
+              Array [
+                Object {
+                  "marginTop": 10,
+                  "paddingHorizontal": 15,
+                },
+                null,
+              ]
             }
           >
             <FormattedText

--- a/app/screens/settings/notification_settings_mentions_keywords/notification_settings_mentions_keywords.test.js
+++ b/app/screens/settings/notification_settings_mentions_keywords/notification_settings_mentions_keywords.test.js
@@ -16,6 +16,7 @@ describe('NotificationSettingsMentionsKeywords', () => {
         },
         componentId: 'component-id',
         keywords: '',
+        isLandscape: false,
         onBack: jest.fn(),
         theme: Preferences.THEMES.default,
     };


### PR DESCRIPTION
#### Summary
On Android the settings screen back button was being replaced by a normal back button after applying the them thus it was not rendering the actual close button.

Also for some reason when setting a root Android is not automatically dismissing all the modals as iOS does, so when resetting the cache the settings screen was not being dismissed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17693