### PR TITLE
[MM-19927] Fix launching app from push notification on iOS

### DIFF
--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -66,6 +66,22 @@ class PushNotification {
         this.onReply = options.onReply;
 
         this.requestNotificationReplyPermissions();
+
+        if (options.popInitialNotification) {
+            NotificationsIOS.getInitialNotification().
+                then((notification) => {
+                    if (notification) {
+                        const data = notification.getData();
+                        if (data) {
+                            ephemeralStore.appStartedFromPushNotification = true;
+                            this.handleNotification(data, false, true);
+                        }
+                    }
+                }).
+                catch((err) => {
+                    console.log('iOS getInitialNotifiation() failed', err); //eslint-disable-line no-console
+                });
+        }
     }
 
     requestNotificationReplyPermissions = () => {

--- a/app/utils/push_notifications.test.js
+++ b/app/utils/push_notifications.test.js
@@ -33,6 +33,7 @@ jest.mock('react-native-notifications', () => {
         NotificationAction: jest.fn(),
         NotificationCategory: jest.fn(),
         localNotification: jest.fn(),
+        getInitialNotification: jest.fn(() => Promise.resolve()),
     };
 });
 


### PR DESCRIPTION
#### Summary
With the upgrade to the notifications library the `consumeBackgroundQueue` API was removed. This was responsible for getting the initial push notification when the app is launched from a push notification. We now fetch the initial push notification on iOS with `getInitialNotification`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19927

#### Device Information
This PR was tested on:
* iPhone 11, iOS 13.1.3