### PR TITLE
MM-19482 Stop rendering New Messages line differently for manually unread channels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7778,8 +7778,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#edaa6ebc4077ec65e51c2864db0abbd04e1d8db9",
-      "from": "github:mattermost/mattermost-redux#edaa6ebc4077ec65e51c2864db0abbd04e1d8db9",
+      "version": "github:mattermost/mattermost-redux#3289f58d196eb527fd02fa57f00835fb10fb279e",
+      "from": "github:mattermost/mattermost-redux#3289f58d196eb527fd02fa57f00835fb10fb279e",
       "requires": {
         "gfycat-sdk": "1.4.18",
         "isomorphic-fetch": "2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4636,7 +4636,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         }
@@ -7778,8 +7778,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#3289f58d196eb527fd02fa57f00835fb10fb279e",
-      "from": "github:mattermost/mattermost-redux#3289f58d196eb527fd02fa57f00835fb10fb279e",
+      "version": "github:mattermost/mattermost-redux#05c056f4cb514fb5bace197bd109c77db79b7c7d",
+      "from": "github:mattermost/mattermost-redux#05c056f4cb514fb5bace197bd109c77db79b7c7d",
       "requires": {
         "gfycat-sdk": "1.4.18",
         "isomorphic-fetch": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.0",
     "jsc-android": "241213.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#edaa6ebc4077ec65e51c2864db0abbd04e1d8db9",
+    "mattermost-redux": "github:mattermost/mattermost-redux#3289f58d196eb527fd02fa57f00835fb10fb279e",
     "mime-db": "1.42.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.0",
     "jsc-android": "241213.1.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#3289f58d196eb527fd02fa57f00835fb10fb279e",
+    "mattermost-redux": "github:mattermost/mattermost-redux#05c056f4cb514fb5bace197bd109c77db79b7c7d",
     "mime-db": "1.42.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",


### PR DESCRIPTION
As discussed, because we can't properly save that `isManuallyUnread` state between sessions, we're going to remove this special behaviour when using the Mark as Unread feature.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19482

#### Related PRs
Redux: https://github.com/mattermost/mattermost-redux/pull/968
Web: https://github.com/mattermost/mattermost-webapp/pull/4138