### PR TITLE
Update webview library to remove deprecated API

### DIFF
--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -117,10 +117,9 @@ class SSO extends PureComponent {
     goToChannel = () => {
         tracker.initialLoad = Date.now();
 
-        setTimeout(() => {
-            this.scheduleSessionExpiredNotification();
-            this.props.actions.resetToChannel();
-        }, 1000);
+        this.scheduleSessionExpiredNotification();
+
+        this.props.actions.resetToChannel();
     };
 
     onMessage = (event) => {
@@ -196,9 +195,7 @@ class SSO extends PureComponent {
     };
 
     renderLoading = () => {
-        return (
-            <Loading/>
-        );
+        return <Loading/>;
     };
 
     webViewRef = (ref) => {

--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -117,9 +117,10 @@ class SSO extends PureComponent {
     goToChannel = () => {
         tracker.initialLoad = Date.now();
 
-        this.scheduleSessionExpiredNotification();
-
-        this.props.actions.resetToChannel();
+        setTimeout(() => {
+            this.scheduleSessionExpiredNotification();
+            this.props.actions.resetToChannel();
+        }, 1000);
     };
 
     onMessage = (event) => {
@@ -195,7 +196,9 @@ class SSO extends PureComponent {
     };
 
     renderLoading = () => {
-        return <Loading/>;
+        return (
+            <Loading/>
+        );
     };
 
     webViewRef = (ref) => {
@@ -226,11 +229,9 @@ class SSO extends PureComponent {
                     startInLoadingState={true}
                     onNavigationStateChange={this.onNavigationStateChange}
                     onShouldStartLoadWithRequest={() => true}
-                    renderLoading={this.renderLoading}
                     injectedJavaScript={jsCode}
                     onLoadEnd={this.onLoadEnd}
                     onMessage={messagingEnabled ? this.onMessage : null}
-                    useWebKit={this.useWebkit}
                     useSharedProcessPool={true}
                     cacheEnabled={true}
                 />

--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -63,7 +63,6 @@
 		7F240ADB220E089300637665 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F240ADA220E089300637665 /* Item.swift */; };
 		7F240ADD220E094A00637665 /* TeamsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F240ADC220E094A00637665 /* TeamsViewController.swift */; };
 		7F2691A11EE1DC6A007574FE /* libRNNotifications.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F2691A01EE1DC51007574FE /* libRNNotifications.a */; };
-		7F26C1CC219C463D00FEB42D /* libRNCWebView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F26C1CB219C463300FEB42D /* libRNCWebView.a */; };
 		7F292A711E8AB73400A450A3 /* SplashScreenResource in Resources */ = {isa = PBXBuildFile; fileRef = 7F292A701E8AB73400A450A3 /* SplashScreenResource */; };
 		7F292AA61E8ABB1100A450A3 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7F292AA41E8ABB1100A450A3 /* LaunchScreen.xib */; };
 		7F292AA71E8ABB1100A450A3 /* splash.png in Resources */ = {isa = PBXBuildFile; fileRef = 7F292AA51E8ABB1100A450A3 /* splash.png */; };
@@ -94,6 +93,7 @@
 		7FABE04622137F5C00D0F595 /* libUploadAttachments.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FABE04522137F2A00D0F595 /* libUploadAttachments.a */; };
 		7FABE0562213884700D0F595 /* libUploadAttachments.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FABE04522137F2A00D0F595 /* libUploadAttachments.a */; };
 		7FBB5E9B1E1F5A4B000DE18A /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FDF290C1E1F4B4E00DBBE56 /* libRNVectorIcons.a */; };
+		7FD1DD0823273C6000E0D948 /* libRNCWebView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F26C1CB219C463300FEB42D /* libRNCWebView.a */; };
 		7FDB92B11F706F58006CDFD1 /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FDB92A71F706F45006CDFD1 /* libRNImagePicker.a */; };
 		7FEB10981F6101710039A015 /* BlurAppScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FEB10971F6101710039A015 /* BlurAppScreen.m */; };
 		7FEB109D1F61019C0039A015 /* MattermostManaged.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FEB109A1F61019C0039A015 /* MattermostManaged.m */; };
@@ -955,7 +955,7 @@
 				7FDB92B11F706F58006CDFD1 /* libRNImagePicker.a in Frameworks */,
 				7F5CA9A0208FE3B9004F91CE /* libRNDocumentPicker.a in Frameworks */,
 				7F43D5DE1F6BF96A001FC614 /* libRCTYouTube.a in Frameworks */,
-				7F26C1CC219C463D00FEB42D /* libRNCWebView.a in Frameworks */,
+				7FD1DD0823273C6000E0D948 /* libRNCWebView.a in Frameworks */,
 				7F88A04422270FD400DC5DE2 /* libRNSentry.a in Frameworks */,
 				7F43D6061F6BF9EB001FC614 /* libPods-Mattermost.a in Frameworks */,
 				A9B746D2CFA9CEBFB8AE2B5B /* libPods-Mattermost.a in Frameworks */,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16898,8 +16898,8 @@
       }
     },
     "react-native-webview": {
-      "version": "github:mattermost/react-native-webview#34e1dbef70413134ddda85df863c962f24b8826e",
-      "from": "github:mattermost/react-native-webview#34e1dbef70413134ddda85df863c962f24b8826e",
+      "version": "github:mattermost/react-native-webview#b5e22940a613869d3999feac9451ee65352f4fbe",
+      "from": "github:mattermost/react-native-webview#b5e22940a613869d3999feac9451ee65352f4fbe",
       "requires": {
         "escape-string-regexp": "1.0.5",
         "invariant": "2.2.4"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-native-svg": "9.4.0",
     "react-native-vector-icons": "6.4.2",
     "react-native-video": "4.4.1",
-    "react-native-webview": "github:mattermost/react-native-webview#34e1dbef70413134ddda85df863c962f24b8826e",
+    "react-native-webview": "github:mattermost/react-native-webview#b5e22940a613869d3999feac9451ee65352f4fbe",
     "react-native-youtube": "github:mattermost/react-native-youtube#3f395b620ae4e05a3f1c6bdeef3a1158e78daadc",
     "react-navigation": "3.9.1",
     "react-redux": "7.0.3",


### PR DESCRIPTION
#### Summary
This PR fixes the warning given by Apple when deploying the app to TestFlilght

```
Dear Developer,

We identified one or more issues with a recent delivery for your app, "Mattermost Beta" 1.23.0 (229). Your delivery was successful, but you may wish to correct the following issues in your next delivery:

ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs . See https://developer.apple.com/documentation/uikit/uiwebview for more information.

After you’ve corrected the issues, you can use Xcode or Application Loader to upload a new binary to App Store Connect.

Best regards,

The App Store Team
```