### PR TITLE
MM-17649 - fix VoiceOver on server select & login

### DIFF
--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -352,7 +352,10 @@ export default class Login extends PureComponent {
         return (
             <View style={style.container}>
                 <StatusBar/>
-                <TouchableWithoutFeedback onPress={this.blur}>
+                <TouchableWithoutFeedback
+                    onPress={this.blur}
+                    accessible={false}
+                >
                     <KeyboardAwareScrollView
                         ref={this.scrollRef}
                         style={style.container}

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -425,7 +425,10 @@ export default class SelectServer extends PureComponent {
                     enabled={Platform.OS === 'ios'}
                 >
                     <StatusBar barStyle={statusStyle}/>
-                    <TouchableWithoutFeedback onPress={this.blur}>
+                    <TouchableWithoutFeedback
+                        onPress={this.blur}
+                        accessible={false}
+                    >
                         <View style={[GlobalStyles.container, GlobalStyles.signupContainer]}>
                             <Image
                                 source={require('assets/images/logo.png')}
@@ -439,6 +442,10 @@ export default class SelectServer extends PureComponent {
                                 />
                             </View>
                             <TextInput
+                                accessibilityLabel={formatMessage({
+                                    id: 'mobile.components.select_server_view.enterServerUrl',
+                                    defaultMessage: 'Enter Server URL',
+                                })}
                                 ref={this.inputRef}
                                 value={url}
                                 editable={!inputDisabled}

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -442,10 +442,6 @@ export default class SelectServer extends PureComponent {
                                 />
                             </View>
                             <TextInput
-                                accessibilityLabel={formatMessage({
-                                    id: 'mobile.components.select_server_view.enterServerUrl',
-                                    defaultMessage: 'Enter Server URL',
-                                })}
                                 ref={this.inputRef}
                                 value={url}
                                 editable={!inputDisabled}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fixes VoiceOver's inability to focus on text inputs on the `select_server` and `login` screens.

`TouchableWithoutFeedback` is by default, accessible, and it overlayed the whole screen, thus preventing VoiceOver from focusing on any inputs. `accessible={false}` fixes that issue.
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-17649
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 
iPhone 6s, 13.3