### PR TITLE
[MM-17817] Apply setNavigatorStyles to all navigation components on theme change

### DIFF
--- a/app/actions/navigation.js
+++ b/app/actions/navigation.js
@@ -291,7 +291,11 @@ export function dismissModal(options = {}) {
     return () => {
         const componentId = EphemeralStore.getNavigationTopComponentId();
 
-        Navigation.dismissModal(componentId, options);
+        Navigation.dismissModal(componentId, options).catch(() => {
+            // RNN returns a promise rejection if there is no modal to
+            // dismiss. We'll do nothing in this case but we will catch
+            // the rejection here so that the caller doesn't have to.
+        });
     };
 }
 

--- a/app/screens/settings/display_settings/display_settings.js
+++ b/app/screens/settings/display_settings/display_settings.js
@@ -3,7 +3,6 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Navigation} from 'react-native-navigation';
 import {intlShape} from 'react-intl';
 import {
     Platform,
@@ -20,7 +19,6 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 export default class DisplaySettings extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            applyTheme: PropTypes.func.isRequired,
             goToScreen: PropTypes.func.isRequired,
         }).isRequired,
         componentId: PropTypes.string,
@@ -37,15 +35,6 @@ export default class DisplaySettings extends PureComponent {
     state = {
         showClockDisplaySettings: false,
     };
-
-    componentDidMount() {
-        this.navigationEventListener = Navigation.events().bindComponent(this);
-    }
-
-    componentDidAppear() {
-        const {actions, componentId} = this.props;
-        actions.applyTheme(componentId);
-    }
 
     closeClockDisplaySettings = () => {
         this.setState({showClockDisplaySettings: false});

--- a/app/screens/settings/display_settings/display_settings.test.js
+++ b/app/screens/settings/display_settings/display_settings.test.js
@@ -16,7 +16,6 @@ jest.mock('react-intl');
 describe('DisplaySettings', () => {
     const baseProps = {
         actions: {
-            applyTheme: jest.fn(),
             goToScreen: jest.fn(),
         },
         theme: Preferences.THEMES.default,

--- a/app/screens/settings/display_settings/index.js
+++ b/app/screens/settings/display_settings/index.js
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {isTimezoneEnabled} from 'mattermost-redux/selectors/entities/timezone';
 
-import {applyTheme, goToScreen} from 'app/actions/navigation';
+import {goToScreen} from 'app/actions/navigation';
 import {getAllowedThemes} from 'app/selectors/theme';
 import {isThemeSwitchingEnabled} from 'app/utils/theme';
 import {isLandscape} from 'app/selectors/device';
@@ -29,7 +29,6 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             goToScreen,
-            applyTheme,
         }, dispatch),
     };
 }

--- a/app/screens/settings/general/index.js
+++ b/app/screens/settings/general/index.js
@@ -9,7 +9,7 @@ import {getCurrentUrl, getConfig} from 'mattermost-redux/selectors/entities/gene
 import {getJoinableTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {applyTheme, goToScreen, dismissModal} from 'app/actions/navigation';
+import {goToScreen, dismissModal} from 'app/actions/navigation';
 import {purgeOfflineStore} from 'app/actions/views/root';
 import {isLandscape} from 'app/selectors/device';
 import {removeProtocol} from 'app/utils/url';
@@ -34,7 +34,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            applyTheme,
             clearErrors,
             purgeOfflineStore,
             goToScreen,

--- a/app/screens/settings/general/settings.js
+++ b/app/screens/settings/general/settings.js
@@ -25,7 +25,6 @@ import LocalConfig from 'assets/config';
 class Settings extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            applyTheme: PropTypes.func.isRequired,
             clearErrors: PropTypes.func.isRequired,
             purgeOfflineStore: PropTypes.func.isRequired,
             goToScreen: PropTypes.func.isRequired,
@@ -50,11 +49,6 @@ class Settings extends PureComponent {
 
     componentDidMount() {
         this.navigationEventListener = Navigation.events().bindComponent(this);
-    }
-
-    componentDidAppear() {
-        const {actions, componentId} = this.props;
-        actions.applyTheme(componentId, true);
     }
 
     navigationButtonPressed({buttonId}) {

--- a/app/screens/settings/theme/theme.js
+++ b/app/screens/settings/theme/theme.js
@@ -6,14 +6,16 @@ import {Text, View} from 'react-native';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
 
+import Preferences from 'mattermost-redux/constants/preferences';
+
 import StatusBar from 'app/components/status_bar';
 import Section from 'app/screens/settings/section';
 import SectionItem from 'app/screens/settings/section_item';
-import ThemeTile from './theme_tile';
 import FormattedText from 'app/components/formatted_text';
-
 import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/utils/theme';
-import Preferences from 'mattermost-redux/constants/preferences';
+import EphemeralStore from 'app/store/ephemeral_store';
+
+import ThemeTile from './theme_tile';
 
 const thumbnailImages = {
     default: require('assets/images/themes/mattermost.png'),
@@ -56,7 +58,9 @@ export default class Theme extends React.PureComponent {
 
     componentDidUpdate(prevProps) {
         if (prevProps.theme !== this.props.theme) {
-            setNavigatorStyles(this.props.componentId, this.props.theme);
+            EphemeralStore.allNavigationComponentIds.forEach((componentId) => {
+                setNavigatorStyles(componentId, this.props.theme);
+            });
         }
     }
 

--- a/app/store/ephemeral_store.js
+++ b/app/store/ephemeral_store.js
@@ -7,20 +7,31 @@ class EphemeralStore {
         this.appStartedFromPushNotification = false;
         this.deviceToken = null;
         this.navigationComponentIdStack = [];
+        this.allNavigationComponentIds = [];
         this.currentServerUrl = null;
     }
 
     getNavigationTopComponentId = () => this.navigationComponentIdStack[0];
-    getNavigationComponentIds = () => this.navigationComponentIdStack;
 
     addNavigationComponentId = (componentId) => {
+        this.addToNavigationComponentIdStack(componentId);
+        this.addToAllNavigationComponentIds(componentId);
+    };
+
+    addToNavigationComponentIdStack = (componentId) => {
         const index = this.navigationComponentIdStack.indexOf(componentId);
         if (index > 0) {
             this.navigationComponentIdStack.slice(index, 1);
         }
 
         this.navigationComponentIdStack.unshift(componentId);
-    };
+    }
+
+    addToAllNavigationComponentIds = (componentId) => {
+        if (!this.allNavigationComponentIds.includes(componentId)) {
+            this.allNavigationComponentIds.unshift(componentId);
+        }
+    }
 
     removeNavigationComponentId = (componentId) => {
         const index = this.navigationComponentIdStack.indexOf(componentId);

--- a/app/utils/theme.js
+++ b/app/utils/theme.js
@@ -31,6 +31,9 @@ export function setNavigatorStyles(componentId, theme) {
             },
             leftButtonColor: theme.sidebarHeaderTextColor,
             rightButtonColor: theme.sidebarHeaderTextColor,
+            backButton: {
+                color: theme.sidebarHeaderTextColor,
+            },
         },
         layout: {
             backgroundColor: theme.centerChannelBg,


### PR DESCRIPTION
#### Summary
IDs for components that have appeared are now tracked in a separate array of EphemeralStore so that when the theme changes, `setNavigatorStyles` can be called on all of them rather than in each component's `componentDidAppear`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17817

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Emulator, Android 8.1
* iPhone 8, iOS 12.3

#### Screenshots
Before:
![before](https://user-images.githubusercontent.com/3208014/63042741-83086400-be7f-11e9-8f72-cede2383b561.gif)

After:
![after](https://user-images.githubusercontent.com/3208014/63042754-86035480-be7f-11e9-8999-b9fa9778f00c.gif)
