### PR TITLE
MM-20184 Remove ios drawer hack and Fix right drawer partially shown …

### DIFF
--- a/app/components/sidebars/drawer_layout.js
+++ b/app/components/sidebars/drawer_layout.js
@@ -120,16 +120,6 @@ export default class DrawerLayout extends Component {
 
     componentDidMount() {
         Dimensions.addEventListener('change', this.handleDimensionsChange);
-        if (Platform.OS === 'ios') {
-            // on iOS force closing the drawers to prevent them for partially showing
-            // when channging the device orientation, probably caused by RN61
-            Animated.timing(this.openValue, {
-                toValue: 0,
-                duration: 10,
-                easing: Easing.out(Easing.cubic),
-                useNativeDriver: this.props.useNativeAnimations,
-            }).start();
-        }
     }
 
     componentWillUnmount() {
@@ -198,9 +188,12 @@ export default class DrawerLayout extends Component {
         };
         /* Drawer styles */
         let outputRange;
-        // ios main sidebar sits mostly under the main screen, with slight move
-        const translateDistance = Platform.OS === 'ios' && drawerPosition === 'left' ?
-            Math.floor(drawerWidth * 0.2) : drawerWidth
+        let translateDistance = drawerWidth;
+        if (Platform.OS === 'ios') {
+            // ios main sidebar sits mostly under the main screen, with slight move
+            translateDistance = drawerPosition === 'left' ?
+            Math.floor(drawerWidth * 0.2) : Math.floor(drawerWidth * 1.2)
+        }
 
         if (this.getDrawerPosition() === 'left') {
             outputRange = [-translateDistance, 0];


### PR DESCRIPTION
#### Summary
on iOS we added a hack that animated the drawers to the initial position cause they were being partially  shown when changing orientation. The actual fix is to add a correction to the translateDistance

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20184