### PR TITLE
[MM-22301] Fix typo in error.message

### DIFF
--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -312,7 +312,7 @@ export default class Downloader extends PureComponent {
                     // do nothing
                 });
             }
-            if (error.message !== 'cancelled' && this.mounted) {
+            if (error.message !== 'canceled' && this.mounted) {
                 this.showDownloadFailedAlert();
             } else {
                 this.downloadDidCancel();


### PR DESCRIPTION
#### Summary
Typo when checking `error.message` caused `showDownloadFailedAlert` to be called.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22301

#### Device Information
This PR was tested on:
* Galaxy S7, Android 8