### PR TITLE
Use bottom sheet over modal

### DIFF
--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -13,6 +13,7 @@ import {
     Text,
     TouchableOpacity,
     View,
+    findNodeHandle,
 } from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -32,8 +33,8 @@ import {getLocalFilePathFromFile, isDocument, isVideo} from 'app/utils/file';
 import {emptyFunction} from 'app/utils/general';
 import {calculateDimensions} from 'app/utils/images';
 import {t} from 'app/utils/i18n';
+import BottomSheet from 'app/utils/bottom_sheet';
 import {
-    showModalOverCurrentContext,
     dismissModal,
     mergeNavigationOptions,
 } from 'app/actions/navigation';
@@ -89,6 +90,8 @@ export default class ImagePreview extends PureComponent {
             showDownloader: false,
             target: props.target,
         };
+
+        this.headerRef = React.createRef();
     }
 
     componentDidMount() {
@@ -267,6 +270,7 @@ export default class ImagePreview extends PureComponent {
 
             return (
                 <TouchableOpacity
+                    ref={this.headerRef}
                     onPress={action}
                     style={style.headerIcon}
                 >
@@ -434,7 +438,9 @@ export default class ImagePreview extends PureComponent {
         }
 
         this.setState({showHeaderFooter: show});
-        StatusBar.setHidden(!show, 'slide');
+        if (Platform.OS === 'ios') {
+            StatusBar.setHidden(!show, 'slide');
+        }
 
         Animated.timing(this.headerFooterAnim, {
             ...ANIM_CONFIG,
@@ -465,7 +471,8 @@ export default class ImagePreview extends PureComponent {
     showDownloadOptionsIOS = async () => {
         const {formatMessage} = this.context.intl;
         const file = this.getCurrentFile();
-        const items = [];
+        const options = [];
+        const actions = [];
         let permissionRequest;
 
         const hasPermissionToStorage = await Permissions.check('photo');
@@ -510,37 +517,37 @@ export default class ImagePreview extends PureComponent {
             const path = getLocalFilePathFromFile(VIDEOS_PATH, file);
             const exist = await RNFetchBlob.fs.exists(path);
             if (exist) {
-                items.push({
-                    action: this.saveVideoIOS,
-                    text: {
-                        id: t('mobile.image_preview.save_video'),
-                        defaultMessage: 'Save Video',
-                    },
-                });
+                options.push(formatMessage({
+                    id: t('mobile.image_preview.save_video'),
+                    defaultMessage: 'Save Video',
+                }));
+                actions.push(this.saveVideoIOS);
             } else {
                 this.showVideoDownloadRequiredAlertIOS();
             }
         } else {
-            items.push({
-                action: this.showDownloader,
-                text: {
-                    id: t('mobile.image_preview.save'),
-                    defaultMessage: 'Save Image',
-                },
-            });
+            options.push(formatMessage({
+                id: t('mobile.image_preview.save'),
+                defaultMessage: 'Save Image',
+            }));
+            actions.push(this.showDownloader);
         }
 
-        if (items.length) {
-            this.setHeaderAndFooterVisible(false);
+        if (options.length) {
+            options.push(formatMessage({
+                id: 'mobile.post.cancel',
+                defaultMessage: 'Cancel',
+            }));
+            actions.push(emptyFunction);
 
-            const screen = 'OptionsModal';
-            const passProps = {
+            BottomSheet.showBottomSheetWithOptions({
+                options,
+                cancelButtonIndex: options.length - 1,
                 title: file.caption,
-                items,
-                onCancelPress: () => this.setHeaderAndFooterVisible(true),
-            };
-
-            showModalOverCurrentContext(screen, passProps);
+                anchor: this.headerRef.current ? findNodeHandle(this.headerRef.current) : null,
+            }, (buttonIndex) => {
+                actions[buttonIndex]();
+            });
         }
     };
 

--- a/app/screens/image_preview/image_preview.test.js
+++ b/app/screens/image_preview/image_preview.test.js
@@ -12,7 +12,6 @@ import Preferences from 'mattermost-redux/constants/preferences';
 
 import * as NavigationActions from 'app/actions/navigation';
 import BottomSheet from 'app/utils/bottom_sheet';
-import {emptyFunction} from 'app/utils/general';
 
 import ImagePreview from './image_preview';
 
@@ -28,7 +27,6 @@ jest.mock('react-native-permissions', () => {
         check: jest.fn(),
     };
 });
-
 
 describe('ImagePreview', () => {
     const baseProps = {
@@ -129,8 +127,8 @@ describe('ImagePreview', () => {
         const files = [{
             caption: 'caption',
             data: {
-                'mime_type': 'video/mp4',
-            } ,
+                mime_type: 'video/mp4',
+            },
         }];
         const props = {
             ...baseProps,
@@ -165,8 +163,8 @@ describe('ImagePreview', () => {
         const files = [{
             caption: 'caption',
             data: {
-                'mime_type': 'video/mp4',
-            } ,
+                mime_type: 'video/mp4',
+            },
         }];
         const props = {
             ...baseProps,
@@ -197,8 +195,8 @@ describe('ImagePreview', () => {
         const files = [{
             caption: 'caption',
             data: {
-                'mime_type': 'image/jpeg',
-            } ,
+                mime_type: 'image/jpeg',
+            },
         }];
         const props = {
             ...baseProps,


### PR DESCRIPTION
#### Summary
Using a modal to show download options in the image preview screen did not play nice with our safe area view component when the modal was dismissed and the status bar visibility returned, so it's been replaced with an action sheet. There was also an issue on Android that when hiding the status bar a white area would be displayed where the status bar previously was, so for Android we are no longer hiding the status bar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20673

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone simulator, iOS 13
* iPad simulator
* Android emulator, 8.1

#### Screenshots
iPhone:
![Simulator Screen Shot - iPhone 11 - 2019-11-27 at 08 22 51](https://user-images.githubusercontent.com/3208014/69741421-409a2880-10f8-11ea-8bd7-ecae0a26899c.png)

iPad:
![Simulator Screen Shot - iPad Pro (11-inch) - 2019-11-27 at 08 25 07](https://user-images.githubusercontent.com/3208014/69741433-44c64600-10f8-11ea-9500-bddff0c5fcf9.png)
