### PR TITLE
MM-19920 MM-19924 Fix mis-align post input field attach and send icons

### DIFF
--- a/app/components/__snapshots__/send_button.test.js.snap
+++ b/app/components/__snapshots__/send_button.test.js.snap
@@ -6,7 +6,7 @@ exports[`SendButton should change theme backgroundColor to 0.3 opacity 1`] = `
     Object {
       "justifyContent": "flex-end",
       "paddingHorizontal": 5,
-      "paddingVertical": 3,
+      "paddingVertical": 2,
     }
   }
 >
@@ -19,6 +19,7 @@ exports[`SendButton should change theme backgroundColor to 0.3 opacity 1`] = `
           "borderRadius": 18,
           "height": 28,
           "justifyContent": "center",
+          "paddingLeft": 3,
           "width": 28,
         },
         Object {
@@ -43,7 +44,7 @@ exports[`SendButton should match snapshot 1`] = `
     Object {
       "justifyContent": "flex-end",
       "paddingHorizontal": 5,
-      "paddingVertical": 3,
+      "paddingVertical": 2,
     }
   }
   type="opacity"
@@ -56,6 +57,7 @@ exports[`SendButton should match snapshot 1`] = `
         "borderRadius": 18,
         "height": 28,
         "justifyContent": "center",
+        "paddingLeft": 3,
         "width": 28,
       }
     }
@@ -76,7 +78,7 @@ exports[`SendButton should render theme backgroundColor 1`] = `
     Object {
       "justifyContent": "flex-end",
       "paddingHorizontal": 5,
-      "paddingVertical": 3,
+      "paddingVertical": 2,
     }
   }
   type="opacity"
@@ -89,6 +91,7 @@ exports[`SendButton should render theme backgroundColor 1`] = `
         "borderRadius": 18,
         "height": 28,
         "justifyContent": "center",
+        "paddingLeft": 3,
         "width": 28,
       }
     }

--- a/app/components/attachment_button/index.js
+++ b/app/components/attachment_button/index.js
@@ -517,7 +517,7 @@ const style = StyleSheet.create({
     attachIcon: {
         marginTop: Platform.select({
             ios: 2,
-            android: 0,
+            android: -5,
         }),
     },
     buttonContainer: {

--- a/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
+++ b/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
@@ -13,6 +13,7 @@ exports[`PostTextBox should match, full snapshot 1`] = `
           "borderTopColor": "rgba(61,60,64,0.2)",
           "borderTopWidth": 1,
           "flexDirection": "row",
+          "justifyContent": "center",
           "paddingVertical": 4,
         },
         null,

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -829,6 +829,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         inputWrapper: {
             alignItems: 'flex-end',
             flexDirection: 'row',
+            justifyContent: 'center',
             paddingVertical: 4,
             backgroundColor: theme.centerChannelBg,
             borderTopWidth: 1,

--- a/app/components/send_button.js
+++ b/app/components/send_button.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {memo} from 'react';
-import {View} from 'react-native';
+import {Platform, View} from 'react-native';
 import PropTypes from 'prop-types';
 
 import TouchableWithFeedback from 'app/components/touchable_with_feedback';
@@ -63,7 +63,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         sendButtonContainer: {
             justifyContent: 'flex-end',
             paddingHorizontal: 5,
-            paddingVertical: 3,
+            paddingVertical: Platform.select({
+                android: 8,
+                ios: 2,
+            }),
         },
         sendButton: {
             backgroundColor: theme.buttonBg,
@@ -72,6 +75,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             width: 28,
             alignItems: 'center',
             justifyContent: 'center',
+            paddingLeft: 3,
         },
     };
 });


### PR DESCRIPTION
#### Summary
Fixes the alignment of the attach file icon and the send icon on the post textbox area

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19920
https://mattermost.atlassian.net/browse/MM-19924

#### Screenshots
Android
![image](https://user-images.githubusercontent.com/6757047/69816665-998cbe00-11d7-11ea-9ebd-89feebd8ea91.png)

iOS
![image](https://user-images.githubusercontent.com/6757047/69816690-a7dada00-11d7-11ea-9c27-4fcc52e14c2e.png)
