### PR TITLE
MM-19708 Adjusted display name width to 80% for landscape

### DIFF
--- a/app/components/post_header/__snapshots__/post_header.test.js.snap
+++ b/app/components/post_header/__snapshots__/post_header.test.js.snap
@@ -31,6 +31,80 @@ exports[`PostHeader should match snapshot when just a base post 1`] = `
               "maxWidth": "60%",
             },
             null,
+            null,
+          ]
+        }
+        type="opacity"
+      >
+        <Text
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Object {
+              "color": "#3d3c40",
+              "flexGrow": 1,
+              "fontSize": 15,
+              "fontWeight": "600",
+              "paddingVertical": 2,
+            }
+          }
+        >
+          John Smith
+        </Text>
+      </TouchableWithFeedbackIOS>
+      <FormattedTime
+        hour12={true}
+        style={
+          Object {
+            "color": "#3d3c40",
+            "flex": 1,
+            "fontSize": 12,
+            "marginTop": 5,
+            "opacity": 0.5,
+          }
+        }
+        timeZone=""
+        value={0}
+      />
+    </View>
+  </View>
+</React.Fragment>
+`;
+
+exports[`PostHeader should match snapshot when just a base post in landscape mode 1`] = `
+<React.Fragment>
+  <View
+    style={
+      Array [
+        Object {
+          "flex": 1,
+          "marginTop": 10,
+        },
+        false,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TouchableWithFeedbackIOS
+        onPress={[Function]}
+        style={
+          Array [
+            Object {
+              "marginBottom": 3,
+              "marginRight": 5,
+              "maxWidth": "60%",
+            },
+            null,
+            Object {
+              "maxWidth": "80%",
+            },
           ]
         }
         type="opacity"
@@ -99,6 +173,7 @@ exports[`PostHeader should match snapshot when post is autoresponder 1`] = `
               "marginRight": 5,
               "maxWidth": "60%",
             },
+            null,
             null,
           ]
         }
@@ -275,6 +350,7 @@ exports[`PostHeader should match snapshot when post is same thread, so dont disp
               "maxWidth": "60%",
             },
             null,
+            null,
           ]
         }
         type="opacity"
@@ -346,6 +422,162 @@ exports[`PostHeader should match snapshot when post isBot and shouldRenderReplyB
             },
             Object {
               "maxWidth": "50%",
+            },
+            null,
+          ]
+        }
+        type="opacity"
+      >
+        <Text
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Object {
+              "color": "#3d3c40",
+              "flexGrow": 1,
+              "fontSize": 15,
+              "fontWeight": "600",
+              "paddingVertical": 2,
+            }
+          }
+        >
+          John Smith
+        </Text>
+      </TouchableWithFeedbackIOS>
+      <BotTag
+        style={
+          Object {
+            "marginBottom": 5,
+            "marginLeft": 0,
+            "marginRight": 5,
+          }
+        }
+        theme={
+          Object {
+            "awayIndicator": "#ffbc42",
+            "buttonBg": "#166de0",
+            "buttonColor": "#ffffff",
+            "centerChannelBg": "#ffffff",
+            "centerChannelColor": "#3d3c40",
+            "codeTheme": "github",
+            "dndIndicator": "#f74343",
+            "errorTextColor": "#fd5960",
+            "linkColor": "#2389d7",
+            "mentionBg": "#ffffff",
+            "mentionBj": "#ffffff",
+            "mentionColor": "#145dbf",
+            "mentionHighlightBg": "#ffe577",
+            "mentionHighlightLink": "#166de0",
+            "newMessageSeparator": "#ff8800",
+            "onlineIndicator": "#06d6a0",
+            "sidebarBg": "#145dbf",
+            "sidebarHeaderBg": "#1153ab",
+            "sidebarHeaderTextColor": "#ffffff",
+            "sidebarText": "#ffffff",
+            "sidebarTextActiveBorder": "#579eff",
+            "sidebarTextActiveColor": "#ffffff",
+            "sidebarTextHoverBg": "#4578bf",
+            "sidebarUnreadText": "#ffffff",
+            "type": "Mattermost",
+          }
+        }
+      />
+      <FormattedTime
+        hour12={true}
+        style={
+          Object {
+            "color": "#3d3c40",
+            "flex": 1,
+            "fontSize": 12,
+            "marginTop": 5,
+            "opacity": 0.5,
+          }
+        }
+        timeZone=""
+        value={0}
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "justifyContent": "flex-end",
+          }
+        }
+      >
+        <TouchableWithFeedbackIOS
+          onPress={[MockFunction]}
+          style={
+            Object {
+              "alignItems": "flex-start",
+              "flex": 1,
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "minWidth": 40,
+              "paddingBottom": 10,
+              "paddingTop": 2,
+            }
+          }
+          type="opacity"
+        >
+          <ReplyIcon
+            color="#2389d7"
+            height={16}
+            width={16}
+          />
+          <Text
+            style={
+              Object {
+                "color": "#2389d7",
+                "fontSize": 12,
+                "marginLeft": 2,
+                "marginTop": 2,
+              }
+            }
+          >
+            0
+          </Text>
+        </TouchableWithFeedbackIOS>
+      </View>
+    </View>
+  </View>
+</React.Fragment>
+`;
+
+exports[`PostHeader should match snapshot when post isBot and shouldRenderReplyButton in landscape mode 1`] = `
+<React.Fragment>
+  <View
+    style={
+      Array [
+        Object {
+          "flex": 1,
+          "marginTop": 10,
+        },
+        false,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TouchableWithFeedbackIOS
+        onPress={[Function]}
+        style={
+          Array [
+            Object {
+              "marginBottom": 3,
+              "marginRight": 5,
+              "maxWidth": "60%",
+            },
+            Object {
+              "maxWidth": "50%",
+            },
+            Object {
+              "maxWidth": "70%",
             },
           ]
         }
@@ -497,6 +729,7 @@ exports[`PostHeader should match snapshot when post renders Commented On for new
               "maxWidth": "60%",
             },
             null,
+            null,
           ]
         }
         type="opacity"
@@ -583,6 +816,7 @@ exports[`PostHeader should match snapshot when post should display reply button 
               "marginRight": 5,
               "maxWidth": "60%",
             },
+            null,
             null,
           ]
         }

