### PR TITLE
[MM-17381] Await dismissModal before calling showSearchModal

### DIFF
--- a/app/screens/flagged_posts/__snapshots__/flagged_posts.test.js.snap
+++ b/app/screens/flagged_posts/__snapshots__/flagged_posts.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FlaggedPosts should match snapshot 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <Connect(StatusBar) />
+  <NoResults
+    description="Flags are a way to mark messages for follow up. Your flags are personal, and cannot be seen by other users."
+    iconName="ios-flag"
+    theme={
+      Object {
+        "awayIndicator": "#ffbc42",
+        "buttonBg": "#166de0",
+        "buttonColor": "#ffffff",
+        "centerChannelBg": "#ffffff",
+        "centerChannelColor": "#3d3c40",
+        "codeTheme": "github",
+        "dndIndicator": "#f74343",
+        "errorTextColor": "#fd5960",
+        "linkColor": "#2389d7",
+        "mentionBj": "#ffffff",
+        "mentionColor": "#145dbf",
+        "mentionHighlightBg": "#ffe577",
+        "mentionHighlightLink": "#166de0",
+        "newMessageSeparator": "#ff8800",
+        "onlineIndicator": "#06d6a0",
+        "sidebarBg": "#145dbf",
+        "sidebarHeaderBg": "#1153ab",
+        "sidebarHeaderTextColor": "#ffffff",
+        "sidebarText": "#ffffff",
+        "sidebarTextActiveBorder": "#579eff",
+        "sidebarTextActiveColor": "#ffffff",
+        "sidebarTextHoverBg": "#4578bf",
+        "sidebarUnreadText": "#ffffff",
+        "type": "Mattermost",
+      }
+    }
+    title="No Flagged Posts"
+  />
+</View>
+`;

--- a/app/screens/flagged_posts/flagged_posts.js
+++ b/app/screens/flagged_posts/flagged_posts.js
@@ -101,7 +101,7 @@ export default class FlaggedPosts extends PureComponent {
     };
 
     handleHashtagPress = async (hashtag) => {
-        dismissModal();
+        await dismissModal();
         showSearchModal('#' + hashtag);
     };
 

--- a/app/screens/flagged_posts/flagged_posts.test.js
+++ b/app/screens/flagged_posts/flagged_posts.test.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import * as NavigationActions from 'app/actions/navigation';
+import {shallowWithIntl} from 'test/intl-test-helper';
+
+import FlaggedPosts from './flagged_posts';
+
+jest.mock('rn-placeholder', () => ({
+    ImageContent: () => {},
+}));
+
+describe('FlaggedPosts', () => {
+    const baseProps = {
+        actions: {
+            clearSearch: jest.fn(),
+            loadChannelsByTeamName: jest.fn(),
+            loadThreadIfNecessary: jest.fn(),
+            getFlaggedPosts: jest.fn(),
+            selectFocusedPostId: jest.fn(),
+            selectPost: jest.fn(),
+        },
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallowWithIntl(
+            <FlaggedPosts {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should call showSearchModal after awaiting dismissModal on handleHashtagPress', async () => {
+        const error = new Error('foo');
+        const dismissModal = jest.spyOn(NavigationActions, 'dismissModal');
+        const showSearchModal = jest.spyOn(NavigationActions, 'showSearchModal');
+
+        const hashtag = 'test';
+        const wrapper = shallowWithIntl(
+            <FlaggedPosts {...baseProps}/>
+        );
+
+        dismissModal.mockImplementation(async () => {
+            throw error;
+        });
+        let caughtError;
+        try {
+            await wrapper.instance().handleHashtagPress(hashtag);
+        } catch (e) {
+            caughtError = e;
+        }
+        expect(caughtError).toBe(error);
+        expect(dismissModal).toHaveBeenCalled();
+        expect(showSearchModal).not.toHaveBeenCalled();
+
+        dismissModal.mockImplementation(async () => (Promise.resolve()));
+        await wrapper.instance().handleHashtagPress(hashtag);
+        expect(dismissModal).toHaveBeenCalled();
+        expect(showSearchModal).toHaveBeenCalledWith(`#${hashtag}`);
+    });
+});

