### PR TITLE
MM-22752 Preserve other teams channel membership

### DIFF
--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -90,7 +90,7 @@ export default class NetworkIndicator extends PureComponent {
 
         // Attempt to connect when this component mounts
         // if the websocket is already connected it does not try and connect again
-        this.connect();
+        this.connect(true);
     }
 
     componentDidUpdate(prevProps) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9974,8 +9974,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#d5f581cfed3ffc273d0e7ca02663dd8fd6b8c241",
-      "from": "github:mattermost/mattermost-redux#d5f581cfed3ffc273d0e7ca02663dd8fd6b8c241",
+      "version": "github:mattermost/mattermost-redux#0847d2fd8038e9cf626697b38e6ae9c441e8d1f6",
+      "from": "github:mattermost/mattermost-redux#0847d2fd8038e9cf626697b38e6ae9c441e8d1f6",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.1",
     "jsc-android": "241213.2.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#d5f581cfed3ffc273d0e7ca02663dd8fd6b8c241",
+    "mattermost-redux": "github:mattermost/mattermost-redux#0847d2fd8038e9cf626697b38e6ae9c441e8d1f6",
     "mime-db": "1.43.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",


### PR DESCRIPTION
#### Summary
Updates mm-redux to preserve channel memberships from other teams and when offline keep the network indicator visible on team switch

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22752

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (https://github.com/mattermost/mattermost-redux/pull/1064)