### PR TITLE
MM-19759 - Added TOS and Privacy Policy default links in About Screen

### DIFF
--- a/app/constants/about_links.js
+++ b/app/constants/about_links.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export default {
+    TERMS_OF_SERVICE: 'https://about.mattermost.com/default-terms/',
+    PRIVACY_POLICY: 'https://about.mattermost.com/default-privacy-policy/',
+};

--- a/app/screens/about/about.js
+++ b/app/screens/about/about.js
@@ -18,6 +18,7 @@ import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/ut
 import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
 import AppIcon from 'app/components/app_icon';
 import Config from 'assets/config';
+import AboutLinks from 'app/constants/about_links';
 
 const MATTERMOST_BUNDLE_IDS = ['com.mattermost.rnbeta', 'com.mattermost.rn'];
 
@@ -53,11 +54,11 @@ export default class About extends PureComponent {
     };
 
     handleTermsOfService = () => {
-        Linking.openURL(this.props.config.TermsOfServiceLink);
+        Linking.openURL(AboutLinks.TERMS_OF_SERVICE);
     };
 
     handlePrivacyPolicy = () => {
-        Linking.openURL(this.props.config.PrivacyPolicyLink);
+        Linking.openURL(AboutLinks.PRIVACY_POLICY);
     }
 
     render() {


### PR DESCRIPTION
#### Summary
Changed Terms of Service and Privacy Policy links in the About screen to always point to MM default links and not rely on the customizable links in the config.

The default links are currently defined in a constant here in the webApp for 5.17 quality release but should be retrieved from the API. This is captured in [this ticket](https://mattermost.atlassian.net/browse/MM-19788) for future release.

#### Ticket Link
[MM-19759](https://mattermost.atlassian.net/browse/MM-19759)

#### Related Pull Requests
- WebApp PR https://github.com/mattermost/mattermost-webapp/pull/4084