### PR TITLE
[MM-17001] Call scrollToIndex only when ref is set and index is in range

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -299,30 +299,33 @@ export default class PostList extends PureComponent {
 
     scrollToBottom = () => {
         setTimeout(() => {
-            if (this.flatListRef && this.flatListRef.current) {
+            if (this.flatListRef?.current) {
                 this.flatListRef.current.scrollToOffset({offset: 0, animated: true});
             }
         }, 250);
     };
 
+    flatListScrollToIndex = (index) => {
+        this.flatListRef.current.scrollToIndex({
+            animated: false,
+            index,
+            viewOffset: 0,
+            viewPosition: 1, // 0 is at bottom
+        });
+    }
+
     scrollToIndex = (index) => {
-        if (this.flatListRef?.current) {
-            this.animationFrameInitialIndex = requestAnimationFrame(() => {
-                this.flatListRef.current.scrollToIndex({
-                    animated: false,
-                    index,
-                    viewOffset: 0,
-                    viewPosition: 1, // 0 is at bottom
-                });
-            });
-        }
+        this.animationFrameInitialIndex = requestAnimationFrame(() => {
+            if (this.flatListRef?.current && index > 0 && index <= this.getItemCount()) {
+                this.flatListScrollToIndex(index);
+            }
+        });
     };
 
     scrollToInitialIndexIfNeeded = (index, count = 0) => {
-        if (!this.hasDoneInitialScroll && this.flatListRef?.current) {
-            this.hasDoneInitialScroll = true;
-
+        if (!this.hasDoneInitialScroll) {
             if (index > 0 && index <= this.getItemCount()) {
+                this.hasDoneInitialScroll = true;
                 this.scrollToIndex(index);
             } else if (count < 3) {
                 setTimeout(() => {

--- a/app/components/post_list/post_list.test.js
+++ b/app/components/post_list/post_list.test.js
@@ -55,4 +55,30 @@ describe('PostList', () => {
         expect(baseProps.actions.handleSelectChannelByName).toHaveBeenCalled();
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    test('should call flatListScrollToIndex only when ref is set and index is in range', () => {
+        jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => cb());
+
+        const instance = wrapper.instance();
+        const flatListScrollToIndex = jest.spyOn(instance, 'flatListScrollToIndex');
+        const indexInRange = baseProps.postIds.length;
+        const indexOutOfRange = [-1, indexInRange + 1];
+
+        instance.flatListRef = {};
+        instance.scrollToIndex(indexInRange);
+        expect(flatListScrollToIndex).not.toHaveBeenCalled();
+
+        instance.flatListRef = {
+            current: {
+                scrollToIndex: jest.fn(),
+            },
+        };
+        for (const index of indexOutOfRange) {
+            instance.scrollToIndex(index);
+            expect(flatListScrollToIndex).not.toHaveBeenCalled();
+        }
+
+        instance.scrollToIndex(indexInRange);
+        expect(flatListScrollToIndex).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
#### Summary
I'm unable to reproduce the crash, however, I made the following changes that might help:
moved the check on `index` and on `flatListRef?.current` to inside the `requestAnimationFrame` callback so the checks are run right before the call to `scrollToIndex`. Also, `this.hasDoneInitialScroll` is set to `true` now only if `this.scrollToIndex` will be called.

I'll keep an eye on Sentry and if the issue still occurs, we'll need to spend more time understanding why the index is out of range.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17001

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 8, iOS 12.4
