### PR TITLE
MM-20947 Don't mark channel as read when reconnecting to manually unread channel

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -33,6 +33,7 @@ import {
     getMyChannelMember,
     getRedirectChannelNameForTeam,
     getChannelsNameMapInTeam,
+    isManuallyUnread,
 } from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId, getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 
@@ -444,6 +445,17 @@ export function markChannelViewedAndRead(channelId, previousChannelId, markOnSer
     return (dispatch) => {
         dispatch(markChannelAsRead(channelId, previousChannelId, markOnServer));
         dispatch(markChannelAsViewed(channelId, previousChannelId));
+    };
+}
+
+export function markChannelViewedAndReadOnReconnect(channelId) {
+    return (dispatch, getState) => {
+        if (isManuallyUnread(getState(), channelId)) {
+            return;
+        }
+
+        dispatch(markChannelAsRead(channelId));
+        dispatch(markChannelAsViewed(channelId));
     };
 }
 

--- a/app/components/network_indicator/index.js
+++ b/app/components/network_indicator/index.js
@@ -9,7 +9,7 @@ import {init as initWebSocket, close as closeWebSocket} from 'mattermost-redux/a
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
 import {connection} from 'app/actions/device';
-import {markChannelViewedAndRead, setChannelRetryFailed} from 'app/actions/views/channel';
+import {markChannelViewedAndReadOnReconnect, setChannelRetryFailed} from 'app/actions/views/channel';
 import {setCurrentUserStatusOffline} from 'app/actions/views/user';
 import {getConnection, isLandscape} from 'app/selectors/device';
 
@@ -35,7 +35,7 @@ function mapDispatchToProps(dispatch) {
             connection,
             initWebSocket,
             logout,
-            markChannelViewedAndRead,
+            markChannelViewedAndReadOnReconnect,
             setChannelRetryFailed,
             setCurrentUserStatusOffline,
             startPeriodicStatusUpdates,

--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -43,7 +43,7 @@ export default class NetworkIndicator extends PureComponent {
             closeWebSocket: PropTypes.func.isRequired,
             connection: PropTypes.func.isRequired,
             initWebSocket: PropTypes.func.isRequired,
-            markChannelViewedAndRead: PropTypes.func.isRequired,
+            markChannelViewedAndReadOnReconnect: PropTypes.func.isRequired,
             logout: PropTypes.func.isRequired,
             setChannelRetryFailed: PropTypes.func.isRequired,
             setCurrentUserStatusOffline: PropTypes.func.isRequired,
@@ -245,7 +245,7 @@ export default class NetworkIndicator extends PureComponent {
                 // foreground by tapping a notification from another channel
                 this.clearNotificationTimeout = setTimeout(() => {
                     PushNotifications.clearChannelNotifications(currentChannelId);
-                    actions.markChannelViewedAndRead(currentChannelId);
+                    actions.markChannelViewedAndReadOnReconnect(currentChannelId);
                 }, 1000);
             }
         } else {


### PR DESCRIPTION
When the app comes from the background, it reconnects to the websocket which triggers the current channel to be marked as read. This no longer happens for manually unread channels.

Note that this doesn't change the behaviour when the app is closed and reopened, but that's a much more difficult case to change since I think that's caused by the "select channel" logic being triggered similar to switching to the channel in the first place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20947

#### Device Information
This PR was tested on: iOS Simulator