### PR TITLE
MM-21288 Fix attaching files on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,8 +29,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize"
-        android:launchMode="singleInstance">
+        android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
@@ -60,7 +59,8 @@
                 android:label="@string/app_name"
                 android:screenOrientation="portrait"
                 android:theme="@style/AppTheme"
-                android:taskAffinity="com.mattermost.share">
+                android:taskAffinity="com.mattermost.share"
+                android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.SEND_MULTIPLE" />

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Linking, NativeModules, Platform} from 'react-native';
+import {Linking} from 'react-native';
 import {Navigation} from 'react-native-navigation';
 import {Provider} from 'react-redux';
 
@@ -21,9 +21,6 @@ import EphemeralStore from 'app/store/ephemeral_store';
 import telemetry from 'app/telemetry';
 import pushNotificationsUtils from 'app/utils/push_notifications';
 
-const {MattermostShare} = NativeModules;
-const sharedExtensionStarted = Platform.OS === 'android' && MattermostShare.isOpened;
-
 const init = async () => {
     const credentials = await getAppCredentials();
     if (EphemeralStore.appStarted) {
@@ -38,10 +35,6 @@ const init = async () => {
     });
 
     registerScreens(store, Provider);
-
-    if (sharedExtensionStarted) {
-        EphemeralStore.appStarted = true;
-    }
 
     if (!EphemeralStore.appStarted) {
         launchAppAndAuthenticateIfNeeded(credentials);


### PR DESCRIPTION
#### Summary
Changed the `launchMode=singleInstance` from the MainActivity to the Share Activity and now images and videos can be upload again from within the app when no default gallery or camera app is selected. Intent works as normal.

To fix the splash screen being stuck when opening the share extension and then the app, the `launchApp` is now called regardless and works as expected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21288