### PR TITLE
MM-18226 Set moment timezone locale as needed to prevent moment and intl locale getting out of sync

### DIFF
--- a/app/i18n/index.js
+++ b/app/i18n/index.js
@@ -108,10 +108,26 @@ function loadTranslation(locale) {
     }
 }
 
+let momentLocale = 'en';
+
+function setMomentLocale(locale) {
+    try {
+        if (momentLocale !== locale) {
+            moment.locale(locale);
+            momentLocale = locale;
+        }
+    } catch (e) {
+        console.error('No moment translation found', e); //eslint-disable-line no-console
+    }
+}
+
 export function getTranslations(locale) {
     if (!TRANSLATIONS[locale]) {
         loadTranslation(locale);
     }
+
+    setMomentLocale(locale.toLowerCase());
+
     return TRANSLATIONS[locale] || TRANSLATIONS[DEFAULT_LOCALE];
 }
 


### PR DESCRIPTION
#### Summary
In some cases, especially when logging out of an account using a non-English language and into another one using English, the timezone locale and the react-intl locale would get out of sync.

Not sure of a good way to unit test this (besides the basic functionality), open to suggestions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18226