--- a/app/components/post_header/__snapshots__/post_header.test.js.snap
+++ b/app/components/post_header/__snapshots__/post_header.test.js.snap
@@ -31,7 +31,6 @@ exports[`PostHeader should match snapshot when just a base post 1`] = `
               "maxWidth": "60%",
             },
             null,
-            null,
           ]
         }
         type="opacity"
@@ -101,7 +100,6 @@ exports[`PostHeader should match snapshot when just a base post in landscape mod
               "marginRight": 5,
               "maxWidth": "60%",
             },
-            null,
             Object {
               "maxWidth": "80%",
             },
@@ -173,7 +171,6 @@ exports[`PostHeader should match snapshot when post is autoresponder 1`] = `
               "marginRight": 5,
               "maxWidth": "60%",
             },
-            null,
             null,
           ]
         }
@@ -350,7 +347,6 @@ exports[`PostHeader should match snapshot when post is same thread, so dont disp
               "maxWidth": "60%",
             },
             null,
-            null,
           ]
         }
         type="opacity"
@@ -423,7 +419,6 @@ exports[`PostHeader should match snapshot when post isBot and shouldRenderReplyB
             Object {
               "maxWidth": "50%",
             },
-            null,
           ]
         }
         type="opacity"
@@ -572,9 +567,6 @@ exports[`PostHeader should match snapshot when post isBot and shouldRenderReplyB
               "marginBottom": 3,
               "marginRight": 5,
               "maxWidth": "60%",
-            },
-            Object {
-              "maxWidth": "50%",
             },
             Object {
               "maxWidth": "70%",
@@ -729,7 +721,6 @@ exports[`PostHeader should match snapshot when post renders Commented On for new
               "maxWidth": "60%",
             },
             null,
-            null,
           ]
         }
         type="opacity"
@@ -816,7 +807,6 @@ exports[`PostHeader should match snapshot when post should display reply button 
               "marginRight": 5,
               "maxWidth": "60%",
             },
-            null,
             null,
           ]
         }

