### PR TITLE
[MM-18336] Upload Sentry debug symbols only when SENTRY_ENABLED is true

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,7 +79,6 @@ project.ext.react = [
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
-apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
 
 if (System.getenv("SENTRY_ENABLED") == "true") {
@@ -87,6 +86,8 @@ if (System.getenv("SENTRY_ENABLED") == "true") {
         logLevel: "error",
         flavorAware: false
     ]
+
+    apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 }
 
 /**

--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* MattermostTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* MattermostTests.m */; };
 		0111A42B7F264BCF8CBDE3ED /* OpenSans-ExtraBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FBBEC29EE2D3418D9AC33BD5 /* OpenSans-ExtraBoldItalic.ttf */; };
@@ -547,7 +548,6 @@
 		E59E66631218605BDAE6978E /* Pods-MattermostTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MattermostTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MattermostTests/Pods-MattermostTests.release.xcconfig"; sourceTree = "<group>"; };
 		E94C0BF2B231F5A5425C51F7 /* libPods-Mattermost.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Mattermost.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBBEC29EE2D3418D9AC33BD5 /* OpenSans-ExtraBoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-ExtraBoldItalic.ttf"; path = "../assets/fonts/OpenSans-ExtraBoldItalic.ttf"; sourceTree = "<group>"; };
-		81061F4CBB31484A94D5A8EE /* libz.tbd */ = {isa = PBXFileReference; name = "libz.tbd"; path = "usr/lib/libz.tbd"; sourceTree = SDKROOT; fileEncoding = undefined; lastKnownFileType = sourcecode.text-based-dylib-definition; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -993,7 +993,6 @@
 				AE4769B235D14E6C9C64EA78 /* Upload Debug Symbols to Sentry */,
 				7FFE32A91FD9CB650038C7A0 /* Embed App Extensions */,
 				495276E541DD0DE6670D28F8 /* [CP] Copy Pods Resources */,
-				E845A3E675044BE39B90E97D /* Upload Debug Symbols to Sentry */,
 			);
 			buildRules = (
 			);
@@ -1663,20 +1662,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		E845A3E675044BE39B90E97D /* Upload Debug Symbols to Sentry */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Upload Debug Symbols to Sentry";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -122,7 +122,7 @@ PODS:
     - React
   - RNReactNativeDocViewer (1.0.0):
     - React
-  - RNSentry (1.0.0):
+  - RNSentry (1.0.4):
     - React
     - Sentry (~> 4.4.0)
   - RNSVG (9.4.0):

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -122,7 +122,7 @@ PODS:
     - React
   - RNReactNativeDocViewer (1.0.0):
     - React
-  - RNSentry (1.0.0-beta.5):
+  - RNSentry (1.0.0):
     - React
     - Sentry (~> 4.4.0)
   - RNSVG (9.4.0):

--- a/package-lock.json
+++ b/package-lock.json
@@ -3302,9 +3302,9 @@
       }
     },
     "@sentry/react-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-1.0.0.tgz",
-      "integrity": "sha512-FP9wTMctFLqXwW200TsXUdfDxXjJ3hgTc9BCtlv+pPiwmI00N2Efu6ox32reYuyv0ycj4Bm66MVqZ8CrdbLigQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-1.0.4.tgz",
+      "integrity": "sha512-k4peP4WUtLpU7JcN3X2I7s299VgTkN7oWBJIj8RT85G8o2dVD6rZEyoTi7GLISVbWe0TMgQ4PRtWmOBoZbyzdw==",
       "requires": {
         "@sentry/browser": "^5.6.3",
         "@sentry/core": "^5.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,13 +3229,13 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.5.0.tgz",
-      "integrity": "sha512-QZw4EXK47Qp9Q+vNpL5H4P4tYyfAN8qpWWeLIM0RDiNLlOugTVUdkfkeNTEJZ9VlqJ5RLx/2G/PITG4R6pwh/A==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.6.3.tgz",
+      "integrity": "sha512-bP1LTbcKPOkkmfJOAM6c7WZ0Ov0ZEW6B9keVZ9wH9fw/lBPd9UyDMDCwJ+FAYKz9M9S5pxQeJ4Ebd7WUUrGVAQ==",
       "requires": {
-        "@sentry/core": "5.5.0",
-        "@sentry/types": "5.5.0",
-        "@sentry/utils": "5.5.0",
+        "@sentry/core": "5.6.2",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
         "tslib": "^1.9.3"
       }
     },
@@ -3260,71 +3260,71 @@
       }
     },
     "@sentry/core": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.5.0.tgz",
