### PR TITLE
[MM-21990] Handle com.compuserve.gif type with dataForPasteboardType

### DIFF
--- a/ios/Mattermost/UIPasteboard+GetImageInfo.m
+++ b/ios/Mattermost/UIPasteboard+GetImageInfo.m
@@ -25,6 +25,7 @@
       }
 
       NSString *type = item.allKeys[j];
+    
 
       @try {
         NSString *uri = self.string;
@@ -32,6 +33,8 @@
         
         if ([type isEqual:@"public.jpeg"] || [type isEqual:@"public.heic"] || [type isEqual:@"public.png"]) {
           fileData = [self getDataForImageItem:item[type] type:type];
+        } else if ([type isEqual:@"com.compuserve.gif"]) {
+          fileData = [self dataForPasteboardType:type];
         }
         
         SwimeProxy *swimeProxy = [SwimeProxy shared];


### PR DESCRIPTION
#### Summary
`getMimeAndExtensionWithData` threw an exception when handling pasted files with type `com.compuserve.gif` because `fileData` in this case is of type `UIImage` rather than `NSData`. I didn't find a way to convert `UIImage` to `NSData` while conserving the GIF, however, the use of `dataForPasteboardType` worked fine in v1.25.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21990

#### Device Information
This PR was tested on:
* iPhone 8, iOS 13.3