### PR TITLE
[MM-18662] Trimming display_name in delete/leave channel alerts

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -213,7 +213,7 @@ export default class ChannelInfo extends PureComponent {
                             defaultMessage: "We couldn't archive the channel {displayName}. Please check your connection and try again.",
                         },
                         {
-                            displayName: channel.display_name,
+                            displayName: channel.display_name.trim(),
                         }
                     );
                     if (result.error.server_error_id === 'api.channel.delete_channel.deleted.app_error') {
@@ -235,7 +235,7 @@ export default class ChannelInfo extends PureComponent {
                 message,
                 {
                     term: term.toLowerCase(),
-                    name: channel.display_name,
+                    name: channel.display_name.trim(),
                 }
             ),
             [{


### PR DESCRIPTION
#### Summary
minor fix to trim away the extra spaces after a channel's `display_name` on the `Archive Channel` and `Leave Channel` alerts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18662

#### Device Information
This PR was tested on:  
* Google Pixel 3 Emulator (Android 9)

#### Screenshots
Note: Notice the empty space before the `?`  
* Before:
![image](https://user-images.githubusercontent.com/29700158/65303253-75e63f80-dbb8-11e9-97cf-96142665e162.png)

---

* After: 
![image](https://user-images.githubusercontent.com/29700158/65303212-5c44f800-dbb8-11e9-9275-bcee9bf9bd04.png)
