### PR TITLE
Automated cherry pick of #3994

### DIFF
--- a/app/components/sidebars/settings/settings_sidebar_base.js
+++ b/app/components/sidebars/settings/settings_sidebar_base.js
@@ -130,21 +130,23 @@ export default class SettingsSidebarBase extends PureComponent {
         logout();
     });
 
-    openModal = (screen, title, passProps) => {
+    openModal = async (screen, title, passProps) => {
         this.closeSettingsSidebar();
 
-        MaterialIcon.getImageSource('close', 20, this.props.theme.sidebarHeaderTextColor).then((source) => {
-            const options = {
-                topBar: {
-                    leftButtons: [{
-                        id: 'close-settings',
-                        icon: source,
-                    }],
-                },
-            };
+        if (!this.closeButton) {
+            this.closeButton = await MaterialIcon.getImageSource('close', 20, this.props.theme.sidebarHeaderTextColor);
+        }
 
-            showModal(screen, title, passProps, options);
-        });
+        const options = {
+            topBar: {
+                leftButtons: [{
+                    id: 'close-settings',
+                    icon: this.closeButton,
+                }],
+            },
+        };
+
+        showModal(screen, title, passProps, options);
     };
 
     updateStatus = (status) => {

--- a/app/components/sidebars/settings/settings_sidebar_base.js
+++ b/app/components/sidebars/settings/settings_sidebar_base.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {InteractionManager, ScrollView, View} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import {General} from 'mattermost-redux/constants';
@@ -36,14 +36,6 @@ export default class SettingsSidebarBase extends PureComponent {
         currentUser: {},
         status: 'offline',
     };
-
-    constructor(props) {
-        super(props);
-
-        MaterialIcon.getImageSource('close', 20, props.theme.sidebarHeaderTextColor).then((source) => {
-            this.closeButton = source;
-        });
-    }
 
     componentDidMount() {
         this.mounted = true;
@@ -141,16 +133,16 @@ export default class SettingsSidebarBase extends PureComponent {
     openModal = (screen, title, passProps) => {
         this.closeSettingsSidebar();
 
-        const options = {
-            topBar: {
-                leftButtons: [{
-                    id: 'close-settings',
-                    icon: this.closeButton,
-                }],
-            },
-        };
+        MaterialIcon.getImageSource('close', 20, this.props.theme.sidebarHeaderTextColor).then((source) => {
+            const options = {
+                topBar: {
+                    leftButtons: [{
+                        id: 'close-settings',
+                        icon: source,
+                    }],
+                },
+            };
 
-        InteractionManager.runAfterInteractions(() => {
             showModal(screen, title, passProps, options);
         });
     };


### PR DESCRIPTION
Cherry pick of #3994 on release-1.29.

- #3994: Ensure modals opened from the Settings Sidebar have a

/cc  @enahum