### PR TITLE
[MM-17873] Update attachment image when image url is updated

### DIFF
--- a/app/components/message_attachments/attachment_image/attachment_image.js
+++ b/app/components/message_attachments/attachment_image/attachment_image.js
@@ -48,6 +48,12 @@ export default class AttachmentImage extends PureComponent {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.imageUrl && (nextProps.imageUrl !== this.props.imageUrl)) {
+            ImageCacheManager.cache(null, nextProps.imageUrl, this.setImageUrl);
+        }
+    }
+
     handlePreviewImage = () => {
         const {actions, imageUrl} = this.props;
         const {


### PR DESCRIPTION
#### Summary

This PR fixes the issue with the "Shuffle" feature of the giphy plugin on mobile, where the image never changes after the giphy response comes back.

The `imageUrl` prop is used to create the giphy image, only when the `AttachmentImage` component is mounted. When the post is updated through a `post_edited` ws message from the giphy response, the `imageUrl` prop is changed, but isn't used to update the image.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17873

#### Checklist

- [ ] Has UI changes

#### Device Information
This PR was tested on:
Google Pixel 2, Android 
