### PR TITLE
[MM-21865] Dispatch loadConfigAndLicense on successful login

### DIFF
--- a/app/actions/views/login.js
+++ b/app/actions/views/login.js
@@ -17,6 +17,7 @@ import {setAppCredentials} from 'app/init/credentials';
 import PushNotifications from 'app/push_notifications';
 import {getDeviceTimezoneAsync} from 'app/utils/timezone';
 import {setCSRFFromCookie} from 'app/utils/security';
+import {loadConfigAndLicense} from 'app/actions/views/root';
 
 export function handleLoginIdChanged(loginId) {
     return async (dispatch, getState) => {
@@ -38,6 +39,8 @@ export function handlePasswordChanged(password) {
 
 export function handleSuccessfulLogin() {
     return async (dispatch, getState) => {
+        await dispatch(loadConfigAndLicense());
+
         const state = getState();
         const config = getConfig(state);
         const license = getLicense(state);

--- a/app/actions/views/login.test.js
+++ b/app/actions/views/login.test.js
@@ -4,11 +4,14 @@
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
+import * as GeneralActions from 'mattermost-redux/actions/general';
+
 import {ViewTypes} from 'app/constants';
 
 import {
     handleLoginIdChanged,
     handlePasswordChanged,
+    handleSuccessfulLogin,
 } from 'app/actions/views/login';
 
 jest.mock('app/init/credentials', () => ({
@@ -36,7 +39,16 @@ describe('Actions.Views.Login', () => {
     let store;
 
     beforeEach(() => {
-        store = mockStore({});
+        store = mockStore({
+            entities: {
+                users: {
+                    currentUserId: 'current-user-id',
+                },
+                general: {
+                    config: {},
+                },
+            },
+        });
     });
 
     test('handleLoginIdChanged', () => {
@@ -59,5 +71,14 @@ describe('Actions.Views.Login', () => {
 
         store.dispatch(handlePasswordChanged(password));
         expect(store.getActions()).toEqual([action]);
+    });
+
+    test('handleSuccessfulLogin gets config and license ', async () => {
+        const getClientConfig = jest.spyOn(GeneralActions, 'getClientConfig');
+        const getLicenseConfig = jest.spyOn(GeneralActions, 'getLicenseConfig');
+
+        await store.dispatch(handleSuccessfulLogin());
+        expect(getClientConfig).toHaveBeenCalled();
+        expect(getLicenseConfig).toHaveBeenCalled();
     });
 });

--- a/app/init/fetch.js
+++ b/app/init/fetch.js
@@ -8,6 +8,8 @@ import urlParse from 'url-parse';
 
 import {Client4} from 'mattermost-redux/client';
 import {ClientError, HEADER_X_VERSION_ID} from 'mattermost-redux/client/client4';
+import EventEmitter from 'mattermost-redux/utils/event_emitter';
+import {General} from 'mattermost-redux/constants';
 
 import mattermostBucket from 'app/mattermost_bucket';
 import mattermostManaged from 'app/mattermost_managed';
@@ -112,6 +114,7 @@ Client4.doFetchWithResponse = async (url, options) => {
     const serverVersion = headers[HEADER_X_VERSION_ID] || headers[HEADER_X_VERSION_ID.toLowerCase()];
     if (serverVersion && !headers['Cache-Control'] && Client4.serverVersion !== serverVersion) {
         Client4.serverVersion = serverVersion; /* eslint-disable-line require-atomic-updates */
+        EventEmitter.emit(General.SERVER_VERSION_CHANGED, serverVersion);
     }
 
     if (response.ok) {

--- a/app/init/fetch.test.js
+++ b/app/init/fetch.test.js
@@ -66,10 +66,7 @@ describe('Fetch', () => {
 
     test('doFetchWithResponse handles server version change', async () => {
         const emit = jest.spyOn(EventEmitter, 'emit');
-
         const serverVersion1 = 'version1';
-        const serverVersion2 = 'version2';
-
         const response = {
             json: () => Promise.resolve('data'),
             ok: true,

--- a/app/init/fetch.test.js
+++ b/app/init/fetch.test.js
@@ -3,6 +3,8 @@
 
 import {Client4} from 'mattermost-redux/client';
 import {HEADER_X_VERSION_ID} from 'mattermost-redux/client/client4';
+import EventEmitter from 'mattermost-redux/utils/event_emitter';
+import {General} from 'mattermost-redux/constants';
 
 import {
     HEADER_X_CLUSTER_ID,
@@ -60,5 +62,26 @@ describe('Fetch', () => {
         expect(Client4.serverVersion).toEqual(headers[HEADER_X_VERSION_ID.toLowerCase()]);
         expect(Client4.clusterId).toEqual(headers[HEADER_X_CLUSTER_ID.toLowerCase()]);
         expect(setToken).toHaveBeenCalledWith(headers[HEADER_TOKEN.toLowerCase()]);
+    });
+
+    test('doFetchWithResponse handles server version change', async () => {
+        const emit = jest.spyOn(EventEmitter, 'emit');
+
+        const serverVersion1 = 'version1';
+        const serverVersion2 = 'version2';
+
+        const response = {
+            json: () => Promise.resolve('data'),
+            ok: true,
+            headers: {
+                [HEADER_X_VERSION_ID]: serverVersion1,
+            },
+        };
+        global.fetch.mockReturnValueOnce(response);
+
+        expect(Client4.serverVersion).not.toEqual(serverVersion1);
+        await Client4.doFetchWithResponse('https://mattermost.com', {method: 'GET'});
+        expect(Client4.serverVersion).toEqual(serverVersion1);
+        expect(emit).toHaveBeenCalledWith(General.SERVER_VERSION_CHANGED, serverVersion1);
     });
 });


### PR DESCRIPTION
#### Summary
Because of this [change](https://github.com/mattermost/mattermost-mobile/pull/3710/files#diff-090700099e8f4c1cf06a416092bd7a9aR117) to set the server version from headers in `doFetchWithResponse`, mattermost-redux no longer emits `General.SERVER_VERSION_CHANGED` and so [GlobalEventHandler's onServerVersionChanged](https://github.com/mattermost/mattermost-mobile/blob/get-config/app/init/global_event_handler.js#L226), which dispatches `loadConfigAndLicense`, never gets called. This leads to `config.CloseUnusedDirectMessages` being undefined and [`isAutoClose`](https://github.com/mattermost/mattermost-redux/blob/d4b655287768cd72089a3f82e43652a9b4e1008b/src/utils/channel_utils.ts#L174) returning an incorrect value causing all DMs to be listed in the main sidebar. To fix this we now dispatch `loadConfigAndLicense` on login success.

#### Ticket
https://mattermost.atlassian.net/browse/MM-21865

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android 8 emulator