### PR TITLE
MM-18791: Add spacing to Helper text on Settings Screen

### DIFF
--- a/app/screens/settings/section.js
+++ b/app/screens/settings/section.js
@@ -87,6 +87,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         footer: {
             marginTop: 10,
+            marginHorizontal: 15,
             fontSize: 12,
             color: changeOpacity(theme.centerChannelColor, 0.5),
         },


### PR DESCRIPTION
Added marginHorizontal spacing to the footer for sections.

#### Summary
Added a marginHorizontal to the footer text found in the Section element to resolve the spacing issue on the helper text.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18791

#### Checklist
- [x] Has UI changes - 15px horizontal margin to footer for section element

#### Device Information
This PR was tested on: 
iPhone X 12.4 (Simulator)
iPhone Xs Max 12.3

#### Screenshots
![Simulator Screen Shot - iPhone X - 2019-09-28 at 22 36 29](https://user-images.githubusercontent.com/38697367/65825352-fd305480-e243-11e9-9e47-c64351c1fe41.png)
![Simulator Screen Shot - iPhone X - 2019-09-28 at 22 36 19](https://user-images.githubusercontent.com/38697367/65825353-fd305480-e243-11e9-8dd2-4891d2b5484c.png)

