### PR TITLE
[MM-22300] Use dismissModal to close ChannelInfo screen

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -18,7 +18,7 @@ import {preventDoubleTap} from 'app/utils/tap';
 import {alertErrorWithFallback} from 'app/utils/general';
 import {changeOpacity, makeStyleSheetFromTheme, setNavigatorStyles} from 'app/utils/theme';
 import {t} from 'app/utils/i18n';
-import {dismissModal, goToScreen, popTopScreen, showModalOverCurrentContext} from 'app/actions/navigation';
+import {dismissModal, goToScreen, showModalOverCurrentContext} from 'app/actions/navigation';
 
 import pinIcon from 'assets/images/channel_info/pin.png';
 
@@ -127,7 +127,7 @@ export default class ChannelInfo extends PureComponent {
             actions.setChannelDisplayName('');
         }
 
-        popTopScreen();
+        dismissModal();
     };
 
     goToChannelAddMembers = preventDoubleTap(() => {

--- a/app/screens/channel_info/channel_info.test.js
+++ b/app/screens/channel_info/channel_info.test.js
@@ -6,6 +6,8 @@ import {shallow} from 'enzyme';
 import Preferences from 'mattermost-redux/constants/preferences';
 import {General} from 'mattermost-redux/constants';
 
+import * as NavigationActions from 'app/actions/navigation';
+
 import ChannelInfo from './channel_info';
 
 // ChannelInfoRow expects to receive the pinIcon as a number
@@ -149,4 +151,19 @@ describe('channel_info', () => {
         const render = instance.renderConvertToPrivateRow();
         expect(render).toBeFalsy();
     });
+
+    test('should dismiss modal on close', () => {
+        const dismissModal = jest.spyOn(NavigationActions, 'dismissModal');
+        const wrapper = shallow(
+            <ChannelInfo
+                {...baseProps}
+            />,
+            {context: {intl: intlMock}},
+        );
+
+        const instance = wrapper.instance();
+        expect(dismissModal).not.toHaveBeenCalled();
+        instance.close();
+        expect(dismissModal).toHaveBeenCalled();
+    })
 });

--- a/app/screens/channel_info/channel_info.test.js
+++ b/app/screens/channel_info/channel_info.test.js
@@ -165,5 +165,5 @@ describe('channel_info', () => {
         expect(dismissModal).not.toHaveBeenCalled();
         instance.close();
         expect(dismissModal).toHaveBeenCalled();
-    })
+    });
 });


### PR DESCRIPTION
#### Summary
Since the ChannelInfo screen is now opened as a modal it must be closed as a modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22300

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Galaxy S7, Android 8