### PR TITLE
[MM-18325] Properly determine if channel is archived

### DIFF
--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -32,7 +32,7 @@ import PostBody from './post_body';
 
 const POST_TIMEOUT = 20000;
 
-function makeMapStateToProps() {
+export function makeMapStateToProps() {
     const memoizeHasEmojisOnly = memoizeResult((message, customEmojis) => hasEmojisOnly(message, customEmojis));
     const getReactionsForPost = makeGetReactionsForPost();
 
@@ -61,9 +61,10 @@ function makeMapStateToProps() {
         const roles = getCurrentUserId(state) ? getCurrentUserRoles(state) : '';
         const isAdmin = checkIsAdmin(roles);
         const isSystemAdmin = checkIsSystemAdmin(roles);
+        const channelIsArchived = ownProps.hasOwnProperty('channelIsArchived') ? ownProps.channelIsArchived : channel?.delete_at !== 0; //eslint-disable-line camelcase
         let canDelete = false;
 
-        if (post && !ownProps.channelIsArchived) {
+        if (post && !channelIsArchived) {
             canDelete = canDeletePost(state, config, license, currentTeamId, currentChannelId, currentUserId, post, isAdmin, isSystemAdmin);
         }
 

--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -61,7 +61,7 @@ export function makeMapStateToProps() {
         const roles = getCurrentUserId(state) ? getCurrentUserRoles(state) : '';
         const isAdmin = checkIsAdmin(roles);
         const isSystemAdmin = checkIsSystemAdmin(roles);
-        const channelIsArchived = ownProps.hasOwnProperty('channelIsArchived') ? ownProps.channelIsArchived : channel?.delete_at !== 0; //eslint-disable-line camelcase
+        const channelIsArchived = channel?.delete_at !== 0; //eslint-disable-line camelcase
         let canDelete = false;
 
         if (post && !channelIsArchived) {

--- a/app/components/post_body/index.test.js
+++ b/app/components/post_body/index.test.js
@@ -1,0 +1,132 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import * as PostUtils from 'mattermost-redux/utils/post_utils';
+
+import {makeMapStateToProps} from './index.js';
+
+jest.mock('mattermost-redux/selectors/entities/channels', () => {
+    const channels = require.requireActual('mattermost-redux/selectors/entities/channels');
+
+    return {
+        ...channels,
+        getChannel: jest.fn(),
+        canManageChannelMembers: jest.fn(),
+        getCurrentChannelId: jest.fn(),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/preferences', () => {
+    const preferences = require.requireActual('mattermost-redux/selectors/entities/preferences');
+    return {
+        ...preferences,
+        getTheme: jest.fn(),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/general', () => {
+    const general = require.requireActual('mattermost-redux/selectors/entities/general');
+    return {
+        ...general,
+        getConfig: jest.fn(),
+        getLicense: jest.fn().mockReturnValue({}),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/users', () => {
+    const users = require.requireActual('mattermost-redux/selectors/entities/users');
+    return {
+        ...users,
+        getCurrentUserId: jest.fn(),
+        getCurrentUserRoles: jest.fn(),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/teams', () => {
+    const teams = require.requireActual('mattermost-redux/selectors/entities/teams');
+    return {
+        ...teams,
+        getCurrentTeamId: jest.fn(),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/emojis', () => {
+    const emojis = require.requireActual('mattermost-redux/selectors/entities/emojis');
+    return {
+        ...emojis,
+        getCustomEmojisByName: jest.fn(),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/posts', () => {
+    const posts = require.requireActual('mattermost-redux/selectors/entities/posts');
+    return {
+        ...posts,
+        makeGetReactionsForPost: () => jest.fn(),
+    };
+});
+
+jest.mock('app/selectors/device', () => ({
+    getDimensions: jest.fn(),
+}));
+
+describe('makeMapStateToProps', () => {
+    const defaultState = {
+        entities: {
+            general: {
+                serverVersion: '',
+            },
+        },
+    };
+    const defaultOwnProps = {
+        post: {},
+    };
+
+    test('should not call canDeletePost if post is not defined', () => {
+        const canDeletePost = jest.spyOn(PostUtils, 'canDeletePost');
+        const mapStateToProps = makeMapStateToProps();
+        const ownProps = {
+            post: '',
+        };
+
+        const props = mapStateToProps(defaultState, ownProps);
+        expect(props.canDelete).toBe(false);
+        expect(canDeletePost).not.toHaveBeenCalled();
+    });
+
+    test('should not call canDeletePost if post is defined and channel is archived', () => {
+        const canDeletePost = jest.spyOn(PostUtils, 'canDeletePost');
+        const mapStateToProps = makeMapStateToProps();
+
+        getChannel.mockReturnValueOnce({delete_at: 1}); //eslint-disable-line camelcase
+        let props = mapStateToProps(defaultState, defaultOwnProps);
+        expect(props.canDelete).toBe(false);
+        expect(canDeletePost).not.toHaveBeenCalled();
+
+        getChannel.mockReturnValueOnce({delete_at: 0}); //eslint-disable-line camelcase
+        const ownProps = {
+            ...defaultOwnProps,
+            channelIsArchived: true,
+        };
+        props = mapStateToProps(defaultState, ownProps);
+        expect(props.canDelete).toBe(false);
+        expect(canDeletePost).not.toHaveBeenCalled();
+    });
+
+    test('should call canDeletePost if post is defined and channel is not archived', () => {
+        const canDeletePost = jest.spyOn(PostUtils, 'canDeletePost');
+        const mapStateToProps = makeMapStateToProps();
+
+        getChannel.mockReturnValue({delete_at: 0}); //eslint-disable-line camelcase
+        mapStateToProps(defaultState, defaultOwnProps);
+        expect(canDeletePost).toHaveBeenCalledTimes(1);
+
+        const ownProps = {
+            ...defaultOwnProps,
+            channelIsArchived: false,
+        };
+        mapStateToProps(defaultState, ownProps);
+        expect(canDeletePost).toHaveBeenCalledTimes(2);
+    });
+});

--- a/app/components/post_body/index.test.js
+++ b/app/components/post_body/index.test.js
@@ -100,16 +100,7 @@ describe('makeMapStateToProps', () => {
         const mapStateToProps = makeMapStateToProps();
 
         getChannel.mockReturnValueOnce({delete_at: 1}); //eslint-disable-line camelcase
-        let props = mapStateToProps(defaultState, defaultOwnProps);
-        expect(props.canDelete).toBe(false);
-        expect(canDeletePost).not.toHaveBeenCalled();
-
-        getChannel.mockReturnValueOnce({delete_at: 0}); //eslint-disable-line camelcase
-        const ownProps = {
-            ...defaultOwnProps,
-            channelIsArchived: true,
-        };
-        props = mapStateToProps(defaultState, ownProps);
+        const props = mapStateToProps(defaultState, defaultOwnProps);
         expect(props.canDelete).toBe(false);
         expect(canDeletePost).not.toHaveBeenCalled();
     });
@@ -121,12 +112,5 @@ describe('makeMapStateToProps', () => {
         getChannel.mockReturnValue({delete_at: 0}); //eslint-disable-line camelcase
         mapStateToProps(defaultState, defaultOwnProps);
         expect(canDeletePost).toHaveBeenCalledTimes(1);
-
-        const ownProps = {
-            ...defaultOwnProps,
-            channelIsArchived: false,
-        };
-        mapStateToProps(defaultState, ownProps);
-        expect(canDeletePost).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
#### Summary
`ownProps.channelIsArchived` was undefined, so `!ownProps.channelIsArchived` was returning true. We now check if `ownProps` has the `channelIsArchived` property. If so, use that, otherwise use `channel.delete_at` to determine if the channel is archived.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18325

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone X simulator, iOS 12.4
