### PR TITLE
Fix typing on input box after returning from an archived channel

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -318,7 +318,6 @@ export function selectPenultimateChannel(teamId) {
             lastChannel.delete_at === 0 &&
             (lastChannel.team_id === teamId || isDMVisible || isGMVisible)
         ) {
-            dispatch(setChannelLoading(true));
             dispatch(handleSelectChannel(lastChannelId));
             return;
         }

--- a/app/components/post_textbox/index.js
+++ b/app/components/post_textbox/index.js
@@ -68,7 +68,6 @@ function mapStateToProps(state, ownProps) {
         channelTeamId: currentChannel ? currentChannel.team_id : '',
         canUploadFiles: canUploadFilesOnMobile(state),
         channelDisplayName: state.views.channel.displayName || (currentChannel ? currentChannel.display_name : ''),
-        channelIsLoading: state.views.channel.loading,
         channelIsReadOnly: isCurrentChannelReadOnly(state) || false,
         channelIsArchived: ownProps.channelIsArchived || (currentChannel ? currentChannel.delete_at !== 0 : false),
         currentUserId,

--- a/app/components/post_textbox/post_textbox.test.js
+++ b/app/components/post_textbox/post_textbox.test.js
@@ -46,7 +46,6 @@ describe('PostTextBox', () => {
         channelId: 'channel-id',
         channelDisplayName: 'Test Channel',
         channelTeamId: 'channel-team-id',
-        channelIsLoading: false,
         channelIsReadOnly: false,
         currentUserId: 'current-user-id',
         deactivatedChannel: false,

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -76,7 +76,6 @@ export default class PostTextBoxBase extends PureComponent {
         channelId: PropTypes.string.isRequired,
         channelDisplayName: PropTypes.string,
         channelTeamId: PropTypes.string.isRequired,
-        channelIsLoading: PropTypes.bool,
         channelIsReadOnly: PropTypes.bool.isRequired,
         currentUserId: PropTypes.string.isRequired,
         deactivatedChannel: PropTypes.bool.isRequired,
@@ -898,7 +897,7 @@ export default class PostTextBoxBase extends PureComponent {
 
     renderTextBox = () => {
         const {intl} = this.context;
-        const {channelDisplayName, channelIsArchived, channelIsLoading, channelIsReadOnly, theme, isLandscape, files, rootId} = this.props;
+        const {channelDisplayName, channelIsArchived, channelIsReadOnly, theme, isLandscape, files, rootId} = this.props;
         const style = getStyleSheet(theme);
 
         if (channelIsArchived) {
@@ -906,7 +905,6 @@ export default class PostTextBoxBase extends PureComponent {
         }
 
         const {value, extraInputPadding} = this.state;
-        const textValue = channelIsLoading ? '' : value;
         const placeholder = this.getPlaceHolder();
 
         let maxHeight = 150;
@@ -939,7 +937,7 @@ export default class PostTextBoxBase extends PureComponent {
                 >
                     <PasteableTextInput
                         ref={this.input}
-                        value={textValue}
+                        value={value}
                         style={{...style.input, ...inputStyle, maxHeight}}
                         onChangeText={this.handleTextChange}
                         onSelectionChange={this.handleOnSelectionChange}


### PR DESCRIPTION
#### Summary
After the removal of the channel loader when switching channels, there was some unwanted/unneeded code tracking if the channel was being loaded to not let people write a message in the wrong channel.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22905