### PR TITLE
MM-22752/MM-22686 global timeout and team switch

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -231,7 +231,7 @@ export function loadPostsIfNecessaryWithRetry(channelId) {
 }
 
 export async function retryGetPostsAction(action, dispatch, getState, maxTries = MAX_RETRIES) {
-    for (let i = 0; i < maxTries; i++) {
+    for (let i = 0; i <= maxTries; i++) {
         const {data} = await dispatch(action); // eslint-disable-line no-await-in-loop
 
         if (data) {
@@ -364,14 +364,14 @@ export function handleSelectChannel(channelId, fromPushNotification = false) {
             dispatch(loadPostsIfNecessaryWithRetry(channelId));
         }
 
-        if (channel && member) {
+        if (channel) {
             dispatch({
                 type: ChannelTypes.SELECT_CHANNEL,
                 data: channelId,
                 extra: {
                     channel,
                     member,
-                    teamId: currentTeamId,
+                    teamId: channel.team_id || currentTeamId,
                 },
             });
         }
@@ -642,9 +642,9 @@ export function loadChannelsForTeam(teamId) {
 
         if (currentUserId) {
             const data = {sync: true, teamId};
-            for (let i = 0; i < MAX_RETRIES; i++) {
+            for (let i = 0; i <= MAX_RETRIES; i++) {
                 try {
-                    console.log('Fetching channels attempt', (i + 1)); //eslint-disable-line no-console
+                    console.log('Fetching channels attempt', teamId, (i + 1)); //eslint-disable-line no-console
                     const [channels, channelMembers] = await Promise.all([ //eslint-disable-line no-await-in-loop
                         Client4.getMyChannels(teamId, true),
                         Client4.getMyChannelMembers(teamId),
@@ -653,10 +653,11 @@ export function loadChannelsForTeam(teamId) {
                     data.channels = channels;
                     data.channelMembers = channelMembers;
                     break;
-                } catch (error) {
-                    const result = await dispatch(forceLogoutIfNecessary(error)); //eslint-disable-line no-await-in-loop
+                } catch (err) {
+                    const result = await dispatch(forceLogoutIfNecessary(err)); //eslint-disable-line no-await-in-loop
                     if (result || i === MAX_RETRIES) {
-                        return {error};
+                        const hasChannelsLoaded = state.entities.channels.channelsInTeam[teamId]?.size > 0;
+                        return {error: hasChannelsLoaded ? null : err};
                     }
                 }
             }
@@ -758,7 +759,7 @@ export function getUsersInChannel(channelId) {
 async function getProfilesFromPromises(dispatch, promiseArray, directChannels) {
     // Get the profiles returned by the promises and retry those that failed
     let promises = promiseArray;
-    for (let i = 0; i < MAX_RETRIES; i++) {
+    for (let i = 0; i <= MAX_RETRIES; i++) {
         if (!promises.length) {
             return;
         }

--- a/app/actions/views/select_team.js
+++ b/app/actions/views/select_team.js
@@ -1,7 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {TeamTypes} from 'mattermost-redux/action_types';
+import {batchActions} from 'redux-batched-actions';
+
+import {ChannelTypes, TeamTypes} from 'mattermost-redux/action_types';
 import {getMyTeams} from 'mattermost-redux/actions/teams';
 import {RequestStatus} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -18,7 +20,10 @@ export function handleTeamChange(teamId) {
             return;
         }
 
-        dispatch({type: TeamTypes.SELECT_TEAM, data: teamId});
+        dispatch(batchActions([
+            {type: TeamTypes.SELECT_TEAM, data: teamId},
+            {type: ChannelTypes.SELECT_CHANNEL, data: '', extra: {}},
+        ]));
     };
 }
 

--- a/app/init/fetch.js
+++ b/app/init/fetch.js
@@ -145,7 +145,10 @@ Client4.doFetchWithResponse = async (url, options) => {
 };
 
 const initFetchConfig = async () => {
-    let fetchConfig = {};
+    const fetchConfig = {
+        auto: true,
+        timeout: 5000, // Set the base timeout for every request to 5s
+    };
 
     try {
         managedConfig = await mattermostManaged.getConfig();
@@ -157,18 +160,10 @@ const initFetchConfig = async () => {
     Client4.setUserAgent(userAgent);
 
     if (Platform.OS === 'ios') {
-        const certificate = await mattermostBucket.getPreference('cert');
-        fetchConfig = {
-            auto: true,
-            certificate,
-        };
-        window.fetch = new RNFetchBlob.polyfill.Fetch(fetchConfig).build();
-    } else {
-        fetchConfig = {
-            auto: true,
-        };
-        window.fetch = new RNFetchBlob.polyfill.Fetch(fetchConfig).build();
+        fetchConfig.certificate = await mattermostBucket.getPreference('cert');
     }
+
+    window.fetch = new RNFetchBlob.polyfill.Fetch(fetchConfig).build();
 
     return true;
 };

--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -216,6 +216,7 @@ export default class ChannelBase extends PureComponent {
             if (EphemeralStore.appStartedFromPushNotification) {
                 EphemeralStore.appStartedFromPushNotification = false;
             } else {
+                this.setState({channelsRequestFailed: false});
                 selectInitialChannel(teamId);
             }
         });


### PR DESCRIPTION
#### Summary
This PR adds a global timeout setting of 5s for every request, also included in this PR is a fix to unset the current channel when switching teams as well as handling the case when not online or fetching the channels for the team fail to use the previously loaded channels for the team.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22752
https://mattermost.atlassian.net/browse/MM-22686
