### PR TITLE
MM-18054: Removed Commented On from new messages in thread with same poster

### DIFF
--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -84,6 +84,7 @@ function makeMapStateToProps() {
             isFlagged: isPostFlagged(post.id, myPreferences),
             isCommentMention,
             isLandscape: isLandscape(state),
+            previousPostExists: (previousPost ? true : false),
         };
     };
 }

--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -41,6 +41,7 @@ function makeMapStateToProps() {
     return function mapStateToProps(state, ownProps) {
         const post = ownProps.post || getPost(state, ownProps.postId);
         const previousPost = getPost(state, ownProps.previousPostId);
+        const beforePrevPost = getPost(state, ownProps.beforePrevPostId);
 
         const myPreferences = getMyPreferences(state);
         const currentUserId = getCurrentUserId(state);
@@ -84,7 +85,8 @@ function makeMapStateToProps() {
             isFlagged: isPostFlagged(post.id, myPreferences),
             isCommentMention,
             isLandscape: isLandscape(state),
-            previousPostExists: (previousPost ? true : false),
+            previousPostExists: Boolean(previousPost),
+            beforePrevPostUser: (beforePrevPost ? beforePrevPost.user_id : null),
         };
     };
 }

--- a/app/components/post/index.js
+++ b/app/components/post/index.js
@@ -86,7 +86,7 @@ function makeMapStateToProps() {
             isCommentMention,
             isLandscape: isLandscape(state),
             previousPostExists: Boolean(previousPost),
-            beforePrevPostUser: (beforePrevPost ? beforePrevPost.user_id : null),
+            beforePrevPostUserId: (beforePrevPost ? beforePrevPost.user_id : null),
         };
     };
 }

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -69,7 +69,7 @@ export default class Post extends PureComponent {
         isBot: PropTypes.bool,
         isLandscape: PropTypes.bool.isRequired,
         previousPostExists: PropTypes.bool,
-        beforePrevPostUser: PropTypes.string,
+        beforePrevPostUserId: PropTypes.string,
     };
 
     static defaultProps = {
@@ -253,7 +253,7 @@ export default class Post extends PureComponent {
             location,
             isLandscape,
             previousPostExists,
-            beforePrevPostUser,
+            beforePrevPostUserId,
         } = this.props;
 
         if (!post) {
@@ -304,7 +304,7 @@ export default class Post extends PureComponent {
                     renderReplies={renderReplies}
                     theme={theme}
                     previousPostExists={previousPostExists}
-                    beforePrevPostUser={beforePrevPostUser}
+                    beforePrevPostUserId={beforePrevPostUserId}
                 />
             );
         }

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -69,6 +69,7 @@ export default class Post extends PureComponent {
         isBot: PropTypes.bool,
         isLandscape: PropTypes.bool.isRequired,
         previousPostExists: PropTypes.bool,
+        beforePrevPostUser: PropTypes.string,
     };
 
     static defaultProps = {

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -252,6 +252,7 @@ export default class Post extends PureComponent {
             location,
             isLandscape,
             previousPostExists,
+            beforePrevPostUser,
         } = this.props;
 
         if (!post) {
@@ -302,6 +303,7 @@ export default class Post extends PureComponent {
                     renderReplies={renderReplies}
                     theme={theme}
                     previousPostExists={previousPostExists}
+                    beforePrevPostUser={beforePrevPostUser}
                 />
             );
         }

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -68,6 +68,7 @@ export default class Post extends PureComponent {
         location: PropTypes.string,
         isBot: PropTypes.bool,
         isLandscape: PropTypes.bool.isRequired,
+        previousPostExists: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -250,6 +251,7 @@ export default class Post extends PureComponent {
             skipPinnedHeader,
             location,
             isLandscape,
+            previousPostExists,
         } = this.props;
 
         if (!post) {
@@ -299,6 +301,7 @@ export default class Post extends PureComponent {
                     onUsernamePress={onUsernamePress}
                     renderReplies={renderReplies}
                     theme={theme}
+                    previousPostExists={previousPostExists}
                 />
             );
         }

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -69,10 +69,10 @@ export default class PostHeader extends PureComponent {
             renderReplies,
             theme,
         } = this.props;
-        if (!renderReplies || !commentedOnDisplayName || (!previousPostExists && post.user_id === beforePrevPostUser) ) {
+        if (!renderReplies || !commentedOnDisplayName || (!previousPostExists && post.user_id === beforePrevPostUser)) {
             return null;
         }
-       
+
         const style = getStyleSheet(theme);
         const displayName = commentedOnDisplayName;
 

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -44,6 +44,8 @@ export default class PostHeader extends PureComponent {
         userTimezone: PropTypes.string,
         enableTimezone: PropTypes.bool,
         previousPostExists: PropTypes.bool,
+        post: PropTypes.object,
+        beforePrevPostUser: PropTypes.string,
     };
 
     static defaultProps = {
@@ -59,7 +61,14 @@ export default class PostHeader extends PureComponent {
     };
 
     renderCommentedOnMessage = () => {
-        const { renderReplies, commentedOnDisplayName, previousPostExists, post, beforePrevPostUser, theme } = this.props;
+        const {
+            beforePrevPostUser,
+            commentedOnDisplayName,
+            post,
+            previousPostExists,
+            renderReplies,
+            theme,
+        } = this.props;
         if (!renderReplies || !commentedOnDisplayName || (!previousPostExists && post.user_id === beforePrevPostUser) ) {
             return null;
         }

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -59,11 +59,11 @@ export default class PostHeader extends PureComponent {
     };
 
     renderCommentedOnMessage = () => {
-        if (!this.props.renderReplies || !this.props.commentedOnDisplayName || !this.props.previousPostExists) {
+        const { renderReplies, commentedOnDisplayName, previousPostExists, post, beforePrevPostUser, theme } = this.props;
+        if (!renderReplies || !commentedOnDisplayName || (!previousPostExists && post.user_id === beforePrevPostUser) ) {
             return null;
         }
-
-        const {commentedOnDisplayName, theme} = this.props;
+       
         const style = getStyleSheet(theme);
         const displayName = commentedOnDisplayName;
 

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -45,7 +45,7 @@ export default class PostHeader extends PureComponent {
         enableTimezone: PropTypes.bool,
         previousPostExists: PropTypes.bool,
         post: PropTypes.object,
-        beforePrevPostUser: PropTypes.string,
+        beforePrevPostUserId: PropTypes.string,
     };
 
     static defaultProps = {
@@ -62,14 +62,14 @@ export default class PostHeader extends PureComponent {
 
     renderCommentedOnMessage = () => {
         const {
-            beforePrevPostUser,
+            beforePrevPostUserId,
             commentedOnDisplayName,
             post,
             previousPostExists,
             renderReplies,
             theme,
         } = this.props;
-        if (!renderReplies || !commentedOnDisplayName || (!previousPostExists && post.user_id === beforePrevPostUser)) {
+        if (!renderReplies || !commentedOnDisplayName || (!previousPostExists && post.user_id === beforePrevPostUserId)) {
             return null;
         }
 

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -43,6 +43,7 @@ export default class PostHeader extends PureComponent {
         isGuest: PropTypes.bool,
         userTimezone: PropTypes.string,
         enableTimezone: PropTypes.bool,
+        previousPostExists: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -58,7 +59,7 @@ export default class PostHeader extends PureComponent {
     };
 
     renderCommentedOnMessage = () => {
-        if (!this.props.renderReplies || !this.props.commentedOnDisplayName) {
+        if (!this.props.renderReplies || !this.props.commentedOnDisplayName || !this.props.previousPostExists) {
             return null;
         }
 

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -260,7 +260,7 @@ export default class PostList extends PureComponent {
         // Remember that the list is rendered with item 0 at the bottom so the "previous" post
         // comes after this one in the list
         const previousPostId = index < this.props.postIds.length - 1 ? this.props.postIds[index + 1] : null;
-        const beforePrevPostId = index < this.props.postIds.length - 1 ? this.props.postIds[index + 2] : null;
+        const beforePrevPostId = index < this.props.postIds.length - 2 ? this.props.postIds[index + 2] : null;
         const nextPostId = index > 0 ? this.props.postIds[index - 1] : null;
 
         const postProps = {

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -260,6 +260,7 @@ export default class PostList extends PureComponent {
         // Remember that the list is rendered with item 0 at the bottom so the "previous" post
         // comes after this one in the list
         const previousPostId = index < this.props.postIds.length - 1 ? this.props.postIds[index + 1] : null;
+        const beforePrevPostId = index < this.props.postIds.length - 1 ? this.props.postIds[index + 2] : null;
         const nextPostId = index > 0 ? this.props.postIds[index - 1] : null;
 
         const postProps = {
@@ -274,6 +275,7 @@ export default class PostList extends PureComponent {
             onPress: this.props.onPostPress,
             renderReplies: this.props.renderReplies,
             shouldRenderReplyButton: this.props.shouldRenderReplyButton,
+            beforePrevPostId,
         };
 
         if (PostListUtils.isCombinedUserActivityPost(item)) {


### PR DESCRIPTION
Added a check for previousPost to use in validating new messages in thread to check if we should display Commented On message.

#### Summary
Added boolean to check if a previousPost object is available.
Used the boolean to validate if a Commented On message should be displayed, as in testing on continued messages in a thread separated by the 'New Messages' line, a previousPost object would not be available.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18054

#### Checklist
No items from checklist other than validating line does not display.

#### Device Information
This PR was tested on:
iPhone X 12.4 (Simulator)
iPhone Xs Max 12.3
Android Pixel 2 API 29 (Simulator)

#### Screenshots
![screenshot](https://user-images.githubusercontent.com/38697367/65848974-70a29680-e316-11e9-9061-2373599586c3.png)

