### PR TITLE
Fix: Performance problems with string concatenation on hermes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -75,7 +75,7 @@ import com.android.build.OutputFile
 project.ext.react = [
     entryFile: "index.js",
     bundleConfig: "metro.config.js",
-    enableHermes: false,
+    enableHermes: true,
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/app/screens/code/code.js
+++ b/app/screens/code/code.js
@@ -56,12 +56,13 @@ export default class Code extends React.PureComponent {
         const style = getStyleSheet(this.props.theme);
 
         const numberOfLines = this.countLines(this.props.content);
-        let lineNumbers = '1';
+        const lineNumbers = '1';
         for (let i = 1; i < numberOfLines; i++) {
             const line = (i + 1).toString();
 
-            lineNumbers += '\n' + line;
+            lineNumbers.push('\n' + line);
         }
+        lineNumbers.join('');
 
         let lineNumbersStyle;
         if (numberOfLines >= 10) {

--- a/app/screens/code/code.js
+++ b/app/screens/code/code.js
@@ -56,7 +56,7 @@ export default class Code extends React.PureComponent {
         const style = getStyleSheet(this.props.theme);
 
         const numberOfLines = this.countLines(this.props.content);
-        const lineNumbers = '1';
+        const lineNumbers = ['1'];
         for (let i = 1; i < numberOfLines; i++) {
             const line = (i + 1).toString();
 

--- a/app/screens/text_preview/text_preview.js
+++ b/app/screens/text_preview/text_preview.js
@@ -41,12 +41,13 @@ export default class TextPreview extends React.PureComponent {
         const style = getStyleSheet(this.props.theme);
 
         const numberOfLines = this.countLines(this.props.content);
-        let lineNumbers = '1';
+        const lineNumbers = ['1'];
         for (let i = 1; i < numberOfLines; i++) {
             const line = (i + 1).toString();
 
-            lineNumbers += '\n' + line;
+            lineNumbers.push('\n' + line);
         }
+        lineNumbers.join('');
 
         let lineNumbersStyle;
         if (numberOfLines >= 10) {

--- a/patches/base-64+0.1.0.patch
+++ b/patches/base-64+0.1.0.patch
@@ -1,0 +1,73 @@
+diff --git a/node_modules/base-64/base64.js b/node_modules/base-64/base64.js
+index 0bb7975..6210d60 100644
+--- a/node_modules/base-64/base64.js
++++ b/node_modules/base-64/base64.js
+@@ -57,7 +57,7 @@
+ 		var bitCounter = 0;
+ 		var bitStorage;
+ 		var buffer;
+-		var output = '';
++		const output = [];
+ 		var position = -1;
+ 		while (++position < length) {
+ 			buffer = TABLE.indexOf(input.charAt(position));
+@@ -65,12 +65,12 @@
+ 			// Unless this is the first of a group of 4 characters…
+ 			if (bitCounter++ % 4) {
+ 				// …convert the first 8 bits to a single ASCII character.
+-				output += String.fromCharCode(
++				output.push(String.fromCharCode(
+ 					0xFF & bitStorage >> (-2 * bitCounter & 6)
+-				);
++				));
+ 			}
+ 		}
+-		return output;
++		return output.join('');
+ 	};
+ 
+ 	// `encode` is designed to be fully compatible with `btoa` as described in the
+@@ -86,7 +86,7 @@
+ 			);
+ 		}
+ 		var padding = input.length % 3;
+-		var output = '';
++		const output = [];
+ 		var position = -1;
+ 		var a;
+ 		var b;
+@@ -104,7 +104,7 @@
+ 			buffer = a + b + c;
+ 			// Turn the 24 bits into four chunks of 6 bits each, and append the
+ 			// matching character for each of them to the output.
+-			output += (
++			output.push(
+ 				TABLE.charAt(buffer >> 18 & 0x3F) +
+ 				TABLE.charAt(buffer >> 12 & 0x3F) +
+ 				TABLE.charAt(buffer >> 6 & 0x3F) +
+@@ -116,7 +116,7 @@
+ 			a = input.charCodeAt(position) << 8;
+ 			b = input.charCodeAt(++position);
+ 			buffer = a + b;
+-			output += (
++			output.push(
+ 				TABLE.charAt(buffer >> 10) +
+ 				TABLE.charAt((buffer >> 4) & 0x3F) +
+ 				TABLE.charAt((buffer << 2) & 0x3F) +
+@@ -124,14 +124,14 @@
+ 			);
+ 		} else if (padding == 1) {
+ 			buffer = input.charCodeAt(position);
+-			output += (
++			output.push(
+ 				TABLE.charAt(buffer >> 2) +
+ 				TABLE.charAt((buffer << 4) & 0x3F) +
+ 				'=='
+ 			);
+ 		}
+ 
+-		return output;
++		return output.join('');
+ 	};
+ 
+ 	var base64 = {


### PR DESCRIPTION
#### Summary
This PR fixes the performance problem with string concatenation on the Hermes engine. This base-64 library https://www.npmjs.com/package/base-64 is used by both **rn-fetch-blob** and **analytics-react-native** packages. The implementation code of the base-64 has a string concatenation within a while loop and the performance of this operation on Hermes is quadratic. As a workaround to fix this performance problem the string concatenation is replaced by initializing it to an empty array and the values are added to array using `array.push()` and `array.join('')` is used to get the final result. The result of this operation is **linear** instead of **quadratic**.

#### Device Information
This PR was tested on: Moto E5, Android 8.0.0