### PR TITLE
[MM-21068] Notify when attempting to enter private channel/group via explicit link

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -406,8 +406,13 @@ export function handleSelectChannelByName(channelName, teamName) {
         const {teams: currentTeams, currentTeamId} = state.entities.teams;
         const currentTeam = currentTeams[currentTeamId];
         const currentTeamName = currentTeam?.name;
-        const {data: channel} = await dispatch(getChannelByNameAndTeamName(teamName || currentTeamName, channelName));
+        const response = await dispatch(getChannelByNameAndTeamName(teamName || currentTeamName, channelName));
+        const {error, data: channel} = response;
         const currentChannelId = getCurrentChannelId(state);
+
+        if (error) {
+            return {error};
+        }
 
         if (teamName && teamName !== currentTeamName) {
             const team = getTeamByName(state, teamName);
@@ -417,6 +422,8 @@ export function handleSelectChannelByName(channelName, teamName) {
         if (channel && currentChannelId !== channel.id) {
             dispatch(handleSelectChannel(channel.id));
         }
+
+        return null;
     };
 }
 

--- a/app/actions/views/channel.test.js
+++ b/app/actions/views/channel.test.js
@@ -152,7 +152,7 @@ describe('Actions.Views.Channel', () => {
     test('handleSelectChannelByName failure from null currentTeamName', async () => {
         const failStoreObj = {...storeObj};
         failStoreObj.entities.teams.teams.currentTeamId = 'not-in-current-teams';
-        store = mockStore(storeObj);
+        store = mockStore(failStoreObj);
 
         await store.dispatch(handleSelectChannelByName(currentChannelName, null));
 
@@ -162,6 +162,23 @@ describe('Actions.Views.Channel', () => {
 
         const storeBatchActions = storeActions.some(({type}) => type === 'BATCHING_REDUCER.BATCH');
         expect(storeBatchActions).toBe(false);
+    });
+
+    test('handleSelectChannelByName failure from no permission to channel', async () => {
+        actions.getChannelByNameAndTeamName = jest.fn(() => {
+            return {
+                type: 'MOCK_ERROR',
+                error: {
+                    message: "Can't get to channel.",
+                },
+            };
+        });
+
+        await store.dispatch(handleSelectChannelByName(currentChannelName, currentTeamName));
+
+        const storeActions = store.getActions();
+        const receivedChannel = storeActions.some((action) => action.type === MOCK_RECEIVE_CHANNEL_TYPE);
+        expect(receivedChannel).toBe(false);
     });
 
     test('loadPostsIfNecessaryWithRetry for the first time', async () => {

--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -12,6 +12,8 @@ import {DeepLinkTypes} from 'app/constants';
 import {getCurrentServerUrl} from 'app/init/credentials';
 import mattermostManaged from 'app/mattermost_managed';
 import BottomSheet from 'app/utils/bottom_sheet';
+import {alertErrorWithFallback} from 'app/utils/general';
+import {t} from 'app/utils/i18n';
 import {preventDoubleTap} from 'app/utils/tap';
 import {matchDeepLink, normalizeProtocol} from 'app/utils/url';
 
@@ -56,7 +58,16 @@ export default class MarkdownLink extends PureComponent {
 
         if (match) {
             if (match.type === DeepLinkTypes.CHANNEL) {
-                this.props.actions.handleSelectChannelByName(match.channelName, match.teamName);
+                const error = await this.props.actions.handleSelectChannelByName(match.channelName, match.teamName);
+
+                if (error) {
+                    const linkFailedMessage = {
+                        id: t('mobile.server_link.private_channel.error'),
+                        defaultMessage: 'You are not a member of this private channel.',
+                    };
+
+                    alertErrorWithFallback(this.context.intl, {}, linkFailedMessage);
+                }
             } else if (match.type === DeepLinkTypes.PERMALINK) {
                 onPermalinkPress(match.postId, match.teamName);
             }

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -445,6 +445,7 @@
   "mobile.select_team.no_teams": "There are no available teams for you to join.",
   "mobile.server_link.error.text": "The link could not be found on this server.",
   "mobile.server_link.error.title": "Link Error",
+  "mobile.server_link.private_channel.error": "You are not a member of this private channel.",
   "mobile.server_upgrade.button": "OK",
   "mobile.server_upgrade.description": "\nA server upgrade is required to use the Mattermost app. Please ask your System Administrator for details.\n",
   "mobile.server_upgrade.title": "Server upgrade required",


### PR DESCRIPTION
#### Summary
Alerts when clicking on a link to a private channel/group.

#### Ticket Link
* [MM-21068](https://mattermost.atlassian.net/browse/MM-21068)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 
* Android 9 device (OnePlus 5)
* iPhone X (simulator)

#### Screenshots

| Denied (Private) | Permitted (Public) |
| --- | --- |
| <img width="373" alt="denied" src="https://user-images.githubusercontent.com/887849/71517837-a233eb00-288e-11ea-88f0-c96926a1bbbe.gif"> | <img width="373" alt="permitted" src="https://user-images.githubusercontent.com/887849/71517838-a2cc8180-288e-11ea-8df3-f582fb7a0c08.gif"> | 

---

**Open Questions**

* ~~I've reused the pre-existing Permalink message (`Permalink belongs to a deleted message or to a channel to which you do not have access`). Should we have a different, more-specific message for this use case?~~
