### PR TITLE
Fix android and iOS deployment on circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,11 +166,13 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: ~/mattermost-mobile
-      - deploy:
+          at: .
+      - attach_workspace:
+          at: ~/mattermost-mobile-private
+      - run:
           name: "Deploy apk to Google Play"
           working_directory: fastlane
-          command: bundle exec fastlane android deploy apk:./<<parameters.apk_path>>
+          command: bundle exec fastlane android deploy apk:$HOME/mattermost-mobile/<<parameters.apk_path>>
 
   deploy-ios:
     description: "Deploy ipa to TestFlight"
@@ -179,19 +181,27 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: ~/mattermost-mobile
-      - deploy:
+          at: .
+      - run:
           name: "Deploy ipa to TestFlight"
           working_directory: fastlane
-          command: bundle exec fastlane ios deploy ipa:./<<parameters.ipa_path>>
+          command: bundle exec fastlane ios deploy ipa:$HOME/mattermost-mobile/<<parameters.ipa_path>>
 
   persist:
     description: "Persist mattermost-mobile directory"
     steps:
       - persist_to_workspace:
-          root: ./
+          root: .
           paths:
-            - ./
+            - .
+
+  persist-private:
+    description: "Persist mattermost-mobile-private directory"
+    steps:
+      - persist_to_workspace:
+          root: ~/mattermost-mobile-private
+          paths:
+            - .
 
   save:
     description: "Save binaries artifacts"
@@ -227,6 +237,7 @@ jobs:
     steps:
       - build-android
       - persist
+      - persist-private
       - save:
           filename: "Mattermost_Beta.apk"
 
@@ -235,6 +246,7 @@ jobs:
     steps:
       - build-android
       - persist
+      - persist-private
       - save:
           filename: "Mattermost.apk"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,49 +159,30 @@ commands:
           no_output_timeout: 30m
           command: bundle exec fastlane ios build || exit 1
 
-  deploy-android:
-    description: "Deploy apk to Google Play"
-    parameters:
-      apk_path:
+  deploy-to-store:
+    description: "Deploy build to store"
+    paramenters:
+      name:
+        type: string
+      target:
+        type: string
+      file:
         type: string
     steps:
       - attach_workspace:
-          at: .
-      - attach_workspace:
-          at: ~/mattermost-mobile-private
+          at: /
       - run:
-          name: "Deploy apk to Google Play"
+          name: <<parameters.name>>
           working_directory: fastlane
-          command: bundle exec fastlane android deploy apk:$HOME/mattermost-mobile/<<parameters.apk_path>>
-
-  deploy-ios:
-    description: "Deploy ipa to TestFlight"
-    parameters:
-      ipa_path:
-        type: string
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: "Deploy ipa to TestFlight"
-          working_directory: fastlane
-          command: bundle exec fastlane ios deploy ipa:$HOME/mattermost-mobile/<<parameters.ipa_path>>
+          command: bundle exec fastlane <<parameters.target>> deploy file:$HOME/mattermost-mobile/<<parameters.file>>
 
   persist:
     description: "Persist mattermost-mobile directory"
     steps:
       - persist_to_workspace:
-          root: .
+          root: /
           paths:
-            - .
-
-  persist-private:
-    description: "Persist mattermost-mobile-private directory"
-    steps:
-      - persist_to_workspace:
-          root: ~/mattermost-mobile-private
-          paths:
-            - .
+            - mattermost-mobile*
 
   save:
     description: "Save binaries artifacts"
@@ -237,7 +218,6 @@ jobs:
     steps:
       - build-android
       - persist
-      - persist-private
       - save:
           filename: "Mattermost_Beta.apk"
 
@@ -246,7 +226,6 @@ jobs:
     steps:
       - build-android
       - persist
-      - persist-private
       - save:
           filename: "Mattermost.apk"
 
@@ -256,7 +235,6 @@ jobs:
       BRANCH_TO_BUILD: ${CIRCLE_BRANCH}
     steps:
       - build-android
