### PR TITLE
Fix SSO login on iOS

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -160,7 +160,13 @@ class GlobalEventHandler {
         PushNotifications.clearNotifications();
         const cacheDir = RNFetchBlob.fs.dirs.CacheDir;
         const mainPath = cacheDir.split('/').slice(0, -1).join('/');
-        await RNFetchBlob.fs.unlink(cacheDir);
+
+        try {
+            await RNFetchBlob.fs.unlink(cacheDir);
+        } catch (e) {
+            console.log('Failed to remove cache folder', e); //eslint-disable-line no-console
+        }
+
         mattermostBucket.removePreference('cert');
         if (Platform.OS === 'ios') {
             mattermostBucket.removeFile('entities');

--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -221,7 +221,6 @@ class SSO extends PureComponent {
                     onLoadEnd={this.onLoadEnd}
                     onMessage={messagingEnabled ? this.onMessage : null}
                     useSharedProcessPool={true}
-                    sharedCookiesEnabled={true}
                     cacheEnabled={false}
                 />
             );


### PR DESCRIPTION
#### Summary
SSO login cannot use share cookies but instead the only use the share process pool in order to be able to access to cookie values.

When removing the cache folder on logout the app was hanging if there was a failure (the cache folder does not exists or something similar)
