### PR TITLE
Enable Deep Links for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,12 @@
             <category android:name="android.intent.category.LAUNCHER" />
             <action android:name="android.intent.action.DOWNLOAD_COMPLETE"/>
         </intent-filter>
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="mattermost" />
+        </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
       <service android:name=".NotificationDismissService"


### PR DESCRIPTION
#### Summary
#1805 enabled support for deep links for iOS. The link parsing mechanism remains the same for both platforms, but this commit enables registration of the URL scheme to the Android OS so that deep links can be accessed.

#### Device Information
This PR was tested on: Android 9 device (OnePlus 5)

#### Screenshots
| to Permalink | to Channel |
| --- | --- |
| <img width="373" alt="permalink" src="https://user-images.githubusercontent.com/887849/71643891-28409f00-2c9e-11ea-9b5b-b1e15487acc7.gif"> | <img width="373" alt="channel" src="https://user-images.githubusercontent.com/887849/71643893-2c6cbc80-2c9e-11ea-8f1a-221b80efbe9b.gif"> |

**Deep Link URL patterns**

* `mattermost://<teamname>/channels/<channelname>`
* `mattermost://<teamname>pl/<permalinkID>`

