### PR TITLE
[MM-16232] Android: remove ID loaded default message

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -120,10 +120,6 @@ public class CustomPushNotification extends PushNotification {
                 @Override
                 public void reject(String code, String message) {
                     Log.e("ReactNative", code + ": " + message);
-                    if (PUSH_TYPE_ID_LOADED.equals(type)) {
-                        initialData.putString("message", "You've received a new message");
-                        mNotificationProps = createProps(initialData);
-                    }
                 }
             });
         }


### PR DESCRIPTION
#### Summary
The server will return a localized default message with the ID loaded push notification so there's no need to add one on the Android side when the fetch fails.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16232

#### Device Information
This PR was tested on:
* Android emulator, 8.1