### PR TITLE
MM-19853 Fix iOS SafeAreaView for Server URL screen

### DIFF
--- a/app/initial_state.js
+++ b/app/initial_state.js
@@ -73,22 +73,6 @@ const state = {
             },
         },
         general: {
-            server: {
-                status: 'not_started',
-                error: null,
-            },
-            config: {
-                status: 'not_started',
-                error: null,
-            },
-            dataRetentionPolicy: {
-                status: 'not_started',
-                error: null,
-            },
-            license: {
-                status: 'not_started',
-                error: null,
-            },
             websocket: {
                 status: 'not_started',
                 error: null,

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -12,6 +12,7 @@ import {
     Keyboard,
     KeyboardAvoidingView,
     Platform,
+    SafeAreaView,
     StatusBar,
     StyleSheet,
     Text,
@@ -28,7 +29,6 @@ import {Client4} from 'mattermost-redux/client';
 
 import ErrorText from 'app/components/error_text';
 import FormattedText from 'app/components/formatted_text';
-import SafeAreaView from 'app/components/safe_area_view';
 import fetchConfig from 'app/init/fetch';
 import mattermostBucket from 'app/mattermost_bucket';
 import {GlobalStyles} from 'app/styles';
@@ -416,8 +416,7 @@ export default class SelectServer extends PureComponent {
 
         return (
             <SafeAreaView
-                excludeHeader={true}
-                useLandscapeMargin={true}
+                style={style.container}
             >
                 <KeyboardAvoidingView
                     behavior='padding'


### PR DESCRIPTION
#### Summary
With the recent changes to the custom SafeAreaView component, the server url screen was not using the right inset at times, by using the one provided by RN this is fixed. We do not need to use any of the custom component functionality in this screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19853
