### PR TITLE
MM-21634 Fix keyboard glitch when returning to channel screen from the code screen

### DIFF
--- a/app/components/markdown/markdown_code_block/markdown_code_block.js
+++ b/app/components/markdown/markdown_code_block/markdown_code_block.js
@@ -6,6 +6,7 @@ import React from 'react';
 import {intlShape} from 'react-intl';
 import {
     Clipboard,
+    Keyboard,
     StyleSheet,
     Text,
     View,
@@ -66,7 +67,10 @@ export default class MarkdownCodeBlock extends React.PureComponent {
             });
         }
 
-        goToScreen(screen, title, passProps);
+        Keyboard.dismiss();
+        requestAnimationFrame(() => {
+            goToScreen(screen, title, passProps);
+        });
     });
 
     handleLongPress = async () => {


### PR DESCRIPTION
#### Summary
Fixes the keyboard not dismissing when entering the code screen that in turn was causing the keyboard staying open when showing  the channel drawer.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21634