### PR TITLE
[MM-22621] Select default team if channel request failed for current team

### DIFF
--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -134,6 +134,12 @@ export default class ChannelBase extends PureComponent {
         if (LocalConfig.EnableMobileClientUpgrade && !ClientUpgradeListener) {
             ClientUpgradeListener = require('app/components/client_upgrade_listener').default;
         }
+
+        if (this.props.currentTeamId &&
+            nextProps.channelsRequestFailed &&
+            nextProps.channelsRequestFailed !== this.props.channelsRequestFailed) {
+            this.props.actions.selectDefaultTeam();
+        }
     }
 
     componentDidUpdate(prevProps) {

--- a/app/screens/channel/channel_base.test.js
+++ b/app/screens/channel/channel_base.test.js
@@ -21,7 +21,7 @@ describe('ChannelBase', () => {
     const componentIds = ['component-1', 'component-2', 'component-3'];
     const baseProps = {
         actions: {
-            loadChannelsIfNecessary: jest.fn(),
+            loadChannelsIfNecessary: jest.fn().mockResolvedValue(),
             loadProfilesAndTeamMembersForDMSidebar: jest.fn(),
             selectDefaultTeam: jest.fn(),
             selectInitialChannel: jest.fn(),
@@ -78,5 +78,20 @@ describe('ChannelBase', () => {
             [componentIds[1], newThemeOptions],
             [componentIds[0], newThemeOptions],
         ]);
+    });
+
+    test('should call selectDefaultTeam if the channel request failed but there is a current team id', () => {
+        const props = {
+            ...baseProps,
+            currentTeamId: 'current-team-id',
+            channelsRequestFailed: false,
+        };
+        const wrapper = shallow(
+            <ChannelBase {...props}/>,
+        );
+
+        expect(baseProps.actions.selectDefaultTeam).not.toHaveBeenCalled();
+        wrapper.setProps({channelsRequestFailed: true});
+        expect(baseProps.actions.selectDefaultTeam).toHaveBeenCalled();
     });
 });

--- a/app/screens/channel/channel_base.test.js
+++ b/app/screens/channel/channel_base.test.js
@@ -83,15 +83,23 @@ describe('ChannelBase', () => {
     test('should call selectDefaultTeam if the channel request failed but there is a current team id', () => {
         const props = {
             ...baseProps,
-            currentTeamId: 'current-team-id',
+            currentTeamId: null,
             channelsRequestFailed: false,
         };
         const wrapper = shallow(
             <ChannelBase {...props}/>,
         );
 
-        expect(baseProps.actions.selectDefaultTeam).not.toHaveBeenCalled();
-        wrapper.setProps({channelsRequestFailed: true});
-        expect(baseProps.actions.selectDefaultTeam).toHaveBeenCalled();
+        // First call is in componentDidMount
+        expect(baseProps.actions.selectDefaultTeam).toHaveBeenCalledTimes(1);
+
+        wrapper.setProps({currentTeamId: null, channelsRequestFailed: true});
+        expect(baseProps.actions.selectDefaultTeam).toHaveBeenCalledTimes(1);
+
+        wrapper.setProps({currentTeamId: 'current-team-id', channelsRequestFailed: false});
+        expect(baseProps.actions.selectDefaultTeam).toHaveBeenCalledTimes(1);
+
+        wrapper.setProps({currentTeamId: 'current-team-id', channelsRequestFailed: true});
+        expect(baseProps.actions.selectDefaultTeam).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
#### Summary
Because the currentTeamId still references a team that the user is no longer a member of, the request to retrieve the team's channels and channel members fails and no request is made to update currentTeamId. This leaves the app in an unusable state. Calling `selectDefaultTeam` in this case fixes the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22621

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android Q emulator