### PR TITLE
MM-22375: Remove mark as unread post option in archived channels

### DIFF
--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -45,8 +45,8 @@ export function makeMapStateToProps() {
         const reactions = getReactionsForPostSelector(state, post.id);
         const channelIsArchived = channel.delete_at !== 0;
         const {serverVersion} = state.entities.general;
-        const canMarkAsUnread = isMinimumServerVersion(serverVersion, 5, 18);
 
+        let canMarkAsUnread = true;
         let canAddReaction = true;
         let canReply = true;
         let canCopyPermalink = true;
@@ -105,6 +105,10 @@ export function makeMapStateToProps() {
 
         if (reactions && Object.values(reactions).length >= MAX_ALLOWED_REACTIONS) {
             canAddReaction = false;
+        }
+
+        if (!isMinimumServerVersion(serverVersion, 5, 18) || channelIsArchived) {
+            canMarkAsUnread = false;
         }
 
         return {

--- a/app/screens/post_options/index.test.js
+++ b/app/screens/post_options/index.test.js
@@ -9,6 +9,7 @@ import * as commonSelectors from 'mattermost-redux/selectors/entities/common';
 import * as teamSelectors from 'mattermost-redux/selectors/entities/teams';
 import * as deviceSelectors from 'app/selectors/device';
 import * as preferencesSelectors from 'mattermost-redux/selectors/entities/preferences';
+import * as postUtils from 'mattermost-redux/utils/post_utils';
 
 channelSelectors.getChannel = jest.fn();
 channelSelectors.getCurrentChannelId = jest.fn();
@@ -23,6 +24,7 @@ teamSelectors.getCurrentTeamUrl = jest.fn();
 deviceSelectors.getDimensions = jest.fn();
 deviceSelectors.isLandscape = jest.fn();
 preferencesSelectors.getTheme = jest.fn();
+postUtils.canEditPost = jest.fn();
 
 describe('makeMapStateToProps', () => {
     const baseState = {
@@ -69,10 +71,22 @@ describe('makeMapStateToProps', () => {
         expect(props.canFlag).toBe(true);
     });
 
-    test('canMarkAsUnread is true when isMinimumServerVersion is 5.18v', () => {
+    test('canMarkAsUnread is true when isMinimumServerVersion is 5.18v and channel not archived', () => {
+        channelSelectors.getChannel = jest.fn().mockReturnValueOnce({
+            delete_at: 0,
+        });
         const mapStateToProps = makeMapStateToProps();
         const props = mapStateToProps(baseState, baseOwnProps);
         expect(props.canMarkAsUnread).toBe(true);
+    });
+
+    test('canMarkAsUnread is false when channel is archived', () => {
+        channelSelectors.getChannel = jest.fn().mockReturnValueOnce({
+            delete_at: 1,
+        });
+        const mapStateToProps = makeMapStateToProps();
+        const props = mapStateToProps(baseState, baseOwnProps);
+        expect(props.canMarkAsUnread).toBe(false);
     });
 
     test('canMarkAsUnread is false when isMinimumServerVersion is not 5.18v', () => {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR removes the option to "Mark as Unread" after long pressing on posts in Archived Channels. This also removes the "Mark as Unread" option after long pressing on the post in search results. This functionality was removed in the webapp and needed parity on mobile.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.
Otherwise, link the JIRA ticket.
-->
Ticket https://mattermost.atlassian.net/browse/MM-22375
Fixes https://github.com/mattermost/mattermost-server/issues/13872

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: iPhone 11 simulator, 13.0

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->
![RemoveMarkAsUnread](https://user-images.githubusercontent.com/20244930/74465166-c00edc80-4e49-11ea-88ae-1acefc101e6f.gif)
