### PR TITLE
[MM-18983] Store insets in ephemeral store

### DIFF
--- a/app/components/safe_area_view/safe_area_view.ios.js
+++ b/app/components/safe_area_view/safe_area_view.ios.js
@@ -8,11 +8,12 @@ import SafeArea from 'react-native-safe-area';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
-import {DeviceTypes} from 'app/constants';
+import {DeviceTypes, ViewTypes} from 'app/constants';
 import mattermostManaged from 'app/mattermost_managed';
 import EphemeralStore from 'app/store/ephemeral_store';
 
 const {StatusBarManager} = NativeModules;
+const {PORTRAIT, LANDSCAPE} = ViewTypes;
 
 export default class SafeAreaIos extends PureComponent {
     static propTypes = {
@@ -60,7 +61,7 @@ export default class SafeAreaIos extends PureComponent {
 
         Dimensions.addEventListener('change', this.getSafeAreaInsets);
         EventEmitter.on('update_safe_area_view', this.getSafeAreaInsets);
-        if (EphemeralStore.safeAreaInsets.portait === null || EphemeralStore.safeAreaInsets.landscape === null) {
+        if (EphemeralStore.safeAreaInsets[PORTRAIT] === null || EphemeralStore.safeAreaInsets[LANDSCAPE] === null) {
             SafeArea.addEventListener('safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsForRootViewChange);
         }
 
@@ -83,7 +84,8 @@ export default class SafeAreaIos extends PureComponent {
     getSafeAreaInsets = async (dimensions) => {
         this.getStatusBarHeight();
 
-        if (DeviceTypes.IS_IPHONE_WITH_INSETS || mattermostManaged.hasSafeAreaInsets) {
+        const safeAreaInsetsStored = EphemeralStore.safeAreaInsets[PORTRAIT] !== null && EphemeralStore.safeAreaInsets[LANDSCAPE] !== null;
+        if ((DeviceTypes.IS_IPHONE_WITH_INSETS || mattermostManaged.hasSafeAreaInsets) && !safeAreaInsetsStored) {
             const window = dimensions?.window || Dimensions.get('window');
             const landscape = window.width > window.length;
             const {safeAreaInsets} = await SafeArea.getSafeAreaInsetsForRootView();
@@ -92,8 +94,8 @@ export default class SafeAreaIos extends PureComponent {
     }
 
     setSafeAreaInsets = (safeAreaInsets, landscape) => {
-        const orientation = landscape ? 'landscape' : 'portrait';
-        if (!EphemeralStore.safeAreaInsets[orientation]) {
+        const orientation = landscape ? LANDSCAPE : PORTRAIT;
+        if (EphemeralStore.safeAreaInsets[orientation] === null) {
             EphemeralStore.safeAreaInsets[orientation] = safeAreaInsets;
         }
 
@@ -119,7 +121,7 @@ export default class SafeAreaIos extends PureComponent {
     };
 
     onSafeAreaInsetsForRootViewChange = ({safeAreaInsets}) => {
-        if (EphemeralStore.safeAreaInsets.portait !== null && EphemeralStore.safeAreaInsets.landscape !== null) {
+        if (EphemeralStore.safeAreaInsets[PORTRAIT] !== null && EphemeralStore.safeAreaInsets[LANDSCAPE] !== null) {
             SafeArea.removeEventListener('safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsForRootViewChange);
             return;
         }

--- a/app/components/safe_area_view/safe_area_view.ios.js
+++ b/app/components/safe_area_view/safe_area_view.ios.js
@@ -3,13 +3,14 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Keyboard, NativeModules, View} from 'react-native';
+import {Dimensions, Keyboard, NativeModules, View} from 'react-native';
 import SafeArea from 'react-native-safe-area';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {DeviceTypes} from 'app/constants';
 import mattermostManaged from 'app/mattermost_managed';
+import EphemeralStore from 'app/store/ephemeral_store';
 
 const {StatusBarManager} = NativeModules;
 
@@ -57,8 +58,12 @@ export default class SafeAreaIos extends PureComponent {
     componentDidMount() {
         this.mounted = true;
 
-        SafeArea.addEventListener('safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsForRootViewChange);
+        Dimensions.addEventListener('change', this.getSafeAreaInsets);
         EventEmitter.on('update_safe_area_view', this.getSafeAreaInsets);
+        if (EphemeralStore.safeAreaInsets.portait === null || EphemeralStore.safeAreaInsets.landscape === null) {
+            SafeArea.addEventListener('safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsForRootViewChange);
+        }
+
         this.keyboardDidShowListener = Keyboard.addListener('keyboardWillShow', this.keyboardWillShow);
         this.keyboardDidHideListener = Keyboard.addListener('keyboardWillHide', this.keyboardWillHide);
 
@@ -66,12 +71,37 @@ export default class SafeAreaIos extends PureComponent {
     }
 
     componentWillUnmount() {
-        SafeArea.removeEventListener('safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsForRootViewChange);
+        Dimensions.removeEventListener('change', this.getSafeAreaInsets);
         EventEmitter.off('update_safe_area_view', this.getSafeAreaInsets);
+        SafeArea.removeEventListener('safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsForRootViewChange);
         this.keyboardDidShowListener.remove();
         this.keyboardDidHideListener.remove();
 
         this.mounted = false;
+    }
+
+    getSafeAreaInsets = async (dimensions) => {
+        this.getStatusBarHeight();
+
+        if (DeviceTypes.IS_IPHONE_WITH_INSETS || mattermostManaged.hasSafeAreaInsets) {
+            const window = dimensions?.window || Dimensions.get('window');
+            const landscape = window.width > window.length;
+            const {safeAreaInsets} = await SafeArea.getSafeAreaInsetsForRootView();
+            this.setSafeAreaInsets(safeAreaInsets, landscape);
+        }
+    }
+
+    setSafeAreaInsets = (safeAreaInsets, landscape) => {
+        const orientation = landscape ? 'landscape' : 'portrait';
+        if (!EphemeralStore.safeAreaInsets[orientation]) {
+            EphemeralStore.safeAreaInsets[orientation] = safeAreaInsets;
+        }
+
+        if (this.mounted) {
+            this.setState({
+                safeAreaInsets: EphemeralStore.safeAreaInsets[orientation],
+            });
+        }
     }
 
     getStatusBarHeight = () => {
@@ -88,26 +118,18 @@ export default class SafeAreaIos extends PureComponent {
         }
     };
 
-    getSafeAreaInsets = () => {
-        this.getStatusBarHeight();
+    onSafeAreaInsetsForRootViewChange = ({safeAreaInsets}) => {
+        if (EphemeralStore.safeAreaInsets.portait !== null && EphemeralStore.safeAreaInsets.landscape !== null) {
+            SafeArea.removeEventListener('safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsForRootViewChange);
+            return;
+        }
 
         if (DeviceTypes.IS_IPHONE_WITH_INSETS || mattermostManaged.hasSafeAreaInsets) {
-            SafeArea.getSafeAreaInsetsForRootView().then((result) => {
-                const {safeAreaInsets} = result;
-
-                if (this.mounted) {
-                    this.setState({safeAreaInsets});
-                }
-            });
-        }
-    };
-
-    onSafeAreaInsetsForRootViewChange = (result) => {
-        const {safeAreaInsets} = result;
-
-        if (this.mounted && (DeviceTypes.IS_IPHONE_WITH_INSETS || mattermostManaged.hasSafeAreaInsets)) {
             this.getStatusBarHeight();
-            this.setState({safeAreaInsets});
+
+            const {width, height} = Dimensions.get('window');
+            const landscape = width > height;
+            this.setSafeAreaInsets(safeAreaInsets, landscape);
         }
     }
 

--- a/app/components/safe_area_view/safe_area_view.ios.test.js
+++ b/app/components/safe_area_view/safe_area_view.ios.test.js
@@ -8,6 +8,7 @@ import Preferences from 'mattermost-redux/constants/preferences';
 
 import {DeviceTypes} from 'app/constants';
 import mattermostManaged from 'app/mattermost_managed';
+import EphemeralStore from 'app/store/ephemeral_store';
 
 import SafeAreaIos from './safe_area_view.ios';
 
@@ -37,8 +38,42 @@ describe('SafeAreaIos', () => {
         },
     };
 
+    const PORTRAIT_INSETS = {
+        safeAreaInsets: {
+            top: 111,
+            left: 111,
+            bottom: 111,
+            right: 111,
+        },
+    };
+
+    const LANDSCAPE_INSETS = {
+        safeAreaInsets: {
+            top: 222,
+            left: 222,
+            bottom: 222,
+            right: 222,
+        },
+    };
+
+    const IGNORED_INSETS = {
+        safeAreaInsets: {
+            top: 333,
+            left: 333,
+            bottom: 333,
+            right: 333,
+        },
+    };
+
     SafeArea.getSafeAreaInsetsForRootView = jest.fn().mockImplementation(() => {
         return Promise.resolve(TEST_INSETS_1);
+    });
+
+    beforeEach(() => {
+        EphemeralStore.safeAreaInsets = {
+            portrait: null,
+            landscape: null,
+        };
     });
 
     test('should match snapshot', () => {
@@ -147,5 +182,122 @@ describe('SafeAreaIos', () => {
         instance.mounted = false;
         instance.onSafeAreaInsetsForRootViewChange(TEST_INSETS_2);
         expect(wrapper.state().safeAreaInsets).not.toEqual(TEST_INSETS_2.safeAreaInsets);
+    });
+
+    test('should set portrait safe area insets', () => {
+        const wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+
+        expect(wrapper.state().safeAreaInsets).not.toEqual(PORTRAIT_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+
+        const landscape = false;
+        const instance = wrapper.instance();
+        instance.setSafeAreaInsets(PORTRAIT_INSETS.safeAreaInsets, landscape);
+        expect(wrapper.state().safeAreaInsets).toEqual(PORTRAIT_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(PORTRAIT_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+    });
+
+    test('should set portrait safe area insets from EphemeralStore', () => {
+        const wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+
+        EphemeralStore.safeAreaInsets.portrait = PORTRAIT_INSETS.safeAreaInsets;
+        expect(wrapper.state().safeAreaInsets).not.toEqual(PORTRAIT_INSETS.safeAreaInsets);
+
+        const landscape = false;
+        const instance = wrapper.instance();
+        instance.setSafeAreaInsets(IGNORED_INSETS.safeAreaInsets, landscape);
+        expect(wrapper.state().safeAreaInsets).toEqual(PORTRAIT_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(PORTRAIT_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+    });
+
+    test('should set landscape safe area insets', () => {
+        const wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+
+        expect(wrapper.state().safeAreaInsets).not.toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+
+        const landscape = true;
+        const instance = wrapper.instance();
+        instance.setSafeAreaInsets(LANDSCAPE_INSETS.safeAreaInsets, landscape);
+        expect(wrapper.state().safeAreaInsets).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+    });
+
+    test('should set landscape safe area insets from EphemeralStore', () => {
+        const wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+
+        EphemeralStore.safeAreaInsets.landscape = LANDSCAPE_INSETS.safeAreaInsets;
+        expect(wrapper.state().safeAreaInsets).not.toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+
+        const landscape = true;
+        const instance = wrapper.instance();
+        instance.setSafeAreaInsets(IGNORED_INSETS.safeAreaInsets, landscape);
+        expect(wrapper.state().safeAreaInsets).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+    });
+
+    test('should add safeAreaInsetsForRootViewDidChange listener when EphemeralStore values are not set', () => {
+        const addEventListener = jest.spyOn(SafeArea, 'addEventListener');
+
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+        let wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+        let instance = wrapper.instance();
+        expect(addEventListener).toHaveBeenCalledWith('safeAreaInsetsForRootViewDidChange', instance.onSafeAreaInsetsForRootViewChange);
+        addEventListener.mockClear();
+
+        EphemeralStore.safeAreaInsets.portrait = TEST_INSETS_1.safeAreaInsets;
+        wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+        instance = wrapper.instance();
+        expect(addEventListener).toHaveBeenCalledWith('safeAreaInsetsForRootViewDidChange', instance.onSafeAreaInsetsForRootViewChange);
+        addEventListener.mockClear();
+
+        EphemeralStore.safeAreaInsets.portrait = TEST_INSETS_1.safeAreaInsets;
+        EphemeralStore.safeAreaInsets.landscape = TEST_INSETS_1.safeAreaInsets;
+        wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+        instance = wrapper.instance();
+        expect(addEventListener).not.toHaveBeenCalled();
+    });
+
+    test('should remove safeAreaInsetsForRootViewDidChange listener when EphemeralStore values are set', () => {
+        const removeEventListener = jest.spyOn(SafeArea, 'removeEventListener');
+
+        const wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+        const instance = wrapper.instance();
+        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+
+        instance.onSafeAreaInsetsForRootViewChange(TEST_INSETS_1);
+        expect(removeEventListener).not.toHaveBeenCalled();
+
+        EphemeralStore.safeAreaInsets.portrait = TEST_INSETS_1.safeAreaInsets;
+        instance.onSafeAreaInsetsForRootViewChange(TEST_INSETS_1);
+        expect(removeEventListener).not.toHaveBeenCalled();
+
+        EphemeralStore.safeAreaInsets.landscape = TEST_INSETS_1.safeAreaInsets;
+        instance.onSafeAreaInsetsForRootViewChange(TEST_INSETS_1);
+        expect(removeEventListener).toHaveBeenCalledWith('safeAreaInsetsForRootViewDidChange', instance.onSafeAreaInsetsForRootViewChange);
     });
 });

--- a/app/components/safe_area_view/safe_area_view.ios.test.js
+++ b/app/components/safe_area_view/safe_area_view.ios.test.js
@@ -6,11 +6,13 @@ import {shallow} from 'enzyme';
 
 import Preferences from 'mattermost-redux/constants/preferences';
 
-import {DeviceTypes} from 'app/constants';
+import {DeviceTypes, ViewTypes} from 'app/constants';
 import mattermostManaged from 'app/mattermost_managed';
 import EphemeralStore from 'app/store/ephemeral_store';
 
 import SafeAreaIos from './safe_area_view.ios';
+
+const {PORTRAIT, LANDSCAPE} = ViewTypes;
 
 describe('SafeAreaIos', () => {
     const baseProps = {
@@ -71,8 +73,8 @@ describe('SafeAreaIos', () => {
 
     beforeEach(() => {
         EphemeralStore.safeAreaInsets = {
-            portrait: null,
-            landscape: null,
+            [PORTRAIT]: null,
+            [LANDSCAPE]: null,
         };
     });
 
@@ -190,15 +192,15 @@ describe('SafeAreaIos', () => {
         );
 
         expect(wrapper.state().safeAreaInsets).not.toEqual(PORTRAIT_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(null);
 
         const landscape = false;
         const instance = wrapper.instance();
         instance.setSafeAreaInsets(PORTRAIT_INSETS.safeAreaInsets, landscape);
         expect(wrapper.state().safeAreaInsets).toEqual(PORTRAIT_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(PORTRAIT_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(PORTRAIT_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(null);
     });
 
     test('should set portrait safe area insets from EphemeralStore', () => {
@@ -206,15 +208,15 @@ describe('SafeAreaIos', () => {
             <SafeAreaIos {...baseProps}/>
         );
 
-        EphemeralStore.safeAreaInsets.portrait = PORTRAIT_INSETS.safeAreaInsets;
+        EphemeralStore.safeAreaInsets[PORTRAIT] = PORTRAIT_INSETS.safeAreaInsets;
         expect(wrapper.state().safeAreaInsets).not.toEqual(PORTRAIT_INSETS.safeAreaInsets);
 
         const landscape = false;
         const instance = wrapper.instance();
         instance.setSafeAreaInsets(IGNORED_INSETS.safeAreaInsets, landscape);
         expect(wrapper.state().safeAreaInsets).toEqual(PORTRAIT_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(PORTRAIT_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(PORTRAIT_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(null);
     });
 
     test('should set landscape safe area insets', () => {
@@ -223,15 +225,15 @@ describe('SafeAreaIos', () => {
         );
 
         expect(wrapper.state().safeAreaInsets).not.toEqual(LANDSCAPE_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(null);
 
         const landscape = true;
         const instance = wrapper.instance();
         instance.setSafeAreaInsets(LANDSCAPE_INSETS.safeAreaInsets, landscape);
         expect(wrapper.state().safeAreaInsets).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(null);
     });
 
     test('should set landscape safe area insets from EphemeralStore', () => {
@@ -239,22 +241,22 @@ describe('SafeAreaIos', () => {
             <SafeAreaIos {...baseProps}/>
         );
 
-        EphemeralStore.safeAreaInsets.landscape = LANDSCAPE_INSETS.safeAreaInsets;
+        EphemeralStore.safeAreaInsets[LANDSCAPE] = LANDSCAPE_INSETS.safeAreaInsets;
         expect(wrapper.state().safeAreaInsets).not.toEqual(LANDSCAPE_INSETS.safeAreaInsets);
 
         const landscape = true;
         const instance = wrapper.instance();
         instance.setSafeAreaInsets(IGNORED_INSETS.safeAreaInsets, landscape);
         expect(wrapper.state().safeAreaInsets).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(LANDSCAPE_INSETS.safeAreaInsets);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(null);
     });
 
     test('should add safeAreaInsetsForRootViewDidChange listener when EphemeralStore values are not set', () => {
         const addEventListener = jest.spyOn(SafeArea, 'addEventListener');
 
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(null);
         let wrapper = shallow(
             <SafeAreaIos {...baseProps}/>
         );
@@ -262,7 +264,7 @@ describe('SafeAreaIos', () => {
         expect(addEventListener).toHaveBeenCalledWith('safeAreaInsetsForRootViewDidChange', instance.onSafeAreaInsetsForRootViewChange);
         addEventListener.mockClear();
 
-        EphemeralStore.safeAreaInsets.portrait = TEST_INSETS_1.safeAreaInsets;
+        EphemeralStore.safeAreaInsets[PORTRAIT] = TEST_INSETS_1.safeAreaInsets;
         wrapper = shallow(
             <SafeAreaIos {...baseProps}/>
         );
@@ -270,8 +272,8 @@ describe('SafeAreaIos', () => {
         expect(addEventListener).toHaveBeenCalledWith('safeAreaInsetsForRootViewDidChange', instance.onSafeAreaInsetsForRootViewChange);
         addEventListener.mockClear();
 
-        EphemeralStore.safeAreaInsets.portrait = TEST_INSETS_1.safeAreaInsets;
-        EphemeralStore.safeAreaInsets.landscape = TEST_INSETS_1.safeAreaInsets;
+        EphemeralStore.safeAreaInsets[PORTRAIT] = TEST_INSETS_1.safeAreaInsets;
+        EphemeralStore.safeAreaInsets[LANDSCAPE] = TEST_INSETS_1.safeAreaInsets;
         wrapper = shallow(
             <SafeAreaIos {...baseProps}/>
         );
@@ -286,18 +288,41 @@ describe('SafeAreaIos', () => {
             <SafeAreaIos {...baseProps}/>
         );
         const instance = wrapper.instance();
-        expect(EphemeralStore.safeAreaInsets.portrait).toEqual(null);
-        expect(EphemeralStore.safeAreaInsets.landscape).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(null);
 
         instance.onSafeAreaInsetsForRootViewChange(TEST_INSETS_1);
         expect(removeEventListener).not.toHaveBeenCalled();
 
-        EphemeralStore.safeAreaInsets.portrait = TEST_INSETS_1.safeAreaInsets;
+        EphemeralStore.safeAreaInsets[PORTRAIT] = TEST_INSETS_1.safeAreaInsets;
         instance.onSafeAreaInsetsForRootViewChange(TEST_INSETS_1);
         expect(removeEventListener).not.toHaveBeenCalled();
 
-        EphemeralStore.safeAreaInsets.landscape = TEST_INSETS_1.safeAreaInsets;
+        EphemeralStore.safeAreaInsets[LANDSCAPE] = TEST_INSETS_1.safeAreaInsets;
         instance.onSafeAreaInsetsForRootViewChange(TEST_INSETS_1);
         expect(removeEventListener).toHaveBeenCalledWith('safeAreaInsetsForRootViewDidChange', instance.onSafeAreaInsetsForRootViewChange);
+    });
+
+    test('getSafeAreaInsets should set safe area insets when not already in ephemeral store', async () => {
+        const wrapper = shallow(
+            <SafeAreaIos {...baseProps}/>
+        );
+        const instance = wrapper.instance();
+        const setSafeAreaInsets = jest.spyOn(instance, 'setSafeAreaInsets');
+
+        expect(EphemeralStore.safeAreaInsets[PORTRAIT]).toEqual(null);
+        expect(EphemeralStore.safeAreaInsets[LANDSCAPE]).toEqual(null);
+        await instance.getSafeAreaInsets();
+        expect(setSafeAreaInsets).toHaveBeenCalled();
+        setSafeAreaInsets.mockClear();
+
+        EphemeralStore.safeAreaInsets[PORTRAIT] = TEST_INSETS_1.safeAreaInsets;
+        await instance.getSafeAreaInsets();
+        expect(setSafeAreaInsets).toHaveBeenCalled();
+        setSafeAreaInsets.mockClear();
+
+        EphemeralStore.safeAreaInsets[LANDSCAPE] = TEST_INSETS_1.safeAreaInsets;
+        await instance.getSafeAreaInsets();
+        expect(setSafeAreaInsets).not.toHaveBeenCalled();
     });
 });

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -95,6 +95,9 @@ const ViewTypes = keyMirror({
     SELECTED_ACTION_MENU: null,
     SUBMIT_ATTACHMENT_MENU_ACTION: null,
     SELECT_CHANNEL_WITH_MEMBER: null,
+
+    PORTRAIT: null,
+    LANDSCAPE: null,
 });
 
 export default {

--- a/app/store/ephemeral_store.js
+++ b/app/store/ephemeral_store.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {ViewTypes} from 'app/constants';
+
 class EphemeralStore {
     constructor() {
         this.appStarted = false;
@@ -10,8 +12,8 @@ class EphemeralStore {
         this.allNavigationComponentIds = [];
         this.currentServerUrl = null;
         this.safeAreaInsets = {
-            portrait: null,
-            landscape: null,
+            [ViewTypes.PORTRAIT]: null,
+            [ViewTypes.LANDSCAPE]: null,
         };
     }
 

--- a/app/store/ephemeral_store.js
+++ b/app/store/ephemeral_store.js
@@ -9,6 +9,10 @@ class EphemeralStore {
         this.navigationComponentIdStack = [];
         this.allNavigationComponentIds = [];
         this.currentServerUrl = null;
+        this.safeAreaInsets = {
+            portrait: null,
+            landscape: null,
+        };
     }
 
     getNavigationTopComponentId = () => this.navigationComponentIdStack[0];


### PR DESCRIPTION
#### Summary
While https://github.com/mattermost/mattermost-mobile/pull/3413 fixed the original issue, it introduced another problem where the insets were removed on a previous screen when navigating back to it. Rather than continuously apply the insets returned by `safeAreaInsetsForRootViewDidChange`, we now store the values returned by it in the ephemeral store and stop listening for changes when both portrait and landscape values have been stored. With those values stored, we can apply the correct insets when the orientation changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18983

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iOS simulator
