### PR TITLE
Fix failing on lint due to merge conflict

### DIFF
--- a/app/screens/settings/notification_settings_mentions_keywords/notification_settings_mentions_keywords.test.js
+++ b/app/screens/settings/notification_settings_mentions_keywords/notification_settings_mentions_keywords.test.js
@@ -19,7 +19,6 @@ describe('NotificationSettingsMentionsKeywords', () => {
         isLandscape: false,
         onBack: jest.fn(),
         theme: Preferences.THEMES.default,
-        isLandscape: false,
     };
 
     test('should match snapshot', () => {


### PR DESCRIPTION
#### Summary
Fix failing on lint due to merge conflict

``Duplicate key 'isLandscape'.eslint(no-dupe-keys)``

#### Ticket Link
none