### PR TITLE
[MM-21771] Call Linking.getInitialURL() in launchApp

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:launchMode="singleTask">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -58,6 +58,10 @@ const launchApp = (credentials) => {
 
     telemetry.startSinceLaunch(['start:splash_screen']);
     EphemeralStore.appStarted = true;
+
+    Linking.getInitialURL().then((url) => {
+        store.dispatch(setDeepLinkURL(url));
+    });
 };
 
 const launchAppAndAuthenticateIfNeeded = async (credentials) => {
@@ -73,10 +77,6 @@ const launchAppAndAuthenticateIfNeeded = async (credentials) => {
             await emmProvider.handleAuthentication(store);
         }
     }
-
-    Linking.getInitialURL().then((url) => {
-        store.dispatch(setDeepLinkURL(url));
-    });
 };
 
 Navigation.events().registerAppLaunchedListener(() => {


### PR DESCRIPTION
#### Summary
 Calling `Linking.getInitialURL()` in `launchApp` ensures that it's called regardless of `EphemeralStore.appStarted`'s value in `init`. I added `launchMode=singleTask` to the MainActivity since without it I would see a second instance of Mattermost opened via deeplink if one was previously running in the background. I tested https://mattermost.atlassian.net/browse/MM-21288 and the `singleTask` change does not cause any issues for me but should be tested by QA as well. iOS should also be tested to ensure deeplink continue to work there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21771
https://mattermost.atlassian.net/browse/MM-21288

#### Device Information
This PR was tested on:
* Android 10 emulator
* iOS 13 simulator