### PR TITLE
Fix regression close/leave/archive channel redirect to channel screen on Android

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
 import {
     Alert,
-    Platform,
     ScrollView,
     View,
 } from 'react-native';
@@ -120,11 +119,8 @@ export default class ChannelInfo extends PureComponent {
         if (redirect) {
             actions.setChannelDisplayName('');
         }
-        if (Platform.OS === 'android') {
-            actions.dismissModal();
-        } else {
-            actions.popTopScreen();
-        }
+
+        actions.popTopScreen();
     };
 
     goToChannelAddMembers = preventDoubleTap(() => {


### PR DESCRIPTION
#### Summary
The channel info screen on both Android and iOS is now pushed to the stack, on previous versions for Android it was opened as a modal. This PR will cause the screen to be popped on both Android and iOS alike when closing/leaving/archiving a channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17880