### PR TITLE
Upgrade jsc-android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6609,9 +6609,9 @@
       "dev": true
     },
     "jsc-android": {
-      "version": "241213.1.0",
-      "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-241213.1.0.tgz",
-      "integrity": "sha512-AH8NYyMNLNhcUEF97QbMxPNLNW+oiSBlvm1rsMNzgJ1d5TQzdh/AOJGsxeeESp3m9YIWGLCgUvGTVoVLs0p68A=="
+      "version": "241213.2.0",
+      "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-241213.2.0.tgz",
+      "integrity": "sha512-nfddejB9jxFSG+Uewf+zwATFi8F2CZEEgoHLoOj13egiBDoC7zMoxK1c5/Ycf3AGmGuwCgjpn3LWe0f4tKYbjw=="
     },
     "jsdom": {
       "version": "11.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fuse.js": "3.4.5",
     "intl": "1.2.5",
     "jail-monkey": "2.3.0",
-    "jsc-android": "241213.1.0",
+    "jsc-android": "241213.2.0",
     "mattermost-redux": "github:mattermost/mattermost-redux#01b1ec33aece728954df6d93b214dadb28e65063",
     "mime-db": "1.42.0",
     "moment-timezone": "0.5.27",


### PR DESCRIPTION
`jsc-android` was accidentally downgraded when I updated to RN 61 and we're seeing many crashes originating in `libjsc.so` in Android. This change upgrades `jsc-android` to the version used in v1.25.