### PR TITLE
[MM-22629] Center-align tall & thin image attachments

### DIFF
--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -186,13 +186,8 @@ const style = StyleSheet.create({
     smallImageOverlay: {
         ...StyleSheet.absoluteFill,
         justifyContent: 'center',
-        borderRadius: 4,
-    },
-    loaderContainer: {
-        position: 'absolute',
-        height: '100%',
-        width: '100%',
         alignItems: 'center',
+        borderRadius: 4,
     },
     singleSmallImageWrapper: {
         height: SMALL_IMAGE_MAX_HEIGHT,


### PR DESCRIPTION
#### Summary

Visual treatment of "tall & thin" image attachments (width < 48 pixels) was pushed left-aligned, instead of center-aligned.

Regression introduced by #3807 

Bug reported in community: https://community.mattermost.com/core/pl/yy39ajg1ajfm386dms6tdyjrtw

#### Ticket Link
[MM-22629](https://mattermost.atlassian.net/browse/MM-22629)

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: Android 10 Simulator (Pixel 3)

#### Screenshots

| Old | New |
| --- | --- |
| <img width="373" alt="Old" src="https://user-images.githubusercontent.com/887849/74672081-451c2d80-518b-11ea-9db1-82b84c58653b.jpg"> | <img width="373" alt="New" src="https://user-images.githubusercontent.com/887849/74672164-73017200-518b-11ea-81e4-7b597c630d7c.png"> |
