### PR TITLE
[MM-12215] Make deep link URL prefix configurable for Release/Beta

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="mattermost" />
+          <data android:scheme="mattermost-beta" />
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -9,6 +9,7 @@ import {Files} from 'mattermost-redux/constants';
 import {DeepLinkTypes} from 'app/constants';
 
 const ytRegex = /(?:http|https):\/\/(?:www\.|m\.)?(?:(?:youtube\.com\/(?:(?:v\/)|(?:(?:watch|embed\/watch)(?:\/|.*v=))|(?:embed\/)|(?:user\/[^/]+\/u\/[0-9]\/)))|(?:youtu\.be\/))([^#&?]*)/;
+const APP_SCHEME = 'mattermost-beta';
 
 export function isValidUrl(url = '') {
     const regex = /^https?:\/\//i;
@@ -103,7 +104,7 @@ export function matchDeepLink(url, serverURL, siteURL) {
         return null;
     }
 
-    const linkRoot = `(?:${escapeRegex('mattermost:/')}|${escapeRegex(serverURL)}|${escapeRegex(siteURL)})?`;
+    const linkRoot = `(?:${escapeRegex(APP_SCHEME)}:\\/|${escapeRegex(serverURL)}|${escapeRegex(siteURL)})?`;
 
     let match = new RegExp('^' + linkRoot + '\\/([^\\/]+)\\/channels\\/(\\S+)').exec(url);
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,6 +167,14 @@ lane :configure do
   # Save the config.json file
   save_config_json('../dist/assets/config.json', json)
 
+  # Set deep link prefix for URL lookups
+  app_scheme = ENV['APP_SCHEME'] || 'mattermost-beta'
+  find_replace_string(
+    path_to_file: './app/utils/url.js',
+    old_string: "APP_SCHEME = 'mattermost-beta'",
+    new_string: "APP_SCHEME = '#{app_scheme}'",
+  )
+
   configured = true
 end
 
@@ -276,7 +284,7 @@ end
 desc 'Create GitHub release'
 lane :github do
   tag = ENV['CIRCLE_TAG'] || ENV['TAG']
-  
+
   if tag
     version = get_version_number(xcodeproj: './ios/Mattermost.xcodeproj', target: 'Mattermost')
     build = get_build_number(xcodeproj: './ios/Mattermost.xcodeproj')
@@ -330,6 +338,7 @@ platform :ios do
     ENV['APP_NAME'] = 'Mattermost'
     ENV['REPLACE_ASSETS'] = 'true'
     ENV['BUILD_FOR_RELEASE'] = 'true'
+    ENV['APP_SCHEME'] = 'mattermost-mobile'
 
     update_identifiers
     replace_assets
@@ -392,6 +401,17 @@ platform :ios do
         new_string: app_bundle_id
     )
 
+    # Set the deep link prefix
+    app_scheme = ENV['APP_SCHEME'] || 'mattermost-beta'
+    update_info_plist(
+        xcodeproj: './ios/Mattermost.xcodeproj',
+        plist_path: 'Mattermost/Info.plist',
+        block: proc do |plist|
+          urlScheme = plist["CFBundleURLTypes"].find{|scheme| scheme["CFBundleURLName"] == "com.mattermost"}
+          urlScheme[:CFBundleURLSchemes] = [app_scheme]
+        end
+    )
+
     # If set update the development team
     unless ENV['FASTLANE_TEAM_ID'].nil? || ENV['FASTLANE_TEAM_ID'].empty?
     update_project_team(
@@ -419,7 +439,6 @@ platform :ios do
         old_string: 'group.com.mattermost.rnbeta',
         new_string: app_group_id
     )
-
 
     update_app_group_identifiers(
         entitlements_file: './ios/MattermostShare/MattermostShare.entitlements',
@@ -490,7 +509,7 @@ platform :ios do
     end
   end
 
-  def build_ios()
+  def build_ios
     app_name =  ENV['APP_NAME'] || 'Mattermost Beta'
     app_name_sub = app_name.gsub(" ", "_")
     config_mode = ENV['BUILD_FOR_RELEASE'] == 'true' ? 'Release' : 'Debug'
@@ -538,6 +557,7 @@ platform :android do
     ENV['APP_NAME'] = 'Mattermost'
     ENV['REPLACE_ASSETS'] = 'true'
     ENV['BUILD_FOR_RELEASE'] = 'true'
+    ENV['APP_SCHEME'] = 'mattermost-mobile'
 
     update_identifiers
     replace_assets
@@ -584,6 +604,13 @@ platform :android do
     package_id = ENV['MAIN_APP_IDENTIFIER'] || 'com.mattermost.rnbeta'
     android_change_package_identifier(newIdentifier: package_id, manifest: './android/app/src/main/AndroidManifest.xml')
     android_update_application_id(app_folder_name: 'android/app', application_id: package_id)
+
+    app_scheme = ENV['APP_SCHEME'] || 'mattermost-beta'
+    find_replace_string(
+      path_to_file: "./android/app/src/main/AndroidManifest.xml",
+      old_string: 'scheme="mattermost-beta"',
+      new_string: "scheme=\'#{app_scheme}\'"
+    )
 
     beta_dir = './android/app/src/main/java/com/mattermost/rnbeta/'
     release_dir = "./android/app/src/main/java/#{package_id.gsub '.', '/'}/"
@@ -661,7 +688,7 @@ platform :android do
                               })
   end
 
-  def build_android()
+  def build_android
     config_mode = ENV['BUILD_FOR_RELEASE'] == 'true' ? 'Release' : 'Debug'
 
     gradle(

--- a/fastlane/env_vars_example
+++ b/fastlane/env_vars_example
@@ -5,6 +5,7 @@ export BRANCH_TO_BUILD=master
 export GIT_LOCAL_BRANCH=build
 
 export APP_NAME="Mattermost Beta"
+export APP_SCHEME=mattermost-beta
 
 #export INCREMENT_BUILD_NUMBER=false
 ## This sets the version number ex: 1.22.0 if not set it uses the one in the code base

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -29,7 +29,7 @@
 			<string>com.mattermost</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>mattermost</string>
+				<string>mattermost-beta</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
#### Summary
Default deep link URL prefix is now `mattermost-beta`

To set to `mattermost-mobile` (or anything else, for that matter) in production releases, set new fastlane ENV variable `DEEPLINK_PREFIX` to `mattermost-mobile`

**IMPORTANT: New ENV variable for Release builds!**

#### Ticket Link
* [MM-12215](https://mattermost.atlassian.net/browse/MM-12215)

#### Device Information
This PR was tested on:
* iPhone 11 Simulator
* Android 9 (OnePlus 5 device)

#### Screenshots

**Release Build**

| to Permalink | to Channel |
| --- | --- |
| <img width="250" alt="permalink-release" src="https://user-images.githubusercontent.com/887849/71686984-80010800-2d7b-11ea-87ce-34fd3843009b.gif"> | <img width="250" alt="channel-release" src="https://user-images.githubusercontent.com/887849/71686983-7f687180-2d7b-11ea-8b78-8005a604cd81.gif"> |

**Beta Build**

| to Permalink | to Channel |
| --- | --- |
| <img width="250" alt="permalink-beta" src="https://user-images.githubusercontent.com/887849/71687199-00c00400-2d7c-11ea-8c4c-aa08e21ea5aa.gif"> | <img width="250" alt="channel-beta" src="https://user-images.githubusercontent.com/887849/71687196-00c00400-2d7c-11ea-9637-0f5857f2b630.gif"> |

---

**Deep Link URL patterns**

**Release Build**

* `mattermost-mobile://<teamname>/channels/<channelname>`
* `mattermost-mobile://<teamname>pl/<permalinkID>`

**Beta Build**

* `mattermost-beta://<teamname>/channels/<channelname>`
* `mattermost-beta://<teamname>pl/<permalinkID>`



