### PR TITLE
[MM-19967] Use componentDidUpdate

### DIFF
--- a/app/screens/settings/notification_settings_mobile/notification_settings_mobile_base.js
+++ b/app/screens/settings/notification_settings_mobile/notification_settings_mobile_base.js
@@ -47,9 +47,9 @@ export default class NotificationSettingsMobileBase extends PureComponent {
         this.navigationEventListener = Navigation.events().bindComponent(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (this.props.theme !== nextProps.theme) {
-            setNavigatorStyles(this.props.componentId, nextProps.theme);
+    componentDidUpdate(prevProps) {
+        if (this.props.theme !== prevProps.theme) {
+            setNavigatorStyles(this.props.componentId, this.props.theme);
         }
     }
 


### PR DESCRIPTION
#### Summary
As part of the effort to remove deprecated lifecycle events, `componentWillReceiveProps` was removed in favor of `componentDidUpdate` in the `NotificationSettingsMobileBase` and `NotificationSettingsMobileAndroid` components on master, however, probably due to a cherry-pick that included changes only in `NotificationSettingsMobileAndroid`, `componentWillReceiveProps` remained and `componentDidUpdate` was missing in the base component on release-1.25.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19967

#### Device Information
This PR was tested on:
* Android emulator, 8.0