### PR TITLE
[MM-19968] Ensure SELECT_CHANNEL_WITH_MEMBER is dispatched when app opened from a push notification

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -404,9 +404,7 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
                 channel: getChannel(state, currentChannelId),
                 member: getMyChannelMember(state, currentChannelId),
             });
-        }
-
-        if (!fromPushNotification) {
+        } else {
             actions.push({
                 type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
                 data: channelId,

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -398,7 +398,7 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
                 data: channelId,
                 channel,
                 member,
-            }
+            },
         ];
 
         dispatch(batchActions(actions));

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -379,34 +379,23 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
             dispatch(loadPostsIfNecessaryWithRetry(channelId));
         }
 
+        let previousChannelId;
+        if (!fromPushNotification && !sameChannel) {
+            previousChannelId = currentChannelId;
+        }
+
         const actions = [
             selectChannel(channelId),
             getChannelStats(channelId),
             setChannelDisplayName(channel.display_name),
-            {
-                type: ViewTypes.SET_INITIAL_POST_VISIBILITY,
-                data: channelId,
-            },
+            setInitialPostVisibility(channelId),
             setChannelLoading(false),
-            {
-                type: ViewTypes.SET_LAST_CHANNEL_FOR_TEAM,
-                teamId: currentTeamId,
-                channelId,
-            },
-            {
-                type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
-                data: channelId,
-                channel,
-                member,
-            },
+            setLastChannelForTeam(currentTeamId, channelId),
+            selectChannelWithMember(channelId, channel, member),
+            markChannelViewedAndRead(channelId, previousChannelId),
         ];
 
         dispatch(batchActions(actions));
-
-        if (!fromPushNotification && !sameChannel) {
-            const markPreviousChannelId = currentChannelId;
-            dispatch(markChannelViewedAndRead(channelId, markPreviousChannelId));
-        }
     };
 }
 
@@ -673,5 +662,29 @@ function setLoadMorePostsVisible(visible) {
     return {
         type: ViewTypes.SET_LOAD_MORE_POSTS_VISIBLE,
         data: visible,
+    };
+}
+
+function setInitialPostVisibility(channelId) {
+    return {
+        type: ViewTypes.SET_INITIAL_POST_VISIBILITY,
+        data: channelId,
+    };
+}
+
+function setLastChannelForTeam(teamId, channelId) {
+    return {
+        type: ViewTypes.SET_LAST_CHANNEL_FOR_TEAM,
+        teamId,
+        channelId,
+    };
+}
+
+function selectChannelWithMember(channelId, channel, member) {
+    return {
+        type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
+        data: channelId,
+        channel,
+        member,
     };
 }

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -393,29 +393,20 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
                 teamId: currentTeamId,
                 channelId,
             },
-        ];
-
-        let markPreviousChannelId;
-        if (!fromPushNotification && !sameChannel) {
-            markPreviousChannelId = currentChannelId;
-            actions.push({
-                type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
-                data: currentChannelId,
-                channel: getChannel(state, currentChannelId),
-                member: getMyChannelMember(state, currentChannelId),
-            });
-        } else {
-            actions.push({
+            {
                 type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
                 data: channelId,
                 channel,
                 member,
-            });
-        }
+            }
+        ];
 
         dispatch(batchActions(actions));
 
-        dispatch(markChannelViewedAndRead(channelId, markPreviousChannelId));
+        if (!fromPushNotification && !sameChannel) {
+            const markPreviousChannelId = currentChannelId;
+            dispatch(markChannelViewedAndRead(channelId, markPreviousChannelId));
+        }
     };
 }
 

--- a/app/actions/views/channel.test.js
+++ b/app/actions/views/channel.test.js
@@ -241,70 +241,15 @@ describe('Actions.Views.Channel', () => {
         expect(receivedPostsSince).not.toBe(null);
     });
 
