### PR TITLE
Not show the guest badge for system messages

### DIFF
--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -205,7 +205,7 @@ export default class PostHeader extends PureComponent {
     };
 
     renderTag = () => {
-        const {fromAutoResponder, fromWebHook, isBot, isGuest, theme} = this.props;
+        const {fromAutoResponder, fromWebHook, isBot, isSystemMessage, isGuest, theme} = this.props;
         const style = getStyleSheet(theme);
 
         if (fromWebHook || isBot) {
@@ -215,6 +215,8 @@ export default class PostHeader extends PureComponent {
                     theme={theme}
                 />
             );
+        } else if (isSystemMessage) {
+            return null;
         } else if (isGuest) {
             return (
                 <GuestTag


### PR DESCRIPTION
#### Summary
Not show the guest badge for system messages. When a guest joins to a channel
the system message is showing the badge for guest and shouldn't.

#### Ticket Link
[MM-18930](https://mattermost.atlassian.net/browse/MM-18930)

#### Device Information
This PR was tested on: [One Plus 5, Android 9]