### PR TITLE
Fix delete the root post on a thread to properly close the thread screen

### DIFF
--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -360,9 +360,10 @@ export default class PostOptions extends PureComponent {
                 text: formatMessage({id: 'post_info.del', defaultMessage: 'Delete'}),
                 style: 'destructive',
                 onPress: () => {
-                    actions.deletePost(post);
-                    actions.removePost(post);
-                    this.closeWithAnimation();
+                    this.closeWithAnimation(() => {
+                        actions.deletePost(post);
+                        actions.removePost(post);
+                    });
                 },
             }]
         );

--- a/app/screens/post_options/post_options.test.js
+++ b/app/screens/post_options/post_options.test.js
@@ -111,8 +111,14 @@ describe('PostOptions', () => {
         expect(Alert.alert).toBeCalled();
 
         // Trigger on press of Delete in the Alert
+        const closeWithAnimation = jest.spyOn(wrapper.instance(), 'closeWithAnimation');
         Alert.alert.mock.calls[0][2][1].onPress();
+        expect(closeWithAnimation).toBeCalled();
 
+        // get the callback that gets called by closeWithAnimation
+        const callback = closeWithAnimation.mock.calls[0][0];
+
+        callback();
         expect(actions.deletePost).toBeCalled();
         expect(actions.removePost).toBeCalled();
     });


### PR DESCRIPTION
#### Summary
Delete the post in the callback after closing the post options screen.
