### PR TITLE
[MM-18174] Replicated missing user functionality for system messages from webapp in RN

### DIFF
--- a/app/components/combined_system_message/combined_system_message.js
+++ b/app/components/combined_system_message/combined_system_message.js
@@ -241,12 +241,16 @@ export default class CombinedSystemMessage extends React.PureComponent {
     getUsernamesByIds = (userIds = []) => {
         const {currentUserId, currentUsername} = this.props;
         const allUsernames = this.getAllUsernames();
+
+        const {formatMessage} = this.context.intl;
+        const someone = formatMessage({id: t('channel_loader.someone'), defaultMessage: 'Someone'});
+
         const usernames = userIds.
             filter((userId) => {
                 return userId !== currentUserId && userId !== currentUsername;
             }).
             map((userId) => {
-                return `@${allUsernames[userId]}`;
+                return allUsernames[userId] ? `@${allUsernames[userId]}` : someone;
             }).filter((username) => {
                 return username && username !== '';
             });


### PR DESCRIPTION
#### Summary
In the mobile app, if a user who isn't loaded joined the channel, the system message will read `@undefined joined the channel`. This PR changes that message to `Someone joined the channel` to reflect what is already done in the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18174

#### Device Information
This PR was tested on: iOS Simulator, iPhone X iOS 12.4
