### PR TITLE
Remove renderHasGuestText

### DIFF
--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -130,7 +130,6 @@ export default class ChannelInfoHeader extends React.PureComponent {
                         {displayName}
                     </Text>
                 </View>
-                {this.renderHasGuestText(style)}
                 {purpose.length > 0 &&
                 <View style={style.section}>
                     <TouchableHighlight


### PR DESCRIPTION
#### Summary
The `renderHasGuestText` function was removed but the call was left behind causing a crash when opening the channel info.

#### Device Information
This PR was tested on:
* iOS simulator
