### PR TITLE
MM-15272: Add closed channels, GMs, DMs, and active users to share extension 

### DIFF
--- a/ios/MattermostShare/ChannelsViewController.swift
+++ b/ios/MattermostShare/ChannelsViewController.swift
@@ -28,6 +28,7 @@ class ChannelsViewController: UIViewController {
   var footerLabel = UILabel()
   var indicator = UIActivityIndicatorView()
   var dispatchGroup = DispatchGroup()
+  var indicatorShown = false
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
@@ -76,10 +77,12 @@ class ChannelsViewController: UIViewController {
     footerFrame.addSubview(indicator)
     
     tableView.tableFooterView = footerFrame
+    indicatorShown = true
   }
   
   func hideActivityIndicator() {
     tableView.tableFooterView = nil
+    indicatorShown = false
     self.tableView.reloadData()
   }
   
@@ -130,7 +133,7 @@ extension ChannelsViewController: UITableViewDataSource {
       }
     }
     
-    if (empty) {
+    if (empty && !indicatorShown) {
       let noDataLabel: UILabel  = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.bounds.size.width, height: tableView.bounds.size.height))
       noDataLabel.text          = "No Results Found"
       noDataLabel.textColor     = UIColor.systemGray

--- a/ios/MattermostShare/Item.swift
+++ b/ios/MattermostShare/Item.swift
@@ -4,4 +4,5 @@ final class Item {
   var id: String?
   var title: String?
   var selected: Bool = false
+  var notCreatedYet: Bool = false
 }

--- a/ios/MattermostShare/TeamsViewController.swift
+++ b/ios/MattermostShare/TeamsViewController.swift
@@ -21,6 +21,14 @@ class TeamsViewController: UIViewController {
     view.addSubview(tableView)
   }
   
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    if #available(iOS 11.0, *) {
+      navigationItem.hidesSearchBarWhenScrolling = false
+    }
+
+    tableView.reloadData()
+  }
 }
 
 private extension TeamsViewController {

--- a/share_extension/android/actions/index.js
+++ b/share_extension/android/actions/index.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {fetchMyChannelsAndMembers} from 'mattermost-redux/actions/channels';
+import {fetchMyChannelsAndMembers, searchChannels, createDirectChannel} from 'mattermost-redux/actions/channels';
 import {getRedirectChannelNameForTeam, getChannelsNameMapInTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getChannelByName} from 'mattermost-redux/utils/channel_utils';
 
@@ -27,5 +27,22 @@ export function extensionSelectTeamId(teamId) {
             type: ViewTypes.EXTENSION_SELECTED_TEAM_ID,
             data: teamId,
         }, getState);
+    };
+}
+
+export function searchChannelsTyping(teamId, term) {
+    return async (dispatch) => {
+        const result = await dispatch(searchChannels(teamId, term, false));
+        return result;
+    };
+}
+
+export function makeDirectChannel(otherUserId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {currentUserId} = state.entities.users;
+        const result = await dispatch(createDirectChannel(currentUserId, otherUserId));
+
+        return result;
     };
 }

