### PR TITLE
Set Sidebar channel item  display name opacity as 0.6 (same as webapp)

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
+++ b/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
@@ -82,7 +82,7 @@ exports[`ChannelItem should match snapshot 1`] = `
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
@@ -197,7 +197,7 @@ exports[`ChannelItem should match snapshot for current user i.e currentUser (you
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
@@ -311,7 +311,7 @@ exports[`ChannelItem should match snapshot for current user i.e currentUser (you
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
@@ -425,7 +425,7 @@ exports[`ChannelItem should match snapshot for deactivated user and is currentCh
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
@@ -528,7 +528,7 @@ exports[`ChannelItem should match snapshot for deactivated user and is searchRes
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
@@ -632,7 +632,7 @@ exports[`ChannelItem should match snapshot for deactivated user and not searchRe
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
@@ -740,7 +740,7 @@ exports[`ChannelItem should match snapshot with draft 1`] = `
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
@@ -846,7 +846,7 @@ exports[`ChannelItem should match snapshot with mentions and muted 1`] = `
             Array [
               Object {
                 "alignSelf": "center",
-                "color": "rgba(255,255,255,0.88)",
+                "color": "rgba(255,255,255,0.6)",
                 "flex": 1,
                 "fontFamily": "Open Sans",
                 "fontSize": 16,

--- a/app/components/sidebars/main/channels_list/channel_item/channel_item.js
+++ b/app/components/sidebars/main/channels_list/channel_item/channel_item.js
@@ -241,7 +241,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             paddingLeft: 11,
         },
         text: {
-            color: changeOpacity(theme.sidebarText, 0.88),
+            color: changeOpacity(theme.sidebarText, 0.6),
             fontSize: 16,
             lineHeight: 24,
             paddingRight: 10,


### PR DESCRIPTION
#### Summary
With the recent improvements to the sidebar the channel item was too bright causing confusion with unread channels.

This PR makes it so the applied opacity is the same as the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19076