### PR TITLE
MM-20682 Android back button to dismiss status modal first

### DIFF
--- a/app/components/sidebars/settings/settings_sidebar.js
+++ b/app/components/sidebars/settings/settings_sidebar.js
@@ -105,7 +105,10 @@ export default class SettingsDrawer extends PureComponent {
     };
 
     handleAndroidBack = () => {
-        if (this.drawerRef && this.drawerOpened) {
+        if (this.statusModal) {
+            this.statusModal = false;
+            return false;
+        } else if (this.drawerRef && this.drawerOpened) {
             this.drawerRef.closeDrawer();
             return true;
         }
@@ -163,6 +166,7 @@ export default class SettingsDrawer extends PureComponent {
             },
         }];
 
+        this.statusModal = true;
         showModalOverCurrentContext('OptionsModal', {items});
     });
 


### PR DESCRIPTION
#### Summary
When the change status options modal is open tapping on the hardware back button now closes the modal first and then tapping again closes the settings drawer

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20682

#### Screenshots
![2019-11-28 10 05 42](https://user-images.githubusercontent.com/6757047/69808787-254a1e80-11c7-11ea-8e37-ce50f941c53e.gif)
