### PR TITLE
MM-22385 RN: iOS - Automatic Replies custom message SafeAreaView fix

### DIFF
--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
@@ -143,7 +143,10 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
                                     blurOnSubmit={false}
                                     onChangeText={this.onAutoResponseChangeText}
                                     multiline={true}
-                                    style={[style.input, padding(isLandscape)]}
+                                    style={[
+                                        style.input,
+                                        isLandscape ? padding(isLandscape) : {paddingHorizontal: 15},
+                                    ]}
                                     autoCapitalize='none'
                                     autoCorrect={false}
                                     placeholder={{id: t('mobile.notification_settings.auto_responder.message_placeholder'), defaultMessage: 'Message'}}

--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
@@ -143,7 +143,7 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
                                     blurOnSubmit={false}
                                     onChangeText={this.onAutoResponseChangeText}
                                     multiline={true}
-                                    style={style.input}
+                                    style={[style.input, padding(isLandscape)]}
                                     autoCapitalize='none'
                                     autoCorrect={false}
                                     placeholder={{id: t('mobile.notification_settings.auto_responder.message_placeholder'), defaultMessage: 'Message'}}
@@ -189,7 +189,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             fontSize: 15,
             height: 150,
-            paddingHorizontal: 15,
             paddingVertical: 10,
         },
         footer: {

--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.js
@@ -143,10 +143,7 @@ export default class NotificationSettingsAutoResponder extends PureComponent {
                                     blurOnSubmit={false}
                                     onChangeText={this.onAutoResponseChangeText}
                                     multiline={true}
-                                    style={[
-                                        style.input,
-                                        isLandscape ? padding(isLandscape) : {paddingHorizontal: 15},
-                                    ]}
+                                    style={[style.input, padding(isLandscape)]}
                                     autoCapitalize='none'
                                     autoCorrect={false}
                                     placeholder={{id: t('mobile.notification_settings.auto_responder.message_placeholder'), defaultMessage: 'Message'}}
@@ -192,6 +189,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             fontSize: 15,
             height: 150,
+            paddingHorizontal: 15,
             paddingVertical: 10,
         },
         footer: {


### PR DESCRIPTION
#### Summary
This PR ensures the textbox doesn't get obstructed by the iPhone's notch in the Automatic Reply settings screen (Landscape view)

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/13871

#### Device Information
This PR was tested on: 
* iPhone 11 (Simulator)

#### Screenshots
Before:
<img width="900" alt="autoreply_before" src="https://user-images.githubusercontent.com/29700158/75881700-edf0ab00-5e62-11ea-998f-ccce0e2c952b.png">

After:
<img width="889" alt="autoreply_after" src="https://user-images.githubusercontent.com/29700158/75881715-f517b900-5e62-11ea-8000-1db87a67e37b.png">
