### PR TITLE
[MM-21270] Handle lower case headers

### DIFF
--- a/app/init/fetch.js
+++ b/app/init/fetch.js
@@ -17,8 +17,8 @@ import {t} from 'app/utils/i18n';
 
 /* eslint-disable no-throw-literal */
 
-const HEADER_X_CLUSTER_ID = 'X-Cluster-Id';
-const HEADER_TOKEN = 'Token';
+export const HEADER_X_CLUSTER_ID = 'X-Cluster-Id';
+export const HEADER_TOKEN = 'Token';
 
 let managedConfig;
 
@@ -99,23 +99,19 @@ Client4.doFetchWithResponse = async (url, options) => {
         });
     }
 
-    if (headers[HEADER_X_CLUSTER_ID] || headers[HEADER_X_CLUSTER_ID.toLowerCase()]) {
-        const clusterId = headers[HEADER_X_CLUSTER_ID] || headers[HEADER_X_CLUSTER_ID.toLowerCase()];
-        if (clusterId && Client4.clusterId !== clusterId) {
-            Client4.clusterId = clusterId; /* eslint-disable-line require-atomic-updates */
-        }
+    const clusterId = headers[HEADER_X_CLUSTER_ID] || headers[HEADER_X_CLUSTER_ID.toLowerCase()];
+    if (clusterId && Client4.clusterId !== clusterId) {
+        Client4.clusterId = clusterId; /* eslint-disable-line require-atomic-updates */
     }
 
-    if (headers[HEADER_TOKEN] || headers[HEADER_TOKEN.toLowerCase()]) {
-        const token = headers[HEADER_TOKEN] || headers[HEADER_TOKEN.toLowerCase()];
+    const token = headers[HEADER_TOKEN] || headers[HEADER_TOKEN.toLowerCase()];
+    if (token) {
         Client4.setToken(token);
     }
 
-    if (headers[HEADER_X_VERSION_ID] && !headers['Cache-Control']) {
-        const serverVersion = headers[HEADER_X_VERSION_ID];
-        if (serverVersion && Client4.serverVersion !== serverVersion) {
-            Client4.serverVersion = serverVersion; /* eslint-disable-line require-atomic-updates */
-        }
+    const serverVersion = headers[HEADER_X_VERSION_ID] || headers[HEADER_X_VERSION_ID.toLowerCase()];
+    if (serverVersion && !headers['Cache-Control'] && Client4.serverVersion !== serverVersion) {
+        Client4.serverVersion = serverVersion; /* eslint-disable-line require-atomic-updates */
     }
 
     if (response.ok) {

--- a/app/init/fetch.test.js
+++ b/app/init/fetch.test.js
@@ -1,0 +1,64 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Client4} from 'mattermost-redux/client';
+import {HEADER_X_VERSION_ID} from 'mattermost-redux/client/client4';
+
+import {
+    HEADER_X_CLUSTER_ID,
+    HEADER_TOKEN,
+} from 'app/init/fetch';
+
+describe('Fetch', () => {
+    test('doFetchWithResponse handles empty headers', async () => {
+        const setToken = jest.spyOn(Client4, 'setToken');
+        const jsonResponse = {
+            json: () => Promise.resolve('data'),
+            headers: {},
+            ok: true,
+        };
+        global.fetch.mockReturnValueOnce(jsonResponse);
+        await Client4.doFetchWithResponse('https://mattermost.com', {method: 'GET'});
+        expect(Client4.serverVersion).toEqual('');
+        expect(Client4.clusterId).toEqual('');
+        expect(setToken).not.toHaveBeenCalled();
+    });
+
+    test('doFetchWithResponse handles title case headers', async () => {
+        const setToken = jest.spyOn(Client4, 'setToken');
+        const headers = {
+            [HEADER_X_VERSION_ID]: 'VersionId',
+            [HEADER_X_CLUSTER_ID]: 'ClusterId',
+            [HEADER_TOKEN]: 'Token',
+        };
+        const jsonResponse = {
+            json: () => Promise.resolve('data'),
+            ok: true,
+            headers,
+        };
+        global.fetch.mockReturnValueOnce(jsonResponse);
+        await Client4.doFetchWithResponse('https://mattermost.com', {method: 'GET'});
+        expect(Client4.serverVersion).toEqual(headers[HEADER_X_VERSION_ID]);
+        expect(Client4.clusterId).toEqual(headers[HEADER_X_CLUSTER_ID]);
+        expect(setToken).toHaveBeenCalledWith(headers[HEADER_TOKEN]);
+    });
+
+    test('doFetchWithResponse handles lower case headers', async () => {
+        const setToken = jest.spyOn(Client4, 'setToken');
+        const headers = {
+            [HEADER_X_VERSION_ID.toLowerCase()]: 'versionid',
+            [HEADER_X_CLUSTER_ID.toLowerCase()]: 'clusterid',
+            [HEADER_TOKEN.toLowerCase()]: 'token',
+        };
+        const jsonResponse = {
+            json: () => Promise.resolve('data'),
+            ok: true,
+            headers,
+        };
+        global.fetch.mockReturnValueOnce(jsonResponse);
+        await Client4.doFetchWithResponse('https://mattermost.com', {method: 'GET'});
+        expect(Client4.serverVersion).toEqual(headers[HEADER_X_VERSION_ID.toLowerCase()]);
+        expect(Client4.clusterId).toEqual(headers[HEADER_X_CLUSTER_ID.toLowerCase()]);
+        expect(setToken).toHaveBeenCalledWith(headers[HEADER_TOKEN.toLowerCase()]);
+    });
+});

--- a/app/init/fetch.test.js
+++ b/app/init/fetch.test.js
@@ -12,12 +12,12 @@ import {
 describe('Fetch', () => {
     test('doFetchWithResponse handles empty headers', async () => {
         const setToken = jest.spyOn(Client4, 'setToken');
-        const jsonResponse = {
+        const response = {
             json: () => Promise.resolve('data'),
             headers: {},
             ok: true,
         };
-        global.fetch.mockReturnValueOnce(jsonResponse);
+        global.fetch.mockReturnValueOnce(response);
         await Client4.doFetchWithResponse('https://mattermost.com', {method: 'GET'});
         expect(Client4.serverVersion).toEqual('');
         expect(Client4.clusterId).toEqual('');
@@ -31,12 +31,12 @@ describe('Fetch', () => {
             [HEADER_X_CLUSTER_ID]: 'ClusterId',
             [HEADER_TOKEN]: 'Token',
         };
-        const jsonResponse = {
+        const response = {
             json: () => Promise.resolve('data'),
             ok: true,
             headers,
         };
-        global.fetch.mockReturnValueOnce(jsonResponse);
+        global.fetch.mockReturnValueOnce(response);
         await Client4.doFetchWithResponse('https://mattermost.com', {method: 'GET'});
         expect(Client4.serverVersion).toEqual(headers[HEADER_X_VERSION_ID]);
         expect(Client4.clusterId).toEqual(headers[HEADER_X_CLUSTER_ID]);
@@ -50,12 +50,12 @@ describe('Fetch', () => {
             [HEADER_X_CLUSTER_ID.toLowerCase()]: 'clusterid',
             [HEADER_TOKEN.toLowerCase()]: 'token',
         };
-        const jsonResponse = {
+        const response = {
             json: () => Promise.resolve('data'),
             ok: true,
             headers,
         };
-        global.fetch.mockReturnValueOnce(jsonResponse);
+        global.fetch.mockReturnValueOnce(response);
         await Client4.doFetchWithResponse('https://mattermost.com', {method: 'GET'});
         expect(Client4.serverVersion).toEqual(headers[HEADER_X_VERSION_ID.toLowerCase()]);
         expect(Client4.clusterId).toEqual(headers[HEADER_X_CLUSTER_ID.toLowerCase()]);


### PR DESCRIPTION
#### Summary
The `X-*` headers returned in responses from the community server are lower case and since we were not checking for lower case `HEADER_X_VERSION_ID`, the mobile app never had a `serverVersion` to use in `isMinimumServerVersion` calls. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21270

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iOS simulator, 13.3