### PR TITLE
MM-22096 Handle links with no server URL provided

### DIFF
--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -103,18 +103,27 @@ export function matchDeepLink(url, serverURL, siteURL) {
         return null;
     }
 
-    const serverURLWithoutProtocol = removeProtocol(serverURL);
-    const siteURLWithoutProtocol = removeProtocol(siteURL);
+    let urlToMatch = url;
 
-    const linkRoot = `(?:${escapeRegex(serverURLWithoutProtocol || siteURLWithoutProtocol)})`;
+    // If url doesn't contain site or server URL, tack it on.
+    // e.g. <jump to convo> URLs from autolink plugin.
+    const urlBase = serverURL || siteURL;
+    let match = new RegExp(escapeRegex(urlBase)).exec(url);
+    if (!match) {
+        urlToMatch = urlBase + url;
+    }
 
-    let match = new RegExp(linkRoot + '\\/([^\\/]+)\\/channels\\/(\\S+)').exec(url);
+    const urlBaseWithoutProtocol = removeProtocol(urlBase);
+
+    const linkRoot = `(?:${escapeRegex(urlBaseWithoutProtocol)})`;
+
+    match = new RegExp(linkRoot + '\\/([^\\/]+)\\/channels\\/(\\S+)').exec(urlToMatch);
 
     if (match) {
         return {type: DeepLinkTypes.CHANNEL, teamName: match[1], channelName: match[2]};
     }
 
-    match = new RegExp(linkRoot + '\\/([^\\/]+)\\/pl\\/(\\w+)').exec(url);
+    match = new RegExp(linkRoot + '\\/([^\\/]+)\\/pl\\/(\\w+)').exec(urlToMatch);
     if (match) {
         return {type: DeepLinkTypes.PERMALINK, teamName: match[1], postId: match[2]};
     }

--- a/app/utils/url.test.js
+++ b/app/utils/url.test.js
@@ -116,6 +116,7 @@ describe('UrlUtils', () => {
             {name: 'should return null if any of the input is null', input: {url: null, serverURL: '', siteURL: ''}, expected: null},
             {name: 'should return null for not supported link', input: {url: 'https://otherserver.com', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: null},
             {name: 'should return null despite url subset match', input: {url: 'http://myserver.com', serverURL: 'http://myserver.co'}, expected: null},
+            {name: 'should match despite no server URL in input link', input: {url: '/ad-1/pl/qe93kkfd7783iqwuwfcwcxbsgy', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: {postId: 'qe93kkfd7783iqwuwfcwcxbsgy', teamName: 'ad-1', type: 'permalink'}},
             {name: 'should match channel link', input: {url: SITE_URL + '/ad-1/channels/town-square', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: {channelName: 'town-square', teamName: 'ad-1', type: 'channel'}},
             {name: 'should match permalink', input: {url: SITE_URL + '/ad-1/pl/qe93kkfd7783iqwuwfcwcxbsgy', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: {postId: 'qe93kkfd7783iqwuwfcwcxbsgy', teamName: 'ad-1', type: 'permalink'}},
             {name: 'should match channel link with deeplink prefix', input: {url: DEEPLINK_URL_ROOT + '/ad-1/channels/town-square', serverURL: SERVER_URL, siteURL: SITE_URL}, expected: {channelName: 'town-square', teamName: 'ad-1', type: 'channel'}},


### PR DESCRIPTION
#### Summary
Default to current server or site URL.

Example case: `<jump to convo>` links generated from autolink plugin have their server/site URL stripped, and it is assumed that generated links are relative to the current server.

Conversation: https://community.mattermost.com/core/pl/78j4a7ozupbci8qxwx1sczc1ua

#### Ticket Links
https://mattermost.atlassian.net/browse/MM-22096

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iPhone 11 simulator
