### PR TITLE
Fix channel navbar title displayName variable

### DIFF
--- a/app/screens/channel/channel_nav_bar/channel_title/__snapshots__/channel_title.test.js.snap
+++ b/app/screens/channel/channel_nav_bar/channel_title/__snapshots__/channel_title.test.js.snap
@@ -33,6 +33,19 @@ exports[`ChannelTitle should match snapshot 1`] = `
           "textAlign": "center",
         }
       }
+    >
+      My Channel
+    </Text>
+    <Icon
+      allowFontScaling={false}
+      name="chevron-down"
+      size={12}
+      style={
+        Object {
+          "color": undefined,
+          "marginHorizontal": 5,
+        }
+      }
     />
   </View>
 </TouchableOpacity>
@@ -77,7 +90,7 @@ exports[`ChannelTitle should match snapshot when isSelfDMChannel is true 1`] = `
         id="channel_header.directchannel.you"
         values={
           Object {
-            "displayname": undefined,
+            "displayName": "My User",
           }
         }
       />

--- a/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
+++ b/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
@@ -99,7 +99,7 @@ export default class ChannelTitle extends PureComponent {
         if (isSelfDMChannel) {
             const messageId = t('channel_header.directchannel.you');
             const defaultMessage = '{displayName} (you)';
-            const values = {displayname: channelDisplayName};
+            const values = {displayName: channelDisplayName};
 
             return (
                 <FormattedText

--- a/app/screens/channel/channel_nav_bar/channel_title/channel_title.test.js
+++ b/app/screens/channel/channel_nav_bar/channel_title/channel_title.test.js
@@ -10,6 +10,7 @@ jest.mock('react-intl');
 
 describe('ChannelTitle', () => {
     const baseProps = {
+        displayName: 'My Channel',
         isGuest: false,
         hasGuests: false,
         canHaveSubtitle: false,
@@ -27,6 +28,7 @@ describe('ChannelTitle', () => {
     test('should match snapshot when isSelfDMChannel is true', () => {
         const props = {
             ...baseProps,
+            displayName: 'My User',
             isSelfDMChannel: true,
         };
         const wrapper = shallow(


### PR DESCRIPTION
The localization string has a variable called `displayName` and we were passing `displayname`