### PR TITLE
[MM-22078] [MM-22083] Sort emojis in EmojiPicker

### DIFF
--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -94,13 +94,18 @@ export default class EmojiSuggestion extends PureComponent {
 
         const results = await fuse.search(matchTerm.toLowerCase());
         const data = results.map((index) => emojis[index]);
-        this.setEmojiData(data);
+        this.setEmojiData(data, matchTerm);
     };
 
-    setEmojiData = (data) => {
+    setEmojiData = (data, matchTerm = null) => {
+        let sorter = compareEmojis;
+        if (matchTerm) {
+            sorter = (a, b) => compareEmojis(a, b, matchTerm);
+        }
+
         this.setState({
             active: data.length > 0,
-            dataSource: data.sort(compareEmojis),
+            dataSource: data.sort(sorter),
         });
 
         this.props.onResultCountChange(data.length);

--- a/app/components/emoji_picker/emoji_picker_base.js
+++ b/app/components/emoji_picker/emoji_picker_base.js
@@ -212,7 +212,9 @@ export default class EmojiPicker extends PureComponent {
         }
 
         const results = fuse.search(searchTermLowerCase);
-        const data = results.map((index) => emojis[index]).sort(compareEmojis);
+        const sorter = (a, b) => compareEmojis(a, b, searchTerm);
+        const data = results.map((index) => emojis[index]).sort(sorter);
+
         return data;
     };
 

--- a/app/components/emoji_picker/emoji_picker_base.js
+++ b/app/components/emoji_picker/emoji_picker_base.js
@@ -24,6 +24,7 @@ import {
     makeStyleSheetFromTheme,
     changeOpacity,
 } from 'app/utils/theme';
+import {compareEmojis} from 'app/utils/emoji_utils';
 import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
 import EmojiPickerRow from './emoji_picker_row';
 
@@ -211,7 +212,7 @@ export default class EmojiPicker extends PureComponent {
         }
 
         const results = fuse.search(searchTermLowerCase);
-        const data = results.map((index) => emojis[index]);
+        const data = results.map((index) => emojis[index]).sort(compareEmojis);
         return data;
     };
 

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -136,6 +136,14 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     const aName = emojiA.name || (emojiA.aliases ? emojiA.aliases[0] : emojiA);
     const bName = emojiB.name || (emojiB.aliases ? emojiB.aliases[0] : emojiB);
 
+    if (!searchedName) {
+        if (customComparisonRules[aName]) {
+            return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
+        }
+
+        return defaultComparisonRule(aName, bName);
+    }
+
     // Have the emojis that start with the search appear first
     const aPrefix = aName.startsWith(searchedName);
     const bPrefix = bName.startsWith(searchedName);
@@ -144,15 +152,17 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     const aIncludes = aName.includes(searchedName);
     const bIncludes = bName.includes(searchedName);
 