-    test('handleSelectChannel does not dispatch markChannelViewedAndRead when from push notification', () => {
-        const markChannelViewedAndRead = jest.spyOn(ChannelActions, 'markChannelViewedAndRead');
+    const handleSelectChannelCases = [
+        [currentChannelId, true],
+        [currentChannelId, false],
+        [`not-${currentChannelId}`, true],
+        [`not-${currentChannelId}`, false],
+    ];
+    test.each(handleSelectChannelCases)('handleSelectChannel dispatches selectChannelWithMember', async (channelId, fromPushNotification) => {
         store = mockStore({...storeObj});
 
-        const channelIds = [currentChannelId, `not-${currentChannelId}`];
-        channelIds.forEach(async (channelId) => {
-            const fromPushNotification = true;
-            await store.dispatch(handleSelectChannel(channelId, fromPushNotification));
-            const storeBatchActions = store.getActions().find(({type}) => type === 'BATCHING_REDUCER.BATCH');
-            const selectChannelWithMember = storeBatchActions.payload.find(({type}) => type === ViewTypes.SELECT_CHANNEL_WITH_MEMBER);
-
-            const expectedSelectChannelWithMember = {
-                type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
-                data: channelId,
-                channel: {
-                    data: channelId,
-                },
-                member: {
-                    data: {
-                        member: {},
-                    },
-                },
-
-            };
-            expect(selectChannelWithMember).toStrictEqual(expectedSelectChannelWithMember);
-            expect(markChannelViewedAndRead).not.toHaveBeenCalled();
-        });
-    });
-
-    test('handleSelectChannel does not dispatch markChannelViewedAndRead when from same channel', () => {
-        const markChannelViewedAndRead = jest.spyOn(ChannelActions, 'markChannelViewedAndRead');
-        store = mockStore({...storeObj});
-
-        const fromPushnotifications = [true, false];
-        fromPushnotifications.forEach(async (fromPushNotification) => {
-            const channelId = currentChannelId;
-            await store.dispatch(handleSelectChannel(channelId, fromPushNotification));
-            const storeBatchActions = store.getActions().find(({type}) => type === 'BATCHING_REDUCER.BATCH');
-            const selectChannelWithMember = storeBatchActions.payload.find(({type}) => type === ViewTypes.SELECT_CHANNEL_WITH_MEMBER);
-
-            const expectedSelectChannelWithMember = {
-                type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
-                data: channelId,
-                channel: {
-                    data: channelId,
-                },
-                member: {
-                    data: {
-                        member: {},
-                    },
-                },
-
-            };
-            expect(selectChannelWithMember).toStrictEqual(expectedSelectChannelWithMember);
-            expect(markChannelViewedAndRead).not.toHaveBeenCalled();
-        });
-    });
-
-    test('handleSelectChannel dispatches markChannelViewedAndRead when not from notification and not from same channel', async () => {
-        const markChannelViewedAndRead = jest.spyOn(ChannelActions, 'markChannelViewedAndRead');
-        store = mockStore({...storeObj});
-
-        const channelId = `not-${currentChannelId}`;
-        const fromPushNotification = false;
         await store.dispatch(handleSelectChannel(channelId, fromPushNotification));
         const storeBatchActions = store.getActions().find(({type}) => type === 'BATCHING_REDUCER.BATCH');
         const selectChannelWithMember = storeBatchActions.payload.find(({type}) => type === ViewTypes.SELECT_CHANNEL_WITH_MEMBER);
@@ -323,6 +268,5 @@ describe('Actions.Views.Channel', () => {
 
         };
         expect(selectChannelWithMember).toStrictEqual(expectedSelectChannelWithMember);
-        expect(markChannelViewedAndRead).not.toHaveBeenCalledWith(channelId, currentChannelId);
     });
 });

--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -47,7 +47,7 @@ export function loadConfigAndLicense() {
     };
 }
 
