### PR TITLE
MM-18790 Fix Keyboard Color Flash

### DIFF
--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
@@ -70,7 +70,9 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
     componentDidMount() {
         setTimeout(() => {
             requestAnimationFrame(() => {
-                this.autoresponderRef.current.focus();
+                if (this.autoresponderRef?.current) {
+                    this.autoresponderRef.current.focus();
+                }
             });
         }, 500);
     }

--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
@@ -44,6 +44,8 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
         const {intl} = this.context;
         const notifyProps = getNotificationProps(currentUser);
 
+        this.autoresponderRef = React.createRef();
+
         const autoResponderDefault = intl.formatMessage({
             id: 'mobile.notification_settings.auto_responder.default_message',
             defaultMessage: 'Hello, I am out of office and unable to respond to messages.',
@@ -68,18 +70,10 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
     componentDidMount() {
         setTimeout(() => {
             requestAnimationFrame(() => {
-                this.focus();
+                this.autoresponderRef.current.focus();
             });
         }, 500);
     }
-
-    focus = () => {
-        this.autoresponderInput.focus();
-    };
-
-    autoresponderRef = (ref) => {
-        this.autoresponderInput = ref;
-    };
 
     saveUserNotifyProps = () => {
         this.props.onBack({

--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
@@ -70,7 +70,7 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
     componentDidMount() {
         setTimeout(() => {
             requestAnimationFrame(() => {
-                if (this.autoresponderRef?.current) {
+                if (this.autoresponderRef.current) {
                     this.autoresponderRef.current.focus();
                 }
             });

--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
@@ -65,6 +65,22 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
         this.saveUserNotifyProps();
     }
 
+    componentDidMount() {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                this.focus();
+            });
+        }, 500);
+    }
+
+    focus = () => {
+        this.autoresponderInput.focus();
+    };
+
+    autoresponderRef = (ref) => {
+        this.autoresponderInput = ref;
+    };
+
     saveUserNotifyProps = () => {
         this.props.onBack({
             ...this.state,
@@ -126,8 +142,7 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
                         >
                             <View style={style.inputContainer}>
                                 <TextInputWithLocalizedPlaceholder
-                                    autoFocus={true}
-                                    ref={this.keywordsRef}
+                                    ref={this.autoresponderRef}
                                     value={autoResponderMessage}
                                     blurOnSubmit={false}
                                     onChangeText={this.onAutoResponseChangeText}


### PR DESCRIPTION
#### Summary
Resolved the autoresponder keyboard flash by adding a 500ms delay to the keyboard focus, allowing for a smooth keyboard interaction without the color flash.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18790

#### Checklist
- [x] Has UI changes - UI transition change of the keyboard displaying after the 500ms delay.

#### Device Information
This PR was tested on:
iPhone X 12.4 (Simulator)
Pixel 2 API 29 (Simulator)

#### Screenshots
Demo video of change
[MM-18790_demo.mov.zip](https://github.com/mattermost/mattermost-mobile/files/3700615/MM-18790_demo.mov.zip)


