### PR TITLE
[MM-20967] Add channel ID to push notification sent on failed reply

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
@@ -133,12 +133,16 @@ public class NotificationReplyBroadcastReceiver extends BroadcastReceiver {
         String packageName = mContext.getPackageName();
         int smallIconResId = res.getIdentifier("ic_notification", "mipmap", packageName);
 
+        Bundle userInfoBundle = new Bundle();
+        userInfoBundle.putString("channel_id", channelId);
+
         NotificationChannel channel = new NotificationChannel(CHANNEL_ID, CHANNEL_ID, NotificationManager.IMPORTANCE_LOW);
         notificationManager.createNotificationChannel(channel);
         Notification notification =
                 new Notification.Builder(mContext, CHANNEL_ID)
                         .setContentTitle("Message failed to send.")
                         .setSmallIcon(smallIconResId)
+                        .addExtras(userInfoBundle)
                         .build();
 
         CustomPushNotification.clearNotification(mContext, notificationId, channelId);


### PR DESCRIPTION
#### Summary
The push notification sent on a failed reply was missing `channel_id` so when `clearChannelNotifications` was called it did not find any delivered notifications for the channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20967

#### Device Information
This PR was tested on:
* Android emulator, 8.1