### PR TITLE
Automated cherry pick of #3105

### DIFF
--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -54,7 +54,9 @@ class PushNotification {
             this.onNotification(this.deviceNotification);
         }
 
-        this.trackForegroundNotification(data.channel_id);
+        if (foreground) {
+            this.trackForegroundNotification(data.channel_id);
+        }
     };
 
     handleReply = (action, completed) => {

--- a/app/push_notifications/push_notifications.ios.test.js
+++ b/app/push_notifications/push_notifications.ios.test.js
@@ -59,6 +59,17 @@ describe('PushNotification', () => {
         expect(foregroundNotifications[channel2ID]).toBe(undefined);
     });
 
+    it('should NOT track foreground notifications for channel when opened', async () => {
+        let item = await AsyncStorage.getItem(FOREGROUND_NOTIFICATIONS_KEY);
+        expect(item).toBe(null);
+
+        PushNotification.trackForegroundNotification = jest.fn();
+        PushNotification.onNotificationOpened(notification);
+        expect(PushNotification.trackForegroundNotification).not.toBeCalled();
+        item = await AsyncStorage.getItem(FOREGROUND_NOTIFICATIONS_KEY);
+        expect(item).toBe(null);
+    });
+
     it('should increment badge number when foreground notification is received', () => {
         const setApplicationIconBadgeNumber = jest.spyOn(PushNotification, 'setApplicationIconBadgeNumber');
 


### PR DESCRIPTION
Cherry pick of #3105 on release-1.22.

- #3105: Do not track foreground notifications when notification is

/cc  @enahum