### PR TITLE
MM-22134: Fix StatusBar after Photo-Camera post in landscape mode

### DIFF
--- a/app/components/attachment_button/index.js
+++ b/app/components/attachment_button/index.js
@@ -8,6 +8,7 @@ import {
     NativeModules,
     Platform,
     StyleSheet,
+    StatusBar,
 } from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 import DeviceInfo from 'react-native-device-info';
@@ -178,6 +179,7 @@ export default class AttachmentButton extends PureComponent {
 
         if (hasCameraPermission) {
             ImagePicker.launchCamera(options, (response) => {
+                StatusBar.setHidden(false);
                 emmProvider.inBackgroundSince = null;
                 if (response.error || response.didCancel) {
                     return;
@@ -213,6 +215,7 @@ export default class AttachmentButton extends PureComponent {
 
         if (hasPhotoPermission) {
             ImagePicker.launchImageLibrary(options, (response) => {
+                StatusBar.setHidden(false);
                 emmProvider.inBackgroundSince = null;
                 if (response.error || response.didCancel) {
                     return;

--- a/app/components/attachment_button/index.test.js
+++ b/app/components/attachment_button/index.test.js
@@ -5,7 +5,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import Permissions from 'react-native-permissions';
-import {Alert} from 'react-native';
+import {Alert, StatusBar} from 'react-native';
 
 import Preferences from 'mattermost-redux/constants/preferences';
 
@@ -15,7 +15,8 @@ import AttachmentButton from './index';
 
 jest.mock('react-intl');
 jest.mock('react-native-image-picker', () => ({
-    launchCamera: jest.fn(),
+    launchCamera: jest.fn().mockImplementation((options, callback) => callback({didCancel: true})),
+    launchImageLibrary: jest.fn().mockImplementation((options, callback) => callback({didCancel: true})),
 }));
 
 describe('AttachmentButton', () => {
@@ -103,5 +104,33 @@ describe('AttachmentButton', () => {
         expect(Permissions.request).not.toHaveBeenCalled();
         expect(Alert.alert).toHaveBeenCalled();
         expect(hasPhotoPermission).toBe(false);
+    });
+
+    test('should re-enable StatusBar after ImagePicker launchCamera finishes', async () => {
+        const wrapper = shallow(
+            <AttachmentButton {...baseProps}/>,
+            {context: {intl: {formatMessage}}},
+        );
+
+        const instance = wrapper.instance();
+        jest.spyOn(instance, 'hasPhotoPermission').mockReturnValue(true);
+        jest.spyOn(StatusBar, 'setHidden');
+
+        await instance.attachFileFromCamera();
+        expect(StatusBar.setHidden).toHaveBeenCalled();
+    });
+
+    test('should re-enable StatusBar after ImagePicker launchImageLibrary finishes', async () => {
+        const wrapper = shallow(
+            <AttachmentButton {...baseProps}/>,
+            {context: {intl: {formatMessage}}},
+        );
+
+        const instance = wrapper.instance();
+        jest.spyOn(instance, 'hasPhotoPermission').mockReturnValue(true);
+        jest.spyOn(StatusBar, 'setHidden');
+
+        await instance.attachFileFromLibrary();
+        expect(StatusBar.setHidden).toHaveBeenCalled();
     });
 });

--- a/app/components/attachment_button/index.test.js
+++ b/app/components/attachment_button/index.test.js
@@ -117,7 +117,7 @@ describe('AttachmentButton', () => {
         jest.spyOn(StatusBar, 'setHidden');
 
         await instance.attachFileFromCamera();
-        expect(StatusBar.setHidden).toHaveBeenCalled();
+        expect(StatusBar.setHidden).toHaveBeenCalledWith(false);
     });
 
     test('should re-enable StatusBar after ImagePicker launchImageLibrary finishes', async () => {
@@ -131,6 +131,6 @@ describe('AttachmentButton', () => {
         jest.spyOn(StatusBar, 'setHidden');
 
         await instance.attachFileFromLibrary();
-        expect(StatusBar.setHidden).toHaveBeenCalled();
+        expect(StatusBar.setHidden).toHaveBeenCalledWith(false);
     });
 });

--- a/app/components/post_textbox/components/camera_button.js
+++ b/app/components/post_textbox/components/camera_button.js
@@ -6,6 +6,7 @@ import {intlShape} from 'react-intl';
 import {
     Alert,
     Platform,
+    StatusBar,
 } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import {ICON_SIZE} from 'app/constants/post_textbox';
@@ -93,6 +94,7 @@ export default class AttachmentButton extends PureComponent {
 
         if (hasCameraPermission) {
             ImagePicker.launchCamera(options, (response) => {
+                StatusBar.setHidden(false);
                 if (response.error || response.didCancel) {
                     return;
                 }

--- a/app/components/post_textbox/components/camera_button.test.js
+++ b/app/components/post_textbox/components/camera_button.test.js
@@ -112,6 +112,6 @@ describe('CameraButton', () => {
         jest.spyOn(StatusBar, 'setHidden');
 
         await instance.attachFileFromCamera();
-        expect(StatusBar.setHidden).toHaveBeenCalled();
+        expect(StatusBar.setHidden).toHaveBeenCalledWith(false);
     });
 });

--- a/app/components/post_textbox/components/camera_button.test.js
+++ b/app/components/post_textbox/components/camera_button.test.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Alert, Platform} from 'react-native';
+import {Alert, Platform, StatusBar} from 'react-native';
 import {shallow} from 'enzyme';
 import Permissions from 'react-native-permissions';
 
@@ -12,7 +12,7 @@ import CameraButton from './camera_button';
 
 jest.mock('react-intl');
 jest.mock('react-native-image-picker', () => ({
-    launchCamera: jest.fn(),
+    launchCamera: jest.fn().mockImplementation((options, callback) => callback({didCancel: true})),
 }));
 
 describe('CameraButton', () => {
@@ -99,5 +99,19 @@ describe('CameraButton', () => {
             expect(request).toHaveBeenCalled();
             expect(hasPermission).toBe(true);
         }
+    });
+
+    test('should re-enable StatusBar after ImagePicker launchCamera finishes', async () => {
+        const wrapper = shallow(
+            <CameraButton {...baseProps}/>,
+            {context: {intl: {formatMessage}}},
+        );
+
+        const instance = wrapper.instance();
+        jest.spyOn(instance, 'hasCameraPermission').mockReturnValue(true);
+        jest.spyOn(StatusBar, 'setHidden');
+
+        await instance.attachFileFromCamera();
+        expect(StatusBar.setHidden).toHaveBeenCalled();
     });
 });

--- a/app/components/post_textbox/components/image_upload_button.js
+++ b/app/components/post_textbox/components/image_upload_button.js
@@ -6,6 +6,7 @@ import {intlShape} from 'react-intl';
 import {
     Alert,
     Platform,
+    StatusBar,
 } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import {ICON_SIZE} from 'app/constants/post_textbox';
@@ -95,6 +96,7 @@ export default class ImageUploadButton extends PureComponent {
 
         if (hasPhotoPermission) {
             ImagePicker.launchImageLibrary(options, (response) => {
+                StatusBar.setHidden(false);
                 if (response.error || response.didCancel) {
                     return;
                 }

--- a/app/components/post_textbox/components/image_upload_button.test.js
+++ b/app/components/post_textbox/components/image_upload_button.test.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Alert, Platform} from 'react-native';
+import {Alert, Platform, StatusBar} from 'react-native';
 import {shallow} from 'enzyme';
 import Permissions from 'react-native-permissions';
 
@@ -12,7 +12,7 @@ import ImageUploadButton from './image_upload_button';
 
 jest.mock('react-intl');
 jest.mock('react-native-image-picker', () => ({
-    launchCamera: jest.fn(),
+    launchImageLibrary: jest.fn().mockImplementation((options, callback) => callback({didCancel: true})),
 }));
 
 describe('ImageUploadButton', () => {
@@ -100,5 +100,19 @@ describe('ImageUploadButton', () => {
             expect(request).toHaveBeenCalled();
             expect(hasPermission).toBe(true);
         }
+    });
+
+    test('should re-enable StatusBar after ImagePicker launchImageLibrary finishes', async () => {
+        const wrapper = shallow(
+            <ImageUploadButton {...baseProps}/>,
+            {context: {intl: {formatMessage}}},
+        );
+
+        const instance = wrapper.instance();
+        jest.spyOn(instance, 'hasPhotoPermission').mockReturnValue(true);
+        jest.spyOn(StatusBar, 'setHidden');
+
+        await instance.attachFileFromLibrary();
+        expect(StatusBar.setHidden).toHaveBeenCalled();
     });
 });

--- a/app/components/post_textbox/components/image_upload_button.test.js
+++ b/app/components/post_textbox/components/image_upload_button.test.js
@@ -113,6 +113,6 @@ describe('ImageUploadButton', () => {
         jest.spyOn(StatusBar, 'setHidden');
 
         await instance.attachFileFromLibrary();
-        expect(StatusBar.setHidden).toHaveBeenCalled();
+        expect(StatusBar.setHidden).toHaveBeenCalledWith(false);
     });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR fixes the issue of the StatusBar being hidden or not recognized when Photo/Camera post is called in landscape mode and returned to portrait mode. Photo and Camera post both use react-native-image-picker which utilizes native `UIImagePickerController` on iOS. According to [Apple docs](https://developer.apple.com/documentation/uikit/uiimagepickercontroller), `UIImagePickerController` only supports portrait mode which may cause the unexpected behavior. This issue can also be reproduced with the Take Photo/Photo Library picker for a user's profile picture in Landscape mode (uses same library).

The proposed solution calls to re-enable StatusBar in the `ImagePicker` callback. Thereafter, StatusBar is recognized after switching back to Portrait mode (behaves as expected).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/13960 
Ticket:  https://mattermost.atlassian.net/browse/MM-22134

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 
iPhone 7 (iOS 13.2), iPhone 11 Simulator (iOS 13), moto g7 play (Android 9)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->
![Visible_StatusBar](https://user-images.githubusercontent.com/20244930/75634880-5a9b4980-5bc6-11ea-9fe9-98a750a0e608.gif)
