### PR TITLE
MM-17157 Only send notification receipt if server url and session token are set

### DIFF
--- a/app/store/store.js
+++ b/app/store/store.js
@@ -166,8 +166,18 @@ export default function configureAppStore(initialState) {
                             profilesInChannel[channelId] = Array.from(profilesInChannel[channelId]);
                         });
 
+                        let url;
+                        if (state.entities.users.currentUserId) {
+                            url = state.entities.general.credentials.url || state.views.selectServer.serverUrl;
+                        }
+
                         const entities = {
                             ...state.entities,
+                            general: {
+                                credentials: {
+                                    url,
+                                },
+                            },
                             channels: {
                                 ...state.entities.channels,
                                 channelsInTeam,

--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -83,7 +83,7 @@ class ShareViewController: SLComposeServiceViewController {
 
     extractDataFromContext()
     
-    if sessionToken == nil {
+    if sessionToken == nil || serverURL == nil {
       showErrorMessage(title: "", message: "Authentication required: Please first login using the app.", VC: self)
     }
   }

--- a/ios/UploadAttachments/UploadAttachments/StoreManager.m
+++ b/ios/UploadAttachments/UploadAttachments/StoreManager.m
@@ -144,19 +144,29 @@
 }
 
 -(NSString *)getServerUrl {
-  NSDictionary *general = [self.entities objectForKey:@"general"];
-  NSDictionary *credentials = [general objectForKey:@"credentials"];
+    NSDictionary *general = [self.entities objectForKey:@"general"];
+    NSDictionary *credentials = [general objectForKey:@"credentials"];
   
-  return [credentials objectForKey:@"url"];
+    if (credentials) {
+        return [credentials objectForKey:@"url"];
+    }
+    
+    return nil;
 }
 
 -(NSString *)getToken {
     NSDictionary *options = @{
         @"accessGroup": APP_GROUP_ID
     };
-    NSDictionary *credentials = [self.keychain getInternetCredentialsForServer:[self getServerUrl] withOptions:options];
+    NSString* serverUrl = [self getServerUrl];
+
+    if (serverUrl) {
+        NSDictionary *credentials = [self.keychain getInternetCredentialsForServer:[self getServerUrl] withOptions:options];
   
-  return [credentials objectForKey:@"password"];
+        return [credentials objectForKey:@"password"];
+    }
+    
+    return nil;
 }
 
 -(UInt64)scanValueFromConfig:(NSDictionary *)config key:(NSString *)key {


### PR DESCRIPTION
#### Summary
The receipt notification needs the serverURL to be set, at some point the url was removed from the `general.credentials` entities and is only being set when resetting the cache.

This fix consist on writing the url to the entities file as needed and also make sure to invoke the requests only if the serverURL and session token are set.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17157