### PR TITLE
MM-18464 Interactive dialog renders out of safe area view on landscape orientation

### DIFF
--- a/app/components/autocomplete_selector/autocomplete_selector.js
+++ b/app/components/autocomplete_selector/autocomplete_selector.js
@@ -15,6 +15,7 @@ import {preventDoubleTap} from 'app/utils/tap';
 import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
 import {ViewTypes} from 'app/constants';
 import {goToScreen} from 'app/actions/navigation';
+import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
 
 export default class AutocompleteSelector extends PureComponent {
     static propTypes = {
@@ -34,6 +35,7 @@ export default class AutocompleteSelector extends PureComponent {
         helpText: PropTypes.node,
         errorText: PropTypes.node,
         roundedBorders: PropTypes.bool,
+        isLandscape: PropTypes.bool.isRequired,
     };
 
     static contextTypes = {
@@ -116,6 +118,7 @@ export default class AutocompleteSelector extends PureComponent {
             optional,
             showRequiredAsterisk,
             roundedBorders,
+            isLandscape,
         } = this.props;
         const {selectedText} = this.state;
         const style = getStyleSheet(theme);
@@ -181,7 +184,9 @@ export default class AutocompleteSelector extends PureComponent {
 
         return (
             <View style={style.container}>
-                {labelContent}
+                <View style={padding(isLandscape)}>
+                    {labelContent}
+                </View>
                 <TouchableWithFeedback
                     style={style.flex}
                     onPress={this.goToSelectorScreen}
@@ -189,7 +194,7 @@ export default class AutocompleteSelector extends PureComponent {
                 >
                     <View style={inputStyle}>
                         <Text
-                            style={selectedStyle}
+                            style={[selectedStyle, padding(isLandscape)]}
                             numberOfLines={1}
                         >
                             {text}
@@ -197,12 +202,14 @@ export default class AutocompleteSelector extends PureComponent {
                         <Icon
                             name='chevron-down'
                             color={changeOpacity(theme.centerChannelColor, 0.5)}
-                            style={style.icon}
+                            style={[style.icon, padding(isLandscape)]}
                         />
                     </View>
                 </TouchableWithFeedback>
-                {helpTextContent}
-                {errorTextContent}
+                <View style={padding(isLandscape)}>
+                    {helpTextContent}
+                    {errorTextContent}
+                </View>
             </View>
         );
     }

--- a/app/components/autocomplete_selector/autocomplete_selector.js
+++ b/app/components/autocomplete_selector/autocomplete_selector.js
@@ -10,12 +10,12 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import FormattedText from 'app/components/formatted_text';
+import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
 import TouchableWithFeedback from 'app/components/touchable_with_feedback';
 import {preventDoubleTap} from 'app/utils/tap';
 import {makeStyleSheetFromTheme, changeOpacity} from 'app/utils/theme';
 import {ViewTypes} from 'app/constants';
 import {goToScreen} from 'app/actions/navigation';
-import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
 
 export default class AutocompleteSelector extends PureComponent {
     static propTypes = {

--- a/app/components/autocomplete_selector/index.js
+++ b/app/components/autocomplete_selector/index.js
@@ -9,11 +9,13 @@ import {getTeammateNameDisplaySetting, getTheme} from 'mattermost-redux/selector
 import {setAutocompleteSelector} from 'app/actions/views/post';
 
 import AutocompleteSelector from './autocomplete_selector';
+import {isLandscape} from 'app/selectors/device';
 
 function mapStateToProps(state) {
     return {
         teammateNameDisplay: getTeammateNameDisplaySetting(state),
         theme: getTheme(state),
+        isLandscape: isLandscape(state),
     };
 }
 

--- a/app/components/custom_list/option_list_row/index.js
+++ b/app/components/custom_list/option_list_row/index.js
@@ -4,12 +4,13 @@
 import {connect} from 'react-redux';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-
+import {isLandscape} from 'app/selectors/device';
 import OptionListRow from './option_list_row';
 
 function mapStateToProps(state) {
     return {
         theme: getTheme(state),
+        isLandscape: isLandscape(state),
     };
 }
 

--- a/app/components/custom_list/option_list_row/option_list_row.js
+++ b/app/components/custom_list/option_list_row/option_list_row.js
@@ -17,10 +17,15 @@ export default class OptionListRow extends React.PureComponent {
         id: PropTypes.string,
         theme: PropTypes.object.isRequired,
         ...CustomListRow.propTypes,
+        isLandscape: PropTypes.bool.isRequired,
     };
 
     static contextTypes = {
         intl: intlShape,
+    };
+
+    static defaultProps = {
+        isLandscape: false,
     };
 
     onPress = () => {
@@ -36,6 +41,7 @@ export default class OptionListRow extends React.PureComponent {
             selected,
             theme,
             item,
+            isLandscape
         } = this.props;
 
         const {text, value} = item;
@@ -48,6 +54,7 @@ export default class OptionListRow extends React.PureComponent {
                 enabled={enabled}
                 selectable={selectable}
                 selected={selected}
+                isLandscape={isLandscape}
             >
                 <View style={style.textContainer}>
                     <View>

--- a/app/components/custom_list/option_list_row/option_list_row.js
+++ b/app/components/custom_list/option_list_row/option_list_row.js
@@ -41,7 +41,7 @@ export default class OptionListRow extends React.PureComponent {
             selected,
             theme,
             item,
-            isLandscape
+            isLandscape,
         } = this.props;
 
         const {text, value} = item;

--- a/app/components/widgets/settings/bool_setting.js
+++ b/app/components/widgets/settings/bool_setting.js
@@ -104,21 +104,23 @@ export default class BoolSetting extends PureComponent {
         }
 
         return (
-            <View style={padding(isLandscape)}>
-                {labelContent}
+            <View>
+                <View style={padding(isLandscape)}>
+                    {labelContent}
+                </View>
                 <View style={style.separator}/>
-                <View style={[style.inputContainer]}>
-                    <Text style={style.placeholderText}>
+                <View style={style.inputContainer}>
+                    <Text style={[style.placeholderText, padding(isLandscape)]}>
                         {placeholder}
                     </Text>
                     <Switch
                         onValueChange={this.handleChange}
                         value={value}
-                        style={style.inputSwitch}
+                        style={[style.inputSwitch, padding(isLandscape)]}
                     />
                 </View>
                 <View style={style.separator}/>
-                <View>
+                <View style={padding(isLandscape)}>
                     {helpTextContent}
                     {errorTextContent}
                 </View>

--- a/app/components/widgets/settings/bool_setting.js
+++ b/app/components/widgets/settings/bool_setting.js
@@ -104,7 +104,7 @@ export default class BoolSetting extends PureComponent {
         }
 
         return (
-            <View>
+            <React.Fragment>
                 <View style={padding(isLandscape)}>
                     {labelContent}
                 </View>
@@ -124,7 +124,7 @@ export default class BoolSetting extends PureComponent {
                     {helpTextContent}
                     {errorTextContent}
                 </View>
-            </View>
+            </React.Fragment>
         );
     }
 }

--- a/app/screens/interactive_dialog/__snapshots__/dialog_introduction_text.test.js.snap
+++ b/app/screens/interactive_dialog/__snapshots__/dialog_introduction_text.test.js.snap
@@ -5,9 +5,12 @@ exports[`DialogIntroductionText should not render the component with an empty va
 exports[`DialogIntroductionText should render the introduction text correctly 1`] = `
 <View
   style={
-    Object {
-      "marginHorizontal": 15,
-    }
+    Array [
+      Object {
+        "marginHorizontal": 15,
+      },
+      null,
+    ]
   }
 >
   <Connect(Markdown)

--- a/app/screens/interactive_dialog/__snapshots__/interactive_dialog.test.js.snap
+++ b/app/screens/interactive_dialog/__snapshots__/interactive_dialog.test.js.snap
@@ -18,6 +18,7 @@ exports[`InteractiveDialog should display introduction text if present 1`] = `
   >
     <Connect(StatusBar) />
     <DialogIntroductionText
+      isLandscape={false}
       theme={
         Object {
           "awayIndicator": "#ffbc42",

--- a/app/screens/interactive_dialog/dialog_element.js
+++ b/app/screens/interactive_dialog/dialog_element.js
@@ -118,6 +118,7 @@ export default class DialogElement extends PureComponent {
                     multiline={multiline}
                     keyboardType={keyboardType}
                     secureTextEntry={secureTextEntry}
+                    isLandscape={isLandscape}
                 />
             );
         } else if (type === 'select') {
@@ -135,6 +136,7 @@ export default class DialogElement extends PureComponent {
                     showRequiredAsterisk={true}
                     selected={this.state.selected}
                     roundedBorders={false}
+                    isLandscape={isLandscape}
                 />
             );
         } else if (type === 'radio') {
@@ -148,6 +150,7 @@ export default class DialogElement extends PureComponent {
                     theme={theme}
                     default={value}
                     onChange={this.onChange}
+                    isLandscape={isLandscape}
                 />
             );
         } else if (type === 'bool') {

--- a/app/screens/interactive_dialog/dialog_introduction_text.js
+++ b/app/screens/interactive_dialog/dialog_introduction_text.js
@@ -9,17 +9,20 @@ import Markdown from 'app/components/markdown';
 
 import {getMarkdownTextStyles, getMarkdownBlockStyles} from 'app/utils/markdown';
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
+import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
 
 export default class DialogIntroductionText extends PureComponent {
     static propTypes = {
         value: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
+        isLandscape: PropTypes.bool.isRequired,
     };
 
     render() {
         const {
             value,
             theme,
+            isLandscape,
         } = this.props;
 
         if (value) {
@@ -28,7 +31,7 @@ export default class DialogIntroductionText extends PureComponent {
             const textStyles = getMarkdownTextStyles(theme);
 
             return (
-                <View style={style.introductionTextView}>
+                <View style={[style.introductionTextView, padding(isLandscape)]}>
                     <Markdown
                         baseTextStyle={style.introductionText}
                         textStyles={textStyles}

--- a/app/screens/interactive_dialog/dialog_introduction_text.test.js
+++ b/app/screens/interactive_dialog/dialog_introduction_text.test.js
@@ -12,6 +12,7 @@ describe('DialogIntroductionText', () => {
     const baseProps = {
         theme: Preferences.THEMES.default,
         value: '**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)',
+        isLandscape: false,
     };
 
     test('should render the introduction text correctly', () => {

--- a/app/screens/interactive_dialog/interactive_dialog.js
+++ b/app/screens/interactive_dialog/interactive_dialog.js
@@ -179,6 +179,7 @@ export default class InteractiveDialog extends PureComponent {
                         <DialogIntroductionText
                             value={introductionText}
                             theme={theme}
+                            isLandscape={isLandscape}
                         />
                     }
                     {elements && elements.map((e) => {

--- a/app/screens/selector_screen/__snapshots__/selector_screen.test.js.snap
+++ b/app/screens/selector_screen/__snapshots__/selector_screen.test.js.snap
@@ -16,9 +16,7 @@ exports[`SelectorScreen should match snapshot for channels 1`] = `
         Object {
           "marginVertical": 5,
         },
-        Object {
-          "paddingHorizontal": 44,
-        },
+        null,
       ]
     }
   >
@@ -55,7 +53,7 @@ exports[`SelectorScreen should match snapshot for channels 1`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={true}
+    isLandscape={false}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -113,9 +111,7 @@ exports[`SelectorScreen should match snapshot for channels 2`] = `
         Object {
           "marginVertical": 5,
         },
-        Object {
-          "paddingHorizontal": 44,
-        },
+        null,
       ]
     }
   >
@@ -152,7 +148,7 @@ exports[`SelectorScreen should match snapshot for channels 2`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={true}
+    isLandscape={false}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -210,9 +206,7 @@ exports[`SelectorScreen should match snapshot for explicit options 1`] = `
         Object {
           "marginVertical": 5,
         },
-        Object {
-          "paddingHorizontal": 44,
-        },
+        null,
       ]
     }
   >
@@ -256,7 +250,7 @@ exports[`SelectorScreen should match snapshot for explicit options 1`] = `
         },
       ]
     }
-    isLandscape={true}
+    isLandscape={false}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -314,9 +308,7 @@ exports[`SelectorScreen should match snapshot for searching 1`] = `
         Object {
           "marginVertical": 5,
         },
-        Object {
-          "paddingHorizontal": 44,
-        },
+        null,
       ]
     }
   >
@@ -353,7 +345,7 @@ exports[`SelectorScreen should match snapshot for searching 1`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={true}
+    isLandscape={false}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -411,9 +403,7 @@ exports[`SelectorScreen should match snapshot for users 1`] = `
         Object {
           "marginVertical": 5,
         },
-        Object {
-          "paddingHorizontal": 44,
-        },
+        null,
       ]
     }
   >
@@ -450,7 +440,7 @@ exports[`SelectorScreen should match snapshot for users 1`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={true}
+    isLandscape={false}
     listType="section"
     loading={false}
     loadingComponent={null}
@@ -508,9 +498,7 @@ exports[`SelectorScreen should match snapshot for users 2`] = `
         Object {
           "marginVertical": 5,
         },
-        Object {
-          "paddingHorizontal": 44,
-        },
+        null,
       ]
     }
   >
@@ -547,7 +535,7 @@ exports[`SelectorScreen should match snapshot for users 2`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={true}
+    isLandscape={false}
     listType="section"
     loading={false}
     loadingComponent={null}

--- a/app/screens/selector_screen/__snapshots__/selector_screen.test.js.snap
+++ b/app/screens/selector_screen/__snapshots__/selector_screen.test.js.snap
@@ -12,9 +12,14 @@ exports[`SelectorScreen should match snapshot for channels 1`] = `
   <Connect(StatusBar) />
   <View
     style={
-      Object {
-        "marginVertical": 5,
-      }
+      Array [
+        Object {
+          "marginVertical": 5,
+        },
+        Object {
+          "paddingHorizontal": 44,
+        },
+      ]
     }
   >
     <SearchBarIos
@@ -50,7 +55,7 @@ exports[`SelectorScreen should match snapshot for channels 1`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={false}
+    isLandscape={true}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -104,9 +109,14 @@ exports[`SelectorScreen should match snapshot for channels 2`] = `
   <Connect(StatusBar) />
   <View
     style={
-      Object {
-        "marginVertical": 5,
-      }
+      Array [
+        Object {
+          "marginVertical": 5,
+        },
+        Object {
+          "paddingHorizontal": 44,
+        },
+      ]
     }
   >
     <SearchBarIos
@@ -142,7 +152,7 @@ exports[`SelectorScreen should match snapshot for channels 2`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={false}
+    isLandscape={true}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -196,9 +206,14 @@ exports[`SelectorScreen should match snapshot for explicit options 1`] = `
   <Connect(StatusBar) />
   <View
     style={
-      Object {
-        "marginVertical": 5,
-      }
+      Array [
+        Object {
+          "marginVertical": 5,
+        },
+        Object {
+          "paddingHorizontal": 44,
+        },
+      ]
     }
   >
     <SearchBarIos
@@ -241,7 +256,7 @@ exports[`SelectorScreen should match snapshot for explicit options 1`] = `
         },
       ]
     }
-    isLandscape={false}
+    isLandscape={true}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -295,9 +310,14 @@ exports[`SelectorScreen should match snapshot for searching 1`] = `
   <Connect(StatusBar) />
   <View
     style={
-      Object {
-        "marginVertical": 5,
-      }
+      Array [
+        Object {
+          "marginVertical": 5,
+        },
+        Object {
+          "paddingHorizontal": 44,
+        },
+      ]
     }
   >
     <SearchBarIos
@@ -333,7 +353,7 @@ exports[`SelectorScreen should match snapshot for searching 1`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={false}
+    isLandscape={true}
     listType="flat"
     loading={false}
     loadingComponent={null}
@@ -387,9 +407,14 @@ exports[`SelectorScreen should match snapshot for users 1`] = `
   <Connect(StatusBar) />
   <View
     style={
-      Object {
-        "marginVertical": 5,
-      }
+      Array [
+        Object {
+          "marginVertical": 5,
+        },
+        Object {
+          "paddingHorizontal": 44,
+        },
+      ]
     }
   >
     <SearchBarIos
@@ -425,7 +450,7 @@ exports[`SelectorScreen should match snapshot for users 1`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={false}
+    isLandscape={true}
     listType="section"
     loading={false}
     loadingComponent={null}
@@ -479,9 +504,14 @@ exports[`SelectorScreen should match snapshot for users 2`] = `
   <Connect(StatusBar) />
   <View
     style={
-      Object {
-        "marginVertical": 5,
-      }
+      Array [
+        Object {
+          "marginVertical": 5,
+        },
+        Object {
+          "paddingHorizontal": 44,
+        },
+      ]
     }
   >
     <SearchBarIos
@@ -517,7 +547,7 @@ exports[`SelectorScreen should match snapshot for users 2`] = `
   </View>
   <CustomList
     data={Array []}
-    isLandscape={false}
+    isLandscape={true}
     listType="section"
     loading={false}
     loadingComponent={null}

--- a/app/screens/selector_screen/index.js
+++ b/app/screens/selector_screen/index.js
@@ -8,7 +8,7 @@ import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getProfiles, searchProfiles} from 'mattermost-redux/actions/users';
 import {getChannels, searchChannels} from 'mattermost-redux/actions/channels';
-
+import {isLandscape} from 'app/selectors/device';
 import SelectorScreen from './selector_screen';
 
 function mapStateToProps(state) {
@@ -22,6 +22,7 @@ function mapStateToProps(state) {
         dataSource: menuAction.dataSource,
         onSelect: menuAction.onSelect,
         theme: getTheme(state),
+        isLandscape: isLandscape(state),
     };
 }
 

--- a/app/screens/selector_screen/selector_screen.js
+++ b/app/screens/selector_screen/selector_screen.js
@@ -34,7 +34,6 @@ import {t} from 'app/utils/i18n';
 import {popTopScreen} from 'app/actions/navigation';
 
 import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
-import { isLandscape } from '../../selectors/device';
 
 export default class SelectorScreen extends PureComponent {
     static propTypes = {
@@ -50,6 +49,7 @@ export default class SelectorScreen extends PureComponent {
         dataSource: PropTypes.string,
         onSelect: PropTypes.func.isRequired,
         theme: PropTypes.object.isRequired,
+        isLandscape: PropTypes.bool.isRequired,
     };
 
     static contextTypes = {
@@ -296,7 +296,7 @@ export default class SelectorScreen extends PureComponent {
 
     render() {
         const {formatMessage} = this.context.intl;
-        const {theme, dataSource} = this.props;
+        const {theme, dataSource, isLandscape} = this.props;
         const {loading, term} = this.state;
         const style = getStyleFromTheme(theme);
 
@@ -325,7 +325,7 @@ export default class SelectorScreen extends PureComponent {
         return (
             <View style={style.container}>
                 <StatusBar/>
-                <View style={[style.searchBar, padding(true)]}>
+                <View style={[style.searchBar, padding(isLandscape)]}>
                     <SearchBar
                         ref='search_bar'
                         placeholder={formatMessage({id: 'search_bar.search', defaultMessage: 'Search'})}
@@ -356,7 +356,7 @@ export default class SelectorScreen extends PureComponent {
                     onRowPress={this.handleSelectItem}
                     renderItem={rowComponent}
                     theme={theme}
-                    isLandscape={true}
+                    isLandscape={isLandscape}
                 />
             </View>
         );

--- a/app/screens/selector_screen/selector_screen.js
+++ b/app/screens/selector_screen/selector_screen.js
@@ -33,6 +33,9 @@ import {
 import {t} from 'app/utils/i18n';
 import {popTopScreen} from 'app/actions/navigation';
 
+import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
+import { isLandscape } from '../../selectors/device';
+
 export default class SelectorScreen extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
@@ -322,7 +325,7 @@ export default class SelectorScreen extends PureComponent {
         return (
             <View style={style.container}>
                 <StatusBar/>
-                <View style={style.searchBar}>
+                <View style={[style.searchBar, padding(true)]}>
                     <SearchBar
                         ref='search_bar'
                         placeholder={formatMessage({id: 'search_bar.search', defaultMessage: 'Search'})}
@@ -353,6 +356,7 @@ export default class SelectorScreen extends PureComponent {
                     onRowPress={this.handleSelectItem}
                     renderItem={rowComponent}
                     theme={theme}
+                    isLandscape={true}
                 />
             </View>
         );

--- a/app/screens/selector_screen/selector_screen.test.js
+++ b/app/screens/selector_screen/selector_screen.test.js
@@ -76,6 +76,7 @@ describe('SelectorScreen', () => {
         data: [{text: 'text', value: 'value'}],
         dataSource: null,
         theme: Preferences.THEMES.default,
+        isLandscape: false,
     };
 
     test('should match snapshot for explicit options', async () => {


### PR DESCRIPTION
#### Summary
Updated Interactive Dialog for support of SafeAreaView on iOS

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18464

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes - SafeAreaView padding in landscape on iOS

#### Device Information
This PR was tested on:
iPhone X 12.4 (Simulator)

#### Screenshots
![Simulator Screen Shot - iPhone X - 2019-09-26 at 23 12 38](https://user-images.githubusercontent.com/38697367/65739616-f1ae2380-e0b3-11e9-8e1e-41ccdf6eb5f8.png)
![Simulator Screen Shot - iPhone X - 2019-09-26 at 23 12 44](https://user-images.githubusercontent.com/38697367/65739617-f246ba00-e0b3-11e9-80aa-0a624b6d8b31.png)
![Simulator Screen Shot - iPhone X - 2019-09-26 at 23 12 31](https://user-images.githubusercontent.com/38697367/65739618-f246ba00-e0b3-11e9-9fee-c810e00bf31e.png)

