### PR TITLE
MM-22165 Fix channel sidebar close gesture

### DIFF
--- a/app/components/sidebars/drawer_layout.js
+++ b/app/components/sidebars/drawer_layout.js
@@ -454,7 +454,7 @@ export default class DrawerLayout extends Component {
     };
 
     _panResponderMove = (e: EventType, { moveX, dx }: PanResponderEventType) => {
-        const useDx = Platform.OS === 'ios' && this.getDrawerPosition() === 'left';
+        const useDx = Platform.OS === 'ios' && this.getDrawerPosition() === 'left' && !this._isClosing;
         let openValue = this._getOpenValueForX(useDx ? dx : moveX);
 
         if (this._isClosing) {


### PR DESCRIPTION
#### Summary
While testing the latest build on iOS is clear how the drawer can be opened by sliding from anywhere in the screen, the open gesture will use the `dx` to keep track of the gesture and position the drawer accordingly, but when closing `dx` will just position the drawer erratically providing a weird behavior.

This PR revert the use of `dx` in favor of `moveX` as it was when the drawer is closing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22165