### PR TITLE
MM-17519: do not stringify booleans for interactive dialogs

### DIFF
--- a/app/components/widgets/settings/bool_setting.js
+++ b/app/components/widgets/settings/bool_setting.js
@@ -41,7 +41,7 @@ export default class BoolSetting extends PureComponent {
     };
 
     handleChange = (value) => {
-        this.props.onChange(this.props.id, `${value}`);
+        this.props.onChange(this.props.id, Boolean(value));
     };
 
     render() {

--- a/app/components/widgets/settings/bool_setting.test.js
+++ b/app/components/widgets/settings/bool_setting.test.js
@@ -26,10 +26,10 @@ describe('components/widgets/settings/TextSetting', () => {
 
         wrapper.instance().handleChange(false);
         expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange).toHaveBeenCalledWith('elementid', 'false');
+        expect(onChange).toHaveBeenCalledWith('elementid', false);
 
         wrapper.instance().handleChange(true);
         expect(onChange).toHaveBeenCalledTimes(2);
-        expect(onChange).toHaveBeenCalledWith('elementid', 'true');
+        expect(onChange).toHaveBeenCalledWith('elementid', true);
     });
 });


### PR DESCRIPTION
#### Summary
Match the webapp behaviour so as to avoid stringifying booleans in the interactive dialog payloads.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-17519

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS mobile simulator

#### Screenshots
Using the demo plugin's `/dialog` trigger, the behaviour before:
![image](https://user-images.githubusercontent.com/1023171/70642663-f9db2100-1c15-11ea-8e54-a8319675319a.png)

and after:
![image](https://user-images.githubusercontent.com/1023171/70642687-06f81000-1c16-11ea-859a-e6edd45dc61d.png)
