### PR TITLE
MM-19328 | Add accessibility label to channel drawer button.

### DIFF
--- a/app/screens/channel/channel_nav_bar/channel_drawer_button/__snapshots__/channel_drawer_button.test.js.snap
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button/__snapshots__/channel_drawer_button.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`ChannelDrawerButton should match, full snapshot 1`] = `
 <TouchableOpacity
+  accessibilityLabel="Channels and teams"
+  accessible={true}
   activeOpacity={0.2}
   onPress={[Function]}
   style={
@@ -38,6 +40,8 @@ exports[`ChannelDrawerButton should match, full snapshot 1`] = `
 
 exports[`ChannelDrawerButton should match, full snapshot 2`] = `
 <TouchableOpacity
+  accessibilityLabel="Channels and teams"
+  accessible={true}
   activeOpacity={0.2}
   onPress={[Function]}
   style={

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button/__snapshots__/channel_drawer_button.test.js.snap
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button/__snapshots__/channel_drawer_button.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`ChannelDrawerButton should match, full snapshot 1`] = `
 <TouchableOpacity
+  accessibilityHint="Opens the channels and teams drawer"
   accessibilityLabel="Channels and teams"
+  accessibilityRole="button"
   accessible={true}
   activeOpacity={0.2}
   onPress={[Function]}
@@ -40,7 +42,9 @@ exports[`ChannelDrawerButton should match, full snapshot 1`] = `
 
 exports[`ChannelDrawerButton should match, full snapshot 2`] = `
 <TouchableOpacity
+  accessibilityHint="Opens the channels and teams drawer"
   accessibilityLabel="Channels and teams"