--- a/share_extension/android/extension_channels/extension_channel_item.js
+++ b/share_extension/android/extension_channels/extension_channel_item.js
@@ -33,7 +33,11 @@ export default class ExtensionChannelItem extends PureComponent {
     onPress = preventDoubleTap(() => {
         const {channel, onSelectChannel} = this.props;
         requestAnimationFrame(() => {
-            onSelectChannel(channel);
+            if (channel.notCreatedYet) {
+                onSelectChannel(channel, true);
+            } else {
+                onSelectChannel(channel, false);
+            }
         });
     });
 

--- a/share_extension/android/extension_channels/extension_channels.js
+++ b/share_extension/android/extension_channels/extension_channels.js
@@ -189,15 +189,18 @@ export default class ExtensionChannel extends PureComponent {
     renderNoResults = () => {
         const style = getStyleSheet(defaultTheme);
 
-        return (
-            <View style={style.noResultContainer}>
-                <FormattedText
-                    id='mobile.custom_list.no_results'
-                    defaultMessage='No Results'
-                    style={style.noResultText}
-                />
-            </View>
-        );
+        if (!this.state.loading) {
+            return (
+                <View style={style.noResultContainer}>
+                    <FormattedText
+                        id='mobile.custom_list.no_results'
+                        defaultMessage='No Results'
+                        style={style.noResultText}
+                    />
+                </View>
+            );
+        }
+        return null;
     };
 
     keyExtractor = (item) => item.id;
@@ -214,6 +217,7 @@ export default class ExtensionChannel extends PureComponent {
                     ItemSeparatorComponent={this.renderItemSeparator}
                     renderItem={this.renderItem}
                     renderSectionHeader={this.renderSectionHeader}
+                    extraData={this.state.loading}
                     ListEmptyComponent={this.renderNoResults}
                     keyExtractor={this.keyExtractor}
                     keyboardShouldPersistTaps='always'

--- a/share_extension/android/extension_channels/index.js
+++ b/share_extension/android/extension_channels/index.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {
@@ -8,15 +9,33 @@ import {
     getExtensionSortedPrivateChannels,
     getExtensionSortedPublicChannels,
 } from 'share_extension/common/selectors';
+import {searchChannelsTyping, makeDirectChannel} from 'share_extension/android/actions';
+import {searchProfiles} from 'mattermost-redux/actions/users';
+import {General} from 'mattermost-redux/constants';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import ExtensionChannels from './extension_channels';
 
 function mapStateToProps(state) {
+    const config = getConfig(state);
+    const restrictDirectMessage = config.RestrictDirectMessage === General.RESTRICT_DIRECT_MESSAGE_ANY;
+
     return {
+        restrictDirectMessage,
         publicChannels: getExtensionSortedPublicChannels(state),
         privateChannels: getExtensionSortedPrivateChannels(state),
         directChannels: getExtensionSortedDirectChannels(state),
     };
 }
 
-export default connect(mapStateToProps)(ExtensionChannels);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            searchChannelsTyping,
+            searchProfiles,
+            makeDirectChannel,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExtensionChannels);

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -266,6 +266,7 @@ export default class ExtensionPost extends PureComponent {
                     defaultMessage: 'Select Channel',
                 }),
                 currentChannelId: this.state.channelId,
+                teamId: this.state.teamId,
                 onSelectChannel: this.handleSelectChannel,
             },
         });

