### PR TITLE
MM-18934 Fix padding on image attachment border

### DIFF
--- a/app/components/message_attachments/attachment_image/__snapshots__/index.test.js.snap
+++ b/app/components/message_attachments/attachment_image/__snapshots__/index.test.js.snap
@@ -23,7 +23,6 @@ exports[`AttachmentImage it matches snapshot 1`] = `
           "borderRadius": 2,
           "borderWidth": 1,
           "flex": 1,
-          "padding": 5,
         },
         Object {
           "height": 28,

--- a/app/components/message_attachments/attachment_image/index.js
+++ b/app/components/message_attachments/attachment_image/index.js
@@ -169,7 +169,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderWidth: 1,
             borderRadius: 2,
             flex: 1,
-            padding: 5,
         },
     };
 });

--- a/app/components/progressive_image/progressive_image.js
+++ b/app/components/progressive_image/progressive_image.js
@@ -190,9 +190,9 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
     },
     attachmentMargin: {
-        marginTop:2.5,
-        marginLeft:2.5,
+        marginTop: 2.5,
+        marginLeft: 2.5,
         marginBottom: 5,
         marginRight: 5,
-    }
+    },
 });

--- a/app/components/progressive_image/progressive_image.js
+++ b/app/components/progressive_image/progressive_image.js
@@ -167,7 +167,7 @@ export default class ProgressiveImage extends PureComponent {
                     resizeMethod={resizeMethod}
                     onError={onError}
                     source={{uri}}
-                    style={StyleSheet.absoluteFill}
+                    style={[StyleSheet.absoluteFill, styles.attachmentMargin]}
                 >
                     {this.props.children}
                 </ImageComponent>
@@ -189,4 +189,10 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         justifyContent: 'center',
     },
+    attachmentMargin: {
+        marginTop:2.5,
+        marginLeft:2.5,
+        marginBottom: 5,
+        marginRight: 5,
+    }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7718,7 +7718,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         }
@@ -17613,6 +17613,7 @@
       "version": "github:mattermost/redux-offline#885024de96b6ec73650c340c8928066585c413df",
       "from": "github:mattermost/redux-offline#885024de96b6ec73650c340c8928066585c413df",
       "requires": {
+        "@react-native-community/netinfo": "^4.1.3",
         "redux-persist": "^4.5.0"
       },
       "dependencies": {


### PR DESCRIPTION
#### Summary
Image container should respect the padding and be larger than the image dimensions and center the image.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18934

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests - snapshot updated
- [x] Has UI changes - Fixed padding for image

#### Device Information
This PR was tested on:
iPhone X 12.4 (Simulator)

#### Screenshots
![Simulator Screen Shot - iPhone X - 2019-10-24 at 22 57 31](https://user-images.githubusercontent.com/38697367/67540176-7b044600-f6b2-11e9-8cf1-e293b15ab61a.png)
