### PR TITLE
[MM-22120] Dispatch loadConfigAndLicense on launchApp

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -8,7 +8,7 @@ import {Provider} from 'react-redux';
 import {loadMe} from 'mattermost-redux/actions/users';
 
 import {resetToChannel, resetToSelectServer} from 'app/actions/navigation';
-import {setDeepLinkURL} from 'app/actions/views/root';
+import {setDeepLinkURL, loadConfigAndLicense} from 'app/actions/views/root';
 import {getAppCredentials} from 'app/init/credentials';
 import emmProvider from 'app/init/emm_provider';
 import 'app/init/device';
@@ -48,7 +48,8 @@ const launchApp = (credentials) => {
     ]);
 
     if (credentials) {
-        waitForHydration(store, () => {
+        waitForHydration(store, async () => {
+            await store.dispatch(loadConfigAndLicense());
             store.dispatch(loadMe());
             resetToChannel({skipMetrics: true});
         });


### PR DESCRIPTION
#### Summary
The problem where all DM/GDM are shown in the left sidebar occurs when certain config keys are missing and this seems to only happen when the default config, usually returned when a server is selected, overrides a previous config. This probably happens as a consequence of not yet having credentials loaded so the config fetch is not authenticated, returning the default config. To avoid this possible (but not easily reproducible) scenario, we call `loadConfigAndLicense` after the app launches and the credentials have loaded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22120

#### Device Information
Sven has been testing on his Android device since Sunday and has not yet experienced the issue.
