### PR TITLE
[MM-19045] Do not focus search box after clicking a hashtag

### DIFF
--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -109,7 +109,7 @@ export default class Search extends PureComponent {
         }
 
         setTimeout(() => {
-            if (this.refs.searchBar) {
+            if (this.refs.searchBar && !this.props.initialValue) {
                 this.refs.searchBar.focus();
             }
         }, 150);
@@ -840,4 +840,3 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
         },
     };
 });
-


### PR DESCRIPTION
#### Summary

This PR ensures that during the mount of the search modal, the search box is only focused when no initial value is provided. All cases of opening the search modal provide an initial value (a hashtag was clicked), other than the search icon in the navbar.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19045

#### Checklist

- [ ] Added or updated unit tests
- [x] Has UI changes

#### Device Information

This PR was tested on: Google Pixel 2

#### Additional Notes

I began writing a unit test for this, but mocking out the ref doesn't seem feasible, before `componentDidMount` is called.
