### PR TITLE
Automated cherry pick of #3268

### DIFF
--- a/app/init/global_event_handler.test.js
+++ b/app/init/global_event_handler.test.js
@@ -15,6 +15,12 @@ jest.mock('app/init/credentials', () => ({
     removeAppCredentials: jest.fn(),
 }));
 
+jest.mock('app/utils/error_handling', () => ({
+    default: {
+        initializeErrorHandling: jest.fn(),
+    },
+}));
+
 jest.mock('react-native-notifications', () => ({
     addEventListener: jest.fn(),
     cancelAllLocalNotifications: jest.fn(),
@@ -34,5 +40,47 @@ describe('GlobalEventHandler', () => {
 
         await GlobalEventHandler.onLogout();
         expect(clearNotifications).toHaveBeenCalled();
+    });
+
+    it('should call onAppStateChange after configuration', () => {
+        const onAppStateChange = jest.spyOn(GlobalEventHandler, 'onAppStateChange');
+
+        GlobalEventHandler.configure({store});
+        expect(GlobalEventHandler.store).not.toBeNull();
+        expect(onAppStateChange).toHaveBeenCalledWith('active');
+    });
+
+    it('should handle onAppStateChange to active if the store set', () => {
+        const appActive = jest.spyOn(GlobalEventHandler, 'appActive');
+        const appInactive = jest.spyOn(GlobalEventHandler, 'appInactive');
+        expect(GlobalEventHandler.store).not.toBeNull();
+
+        GlobalEventHandler.onAppStateChange('active');
+        expect(appActive).toHaveBeenCalled();
+        expect(appInactive).not.toHaveBeenCalled();
+    });
+
+    it('should handle onAppStateChange to background if the store set', () => {
+        const appActive = jest.spyOn(GlobalEventHandler, 'appActive');
+        const appInactive = jest.spyOn(GlobalEventHandler, 'appInactive');
+        expect(GlobalEventHandler.store).not.toBeNull();
+
+        GlobalEventHandler.onAppStateChange('background');
+        expect(appActive).not.toHaveBeenCalled();
+        expect(appInactive).toHaveBeenCalled();
+    });
+
+    it('should not handle onAppStateChange if the store is not set', () => {
+        const appActive = jest.spyOn(GlobalEventHandler, 'appActive');
+        const appInactive = jest.spyOn(GlobalEventHandler, 'appInactive');
+        GlobalEventHandler.store = null;
+
+        GlobalEventHandler.onAppStateChange('active');
+        expect(appActive).not.toHaveBeenCalled();
+        expect(appInactive).not.toHaveBeenCalled();
+
+        GlobalEventHandler.onAppStateChange('background');
+        expect(appActive).not.toHaveBeenCalled();
+        expect(appInactive).not.toHaveBeenCalled();
     });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -46,6 +46,9 @@ jest.mock('NativeModules', () => {
         RNReactNativeHapticFeedback: {
             trigger: jest.fn(),
         },
+        StatusBarManager: {
+            getHeight: jest.fn(),
+        },
     };
 });
 jest.mock('NativeEventEmitter');


### PR DESCRIPTION
Cherry pick of #3268 on release-1.24.

- #3268: Ensure onAppStateChange runs only after GlobalEventHandler is

/cc  @migbot