### PR TITLE
MM-21148 -  `make i18n-extract` throws an error if mobile repo is not checked out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8291,8 +8291,8 @@
       }
     },
     "mmjstool": {
-      "version": "github:mattermost/mattermost-utilities#ce99d7a9e82128a02fd36e44720a4aef2653810d",
-      "from": "github:mattermost/mattermost-utilities",
+      "version": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e8",
+      "from": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e",
       "dev": true,
       "requires": {
         "estree-walk": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "jetifier": "1.6.4",
     "jsdom-global": "3.0.2",
     "metro-react-native-babel-preset": "0.56.0",
-    "mmjstool": "github:mattermost/mattermost-utilities",
+    "mmjstool": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e",
     "mock-async-storage": "2.2.0",
     "nyc": "14.1.1",
     "patch-package": "6.2.0",


### PR DESCRIPTION
#### Summary
updated mmjstool reference

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-21148

#### Related PRs
mmjstool - https://github.com/mattermost/mattermost-utilities/pull/21
webapp - https://github.com/mattermost/mattermost-webapp/pull/4580