### PR TITLE
[MM-19698] [MM-19084] Ensure setNavigatorStyles is called with Channel componentId

### DIFF
--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -108,6 +108,8 @@ export default class ChannelBase extends PureComponent {
 
     componentWillReceiveProps(nextProps) {
         if (this.props.theme !== nextProps.theme) {
+            setNavigatorStyles(this.props.componentId, nextProps.theme);
+
             EphemeralStore.allNavigationComponentIds.forEach((componentId) => {
                 setNavigatorStyles(componentId, nextProps.theme);
             });

--- a/app/screens/channel/channel_base.test.js
+++ b/app/screens/channel/channel_base.test.js
@@ -14,6 +14,7 @@ import ChannelBase from './channel_base';
 jest.mock('react-intl');
 
 describe('ChannelBase', () => {
+    const channelBaseComponentId = 'component-0';
     const componentIds = ['component-1', 'component-2', 'component-3'];
     const baseProps = {
         actions: {
@@ -24,7 +25,7 @@ describe('ChannelBase', () => {
             recordLoadTime: jest.fn(),
             getChannelStats: jest.fn(),
         },
-        componentId: componentIds[0],
+        componentId: channelBaseComponentId,
         theme: Preferences.THEMES.default,
     };
     const optionsForTheme = (theme) => {
@@ -61,7 +62,7 @@ describe('ChannelBase', () => {
 
         const themeOptions = optionsForTheme(Preferences.THEMES.default);
         expect(mergeNavigationOptions.mock.calls).toEqual([
-            [componentIds[0], themeOptions],
+            [baseProps.componentId, themeOptions],
         ]);
         mergeNavigationOptions.mockClear();
 
@@ -69,6 +70,7 @@ describe('ChannelBase', () => {
 
         const newThemeOptions = optionsForTheme(Preferences.THEMES.mattermostDark);
         expect(mergeNavigationOptions.mock.calls).toEqual([
+            [baseProps.componentId, newThemeOptions],
             [componentIds[2], newThemeOptions],
             [componentIds[1], newThemeOptions],
             [componentIds[0], newThemeOptions],


### PR DESCRIPTION
#### Summary
The Channel component ID is not yet included in the ephemeral store's `allNavigationComponentIds` when it receives a new theme after login so I added a direct call to `setNavigatorStyles` with the component ID.

This change also fixes transitions back to the channel screen after logging in / clearing data from the advanced settings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19698
https://mattermost.atlassian.net/browse/MM-19084

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iOS simulator, 13.1