### PR TITLE
[MM-21355] Add set_online=false query param

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
@@ -63,7 +63,6 @@ public class NotificationReplyBroadcastReceiver extends BroadcastReceiver {
                         String token = map.getString("password");
                         String serverUrl = map.getString("service");
 
-                        Log.i("ReactNative", String.format("URL=%s", serverUrl));
                         replyToMessage(serverUrl, token, notificationId, message);
                     }
                 }
@@ -88,12 +87,16 @@ public class NotificationReplyBroadcastReceiver extends BroadcastReceiver {
         final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
         String json = buildReplyPost(channelId, rootId, message.toString());
         RequestBody body = RequestBody.create(JSON, json);
+
+        String postsEndpoint = "/api/v4/posts?set_online=false";
+        String url = String.format("%s%s", serverUrl.replaceAll("/$", ""), postsEndpoint);
+        Log.i("ReactNative", String.format("Reply URL=%s", url));
         Request request = new Request.Builder()
-                .header("Authorization", String.format("Bearer %s", token))
-                .header("Content-Type", "application/json")
-                .url(String.format("%s/api/v4/posts", serverUrl.replaceAll("/$", "")))
-                .post(body)
-                .build();
+            .header("Authorization", String.format("Bearer %s", token))
+            .header("Content-Type", "application/json")
+            .url(url)
+            .post(body)
+            .build();
 
         client.newCall(request).enqueue(new okhttp3.Callback() {
             @Override

--- a/ios/Mattermost/RNNotificationEventHandler+HandleReplyAction.m
+++ b/ios/Mattermost/RNNotificationEventHandler+HandleReplyAction.m
@@ -71,9 +71,10 @@ NSString *const ReplyActionID = @"REPLY_ACTION";
     [self handleReplyFailure:channelId completionHandler:notificationCompletionHandler];
     return;
   }
-  
-  NSString *urlString = [NSString stringWithFormat:@"%@/api/v4/posts", serverUrl];
-  NSURL *url = [NSURL URLWithString:urlString];
+
+  NSString *urlString = [serverUrl stringByReplacingOccurrencesOfString:@"/$" withString:@"" options:NSRegularExpressionSearch range:NSMakeRange(0, [serverUrl length])];
+  NSString *postsEndpoint = @"/api/v4/posts?set_online=false";
+  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlString, postsEndpoint]];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
   [request setHTTPMethod:@"POST"];
   [request setValue:[NSString stringWithFormat:@"Bearer %@", sessionToken] forHTTPHeaderField:@"Authorization"];


### PR DESCRIPTION
#### Summary
Passing `set_online=false` in the post request sent when replying from a push notification so that the user's status is not set to online. ~~I've confirmed that a v5.20 server parses the query param and does not call `c.App.SetStatusOnline`, however, the user's status is still set to online. This might be the server not working properly...I'm still investigating and will add a QA reviewer once I can confirm the server fix for it.~~ The status in the database remains `offline` for the user, however, the webapp displays the user as online for some time after receiving the reply. I've created the following ticket for that issue: https://mattermost.atlassian.net/browse/MM-22706

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21355

#### Device Information
This PR was tested on:
* Android Q emulator
* iPhone 7, iOS 13.3