### PR TITLE
MM-20149 Fix marking channels as read

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -392,10 +392,10 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
             setChannelLoading(false),
             setLastChannelForTeam(currentTeamId, channelId),
             selectChannelWithMember(channelId, channel, member),
-            markChannelViewedAndRead(channelId, previousChannelId),
         ];
 
         dispatch(batchActions(actions));
+        dispatch(markChannelViewedAndRead(channelId, previousChannelId));
     };
 }
 

--- a/app/actions/views/channel.test.js
+++ b/app/actions/views/channel.test.js
@@ -17,12 +17,15 @@ const {
 
 import postReducer from 'mattermost-redux/reducers/entities/posts';
 
+const MOCK_CHANNEL_MARK_AS_READ = 'MOCK_CHANNEL_MARK_AS_READ';
+const MOCK_CHANNEL_MARK_AS_VIEWED = 'MOCK_CHANNEL_MARK_AS_VIEWED';
+
 jest.mock('mattermost-redux/actions/channels', () => {
     const channelActions = require.requireActual('mattermost-redux/actions/channels');
     return {
         ...channelActions,
-        markChannelAsRead: jest.fn().mockReturnValue({type: ''}),
-        markChannelAsViewed: jest.fn().mockReturnValue({type: ''}),
+        markChannelAsRead: jest.fn().mockReturnValue({type: 'MOCK_CHANNEL_MARK_AS_READ'}),
+        markChannelAsViewed: jest.fn().mockReturnValue({type: 'MOCK_CHANNEL_MARK_AS_VIEWED'}),
     };
 });
 
@@ -251,8 +254,11 @@ describe('Actions.Views.Channel', () => {
         store = mockStore({...storeObj});
 
         await store.dispatch(handleSelectChannel(channelId, fromPushNotification));
-        const storeBatchActions = store.getActions().find(({type}) => type === 'BATCHING_REDUCER.BATCH');
+        const storeActions = store.getActions();
+        const storeBatchActions = storeActions.find(({type}) => type === 'BATCHING_REDUCER.BATCH');
         const selectChannelWithMember = storeBatchActions.payload.find(({type}) => type === ViewTypes.SELECT_CHANNEL_WITH_MEMBER);
+        const viewedAction = storeActions.find(({type}) => type === MOCK_CHANNEL_MARK_AS_VIEWED);
+        const readAction = storeActions.find(({type}) => type === MOCK_CHANNEL_MARK_AS_READ);
 
         const expectedSelectChannelWithMember = {
             type: ViewTypes.SELECT_CHANNEL_WITH_MEMBER,
@@ -268,5 +274,7 @@ describe('Actions.Views.Channel', () => {
 
         };
         expect(selectChannelWithMember).toStrictEqual(expectedSelectChannelWithMember);
+        expect(viewedAction).not.toBe(null);
+        expect(readAction).not.toBe(null);
     });
 });


### PR DESCRIPTION
#### Summary
The action for `markChannelViewedAndRead` is a thunk and it does not get trigger when is part of a batch, dispatching the action independently fixes the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20149