### PR TITLE
Automated cherry pick of #3664

### DIFF
--- a/app/components/sidebars/settings/settings_sidebar.test.js
+++ b/app/components/sidebars/settings/settings_sidebar.test.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Preferences from 'mattermost-redux/constants/preferences';
+
+import SettingsSidebar from './settings_sidebar';
+
+jest.mock('react-intl');
+
+jest.mock('react-native-vector-icons/MaterialIcons', () => ({
+    getImageSource: jest.fn().mockResolvedValue(null),
+}));
+
+describe('SettingsSidebar', () => {
+    const baseProps = {
+        actions: {
+            logout: jest.fn(),
+            setStatus: jest.fn(),
+        },
+        blurPostTextBox: jest.fn(),
+        currentUser: {},
+        status: 'online',
+        theme: Preferences.THEMES.default,
+    };
+
+    test('Android back button should dismiss status modal first', () => {
+        const wrapper = shallow(<SettingsSidebar {...baseProps}/>);
+
+        const instance = wrapper.instance();
+
+        // Mocking the reference the DrawerLayout as the component is not really being mounted
+        instance.drawerRef = {
+            closeDrawer: jest.fn(() => {
+                instance.drawerOpened = false;
+            }),
+        };
+
+        // simulate that the drawer is opened
+        instance.drawerOpened = true;
+
+        // simulate that the status modal is opened
+        instance.statusModal = true;
+
+        // this simulates the first tap on the back button that closes the status modal
+        let backButtonResult = instance.handleAndroidBack();
+        expect(backButtonResult).toBe(false);
+        expect(instance.drawerOpened).toBe(true);
+
+        // this simulates a second tap on the back button that closes the drawer
+        backButtonResult = instance.handleAndroidBack();
+        expect(backButtonResult).toBe(true);
+        expect(instance.drawerOpened).toBe(false);
+    });
+});


### PR DESCRIPTION
Cherry pick of #3664 on release-1.27.

- #3664: MM-20682 Unit test for dimissing the status modal before the

/cc  @enahum