### PR TITLE
MM-21176 Preserve text on input if command fails

### DIFF
--- a/app/components/post_textbox/post_textbox.test.js
+++ b/app/components/post_textbox/post_textbox.test.js
@@ -333,6 +333,29 @@ describe('PostTextBox', () => {
         });
     });
 
+    test('should preseve post message in the input field if the command failed', async () => {
+        const props = {...baseProps};
+        props.actions.executeCommand = jest.fn().mockResolvedValue({
+            error: {
+                message: 'Command with a trigger of \'fail\' not found. To send a message beginning with "/", try adding an empty space at the beginning of the message.',
+            },
+        });
+        const msg = '/fail preserve this text in the post draft';
+        const wrapper = shallowWithIntl(
+            <PostTextbox {...baseProps}/>
+        );
+
+        const instance = wrapper.instance();
+        instance.handleTextChange(msg);
+        expect(wrapper.state('value')).toBe(msg);
+
+        wrapper.setState({sendingMessage: true});
+        await instance.sendCommand(msg);
+        expect(wrapper.state('value')).toBe(msg);
+        expect(wrapper.state('sendingMessage')).toBe(false);
+        expect(Alert.alert).toHaveBeenCalledTimes(1);
+    });
+
     describe('Paste images', () => {
         test('should show error dialog if error occured', () => {
             jest.spyOn(Alert, 'alert').mockReturnValue(null);

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -599,10 +599,9 @@ export default class PostTextBoxBase extends PureComponent {
         }
 
         const {error} = await actions.executeCommand(msg, channelId, rootId);
+        this.setState({sendingMessage: false});
 
         if (error) {
-            this.handleTextChange(msg);
-            this.changeDraft(msg);
             Alert.alert(
                 intl.formatMessage({
                     id: 'mobile.commands.error_title',
@@ -610,12 +609,11 @@ export default class PostTextBoxBase extends PureComponent {
                 }),
                 error.message
             );
+            return;
         }
 
         this.handleTextChange('');
         this.changeDraft('');
-
-        this.setState({sendingMessage: false});
     };
 
     sendReaction = (emoji) => {


### PR DESCRIPTION
#### Summary
When a slash command failed to execute an alert is being displayed but the execution was not stopped thus the text and draft was cleared

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21176