### PR TITLE
MM-17792 Do not show download option for files uploaded locally

### DIFF
--- a/app/screens/image_preview/__snapshots__/image_preview.test.js.snap
+++ b/app/screens/image_preview/__snapshots__/image_preview.test.js.snap
@@ -234,6 +234,8 @@ exports[`ImagePreview should match snapshot 1`] = `
 </AnimatedComponent>
 `;
 
+exports[`ImagePreview should match snapshot and not renderDownloadButton for local files 1`] = `null`;
+
 exports[`ImagePreview should match snapshot, renderDownloadButton 1`] = `
 <TouchableOpacity
   activeOpacity={0.2}

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -227,6 +227,11 @@ export default class ImagePreview extends PureComponent {
         const {canDownloadFiles} = this.props;
         const file = this.getCurrentFile();
 
+        if (file?.data?.localPath) {
+            // we already have the file locally we don't need to download it
+            return null;
+        }
+
         if (file) {
             let icon;
             let action = emptyFunction;

--- a/app/screens/image_preview/image_preview.test.js
+++ b/app/screens/image_preview/image_preview.test.js
@@ -67,6 +67,21 @@ describe('ImagePreview', () => {
         expect(wrapper.instance().renderDownloadButton()).toMatchSnapshot();
     });
 
+    test('should match snapshot and not renderDownloadButton for local files', () => {
+        const props = {
+            ...baseProps,
+            files: [{caption: 'Caption 1', source: 'source', data: {localPath: 'path'}}],
+        };
+
+        const wrapper = shallow(
+            <ImagePreview {...props}/>,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        expect(wrapper.instance().renderDownloadButton()).toMatchSnapshot();
+        expect(wrapper.instance().renderDownloadButton()).toBeNull();
+    });
+
     test('should match state on handleChangeImage', () => {
         const wrapper = shallow(
             <ImagePreview {...baseProps}/>,


### PR DESCRIPTION
#### Summary
Do not show the option to download a file when the file was uploaded from the same device unless the cache is cleared

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17792
