### PR TITLE
MM-20790 Mark as Unread option should not be available on mobile if the server does not support it

### DIFF
--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -45,12 +45,13 @@ export function makeMapStateToProps() {
         const reactions = getReactionsForPostSelector(state, post.id);
         const channelIsArchived = channel.delete_at !== 0;
         const {serverVersion} = state.entities.general;
+        const canMarkAsUnread = isMinimumServerVersion(serverVersion, 5, 18);
+
         let canAddReaction = true;
         let canReply = true;
         let canCopyPermalink = true;
         let canCopyText = false;
         let canEdit = false;
-        let canMarkAsUnread = false;
         let canEditUntil = -1;
         let {canDelete} = ownProps;
         let canFlag = true;
@@ -104,10 +105,6 @@ export function makeMapStateToProps() {
 
         if (reactions && Object.values(reactions).length >= MAX_ALLOWED_REACTIONS) {
             canAddReaction = false;
-        }
-
-        if (isMinimumServerVersion(serverVersion, 5, 18)) {
-            canMarkAsUnread = true;
         }
 
         return {

--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -22,6 +22,7 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeamId, getCurrentTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {canEditPost} from 'mattermost-redux/utils/post_utils';
+import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
 import {MAX_ALLOWED_REACTIONS} from 'app/constants/emoji';
 import {THREAD} from 'app/constants/screen';
@@ -43,12 +44,13 @@ export function makeMapStateToProps() {
         const currentChannelId = getCurrentChannelId(state);
         const reactions = getReactionsForPostSelector(state, post.id);
         const channelIsArchived = channel.delete_at !== 0;
-
+        const {serverVersion} = state.entities.general;
         let canAddReaction = true;
         let canReply = true;
         let canCopyPermalink = true;
         let canCopyText = false;
         let canEdit = false;
+        let canMarkAsUnread = false;
         let canEditUntil = -1;
         let {canDelete} = ownProps;
         let canFlag = true;
@@ -104,6 +106,10 @@ export function makeMapStateToProps() {
             canAddReaction = false;
         }
 
+        if (isMinimumServerVersion(serverVersion, 5, 18)) {
+            canMarkAsUnread = true;
+        }
+
         return {
             ...getDimensions(state),
             canAddReaction,
@@ -115,9 +121,9 @@ export function makeMapStateToProps() {
             canDelete,
             canFlag,
             canPin,
+            canMarkAsUnread,
             currentTeamUrl: getCurrentTeamUrl(state),
             currentUserId,
-            isMyPost: currentUserId === post.user_id,
             theme: getTheme(state),
             isLandscape: isLandscape(state),
         };

--- a/app/screens/post_options/index.test.js
+++ b/app/screens/post_options/index.test.js
@@ -35,6 +35,9 @@ describe('makeMapStateToProps', () => {
                     post_id: {},
                 },
             },
+            general: {
+                serverVersion: '5.18',
+            },
         },
     };
 
@@ -64,5 +67,26 @@ describe('makeMapStateToProps', () => {
         const mapStateToProps = makeMapStateToProps();
         const props = mapStateToProps(baseState, ownProps);
         expect(props.canFlag).toBe(true);
+    });
+
+    test('canMarkAsUnread is true when isMinimumServerVersion is 5.18v', () => {
+        const mapStateToProps = makeMapStateToProps();
+        const props = mapStateToProps(baseState, baseOwnProps);
+        expect(props.canMarkAsUnread).toBe(true);
+    });
+
+    test('canMarkAsUnread is false when isMinimumServerVersion is not 5.18v', () => {
+        const state = {
+            entities: {
+                ...baseState.entities,
+                general: {
+                    serverVersion: '5.17',
+                },
+            },
+        };
+
+        const mapStateToProps = makeMapStateToProps();
+        const props = mapStateToProps(state, baseOwnProps);
+        expect(props.canMarkAsUnread).toBe(false);
     });
 });

--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -38,12 +38,12 @@ export default class PostOptions extends PureComponent {
         canFlag: PropTypes.bool,
         canPin: PropTypes.bool,
         canEdit: PropTypes.bool,
+        canMarkAsUnread: PropTypes.bool, //#backwards-compatibility:5.18v
         canEditUntil: PropTypes.number.isRequired,
         currentTeamUrl: PropTypes.string.isRequired,
         currentUserId: PropTypes.string.isRequired,
         deviceHeight: PropTypes.number.isRequired,
         isFlagged: PropTypes.bool,
-        isMyPost: PropTypes.bool,
         post: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
         isLandscape: PropTypes.bool.isRequired,
@@ -231,7 +231,7 @@ export default class PostOptions extends PureComponent {
         const {post, isLandscape, theme} = this.props;
         const {formatMessage} = this.context.intl;
 
-        if (!isSystemMessage(post)) {
+        if (!isSystemMessage(post) && this.props.canMarkAsUnread) {
             return (
                 <PostOption
                     key='markUnread'

--- a/app/screens/post_options/post_options.test.js
+++ b/app/screens/post_options/post_options.test.js
@@ -38,6 +38,7 @@ describe('PostOptions', () => {
         canDelete: true,
         canPin: true,
         canEdit: true,
+        canMarkAsUnread: true,
         canEditUntil: -1,
         channelIsReadOnly: false,
         currentTeamUrl: 'http://localhost:8065/team-name',
@@ -45,7 +46,6 @@ describe('PostOptions', () => {
         deviceHeight: 600,
         hasBeenDeleted: false,
         isFlagged: false,
-        isMyPost: true,
         isSystemMessage: false,
         managedConfig: {},
         post,
@@ -96,6 +96,12 @@ describe('PostOptions', () => {
         const wrapper = getWrapper({canReply: false});
 
         expect(wrapper.findWhere((node) => node.key() === 'reply')).toMatchObject({});
+    });
+
+    test('should not show mark as unread option', () => {
+        const wrapper = getWrapper({canMarkAsUnread: false});
+
+        expect(wrapper.findWhere((node) => node.key() === 'markUnread')).toMatchObject({});
     });
 
     test('should remove post after delete', () => {


### PR DESCRIPTION
#### Summary
 * Check for server version with min 5.18v for showing the option to mark as unread

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20790

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
Tested on an iphone X simulator

#### Screenshots
Before:
<img width="394" alt="Screenshot 2019-12-03 at 5 48 09 PM" src="https://user-images.githubusercontent.com/4973621/70044568-334bd500-15f5-11ea-8eae-2aea3196c10a.png">
After:
<img width="406" alt="Screenshot 2019-12-03 at 5 48 23 PM" src="https://user-images.githubusercontent.com/4973621/70044570-334bd500-15f5-11ea-9006-b3b04d680eda.png">
