### PR TITLE
[MM-16604] Upgrade to firebase-messaging v17.3.4

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -242,7 +242,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "com.google.firebase:firebase-messaging:17.3.0"
+    implementation 'com.google.firebase:firebase-messaging:17.3.2'
     implementation project(':react-native-document-picker')
     implementation project(':react-native-keychain')
     implementation project(':react-native-doc-viewer')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -242,7 +242,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.firebase:firebase-messaging:17.3.2'
+    implementation 'com.google.firebase:firebase-messaging:17.3.4'
     implementation project(':react-native-document-picker')
     implementation project(':react-native-keychain')
     implementation project(':react-native-doc-viewer')


### PR DESCRIPTION
#### Summary
There seems to be two possible causes for these ANRs: [background execution limits](https://stackoverflow.com/questions/46117554/firebasemessagingservice-crashes-on-android-o-due-to-background-execution-limits) introduced in Android 8 and [timing issues](https://github.com/firebase/quickstart-android/issues/594#issuecomment-451528198).
While I've been unable to repro, the [release notes for v17.3.2](https://firebase.google.com/support/release-notes/android#version_1732) state that an issue causing ANRs when receiving messages was fixed. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16604

#### Device Information
This PR was tested on:
* Samsung S7, Android 8.0.0