### PR TITLE
Fixes crash when sso cookies does not contain an expiration date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5665,9 +5665,9 @@
       "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handlebars": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -10669,8 +10669,8 @@
       }
     },
     "react-native-cookies": {
-      "version": "github:mattermost/react-native-cookies#48240c34cfd9dbfa0a590f0b740c74b2211cec93",
-      "from": "github:mattermost/react-native-cookies#48240c34cfd9dbfa0a590f0b740c74b2211cec93",
+      "version": "github:mattermost/react-native-cookies#a54c0ffd28679871dd11e3396d8382cc8ff204d1",
+      "from": "github:mattermost/react-native-cookies#a54c0ffd28679871dd11e3396d8382cc8ff204d1",
       "requires": {
         "invariant": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-native-button": "2.4.0",
     "react-native-calendars": "github:mattermost/react-native-calendars#4937ec5a3bf7e86f9f35fcd85eb4aa6133f45b58",
     "react-native-circular-progress": "1.3.0",
-    "react-native-cookies": "github:mattermost/react-native-cookies#48240c34cfd9dbfa0a590f0b740c74b2211cec93",
+    "react-native-cookies": "github:mattermost/react-native-cookies#a54c0ffd28679871dd11e3396d8382cc8ff204d1",
     "react-native-device-info": "github:mattermost/react-native-device-info#f7175f10822d8f66b9806206e3313eaf2f4aabc6",
     "react-native-doc-viewer": "github:mattermost/react-native-doc-viewer#c913e54ec8e4a60753bc7dd39256fa4be8229d19",
     "react-native-document-picker": "3.2.4",


### PR DESCRIPTION
#### Summary
When forking the [react-native-cookie repo](https://github.com/mattermost/react-native-cookies) we forgot to include [the patched](https://github.com/mattermost/react-native-cookies/commit/a54c0ffd28679871dd11e3396d8382cc8ff204d1) that lived in `native_modules` causing this bug to re-appear.

Note: This needs to be cherry-picked to the release-1.26 and **release-1.25** so it can be included in the next release and 1.25.1 dot release

**Important: The cherry-pick for 1.25 needs to be done manually**

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20355