### PR TITLE
[MM-18365] When searching for profiles, allow inactive

### DIFF
--- a/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
+++ b/app/components/sidebars/main/channels_list/filtered_list/filtered_list.js
@@ -102,7 +102,7 @@ class FilteredList extends Component {
                     return;
                 }
 
-                searchProfiles(term);
+                searchProfiles(term, {allow_inactive: true});
                 searchChannels(currentTeam.id, term);
             }, General.SEARCH_TIMEOUT_MILLISECONDS);
         }


### PR DESCRIPTION
#### Summary
Enables the allow inactive option when searching for user profiles from the "jump to" search box

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18365
