### PR TITLE
[MM-17842] Revert "Pass cookie for post actions"

### DIFF
--- a/app/components/message_attachments/action_button/action_button.js
+++ b/app/components/message_attachments/action_button/action_button.js
@@ -12,18 +12,17 @@ import ActionButtonText from './action_button_text';
 export default class ActionButton extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            doPostActionWithCookie: PropTypes.func.isRequired,
+            doPostAction: PropTypes.func.isRequired,
         }).isRequired,
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
         postId: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
-        cookie: PropTypes.string.isRequired,
     };
 
     handleActionPress = preventDoubleTap(() => {
-        const {actions, id, postId, cookie} = this.props;
-        actions.doPostActionWithCookie(postId, id, cookie);
+        const {actions, id, postId} = this.props;
+        actions.doPostAction(postId, id);
     }, 4000);
 
     render() {

--- a/app/components/message_attachments/action_button/index.js
+++ b/app/components/message_attachments/action_button/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {doPostActionWithCookie} from 'mattermost-redux/actions/posts';
+import {doPostAction} from 'mattermost-redux/actions/posts';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import ActionButton from './action_button';
@@ -18,7 +18,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            doPostActionWithCookie,
+            doPostAction,
         }, dispatch),
     };
 }

--- a/app/components/message_attachments/attachment_actions.js
+++ b/app/components/message_attachments/attachment_actions.js
@@ -50,7 +50,6 @@ export default class AttachmentActions extends PureComponent {
                     <ActionButton
                         key={action.id}
                         id={action.id}
-                        cookie={action.cookie}
                         name={action.name}
                         postId={postId}
                     />


### PR DESCRIPTION
#### Summary

This PR reverts https://github.com/mattermost/mattermost-mobile/pull/2945 which was meant to fix any interactive action buttons that require a cookie. After reverting the PR, no action buttons that rely on a cookie will work.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17842

#### Device Information
This PR was tested on: Android 8.1.0 Google Pixel 2

-----

The behavior we're noticing:

Before reverting PR:

- `/giphy yes` shows ephemeral post of gif and the three actions (Send, Shuffle, Cancel). Ephemeral post shows on an active webapp screen as well
- "Send" action sends gif correctly
- **"Shuffle" changes the gif on the webapp, but RN continues to show originally loaded gif** (I'm thinking this may be a websocket issue)
- "Cancel" removes the ephemeral post correctly

After reverting PR:

- `/giphy yes` shows ephemeral post of gif and the three actions (Send, Shuffle, Cancel). Ephemeral post shows on an active webapp screen as well
- "Send" action does nothing
- "Shuffle" action does nothing
- "Cancel" action does nothing