--- a/app/screens/recent_mentions/__snapshots__/recent_mentions.test.js.snap
+++ b/app/screens/recent_mentions/__snapshots__/recent_mentions.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RecentMentions should match snapshot 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <Connect(StatusBar) />
+  <NoResults
+    description="Messages containing your username and other words that trigger mentions will appear here."
+    iconName="ios-at"
+    theme={
+      Object {
+        "awayIndicator": "#ffbc42",
+        "buttonBg": "#166de0",
+        "buttonColor": "#ffffff",
+        "centerChannelBg": "#ffffff",
+        "centerChannelColor": "#3d3c40",
+        "codeTheme": "github",
+        "dndIndicator": "#f74343",
+        "errorTextColor": "#fd5960",
+        "linkColor": "#2389d7",
+        "mentionBj": "#ffffff",
+        "mentionColor": "#145dbf",
+        "mentionHighlightBg": "#ffe577",
+        "mentionHighlightLink": "#166de0",
+        "newMessageSeparator": "#ff8800",
+        "onlineIndicator": "#06d6a0",
+        "sidebarBg": "#145dbf",
+        "sidebarHeaderBg": "#1153ab",
+        "sidebarHeaderTextColor": "#ffffff",
+        "sidebarText": "#ffffff",
+        "sidebarTextActiveBorder": "#579eff",
+        "sidebarTextActiveColor": "#ffffff",
+        "sidebarTextHoverBg": "#4578bf",
+        "sidebarUnreadText": "#ffffff",
+        "type": "Mattermost",
+      }
+    }
+    title="No Recent Mentions"
+  />
+</View>
+`;

--- a/app/screens/recent_mentions/recent_mentions.js
+++ b/app/screens/recent_mentions/recent_mentions.js
@@ -95,7 +95,7 @@ export default class RecentMentions extends PureComponent {
     };
 
     handleHashtagPress = async (hashtag) => {
-        dismissModal();
+        await dismissModal();
         showSearchModal('#' + hashtag);
     };
 

--- a/app/screens/recent_mentions/recent_mentions.test.js
+++ b/app/screens/recent_mentions/recent_mentions.test.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import * as NavigationActions from 'app/actions/navigation';
+import {shallowWithIntl} from 'test/intl-test-helper';
+
+import RecentMentions from './recent_mentions';
+
+jest.mock('rn-placeholder', () => ({
+    ImageContent: () => {},
+}));
+
+describe('RecentMentions', () => {
+    const baseProps = {
+        actions: {
+            clearSearch: jest.fn(),
+            loadChannelsByTeamName: jest.fn(),
+            loadThreadIfNecessary: jest.fn(),
+            getRecentMentions: jest.fn(),
+            selectFocusedPostId: jest.fn(),
+            selectPost: jest.fn(),
+        },
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallowWithIntl(
+            <RecentMentions {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should call showSearchModal after awaiting dismissModal on handleHashtagPress', async () => {
+        const error = new Error('foo');
+        const dismissModal = jest.spyOn(NavigationActions, 'dismissModal');
+        const showSearchModal = jest.spyOn(NavigationActions, 'showSearchModal');
+
+        const hashtag = 'test';
+        const wrapper = shallowWithIntl(
+            <RecentMentions {...baseProps}/>
+        );
+
+        dismissModal.mockImplementation(async () => {
+            throw error;
+        });
+        let caughtError;
+        try {
+            await wrapper.instance().handleHashtagPress(hashtag);
+        } catch (e) {
+            caughtError = e;
+        }
+        expect(caughtError).toBe(error);
+        expect(dismissModal).toHaveBeenCalled();
+        expect(showSearchModal).not.toHaveBeenCalled();
+
+        dismissModal.mockImplementation(async () => (Promise.resolve()));
+        await wrapper.instance().handleHashtagPress(hashtag);
+        expect(dismissModal).toHaveBeenCalled();
+        expect(showSearchModal).toHaveBeenCalledWith(`#${hashtag}`);
+    });
+});


### PR DESCRIPTION
#### Summary
The `dismissModal` navigation action must complete prior to calling `showSearchModal`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17381

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPad and Android emulator