### PR TITLE
MM-22963 Fix Android post GIF from keyboard

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/RNPasteableEditTextOnPasteListener.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/RNPasteableEditTextOnPasteListener.java
@@ -19,6 +19,7 @@ import com.mattermost.share.RealPathUtil;
 import com.mattermost.share.ShareModule;
 
 import java.io.FileNotFoundException;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.regex.Matcher;
@@ -133,9 +134,16 @@ public class RNPasteableEditTextOnPasteListener implements RNEditTextOnPasteList
 
     private String moveToImagesCache(String src, String fileName) {
         ReactContext ctx = (ReactContext)mEditText.getContext();
-        String dest = ctx.getCacheDir().getAbsolutePath() + "/Images/" + fileName;
+        String cacheFolder = ctx.getCacheDir().getAbsolutePath() + "/Images/";
+        String dest = cacheFolder + fileName;
+        File folder = new File(cacheFolder);
+
 
         try {
+            if (!folder.exists()) {
+                folder.mkdirs();
+            }
+
             Files.move(Paths.get(src), Paths.get(dest));
         } catch (Exception err) {
             return null;


### PR DESCRIPTION
#### Summary
With the work done in #3971 we were deleting every file and folder under `cache` and when trying to attach a GIF or any other element from the Android Keyboard (including paste of files) there was no attachment and it failed silently.

This PR will create the needed folder if it does not exists to allow the file to be stored.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22953