### PR TITLE
MM-12148: Prevent emdash convert in a Code Block on ios

### DIFF
--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -418,26 +418,14 @@ export default class PostTextBoxBase extends PureComponent {
         const cursorIsInsideCodeBlock = matches.some((match) => cursorPosition >= match.startOfMatch && cursorPosition <= match.endOfMatch);
 
         // 'email-address' keyboardType prevents iOS emdash autocorrect
-        if (cursorIsInsideCodeBlock) {
-            this.setState({
-                cursorPosition,
-                keyboardType: 'email-address',
-            });
-        } else {
-            this.setState({
-                cursorPosition,
-                keyboardType: 'default',
-            });
-        }
+        this.setState({
+            cursorPosition,
+            keyboardType: cursorIsInsideCodeBlock ? 'email-address' : 'default',
+        });
     };
 
     handlePostDraftSelectionChanged = (event, fromHandleTextChange) => {
-        let cursorPosition;
-        if (fromHandleTextChange) {
-            cursorPosition = this.state.cursorPosition;
-        } else {
-            cursorPosition = event.nativeEvent.selection.end;
-        }
+        const cursorPosition = fromHandleTextChange ? this.state.cursorPosition : event.nativeEvent.selection.end;
 
         const {cursorPositionEvent} = this.props;
 
@@ -448,9 +436,7 @@ export default class PostTextBoxBase extends PureComponent {
         if (Platform.OS === 'ios') {
             this.switchKeyboardForCodeBlocks(fromHandleTextChange, cursorPosition);
         } else {
-            this.setState({
-                cursorPosition,
-            });
+            this.setState({cursorPosition});
         }
     };
 

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -407,17 +407,68 @@ export default class PostTextBoxBase extends PureComponent {
         }
     };
 
