### PR TITLE
MM-18353 Do not update the theme when resetting the cache

### DIFF
--- a/app/screens/settings/advanced_settings/advanced_settings.js
+++ b/app/screens/settings/advanced_settings/advanced_settings.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {PureComponent} from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {injectIntl, intlShape} from 'react-intl';
 import {
@@ -25,7 +25,7 @@ import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import Config from 'assets/config';
 
-class AdvancedSettings extends PureComponent {
+class AdvancedSettings extends Component {
     static propTypes = {
         actions: PropTypes.shape({
             dismissAllModals: PropTypes.func.isRequired,
@@ -43,6 +43,10 @@ class AdvancedSettings extends PureComponent {
 
     componentDidMount() {
         this.getDownloadCacheSize();
+    }
+
+    shouldComponentUpdate(nextProps) {
+        return this.props.theme === nextProps.theme;
     }
 
     clearOfflineCache = preventDoubleTap(() => {


### PR DESCRIPTION
#### Summary
When resetting the cache on the mobile app the theme changes so it uses the default one as there is no data in the redux store right after the cache is reset. This causes a momentary white screen to be displayed. (there is no way to avoid the screen from flashing white as the theme will eventually change while data is being loaded again) but with this PR at least we preserve the current theme in the Advanced settings screen so only the channel loader displays in white for a shorter period of time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18353