### PR TITLE
MM-19966 Fixed Notification Settings

### DIFF
--- a/app/screens/settings/notification_settings/notification_settings.js
+++ b/app/screens/settings/notification_settings/notification_settings.js
@@ -134,12 +134,13 @@ export default class NotificationSettings extends PureComponent {
 
     saveNotificationProps = (notifyProps) => {
         const {currentUser} = this.props;
+        const prevProps = getNotificationProps(currentUser);
         const updatedProps = {
-            ...getNotificationProps(currentUser),
+            ...prevProps,
             ...notifyProps,
         };
 
-        if (!deepEqual(updatedProps, notifyProps)) {
+        if (!deepEqual(prevProps, notifyProps)) {
             this.props.actions.updateMe({notify_props: updatedProps});
         }
     };

--- a/app/screens/settings/notification_settings/notification_settings.test.js
+++ b/app/screens/settings/notification_settings/notification_settings.test.js
@@ -9,13 +9,16 @@ import {shallowWithIntl} from 'test/intl-test-helper';
 
 import NotificationSettings from './notification_settings.js';
 
+import {getNotificationProps} from 'app/utils/notify_props';
+
 describe('NotificationSettings', () => {
+    const currentUser = {id: 'current_user_id'};
     const baseProps = {
         actions: {
             updateMe: jest.fn(),
         },
         componentId: 'component-id',
-        currentUser: {id: 'current_user_id'},
+        currentUser,
         theme: Preferences.THEMES.default,
         updateMeRequest: {},
         currentUserStatus: 'status',
@@ -32,17 +35,22 @@ describe('NotificationSettings', () => {
     });
 
     test('should include previous notification props when saving new ones', () => {
-        baseProps.currentUser.notify_props = {previous: 'previous'};
         const wrapper = shallowWithIntl(
             <NotificationSettings {...baseProps}/>
         );
 
         const instance = wrapper.instance();
+
+        const defaultNotifyProps = getNotificationProps(currentUser);
+        instance.saveNotificationProps(defaultNotifyProps);
+        expect(baseProps.actions.updateMe).toHaveBeenCalledTimes(0);
+
         const newProps = {new: 'new'};
         instance.saveNotificationProps(newProps);
+        expect(baseProps.actions.updateMe).toHaveBeenCalledTimes(1);
         expect(baseProps.actions.updateMe).toHaveBeenCalledWith({
             notify_props: {
-                ...baseProps.currentUser.notify_props,
+                ...defaultNotifyProps,
                 ...newProps,
             },
         });


### PR DESCRIPTION
#### Summary
Fixed the save functionality for props. There was a change to combine notification settings that then did a deep comparison on two like objects. This change makes the comparison of the newly changed notification props and the previous props.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19966

#### Device Information
This PR was tested on:
iPhone X 12.4 (Simulator)
Android Pixel API 29 (Simulator)