-    handlePostDraftSelectionChanged = (event) => {
-        const cursorPosition = event.nativeEvent.selection.end;
+    handlePostDraftSelectionChanged = (event, fromHandleTextChange) => {
+        let cursorPosition;
+
+        // When called from PasteableTextInput's onSelectionChange, nativeEvent gets passsed with
+        // updated cursorPosition. When called fromHandleTextChange, there's no nativeEvent passed but
+        // cursorPosition is already updated and available in state.
+        if (fromHandleTextChange) {
+            cursorPosition = this.state.cursorPosition;
+        } else {
+            cursorPosition = event.nativeEvent.selection.end;
+        }
+
         const {cursorPositionEvent} = this.props;
 
         if (cursorPositionEvent) {
             EventEmitter.emit(cursorPositionEvent, cursorPosition);
         }
 
-        this.setState({
-            cursorPosition,
-        });
+        // Workaround to avoid iOS emdash autocorrect in Code Blocks
+        if (Platform.OS === 'ios') {
+            // Matches all text between a pair of triple backticks ```, inclusive
+            // OR all text after a dangling triple backtick ```, inclusive
+            // Triple backticks must also be on their own separate line to be matched
+            const regexForCodeBlock = /^```$(.*?)^```$|^```$(.*)/gms;
+
+            // Loop through this.state.value and create array of all regex match positions, start and end
+            // exec() method details: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
+            const matches = [];
+            let match;
+            while ((match = regexForCodeBlock.exec(this.state.value)) !== null) {
+                matches.push({
+                    start: regexForCodeBlock.lastIndex - match[0].length, // start position of a regex match
+                    end: fromHandleTextChange ? regexForCodeBlock.lastIndex : regexForCodeBlock.lastIndex + 1, // end position of a regex match
+                });
+            }
+
+            // Check if current cursor position is within the bounds of a matched triple backtick (```) Code Block
+            let insideCodeBlock = false;
+            for (let i = 0; i < matches.length; i++) {
+                if (cursorPosition >= matches[i].start && cursorPosition <= matches[i].end) {
+                    insideCodeBlock = true;
+                    break;
+                }
+            }
+
+            // 'email-address' keyboardType prevents iOS emdash autocorrect
+            if (insideCodeBlock) {
+                this.setState({
+                    cursorPosition,
+                    keyboardType: 'email-address',
+                });
+            } else {
+                this.setState({
+                    cursorPosition,
+                    keyboardType: 'default',
+                });
+            }
+        } else {
+            this.setState({
+                cursorPosition,
+            });
+        }
     };
 
     handleSendMessage = () => {
@@ -515,7 +566,13 @@ export default class PostTextBoxBase extends PureComponent {
 
         this.checkMessageLength(value);
 
-        this.setState(nextState);
+        // Workaround to avoid iOS emdash autocorrect in Code Blocks
+        if (Platform.OS === 'ios') {
+            const callback = () => this.handlePostDraftSelectionChanged(null, true);
+            this.setState(nextState, callback);
+        } else {
+            this.setState(nextState);
+        }
 
         if (value) {
             actions.userTyping(channelId, rootId);
@@ -891,7 +948,7 @@ export default class PostTextBoxBase extends PureComponent {
                         ref={this.input}
                         value={textValue}
                         onChangeText={this.handleTextChange}
-                        onSelectionChange={this.handlePostDraftSelectionChanged}
+                        onSelectionChange={(event) => this.handlePostDraftSelectionChanged(event, false)}
                         placeholder={intl.formatMessage(placeholder, {channelDisplayName})}
                         placeholderTextColor={changeOpacity(theme.centerChannelColor, 0.5)}
                         multiline={true}

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -408,9 +408,9 @@ export default class PostTextBoxBase extends PureComponent {
         }
     };
 
-    handleOnSelectionChange = (e) => {
-        if (e) {
-            this.handlePostDraftSelectionChanged(e, false);
+    handleOnSelectionChange = (event) => {
+        if (event) {
+            this.handlePostDraftSelectionChanged(event, false);
         }
     };
 

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -409,9 +409,7 @@ export default class PostTextBoxBase extends PureComponent {
     };
 
     handleOnSelectionChange = (event) => {
-        if (event) {
-            this.handlePostDraftSelectionChanged(event, false);
-        }
+        this.handlePostDraftSelectionChanged(event, false);
     };
 
     handlePostDraftSelectionChanged = (event, fromHandleTextChange) => {

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -432,28 +432,15 @@ export default class PostTextBoxBase extends PureComponent {
             // Triple backticks must also be on their own separate line to be matched
             const regexForCodeBlock = /^```$(.*?)^```$|^```$(.*)/gms;
 
-            // Loop through this.state.value and create array of all regex match positions, start and end
-            // exec() method details: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
-            const matches = [];
-            let match;
-            while ((match = regexForCodeBlock.exec(this.state.value)) !== null) {
-                matches.push({
-                    start: regexForCodeBlock.lastIndex - match[0].length, // start position of a regex match
-                    end: fromHandleTextChange ? regexForCodeBlock.lastIndex : regexForCodeBlock.lastIndex + 1, // end position of a regex match
-                });
-            }
+            const matches = [...this.state.value.matchAll(regexForCodeBlock)].map((match) => ({
+                startOfMatch: match.index,
+                endOfMatch: fromHandleTextChange ? match.index + match[0].length : match.index + match[0].length + 1,
+            }));
 
-            // Check if current cursor position is within the bounds of a matched triple backtick (```) Code Block
-            let insideCodeBlock = false;
-            for (let i = 0; i < matches.length; i++) {
-                if (cursorPosition >= matches[i].start && cursorPosition <= matches[i].end) {
-                    insideCodeBlock = true;
-                    break;
-                }
-            }
+            const cursorIsInsideCodeBlock = matches.some((match) => cursorPosition >= match.startOfMatch && cursorPosition <= match.endOfMatch);
 
             // 'email-address' keyboardType prevents iOS emdash autocorrect
-            if (insideCodeBlock) {
+            if (cursorIsInsideCodeBlock) {
                 this.setState({
                     cursorPosition,
                     keyboardType: 'email-address',

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -18,6 +18,7 @@ import Loading from 'app/components/loading';
 import StatusBar from 'app/components/status_bar';
 import TextInputWithLocalizedPlaceholder from 'app/components/text_input_with_localized_placeholder';
 import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
+import {switchKeyboardForCodeBlocks} from 'app/utils/markdown';
 import {
     changeOpacity,
     makeStyleSheetFromTheme,
@@ -167,28 +168,18 @@ export default class EditPost extends PureComponent {
         }
     };
 
-    switchKeyboardForCodeBlocks = (fromOnPostChangeText, cursorPosition) => {
-        const regexForCodeBlock = /^```$(.*?)^```$|^```$(.*)/gms;
-
-        const matches = [...this.state.message.matchAll(regexForCodeBlock)].map((match) => ({
-            startOfMatch: match.index,
-            endOfMatch: fromOnPostChangeText ? match.index + match[0].length : match.index + match[0].length + 1,
-        }));
-
-        const cursorIsInsideCodeBlock = matches.some((match) => cursorPosition >= match.startOfMatch && cursorPosition <= match.endOfMatch);
-
-        // 'email-address' keyboardType prevents iOS emdash autocorrect
-        this.setState({
-            cursorPosition,
-            keyboardType: cursorIsInsideCodeBlock ? 'email-address' : 'default',
-        });
+    handleOnSelectionChange = (e) => {
+        if (e) {
+            this.onPostSelectionChange(e, false);
+        }
     };
 
     onPostSelectionChange = (event, fromOnPostChangeText) => {
         const cursorPosition = fromOnPostChangeText ? this.state.cursorPosition : event.nativeEvent.selection.end;
 
         if (Platform.OS === 'ios') {
-            this.switchKeyboardForCodeBlocks(fromOnPostChangeText, cursorPosition);
+            const keyboardType = switchKeyboardForCodeBlocks(this.state.message, cursorPosition);
+            this.setState({cursorPosition, keyboardType});
         } else {
             this.setState({cursorPosition});
         }
@@ -250,7 +241,7 @@ export default class EditPost extends PureComponent {
                             underlineColorAndroid='transparent'
                             disableFullscreenUI={true}
                             keyboardAppearance={getKeyboardAppearanceFromTheme(this.props.theme)}
-                            onSelectionChange={(event) => this.onPostSelectionChange(event, false)}
+                            onSelectionChange={this.handleOnSelectionChange}
                             keyboardType={this.state.keyboardType}
                         />
                     </View>

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -169,9 +169,7 @@ export default class EditPost extends PureComponent {
     };
 
     handleOnSelectionChange = (event) => {
-        if (event) {
-            this.onPostSelectionChange(event, false);
-        }
+        this.onPostSelectionChange(event, false);
     };
 
     onPostSelectionChange = (event, fromOnPostChangeText) => {

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -168,9 +168,9 @@ export default class EditPost extends PureComponent {
         }
     };
 
-    handleOnSelectionChange = (e) => {
-        if (e) {
-            this.onPostSelectionChange(e, false);
+    handleOnSelectionChange = (event) => {
+        if (event) {
+            this.onPostSelectionChange(event, false);
         }
     };
 

--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -182,3 +182,24 @@ export function getDisplayNameForLanguage(language) {
 export function escapeRegex(text) {
     return text.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
+
+export function switchKeyboardForCodeBlocks(value, cursorPosition) {
+    const regexForCodeBlock = /^```$(.*?)^```$|^```$(.*)/gms;
+
+    const matches = [];
+    let nextMatch;
+    while ((nextMatch = regexForCodeBlock.exec(value)) !== null) {
+        matches.push({
+            startOfMatch: regexForCodeBlock.lastIndex - nextMatch[0].length,
+            endOfMatch: regexForCodeBlock.lastIndex + 1,
+        });
+    }
+
+    const cursorIsInsideCodeBlock = matches.some((match) => cursorPosition >= match.startOfMatch && cursorPosition <= match.endOfMatch);
+
+    // 'email-address' keyboardType prevents iOS emdash autocorrect
+    if (cursorIsInsideCodeBlock) {
+        return 'email-address';
+    }
+    return 'default';
+}

--- a/app/utils/markdown.test.js
+++ b/app/utils/markdown.test.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {switchKeyboardForCodeBlocks} from './markdown';
+
+describe('switchKeyboardForCodeBlocks', () => {
+    const testCases = [{
+        name: 'Empty text input',
+        value: '',
+        cursorPosition: 0,
+        expected: 'default',
+    }, {
+        name: 'Cursor within an open Code Block',
+        value: '```',
+        cursorPosition: 3,
+        expected: 'email-address',
+    }, {
+        name: 'Cursor within a closed Code Block',
+        value: '```\ntest\n```',
+        cursorPosition: 4,
+        expected: 'email-address',
+    }, {
+        name: 'Cursor outside AFTER a closed Code Block',
+        value: '```\ntest\n```\ntest',
+        cursorPosition: 14,
+        expected: 'default',
+    }, {
+        name: 'Cursor outside BEFORE a closed Code Block',
+        value: 'test\n```\ntest\n```',
+        cursorPosition: 4,
+        expected: 'default',
+    }, {
+        name: 'Cursor outside BEFORE an open Code Block',
+        value: 'test\n```',
+        cursorPosition: 4,
+        expected: 'default',
+    }, {
+        name: 'Cursor outside between two Code Blocks',
+        value: '```\ntest\n```\ntest\n```\ntest',
+        cursorPosition: 14,
+        expected: 'default',
+    }, {
+        name: 'Opening triple backtick not on its own line - text after backticks',
+        value: '```test',
+        cursorPosition: 3,
+        expected: 'default',
+    }, {
+        name: 'Opening triple backtick not on its own line - text before backticks',
+        value: 'test```',
+        cursorPosition: 7,
+        expected: 'default',
+    }, {
+        name: 'Closing triple backtick not on its own line - text after backticks',
+        value: '```\ntest\n```test',
+        cursorPosition: 12,
+        expected: 'email-address',
+    }, {
+        name: 'Closing triple backtick not on its own line - text before backticks',
+        value: '```\ntest\ntest```',
+        cursorPosition: 16,
+        expected: 'email-address',
+    }];
+
+    for (const testCase of testCases) {
+        it(`test - ${testCase.name}`, () => {
+            expect(switchKeyboardForCodeBlocks(testCase.value, testCase.cursorPosition)).toEqual(testCase.expected);
+        });
+    }
+});


### PR DESCRIPTION
#### Summary
This PR adds a fix to prevent iOS from converting double dash (--) / triple dash (---) to an emdash (–) while typing a Code Block (w/ triple backtick ``` markdown). 

The iOS smart dash behavior occurs based on the keyboard type ( ‘default’). The proposed solution here is to change keyboardType to ‘email-address’ when cursorPosition is within the bounds of a Code Block and back to ‘default’ when otherwise.

The TextInput’s onSelectionChange handles cursor movements without key strokes. The TextInput’s onChangeText handles cursor movements upon new keystrokes once the TextInput’s (state) value has finished updating.

#### Ticket Link
Ticket https://mattermost.atlassian.net/browse/MM-12148
Fixes https://github.com/mattermost/mattermost-server/issues/9432

#### Checklist
- [x] Has UI changes - keyboardType changes while typing a Code Block

#### Device Information
This PR was tested on: iPhone 7 simulator, 13.0;  iPhone 11 simulator, 13.0

#### Screenshots
![emdash](https://user-images.githubusercontent.com/20244930/73701800-91517300-469f-11ea-81c6-48e126e39f70.gif)
