### PR TITLE
MM-19697 - Fixed CameraRoll for iOS

### DIFF
--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -8,7 +8,7 @@ import RNFetchBlob from 'rn-fetch-blob';
 import {CircularProgress} from 'react-native-circular-progress';
 import Icon from 'react-native-vector-icons/Ionicons';
 import {intlShape} from 'react-intl';
-import CameraRoll from "@react-native-community/cameraroll";
+import CameraRoll from '@react-native-community/cameraroll';
 
 import {Client4} from 'mattermost-redux/client';
 

--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -3,11 +3,12 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Alert, Animated, CameraRoll, InteractionManager, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {Alert, Animated, InteractionManager, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 import {CircularProgress} from 'react-native-circular-progress';
 import Icon from 'react-native-vector-icons/Ionicons';
 import {intlShape} from 'react-intl';
+import CameraRoll from "@react-native-community/cameraroll";
 
 import {Client4} from 'mattermost-redux/client';
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -191,6 +191,8 @@ PODS:
     - React-cxxreact (= 0.61.2)
     - React-jsi (= 0.61.2)
   - React-jsinspector (0.61.2)
+  - react-native-cameraroll (1.3.0):
+    - React
   - react-native-cookies (3.2.0):
     - React
   - react-native-document-picker (3.2.4):
@@ -301,6 +303,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
+  - "react-native-cameraroll (from `../node_modules/@react-native-community/cameraroll`)"
   - react-native-cookies (from `../node_modules/react-native-cookies/ios`)
   - react-native-document-picker (from `../node_modules/react-native-document-picker`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
@@ -382,6 +385,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
+  react-native-cameraroll:
+    :path: "../node_modules/@react-native-community/cameraroll"
   react-native-cookies:
     :path: "../node_modules/react-native-cookies/ios"
   react-native-document-picker:
@@ -467,6 +472,7 @@ SPEC CHECKSUMS:
   React-jsi: 32285a21b1b24c36060493ed3057a34677d58d09
   React-jsiexecutor: 8909917ff7d8f21a57e443a866fd8d4560e50c65
   React-jsinspector: 111d7d342b07a904c400592e02a2b958f1098b60
+  react-native-cameraroll: ad20f5a93c25cb83a76455df57a2c62fbb63aaed
   react-native-cookies: 854d59c4135c70b92a02ca4930e68e4e2eb58150
   react-native-document-picker: c36bf5f067a581657ecaf7124dcd921a8be19061
   react-native-image-picker: fd93361c666f397bdf72f9c6c23f13d2685b9173

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
       "assets/images/video_player/(.*).png": "<rootDir>/dist/assets/images/video_player/$1@2x.png"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!react-native|jail-monkey|@sentry/react-native|react-navigation)"
+      "node_modules/(?!react-native|jail-monkey|@sentry/react-native|react-navigation|@react-native-community/cameraroll)"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/runtime": "7.6.3",
     "@react-native-community/async-storage": "1.6.2",
+    "@react-native-community/cameraroll": "1.3.0",
     "@react-native-community/netinfo": "4.4.0",
     "@sentry/react-native": "1.0.9",
     "analytics-react-native": "1.2.0",


### PR DESCRIPTION

#### Summary
Switched CameraRoll over to the react-native-community version as it was removed from the core package with RN 0.61.2

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19697

#### Checklist
- [x] Added new package - @react-native-community/cameraroll

#### Device Information
This PR was tested on:
iPhone 11 Pro 13.1
