### PR TITLE
Set default app scheme to `mattermost`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="mattermost-beta" />
+          <data android:scheme="mattermost" />
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />

--- a/app/components/post_list/post_list.test.js
+++ b/app/components/post_list/post_list.test.js
@@ -14,7 +14,7 @@ jest.mock('react-intl');
 
 describe('PostList', () => {
     const serverURL = 'https://server-url.fake';
-    const deeplinkRoot = 'mattermost-beta://server-url.fake';
+    const deeplinkRoot = 'mattermost://server-url.fake';
 
     const baseProps = {
         actions: {

--- a/app/utils/url.test.js
+++ b/app/utils/url.test.js
@@ -107,7 +107,7 @@ describe('UrlUtils', () => {
     describe('matchDeepLink', () => {
         const SITE_URL = 'http://localhost:8065';
         const SERVER_URL = 'http://localhost:8065';
-        const DEEPLINK_URL_ROOT = 'mattermost-beta://localhost:8065';
+        const DEEPLINK_URL_ROOT = 'mattermost://localhost:8065';
 
         const tests = [
             {name: 'should return null if all inputs are empty', input: {url: '', serverURL: '', siteURL: ''}, expected: null},

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -394,7 +394,7 @@ platform :ios do
     )
 
     # Set the deep link prefix
-    app_scheme = ENV['APP_SCHEME'] || 'mattermost-beta'
+    app_scheme = ENV['APP_SCHEME'] || 'mattermost'
     update_info_plist(
         xcodeproj: './ios/Mattermost.xcodeproj',
         plist_path: 'Mattermost/Info.plist',
@@ -597,10 +597,10 @@ platform :android do
     android_change_package_identifier(newIdentifier: package_id, manifest: './android/app/src/main/AndroidManifest.xml')
     android_update_application_id(app_folder_name: 'android/app', application_id: package_id)
 
-    app_scheme = ENV['APP_SCHEME'] || 'mattermost-beta'
+    app_scheme = ENV['APP_SCHEME'] || 'mattermost'
     find_replace_string(
       path_to_file: "./android/app/src/main/AndroidManifest.xml",
-      old_string: 'scheme="mattermost-beta"',
+      old_string: 'scheme="mattermost"',
       new_string: "scheme=\'#{app_scheme}\'"
     )
 

--- a/fastlane/env_vars_example
+++ b/fastlane/env_vars_example
@@ -5,7 +5,7 @@ export BRANCH_TO_BUILD=master
 export GIT_LOCAL_BRANCH=build
 
 export APP_NAME="Mattermost Beta"
-export APP_SCHEME=mattermost-beta
+export APP_SCHEME=mattermost
 
 #export INCREMENT_BUILD_NUMBER=false
 ## This sets the version number ex: 1.22.0 if not set it uses the one in the code base

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -29,7 +29,7 @@
 			<string>com.mattermost</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>mattermost-beta</string>
+				<string>mattermost</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
#### Summary

Was originally set to `mattermost-beta` as per #3767 . Setting default to `mattermost` per apps grooming conversation.

**IMPORTANT**
Environment variables in various CircleCI schemes must be updated with `APP_SCHEME` set to `mattermost`, instead of current `mattermost-beta`.

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 11 Simulator