-      "integrity": "sha512-xOcBud0t5mfhFdyd2tQQti4uuWSrLiJihpXzxeRpdCfk2ic+xmpeQs3G4UqnluvQDc48ug/Igt7LXfSBRBx4eg==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.6.2.tgz",
+      "integrity": "sha512-grbjvNmyxP5WSPR6UobN2q+Nss7Hvz+BClBT8QTr7VTEG5q89TwNddn6Ej3bGkaUVbct/GpVlI3XflWYDsnU6Q==",
       "requires": {
-        "@sentry/hub": "5.5.0",
-        "@sentry/minimal": "5.5.0",
-        "@sentry/types": "5.5.0",
-        "@sentry/utils": "5.5.0",
+        "@sentry/hub": "5.6.1",
+        "@sentry/minimal": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.5.0.tgz",
-      "integrity": "sha512-+jKh5U1nv8ufoquGciWoZPOmKuEjFPH5m0VifCs6t3NcEbAq2qnfF26KUGqhUNznlUN/PkbWB4qMfKn14uNE2Q==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.6.1.tgz",
+      "integrity": "sha512-m+OhkIV5yTAL3R1+XfCwzUQka0UF/xG4py8sEfPXyYIcoOJ2ZTX+1kQJLy8QQJ4RzOBwZA+DzRKP0cgzPJ3+oQ==",
       "requires": {
-        "@sentry/types": "5.5.0",
-        "@sentry/utils": "5.5.0",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.5.0.tgz",
-      "integrity": "sha512-27B2CZEER50h5BIA7z32Cg80oD4UsVrreKglqpHLrhKhJ7KpoY3VhlEIEsoGclUyNuLXs1KtI0Op33EsgUpCxA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.6.1.tgz",
+      "integrity": "sha512-bPtJbmhLDH9Exy0luIKxjlfqmuyAjUPTHZ2CLIw6YlhA5WgK9aYyyjLHTmWK+E9baZBqSp0ShVPAgue2jfpQmQ==",
       "requires": {
-        "@sentry/types": "5.5.0",
-        "@sentry/utils": "5.5.0",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.5.0.tgz",
-      "integrity": "sha512-o6O30+/pNrO7fTgwKxgZynHB7cMScJlw9HXgnNXgLXS6LBiqjYCQfVnWAgV//SyyG0uUlcjH3P6PnV6TsJOmVQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.6.1.tgz",
+      "integrity": "sha512-ercCKuBWHog6aS6SsJRuKhJwNdJ2oRQVWT2UAx1zqvsbHT9mSa8ZRjdPHYOtqY3DoXKk/pLUFW/fkmAnpdMqRw==",
       "requires": {
-        "@sentry/hub": "5.5.0",
-        "@sentry/types": "5.5.0",
+        "@sentry/hub": "5.6.1",
+        "@sentry/types": "5.6.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/react-native": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-1.0.0-beta.5.tgz",
-      "integrity": "sha512-mtWYfwE1We8b7dS9vVhvkdjtlxTeVzgBSZKRvuIUhNL7iG90mGHa/+nUsLJU38dpnA2xYVSwfxp8JHo4DJjIsg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-1.0.0.tgz",
+      "integrity": "sha512-FP9wTMctFLqXwW200TsXUdfDxXjJ3hgTc9BCtlv+pPiwmI00N2Efu6ox32reYuyv0ycj4Bm66MVqZ8CrdbLigQ==",
       "requires": {
-        "@sentry/browser": "^5.5.0",
-        "@sentry/core": "^5.5.0",
-        "@sentry/integrations": "^5.5.0",
-        "@sentry/types": "^5.5.0",
-        "@sentry/utils": "^5.5.0",
+        "@sentry/browser": "^5.6.3",
+        "@sentry/core": "^5.6.2",
+        "@sentry/integrations": "^5.6.1",
+        "@sentry/types": "^5.6.1",
+        "@sentry/utils": "^5.6.1",
         "@sentry/wizard": "^1.0.0"
       }
     },
     "@sentry/types": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.5.0.tgz",
-      "integrity": "sha512-3otF/miVDth91o+iign00x0o31McUPeyIFbMjLbgeTRRW9rXpu2jGrcRrvHfofECtoqCf5Y734hwvvlBvFZeIw=="
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.6.1.tgz",
+      "integrity": "sha512-Kub8TETefHpdhvtnDj3kKfhCj0u/xn3Zi2zIC7PB11NJHvvPXENx97tciz4roJGp7cLRCJsFqCg4tHXniqDSnQ=="
     },
     "@sentry/utils": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.5.0.tgz",
-      "integrity": "sha512-gO8Bs/QcKDn7ncc2f2fIOTPx2AiZKrGj4us1Yxu6mBU8JZqMQRl9XjDMFAUECJQvquBAta+TFJyYj71ZedeQUQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.6.1.tgz",
+      "integrity": "sha512-rfgha+UsHW816GqlSRPlniKqAZylOmQWML2JsujoUP03nPu80zdN43DK9Poy/d9OxBxv0gd5K2n+bFdM2kqLQQ==",
       "requires": {
-        "@sentry/types": "5.5.0",
+        "@sentry/types": "5.6.1",
         "tslib": "^1.9.3"
       }
     },
@@ -3371,9 +3371,9 @@
           }
         },
         "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
           "requires": {
             "ansi-escapes": "^3.2.0",
             "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "7.5.5",
     "@react-native-community/async-storage": "1.4.0",
     "@react-native-community/netinfo": "3.1.3",
-    "@sentry/react-native": "1.0.0-beta.5",
+    "@sentry/react-native": "1.0.0",
     "analytics-react-native": "1.2.0",
     "commonmark": "github:mattermost/commonmark.js#52053271715afbb515d96c74e0d8a4292f4d9e4a",
     "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "7.5.5",
     "@react-native-community/async-storage": "1.4.0",
     "@react-native-community/netinfo": "3.1.3",
-    "@sentry/react-native": "1.0.0",
+    "@sentry/react-native": "1.0.4",
     "analytics-react-native": "1.2.0",
     "commonmark": "github:mattermost/commonmark.js#52053271715afbb515d96c74e0d8a4292f4d9e4a",
     "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",


### PR DESCRIPTION
#### Summary
Upgraded to the latest @sentry/react-native and made changes to ensure that the debug symbols only upload when Sentry is enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18336

#### Device Information
This PR was tested on:
* Android emulator, 8.1
* iOS simulator, 12.3
