### PR TITLE
[MM-17970] Check for valid server URL

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -38,6 +38,13 @@ public class ReceiptDelivery {
                 if (map != null) {
                     String token = map.getString("password");
                     String serverUrl = map.getString("service");
+                    if (serverUrl.isEmpty()) {
+                        String[] credentials = token.split(",[ ]*");
+                        if (credentials.length == 2) {
+                            token = credentials[0];
+                            serverUrl = credentials[1];
+                        }
+                    }
 
                     Log.i("ReactNative", String.format("Send receipt delivery ACK=%s TYPE=%s to URL=%s with TOKEN=%s", ackId, type, serverUrl, token));
                     execute(serverUrl, token, ackId, type);

--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -11,6 +11,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.HttpUrl;
 
 import org.json.JSONObject;
 import org.json.JSONException;
@@ -64,21 +65,24 @@ public class ReceiptDelivery {
             return;
         }
 
-        final OkHttpClient client = new OkHttpClient();
-        final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-        RequestBody body = RequestBody.create(JSON, json.toString());
-        Request request = new Request.Builder()
-                .header("Authorization", String.format("Bearer %s", token))
-                .header("Content-Type", "application/json")
-                .url(String.format("%s/api/v4/notifications/ack", serverUrl.replaceAll("/$", "")))
-                .post(body)
-                .build();
+        final HttpUrl url = HttpUrl.parse(
+            String.format("%s/api/v4/notifications/ack", serverUrl.replaceAll("/$", "")));
+        if (url != null) {
+            final OkHttpClient client = new OkHttpClient();
+            final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+            RequestBody body = RequestBody.create(JSON, json.toString());
+            Request request = new Request.Builder()
+                    .header("Authorization", String.format("Bearer %s", token))
+                    .header("Content-Type", "application/json")
+                    .url(url)
+                    .post(body)
+                    .build();
 
-        try {
-            client.newCall(request).execute();
-        } catch (Exception e) {
-            Log.e("ReactNative", "Receipt delivery failed to send");
+            try {
+                client.newCall(request).execute();
+            } catch (Exception e) {
+                Log.e("ReactNative", "Receipt delivery failed to send");
+            }
         }
-
     }
 }


### PR DESCRIPTION
#### Summary
As part of the app initialization refactoring of 1.22, the server URL is now stored in AsyncStorage when the app is first launched. When a push notification is received we grab that server URL to send an ack request, however, the app was crashing in the scenario where the app was upgraded to 1.22 but not yet relaunched and push notifications were being received. This PR fixes the crash by falling back to extracting the server URL from the token and also checking that the server URL is valid.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17970

#### Device Information
This PR was tested on:
* Emulator, Android 8.1
