### PR TITLE
Set launchMode to singleInstance

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:launchMode="singleInstance">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
@@ -52,7 +53,8 @@
                 android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
                 android:label="@string/app_name"
                 android:screenOrientation="portrait"
-                android:theme="@style/AppTheme">
+                android:theme="@style/AppTheme"
+                android:taskAffinity="com.mattermost.share">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.SEND_MULTIPLE" />


### PR DESCRIPTION
#### Summary
Apply the following changes from master: https://github.com/mattermost/mattermost-mobile/commit/1efb01deda81cc0ee0fa0a36af8c02e342272f11#diff-020edf1fd6d483b0e2c8f5a5734ea1f2L32-L55

This prevents a white screen flashing when returning the app to the foreground on Android.

#### Device Information
This PR was tested on:
* Android emulator, 8.0