### PR TITLE
Fixing mention text color

### DIFF
--- a/app/screens/channel_info/__snapshots__/channel_info_header.test.js.snap
+++ b/app/screens/channel_info/__snapshots__/channel_info_header.test.js.snap
@@ -213,6 +213,7 @@ exports[`channel_info_header should match snapshot 1`] = `
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -360,6 +361,7 @@ exports[`channel_info_header should match snapshot 1`] = `
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -649,6 +651,7 @@ exports[`channel_info_header should match snapshot when DM and hasGuests 1`] = `
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -796,6 +799,7 @@ exports[`channel_info_header should match snapshot when DM and hasGuests 1`] = `
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -1085,6 +1089,7 @@ exports[`channel_info_header should match snapshot when GM and hasGuests 1`] = `
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -1232,6 +1237,7 @@ exports[`channel_info_header should match snapshot when GM and hasGuests 1`] = `
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -1493,6 +1499,7 @@ exports[`channel_info_header should match snapshot when is group constrained 1`]
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -1640,6 +1647,7 @@ exports[`channel_info_header should match snapshot when is group constrained 1`]
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -1950,6 +1958,7 @@ exports[`channel_info_header should match snapshot when public channel and hasGu
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",
@@ -2097,6 +2106,7 @@ exports[`channel_info_header should match snapshot when public channel and hasGu
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
+                  "color": "#166de0",
                 },
                 "strong": Object {
                   "fontWeight": "bold",

--- a/app/screens/channel_info/__snapshots__/channel_info_header.test.js.snap
+++ b/app/screens/channel_info/__snapshots__/channel_info_header.test.js.snap
@@ -209,7 +209,7 @@ exports[`channel_info_header should match snapshot 1`] = `
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -356,7 +356,7 @@ exports[`channel_info_header should match snapshot 1`] = `
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -645,7 +645,7 @@ exports[`channel_info_header should match snapshot when DM and hasGuests 1`] = `
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -792,7 +792,7 @@ exports[`channel_info_header should match snapshot when DM and hasGuests 1`] = `
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -1081,7 +1081,7 @@ exports[`channel_info_header should match snapshot when GM and hasGuests 1`] = `
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -1228,7 +1228,7 @@ exports[`channel_info_header should match snapshot when GM and hasGuests 1`] = `
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -1489,7 +1489,7 @@ exports[`channel_info_header should match snapshot when is group constrained 1`]
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -1636,7 +1636,7 @@ exports[`channel_info_header should match snapshot when is group constrained 1`]
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -1946,7 +1946,7 @@ exports[`channel_info_header should match snapshot when public channel and hasGu
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",
@@ -2093,7 +2093,7 @@ exports[`channel_info_header should match snapshot when public channel and hasGu
                   "color": "#2389d7",
                 },
                 "mention": Object {
-                  "color": "#2389d7",
+                  "color": "#166de0",
                 },
                 "mention_highlight": Object {
                   "backgroundColor": "#ffe577",

--- a/app/screens/interactive_dialog/__snapshots__/dialog_introduction_text.test.js.snap
+++ b/app/screens/interactive_dialog/__snapshots__/dialog_introduction_text.test.js.snap
@@ -113,6 +113,7 @@ exports[`DialogIntroductionText should render the introduction text correctly 1`
         },
         "mention_highlight": Object {
           "backgroundColor": "#ffe577",
+          "color": "#166de0",
         },
         "strong": Object {
           "fontWeight": "bold",

--- a/app/screens/interactive_dialog/__snapshots__/dialog_introduction_text.test.js.snap
+++ b/app/screens/interactive_dialog/__snapshots__/dialog_introduction_text.test.js.snap
@@ -109,7 +109,7 @@ exports[`DialogIntroductionText should render the introduction text correctly 1`
           "color": "#2389d7",
         },
         "mention": Object {
-          "color": "#2389d7",
+          "color": "#166de0",
         },
         "mention_highlight": Object {
           "backgroundColor": "#ffe577",

--- a/app/screens/terms_of_service/__snapshots__/terms_of_service.test.js.snap
+++ b/app/screens/terms_of_service/__snapshots__/terms_of_service.test.js.snap
@@ -119,6 +119,7 @@ exports[`TermsOfService should enable/disable navigator buttons on setNavigatorB
           },
           "mention_highlight": Object {
             "backgroundColor": "#ffe577",
+            "color": "#166de0",
           },
           "strong": Object {
             "fontWeight": "bold",
@@ -253,6 +254,7 @@ exports[`TermsOfService should enable/disable navigator buttons on setNavigatorB
           },
           "mention_highlight": Object {
             "backgroundColor": "#ffe577",
+            "color": "#166de0",
           },
           "strong": Object {
             "fontWeight": "bold",
@@ -451,6 +453,7 @@ exports[`TermsOfService should match snapshot on enableNavigatorLogout 1`] = `
           },
           "mention_highlight": Object {
             "backgroundColor": "#ffe577",
+            "color": "#166de0",
           },
           "strong": Object {
             "fontWeight": "bold",

--- a/app/screens/terms_of_service/__snapshots__/terms_of_service.test.js.snap
+++ b/app/screens/terms_of_service/__snapshots__/terms_of_service.test.js.snap
@@ -115,7 +115,7 @@ exports[`TermsOfService should enable/disable navigator buttons on setNavigatorB
             "color": "#2389d7",
           },
           "mention": Object {
-            "color": "#2389d7",
+            "color": "#166de0",
           },
           "mention_highlight": Object {
             "backgroundColor": "#ffe577",
@@ -249,7 +249,7 @@ exports[`TermsOfService should enable/disable navigator buttons on setNavigatorB
             "color": "#2389d7",
           },
           "mention": Object {
-            "color": "#2389d7",
+            "color": "#166de0",
           },
           "mention_highlight": Object {
             "backgroundColor": "#ffe577",
@@ -447,7 +447,7 @@ exports[`TermsOfService should match snapshot on enableNavigatorLogout 1`] = `
             "color": "#2389d7",
           },
           "mention": Object {
-            "color": "#2389d7",
+            "color": "#166de0",
           },
           "mention_highlight": Object {
             "backgroundColor": "#ffe577",

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -91,6 +91,7 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
         },
         mention_highlight: {
             backgroundColor: theme.mentionHighlightBg,
+            color: theme.mentionHighlightLink,
         },
     };
 });

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -81,7 +81,7 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme) => {
             fontFamily: codeFont,
         },
         mention: {
-            color: theme.linkColor,
+            color: theme.mentionHighlightLink,
         },
         error: {
             color: theme.errorTextColor,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5541,6 +5541,21 @@
         }
       }
     },
