### PR TITLE
[MM-19727] Disable scroll and use pan handler for Android

### DIFF
--- a/app/components/__snapshots__/swiper.test.js.snap
+++ b/app/components/__snapshots__/swiper.test.js.snap
@@ -24,9 +24,11 @@ exports[`Swiper should match snapshot 1`] = `
         undefined,
       ]
     }
+    directionalLockEnabled={true}
     horizontal={true}
     keyboardShouldPersistTaps="handled"
     onMomentumScrollEnd={[Function]}
+    onScroll={null}
     onScrollBeginDrag={[Function]}
     pagingEnabled={true}
     removeClippedSubviews={true}

--- a/app/components/sidebars/drawer_layout.js
+++ b/app/components/sidebars/drawer_layout.js
@@ -118,7 +118,7 @@ export default class DrawerLayout extends Component {
             swiperIndex: props.swiperIndex,
         };
         this.openValue.addListener(this.handleOpenValueChanged);
-        if (props.drawerPosition === 'left') {
+        if (Platform.OS === 'android' && props.drawerPosition === 'left') {
             this.scrollValue = new Animated.Value(0);
             this.scrollValue.addListener(props.onScrollValueChange);
         }

--- a/app/components/sidebars/main/__snapshots__/main_sidebar.test.js.snap
+++ b/app/components/sidebars/main/__snapshots__/main_sidebar.test.js.snap
@@ -7,7 +7,9 @@ exports[`MainSidebar should match, full snapshot 1`] = `
   isTablet={false}
   onDrawerClose={[Function]}
   onDrawerOpen={[Function]}
+  onScrollValueChange={[Function]}
   renderNavigationView={[Function]}
