### PR TITLE
MM-13669: Fix stutter on long reaction lists

### DIFF
--- a/app/components/slide_up_panel/slide_up_panel.js
+++ b/app/components/slide_up_panel/slide_up_panel.js
@@ -177,42 +177,38 @@ export default class SlideUpPanel extends PureComponent {
                 destSnapPoint = this.snapPoints[2];
             } else if (isGoingDown) {
                 destSnapPoint = this.snapPoints.find((s) => s >= endOffsetY);
+                if (!destSnapPoint) {
+                    destSnapPoint = this.snapPoints[2];
+                }
             } else {
                 destSnapPoint = this.snapPoints.find((s) => s <= endOffsetY);
+                if (!destSnapPoint) {
+                    destSnapPoint = this.snapPoints[0];
+                }
             }
 
-            if (destSnapPoint) {
-                this.translateYOffset.extractOffset();
-                this.translateYOffset.setValue(translationY);
-                this.translateYOffset.flattenOffset();
-                this.dragY.setValue(0);
+            this.translateYOffset.extractOffset();
+            this.translateYOffset.setValue(translationY);
+            this.translateYOffset.flattenOffset();
+            this.dragY.setValue(0);
 
-                if (destSnapPoint === this.snapPoints[2]) {
-                    this.closeWithAnimation();
-                } else {
-                    Animated.spring(this.translateYOffset, {
-                        velocity: velocityY,
-                        tension: 68,
-                        friction: 12,
-                        toValue: destSnapPoint,
-                        useNativeDriver: true,
-                    }).start(() => {
-                        this.setState({lastSnap: destSnapPoint});
-
-                        // When dragging down the panel when is fully open reset the scrollView to the top
-                        if (isGoingDown && destSnapPoint !== this.snapPoints[0]) {
-                            this.scrollToTop();
-                        }
-                    });
-                }
+            if (destSnapPoint === this.snapPoints[2]) {
+                this.closeWithAnimation();
             } else {
                 Animated.spring(this.translateYOffset, {
                     velocity: velocityY,
                     tension: 68,
                     friction: 12,
-                    toValue: lastSnap,
+                    toValue: destSnapPoint,
                     useNativeDriver: true,
-                }).start();
+                }).start(() => {
+                    this.setState({lastSnap: destSnapPoint});
+
+                    // When dragging down the panel when is fully open reset the scrollView to the top
+                    if (isGoingDown && destSnapPoint !== this.snapPoints[0]) {
+                        this.scrollToTop();
+                    }
+                });
             }
         }
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR resolves an issue where an Emoji Reaction List of over ~12 or so would stutter/jitter when swiping up at the end of the list (as if trying to scroll further).

There are cases where the ` onHandlerStateChange` function leaves `destSnapPoint` to be undefined. An edge case which has this outcome is when the user swipes up on the Pan component so far, as to release their touch beyond the safe area. The subsequent swipe will then have the jitter. This PR attempts to cover these scenarios.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/MM-13669
Fixes:  https://github.com/mattermost/mattermost-server/issues/13028

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->

#### Device Information
This PR was tested on: moto g7 play (Android 9), iPhone 7 (iOS 13.2), iPhone 11 Simulator (iOS 13)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->
![ios](https://user-images.githubusercontent.com/20244930/75050604-2070d000-5481-11ea-977b-10f2c4df80f8.gif)
![android](https://user-images.githubusercontent.com/20244930/75050666-45fdd980-5481-11ea-81a6-010c13eef331.gif)
