### PR TITLE
Fix loosing the server config when handleManagedConfig

### DIFF
--- a/app/actions/views/select_server.js
+++ b/app/actions/views/select_server.js
@@ -16,6 +16,10 @@ export function handleServerUrlChanged(serverUrl) {
     };
 }
 
+export function setServerUrl(serverUrl) {
+    return {type: ViewTypes.SERVER_URL_CHANGED, serverUrl};
+}
+
 export default {
     handleServerUrlChanged,
 };

--- a/app/init/emm_provider.js
+++ b/app/init/emm_provider.js
@@ -4,7 +4,7 @@
 import {Alert, Platform} from 'react-native';
 
 import {handleLoginIdChanged} from 'app/actions/views/login';
-import {handleServerUrlChanged} from 'app/actions/views/select_server';
+import {setServerUrl} from 'app/actions/views/select_server';
 import {getTranslations} from 'app/i18n';
 import mattermostBucket from 'app/mattermost_bucket';
 import mattermostManaged from 'app/mattermost_managed';
@@ -93,7 +93,7 @@ class EMMProvider {
         const {dispatch} = store;
 
         if (LocalConfig.AutoSelectServerUrl) {
-            dispatch(handleServerUrlChanged(LocalConfig.DefaultServerUrl));
+            dispatch(setServerUrl(LocalConfig.DefaultServerUrl));
             this.allowOtherServers = false;
         }
 
@@ -122,7 +122,7 @@ class EMMProvider {
             }
 
             if (this.emmServerUrl) {
-                dispatch(handleServerUrlChanged(this.emmServerUrl));
+                dispatch(setServerUrl(this.emmServerUrl));
             }
 
             if (this.emmUsername) {


### PR DESCRIPTION
#### Summary
Reported by a customer:
on Android when the app is brought up from the background the `managedConfigDidChange` gets triggered and if a default server url is set either in the managed config or the local config then it will set the serverURL but will wipe the config/license from the general entities.

With this PR we will only set the server url without wiping the existing config/license.

#### Ticket Link
Fixes: #3110 
