### PR TITLE
[MM-20200] Fix autocomplete when editing channel header

### DIFF
--- a/app/components/autocomplete/autocomplete.js
+++ b/app/components/autocomplete/autocomplete.js
@@ -164,14 +164,14 @@ export default class Autocomplete extends PureComponent {
         const {theme, isSearch, expandDown} = this.props;
         const style = getStyleFromTheme(theme);
 
-        const wrapperStyle = [];
-        const containerStyle = [];
+        const wrapperStyles = [];
+        const containerStyles = [];
         if (isSearch) {
-            wrapperStyle.push(style.base, style.searchContainer);
-            containerStyle.push(style.content);
+            wrapperStyles.push(style.base, style.searchContainer);
+            containerStyles.push(style.content);
         } else {
-            const container = expandDown ? style.containerExpandDown : style.container;
-            containerStyle.push(style.base, container);
+            const containerStyle = expandDown ? style.containerExpandDown : style.container;
+            containerStyles.push(style.base, containerStyle);
         }
 
         // We always need to render something, but we only draw the borders when we have results to show
@@ -180,15 +180,15 @@ export default class Autocomplete extends PureComponent {
             if (this.props.isSearch) {
                 wrapperStyle.push(style.bordersSearch);
             } else {
-                containerStyle.push(style.borders);
+                containerStyles.push(style.borders);
             }
         }
 
         const maxListHeight = this.maxListHeight();
 
         return (
-            <View style={wrapperStyle}>
-                <View style={containerStyle}>
+            <View style={wrapperStyles}>
+                <View style={containerStyles}>
                     <AtMention
                         {...this.props}
                         cursorPosition={cursorPosition}
@@ -261,7 +261,6 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
         },
         containerExpandDown: {
             top: 0,
-            zIndex: 1,
         },
         content: {
             flex: 1,

--- a/app/components/autocomplete/autocomplete.js
+++ b/app/components/autocomplete/autocomplete.js
@@ -34,6 +34,7 @@ export default class Autocomplete extends PureComponent {
         valueEvent: PropTypes.string,
         cursorPositionEvent: PropTypes.string,
         nestedScrollEnabled: PropTypes.bool,
+        expandDown: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -160,15 +161,17 @@ export default class Autocomplete extends PureComponent {
     }
 
     render() {
-        const style = getStyleFromTheme(this.props.theme);
+        const {theme, isSearch, expandDown} = this.props;
+        const style = getStyleFromTheme(theme);
 
         const wrapperStyle = [];
         const containerStyle = [];
-        if (this.props.isSearch) {
+        if (isSearch) {
             wrapperStyle.push(style.base, style.searchContainer);
             containerStyle.push(style.content);
         } else {
-            containerStyle.push(style.base, style.container);
+            const container = expandDown ? style.containerExpandDown : style.container;
+            containerStyle.push(style.base, container);
         }
 
         // We always need to render something, but we only draw the borders when we have results to show
@@ -255,6 +258,10 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
         },
         container: {
             bottom: 0,
+        },
+        containerExpandDown: {
+            top: 0,
+            zIndex: 1,
         },
         content: {
             flex: 1,

--- a/app/components/autocomplete/autocomplete.js
+++ b/app/components/autocomplete/autocomplete.js
@@ -178,7 +178,7 @@ export default class Autocomplete extends PureComponent {
         const {atMentionCount, channelMentionCount, emojiCount, commandCount, dateCount, cursorPosition, value} = this.state;
         if (atMentionCount + channelMentionCount + emojiCount + commandCount + dateCount > 0) {
             if (this.props.isSearch) {
-                wrapperStyle.push(style.bordersSearch);
+                wrapperStyles.push(style.bordersSearch);
             } else {
                 containerStyles.push(style.borders);
             }

--- a/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
+++ b/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
@@ -9,7 +9,6 @@ exports[`EditChannelInfo should match snapshot 1`] = `
     enableResetScrollToCoords={true}
     extraHeight={75}
     extraScrollHeight={0}
-    innerRef={[Function]}
     keyboardOpeningTime={250}
     keyboardShouldPersistTaps="always"
     onKeyboardDidHide={[Function]}

--- a/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
+++ b/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
@@ -9,6 +9,7 @@ exports[`EditChannelInfo should match snapshot 1`] = `
     enableResetScrollToCoords={true}
     extraHeight={75}
     extraScrollHeight={0}
+    innerRef={[Function]}
     keyboardOpeningTime={250}
     keyboardShouldPersistTaps="always"
     onKeyboardDidHide={[Function]}
@@ -292,7 +293,13 @@ exports[`EditChannelInfo should match snapshot 1`] = `
           onChangeText={[Function]}
           value="header"
         />
-        <View>
+        <View
+          style={
+            Object {
+              "zIndex": -1,
+            }
+          }
+        >
           <FormattedText
             defaultMessage="Set text that will appear in the header of the channel beside the channel name. For example, include frequently used links by typing [Link Title](http://example.com)."
             id="channel_modal.headerHelp"

--- a/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
+++ b/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
@@ -11,6 +11,8 @@ exports[`EditChannelInfo should match snapshot 1`] = `
     extraScrollHeight={0}
     keyboardOpeningTime={250}
     keyboardShouldPersistTaps="always"
+    onKeyboardDidHide={[Function]}
+    onKeyboardDidShow={[Function]}
     style={
       Object {
         "backgroundColor": "#ffffff",
@@ -199,6 +201,7 @@ exports[`EditChannelInfo should match snapshot 1`] = `
           </View>
         </View>
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
@@ -234,13 +237,6 @@ exports[`EditChannelInfo should match snapshot 1`] = `
             }
           />
         </View>
-        <ForwardRef(forwardConnectRef)
-          cursorPosition={6}
-          maxHeight={200}
-          nestedScrollEnabled={true}
-          onChangeText={[Function]}
-          value="header"
-        />
         <View
           style={
             Array [
@@ -288,6 +284,14 @@ exports[`EditChannelInfo should match snapshot 1`] = `
             value="header"
           />
         </View>
+        <ForwardRef(forwardConnectRef)
+          cursorPosition={6}
+          expandDown={true}
+          maxHeight={200}
+          nestedScrollEnabled={true}
+          onChangeText={[Function]}
+          value="header"
+        />
         <View>
           <FormattedText
             defaultMessage="Set text that will appear in the header of the channel beside the channel name. For example, include frequently used links by typing [Link Title](http://example.com)."

--- a/app/components/edit_channel_info/edit_channel_info.js
+++ b/app/components/edit_channel_info/edit_channel_info.js
@@ -7,7 +7,6 @@ import {
     Platform,
     TouchableWithoutFeedback,
     View,
-    findNodeHandle,
 } from 'react-native';
 import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 
@@ -67,7 +66,6 @@ export default class EditChannelInfo extends PureComponent {
         this.urlInput = React.createRef();
         this.purposeInput = React.createRef();
         this.headerInput = React.createRef();
-        this.lastText = React.createRef();
         this.scroll = React.createRef();
     }
 
@@ -154,11 +152,36 @@ export default class EditChannelInfo extends PureComponent {
         }
     };
 
-    scrollToEnd = () => {
-        if (this.scroll?.current && this.lastText?.current) {
-            this.scroll.current.scrollToFocusedInput(findNodeHandle(this.lastText.current));
+    onHeaderLayout = ({nativeEvent}) => {
+        this.setState({headerPosition: nativeEvent.layout.y});
+    }
+
+    onKeyboardDidShow = () => {
+        this.setState({keyboardVisible: true});
+
+        if (this.state.headerHasFocus) {
+            this.setState({headerHasFocus: false});
+            this.scrollHeaderToTop();
+        }
+    }
+
+    onKeyboardDidHide = () => {
+        this.setState({keyboardVisible: false});
+    }
+
+    onHeaderFocus = () => {
+        if (this.state.keyboardVisible) {
+            this.scrollHeaderToTop();
+        } else {
+            this.setState({headerHasFocus: true});
         }
     };
+
+    scrollHeaderToTop = () => {
+        if (this.scroll.current) {
+            this.scroll.current.scrollToPosition(0, this.state.headerPosition);
+        }
+    }
 
     render() {
         const {
@@ -170,8 +193,9 @@ export default class EditChannelInfo extends PureComponent {
             header,
             purpose,
             isLandscape,
+            error,
+            saving,
         } = this.props;
-        const {error, saving} = this.props;
 
         const style = getStyleSheet(theme);
 
@@ -205,6 +229,8 @@ export default class EditChannelInfo extends PureComponent {
                     ref={this.scroll}
                     style={style.container}
                     keyboardShouldPersistTaps={'always'}
+                    onKeyboardDidShow={this.onKeyboardDidShow}
+                    onKeyboardDidHide={this.onKeyboardDidHide}
                 >
                     {displayError}
                     <TouchableWithoutFeedback onPress={this.blur}>
@@ -277,7 +303,10 @@ export default class EditChannelInfo extends PureComponent {
                                     </View>
                                 </View>
                             )}
-                            <View style={[style.titleContainer15, padding(isLandscape)]}>
+                            <View
+                                onLayout={this.onHeaderLayout}
+                                style={[style.titleContainer15, padding(isLandscape)]}
+                            >
                                 <FormattedText
                                     style={style.title}
                                     id='channel_modal.header'
@@ -289,13 +318,6 @@ export default class EditChannelInfo extends PureComponent {
                                     defaultMessage='(optional)'
                                 />
                             </View>
-                            <Autocomplete
-                                cursorPosition={header.length}
-                                maxHeight={200}
-                                onChangeText={this.onHeaderChangeText}
-                                value={header}
-                                nestedScrollEnabled={true}
-                            />
                             <View style={[style.inputContainer, padding(isLandscape)]}>
                                 <TextInputWithLocalizedPlaceholder
                                     ref={this.headerInput}
@@ -308,14 +330,22 @@ export default class EditChannelInfo extends PureComponent {
                                     placeholderTextColor={changeOpacity(theme.centerChannelColor, 0.5)}
                                     multiline={true}
                                     blurOnSubmit={false}
-                                    onFocus={this.scrollToEnd}
+                                    onFocus={this.onHeaderFocus}
                                     textAlignVertical='top'
                                     underlineColorAndroid='transparent'
                                     disableFullscreenUI={true}
                                     keyboardAppearance={getKeyboardAppearanceFromTheme(theme)}
                                 />
                             </View>
-                            <View ref={this.lastText}>
+                            <Autocomplete
+                                cursorPosition={header.length}
+                                maxHeight={200}
+                                onChangeText={this.onHeaderChangeText}
+                                value={header}
+                                nestedScrollEnabled={true}
+                                expandDown={true}
+                            />
+                            <View>
                                 <FormattedText
                                     style={[style.helpText, padding(isLandscape)]}
                                     id='channel_modal.headerHelp'

--- a/app/components/edit_channel_info/edit_channel_info.js
+++ b/app/components/edit_channel_info/edit_channel_info.js
@@ -67,6 +67,10 @@ export default class EditChannelInfo extends PureComponent {
         this.purposeInput = React.createRef();
         this.headerInput = React.createRef();
         this.scroll = React.createRef();
+
+        this.state = {
+            keyboardVisible: false,
+        }
     }
 
     blur = () => {
@@ -179,7 +183,7 @@ export default class EditChannelInfo extends PureComponent {
 
     scrollHeaderToTop = () => {
         if (this.scroll.current) {
-            this.scroll.current.scrollToPosition(0, this.state.headerPosition);
+            this.innerRef.props.scrollToPosition(0, this.state.headerPosition);
         }
     }
 
@@ -196,6 +200,7 @@ export default class EditChannelInfo extends PureComponent {
             error,
             saving,
         } = this.props;
+        const {keyboardVisible} = this.state;
 
         const style = getStyleSheet(theme);
 
@@ -231,6 +236,8 @@ export default class EditChannelInfo extends PureComponent {
                     keyboardShouldPersistTaps={'always'}
                     onKeyboardDidShow={this.onKeyboardDidShow}
                     onKeyboardDidHide={this.onKeyboardDidHide}
+                    enableAutomaticScroll={!keyboardVisible}
+                    innerRef={(ref) => this.innerRef = ref}
                 >
                     {displayError}
                     <TouchableWithoutFeedback onPress={this.blur}>

--- a/app/components/edit_channel_info/edit_channel_info.js
+++ b/app/components/edit_channel_info/edit_channel_info.js
@@ -70,7 +70,7 @@ export default class EditChannelInfo extends PureComponent {
 
         this.state = {
             keyboardVisible: false,
-        }
+        };
     }
 
     blur = () => {

--- a/app/components/edit_channel_info/edit_channel_info.js
+++ b/app/components/edit_channel_info/edit_channel_info.js
@@ -183,7 +183,7 @@ export default class EditChannelInfo extends PureComponent {
 
     scrollHeaderToTop = () => {
         if (this.scroll.current) {
-            this.innerRef.props.scrollToPosition(0, this.state.headerPosition);
+            this.scroll.current.scrollToPosition(0, this.state.headerPosition);
         }
     }
 
@@ -237,7 +237,6 @@ export default class EditChannelInfo extends PureComponent {
                     onKeyboardDidShow={this.onKeyboardDidShow}
                     onKeyboardDidHide={this.onKeyboardDidHide}
                     enableAutomaticScroll={!keyboardVisible}
-                    innerRef={(ref) => this.innerRef = ref}
                 >
                     {displayError}
                     <TouchableWithoutFeedback onPress={this.blur}>

--- a/app/components/edit_channel_info/edit_channel_info.js
+++ b/app/components/edit_channel_info/edit_channel_info.js
@@ -352,7 +352,7 @@ export default class EditChannelInfo extends PureComponent {
                                 nestedScrollEnabled={true}
                                 expandDown={true}
                             />
-                            <View>
+                            <View style={style.headerHelpText}>
                                 <FormattedText
                                     style={[style.helpText, padding(isLandscape)]}
                                     id='channel_modal.headerHelp'
@@ -418,6 +418,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.5),
             marginTop: 10,
             marginHorizontal: 15,
+        },
+        headerHelpText: {
+            zIndex: -1,
         },
     };
 });

--- a/app/components/edit_channel_info/edit_channel_info.test.js
+++ b/app/components/edit_channel_info/edit_channel_info.test.js
@@ -64,4 +64,31 @@ describe('EditChannelInfo', () => {
         expect(instance.enableRightButton).toHaveBeenCalledTimes(1);
         expect(instance.enableRightButton).toHaveBeenCalledWith(true);
     });
+
+    test('should call scrollHeaderToTop', () => {
+        const wrapper = shallow(
+            <EditChannelInfo {...baseProps}/>
+        );
+
+        const instance = wrapper.instance();
+        instance.scrollHeaderToTop = jest.fn();
+
+        expect(instance.scrollHeaderToTop).not.toHaveBeenCalled();
+
+        wrapper.setState({keyboardVisible: false});
+        instance.onHeaderFocus();
+        expect(instance.scrollHeaderToTop).not.toHaveBeenCalled();
+
+        wrapper.setState({keyboardVisible: true});
+        instance.onHeaderFocus();
+        expect(instance.scrollHeaderToTop).toHaveBeenCalledTimes(1);
+
+        wrapper.setState({headerHasFocus: false});
+        instance.onKeyboardDidShow();
+        expect(instance.scrollHeaderToTop).toHaveBeenCalledTimes(1);
+
+        wrapper.setState({headerHasFocus: true});
+        instance.onKeyboardDidShow();
+        expect(instance.scrollHeaderToTop).toHaveBeenCalledTimes(2);
+    });
 });


### PR DESCRIPTION
#### Summary
Moved the autocomplete below the header input and made it so that it expands down. In order to have enough space for the autocomplete dropdown to show correctly, we auto-scroll so that the header section is at the top of the screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20200

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Android emulator, 8.1
* iOS simulator, 13

#### Screenshots
Android:
![Screenshot_20191121-145845_Mattermost Beta](https://user-images.githubusercontent.com/3208014/69383855-06540580-0c78-11ea-83ba-6de9d1e039fc.jpg)

iOS:
![Simulator Screen Shot - iPhone 11 - 2019-11-21 at 17 42 44](https://user-images.githubusercontent.com/3208014/69388597-913bfc80-0c86-11ea-9d3e-c1fc3edd080d.png)

