### PR TITLE
Fix Android unsigned releases to work with Hermes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -232,6 +232,7 @@ dependencies {
         def hermesPath = "../../node_modules/hermes-engine/android/";
         debugImplementation files(hermesPath + "hermes-debug.aar")
         releaseImplementation files(hermesPath + "hermes-release.aar")
+        unsignedImplementation files(hermesPath + "hermes-release.aar")
     } else {
         implementation jscFlavor
     }


### PR DESCRIPTION
#### Summary
Fixes following fatal error with Release builds:

`java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libhermes.so`

#### Device Information
This PR was tested on:
* Android 9 device (OnePlus 5)
