### PR TITLE
MM-19837 Remove Opacity from AtMention Markdown

### DIFF
--- a/app/components/combined_system_message/combined_system_message.js
+++ b/app/components/combined_system_message/combined_system_message.js
@@ -383,6 +383,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         baseText: {
             color: theme.centerChannelColor,
+            opacity: 0.6,
         },
         linkText: {
             color: theme.linkColor,

--- a/app/components/combined_system_message/combined_system_message.js
+++ b/app/components/combined_system_message/combined_system_message.js
@@ -383,7 +383,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         baseText: {
             color: theme.centerChannelColor,
-            opacity: 0.6,
         },
         linkText: {
             color: theme.linkColor,

--- a/app/components/formatted_markdown_text.js
+++ b/app/components/formatted_markdown_text.js
@@ -110,12 +110,14 @@ class FormattedMarkdownText extends React.PureComponent {
     }
 
     renderAtMention = ({context, mentionName}) => {
+        const style = getStyleSheet(this.props.theme);
+
         return (
             <AtMention
                 mentionStyle={this.props.textStyles.mention}
                 mentionName={mentionName}
                 onPostPress={this.props.onPostPress}
-                textStyle={this.computeTextStyle(this.props.baseTextStyle, context)}
+                textStyle={[this.computeTextStyle(this.props.baseTextStyle, context), style.atMentionOpacity]}
             />
         );
     }
@@ -138,6 +140,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.8),
             fontSize: 15,
             lineHeight: 22,
+        },
+        atMentionOpacity: {
+            opacity: 1,
         },
     };
 });

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -199,10 +199,12 @@ export default class Markdown extends PureComponent {
             return this.renderText({context, literal: `@${mentionName}`});
         }
 
+        const style = getStyleSheet(this.props.theme);
+
         return (
             <AtMention
                 mentionStyle={this.props.textStyles.mention}
-                textStyle={this.computeTextStyle(this.props.baseTextStyle, context)}
+                textStyle={[this.computeTextStyle(this.props.baseTextStyle, context), style.atMentionOpacity]}
                 isSearchResult={this.props.isSearchResult}
                 mentionName={mentionName}
                 onPostPress={this.props.onPostPress}
@@ -461,6 +463,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         editedIndicatorText: {
             color: editedColor,
             opacity: editedOpacity,
+        },
+        atMentionOpacity: {
+            opacity: 1,
         },
     };
 });


### PR DESCRIPTION

#### Summary
Removed the opacity that was set on the base text style for the markdown on AtMention for system messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19837

#### Checklist
- [x] Has UI changes - Opacity removed from system message markdown

#### Device Information
This PR was tested on: 
iPhone X 13.2 Simulator
Pixel 2 API 29 Simulator

#### Screenshots
![Simulator Screen Shot - iPhone 11 - 2019-11-30 at 22 02 42](https://user-images.githubusercontent.com/38697367/69908868-b257c800-13bf-11ea-9964-40bfde7901c0.png)
