### PR TITLE
MM-18173 Removed getState from Add Channel Member method

### DIFF
--- a/app/actions/views/channel_add_members.js
+++ b/app/actions/views/channel_add_members.js
@@ -4,9 +4,9 @@
 import {addChannelMember} from 'mattermost-redux/actions/channels';
 
 export function handleAddChannelMembers(channelId, members) {
-    return async (dispatch, getState) => {
+    return async (dispatch) => {
         try {
-            const requests = members.map((m) => dispatch(addChannelMember(channelId, m, getState)));
+            const requests = members.map((m) => dispatch(addChannelMember(channelId, m)));
 
             return await Promise.all(requests);
         } catch (error) {


### PR DESCRIPTION
Removed getState from Add Channel Member method.

#### Summary
Removed getState from Add Channel Member method since the Redux store is not looking for it. 3rd param for this method is a postRootID, which is not sent from this request.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18173

#### Checklist
No changes to the UI or the result of the request.

#### Device Information
This PR was tested on:
iPhone X 12.4 (Simulator)
iPhone Xs Mac 12.3
