### PR TITLE
WIP: MM-9746 - display markdown svgs

### DIFF
--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -13,6 +13,7 @@ import {
     Text,
     View,
 } from 'react-native';
+import {SvgUri} from 'react-native-svg';
 
 import FormattedText from 'app/components/formatted_text';
 import ProgressiveImage from 'app/components/progressive_image';
@@ -23,7 +24,7 @@ import mattermostManaged from 'app/mattermost_managed';
 import BottomSheet from 'app/utils/bottom_sheet';
 import ImageCacheManager from 'app/utils/image_cache_manager';
 import {previewImageAtIndex, calculateDimensions, isGifTooLarge} from 'app/utils/images';
-import {normalizeProtocol} from 'app/utils/url';
+import {normalizeProtocol, isSvgLink} from 'app/utils/url';
 
 import brokenImageIcon from 'assets/images/icons/brokenimage.png';
 
@@ -268,6 +269,19 @@ export default class MarkdownImage extends React.Component {
                     </TouchableWithFeedback>
                 );
             }
+        } else if (isSvgLink(this.props.source)) {
+            image = (
+                <TouchableWithFeedback
+                    onLongPress={this.handleLinkLongPress}
+                    onPress={this.handlePreviewImage}
+                >
+                    <SvgUri
+                        width='100%'
+                        height='100'
+                        uri={this.props.source}
+                    />
+                </TouchableWithFeedback>
+            );
         } else if (this.state.failed) {
             image = (
                 <Image

--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -270,6 +270,11 @@ export default class MarkdownImage extends React.Component {
                 );
             }
         } else if (isSvgLink(this.props.source)) {
+            let source = null;
+            if (uri) {
+                source = uri.startsWith('http') ? uri : `file://${uri}`;
+            }
+
             image = (
                 <TouchableWithFeedback
                     onLongPress={this.handleLinkLongPress}
@@ -278,7 +283,7 @@ export default class MarkdownImage extends React.Component {
                     <SvgUri
                         width='100%'
                         height='100'
-                        uri={this.props.source}
+                        uri={source}
                     />
                 </TouchableWithFeedback>
             );

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -62,6 +62,10 @@ export function isImageLink(link) {
     return false;
 }
 
+export function isSvgLink(link) {
+    return link.startsWith('http') && link.endsWith('.svg');
+}
+
 // Converts the protocol of a link (eg. http, ftp) to be lower case since
 // Android doesn't handle uppercase links.
 export function normalizeProtocol(url) {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -291,7 +291,7 @@ PODS:
   - RNSentry (1.2.1):
     - React
     - Sentry (~> 4.4.0)
-  - RNSVG (10.1.0):
+  - RNSVG (11.0.1):
     - React
   - RNVectorIcons (6.6.0):
     - React

--- a/package-lock.json
+++ b/package-lock.json
@@ -12887,9 +12887,9 @@
       "integrity": "sha512-wG9YRcAECGM6i87T1j8mZqGG6FXHTJ8ME6+agweocvXLQqeYOeDyqSiMn+dhtDDJAD7F3JXyMU+tepjcydtvsg=="
     },
     "react-native-svg": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-10.1.0.tgz",
-      "integrity": "sha512-mgo6CshQIQrDDBVUPqJK/iOsJEdlagk7N4q8fyo1sqCiSUP2efpt+AQ1IRXZtHXut210/7TliAamvM59NV0Bzg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-11.0.1.tgz",
+      "integrity": "sha512-XriIwSoe9eTtKyqxpNC6POSOqmXAB9mZQOm5tMoaimEqQOMfzgYrBoF9nY6VPGmaH5dRlWBqnnBf389APiZFcQ==",
       "requires": {
         "css-select": "^2.1.0",
         "css-tree": "^1.0.0-alpha.39"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-section-list-get-item-layout": "2.2.3",
     "react-native-slider": "0.11.0",
     "react-native-status-bar-size": "0.3.3",
-    "react-native-svg": "10.1.0",
+    "react-native-svg": "11.0.1",
     "react-native-v8": "0.61.5-patch.0",
     "react-native-vector-icons": "6.6.0",
     "react-native-video": "5.0.2",


### PR DESCRIPTION
- update svg package
- display svgs when detected

#### Summary
Integrated **react-native-svg** to display inline markdown SVG's.
Enter `[![Mattermost](https://about.mattermost.com/wp-content/uploads/2017/08/Mattermost-Logo-Blue.svg)](https://github.com/mattermost/mattermost-server)` to see svg displayed.

Helped and guidance appreciated because I've noticed multiple issues: 

1. Svg preview is nonexistent if you just enter the SVG url, unlike JPG's: `https://about.mattermost.com/wp-content/uploads/2017/08/Mattermost-Logo-Blue.svg`
2. If you tap on the displayed SVG, the full screen view will show a black screen
3. please review my function `isSvgLink`. It might not cover all the bases correctly.
4. ~~I couldn't use **ImageCacheManager's** image url as **react-native-svg** does not support a local system url, so I'm using `this.props.source`. My understanding of this may be incorrect.~~ (resolved)
5. My hardcoded `height` and `width` currently works for my android and iOS devices, but it may not work on others. A lot of UI testing might be required.

#1 and #2 are features unrelated to the focus of this ticket, in my opinion, as this ticket was made to address specifically Inline **Markdown** SVG's only. 

Would appreciate any suggestions on how I can improve this implementation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9746
Fixes https://github.com/mattermost/mattermost-server/issues/13219

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Has UI changes
#### Device Information
iPhone 6s, 13.3
iPhone XS Max Simulator, 13.3
Google Pixel 2 XL, Android 10

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->