### PR TITLE
MM-17886 Do not wait to cancel the video download

### DIFF
--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -282,19 +282,16 @@ export default class Downloader extends PureComponent {
             if (this.mounted) {
                 this.setState({
                     progress: 100,
-                }, () => {
-                    // need to wait a bit for the progress circle UI to update to the give progress
-                    setTimeout(async () => {
-                        if (this.state.didCancel) {
-                            try {
-                                await RNFetchBlob.fs.unlink(path);
-                            } finally {
-                                this.props.onDownloadCancel();
-                            }
-                        } else {
-                            this.props.onDownloadSuccess();
+                }, async () => {
+                    if (this.state.didCancel) {
+                        try {
+                            await RNFetchBlob.fs.unlink(path);
+                        } finally {
+                            this.downloadDidCancel();
                         }
-                    }, 2000);
+                    } else {
+                        this.props.onDownloadSuccess();
+                    }
                 });
             }
 
@@ -306,7 +303,9 @@ export default class Downloader extends PureComponent {
         } catch (error) {
             // cancellation throws so we need to catch
             if (downloadPath) {
-                RNFetchBlob.fs.unlink(getLocalFilePathFromFile(downloadPath, file));
+                RNFetchBlob.fs.unlink(getLocalFilePathFromFile(downloadPath, file)).catch(() => {
+                    // do nothing
+                });
             }
             if (error.message !== 'cancelled' && this.mounted) {
                 this.showDownloadFailedAlert();


### PR DESCRIPTION
#### Summary
Once we cancelled the download there was a 2 second wait to actually remove and trigger the cancel callback, this gave time to a race condition if we initiated the download once again, thus the file downloaded was incomplete and the video failed to playback.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17886
