### PR TITLE
MM-17589 Update "passcode required" help text

### DIFF
--- a/app/init/emm_provider.js
+++ b/app/init/emm_provider.js
@@ -134,7 +134,7 @@ class EMMProvider {
     };
 
     showNotSecuredAlert = (translations) => {
-        return new Promise((resolve) => {
+        return new Promise(async (resolve) => {
             const options = [];
 
             if (Platform.OS === 'android') {
@@ -152,9 +152,22 @@ class EMMProvider {
                 style: 'cancel',
             });
 
+            let message;
+            if (Platform.OS === 'ios') {
+                const {supportsFaceId} = await mattermostManaged.supportsFaceId();
+
+                if (supportsFaceId) {
+                    message = translations[t('mobile.managed.not_secured.ios')];
+                } else {
+                    message = translations[t('mobile.managed.not_secured.ios.touchId')];
+                }
+            } else {
+                message = translations[t('mobile.managed.not_secured.android')];
+            }
+
             Alert.alert(
                 translations[t('mobile.managed.blocked_by')].replace('{vendor}', this.vendor),
-                Platform.OS === 'ios' ? translations[t('mobile.managed.not_secured.ios')] : translations[t('mobile.managed.not_secured.android')],
+                message,
                 options,
                 {cancelable: false, onDismiss: resolve},
             );

--- a/app/mattermost_managed/mattermost-managed.android.js
+++ b/app/mattermost_managed/mattermost-managed.android.js
@@ -66,5 +66,6 @@ export default {
 
         return JailMonkey.trustFall();
     },
+    supportsFaceId: async () => false,
     quitApp: MattermostManaged.quitApp,
 };

--- a/app/mattermost_managed/mattermost-managed.ios.js
+++ b/app/mattermost_managed/mattermost-managed.ios.js
@@ -68,5 +68,6 @@ export default {
 
         return JailMonkey.trustFall();
     },
+    supportsFaceId: MattermostManaged.supportsFaceId,
     quitApp: MattermostManaged.quitApp,
 };

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -279,6 +279,7 @@
   "mobile.managed.jailbreak": "Jailbroken devices are not trusted by {vendor}, please exit the app.",
   "mobile.managed.not_secured.android": "This device must be secured with a screen lock to use Mattermost.",
   "mobile.managed.not_secured.ios": "This device must be secured with a passcode to use Mattermost.\n\nGo to Settings > Face ID & Passcode.",
+  "mobile.managed.not_secured.ios.touchId": "This device must be secured with a passcode to use Mattermost.\n\nGo to Settings > Touch ID & Passcode.",
   "mobile.managed.secured_by": "Secured by {vendor}",
   "mobile.managed.settings": "Go to settings",
   "mobile.markdown.code.copy_code": "Copy Code",

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -7,6 +7,7 @@
 //
 
 #import "MattermostManaged.h"
+#import <LocalAuthentication/LocalAuthentication.h>
 #import <UploadAttachments/MMMConstants.h>
 
 @implementation MattermostManaged {
@@ -165,6 +166,19 @@ RCT_EXPORT_METHOD(isRunningInSplitView:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(quitApp)
 {
   exit(0);
+}
+
+RCT_EXPORT_METHOD(supportsFaceId:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  LAContext *context = [[LAContext alloc] init];
+  NSError *error;
+
+  // context.biometryType is initialized when canEvaluatePolicy, regardless of the error or return value
+  [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error];
+
+  resolve(@{
+            @"supportsFaceId": @(context.biometryType == LABiometryTypeFaceID && @available(iOS 11.0, *))
+            });
 }
 
 @end

--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -47,9 +47,16 @@ class ShareViewController: SLComposeServiceViewController {
     var error: NSError?
     if !context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
       if let error = error, error.code == kLAErrorPasscodeNotSet {
+        var message = "This device must be secured with a passcode to use Mattermost.\n\nGo to Settings > Touch ID & Passcode."
+        if #available(iOS 11.0, *) {
+          if (context.biometryType == LABiometryType.faceID) {
+            message = "This device must be secured with a passcode to use Mattermost.\n\nGo to Settings > Face ID & Passcode."
+          }
+        }
+
         self.showErrorMessage(
           title: "",
-          message: "This device must be secured with a passcode to use Mattermost.\n\nGo to Settings > Face ID & Passcode.",
+          message: message,
           VC: self
         )
       } else {


### PR DESCRIPTION
The previous help text told the user to go to the "Touch ID & Passcode" section of the settings, even if the device didn't support Touch ID. This fixes that by checking whether or not the phone supports Touch ID.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17589

#### Checklist
- Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone 6, iPad Pro, iPhone 7 Simulator, iPhone X Simulator