### PR TITLE
MM-23039 Fix crash for unarchived system message

### DIFF
--- a/app/components/post_body/__snapshots__/system_message_helpers.test.js.snap
+++ b/app/components/post_body/__snapshots__/system_message_helpers.test.js.snap
@@ -49,3 +49,5 @@ exports[`renderSystemMessage uses renderer for unarchived channel 1`] = `
   value="{username} unarchived the channel"
 />
 `;
+
+exports[`renderSystemMessage uses renderer for unarchived channel 2`] = `null`;

--- a/app/components/post_body/system_message_helpers.js
+++ b/app/components/post_body/system_message_helpers.js
@@ -147,6 +147,9 @@ const renderArchivedMessage = (postBodyProps, styles, intl) => {
 
 const renderUnarchivedMessage = (postBodyProps, styles, intl) => {
     const {postProps} = postBodyProps;
+    if (!postProps?.username) {
+        return null;
+    }
 
     const username = renderUsername(postProps.username);
     const localeHolder = {

--- a/app/components/post_body/system_message_helpers.test.js
+++ b/app/components/post_body/system_message_helpers.test.js
@@ -87,7 +87,16 @@ describe('renderSystemMessage', () => {
             postType: Posts.POST_TYPES.CHANNEL_UNARCHIVED,
         };
 
-        const renderedMessage = SystemMessageHelpers.renderSystemMessage(postBodyProps, mockStyles, mockIntl);
+        let renderedMessage = SystemMessageHelpers.renderSystemMessage(postBodyProps, mockStyles, mockIntl);
+        expect(renderedMessage).toMatchSnapshot();
+
+        const noUserInPostBodyProps = {
+            ...basePostBodyProps,
+            postProps: {},
+            postType: Posts.POST_TYPES.CHANNEL_UNARCHIVED,
+        };
+
+        renderedMessage = SystemMessageHelpers.renderSystemMessage(noUserInPostBodyProps, mockStyles, mockIntl);
         expect(renderedMessage).toMatchSnapshot();
     });
 


### PR DESCRIPTION
#### Summary
With the addition for unarchiving channels there is a system message that is being parsed, if the post props does not contain the username of whom unarchived the channel then the app just renders a blank screen.

This PR handles the case to avoid the fix.
@jasonblais this was a community contribution and I think the problem is at the server level where the username is not set in the post properties if you want to take another look or file a ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23039

#### Screenshot
Notice how the unarchived message does not link the username
![image](https://user-images.githubusercontent.com/6757047/75902393-b19b5b80-5e1e-11ea-84ab-2e4871240923.png)