-export function loadFromPushNotification(notification, startAppFromPushNotification) {
+export function loadFromPushNotification(notification) {
     return async (dispatch, getState) => {
         const state = getState();
         const {data} = notification;
@@ -84,7 +84,7 @@ export function loadFromPushNotification(notification, startAppFromPushNotificat
             dispatch(selectTeam({id: teamId}));
         }
 
-        dispatch(handleSelectChannel(channelId, startAppFromPushNotification));
+        dispatch(handleSelectChannel(channelId, true));
     };
 }
 

--- a/app/screens/notification/__snapshots__/notification.test.js.snap
+++ b/app/screens/notification/__snapshots__/notification.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notification should match snapshot 1`] = `null`;

--- a/app/screens/notification/notification.test.js
+++ b/app/screens/notification/notification.test.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import Notification from './notification.js';
+
+jest.mock('react-native-navigation', () => ({
+    Navigation: {
+        events: jest.fn(() => ({
+            registerComponentDidDisappearListener: jest.fn(),
+        })),
+    },
+}));
+
+describe('Notification', () => {
+    const baseProps = {
+        actions: {
+            loadFromPushNotification: jest.fn(),
+        },
+        componentId: 'component-id',
+        deviceWidth: 100,
+        notification: {},
+        theme: Preferences.THEMES.default,
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <Notification {...baseProps}/>,
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should call loadFromPushNotification on notification tap for non-local notification', () => {
+        const props = {
+            ...baseProps,
+            notification: {
+                localNotification: true,
+            },
+        };
+        const wrapper = shallow(
+            <Notification {...props}/>,
+        );
+        const instance = wrapper.instance();
+
+        instance.notificationTapped();
+        expect(baseProps.actions.loadFromPushNotification).not.toHaveBeenCalled();
+
+        const notification = {
+            localNotification: false,
+        };
+        wrapper.setProps({notification});
+        instance.notificationTapped();
+        expect(baseProps.actions.loadFromPushNotification).toHaveBeenCalledWith(notification);
+    });
+});

--- a/app/utils/push_notifications.js
+++ b/app/utils/push_notifications.js
@@ -47,7 +47,7 @@ class PushNotificationUtils {
     loadFromNotification = async (notification) => {
         // Set appStartedFromPushNotification to avoid channel screen to call selectInitialChannel
         EphemeralStore.appStartedFromPushNotification = true;
-        await this.store.dispatch(loadFromPushNotification(notification, true));
+        await this.store.dispatch(loadFromPushNotification(notification));
 
         // if we have a componentId means that the app is already initialized
         const componentId = EphemeralStore.getNavigationTopComponentId();

--- a/test/setup.js
+++ b/test/setup.js
@@ -23,12 +23,18 @@ jest.doMock('react-native', () => {
         ImagePickerManager,
         requireNativeComponent,
         Alert: RNAlert,
+        InteractionManager: RNInteractionManager,
         NativeModules: RNNativeModules,
     } = ReactNative;
 
     const Alert = {
         ...RNAlert,
         alert: jest.fn(),
+    };
+
+    const InteractionManager = {
+        ...RNInteractionManager,
+        runAfterInteractions: jest.fn((cb) => cb()),
     };
 
     const NativeModules = {
@@ -87,6 +93,7 @@ jest.doMock('react-native', () => {
         ImagePickerManager,
         requireNativeComponent,
         Alert,
+        InteractionManager,
         NativeModules,
     }, ReactNative);
 });


### PR DESCRIPTION
#### Summary
Prior to the changes in this PR, when launching the app from a push notification to a channel that had not yet been loaded, `lastViewedAt` was undefined and since `SELECT_CHANNEL_WITH_MEMBER` was not dispatched it remained undefined. This prevented the `START_OF_NEW_MESSAGES` item from being added to the postIds list. I've fixed this by always dispatching `SELECT_CHANNEL_WITH_MEMBER`, regardless of whether `handleSelectChannel` was called from a push notification, and regardless of whether the `channelId` pass is the `currentChannelId`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19968

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android emulator, 8.1
* iPhone 11, iOS 13.1