+    "character-entities": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -5758,6 +5773,17 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -5839,6 +5865,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-separated-tokens": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
+      "integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
     },
     "commander": {
       "version": "2.19.0",
@@ -6311,6 +6342,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -7524,6 +7561,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fault": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+      "requires": {
+        "format": "^0.2.2"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -8378,6 +8423,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -9132,6 +9182,15 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
       "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -9170,9 +9229,9 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -9195,13 +9254,13 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.5.10",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-          "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
+          "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "commander": "~2.20.0",
+            "commander": "2.20.0",
             "source-map": "~0.6.1"
           }
         }
@@ -9323,6 +9382,27 @@
       "requires": {
         "is-stream": "^1.0.1"
       }
+    },
+    "hast-util-parse-selector": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz",
+      "integrity": "sha512-jIMtnzrLTjzqgVEQqPEmwEZV+ea4zHRFTP8Z2Utw0I5HuBOXHzUPPQWr6ouJdJqDKLbFU/OEiYwZ79LalZkmmw=="
+    },
+    "hastscript": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.0.tgz",
+      "integrity": "sha512-7mOQX5VfVs/gmrOGlN8/EDfp1GqV6P3gTNVt+KnX4gbYhpASTM8bklFdFQCbFRAadURXAmw0R1QQdBdqp7jswQ==",
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.2.0",
+        "property-information": "^5.0.1",
+        "space-separated-tokens": "^1.0.0"
+      }
+    },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -9682,6 +9762,20 @@
         }
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -9755,6 +9849,11 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-decimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -9818,6 +9917,11 @@
       "requires": {
         "is-extglob": "^1.0.0"
       }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -13974,6 +14078,15 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lowlight": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+      "requires": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.12.0"
+      }
+    },
     "lru-cache": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
@@ -14941,9 +15054,9 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -15723,6 +15836,19 @@
         }
       }
     },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -16056,6 +16182,14 @@
         }
       }
     },
+    "prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -16132,6 +16266,14 @@
         "extend": "^3.0.0",
         "graceful-fs": "^4.1.2",
         "retry": "^0.10.0"
+      }
+    },
+    "property-information": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.3.0.tgz",
+      "integrity": "sha512-IslotQn1hBCZDY7SaJ3zmCjVea219VTwmOk6Pu3z9haU9m4+T8GwaDubur+6NMHEU+Fjs/6/p66z6QULPkcL1w==",
+      "requires": {
+        "xtend": "^4.0.1"
       }
     },
     "proxy-from-env": {
@@ -16519,6 +16661,16 @@
       "resolved": "https://registry.npmjs.org/react-native-exception-handler/-/react-native-exception-handler-2.10.7.tgz",
       "integrity": "sha512-e2zv0BiP9SRdr1vLDUyC2WbWHfgNV1a3BhRxK1ENjXVRY8mu+dfaaIHhFXdvYue//MEuGUQstu61NZoiO1u2KA=="
     },
