### PR TITLE
MM-18176 Fix network indicator stock after re-connect

### DIFF
--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -113,7 +113,7 @@ export default class NetworkIndicator extends PureComponent {
         }
 
         if (this.props.isOnline) {
-            if (previousWebsocketStatus === RequestStatus.STARTED && websocketStatus === RequestStatus.SUCCESS) {
+            if (previousWebsocketStatus !== RequestStatus.SUCCESS && websocketStatus === RequestStatus.SUCCESS) {
                 // Show the connected animation only if we had a previous network status
                 this.connected();
                 clearTimeout(this.connectionRetryTimeout);


### PR DESCRIPTION
#### Summary
When the Network indicator component updated at times the previous request status from the WebSocket was different than `STARTED` thus the animation to dismiss the connecting bar was not being ran. Now we check if the current status is `SUCCESS` and the previous one was different than that to determine if the animation needs to run or not.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18176