### PR TITLE
Revert "MM-17519: do not stringify booleans (#3717)"

### DIFF
--- a/app/components/widgets/settings/bool_setting.js
+++ b/app/components/widgets/settings/bool_setting.js
@@ -41,7 +41,7 @@ export default class BoolSetting extends PureComponent {
     };
 
     handleChange = (value) => {
-        this.props.onChange(this.props.id, Boolean(value));
+        this.props.onChange(this.props.id, `${value}`);
     };
 
     render() {

--- a/app/components/widgets/settings/bool_setting.test.js
+++ b/app/components/widgets/settings/bool_setting.test.js
@@ -26,10 +26,10 @@ describe('components/widgets/settings/TextSetting', () => {
 
         wrapper.instance().handleChange(false);
         expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange).toHaveBeenCalledWith('elementid', false);
+        expect(onChange).toHaveBeenCalledWith('elementid', 'false');
 
         wrapper.instance().handleChange(true);
         expect(onChange).toHaveBeenCalledTimes(2);
-        expect(onChange).toHaveBeenCalledWith('elementid', true);
+        expect(onChange).toHaveBeenCalledWith('elementid', 'true');
     });
 });


### PR DESCRIPTION
#### Summary
This reverts commit 765545570f88fd99c186c2b7927787b939ea90e3, with the original and now larger set of improvements to checkbox handling in interactive dialogs deferred until the next release.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-21632