### PR TITLE
[MM-21582] Show alert when not a member of a team

### DIFF
--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -252,6 +252,7 @@
   "mobile.extension.file_limit": "Sharing is limited to a maximum of 5 files.",
   "mobile.extension.max_file_size": "File attachments shared in Mattermost must be less than {size}.",
   "mobile.extension.permission": "Mattermost needs access to the device storage to share files.",
+  "mobile.extension.team_required": "You must belong to a team before you can share files.",
   "mobile.extension.title": "Share in Mattermost",
   "mobile.failed_network_action.retry": "try again",
   "mobile.failed_network_action.shortDescription": "Messages will load when you have an internet connection or {tryAgainAction}.",

--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -90,6 +90,8 @@ class ShareViewController: SLComposeServiceViewController {
     
     if sessionToken == nil || serverURL == nil {
       showErrorMessage(title: "", message: "Authentication required: Please first login using the app.", VC: self)
+    } else if store.getCurrentTeamId() == "" {
+      showErrorMessage(title: "", message: "You must belong to a team before you can share files.", VC: self)
     }
   }
   

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -608,7 +608,7 @@ export default class ExtensionPost extends PureComponent {
     render() {
         const {formatMessage} = this.context.intl;
         const {maxFileSize} = this.props;
-        const {error, hasPermission, files, totalSize, loaded} = this.state;
+        const {error, hasPermission, files, totalSize, loaded, teamId} = this.state;
 
         if (!loaded) {
             return (
@@ -618,6 +618,15 @@ export default class ExtensionPost extends PureComponent {
 
         if (error) {
             return this.renderErrorMessage(error);
+        }
+
+        if (!teamId) {
+            const teamRequired = formatMessage({
+                id: 'mobile.extension.team_required',
+                defaultMessage: 'You must belong to a team before you can share files.',
+            });
+
+            return this.renderErrorMessage(teamRequired);
         }
 
         if (this.token && this.url) {


### PR DESCRIPTION
#### Summary
When not a member of any team and trying to share a file via the share extension, the Android app would crash as it allowed for posting of a message without a channel ID. This crash did not happen on iOS since the "post" button is greyed out until a team and channel are selected, however, the channel dropdown just displayed a loading spinner. With this change we alert the user that they must be a part of a team before they can share files. The alert message is `You must belong to a team before you can share files.` Let me know if that needs to change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21582

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
* Android emulator, Q
* iOS simulator, 13.3

#### Screenshots
Android:
![android](https://user-images.githubusercontent.com/3208014/71929749-8dd9d300-3157-11ea-9b29-4287c0b8662d.png)

iOS:
![ios](https://user-images.githubusercontent.com/3208014/71929743-8adee280-3157-11ea-8a1c-aa1b900b9b9b.png)
