### PR TITLE
[MM-20964] Set number to 0 only if null

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -279,7 +279,7 @@ public class CustomPushNotification extends PushNotification {
 
     private void setNotificationNumber(Notification.Builder notification, String channelId) {
         Integer number = channelIdToNotificationCount.get(channelId);
-        if (number != null) {
+        if (number == null) {
             number = 0;
         }
         notification.setNumber(number);


### PR DESCRIPTION
#### Summary
The notification number was being set to 0 when not null, overriding the correct count.

Note: Stylianos found the same issue on iOS, however, I've been unable to reproduce.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20964

#### Device Information
This PR was tested on:
* Android emulator, 8.1