### PR TITLE
MM-18588 Expand text input area in Android Share extension to use available space

### DIFF
--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -651,9 +651,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
         },
         scrollView: {
+            flex: 1,
             padding: 15,
         },
         input: {
+            flex: 1,
             color: theme.centerChannelColor,
             fontSize: 17,
             height: INPUT_HEIGHT,


### PR DESCRIPTION
#### Summary
Add `flex: 1` setting to TextInput/ScrollView in Share extension post window (Android) to utilize all available screen real estate, up to the Team and Channel selectors below.

#### Ticket Link
#3261 

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: OnePlus 5, Android 9

#### Screenshots

**Before**

<img width="486" alt="Screen Shot 2019-09-16 at 13 17 53" src="https://user-images.githubusercontent.com/887849/64975088-947ccb80-d884-11e9-99ef-98094b286d48.png">

**After**

<img width="503" alt="Screen Shot 2019-09-16 at 13 18 38" src="https://user-images.githubusercontent.com/887849/64975109-9f376080-d884-11e9-8925-fcbf37fd2dcf.png">

