### PR TITLE
[MM-18779] Reset moment local on logout

### DIFF
--- a/app/i18n/index.js
+++ b/app/i18n/index.js
@@ -108,20 +108,14 @@ function loadTranslation(locale) {
     }
 }
 
-let momentLocale = DEFAULT_LOCALE;
-
-function setMomentLocale(locale) {
-    if (momentLocale !== locale) {
-        momentLocale = moment.locale(locale);
-    }
+export function resetMomentLocale() {
+    moment.locale(DEFAULT_LOCALE);
 }
 
 export function getTranslations(locale) {
     if (!TRANSLATIONS[locale]) {
         loadTranslation(locale);
     }
-
-    setMomentLocale(locale.toLowerCase());
 
     return TRANSLATIONS[locale] || TRANSLATIONS[DEFAULT_LOCALE];
 }

--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -18,7 +18,7 @@ import {selectDefaultChannel} from 'app/actions/views/channel';
 import {showOverlay} from 'app/actions/navigation';
 import {loadConfigAndLicense, setDeepLinkURL, startDataCleanup} from 'app/actions/views/root';
 import {NavigationTypes, ViewTypes} from 'app/constants';
-import {getTranslations} from 'app/i18n';
+import {getTranslations, resetMomentLocale} from 'app/i18n';
 import mattermostManaged from 'app/mattermost_managed';
 import PushNotifications from 'app/push_notifications';
 import {getCurrentLocale} from 'app/selectors/i18n';
@@ -145,6 +145,7 @@ class GlobalEventHandler {
         this.store.dispatch(setServerVersion(''));
         deleteFileCache();
         removeAppCredentials();
+        resetMomentLocale();
 
         PushNotifications.clearNotifications();
 

--- a/app/init/global_event_handler.test.js
+++ b/app/init/global_event_handler.test.js
@@ -6,6 +6,7 @@ import thunk from 'redux-thunk';
 
 import intitialState from 'app/initial_state';
 import PushNotification from 'app/push_notifications';
+import * as I18n from 'app/i18n';
 
 import GlobalEventHandler from './global_event_handler';
 
@@ -35,11 +36,13 @@ GlobalEventHandler.store = store;
 
 // TODO: Add Android test as part of https://mattermost.atlassian.net/browse/MM-17110
 describe('GlobalEventHandler', () => {
-    it('should clear notifications on logout', async () => {
+    it('should clear notifications and reset moment locale on logout', async () => {
         const clearNotifications = jest.spyOn(PushNotification, 'clearNotifications');
+        const resetMomentLocale = jest.spyOn(I18n, 'resetMomentLocale');
 
         await GlobalEventHandler.onLogout();
         expect(clearNotifications).toHaveBeenCalled();
+        expect(resetMomentLocale).toHaveBeenCalledWith();
     });
 
     it('should call onAppStateChange after configuration', () => {

--- a/app/selectors/i18n.js
+++ b/app/selectors/i18n.js
@@ -9,7 +9,7 @@ import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
 // Not a proper selector since the device locale isn't in the redux store
 export function getCurrentLocale(state) {
     const deviceLocale = DeviceInfo.getDeviceLocale().split('-')[0];
-    const defaultLocale = deviceLocale|| DEFAULT_LOCALE;
+    const defaultLocale = deviceLocale || DEFAULT_LOCALE;
 
     return getCurrentUserLocale(state, defaultLocale);
 }

--- a/app/selectors/i18n.js
+++ b/app/selectors/i18n.js
@@ -9,7 +9,7 @@ import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
 // Not a proper selector since the device locale isn't in the redux store
 export function getCurrentLocale(state) {
     const deviceLocale = DeviceInfo.getDeviceLocale().split('-')[0];
-    const defaultLocale = deviceLocale || DEFAULT_LOCALE;
+    const defaultLocale = deviceLocale|| DEFAULT_LOCALE;
 
     return getCurrentUserLocale(state, defaultLocale);
 }


### PR DESCRIPTION
#### Summary
There was a crash on Android in the call to `setMomentLocale`. I've removed that function and instead am resetting the moment locale to the DEFAULT_LOCALE on logout to handle https://mattermost.atlassian.net/browse/MM-18226.

Will manually cherry-pick into 1.23.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18779

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone sim, iOS 12.3
