### PR TITLE
MM-18372 Fix edit profile screen being dismissed when removing profile picture

### DIFF
--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -258,7 +258,6 @@ export default class EditProfile extends PureComponent {
     handleRemoveProfileImage = () => {
         this.setState({profileImageRemove: true});
         this.emitCanUpdateAccount(true);
-        this.props.actions.dismissModal();
     }
 
     uploadProfileImage = async () => {


### PR DESCRIPTION
#### Summary
The screen was being dismissed when it should stay open and only complete changes if the user clicks 'Save'.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18372