--- a/share_extension/common/selectors/index.js
+++ b/share_extension/common/selectors/index.js
@@ -6,10 +6,7 @@ import {createSelector} from 'reselect';
 import {General} from 'mattermost-redux/constants';
 import {getAllChannels, getChannelsInTeam, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUser, getUsers} from 'mattermost-redux/selectors/entities/users';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getLastPostPerChannel} from 'mattermost-redux/selectors/entities/posts';
 import {
-    getMyPreferences,
     getTeammateNameDisplaySetting,
     getVisibleTeammate,
     getVisibleGroupIds,
@@ -19,9 +16,8 @@ import {
     completeDirectChannelDisplayName,
     getDirectChannelName,
     getGroupDisplayNameFromUserIds,
-    getUserIdFromChannelName,
-    isAutoClosed,
     sortChannelsByDisplayName,
+    getChannelByName,
 } from 'mattermost-redux/utils/channel_utils';
 import {createIdsSelector} from 'mattermost-redux/utils/helpers';
 
@@ -45,10 +41,6 @@ export const getExtensionSortedPublicChannels = createSelector(
 
         const locale = currentUser.locale || 'en';
         return teamChannelIds.reduce((publicChannels, id) => {
-            if (!myMembers[id]) {
-                return publicChannels;
-            }
-
             const channel = channels[id];
             if (channel.type === General.OPEN_CHANNEL) {
                 publicChannels.push(channel);
@@ -71,10 +63,6 @@ export const getExtensionSortedPrivateChannels = createSelector(
 
         const locale = currentUser.locale || 'en';
         return teamChannelIds.reduce((privateChannels, id) => {
-            if (!myMembers[id]) {
-                return privateChannels;
-            }
-
             const channel = channels[id];
             if (channel.type === General.PRIVATE_CHANNEL) {
                 privateChannels.push(channel);
@@ -93,10 +81,7 @@ export const getExtensionSortedDirectChannels = createSelector(
     getVisibleTeammate,
     getVisibleGroupIds,
     getTeammateNameDisplaySetting,
-    getConfig,
-    getMyPreferences,
-    getLastPostPerChannel,
-    (currentUser, profiles, profilesInChannel, channels, teammates, groupIds, settings, config, preferences, lastPosts) => {
+    (currentUser, profiles, profilesInChannel, channels, teammates, groupIds, settings) => {
         if (!currentUser) {
             return [];
         }
@@ -108,30 +93,51 @@ export const getExtensionSortedDirectChannels = createSelector(
             const name = getDirectChannelName(currentUser.id, teammateId);
             const channel = channelValues.find((c) => c.name === name); //eslint-disable-line max-nested-callbacks
             if (channel) {
-                const lastPost = lastPosts[channel.id];
-                const otherUser = profiles[getUserIdFromChannelName(currentUser.id, channel.name)];
-                if (!isAutoClosed(config, preferences, channel, lastPost ? lastPost.create_at : 0, otherUser ? otherUser.delete_at : 0)) {
-                    result.push(channel.id);
-                }
+                result.push(channel.id);
             }
             return result;
         }, directChannelsIds);
-        const directChannels = groupIds.filter((id) => {
-            const channel = channels[id];
-            if (channel) {
-                const lastPost = lastPosts[channel.id];
-                return !isAutoClosed(config, preferences, channels[id], lastPost ? lastPost.create_at : 0);
-            }
 
-            return false;
-        }).concat(directChannelsIds).map((id) => {
+        const directChannels = groupIds.concat(directChannelsIds).map((id) => {
             const channel = channels[id];
             if (channel.type === General.GM_CHANNEL) {
                 return completeDirectGroupInfo(currentUser.id, profiles, profilesInChannel, settings, channel);
             }
             return completeDirectChannelDisplayName(currentUser.id, profiles, profilesInChannel[id], settings, channel);
         }).sort(sortChannelsByDisplayName.bind(null, locale));
-        return directChannels;
+
+        const globalActiveUserChannels = Object.keys(profiles).reduce((result, id) => {
+            if (profiles[id].delete_at === 0) {
+                const channelName = getDirectChannelName(currentUser.id, id);
+                const channel = getChannelByName(channels, channelName);
+
+                if (channel) {
+                    // add existing (but closed) DM channels, removing duplicates
+                    for (let i = 0; i < directChannelsIds.length; i++) {
+                        if (channel.id === directChannelsIds[i]) {
+                            return result;
+                        }
+                    }
+                    result.push(completeDirectChannelDisplayName(currentUser.id, profiles, profilesInChannel[id], settings, channel));
+                } else {
+                    // create placeholder channel to display item, and facilitate channel creation if user selects
+                    const placeholderChannel = {
+                        notCreatedYet: true,
+                        id,
+                        otherUserId: id,
+                        type: 'D',
+                        delete_at: 0,
+                        display_name: profiles[id].username,
+                    };
+                    result.push(placeholderChannel);
+                }
+                return result;
+            }
+            return result;
+        }, []).sort(sortChannelsByDisplayName.bind(null, locale));
+
+        const allDirectChannels = directChannels.concat(globalActiveUserChannels);
+        return allDirectChannels;
     },
 );
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR adds to the share extension the ability to send to: 
(1) channels, GMs, and DMs that have been previously closed
(2) active users on the server.

The proposed solution first renders all channels available in the store (redux on Android, StoreManager.m on iOS), and then makes one server request for other available channels. 

Upon search keystrokes, other "active users" are searched for and also added to the list of Direct Messages available to send to. If a Direct Message channel doesn't exist yet between the currentUser and otherUser, a new one is created beforehand.

The user is made aware of channels loading (server requests) with an activity indicator/message as described in the design docs.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.
  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Ticket: https://mattermost.atlassian.net/browse/MM-15272
Fixes: https://github.com/mattermost/mattermost-server/issues/11263

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Includes text changes

#### Device Information
This PR was tested on: moto g7 play (Android 9), iPhone 7 Simulator (iOS 13), iPhone 11 Simulator (iOS 13)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->
![android](https://user-images.githubusercontent.com/20244930/74805834-34f27400-5299-11ea-8ed0-79d7a3c7e4dd.png)
![ios](https://user-images.githubusercontent.com/20244930/74805838-391e9180-5299-11ea-817b-b138da24d68c.png)
