### PR TITLE
Fix in-app notification crashing when receiving multiple

### DIFF
--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -347,7 +347,6 @@ export function showOverlay(name, passProps, options = {}) {
 
     Navigation.showOverlay({
         component: {
-            id: name,
             name,
             passProps,
             options: merge(defaultOptions, options),

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -440,7 +440,6 @@ describe('app/actions/navigation', () => {
 
         const expectedLayout = {
             component: {
-                id: name,
                 name,
                 passProps,
                 options: merge(defaultOptions, options),

--- a/app/screens/notification/notification.js
+++ b/app/screens/notification/notification.js
@@ -145,8 +145,8 @@ export default class Notification extends PureComponent {
 
         EventEmitter.emit(NavigationTypes.CLOSE_MAIN_SIDEABR);
         EventEmitter.emit(NavigationTypes.CLOSE_SETTINGS_SIDEBAR);
+        this.dismissOverlay();
         InteractionManager.runAfterInteractions(() => {
-            this.dismissOverlay();
             if (!notification.localNotification) {
                 actions.loadFromPushNotification(notification);
             }


### PR DESCRIPTION
#### Summary
With the changes to the navigation library, if the overlay screen contains the same id it will cause the data not to be assigned and therefore causing a crash.

With this PR we ensure that the Notification overlay screen does not have the same id as a previous one.

### Ticket
https://mattermost.atlassian.net/browse/MM-22702