### PR TITLE
MM-21613 Fix iOS Share extension alert message when file size is larger than allowed

### DIFF
--- a/app/store/store.js
+++ b/app/store/store.js
@@ -175,6 +175,7 @@ export default function configureAppStore(initialState) {
                         const entities = {
                             ...state.entities,
                             general: {
+                                ...state.entities.general,
                                 credentials: {
                                     url,
                                 },

--- a/ios/UploadAttachments/UploadAttachments/UploadSession.swift
+++ b/ios/UploadAttachments/UploadAttachments/UploadSession.swift
@@ -82,11 +82,13 @@ import os.log
         guard let identifier = session.configuration.identifier else {return}
         do {
             let jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as! NSDictionary
-            let fileInfos = jsonObject.object(forKey: "file_infos") as! NSArray
-            if fileInfos.count > 0 {
-                let fileInfoData = fileInfos[0] as! NSDictionary
-                let fileId = fileInfoData.object(forKey: "id") as! String
-                UploadSessionManager.shared.appendCompletedUploadToSession(identifier: identifier, fileId: fileId)
+            if jsonObject.object(forKey: "file_infos") != nil {
+                let fileInfos = jsonObject.object(forKey: "file_infos") as! NSArray
+                if fileInfos.count > 0 {
+                    let fileInfoData = fileInfos[0] as! NSDictionary
+                    let fileId = fileInfoData.object(forKey: "id") as! String
+                    UploadSessionManager.shared.appendCompletedUploadToSession(identifier: identifier, fileId: fileId)
+                }
             }
         } catch {
             if #available(iOS 12.0, *) {


### PR DESCRIPTION
#### Summary
When removing the user session token from the entities file the `config` and `license` were also removed, this PR adds back the `config` and `license` needed by the share extension.

Also makes a bit more robust the parsing of the file_info of the uploaded files to avoid creating a complete empty post.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21613
