### PR TITLE
[MM-17838] Remove max reaction limit

### DIFF
--- a/app/components/reactions/index.js
+++ b/app/components/reactions/index.js
@@ -14,7 +14,6 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getChannel, isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 
 import {addReaction} from 'app/actions/views/emoji';
-import {MAX_ALLOWED_REACTIONS} from 'app/constants/emoji';
 
 import Reactions from './reactions';
 
@@ -33,18 +32,15 @@ function makeMapStateToProps() {
 
         let canAddReaction = true;
         let canRemoveReaction = true;
-        let canAddMoreReactions = true;
         if (channelIsArchived || channelIsReadOnly) {
             canAddReaction = false;
             canRemoveReaction = false;
-            canAddMoreReactions = false;
         } else if (hasNewPermissions(state)) {
             canAddReaction = haveIChannelPermission(state, {
                 team: teamId,
                 channel: channelId,
                 permission: Permissions.ADD_REACTION,
             });
-            canAddMoreReactions = Object.values(reactions).length < MAX_ALLOWED_REACTIONS;
             canRemoveReaction = haveIChannelPermission(state, {
                 team: teamId,
                 channel: channelId,
@@ -57,7 +53,6 @@ function makeMapStateToProps() {
             reactions,
             theme: getTheme(state),
             canAddReaction,
-            canAddMoreReactions,
             canRemoveReaction,
         };
     };

--- a/app/components/reactions/reactions.js
+++ b/app/components/reactions/reactions.js
@@ -27,7 +27,6 @@ export default class Reactions extends PureComponent {
             removeReaction: PropTypes.func.isRequired,
         }).isRequired,
         canAddReaction: PropTypes.bool,
-        canAddMoreReactions: PropTypes.bool,
         canRemoveReaction: PropTypes.bool.isRequired,
         currentUserId: PropTypes.string.isRequired,
         position: PropTypes.oneOf(['right', 'left']),
@@ -133,29 +132,26 @@ export default class Reactions extends PureComponent {
     };
 
     render() {
-        const {position, reactions, canAddMoreReactions} = this.props;
+        const {position, reactions} = this.props;
         const styles = getStyleSheet(this.props.theme);
 
         if (!reactions) {
             return null;
         }
 
-        let addMoreReactions = null;
-        if (canAddMoreReactions) {
-            addMoreReactions = (
-                <TouchableWithFeedback
-                    key='addReaction'
-                    onPress={this.handleAddReaction}
-                    style={[styles.reaction]}
-                    type={'opacity'}
-                >
-                    <Image
-                        source={addReactionIcon}
-                        style={styles.addReaction}
-                    />
-                </TouchableWithFeedback>
-            );
-        }
+        const addMoreReactions = (
+            <TouchableWithFeedback
+                key='addReaction'
+                onPress={this.handleAddReaction}
+                style={[styles.reaction]}
+                type={'opacity'}
+            >
+                <Image
+                    source={addReactionIcon}
+                    style={styles.addReaction}
+                />
+            </TouchableWithFeedback>
+        );
 
         const reactionElements = [];
         switch (position) {

--- a/app/constants/emoji.js
+++ b/app/constants/emoji.js
@@ -2,4 +2,3 @@
 // See LICENSE.txt for license information.
 
 export const ALL_EMOJIS = 'all_emojis';
-export const MAX_ALLOWED_REACTIONS = 40;

--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -14,7 +14,6 @@ import {
     setUnreadPost,
 } from 'mattermost-redux/actions/posts';
 import {General, Permissions} from 'mattermost-redux/constants';
-import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig, getLicense, hasNewPermissions} from 'mattermost-redux/selectors/entities/general';
@@ -24,7 +23,6 @@ import {getCurrentTeamId, getCurrentTeamUrl} from 'mattermost-redux/selectors/en
 import {canEditPost} from 'mattermost-redux/utils/post_utils';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
-import {MAX_ALLOWED_REACTIONS} from 'app/constants/emoji';
 import {THREAD} from 'app/constants/screen';
 import {addReaction} from 'app/actions/views/emoji';
 import {getDimensions, isLandscape} from 'app/selectors/device';
@@ -32,8 +30,6 @@ import {getDimensions, isLandscape} from 'app/selectors/device';
 import PostOptions from './post_options';
 
 export function makeMapStateToProps() {
-    const getReactionsForPostSelector = makeGetReactionsForPost();
-
     return (state, ownProps) => {
         const post = ownProps.post;
         const channel = getChannel(state, post.channel_id) || {};
@@ -42,7 +38,6 @@ export function makeMapStateToProps() {
         const currentUserId = getCurrentUserId(state);
         const currentTeamId = getCurrentTeamId(state);
         const currentChannelId = getCurrentChannelId(state);
-        const reactions = getReactionsForPostSelector(state, post.id);
         const channelIsArchived = channel.delete_at !== 0;
         const {serverVersion} = state.entities.general;
         const canMarkAsUnread = isMinimumServerVersion(serverVersion, 5, 18);
@@ -101,10 +96,6 @@ export function makeMapStateToProps() {
 
         if (!ownProps.isSystemMessage && ownProps.managedConfig?.copyAndPasteProtection !== 'true' && post.message) {
             canCopyText = true;
-        }
-
-        if (reactions && Object.values(reactions).length >= MAX_ALLOWED_REACTIONS) {
-            canAddReaction = false;
         }
 
         return {

--- a/app/screens/post_options/index.test.js
+++ b/app/screens/post_options/index.test.js
@@ -31,9 +31,6 @@ describe('makeMapStateToProps', () => {
                 posts: {
                     post_id: {},
                 },
-                reactions: {
-                    post_id: {},
-                },
             },
             general: {
                 serverVersion: '5.18',


### PR DESCRIPTION
#### Summary
Removed the limit of 40 max reactions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17838

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Android emulator, 8.1

#### Screenshots
![Screenshot_1575939564](https://user-images.githubusercontent.com/3208014/70486020-aa79e100-1aad-11ea-9696-b3e1020d60b1.png)
