### PR TITLE
[MM-18172] Added state for message length such that alerts for long length aren't fired too often

### DIFF
--- a/app/components/post_textbox/post_textbox.test.js
+++ b/app/components/post_textbox/post_textbox.test.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {Alert} from 'react-native';
 import assert from 'assert';
 import {shallowWithIntl} from 'test/intl-test-helper';
 
@@ -13,6 +14,12 @@ import SendButton from 'app/components/send_button';
 import PostTextbox from './post_textbox.ios';
 
 jest.mock('NativeEventEmitter');
+
+jest.mock('Alert', () => {
+    return {
+        alert: jest.fn(),
+    };
+});
 
 describe('PostTextBox', () => {
     const baseProps = {
@@ -89,6 +96,21 @@ describe('PostTextBox', () => {
         instance.handleAppStateChange('background');
         expect(baseProps.actions.handlePostDraftChanged).toHaveBeenCalledWith(baseProps.channelId, value);
         expect(baseProps.actions.handlePostDraftChanged).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not send multiple alerts when message is too long', () => {
+        const wrapper = shallowWithIntl(
+            <PostTextbox {...baseProps}/>
+        );
+
+        const instance = wrapper.instance();
+        const longString = [...Array(baseProps.maxMessageLength + 2).keys()].map(() => Math.random().toString(36).slice(0, 1)).join('');
+
+        instance.handleTextChange(longString);
+        instance.handleTextChange(longString.slice(1));
+
+        expect(Alert.alert).toBeCalled();
+        expect(Alert.alert).toHaveBeenCalledTimes(1);
     });
 
     test('should return correct @all (same for @channel)', () => {

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -106,6 +106,7 @@ export default class PostTextBoxBase extends PureComponent {
             top: 0,
             value: props.value,
             channelTimezoneCount: 0,
+            isMessageTooLong: false,
         };
     }
 
@@ -192,19 +193,25 @@ export default class PostTextBoxBase extends PureComponent {
         const valueLength = value.trim().length;
 
         if (valueLength > maxMessageLength) {
-            Alert.alert(
-                intl.formatMessage({
-                    id: 'mobile.message_length.title',
-                    defaultMessage: 'Message Length',
-                }),
-                intl.formatMessage({
-                    id: 'mobile.message_length.message',
-                    defaultMessage: 'Your current message is too long. Current character count: {max}/{count}',
-                }, {
-                    max: maxMessageLength,
-                    count: valueLength,
-                })
-            );
+            // Check if component is already aware message is too long
+            if (!this.state.isMessageTooLong) {
+                Alert.alert(
+                    intl.formatMessage({
+                        id: 'mobile.message_length.title',
+                        defaultMessage: 'Message Length',
+                    }),
+                    intl.formatMessage({
+                        id: 'mobile.message_length.message',
+                        defaultMessage: 'Your current message is too long. Current character count: {max}/{count}',
+                    }, {
+                        max: maxMessageLength,
+                        count: valueLength,
+                    })
+                );
+                this.setState({isMessageTooLong: true});
+            }
+        } else if (this.state.isMessageTooLong) {
+            this.setState({isMessageTooLong: false});
         }
     };
 

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -106,7 +106,7 @@ export default class PostTextBoxBase extends PureComponent {
             top: 0,
             value: props.value,
             channelTimezoneCount: 0,
-            isMessageTooLong: false,
+            longMessageAlertShown: false,
         };
     }
 
@@ -194,7 +194,7 @@ export default class PostTextBoxBase extends PureComponent {
 
         if (valueLength > maxMessageLength) {
             // Check if component is already aware message is too long
-            if (!this.state.isMessageTooLong) {
+            if (!this.state.longMessageAlertShown) {
                 Alert.alert(
                     intl.formatMessage({
                         id: 'mobile.message_length.title',
@@ -208,10 +208,10 @@ export default class PostTextBoxBase extends PureComponent {
                         count: valueLength,
                     })
                 );
-                this.setState({isMessageTooLong: true});
+                this.setState({longMessageAlertShown: true});
             }
-        } else if (this.state.isMessageTooLong) {
-            this.setState({isMessageTooLong: false});
+        } else if (this.state.longMessageAlertShown) {
+            this.setState({longMessageAlertShown: false});
         }
     };
 


### PR DESCRIPTION
#### Summary
The current implementation was checking and sending an alert each time a user changed the value of the textbox, if the message was too long. This PR makes sure only one alert is sent when a message of large length is added. It will only fire an alert when the message has gone from being of proper length (or 0) to too long.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18172

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: 
Android Emulator, Pixel 2 Android Q
iOS Simulator, iPhone XS iOS 12.4