+    "react-native-gesture-handler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.3.0.tgz",
+      "integrity": "sha512-ASRFIXBuKRvqlmwkWJhV8yP2dTpvcqVrLNpd7FKVBFHYWr6SAxjGyO9Ik8w1lAxDhMlRP2IcJ9p9eq5X2WWeLQ==",
+      "requires": {
+        "hoist-non-react-statics": "^2.3.1",
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.10"
+      }
+    },
     "react-native-haptic-feedback": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/react-native-haptic-feedback/-/react-native-haptic-feedback-1.8.2.tgz",
@@ -16674,6 +16826,14 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-9.4.0.tgz",
       "integrity": "sha512-IVJlVbS2dAPerPr927fEi4uXzrPXzlra5ddgyJXZZ2IKA2ZygyYWFZDM+vsQs+Vj20CfL8nOWszQQV57vdQgFg=="
+    },
+    "react-native-syntax-highlighter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-syntax-highlighter/-/react-native-syntax-highlighter-2.1.0.tgz",
+      "integrity": "sha512-upu8gpKT2ZeslXn2d763KwtzzhM9OUHGgJjIKKIUw1JnFAzVwQmKCaFGoI6PkQa7T1LVggBW5k5VoaLFhZDb+g==",
+      "requires": {
+        "react-syntax-highlighter": "^6.0.4"
+      }
     },
     "react-native-tab-view": {
       "version": "1.3.5",
@@ -16973,6 +17133,18 @@
             "react-is": "^16.7.0"
           }
         }
+      }
+    },
+    "react-syntax-highlighter": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-6.1.2.tgz",
+      "integrity": "sha512-ahNwcZ0FhUd8U5TQYcmAqC/pec6Q308mUAATKMcLFmNYkvGhN9wfmoqxzjACcccGb2e85d5ZnGpOiCIIzGO3yA==",
+      "requires": {
+        "babel-runtime": "^6.18.0",
+        "highlight.js": "~9.12.0",
+        "lowlight": "~1.9.1",
+        "prismjs": "^1.8.4",
+        "refractor": "^2.0.0"
       }
     },
     "react-test-renderer": {
@@ -17472,6 +17644,16 @@
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
       "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
       "dev": true
+    },
+    "refractor": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.0.tgz",
+      "integrity": "sha512-maW2ClIkm9IYruuFYGTqKzj+m31heq92wlheW4h7bOstP+gf8bocmMec+j7ljLcaB1CAID85LMB3moye31jH1g==",
+      "requires": {
+        "hastscript": "^5.0.0",
+        "parse-entities": "^1.1.2",
+        "prismjs": "~1.17.0"
+      }
     },
     "regenerate": {
       "version": "1.4.0",
@@ -18292,6 +18474,12 @@
         "object-assign": "^4.1.1"
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
+    },
     "semver": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
@@ -18851,6 +19039,11 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
+    "space-separated-tokens": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
+      "integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
+    },
     "spawn-wrap": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
@@ -19362,6 +19555,12 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "tinycolor2": {
       "version": "1.4.1",


### PR DESCRIPTION
#### Summary
Changes a mention's text color to use `mentionHighlightLink` instead of `linkColor`

This issue becomes most noticeable when the `linkColor` and `mentionHighlightBg` are set to be the same. This is the theme I used when I noticed the bug:

```
{"sidebarBg":"#327c7e","sidebarText":"#ffffff","sidebarUnreadText":"#ffffff","sidebarTextHoverBg":"#001f7e","sidebarTextActiveBorder":"#001f7e","sidebarTextActiveColor":"#ffffff","sidebarHeaderBg":"#001f7e","sidebarHeaderTextColor":"#ffffff","onlineIndicator":"#00ff00","awayIndicator":"#ffff00","dndIndicator":"#f74343","mentionBj":"#00ffff","mentionColor":"#ffffff","centerChannelBg":"#dcdfe2","centerChannelColor":"#000000","newMessageSeparator":"#f80","linkColor":"#0000ff","buttonBg":"#0000ff","buttonColor":"#ffffff","errorTextColor":"#fd5960","mentionHighlightBg":"#0000ff","mentionHighlightLink":"#ff00ff","codeTheme":"github","mentionBg":"#00ffff"}
```

#### Device Information
This PR was tested on:
- iPhone X (simulator)

#### Screenshots
Before fix:
<img width="387" alt="Screen Shot 2019-10-07 at 2 13 41 PM" src="https://user-images.githubusercontent.com/29700158/66286767-d8a43e80-e90d-11e9-81bb-6a9e3e547602.png">

After fix:
<img width="384" alt="Screen Shot 2019-10-07 at 2 14 03 PM" src="https://user-images.githubusercontent.com/29700158/66286773-e2c63d00-e90d-11e9-8bf2-5616c6eab7ce.png">

Same post on the web app for reference:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/29700158/66286801-f07bc280-e90d-11e9-96f2-ae3d4125b64d.png">

