### PR TITLE
Updated Info.plist with new bluetooth usage description key

### DIFF
--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -56,6 +56,8 @@
 	</dict>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>Let Mattermost access your Media files</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Share post data accross devices with Mattermost</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Share post data accross devices with Mattermost</string>
 	<key>NSCalendarsUsageDescription</key>


### PR DESCRIPTION
#### Summary
`NSBluetoothPeripheralUsageDescription` is deprecated in iOS 13. Adding the new `NSBluetoothAlwaysUsageDescription` key to support that.
