### PR TITLE
[MM-18550] Force drawer to open to channel menu when new teams are added

### DIFF
--- a/app/components/sidebars/main/drawer_swipper/drawer_swiper.js
+++ b/app/components/sidebars/main/drawer_swipper/drawer_swiper.js
@@ -52,6 +52,12 @@ export default class DrawerSwiper extends Component {
         }
     };
 
+    scrollToInitial = () => {
+        if (this.swiperRef?.current) {
+            this.swiperRef.current.scrollToInitial();
+        }
+    }
+
     swiperPageSelected = (index) => {
         this.props.onPageSelected(index);
     };

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -338,6 +338,7 @@ export default class ChannelSidebar extends Component {
         if (this.drawerSwiper) {
             if (multipleTeams) {
                 this.drawerSwiper.runOnLayout();
+                this.drawerSwiper.scrollToInitial();
             } else if (!openDrawerOffset) {
                 this.drawerSwiper.scrollToStart();
             }

--- a/app/components/swiper.js
+++ b/app/components/swiper.js
@@ -107,6 +107,14 @@ export default class Swiper extends PureComponent {
         });
     };
 
+    scrollToInitial = () => {
+        setTimeout(() => {
+            if (this.scrollView) {
+                this.scrollView.scrollTo({x: this.props.width * this.props.initialPage, animated: false});
+            }
+        }, 0);
+    };
+
     refScrollView = (view) => {
         this.scrollView = view;
     };


### PR DESCRIPTION
#### Summary
When a user is added to a new team where they didn't have a second one before, the teams page would be added to the `drawer_swiper` component, but the drawer position was not updated, thus it would open to the teams menu. This PR forcibly updates the drawer position such that the channel menu is still the first menu shown when opening the sidebar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18550

#### Device Information
This PR was tested on:
iOS Simulator, iPhone XS iOS 12.4
OnePlus 5, Android 9
