### PR TITLE
[MM-14470] Deep links launch when app is not already open

### DIFF
--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -98,7 +98,15 @@ export default class PostList extends PureComponent {
     }
 
     componentDidMount() {
+        const {actions, deepLinkURL} = this.props;
+
         EventEmitter.on('scroll-to-bottom', this.handleSetScrollToBottom);
+
+        // Invoked when hitting a deep link and app is not already running.
+        if (deepLinkURL) {
+            this.handleDeepLink(deepLinkURL);
+            actions.setDeepLinkURL('');
+        }
     }
 
     componentDidUpdate(prevProps) {
@@ -108,6 +116,7 @@ export default class PostList extends PureComponent {
             this.resetPostList();
         }
 
+        // Invoked when hitting a deep link and app is already running.
         if (deepLinkURL && deepLinkURL !== prevProps.deepLinkURL) {
             this.handleDeepLink(deepLinkURL);
             actions.setDeepLinkURL('');


### PR DESCRIPTION
#### Summary

Previously, deep links would only work when the app was already open/previously launched.

Now, invoking a deep link launches the app if not already open, and opens the deep link destination.

#### Ticket Link

* [MM-14470](https://mattermost.atlassian.net/browse/MM-14470)

#### Device Information
This PR was tested on: 
* Android 9 (OnePlus 5 device)
* iPhone 11 device

#### Screenshots

<img width="300" alt="Deep Link Cold Start" src="https://user-images.githubusercontent.com/887849/72278588-156d8900-3613-11ea-9def-db6772ec017a.gif">

---

**Format for deep links (Beta builds)**

* Channel: `mattermost-beta://<server-url>/<team-name>/channels/<channelID>`
* Permalink: `mattermost-beta://<server-url>/<team-name>/pl/<permalinkID>`
