### PR TITLE
MM-20989: Ensuring keyboard doesn't dismiss while submitting post

### DIFF
--- a/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
+++ b/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
@@ -26,6 +26,7 @@ exports[`PostTextBox should match, full snapshot 1`] = `
           "alignItems": "stretch",
         }
       }
+      keyboardShouldPersistTaps="always"
       style={
         Array [
           Object {

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -844,6 +844,7 @@ export default class PostTextBoxBase extends PureComponent {
                 <ScrollView
                     style={this.getInputContainerStyle()}
                     contentContainerStyle={style.inputContentContainer}
+                    keyboardShouldPersistTaps={'always'}
                 >
                     <PasteableTextInput
                         ref={this.input}


### PR DESCRIPTION
#### Summary
This PR makes sure that while a user is writing a post, they won't need to dismiss the keyboard before being able to tap any of the buttons in the post draft area.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20989

#### Device Information
This PR was tested on: 
* iPhone 11 Simulator
