### PR TITLE
circleCI change persist root from / to ~/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ commands:
     description: "Persist mattermost-mobile directory"
     steps:
       - persist_to_workspace:
-          root: /
+          root: ~/
           paths:
             - mattermost-mobile*
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
In circleCi we are trying to persist the `mattermost-mobile*` directories but the root path was set to `/` instead of the home directory `~/`
