### PR TITLE
MM-19731 Fix at-channel autocomplete to return out of channel mentions

### DIFF
--- a/app/selectors/autocomplete.js
+++ b/app/selectors/autocomplete.js
@@ -99,15 +99,20 @@ export const filterMembersNotInChannel = createSelector(
         let profiles;
         if (matchTerm) {
             profiles = profilesNotInChannel.filter((p) => {
-                return ((p.id !== currentUserId && p.detele_at === 0) && (
-                    p.username.toLowerCase().includes(matchTerm) || p.email.toLowerCase().includes(matchTerm) ||
-                    p.first_name.toLowerCase().includes(matchTerm) || p.last_name.toLowerCase().includes(matchTerm)));
+                return (
+                    p.username.toLowerCase().includes(matchTerm) ||
+                    p.email.toLowerCase().includes(matchTerm) ||
+                    p.first_name.toLowerCase().includes(matchTerm) ||
+                    p.last_name.toLowerCase().includes(matchTerm)
+                ) && (p.delete_at === 0 && p.id !== currentUserId);
             });
         } else {
             profiles = profilesNotInChannel.filter((p) => p.delete_at === 0);
         }
 
-        return profiles.map((p) => p.id);
+        return profiles.map((p) => {
+            return p.id;
+        });
     }
 );
 

--- a/app/selectors/autocomplete.test.js
+++ b/app/selectors/autocomplete.test.js
@@ -5,6 +5,7 @@ import assert from 'assert';
 
 import {
     getMatchTermForAtMention,
+    filterMembersNotInChannel,
 } from 'app/selectors/autocomplete';
 
 /* eslint-disable max-nested-callbacks */
@@ -55,5 +56,42 @@ describe('Selectors.Autocomplete', () => {
                 });
             });
         });
+    });
+
+    it('Should return profiles not in channel', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'current-channel-id',
+                },
+                users: {
+                    currentUserId: 'current-user-id',
+                    profiles: {
+                        'current-user-id': {id: 'current-user-id', username: 'current', detele_at: 0},
+                        'test-user-id': {id: 'test-user-id', username: 'test', first_name: 'Test', last_name: 'User', email: 'test@example.com', delete_at: 0},
+                        'another-user-id': {id: 'another-user-id', username: 'another', first_name: 'Another', last_name: 'One', email: 'another@example.com', delete_at: 0},
+                    },
+                    profilesNotInChannel: {
+                        'current-channel-id': new Set(['test-user-id', 'another-user-id']),
+                    },
+                },
+            },
+        };
+
+        let profiles = filterMembersNotInChannel(state, '');
+        expect(profiles.length).toBe(2);
+
+        // filter to get the current user, should return zero results
+        profiles = filterMembersNotInChannel(state, 'current');
+        expect(profiles.length).toBe(0);
+
+        profiles = filterMembersNotInChannel(state, 'tes');
+        expect(profiles.length).toBe(1);
+
+        profiles = filterMembersNotInChannel(state, 'one');
+        expect(profiles.length).toBe(1);
+
+        profiles = filterMembersNotInChannel(state, 'example');
+        expect(profiles.length).toBe(2);
     });
 });

--- a/app/selectors/autocomplete.test.js
+++ b/app/selectors/autocomplete.test.js
@@ -67,7 +67,7 @@ describe('Selectors.Autocomplete', () => {
                 users: {
                     currentUserId: 'current-user-id',
                     profiles: {
-                        'current-user-id': {id: 'current-user-id', username: 'current', detele_at: 0},
+                        'current-user-id': {id: 'current-user-id', username: 'current', delete_at: 0},
                         'test-user-id': {id: 'test-user-id', username: 'test', first_name: 'Test', last_name: 'User', email: 'test@example.com', delete_at: 0},
                         'another-user-id': {id: 'another-user-id', username: 'another', first_name: 'Another', last_name: 'One', email: 'another@example.com', delete_at: 0},
                         'deleted-user-id': {id: 'deleted-user-id', username: 'deleted', first_name: 'Remvoed', last_name: 'Friend', email: 'deleted@example.com', delete_at: 123},

--- a/app/selectors/autocomplete.test.js
+++ b/app/selectors/autocomplete.test.js
@@ -70,9 +70,10 @@ describe('Selectors.Autocomplete', () => {
                         'current-user-id': {id: 'current-user-id', username: 'current', detele_at: 0},
                         'test-user-id': {id: 'test-user-id', username: 'test', first_name: 'Test', last_name: 'User', email: 'test@example.com', delete_at: 0},
                         'another-user-id': {id: 'another-user-id', username: 'another', first_name: 'Another', last_name: 'One', email: 'another@example.com', delete_at: 0},
+                        'deleted-user-id': {id: 'deleted-user-id', username: 'deleted', first_name: 'Remvoed', last_name: 'Friend', email: 'deleted@example.com', delete_at: 123},
                     },
                     profilesNotInChannel: {
-                        'current-channel-id': new Set(['test-user-id', 'another-user-id']),
+                        'current-channel-id': new Set(['test-user-id', 'another-user-id', 'deleted-user-id']),
                     },
                 },
             },


### PR DESCRIPTION
#### Summary
Reported by whitestar `at-mentions` autocomplete was not returning out of channel results in any type of channel

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19731