### PR TITLE
[MM-19307] Make LHS channel item display name not overlap with mention count

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
+++ b/app/components/sidebars/main/channels_list/channel_item/__snapshots__/channel_item.test.js.snap
@@ -87,6 +87,7 @@ exports[`ChannelItem should match snapshot 1`] = `
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {
@@ -202,6 +203,7 @@ exports[`ChannelItem should match snapshot for current user i.e currentUser (you
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {
@@ -316,6 +318,7 @@ exports[`ChannelItem should match snapshot for current user i.e currentUser (you
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {
@@ -430,6 +433,7 @@ exports[`ChannelItem should match snapshot for deactivated user and is currentCh
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {
@@ -533,6 +537,7 @@ exports[`ChannelItem should match snapshot for deactivated user and is searchRes
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {
@@ -637,6 +642,7 @@ exports[`ChannelItem should match snapshot for deactivated user and not searchRe
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {
@@ -745,6 +751,7 @@ exports[`ChannelItem should match snapshot with draft 1`] = `
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {
@@ -851,6 +858,7 @@ exports[`ChannelItem should match snapshot with mentions and muted 1`] = `
                 "fontFamily": "Open Sans",
                 "fontSize": 16,
                 "lineHeight": 24,
+                "maxWidth": "80%",
                 "paddingRight": 10,
               },
               Object {

--- a/app/components/sidebars/main/channels_list/channel_item/channel_item.js
+++ b/app/components/sidebars/main/channels_list/channel_item/channel_item.js
@@ -245,6 +245,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 16,
             lineHeight: 24,
             paddingRight: 10,
+            maxWidth: '80%',
             flex: 1,
             alignSelf: 'center',
             fontFamily: 'Open Sans',


### PR DESCRIPTION
#### Summary

This PR makes the channel item display name more narrow, so the name does not overlap with the mention count.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19307

#### Checklist

- [x] Has UI changes

#### Device Information
This PR was tested on: Google Pixel 2, Android 8.1.0

#### Screenshots

Before fix:

![image](https://user-images.githubusercontent.com/6913320/66765905-d7799100-ee7a-11e9-8c79-c1c1fdd6123a.png)

80% max width (This PR is currently at this value):

![image](https://user-images.githubusercontent.com/6913320/66765924-e3655300-ee7a-11e9-986b-3b71492661f9.png)

75% max width:

![image](https://user-images.githubusercontent.com/6913320/66765947-f2e49c00-ee7a-11e9-994d-55756fad7cd0.png)