--- a/app/components/post_header/index.js
+++ b/app/components/post_header/index.js
@@ -15,6 +15,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {fromAutoResponder} from 'app/utils/general';
 import {isGuest} from 'app/utils/users';
+import {isLandscape} from 'app/selectors/device';
 
 import PostHeader from './post_header';
 
@@ -47,6 +48,7 @@ function makeMapStateToProps() {
             username: user.username,
             isBot: user.is_bot || false,
             isGuest: isGuest(user),
+            isLandscape: isLandscape(state),
             userTimezone,
         };
     };

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -62,6 +62,8 @@ export default class PostHeader extends PureComponent {
         }
     };
 
+    
+
     renderCommentedOnMessage = () => {
         const {
             beforePrevPostUserId,
@@ -111,6 +113,33 @@ export default class PostHeader extends PureComponent {
         );
     };
 
+    calcNameWidth = () => {
+        const {
+            fromWebHook,
+            fromAutoResponder,
+            renderReplies,
+            shouldRenderReplyButton,
+            commentedOnDisplayName,
+            commentCount,
+            isBot,
+            isLandscape,
+            theme,
+        } = this.props;
+
+        const style = getStyleSheet(theme);
+        const showReply = shouldRenderReplyButton || (!commentedOnDisplayName && commentCount > 0 && renderReplies);
+        const reduceWidth = showReply && (isBot || fromAutoResponder || fromWebHook);
+
+        if (reduceWidth && isLandscape) {
+            return style.displayNameContainerLandscapeBotReplyWidth;
+        } else if (isLandscape) {
+            return style.displayNameContainerLandscape;
+        } else if (reduceWidth) {
+            return style.displayNameContainerBotReplyWidth;
+        }
+        return null;
+    }
+
     renderDisplayName = () => {
         const {
             displayName,
@@ -120,23 +149,12 @@ export default class PostHeader extends PureComponent {
             fromAutoResponder,
             overrideUsername,
             theme,
-            renderReplies,
-            shouldRenderReplyButton,
-            commentedOnDisplayName,
-            commentCount,
-            isBot,
-            isLandscape,
         } = this.props;
 
         const style = getStyleSheet(theme);
-        const showReply = shouldRenderReplyButton || (!commentedOnDisplayName && commentCount > 0 && renderReplies);
-
-        const reduceWidth = showReply && (isBot || fromAutoResponder || fromWebHook);
-        const isLandscapeStyle = isLandscape && reduceWidth ? style.displayNameContainerLandscapeBotReplyWidth : isLandscape ? style.displayNameContainerLandscape : null; //eslint-disable-line no-nested-ternary
-        const displayNameStyle = [style.displayNameContainer, reduceWidth ? style.displayNameContainerBotReplyWidth : null, isLandscapeStyle];
-
-        //const displayNameWidth = calcNameWidth();
-        //const displayNameStyle = [style.displayNameContainer, reduceWidth ? style.displayNameContainerBotReplyWidth : null, isLandscapeStyle];
+      
+        const displayNameWidth = this.calcNameWidth();
+        const displayNameStyle = [style.displayNameContainer, displayNameWidth];
 
         if (fromAutoResponder || fromWebHook) {
             let name = displayName;
@@ -383,5 +401,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         displayNameContainerLandscapeBotReplyWidth: {
             maxWidth: '70%',
         },
+
     };
 });

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -130,9 +130,13 @@ export default class PostHeader extends PureComponent {
 
         const style = getStyleSheet(theme);
         const showReply = shouldRenderReplyButton || (!commentedOnDisplayName && commentCount > 0 && renderReplies);
+
         const reduceWidth = showReply && (isBot || fromAutoResponder || fromWebHook);
         const isLandscapeStyle = isLandscape && reduceWidth ? style.displayNameContainerLandscapeBotReplyWidth : isLandscape ? style.displayNameContainerLandscape : null; //eslint-disable-line no-nested-ternary
         const displayNameStyle = [style.displayNameContainer, reduceWidth ? style.displayNameContainerBotReplyWidth : null, isLandscapeStyle];
+
+        //const displayNameWidth = calcNameWidth();
+        //const displayNameStyle = [style.displayNameContainer, reduceWidth ? style.displayNameContainerBotReplyWidth : null, isLandscapeStyle];
 
         if (fromAutoResponder || fromWebHook) {
             let name = displayName;

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -62,8 +62,6 @@ export default class PostHeader extends PureComponent {
         }
     };
 
-    
-
     renderCommentedOnMessage = () => {
         const {
             beforePrevPostUserId,
@@ -152,7 +150,7 @@ export default class PostHeader extends PureComponent {
         } = this.props;
 
         const style = getStyleSheet(theme);
-      
+
         const displayNameWidth = this.calcNameWidth();
         const displayNameStyle = [style.displayNameContainer, displayNameWidth];
 

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -47,6 +47,7 @@ export default class PostHeader extends PureComponent {
         post: PropTypes.object,
         beforePrevPostUserId: PropTypes.string,
         isFirstReply: PropTypes.bool,
+        isLandscape: PropTypes.bool.isRequired,
     };
 
     static defaultProps = {
@@ -124,11 +125,14 @@ export default class PostHeader extends PureComponent {
             commentedOnDisplayName,
             commentCount,
             isBot,
+            isLandscape,
         } = this.props;
 
         const style = getStyleSheet(theme);
         const showReply = shouldRenderReplyButton || (!commentedOnDisplayName && commentCount > 0 && renderReplies);
-        const displayNameStyle = [style.displayNameContainer, showReply && (isBot || fromAutoResponder || fromWebHook) ? style.displayNameContainerBotReplyWidth : null];
+        const reduceWidth = showReply && (isBot || fromAutoResponder || fromWebHook);
+        const isLandscapeStyle = isLandscape && reduceWidth ? style.displayNameContainerLandscapeBotReplyWidth : isLandscape ? style.displayNameContainerLandscape : null; //eslint-disable-line no-nested-ternary
+        const displayNameStyle = [style.displayNameContainer, reduceWidth ? style.displayNameContainerBotReplyWidth : null, isLandscapeStyle];
 
         if (fromAutoResponder || fromWebHook) {
             let name = displayName;
@@ -368,6 +372,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         displayNameContainerBotReplyWidth: {
             maxWidth: '50%',
+        },
+        displayNameContainerLandscape: {
+            maxWidth: '80%',
+        },
+        displayNameContainerLandscapeBotReplyWidth: {
+            maxWidth: '70%',
         },
     };
 });

--- a/app/components/post_header/post_header.test.js
+++ b/app/components/post_header/post_header.test.js
@@ -29,6 +29,7 @@ describe('PostHeader', () => {
         username: 'JohnSmith',
         isBot: false,
         isGuest: false,
+        isLandscape: false,
         userTimezone: '',
         enableTimezone: false,
         previousPostExists: false,
@@ -119,6 +120,33 @@ describe('PostHeader', () => {
             renderReplies: true,
             commentedOnDisplayName: 'John Doe',
             previousPostExists: true,
+        };
+
+        const wrapper = shallow(
+            <PostHeader {...props}/>
+        );
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should match snapshot when just a base post in landscape mode', () => {
+        const props = {
+            ...baseProps,
+            isLandscape: true,
+        };
+
+        const wrapper = shallow(
+            <PostHeader {...props}/>
+        );
+        expect(wrapper.getElement()).toMatchSnapshot();
+        expect(wrapper.find('#ReplyIcon').exists()).toEqual(false);
+    });
+
+    test('should match snapshot when post isBot and shouldRenderReplyButton in landscape mode', () => {
+        const props = {
+            ...baseProps,
+            shouldRenderReplyButton: true,
+            isBot: true,
+            isLandscape: true,
         };
 
         const wrapper = shallow(


### PR DESCRIPTION
#### Summary
Adjusted landscape maxWidth for both the base display of the name and the adjusted width with bot/reply buttons.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19708

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes - Display name maxWidth adjusted for landscape

#### Device Information
This PR was tested on: 
iPhone X 13.2 (Simulator)
Android Pixel API 29 (Simulator)

#### Screenshots
![Simulator Screen Shot - iPhone 11 - 2019-11-22 at 09 53 07](https://user-images.githubusercontent.com/38697367/69446080-a74acb00-0d21-11ea-85f8-b60f4306a0ce.png)
