### PR TITLE
Automated cherry pick of #3935

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         missingDimensionStrategy "RNN.reactNativeVersion", "reactNative60"
         versionCode 268
-        versionName "1.28.0"
+        versionName "1.29.0"
         multiDexEnabled = true
         ndk {
             abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/MattermostShare/Info.plist
+++ b/ios/MattermostShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleVersion</key>
 	<string>268</string>
 	<key>NSAppTransportSecurity</key>

--- a/ios/MattermostTests/Info.plist
+++ b/ios/MattermostTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/NotificationService/Info.plist
+++ b/ios/NotificationService/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleVersion</key>
 	<string>268</string>
 	<key>NSExtension</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-mobile",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-mobile",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Mattermost Mobile with React Native",
   "repository": "git@github.com:mattermost/mattermost-mobile.git",
   "author": "Mattermost, Inc.",


### PR DESCRIPTION
Cherry pick of #3935 on release-1.29.

- #3935: Bump app version number to 1.29.0

/cc  @migbot