### PR TITLE
[MM-20667] Fixes crash on Android release build

### DIFF
--- a/assets/base/release/splash_screen/android/layout/launch_screen.xml
+++ b/assets/base/release/splash_screen/android/layout/launch_screen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.percent.PercentRelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -16,4 +16,4 @@
         android:adjustViewBounds="true"
         android:src="@drawable/splash" />
 
-</android.support.percent.PercentRelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
#### Summary
When running the build script for Android release the splash screen layout is being overwritten by the one in the assets folder, that file was not updated to make use of `androidx` and the previous `android.support` libraries are no longer included causing the crash.

**Note:** This PR also updates the Podfile.lock that was outdated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20667
