### PR TITLE
[MM-21310] Use file URL over preview URL for GIFs

### DIFF
--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -93,7 +93,7 @@ export default class FileAttachmentImage extends PureComponent {
             imageProps.defaultSource = {uri: file.localPath};
         } else if (file.id) {
             imageProps.thumbnailUri = Client4.getFileThumbnailUrl(file.id);
-            imageProps.imageUri = Client4.getFilePreviewUrl(file.id);
+            imageProps.imageUri = isGif(file) ? Client4.getFileUrl(file.id) : Client4.getFilePreviewUrl(file.id);
         }
         return imageProps;
     };


### PR DESCRIPTION
#### Summary
Use `Client4.getFileUrl()` over `Client4.getFilePreviewUrl()` for GIFs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21310

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Mi A3, Android 9
* iOS 13 simulator

#### Screenshots
![gif](https://user-images.githubusercontent.com/3208014/75587215-36f3ca00-5a33-11ea-9e1d-b3d43713678f.gif)
