### PR TITLE
Update mattermost-redux version to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9955,8 +9955,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#cbcc077d0be1b4d3c743422eb990f6ae7c30700a",
-      "from": "github:mattermost/mattermost-redux#cbcc077d0be1b4d3c743422eb990f6ae7c30700a",
+      "version": "github:mattermost/mattermost-redux#d5f581cfed3ffc273d0e7ca02663dd8fd6b8c241",
+      "from": "github:mattermost/mattermost-redux#d5f581cfed3ffc273d0e7ca02663dd8fd6b8c241",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.1",
     "jsc-android": "241213.2.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#cbcc077d0be1b4d3c743422eb990f6ae7c30700a",
+    "mattermost-redux": "github:mattermost/mattermost-redux#d5f581cfed3ffc273d0e7ca02663dd8fd6b8c241",
     "mime-db": "1.43.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",


### PR DESCRIPTION
#### Summary

As part of https://mattermost.atlassian.net/browse/MM-14661 we need to update the mattermost-redux version.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-14661

#### Checklist

- [ x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
