### PR TITLE
[MM-17513] Rebuild emojis when emojis change and use props.deviceWidth

### DIFF
--- a/app/components/emoji_picker/emoji_picker.js
+++ b/app/components/emoji_picker/emoji_picker.js
@@ -106,14 +106,14 @@ export default class EmojiPicker extends PureComponent {
 
         if (this.props.emojis !== nextProps.emojis) {
             this.rebuildEmojis = true;
-            this.deviceWidth = nextProps.deviceWidth;
+            this.setRebuiltEmojis();
         }
     }
 
-    setRebuiltEmojis = (searchBarAnimationComplete) => {
+    setRebuiltEmojis = (searchBarAnimationComplete = true) => {
         if (this.rebuildEmojis && searchBarAnimationComplete) {
             this.rebuildEmojis = false;
-            const emojis = this.renderableEmojis(this.props.emojisBySection, this.deviceWidth);
+            const emojis = this.renderableEmojis(this.props.emojisBySection, this.props.deviceWidth);
             this.setState({emojis});
         }
     }

--- a/app/components/emoji_picker/emoji_picker.test.js
+++ b/app/components/emoji_picker/emoji_picker.test.js
@@ -59,19 +59,17 @@ describe('components/emoji_picker/EmojiPicker', () => {
         expect(instance.rebuildEmojis).toBe(true);
     });
 
-    test('should set rebuildEmojis to true and new deviceWidth when emojis change', () => {
+    test('should rebuild emojis emojis when emojis change', () => {
         const wrapper = shallowWithIntl(<EmojiPicker {...baseProps}/>);
         const instance = wrapper.instance();
+        const renderableEmojis = jest.spyOn(instance, 'renderableEmojis');
 
         expect(instance.rebuildEmojis).toBe(undefined);
-        expect(instance.deviceWidth).toBe(undefined);
 
-        const newDeviceWidth = baseProps.deviceWidth * 2;
         const newEmojis = [{}];
-        wrapper.setProps({deviceWidth: newDeviceWidth, emojis: newEmojis});
+        wrapper.setProps({emojis: newEmojis});
 
-        expect(instance.rebuildEmojis).toBe(true);
-        expect(instance.deviceWidth).toBe(newDeviceWidth);
+        expect(renderableEmojis).toHaveBeenCalledWith(baseProps.emojisBySection, baseProps.deviceWidth);
     });
 
     test('should set rebuilt emojis when rebuildEmojis is true and searchBarAnimationComplete is true', () => {


### PR DESCRIPTION
#### Summary
Fixes PR https://github.com/mattermost/mattermost-mobile/pull/3191

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17513

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iOS simulator, 12.3