-      - persist
       - save:
           filename: "Mattermost_Beta.apk"
 
@@ -282,7 +260,6 @@ jobs:
       BRANCH_TO_BUILD: ${CIRCLE_BRANCH}
     steps:
       - build-ios
-      - persist
       - save:
           filename: "Mattermost_Beta.ipa"
 
@@ -291,7 +268,9 @@ jobs:
       name: android
       resource_class: medium
     steps:
-      - deploy-android:
+      - deploy-to-store:
+          name: "Deploy to Google Play"
+          target: android
           apk_path: Mattermost.apk
 
   deploy-android-beta:
@@ -299,20 +278,26 @@ jobs:
       name: android
       resource_class: medium
     steps:
-      - deploy-android:
-          apk_path: Mattermost_Beta.apk
+      - deploy-to-store:
+          name: "Deploy to Google Play"
+          target: android
+          file: Mattermost_Beta.apk
 
   deploy-ios-release:
     executor: ios
     steps:
-      - deploy-ios:
-          ipa_path: Mattermost.ipa
+      - deploy-to-store:
+          name: "Deploy to TestFlight"
+          target: ios
+          file: Mattermost.ipa
 
   deploy-ios-beta:
     executor: ios
     steps:
       - deploy-ios:
-          ipa_path: Mattermost_Beta.ipa
+          name: "Deploy to TestFlight"
+          target: ios
+          file: Mattermost_Beta.ipa
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,8 @@ commands:
 
   deploy-to-store:
     description: "Deploy build to store"
-    paramenters:
-      name:
+    parameters:
+      task:
         type: string
       target:
         type: string
@@ -172,7 +172,7 @@ commands:
       - attach_workspace:
           at: /
       - run:
-          name: <<parameters.name>>
+          name: <<parameters.task>>
           working_directory: fastlane
           command: bundle exec fastlane <<parameters.target>> deploy file:$HOME/mattermost-mobile/<<parameters.file>>
 
@@ -269,9 +269,9 @@ jobs:
       resource_class: medium
     steps:
       - deploy-to-store:
-          name: "Deploy to Google Play"
+          task: "Deploy to Google Play"
           target: android
-          apk_path: Mattermost.apk
+          file: Mattermost.apk
 
   deploy-android-beta:
     executor:
@@ -279,7 +279,7 @@ jobs:
       resource_class: medium
     steps:
       - deploy-to-store:
-          name: "Deploy to Google Play"
+          task: "Deploy to Google Play"
           target: android
           file: Mattermost_Beta.apk
 
@@ -287,15 +287,15 @@ jobs:
     executor: ios
     steps:
       - deploy-to-store:
-          name: "Deploy to TestFlight"
+          task: "Deploy to TestFlight"
           target: ios
           file: Mattermost.ipa
 
   deploy-ios-beta:
     executor: ios
     steps:
-      - deploy-ios:
-          name: "Deploy to TestFlight"
+      - deploy-to-store:
+          task: "Deploy to TestFlight"
           target: ios
           file: Mattermost_Beta.ipa
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -729,7 +729,7 @@ def submit_to_testflight(ipa_path)
 
   if(File.file?(ipa_path))
     UI.success("ipa file #{ipa_path}")
-    upload_to_tesflight(
+    pilot(
         ipa: ipa_path
     )
   else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -428,7 +428,7 @@ platform :ios do
   end
 
   lane :deploy do |options|
-    ipa_path = options[:ipa]
+    ipa_path = options[:file]
 
     unless ipa_path.nil?
       submit_to_testflight(ipa_path)
@@ -612,7 +612,7 @@ platform :android do
   end
 
   lane :deploy do |options|
-    apk_path = options[:apk]
+    apk_path = options[:file]
 
     unless apk_path.nil?
       submit_to_google_play(apk_path)


### PR DESCRIPTION
#### Summary
For iOS the lane `upload_to_tesflight` is not available on circleCI and we needed to switch back to `pilot`
For Android we needed to include the private repo to get the keystore
For both: Fixed the deployment file path