### PR TITLE
MM-15469 (Android) Alert if shared text is longer than message limit

### DIFF
--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -453,6 +453,8 @@
   "mobile.share_extension.error_message": "An error has occurred while using the share extension.",
   "mobile.share_extension.error_title": "Extension Error",
   "mobile.share_extension.team": "Team",
+  "mobile.share_extension.too_long_message": "Character count: {count}/{max}",
+  "mobile.share_extension.too_long_title": "Message is too long",
   "mobile.sidebar_settings.permanent": "Permanent Sidebar",
   "mobile.sidebar_settings.permanent_description": "Keep the sidebar open permanently",
   "mobile.storage_permission_denied_description": "Upload files to your Mattermost instance. Open Settings to grant Mattermost Read and Write access to files on this device.",

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -452,7 +452,6 @@ export default class ExtensionPost extends PureComponent {
                 <TextInput
                     ref={this.getInputRef}
                     autoCapitalize='sentences'
-                    maxLength={MAX_MESSAGE_LENGTH}
                     multiline={true}
                     onBlur={this.handleBlur}
                     onChangeText={this.handleTextChange}

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -583,6 +583,29 @@ export default class ExtensionPost extends PureComponent {
         );
     };
 
+    lengthCounterColor = (count) => {
+        if (count < 0) {
+            return styles.textTooLong;
+        }
+        return styles.textLengthOk;
+    }
+
+    renderMessageLengthRemaining = () => {
+        const {value} = this.state;
+        const messageLengthRemaining = MAX_MESSAGE_LENGTH - value.length;
+
+        if (value.length === 0) {
+            return null;
+        }
+
+        const renderStyle = [styles.messageLengthRemaining, this.lengthCounterColor(messageLengthRemaining)];
+        return (
+            <Text style={renderStyle}>
+                {messageLengthRemaining}
+            </Text>
+        );
+    };
+
     render() {
         const {formatMessage} = this.context.intl;
         const {maxFileSize} = this.props;
@@ -627,6 +650,7 @@ export default class ExtensionPost extends PureComponent {
                     <View style={styles.wrapper}>
                         {this.renderBody()}
                         <View style={styles.flex}>
+                            {this.renderMessageLengthRemaining()}
                             {this.renderTeamButton()}
                             {this.renderChannelButton()}
                         </View>
@@ -670,6 +694,19 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         scrollView: {
             flex: 1,
             padding: 15,
+        },
+        messageLengthRemaining: {
+            paddingTop: 5,
+            paddingBottom: 5,
+            paddingLeft: 15,
+            paddingRight: 15,
+            opacity: 0.5,
+        },
+        textLengthOk: {
+            color: theme.centerChannelColor,
+        },
+        textTooLong: {
+            color: theme.errorTextColor,
         },
         input: {
             flex: 1,

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -406,17 +406,34 @@ export default class ExtensionPost extends PureComponent {
     onPost = () => {
         const {channelId, files, value} = this.state;
         const {currentUserId} = this.props;
+        const {formatMessage} = this.context.intl;
 
-        const data = {
-            channelId,
-            currentUserId,
-            files,
-            token: this.token,
-            url: this.url,
-            value,
-        };
+        if (value.length > MAX_MESSAGE_LENGTH) {
+            Alert.alert(
+                formatMessage({
+                    id: 'mobile.share_extension.too_long_title',
+                    defaultMessage: 'Message is too long',
+                }),
+                formatMessage({
+                    id: 'mobile.share_extension.too_long_message',
+                    defaultMessage: 'Character count: {count}/{max}',
+                }, {
+                    count: value.length,
+                    max: MAX_MESSAGE_LENGTH,
+                })
+            );
+        } else {
+            const data = {
+                channelId,
+                currentUserId,
+                files,
+                token: this.token,
+                url: this.url,
+                value,
+            };
 
-        this.onClose(data);
+            this.onClose(data);
+        }
     };
 
     renderBody = () => {

--- a/share_extension/android/extension_post/extension_post.test.js
+++ b/share_extension/android/extension_post/extension_post.test.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {Alert, PermissionsAndroid} from 'react-native';
+import {shallowWithIntl} from 'test/intl-test-helper';
+
+import ExtensionPost from './extension_post';
+
+jest.spyOn(Alert, 'alert').mockReturnValue(true);
+jest.spyOn(PermissionsAndroid, 'check').mockReturnValue(PermissionsAndroid.RESULTS.GRANTED);
+
+jest.mock('react-navigation-stack/dist/views/TouchableItem', () => {});
+
+jest.mock('NativeModules', () => ({
+    MattermostShare: {
+        close: jest.fn(),
+    },
+    RNKeychainManager: {
+        SECURITY_LEVEL_ANY: 'ANY',
+    },
+}));
+
+jest.mock('app/mattermost_managed', () => ({
+    getConfig: jest.fn().mockReturnValue(false),
+}));
+
+const MAX_MESSAGE_LENGTH = 4000;
+
+describe('ExtensionPost', () => {
+    const baseProps = {
+        actions: {
+            getTeamChannels: jest.fn(),
+        },
+        channelId: 'channel-id',
+        channels: {},
+        currentUserId: 'current-user-id',
+        maxFileSize: 1024,
+        navigation: {
+            setParams: jest.fn(),
+        },
+        teamId: 'team-id',
+    };
+
+    const wrapper = shallowWithIntl(
+        <ExtensionPost {...baseProps}/>
+    );
+
+    const instance = wrapper.instance();
+
+    const postMessage = (message) => {
+        wrapper.setState({value: message});
+        instance.onPost();
+    };
+
+    test('should show Alert dialog if shared message is longer than maximum length permitted', () => {
+        const longMessage = 'a'.repeat(MAX_MESSAGE_LENGTH + 1);
+        postMessage(longMessage);
+
+        expect(Alert.alert).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not show Alert dialog if shared message is within maximum length permitted', () => {
+        const message = 'a'.repeat(MAX_MESSAGE_LENGTH - 1);
+        postMessage(message);
+
+        expect(Alert.alert).not.toHaveBeenCalled();
+    });
+
+    test('should not show Alert dialog if shared message is at maximum length permitted', () => {
+        const exactLengthMessage = 'a'.repeat(MAX_MESSAGE_LENGTH);
+        postMessage(exactLengthMessage);
+
+        expect(Alert.alert).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
#### Summary
On Android, one can't manually enter text into the share extension's text box past 4000 characters (the default/defined text size limit). However, this restriction can still be circumvented by sharing a large item of text. In this latter case, the textarea displays just the first 4000 characters, but the value buffer still contains the entire shared text. On hitting "Send", the oversize text can still be posted.

This commit implements [MM-15469](https://mattermost.atlassian.net/browse/MM-15469) to better align the Android sharing user experience with the existing iOS experience.

Bonus: Additional widget to show number of available characters remaining until textarea limit (default = 4000). Similar to iOS experience.

~Since a pre-existing i18n string was used (`mobile.message_length.message`), no additional translations are required.~

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/11431

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: OnePlus 5, Android 9.

#### Screenshots

**Error alert (over share character limit)**

![ezgif-3-d930ab62d5da](https://user-images.githubusercontent.com/887849/65008625-5e6d3500-d8e0-11e9-8449-852490fae71e.gif)

| iOS (normal) - existing | Android (normal) - new |
| --- | --- |
| <img alt="iOS (normal)" width="487" src="https://user-images.githubusercontent.com/887849/65007527-d6d1f700-d8dc-11e9-9382-7e4b3c6f4f5d.png"> | <img alt="Android (normal)" width="487" src="https://user-images.githubusercontent.com/887849/65007570-f2d59880-d8dc-11e9-9795-ed137e4dd506.jpg"> |

| iOS (past limit) - existing | Android (past limit) - new |
| --- | --- |
| <img alt="iOS (past limit)" width="487" src="https://user-images.githubusercontent.com/887849/65007638-2b757200-d8dd-11e9-987d-f5e89b2aa0d3.png"> | <img alt="Android (past limit)" width="487" src="https://user-images.githubusercontent.com/887849/65007720-5e1f6a80-d8dd-11e9-97ba-370fa6c8db58.jpg"> |






