### PR TITLE
[MM-19243] Disable reactions on read only channel

### DIFF
--- a/app/components/reactions/index.js
+++ b/app/components/reactions/index.js
@@ -11,7 +11,7 @@ import {hasNewPermissions} from 'mattermost-redux/selectors/entities/general';
 import Permissions from 'mattermost-redux/constants/permissions';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 
 import {addReaction} from 'app/actions/views/emoji';
 
@@ -25,10 +25,11 @@ function makeMapStateToProps() {
         const channel = getChannel(state, channelId) || {};
         const teamId = channel.team_id;
         const channelIsArchived = channel.delete_at !== 0;
+        const channelIsReadOnly = isChannelReadOnlyById(state, channelId);
 
         let canAddReaction = true;
         let canRemoveReaction = true;
-        if (channelIsArchived) {
+        if (channelIsArchived || channelIsReadOnly) {
             canAddReaction = false;
             canRemoveReaction = false;
         } else if (hasNewPermissions(state)) {


### PR DESCRIPTION
#### Summary

This PR disables the ability to add emoji reactions to posts in a read-only channel. The plus sign is now not present, and tapping on an existing emoji now has no effect.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19243

#### Screenshots

I had reacted to a post before making the channel read-only, to show the behavior of the fix:

![image](https://user-images.githubusercontent.com/6913320/66590864-b275dd00-eb5f-11e9-8135-af66077ab382.png)