-    if (aPrefix && aPrefix === bPrefix) {
+    if (aPrefix && bPrefix) {
         if (customComparisonRules[aName]) {
             return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
         }
 
-        return defaultComparisonRule(aName, bName, searchedName);
+        return defaultComparisonRule(aName, bName);
     } else if (aPrefix) {
         return -1;
-    } else if (aIncludes === bIncludes) {
+    } else if (bPrefix) {
+        return 1;
+    } else if (aIncludes && bIncludes) {
         if (customComparisonRules[aName]) {
             return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
         }

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -163,7 +163,7 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     } else if (bPrefix) {
         return 1;
     }
-    
+
     // Have the emojis that contain the search appear next
     const aIncludes = aName.includes(searchedName);
     const bIncludes = bName.includes(searchedName);

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -136,9 +136,9 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     const aName = emojiA.name || (emojiA.aliases ? emojiA.aliases[0] : emojiA);
     const bName = emojiB.name || (emojiB.aliases ? emojiB.aliases[0] : emojiB);
 
-    // Have the emojis that contain the search appear first
-    const aPrefix = aName.startsWith(searchedName);
-    const bPrefix = bName.startsWith(searchedName);
+    // Have the emojis that include the search appear first
+    const aPrefix = aName.includes(searchedName);
+    const bPrefix = bName.includes(searchedName);
 
     if (aPrefix === bPrefix) {
         if (customComparisonRules[aName]) {

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -136,17 +136,29 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     const aName = emojiA.name || (emojiA.aliases ? emojiA.aliases[0] : emojiA);
     const bName = emojiB.name || (emojiB.aliases ? emojiB.aliases[0] : emojiB);
 
-    // Have the emojis that include the search appear first
-    const aPrefix = aName.includes(searchedName);
-    const bPrefix = bName.includes(searchedName);
+    // Have the emojis that start with the search appear first
+    const aPrefix = aName.startsWith(searchedName);
+    const bPrefix = bName.startsWith(searchedName);
 
-    if (aPrefix === bPrefix) {
+    // Have the emojis that contain the search appear next
+    const aIncludes = aName.includes(searchedName);
+    const bIncludes = bName.includes(searchedName);
+
+    if (aPrefix && aPrefix === bPrefix) {
         if (customComparisonRules[aName]) {
             return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
         }
 
         return defaultComparisonRule(aName, bName, searchedName);
     } else if (aPrefix) {
+        return -1;
+    } else if (aIncludes === bIncludes) {
+        if (customComparisonRules[aName]) {
+            return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
+        }
+
+        return defaultComparisonRule(aName, bName, searchedName);
+    } else if (aIncludes) {
         return -1;
     }
 

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -132,16 +132,20 @@ const customComparisonRules = {
     '+1': thumbsUpComparisonRule,
 };
 
+function doDefaultComparison(aName, bName) {
+    if (customComparisonRules[aName]) {
+        return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
+    }
+
+    return defaultComparisonRule(aName, bName);
+}
+
 export function compareEmojis(emojiA, emojiB, searchedName) {
     const aName = emojiA.name || (emojiA.aliases ? emojiA.aliases[0] : emojiA);
     const bName = emojiB.name || (emojiB.aliases ? emojiB.aliases[0] : emojiB);
 
     if (!searchedName) {
-        if (customComparisonRules[aName]) {
-            return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
-        }
-
-        return defaultComparisonRule(aName, bName);
+        return doDefaultComparison(aName, bName);
     }
 
     // Have the emojis that start with the search appear first
@@ -170,7 +174,9 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
         return defaultComparisonRule(aName, bName, searchedName);
     } else if (aIncludes) {
         return -1;
+    } else if (bIncludes) {
+        return 1;
     }
 
-    return 1;
+    return doDefaultComparison(aName, bName);
 }

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -153,11 +153,7 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     const bPrefix = bName.startsWith(searchedName);
 
     if (aPrefix && bPrefix) {
-        if (customComparisonRules[aName]) {
-            return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
-        }
-
-        return defaultComparisonRule(aName, bName);
+        return doDefaultComparison(aName, bName);
     } else if (aPrefix) {
         return -1;
     } else if (bPrefix) {
@@ -169,11 +165,7 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     const bIncludes = bName.includes(searchedName);
 
     if (aIncludes && bIncludes) {
-        if (customComparisonRules[aName]) {
-            return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
-        }
-
-        return defaultComparisonRule(aName, bName, searchedName);
+        return doDefaultComparison(aName, bName);
     } else if (aIncludes) {
         return -1;
     } else if (bIncludes) {

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -152,10 +152,6 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
     const aPrefix = aName.startsWith(searchedName);
     const bPrefix = bName.startsWith(searchedName);
 
-    // Have the emojis that contain the search appear next
-    const aIncludes = aName.includes(searchedName);
-    const bIncludes = bName.includes(searchedName);
-
     if (aPrefix && bPrefix) {
         if (customComparisonRules[aName]) {
             return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
@@ -166,7 +162,13 @@ export function compareEmojis(emojiA, emojiB, searchedName) {
         return -1;
     } else if (bPrefix) {
         return 1;
-    } else if (aIncludes && bIncludes) {
+    }
+    
+    // Have the emojis that contain the search appear next
+    const aIncludes = aName.includes(searchedName);
+    const bIncludes = bName.includes(searchedName);
+
+    if (aIncludes && bIncludes) {
         if (customComparisonRules[aName]) {
             return customComparisonRules[aName](bName) || defaultComparisonRule(aName, bName);
         }

--- a/app/utils/emoji_utils.test.js
+++ b/app/utils/emoji_utils.test.js
@@ -411,4 +411,16 @@ describe('compareEmojis', () => {
 
         expect(emojiArray).toEqual([thumbsUpEmoji, thumbsDownEmoji, smileEmoji]);
     });
+
+    test('it sorts emojis that include search term first, then alphabetically', () => {
+        const pointDownEmoji = 'point_down';
+        const paintBrushEmoji = 'paintbrush';
+        const footPrintsEmoji = 'footprints';
+        const sixPointedStarEmoji = 'six_pointed_star';
+
+        const emojiArray = [pointDownEmoji, paintBrushEmoji, footPrintsEmoji, sixPointedStarEmoji];
+        emojiArray.sort((a, b) => compareEmojis(a, b, 'point'));
+
+        expect(emojiArray).toEqual([pointDownEmoji, sixPointedStarEmoji, footPrintsEmoji, paintBrushEmoji]);
+    });
 });

--- a/app/utils/emoji_utils.test.js
+++ b/app/utils/emoji_utils.test.js
@@ -412,15 +412,16 @@ describe('compareEmojis', () => {
         expect(emojiArray).toEqual([thumbsUpEmoji, thumbsDownEmoji, smileEmoji]);
     });
 
-    test('it sorts emojis that include search term first, then alphabetically', () => {
+    test('it sorts emojis that start with search term first, then includes search term, then alphabetically', () => {
         const pointDownEmoji = 'point_down';
         const paintBrushEmoji = 'paintbrush';
         const footPrintsEmoji = 'footprints';
+        const disappointedEmoji = 'disappointed';
         const sixPointedStarEmoji = 'six_pointed_star';
 
-        const emojiArray = [pointDownEmoji, paintBrushEmoji, footPrintsEmoji, sixPointedStarEmoji];
+        const emojiArray = [pointDownEmoji, paintBrushEmoji, footPrintsEmoji, disappointedEmoji, sixPointedStarEmoji];
         emojiArray.sort((a, b) => compareEmojis(a, b, 'point'));
 
-        expect(emojiArray).toEqual([pointDownEmoji, sixPointedStarEmoji, footPrintsEmoji, paintBrushEmoji]);
+        expect(emojiArray).toEqual([pointDownEmoji, disappointedEmoji, sixPointedStarEmoji, footPrintsEmoji, paintBrushEmoji]);
     });
 });

--- a/app/utils/emoji_utils.test.js
+++ b/app/utils/emoji_utils.test.js
@@ -413,15 +413,16 @@ describe('compareEmojis', () => {
     });
 
     test('it sorts emojis that start with search term first, then includes search term, then alphabetically', () => {
+        const printerEmoji = 'printer';
         const pointDownEmoji = 'point_down';
         const paintBrushEmoji = 'paintbrush';
         const footPrintsEmoji = 'footprints';
         const disappointedEmoji = 'disappointed';
         const sixPointedStarEmoji = 'six_pointed_star';
 
-        const emojiArray = [pointDownEmoji, paintBrushEmoji, footPrintsEmoji, disappointedEmoji, sixPointedStarEmoji];
+        const emojiArray = [printerEmoji, pointDownEmoji, paintBrushEmoji, footPrintsEmoji, disappointedEmoji, sixPointedStarEmoji];
         emojiArray.sort((a, b) => compareEmojis(a, b, 'point'));
 
-        expect(emojiArray).toEqual([pointDownEmoji, disappointedEmoji, sixPointedStarEmoji, footPrintsEmoji, paintBrushEmoji]);
+        expect(emojiArray).toEqual([pointDownEmoji, disappointedEmoji, sixPointedStarEmoji, footPrintsEmoji, paintBrushEmoji, printerEmoji]);
     });
 });


### PR DESCRIPTION
#### Summary
Applies the same emoji sorting in `EmojiPicker` as in `EmojiSuggestion` for consistency and passes the search term to `compareEmojis` so that the results are sorted correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22078
https://mattermost.atlassian.net/browse/MM-22083

#### Device Information
This PR was tested on:
* iOS 13.3 

#### Screenshots
`EmojiSuggestion`
![suggestion1](https://user-images.githubusercontent.com/3208014/73278809-6354c600-41a9-11ea-891a-9a9b18654168.png)
![suggestion2](https://user-images.githubusercontent.com/3208014/73278811-6485f300-41a9-11ea-9dcd-c3f6e4fe2da7.png)

`EmojiPicker`
![Screen Shot 2020-01-28 at 12 35 36 PM](https://user-images.githubusercontent.com/3208014/73298721-171a7d80-41cb-11ea-9512-819d484694e3.png)

