### PR TITLE
MM-20998 - Preventing the @ icon from being repeatedly tappable

### DIFF
--- a/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
+++ b/app/components/post_textbox/__snapshots__/post_textbox.test.js.snap
@@ -90,6 +90,7 @@ exports[`PostTextBox should match, full snapshot 1`] = `
         >
           <TouchableOpacity
             activeOpacity={0.2}
+            disabled={false}
             onPress={[Function]}
             style={
               Object {

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -237,13 +237,19 @@ export default class PostTextBoxBase extends PureComponent {
 
         let button = null;
         const buttonStyle = [];
-        const slashDisabled = this.state.value.length > 0;
+        let iconColor = theme.centerChannelColor;
+        let isDisabled = false;
 
         if (!channelIsReadOnly) {
             switch (actionType) {
             case 'at':
+                isDisabled = this.state.value[this.state.value.length - 1] === '@';
+                if (isDisabled) {
+                    iconColor = changeOpacity(theme.centerChannelColor, 0.6);
+                }
                 button = (
                     <TouchableOpacity
+                        disabled={isDisabled}
                         onPress={() => {
                             this.handleTextChange(`${this.state.value}@`, true);
                             this.focus();
@@ -251,7 +257,7 @@ export default class PostTextBoxBase extends PureComponent {
                         style={style.iconWrapper}
                     >
                         <MaterialCommunityIcons
-                            color={theme.centerChannelColor}
+                            color={iconColor}
                             name='at'
                             size={20}
                         />
@@ -259,15 +265,16 @@ export default class PostTextBoxBase extends PureComponent {
                 );
                 break;
             case 'slash':
+                isDisabled = this.state.value.length > 0;
                 buttonStyle.push(style.slashIcon);
-                if (slashDisabled) {
-                    buttonStyle.push(style.slashIconDisabled);
+                if (isDisabled) {
+                    buttonStyle.push(style.iconDisabled);
                 }
 
                 button = (
                     <TouchableOpacity
-                        disabled={slashDisabled}
-                        onPress={slashDisabled ? null : () => {
+                        disabled={isDisabled}
+                        onPress={() => {
                             this.handleTextChange('/', true);
                             this.focus();
                         }}
@@ -910,7 +917,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             opacity: 1,
             tintColor: theme.centerChannelColor,
         },
-        slashIconDisabled: {
+        iconDisabled: {
             tintColor: changeOpacity(theme.centerChannelColor, 0.6),
         },
         iconWrapper: {


### PR DESCRIPTION
#### Summary
This PR disables the `@` button in the post draft when the user has already tapped it, or manually inputted `@` (the icon is re-enabled once the user inputs more text or selects a user from the suggestion list)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20998

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
- iPhone 11 Simulator

#### Screenshots
<img width="416" alt="image" src="https://user-images.githubusercontent.com/29700158/71868037-e86f3100-314f-11ea-8d05-5d9b1aeaf44e.png">
`@` icon disabled when button was just pressed
