### PR TITLE
[MM-19209] Pass fileInfoContainer style directly to Touchable

### DIFF
--- a/app/components/file_attachment_list/__snapshots__/file_attachment.test.js.snap
+++ b/app/components/file_attachment_list/__snapshots__/file_attachment.test.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileAttachment should match snapshot 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "borderColor": "rgba(61,60,64,0.2)",
+        "borderRadius": 2,
+        "borderWidth": 1,
+        "flex": 1,
+        "flexDirection": "row",
+        "marginRight": 10,
+        "marginTop": 10,
+        "width": 300,
+      },
+    ]
+  }
+>
+  <TouchableWithFeedbackIOS
+    onPress={[Function]}
+    type="opacity"
+  >
+    <FileAttachmentIcon
+      backgroundColor="#fff"
+      file={
+        Object {
+          "mime_type": "image/png",
+        }
+      }
+      iconHeight={60}
+      iconWidth={60}
+      onCaptureRef={[Function]}
+      theme={
+        Object {
+          "awayIndicator": "#ffbc42",
+          "buttonBg": "#166de0",
+          "buttonColor": "#ffffff",
+          "centerChannelBg": "#ffffff",
+          "centerChannelColor": "#3d3c40",
+          "codeTheme": "github",
+          "dndIndicator": "#f74343",
+          "errorTextColor": "#fd5960",
+          "linkColor": "#2389d7",
+          "mentionBj": "#ffffff",
+          "mentionColor": "#145dbf",
+          "mentionHighlightBg": "#ffe577",
+          "mentionHighlightLink": "#166de0",
+          "newMessageSeparator": "#ff8800",
+          "onlineIndicator": "#06d6a0",
+          "sidebarBg": "#145dbf",
+          "sidebarHeaderBg": "#1153ab",
+          "sidebarHeaderTextColor": "#ffffff",
+          "sidebarText": "#ffffff",
+          "sidebarTextActiveBorder": "#579eff",
+          "sidebarTextActiveColor": "#ffffff",
+          "sidebarTextHoverBg": "#4578bf",
+          "sidebarUnreadText": "#ffffff",
+          "type": "Mattermost",
+        }
+      }
+      wrapperHeight={80}
+      wrapperWidth={80}
+    />
+  </TouchableWithFeedbackIOS>
+  <TouchableWithFeedbackIOS
+    onPress={[Function]}
+    style={
+      Object {
+        "borderLeftColor": "rgba(61,60,64,0.2)",
+        "borderLeftWidth": 1,
+        "flex": 1,
+        "paddingHorizontal": 8,
+        "paddingVertical": 5,
+      }
+    }
+    type="opacity"
+  />
+</View>
+`;

--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -140,15 +140,14 @@ export default class FileAttachment extends PureComponent {
         return (
             <View style={[style.fileWrapper]}>
                 {fileAttachmentComponent}
-                <View style={style.fileInfoContainer}>
-                    <TouchableWithFeedback
-                        onLongPress={onLongPress}
-                        onPress={this.handlePreviewPress}
-                        type={'opacity'}
-                    >
-                        {this.renderFileInfo()}
-                    </TouchableWithFeedback>
-                </View>
+                <TouchableWithFeedback
+                    style={style.fileInfoContainer}
+                    onLongPress={onLongPress}
+                    onPress={this.handlePreviewPress}
+                    type={'opacity'}
+                >
+                    {this.renderFileInfo()}
+                </TouchableWithFeedback>
             </View>
         );
     }

--- a/app/components/file_attachment_list/file_attachment.test.js
+++ b/app/components/file_attachment_list/file_attachment.test.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import FileAttachment from './file_attachment.js';
+import Preferences from 'mattermost-redux/constants/preferences';
+
+jest.mock('react-native-doc-viewer', () => ({
+    openDoc: jest.fn(),
+}));
+
+describe('FileAttachment', () => {
+    const baseProps = {
+        canDownloadFiles: true,
+        file: {
+            create_at: 1546893090093,
+            delete_at: 0,
+            extension: 'png',
+            has_preview_image: true,
+            height: 171,
+            id: 'fileId',
+            name: 'image.png',
+            post_id: 'postId',
+            size: 14894,
+            update_at: 1546893090093,
+            user_id: 'userId',
+            width: 425,
+            data: {
+                mime_type: 'image/png',
+            },
+        },
+        id: 'id',
+        index: 0,
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <FileAttachment {...baseProps}/>
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
`style.fileInfoContainer` was a prop of the `TouchableOpacity` component prior to using the custom `TouchableWithFeedback` component so here I just remove the wrapping `View` and pass the style directly to `TouchableWithFeedback`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19209

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPad and Android emulator
