### PR TITLE
MM-19734 Patch RN to remove the placeholder for emojis in a markdown

### DIFF
--- a/patches/react-native+0.59.9.patch
+++ b/patches/react-native+0.59.9.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/react-native/Libraries/Text/Text/RCTTextShadowView.m b/node_modules/react-native/Libraries/Text/Text/RCTTextShadowView.m
+index d464e6a..6c397c5 100644
+--- a/node_modules/react-native/Libraries/Text/Text/RCTTextShadowView.m
++++ b/node_modules/react-native/Libraries/Text/Text/RCTTextShadowView.m
+@@ -170,6 +170,12 @@ - (void)postprocessAttributedText:(NSMutableAttributedString *)attributedText
+ 
+ - (NSAttributedString *)attributedTextWithMeasuredAttachmentsThatFitSize:(CGSize)size
+ {
++  static UIImage *placeholderImage;
++  static dispatch_once_t onceToken;
++  dispatch_once(&onceToken, ^{
++    placeholderImage = [UIImage new];
++  });
++
+   NSMutableAttributedString *attributedText =
+     [[NSMutableAttributedString alloc] initWithAttributedString:[self attributedTextWithBaseTextAttributes:nil]];
+ 
+@@ -188,6 +194,7 @@ - (NSAttributedString *)attributedTextWithMeasuredAttachmentsThatFitSize:(CGSize
+                                                    maximumSize:size];
+       NSTextAttachment *attachment = [NSTextAttachment new];
+       attachment.bounds = (CGRect){CGPointZero, fittingSize};
++      attachment.image = placeholderImage;
+       [attributedText addAttribute:NSAttachmentAttributeName value:attachment range:range];
+     }
+   ];


### PR DESCRIPTION
#### Summary
There is an outstanding bug in RN that adds a placeholder to an image where the image is inside a Text node, this happens only on iOS 13 but the fix does not causes side effects in previous iOS versions.

The RN commit is https://github.com/facebook/react-native/commit/06599b3e594355a1d5062ede049ff3e333285516 but has not been cherry-picked to any of the current releases

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19734