### PR TITLE
Fix theme color for the more channel options

### DIFF
--- a/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
+++ b/app/screens/more_channels/__snapshots__/more_channels.test.js.snap
@@ -56,6 +56,7 @@ exports[`MoreChannels should match snapshot 1`] = `
         onPress={[Function]}
         style={
           Object {
+            "color": "#3d3c40",
             "fontWeight": "bold",
             "marginBottom": 10,
             "marginLeft": 10,

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -489,6 +489,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.5),
         },
         channelDropdown: {
+            color: theme.centerChannelColor,
             fontWeight: 'bold',
             marginLeft: 10,
             marginTop: 20,


### PR DESCRIPTION
#### Summary
The options were using the default color for the font which is `black` this PR changes to use the `theme.centerChannelColor`