### PR TITLE
[MM-17565] Set top bar buttons once component is mounted

### DIFF
--- a/app/screens/create_channel/create_channel.js
+++ b/app/screens/create_channel/create_channel.js
@@ -67,16 +67,6 @@ export default class CreateChannel extends PureComponent {
         if (props.closeButton) {
             this.left = {...this.leftButton, icon: props.closeButton};
         }
-
-        const buttons = {
-            rightButtons: [this.rightButton],
-        };
-
-        if (this.left) {
-            buttons.leftButtons = [this.left];
-        }
-
-        props.actions.setButtons(props.componentId, buttons);
     }
 
     componentDidMount() {

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -76,21 +76,12 @@ export default class MoreChannels extends PureComponent {
             id: 'close-more-channels',
             icon: props.closeButton,
         };
-
-        const buttons = {
-            leftButtons: [this.leftButton],
-        };
-
-        if (props.canCreateChannels) {
-            buttons.rightButtons = [this.rightButton];
-        }
-
-        props.actions.setButtons(props.componentId, buttons);
     }
 
     componentDidMount() {
         this.navigationEventListener = Navigation.events().bindComponent(this);
         this.mounted = true;
+        this.setHeaderButtons(this.props.canCreateChannels);
         this.doGetChannels();
     }
 
@@ -166,7 +157,7 @@ export default class MoreChannels extends PureComponent {
 
     getChannels = debounce(this.doGetChannels, 100);
 
-    headerButtons = (createEnabled) => {
+    setHeaderButtons = (createEnabled) => {
         const {actions, canCreateChannels, componentId} = this.props;
         const buttons = {
             leftButtons: [this.leftButton],
@@ -195,7 +186,7 @@ export default class MoreChannels extends PureComponent {
         const {actions, currentTeamId, currentUserId} = this.props;
         const {channels} = this.state;
 
-        this.headerButtons(false);
+        this.setHeaderButtons(false);
         this.setState({adding: true});
 
         const channel = channels.find((c) => c.id === id);
@@ -213,7 +204,7 @@ export default class MoreChannels extends PureComponent {
                     displayName: channel ? channel.display_name : '',
                 }
             );
-            this.headerButtons(true);
+            this.setHeaderButtons(true);
             this.setState({adding: false});
         } else {
             if (channel) {

--- a/app/screens/more_channels/more_channels.test.js
+++ b/app/screens/more_channels/more_channels.test.js
@@ -53,14 +53,14 @@ describe('MoreChannels', () => {
         expect(baseProps.actions.dismissModal).toHaveBeenCalledTimes(1);
     });
 
-    test('should call props.actions.setButtons on headerButtons', () => {
+    test('should call props.actions.setButtons on setHeaderButtons', () => {
         const wrapper = shallow(
             <MoreChannels {...baseProps}/>,
             {context: {intl: {formatMessage: jest.fn()}}},
         );
 
         expect(baseProps.actions.setButtons).toHaveBeenCalledTimes(1);
-        wrapper.instance().headerButtons(true);
+        wrapper.instance().setHeaderButtons(true);
         expect(baseProps.actions.setButtons).toHaveBeenCalledTimes(2);
     });
 

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -75,13 +75,12 @@ export default class MoreDirectMessages extends PureComponent {
             selectedIds: {},
             selectedCount: 0,
         };
-
-        this.updateNavigationButtons(false, context);
     }
 
     componentDidMount() {
         this.navigationEventListener = Navigation.events().bindComponent(this);
         this.mounted = true;
+        this.updateNavigationButtons(false);
 
         this.getProfiles();
     }


### PR DESCRIPTION
#### Summary
While I was only able to reproduce the issue once, I have a feeling the issue is that `Navigation.mergeOptions` is being called with a component ID _prior_ to the component being added to the navigation stack since it's triggered in the component constructor.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17565

#### Device Information
This PR was tested on:
* Emulator, Android 8.1
* iPhone 8, iOS 12.3.1
