### PR TITLE
GH-11948 Adding expand button to markdown tables

### DIFF
--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -127,7 +127,7 @@ export default class MarkdownTable extends React.PureComponent {
         }
 
         const expandButton = (
-            <TouchableOpacity
+            <TouchableWithFeedback
                 onPress={this.handlePress}
                 style={{...style.expandButton, left: this.state.containerWidth - 20}}
             >
@@ -135,12 +135,12 @@ export default class MarkdownTable extends React.PureComponent {
                     name={'expand'}
                     style={style.icon}
                 />
-            </TouchableOpacity>
+            </TouchableWithFeedback>
         );
 
         return (
             <TouchableWithFeedback
-                style={{paddingRight: 10}}
+                style={style.tablePadding}
                 onPress={this.handlePress}
                 type={'opacity'}
             >
@@ -189,6 +189,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderLeftWidth: 1,
             borderTopWidth: 1,
+        },
+        tablePadding: {
+            paddingRight: 10,
         },
         tableExtraBorders: {
             borderBottomWidth: 1,

--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -9,6 +9,7 @@ import {
     View,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
 import {CELL_WIDTH} from 'app/components/markdown/markdown_table_cell/markdown_table_cell';
 
@@ -107,7 +108,7 @@ export default class MarkdownTable extends React.PureComponent {
                     ]}
                     start={{x: 0, y: 0}}
                     end={{x: 1, y: 0}}
-                    style={style.moreRight}
+                    style={[style.moreRight, {height: this.state.contentHeight}]}
                 />
             );
         }
@@ -120,13 +121,26 @@ export default class MarkdownTable extends React.PureComponent {
                         changeOpacity(this.props.theme.centerChannelColor, 0.0),
                         changeOpacity(this.props.theme.centerChannelColor, 0.1),
                     ]}
-                    style={style.moreBelow}
+                    style={[style.moreBelow, {width: this.getTableWidth()}]}
                 />
             );
         }
 
+        const expandButton = (
+            <TouchableOpacity
+                onPress={this.handlePress}
+                style={{...style.expandButton, left: this.state.containerWidth - 20}}
+            >
+                <Icon
+                    name={'expand'}
+                    style={style.icon}
+                />
+            </TouchableOpacity>
+        );
+
         return (
             <TouchableWithFeedback
+                style={{paddingRight: 10}}
                 onPress={this.handlePress}
                 type={'opacity'}
             >
@@ -142,6 +156,7 @@ export default class MarkdownTable extends React.PureComponent {
                 </ScrollView>
                 {moreRight}
                 {moreBelow}
+                {expandButton}
             </TouchableWithFeedback>
         );
     }
@@ -155,6 +170,21 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderRightWidth: 1,
             maxHeight: MAX_HEIGHT,
         },
+        expandButton: {
+            height: 30,
+            width: 30,
+            borderWidth: 1,
+            paddingTop: 6,
+            paddingLeft: 7,
+            borderColor: changeOpacity(theme.centerChannelColor, 0.2),
+            borderRadius: 15,
+            bottom: 20,
+            backgroundColor: theme.centerChannelBg,
+        },
+        icon: {
+            fontSize: 15,
+            color: theme.linkColor,
+        },
         table: {
             borderColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderLeftWidth: 1,
@@ -165,16 +195,16 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderRightWidth: 1,
         },
         moreBelow: {
-            bottom: 0,
+            bottom: 30,
             height: 20,
             position: 'absolute',
-            right: 0,
+            left: 0,
             width: '100%',
         },
         moreRight: {
-            height: '100%',
+            maxHeight: MAX_HEIGHT,
             position: 'absolute',
-            right: 0,
+            right: 10,
             top: 0,
             width: 20,
         },


### PR DESCRIPTION
#### Summary
Adds a button on the bottom-right corner of markdown tables to hint at the fact that they can be expanded upon being tapped

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/11948

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Google Pixel 3 Emulator (Android 9)

#### Screenshots
![image](https://user-images.githubusercontent.com/29700158/65248883-e300c300-db2d-11e9-82a1-9ae9c7cf7691.png)