+  swiperIndex={1}
   useNativeAnimations={true}
 />
 `;

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -55,7 +55,6 @@ export default class ChannelSidebar extends Component {
     constructor(props) {
         super(props);
 
-        this.swiperIndex = 1;
         this.drawerRef = React.createRef();
         this.channelListRef = React.createRef();
         this.state = {
@@ -65,6 +64,7 @@ export default class ChannelSidebar extends Component {
             drawerOpened: false,
             searching: false,
             isSplitView: false,
+            swiperIndex: 1,
         };
     }
 
@@ -82,10 +82,22 @@ export default class ChannelSidebar extends Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        const {currentTeamId, teamsCount, theme} = this.props;
-        const {deviceWidth, openDrawerOffset, isSplitView, permanentSidebar, show, searching} = this.state;
+        const { currentTeamId, teamsCount, theme} = this.props;
+        const {
+            deviceWidth,
+            openDrawerOffset,
+            isSplitView,
+            permanentSidebar,
+            show,
+            searching,
+            swiperIndex,
+        } = this.state;
 
-        if (nextState.openDrawerOffset !== openDrawerOffset || nextState.show !== show || nextState.searching !== searching || nextState.deviceWidth !== deviceWidth) {
+        if (nextState.openDrawerOffset !== openDrawerOffset ||
+            nextState.show !== show ||
+            nextState.searching !== searching ||
+            nextState.deviceWidth !== deviceWidth ||
+            (Platform.OS === 'android' && nextState.swiperIndex !== swiperIndex)) {
             return true;
         }
 
@@ -276,10 +288,10 @@ export default class ChannelSidebar extends Component {
     };
 
     onPageSelected = (index) => {
-        this.swiperIndex = index;
+        this.setState({swiperIndex: index});
 
         if (this.drawerRef?.current) {
-            this.drawerRef.current.canClose = this.swiperIndex !== 0;
+            this.drawerRef.current.canClose = index !== 0;
         }
     };
 
@@ -293,6 +305,11 @@ export default class ChannelSidebar extends Component {
         }
         this.setState({searching: true});
     };
+
+    onScrollValueChange = ({value}) => {
+        const drawerWidth = this.drawerSwiper?.swiperRef.current.props.width;
+        this.drawerSwiper?.swiperRef.current?.scrollView?.scrollTo({x: drawerWidth - value, animated: true});
+    }
 
     showTeams = () => {
         if (this.drawerSwiper && this.props.teamsCount > 1) {
@@ -400,7 +417,7 @@ export default class ChannelSidebar extends Component {
 
     render() {
         const {children} = this.props;
-        const {deviceWidth, openDrawerOffset} = this.state;
+        const {deviceWidth, openDrawerOffset, swiperIndex} = this.state;
         const isTablet = DeviceTypes.IS_TABLET && !this.state.isSplitView && this.state.permanentSidebar;
         const drawerWidth = DeviceTypes.IS_TABLET ? TABLET_WIDTH : (deviceWidth - openDrawerOffset);
 
@@ -413,6 +430,8 @@ export default class ChannelSidebar extends Component {
                 drawerWidth={drawerWidth}
                 useNativeAnimations={true}
                 isTablet={isTablet}
+                onScrollValueChange={this.onScrollValueChange}
+                swiperIndex={swiperIndex}
             >
                 {children}
             </DrawerLayout>

--- a/app/components/sidebars/main/main_sidebar.js
+++ b/app/components/sidebars/main/main_sidebar.js
@@ -9,6 +9,7 @@ import {
     Keyboard,
     StyleSheet,
     View,
+    Platform,
 } from 'react-native';
 import {intlShape} from 'react-intl';
 import AsyncStorage from '@react-native-community/async-storage';
@@ -82,7 +83,7 @@ export default class ChannelSidebar extends Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        const { currentTeamId, teamsCount, theme} = this.props;
+        const {currentTeamId, teamsCount, theme} = this.props;
         const {
             deviceWidth,
             openDrawerOffset,
@@ -307,8 +308,10 @@ export default class ChannelSidebar extends Component {
     };
 
     onScrollValueChange = ({value}) => {
-        const drawerWidth = this.drawerSwiper?.swiperRef.current.props.width;
-        this.drawerSwiper?.swiperRef.current?.scrollView?.scrollTo({x: drawerWidth - value, animated: true});
+        const swiper = this.drawerSwiper?.swiperRef.current;
+        if (swiper && swiper.scrollView) {
+            swiper.scrollView.scrollTo({x: swiper.props.width - value, animated: true});
+        }
     }
 
     showTeams = () => {

--- a/app/components/swiper.js
+++ b/app/components/swiper.js
@@ -121,6 +121,13 @@ export default class Swiper extends PureComponent {
         }, 0);
     };
 
+    onScroll = ({nativeEvent}) => {
+        if (this.state.index === 1 && nativeEvent.contentOffset.x === 0) {
+            this.offset = 0;
+            this.setState({index: 0});
+        }
+    }
+
     refScrollView = (view) => {
         this.scrollView = view;
     };
@@ -130,6 +137,14 @@ export default class Swiper extends PureComponent {
             keyboardShouldPersistTaps,
             scrollEnabled,
         } = this.props;
+
+        const pagingEnabled = scrollEnabled;
+        let platformScrollEnabled = scrollEnabled;
+        let platformOnScroll = null;
+        if (Platform.OS === 'android') {
+            platformScrollEnabled = this.state.index === 0;
+            platformOnScroll = this.onScroll;
+        }
 
         return (
             <ScrollView
@@ -143,9 +158,11 @@ export default class Swiper extends PureComponent {
                 contentContainerStyle={[styles.wrapper, this.props.style]}
                 onScrollBeginDrag={this.onScrollBegin}
                 onMomentumScrollEnd={this.onScrollEnd}
-                pagingEnabled={scrollEnabled}
+                pagingEnabled={pagingEnabled}
                 keyboardShouldPersistTaps={keyboardShouldPersistTaps}
-                scrollEnabled={scrollEnabled}
+                scrollEnabled={platformScrollEnabled}
+                onScroll={platformOnScroll}
+                directionalLockEnabled={true}
             >
                 {pages}
             </ScrollView>


### PR DESCRIPTION
#### Summary
On Android, if the ScrollView has scroll enabled then it will handle all gestures initiated in it, so our pan handler in DrawerLayout never fires. To overcome this I disabled scroll for Android if the page index is 1 and then used `scrollTo` to achieve scrolling when swiping/dragging right. When swiping/dragging left on page 1, the drawer can now be closed as the pan handler handles the gesture. On page 0, scroll is enabled so the ScrollView functionality works as before. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19727

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Android emulator, 9
* Galaxy S7, 8.1
* iPhone 11 simulator, 13.2