### PR TITLE
[MM-18769]: Remove deprecated lifecycle methods from login screens

### DIFF
--- a/app/components/client_upgrade_listener/client_upgrade_listener.js
+++ b/app/components/client_upgrade_listener/client_upgrade_listener.js
@@ -60,7 +60,10 @@ export default class ClientUpgradeListener extends PureComponent {
         if (prevState.isLandscape !== nextProps.isLandscape &&
           isUpgradeAvailable(prevState.upgradeType) && DeviceTypes.IS_IPHONE_WITH_INSETS) {
             const newTop = nextProps.isLandscape ? 45 : 100;
-            return {top: new Animated.Value(newTop)};
+            return {
+                top: new Animated.Value(newTop),
+                isLandscape: nextProps.isLandscape,
+            };
         }
 
         return null;

--- a/app/components/client_upgrade_listener/client_upgrade_listener.js
+++ b/app/components/client_upgrade_listener/client_upgrade_listener.js
@@ -40,6 +40,7 @@ export default class ClientUpgradeListener extends PureComponent {
     };
 
     static contextTypes = {
+        isLandscape: this.props.isLandscape,
         intl: intlShape,
     };
 
@@ -55,6 +56,16 @@ export default class ClientUpgradeListener extends PureComponent {
         };
     }
 
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.isLandscape !== nextProps.isLandscape &&
+          isUpgradeAvailable(prevState.upgradeType) && DeviceTypes.IS_IPHONE_WITH_INSETS) {
+            const newTop = nextProps.isLandscape ? 45 : 100;
+            return {top: new Animated.Value(newTop)};
+        }
+
+        return null;
+    }
+
     componentDidMount() {
         const {forceUpgrade, isLandscape, lastUpgradeCheck, latestVersion, minVersion} = this.props;
         if (forceUpgrade || Date.now() - lastUpgradeCheck > UPDATE_TIMEOUT) {
@@ -62,17 +73,13 @@ export default class ClientUpgradeListener extends PureComponent {
         }
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        const {forceUpgrade, latestVersion, minVersion} = this.props;
-        const {latestVersion: nextLatestVersion, minVersion: nextMinVersion, lastUpgradeCheck} = nextProps;
+    componentDidUpdate(prevProps) {
+        const {forceUpgrade, latestVersion, minVersion, isLandscape} = this.props;
+        const {latestVersion: prevLatestVersion, minVersion: prevMinVersion, lastUpgradeCheck} = prevProps;
 
-        const versionMismatch = latestVersion !== nextLatestVersion || minVersion !== nextMinVersion;
+        const versionMismatch = latestVersion !== prevLatestVersion || minVersion !== prevMinVersion;
         if (versionMismatch && (forceUpgrade || Date.now() - lastUpgradeCheck > UPDATE_TIMEOUT)) {
-            this.checkUpgrade(minVersion, latestVersion, nextProps.isLandscape);
-        } else if (this.props.isLandscape !== nextProps.isLandscape &&
-            isUpgradeAvailable(this.state.upgradeType) && DeviceTypes.IS_IPHONE_WITH_INSETS) {
-            const newTop = nextProps.isLandscape ? 45 : 100;
-            this.setState({top: new Animated.Value(newTop)});
+            this.checkUpgrade(minVersion, latestVersion, isLandscape);
         }
     }
 

--- a/app/components/client_upgrade_listener/client_upgrade_listener.js
+++ b/app/components/client_upgrade_listener/client_upgrade_listener.js
@@ -62,7 +62,7 @@ export default class ClientUpgradeListener extends PureComponent {
         }
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
         const {forceUpgrade, latestVersion, minVersion} = this.props;
         const {latestVersion: nextLatestVersion, minVersion: nextMinVersion, lastUpgradeCheck} = nextProps;
 

--- a/app/components/client_upgrade_listener/client_upgrade_listener.js
+++ b/app/components/client_upgrade_listener/client_upgrade_listener.js
@@ -62,7 +62,7 @@ export default class ClientUpgradeListener extends PureComponent {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         const {forceUpgrade, latestVersion, minVersion} = this.props;
         const {latestVersion: nextLatestVersion, minVersion: nextMinVersion, lastUpgradeCheck} = nextProps;
 

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -68,25 +68,19 @@ export default class Login extends PureComponent {
         };
     }
 
-    static getDerivedStateFromProps(nextProps, prevState) {
-        if (prevState.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
-            return {isLoading: false};
-        }
-
-        return null;
-    }
-
     componentDidMount() {
         Dimensions.addEventListener('change', this.orientationDidChange);
 
         setMfaPreflightDone(false);
     }
 
-    componentDidUpdate(prevProps) {
-        const {loginRequest, actions} = this.props;
-        if (prevProps.loginRequest.status === RequestStatus.STARTED && loginRequest.status === RequestStatus.SUCCESS) {
-            actions.handleSuccessfulLogin().then(this.goToChannel);
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
+            return {isLoading: false};
+        } else if (nextProps.loginRequest.status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
+            return nextProps.actions.handleSuccessfulLogin().then(this.goToChannel);
         }
+        return null;
     }
 
     componentWillUnmount() {

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -74,11 +74,9 @@ export default class Login extends PureComponent {
         setMfaPreflightDone(false);
     }
 
-    componentDidUpdate(nextProps) {
-        const {loginRequest: {status}, actions: {handleSuccessfulLogin}} = this.props;
-
-        if (status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
-            handleSuccessfulLogin().then(this.goToChannel);
+    componentDidUpdate(prevProps) {
+        if (this.props.loginRequest.status === RequestStatus.STARTED && prevProps.loginRequest.status === RequestStatus.SUCCESS) {
+            this.props.actions.handleSuccessfulLogin().then(this.goToChannel);
         }
     }
 
@@ -87,8 +85,13 @@ export default class Login extends PureComponent {
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
-        if (prevState.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
-            return {isLoading: false};
+        if (prevState.loginRequest.status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
+            return null;
+        } else if (prevState.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
+            return {
+                isLoading: false,
+                loginRequest: nextProps.loginRequest,
+            };
         }
         return null;
     }

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -63,8 +63,17 @@ export default class Login extends PureComponent {
         super(props);
 
         this.state = {
+            loginRequest: this.props.loginRequest,
             error: null,
         };
+    }
+
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
+            return {isLoading: false};
+        }
+
+        return null;
     }
 
     componentDidMount() {
@@ -73,11 +82,10 @@ export default class Login extends PureComponent {
         setMfaPreflightDone(false);
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (this.props.loginRequest.status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
-            this.props.actions.handleSuccessfulLogin().then(this.goToChannel);
-        } else if (this.props.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
-            this.setState({isLoading: false});
+    componentDidUpdate() {
+        const {loginRequest, actions} = this.props;
+        if (loginRequest.status === RequestStatus.STARTED && loginRequest.status === RequestStatus.SUCCESS) {
+            actions.handleSuccessfulLogin().then(this.goToChannel);
         }
     }
 

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -63,7 +63,6 @@ export default class Login extends PureComponent {
         super(props);
 
         this.state = {
-            loginRequest: this.props.loginRequest,
             error: null,
         };
     }
@@ -74,13 +73,14 @@ export default class Login extends PureComponent {
         setMfaPreflightDone(false);
     }
 
-    static getDerivedStateFromProps(nextProps, prevState) {
-        if (prevState.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
-            return {isLoading: false};
-        } else if (nextProps.loginRequest.status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
-            return nextProps.actions.handleSuccessfulLogin().then(this.goToChannel);
-        }
-        return null;
+    componentDidUpdate(nextProps) {
+       const {loginRequest:{status}, actions:{handleSuccessfulLogin}} = this.props;
+
+        if (status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
+           handleSuccessfulLogin().then(this.goToChannel);
+       } else if (status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
+           this.setState({isLoading: false});
+       }
     }
 
     componentWillUnmount() {

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -63,6 +63,7 @@ export default class Login extends PureComponent {
         super(props);
 
         this.state = {
+            loginRequest: this.props.loginRequest,
             error: null,
         };
     }
@@ -74,17 +75,22 @@ export default class Login extends PureComponent {
     }
 
     componentDidUpdate(nextProps) {
-       const {loginRequest:{status}, actions:{handleSuccessfulLogin}} = this.props;
+        const {loginRequest: {status}, actions: {handleSuccessfulLogin}} = this.props;
 
         if (status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
-           handleSuccessfulLogin().then(this.goToChannel);
-       } else if (status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
-           this.setState({isLoading: false});
-       }
+            handleSuccessfulLogin().then(this.goToChannel);
+        }
     }
 
     componentWillUnmount() {
         Dimensions.removeEventListener('change', this.orientationDidChange);
+    }
+
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {
+            return {isLoading: false};
+        }
+        return null;
     }
 
     goToChannel = () => {

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -82,9 +82,9 @@ export default class Login extends PureComponent {
         setMfaPreflightDone(false);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps) {
         const {loginRequest, actions} = this.props;
-        if (loginRequest.status === RequestStatus.STARTED && loginRequest.status === RequestStatus.SUCCESS) {
+        if (prevProps.loginRequest.status === RequestStatus.STARTED && loginRequest.status === RequestStatus.SUCCESS) {
             actions.handleSuccessfulLogin().then(this.goToChannel);
         }
     }

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -73,7 +73,7 @@ export default class Login extends PureComponent {
         setMfaPreflightDone(false);
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         if (this.props.loginRequest.status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
             this.props.actions.handleSuccessfulLogin().then(this.goToChannel);
         } else if (this.props.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -73,7 +73,7 @@ export default class Login extends PureComponent {
         setMfaPreflightDone(false);
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
         if (this.props.loginRequest.status === RequestStatus.STARTED && nextProps.loginRequest.status === RequestStatus.SUCCESS) {
             this.props.actions.handleSuccessfulLogin().then(this.goToChannel);
         } else if (this.props.loginRequest.status !== nextProps.loginRequest.status && nextProps.loginRequest.status !== RequestStatus.STARTED) {

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -68,13 +68,15 @@ export default class SelectTeam extends PureComponent {
         this.getTeams();
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (this.props.theme !== nextProps.theme) {
-            setNavigatorStyles(this.props.componentId, nextProps.theme);
+    componentDidUpdate(prevProps) {
+        const {theme, componentId, teams} = this.props;
+
+        if (theme !== prevProps.theme) {
+            setNavigatorStyles(componentId, theme);
         }
 
-        if (this.props.teams !== nextProps.teams) {
-            this.buildData(nextProps);
+        if (teams !== prevProps.teams) {
+            this.buildData(teams);
         }
     }
 

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -76,7 +76,7 @@ export default class SelectTeam extends PureComponent {
         }
 
         if (teams !== prevProps.teams) {
-            this.buildData(teams);
+            this.buildData(this.props);
         }
     }
 

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -68,7 +68,7 @@ export default class SelectTeam extends PureComponent {
         this.getTeams();
     }
 
-    componentWillReceiveProps(nextProps) {
+     UNSAFE_componentWillReceiveProps(nextProps) {
         if (this.props.theme !== nextProps.theme) {
             setNavigatorStyles(this.props.componentId, nextProps.theme);
         }

--- a/app/screens/select_team/select_team.js
+++ b/app/screens/select_team/select_team.js
@@ -68,7 +68,7 @@ export default class SelectTeam extends PureComponent {
         this.getTeams();
     }
 
-     UNSAFE_componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
         if (this.props.theme !== nextProps.theme) {
             setNavigatorStyles(this.props.componentId, nextProps.theme);
         }


### PR DESCRIPTION
Please make sure you've read the [pull request](https://developers.mattermost.com/contribute/getting-started/contribution-checklist/) section of our [code contribution guidelines](https://developers.mattermost.com/contribute/getting-started/).

When filling in a section please remove the help text and the above text.

#### Summary
Remove deprecated lifecycle methods from login screens

#### Ticket Link
MM-18769

Fixes https://github.com/mattermost/mattermost-server/issues/12350

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
