### PR TITLE
MM-20007 Fix app crashes when previewing some gif files

### DIFF
--- a/app/components/message_attachments/attachment_thumbnail.js
+++ b/app/components/message_attachments/attachment_thumbnail.js
@@ -2,8 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React, {PureComponent} from 'react';
-import {Image, StyleSheet, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import PropTypes from 'prop-types';
+import FastImage from 'react-native-fast-image';
 
 export default class AttachmentThumbnail extends PureComponent {
     static propTypes = {
@@ -19,7 +20,7 @@ export default class AttachmentThumbnail extends PureComponent {
 
         return (
             <View style={style.container}>
-                <Image
+                <FastImage
                     source={{uri}}
                     resizeMode='contain'
                     resizeMethod='scale'

--- a/app/components/progressive_image/progressive_image.js
+++ b/app/components/progressive_image/progressive_image.js
@@ -4,12 +4,14 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {Animated, Image, ImageBackground, Platform, View, StyleSheet} from 'react-native';
+import FastImage from 'react-native-fast-image';
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
 import ImageCacheManager from 'app/utils/image_cache_manager';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 const AnimatedImageBackground = Animated.createAnimatedComponent(ImageBackground);
+const AnimatedImage = Animated.createAnimatedComponent(FastImage);
 
 export default class ProgressiveImage extends PureComponent {
     static propTypes = {
@@ -131,7 +133,7 @@ export default class ProgressiveImage extends PureComponent {
             ImageComponent = AnimatedImageBackground;
         } else {
             DefaultComponent = Image;
-            ImageComponent = Animated.Image;
+            ImageComponent = AnimatedImage;
         }
 
         const styles = getStyleSheet(theme);

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {
     Alert,
     Animated,
-    Image,
     Platform,
     SafeAreaView,
     StatusBar,
@@ -22,6 +21,7 @@ import {intlShape} from 'react-intl';
 import Permissions from 'react-native-permissions';
 import Gallery from 'react-native-image-gallery';
 import DeviceInfo from 'react-native-device-info';
+import FastImage from 'react-native-fast-image';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
@@ -374,7 +374,7 @@ export default class ImagePreview extends PureComponent {
 
             return (
                 <View style={[style, {justifyContent: 'center', alignItems: 'center'}]}>
-                    <Image
+                    <FastImage
                         source={source}
                         style={imageStyle}
                     />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,6 +1293,11 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.6.2.tgz",
       "integrity": "sha512-EJGsbrHubK1mGxPjWB74AaHAd5m9I+Gg2RRPZzMK6org7QOU9WOBnIMFqoeVto3hKOaEPlk8NV74H6G34/2pZQ=="
     },
+    "@react-native-community/cameraroll": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-1.3.0.tgz",
+      "integrity": "sha512-QJl9N34euvGU7s/Gn6jhsqi70O4SmxFxuy+yBnW7ehE8qtPYO91gyLLrtiWdTfYvuVCUNvX/G0LKJQLm8SojAA=="
+    },
     "@react-native-community/cli-platform-android": {
       "version": "3.0.0-alpha.7",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-3.0.0-alpha.7.tgz",


### PR DESCRIPTION
#### Summary
Use `FastImage` for the **ProgressiveImage** component and in the **ImagePreview** that has a better image processing and memory management that the RN `Image` component. After applying this change iOS no longer crash on some `gif` images.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20007

#### Device Information
This PR was tested on: iPhone 6s, iPhone Xs, Android emulator