### PR TITLE
#12354 Remove deprecated lifecycle methods from settings screens

### DIFF
--- a/app/components/radio_button/radio_button_group.js
+++ b/app/components/radio_button/radio_button_group.js
@@ -24,11 +24,11 @@ export default class RadioButtonGroup extends PureComponent {
             selected: this.getSelectedValue(props.options),
         };
     }
-
-    componentWillReceiveProps(nextProps) {
-        if (this.props.options !== nextProps.options) {
-            this.setState({selected: this.getSelectedValue(nextProps.options)});
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.options !== nextProps.options) {
+            return { selected: prevState.getSelectedValue(nextProps.options) };
         }
+        return null;
     }
 
     getSelectedValue = (options = []) => {

--- a/app/screens/settings/notification_settings/notification_settings.js
+++ b/app/screens/settings/notification_settings/notification_settings.js
@@ -38,13 +38,12 @@ class NotificationSettings extends PureComponent {
         isLandscape: PropTypes.bool.isRequired,
     };
 
-    componentWillReceiveProps(nextProps) {
-        if (this.props.theme !== nextProps.theme) {
-            setNavigatorStyles(this.props.componentId, nextProps.theme);
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.theme !== nextProps.theme) {
+            setNavigatorStyles(prevState.componentId, nextProps.theme)
         }
-
         const {updateMeRequest, intl} = nextProps;
-        if (this.props.updateMeRequest !== updateMeRequest && updateMeRequest.status === RequestStatus.FAILURE) {
+        if (prevState.updateMeRequest !== updateMeRequest && updateMeRequest.status === RequestStatus.FAILURE) {
             Alert.alert(
                 intl.formatMessage({
                     id: 'mobile.notification_settings.save_failed_title',
@@ -56,6 +55,8 @@ class NotificationSettings extends PureComponent {
                 })
             );
         }
+
+        return null;
     }
 
     handlePress = preventDoubleTap((action) => {

--- a/app/screens/settings/notification_settings_email/notification_settings_email_base.js
+++ b/app/screens/settings/notification_settings_email/notification_settings_email_base.js
@@ -41,7 +41,7 @@ export default class NotificationSettingsEmailBase extends PureComponent {
 
         this.state = {
             emailInterval,
-            newInterval: this.computeEmailInterval(notifyProps?.email === 'true' && sendEmailNotifications, enableEmailBatching, emailInterval),
+            newInterval: this.computeEmailInterval(notifyProps.email === 'true' && sendEmailNotifications, enableEmailBatching, emailInterval),
             showEmailNotificationsModal: false,
         };
     }
@@ -49,9 +49,8 @@ export default class NotificationSettingsEmailBase extends PureComponent {
     componentDidMount() {
         this.navigationEventListener = Navigation.events().bindComponent(this);
     }
-
-    componentWillReceiveProps(nextProps) {
-        if (this.props.theme !== nextProps.theme) {
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.theme !== nextProps.theme) {
             setNavigatorStyles(this.props.componentId, nextProps.theme);
         }
 
@@ -63,17 +62,19 @@ export default class NotificationSettingsEmailBase extends PureComponent {
         } = nextProps;
 
         if (
-            this.props.sendEmailNotifications !== sendEmailNotifications ||
-            this.props.enableEmailBatching !== enableEmailBatching ||
-            this.props.emailInterval !== emailInterval
+            prevState.sendEmailNotifications !== sendEmailNotifications ||
+            prevState.enableEmailBatching !== enableEmailBatching ||
+            prevState.emailInterval !== emailInterval
         ) {
             const notifyProps = getNotificationProps(currentUser);
 
-            this.setState({
+            return {
                 emailInterval,
-                newInterval: this.computeEmailInterval(notifyProps?.email === 'true' && sendEmailNotifications, enableEmailBatching, emailInterval),
-            });
+                newInterval: prevState.computeEmailInterval(notifyProps.email === 'true' && sendEmailNotifications, enableEmailBatching, emailInterval)
+            }
         }
+
+        return null;
     }
 
     componentDidDisappear() {

--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile.android.js
@@ -370,11 +370,9 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
         );
     }
 
-    componentWillReceiveProps(nextProps) {
-        super.componentWillReceiveProps(nextProps);
-
+    static getDerivedStateFromProps(nextProps, prevState) {
         const {updateMeRequest, intl} = nextProps;
-        if (this.props.updateMeRequest !== updateMeRequest && updateMeRequest.status === RequestStatus.FAILURE) {
+        if (prevState.updateMeRequest !== updateMeRequest && updateMeRequest.status === RequestStatus.FAILURE) {
             Alert.alert(
                 intl.formatMessage({
                     id: 'mobile.notification_settings.save_failed_title',
@@ -386,6 +384,7 @@ class NotificationSettingsMobileAndroid extends NotificationSettingsMobileBase {
                 })
             );
         }
+        return null;
     }
 
     renderMobilePushSection() {


### PR DESCRIPTION
#### Summary
Remove deprecated lifecycle method (UNSAFE_componentWillRecieveProps, v.React 17+ ) to newer feature lifecycle method called _static getDerivedStateFromProps_ .
Not specially a UI change just a background behaviour changes, thats why no screenshots are included and no need.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/12354

#### Checklist
- [x] Has UI changes (Lifecycle component re-done)

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 
MacOS

#### Screenshots
