### PR TITLE
MM-18766 - componentWillReceiveProps is being deprecated

### DIFF
--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -48,6 +48,16 @@ export default class Downloader extends PureComponent {
         intl: intlShape,
     };
 
+    static getDerivedStateFromProps(props, state) {
+        if (!props.show) {
+            return {
+                didCancel: false,
+                progress: 0,
+            };
+        }
+        return null;
+    }
+
     constructor(props) {
         super(props);
 
@@ -74,17 +84,11 @@ export default class Downloader extends PureComponent {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (!this.props.show && nextProps.show) {
-            this.toggleDownloader();
-            this.setState({
-                didCancel: false,
-                progress: 0,
-            });
-        } else if (!nextProps.show && this.props.show) {
-            this.toggleDownloader(false);
-        } else if (this.props.deviceHeight !== nextProps.deviceHeight) {
-            this.recenterDownloader(nextProps);
+    componentDidUpdate(prevProps) {
+        if (this.props.show !== prevProps.show) {
+            this.toggleDownloader(this.props.show);
+        } else if (this.props.deviceHeight !== prevProps.deviceHeight) {
+            this.recenterDownloader(this.props);
         }
     }
 
@@ -423,7 +427,8 @@ const styles = StyleSheet.create({
         width: 200,
         height: 200,
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 40,
     },
     progressCirclePercentage: {
         flex: 1,

--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -48,7 +48,7 @@ export default class Downloader extends PureComponent {
         intl: intlShape,
     };
 
-    static getDerivedStateFromProps(props, state) {
+    static getDerivedStateFromProps(props, _) {
         if (!props.show) {
             return {
                 didCancel: false,

--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -48,7 +48,7 @@ export default class Downloader extends PureComponent {
         intl: intlShape,
     };
 
-    static getDerivedStateFromProps(props, _) {
+    static getDerivedStateFromProps(props) {
         if (!props.show) {
             return {
                 didCancel: false,


### PR DESCRIPTION
#### Summary

* componentWillReceiveProps is being deprecated. Replace its usage in app/screens/image_preview/downloader.ios.js.
* Bonus UI polish - The download progress component's contents shift up after the component is displayed - avoid this jitter. 

#### Ticket Link

GH: https://github.com/mattermost/mattermost-server/issues/12353 (the ticket calls out several components - since this my first contribution I wanted to keep the PR small and started with just one).
JIRA:  https://mattermost.atlassian.net/browse/MM-18766

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone X Simulator Running IOS 13.

#### Screenshots

Successfully download the image:
![download_image_success](https://user-images.githubusercontent.com/1521460/69121531-6e74d280-0a51-11ea-9f56-3e0e5f62753e.gif)

Canceling the download then trying again:
![download_image_cancel2](https://user-images.githubusercontent.com/1521460/69121579-8ea49180-0a51-11ea-84a2-5641785455aa.gif)