+  accessibilityRole="button"
   accessible={true}
   activeOpacity={0.2}
   onPress={[Function]}

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button/channel_drawer_button.js
@@ -69,12 +69,19 @@ export default class ChannelDrawerButton extends PureComponent {
 
         const {formatMessage} = this.context.intl;
 
-        const descriptor = {
+        const buttonDescriptor = {
             id: t('navbar.channel_drawer.button'),
             defaultMessage: 'Channels and teams',
             description: 'Accessibility helper for channel drawer button.',
         };
-        const accessibilityLabel = formatMessage(descriptor);
+        const accessibilityLabel = formatMessage(buttonDescriptor);
+
+        const buttonHint = {
+            id: t('navbar.channel_drawer.hint'),
+            defaultMessage: 'Opens the channels and teams drawer',
+            description: 'Accessibility helper for explaining what the channel drawer button will do.',
+        };
+        const accessibilityHint = formatMessage(buttonHint);
 
         const style = getStyleFromTheme(theme);
 
@@ -111,7 +118,9 @@ export default class ChannelDrawerButton extends PureComponent {
         return (
             <TouchableOpacity
                 accessible={true}
+                accessibilityHint={accessibilityHint}
                 accessibilityLabel={accessibilityLabel}
+                accessibilityRole='button'
                 onPress={this.handlePress}
                 style={containerStyle}
             >

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button/channel_drawer_button.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button/channel_drawer_button.js
@@ -14,6 +14,8 @@ import Badge from 'app/components/badge';
 import PushNotifications from 'app/push_notifications';
 import {preventDoubleTap} from 'app/utils/tap';
 import {makeStyleSheetFromTheme} from 'app/utils/theme';
+import {t} from 'app/utils/i18n';
+import {intlShape} from 'react-intl';
 
 import telemetry from 'app/telemetry';
 
@@ -23,6 +25,10 @@ export default class ChannelDrawerButton extends PureComponent {
         badgeCount: PropTypes.number,
         theme: PropTypes.object,
         visible: PropTypes.bool,
+    };
+
+    static contextTypes = {
+        intl: intlShape.isRequired,
     };
 
     static defaultProps = {
@@ -61,6 +67,15 @@ export default class ChannelDrawerButton extends PureComponent {
             visible,
         } = this.props;
 
+        const {formatMessage} = this.context.intl;
+
+        const descriptor = {
+            id: t('navbar.channel_drawer.button'),
+            defaultMessage: 'Channels and teams',
+            description: 'Accessibility helper for channel drawer button.',
+        };
+        const accessibilityLabel = formatMessage(descriptor);
+
         const style = getStyleFromTheme(theme);
 
         let badge;
@@ -95,6 +110,8 @@ export default class ChannelDrawerButton extends PureComponent {
 
         return (
             <TouchableOpacity
+                accessible={true}
+                accessibilityLabel={accessibilityLabel}
                 onPress={this.handlePress}
                 style={containerStyle}
             >

--- a/app/screens/channel/channel_nav_bar/channel_drawer_button/channel_drawer_button.test.js
+++ b/app/screens/channel/channel_nav_bar/channel_drawer_button/channel_drawer_button.test.js
@@ -2,13 +2,13 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
 import NotificationsIOS from 'react-native-notifications';
 
 import Preferences from 'mattermost-redux/constants/preferences';
 
 import Badge from 'app/components/badge';
 import PushNotification from 'app/push_notifications/push_notifications.ios';
+import {shallowWithIntl} from 'test/intl-test-helper';
 
 import ChannelDrawerButton from './channel_drawer_button';
 
@@ -48,7 +48,7 @@ describe('ChannelDrawerButton', () => {
     afterEach(() => NotificationsIOS.setBadgesCount(0));
 
     test('should match, full snapshot', () => {
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <ChannelDrawerButton {...baseProps}/>
         );
 
@@ -69,7 +69,7 @@ describe('ChannelDrawerButton', () => {
             badgeCount: 0,
         };
 
-        shallow(
+        shallowWithIntl(
             <ChannelDrawerButton {...props}/>
         );
         expect(setApplicationIconBadgeNumber).not.toBeCalled();
@@ -83,7 +83,7 @@ describe('ChannelDrawerButton', () => {
             badgeCount: 1,
         };
 
-        shallow(
+        shallowWithIntl(
             <ChannelDrawerButton {...props}/>
         );
         expect(setApplicationIconBadgeNumber).toHaveBeenCalledTimes(1);
@@ -97,7 +97,7 @@ describe('ChannelDrawerButton', () => {
             badgeCount: 0,
         };
 
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <ChannelDrawerButton {...props}/>
         );
         NotificationsIOS.getBadgesCount((count) => expect(count).toBe(0));
@@ -115,7 +115,7 @@ describe('ChannelDrawerButton', () => {
             badgeCount: 0,
         };
 
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <ChannelDrawerButton {...props}/>
         );
         wrapper.setProps({badgeCount: 2});

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -487,6 +487,7 @@
   "msg_typing.isTyping": "{user} is typing...",
   "navbar_dropdown.logout": "Logout",
   "navbar.channel_drawer.button": "Channels and teams",
+  "navbar.channel_drawer.hint": "Opens the channels and teams drawer",
   "navbar.leave": "Leave Channel",
   "password_form.title": "Password Reset",
   "password_send.checkInbox": "Please check your inbox.",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -486,6 +486,7 @@
   "msg_typing.areTyping": "{users} and {last} are typing...",
   "msg_typing.isTyping": "{user} is typing...",
   "navbar_dropdown.logout": "Logout",
+  "navbar.channel_drawer.button": "Channels and teams",
   "navbar.leave": "Leave Channel",
   "password_form.title": "Password Reset",
   "password_send.checkInbox": "Please check your inbox.",


### PR DESCRIPTION
#### Summary
Adds an accessibility label to the channel drawer button.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12839
JIRA: https://mattermost.atlassian.net/browse/MM-19328

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
- iPhone X iOS 12.4 Simulator
- iPhone 11 Pro iOS 13.1 Simulator

#### Screenshots
**X - 12.4**
![Screen Shot 2019-10-21 at 00 39 50](https://user-images.githubusercontent.com/31187/67177246-b72a6480-f39b-11e9-9b5e-0349c06d4584.png)
**11 Pro - 13.1**
![Screen Shot 2019-10-21 at 00 56 13](https://user-images.githubusercontent.com/31187/67177694-ada1fc00-f39d-11e9-99bb-11cdaf5b2f97.png)

