### PR TITLE
[MM-20976] Pass callback to waitForHydration instead of using await

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -48,16 +48,17 @@ const init = async () => {
     }
 };
 
-const launchApp = async (credentials) => {
+const launchApp = (credentials) => {
     telemetry.start([
         'start:select_server_screen',
         'start:channel_screen',
     ]);
 
     if (credentials) {
-        await waitForHydration(store);
-        store.dispatch(loadMe());
-        resetToChannel({skipMetrics: true});
+        waitForHydration(store, () => {
+            store.dispatch(loadMe());
+            resetToChannel({skipMetrics: true});
+        });
     } else {
         resetToSelectServer(emmProvider.allowOtherServers);
     }

--- a/app/store/utils.js
+++ b/app/store/utils.js
@@ -42,23 +42,14 @@ export function transformSet(incoming, setTransforms, toStorage = true) {
 }
 
 export function waitForHydration(store, callback) {
-    let unsubscribeFromStore;
-    return new Promise((resolve) => {
-        if (__DEV__) {
-            // when in DEV mode resetting the app can get into a white screen
-            resolve();
-            return;
-        }
-        const subscription = () => {
-            if (store.getState().views.root.hydrationComplete) {
-                unsubscribeFromStore();
-                if (callback && typeof callback === 'function') {
-                    callback();
-                }
-                resolve();
+    const subscription = () => {
+        if (store.getState().views.root.hydrationComplete) {
+            unsubscribeFromStore();
+            if (callback && typeof callback === 'function') {
+                callback();
             }
-        };
+        }
+    };
 
-        unsubscribeFromStore = store.subscribe(subscription);
-    });
+    const unsubscribeFromStore = store.subscribe(subscription);
 }


### PR DESCRIPTION
#### Summary
For some reason, even though the promise in `waitForHydrarion` called `resolve()`, the await call would not resolve. By passing a callback we avoid this issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20976

#### Device Information
This PR was tested on:
* Android emulator, 8.1