### PR TITLE
[MM-19841] Keep currentTeamId and team theme preferences when resetting state

### DIFF
--- a/app/store/store.js
+++ b/app/store/store.js
@@ -6,6 +6,7 @@ import {Platform} from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import {createBlacklistFilter} from 'redux-persist-transform-filter';
 import {createTransform, persistStore} from 'redux-persist';
+import merge from 'deepmerge';
 
 import {ErrorTypes, GeneralTypes} from 'mattermost-redux/action_types';
 import {General, RequestStatus} from 'mattermost-redux/constants';
@@ -241,10 +242,29 @@ export default function configureAppStore(initialState) {
 
                     await persistor.purge();
 
+                    const {currentTeamId} = state.entities.teams;
+                    const myPreferences = {...state.entities.preferences.myPreferences};
+                    Object.keys(myPreferences).forEach((key) => {
+                        if (!key.startsWith('theme--')) {
+                            Reflect.deleteProperty(myPreferences, key);
+                        }
+                    })
+
+                    const initialStateWithTeamAndThemePreferences = merge(initialState, {
+                        entities: {
+                            teams: {
+                                currentTeamId,
+                            },
+                            preferences: {
+                                myPreferences,
+                            },
+                        },
+                    });
+
                     store.dispatch(batchActions([
                         {
                             type: General.OFFLINE_STORE_RESET,
-                            data: initialState,
+                            data: initialStateWithTeamAndThemePreferences,
                         },
                         {
                             type: ErrorTypes.RESTORE_ERRORS,

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -248,7 +248,7 @@ export default function configureAppStore(initialState) {
                         if (!key.startsWith('theme--')) {
                             Reflect.deleteProperty(myPreferences, key);
                         }
-                    })
+                    });
 
                     const initialStateWithTeamAndThemePreferences = merge(initialState, {
                         entities: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7759,8 +7759,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#e77647700ad23d0b1d0c98aa6b48f3330c425e4f",
-      "from": "github:mattermost/mattermost-redux#e77647700ad23d0b1d0c98aa6b48f3330c425e4f",
+      "version": "github:mattermost/mattermost-redux#e09899fda322c362c55c8ebbddc967920864a385",
+      "from": "github:mattermost/mattermost-redux#e09899fda322c362c55c8ebbddc967920864a385",
       "requires": {
         "gfycat-sdk": "1.4.18",
         "isomorphic-fetch": "2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4884,8 +4884,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4903,13 +4902,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4922,18 +4919,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5036,8 +5030,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5047,7 +5040,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5060,20 +5052,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5090,7 +5079,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5163,8 +5151,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5174,7 +5161,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5250,8 +5236,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5281,7 +5266,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5299,7 +5283,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5338,13 +5321,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -7778,8 +7759,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#1c2faee2660a3fdd69485ea44f0dea89b0204426",
-      "from": "github:mattermost/mattermost-redux#1c2faee2660a3fdd69485ea44f0dea89b0204426",
+      "version": "github:mattermost/mattermost-redux#e77647700ad23d0b1d0c98aa6b48f3330c425e4f",
+      "from": "github:mattermost/mattermost-redux#e77647700ad23d0b1d0c98aa6b48f3330c425e4f",
       "requires": {
         "gfycat-sdk": "1.4.18",
         "isomorphic-fetch": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.0",
     "jsc-android": "241213.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#e77647700ad23d0b1d0c98aa6b48f3330c425e4f",
+    "mattermost-redux": "github:mattermost/mattermost-redux#e09899fda322c362c55c8ebbddc967920864a385",
     "mime-db": "1.42.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.0",
     "jsc-android": "241213.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#1c2faee2660a3fdd69485ea44f0dea89b0204426",
+    "mattermost-redux": "github:mattermost/mattermost-redux#e77647700ad23d0b1d0c98aa6b48f3330c425e4f",
     "mime-db": "1.42.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",


### PR DESCRIPTION
#### Summary
Because the current team's theme was lost during a state reset, the header color in the Advanced Settings screen would revert to the default Mattermost theme color. This is fixed by keeping currentTeamId and the theme preferences in the state.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19841

#### Checklist
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux/pull/965)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iOS simulator, 13.1