### PR TITLE
MM-19449 Changed adjustResize to adjustPan

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustPan">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
+++ b/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
@@ -8,7 +8,7 @@ exports[`PostTextBox should match, full snapshot 1`] = `
     style={
       Array [
         Object {
-          "alignItems": "flex-end",
+          "alignItems": "flex-start",
           "backgroundColor": "#ffffff",
           "borderTopColor": "rgba(61,60,64,0.2)",
           "borderTopWidth": 1,

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -806,7 +806,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             paddingBottom: 8,
             paddingLeft: 12,
             paddingRight: 12,
-            paddingTop: 8,
+            paddingTop: Platform.select({
+                ios: 8,
+                android: 4,
+            }),
         },
         hidden: {
             position: 'absolute',
@@ -827,7 +830,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             marginLeft: 10,
         },
         inputWrapper: {
-            alignItems: 'flex-end',
+            alignItems: 'flex-start',
             flexDirection: 'row',
             paddingVertical: 4,
             backgroundColor: theme.centerChannelBg,


### PR DESCRIPTION
#### Summary
Changed how the keyboard displays opening by changing adjustResize to adjustPan in android manifest file. This was the cause of the color flash showing it appears. Also did some minor adjustments to fix the Android Textbox that appeared out of line and were more apparent after removing adjustResize.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19449

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes - Minor adjustments to post text box

#### Device Information
This PR was tested on:
Android Pixel 29 API (Simulator)
iPhone X 12.4 (Simulator)

#### Screenshots
<img width="358" alt="Screen Shot 2019-10-26 at 8 08 48 PM" src="https://user-images.githubusercontent.com/38697367/67627682-e83ce600-f82e-11e9-9f03-0bcebe4ac41d.png">
<img width="359" alt="Screen Shot 2019-10-26 at 8 09 34 PM" src="https://user-images.githubusercontent.com/38697367/67627685-eb37d680-f82e-11e9-835a-5904b9861596.png">
![Simulator Screen Shot - iPhone X - 2019-10-26 at 20 16 33](https://user-images.githubusercontent.com/38697367/67627686-ef63f400-f82e-11e9-9bc5-bc15749c7ba6.png)
![Simulator Screen Shot - iPhone X - 2019-10-26 at 20 16 45](https://user-images.githubusercontent.com/38697367/67627687-f25ee480-f82e-11e9-980f-bcb692815d0e.png)

