### PR TITLE
[MM-22622] Disable at channel mention highlight in channel header

### DIFF
--- a/app/screens/channel_info/__snapshots__/channel_info_header.test.js.snap
+++ b/app/screens/channel_info/__snapshots__/channel_info_header.test.js.snap
@@ -190,6 +190,7 @@ exports[`channel_info_header should match snapshot 1`] = `
               },
             }
           }
+          disableAtChannelMentionHighlight={true}
           onChannelLinkPress={[MockFunction]}
           onPermalinkPress={[MockFunction]}
           textStyles={
@@ -534,6 +535,7 @@ exports[`channel_info_header should match snapshot when DM and hasGuests and is 
               },
             }
           }
+          disableAtChannelMentionHighlight={true}
           onChannelLinkPress={[MockFunction]}
           onPermalinkPress={[MockFunction]}
           textStyles={
@@ -850,6 +852,7 @@ exports[`channel_info_header should match snapshot when DM and hasGuests but its
               },
             }
           }
+          disableAtChannelMentionHighlight={true}
           onChannelLinkPress={[MockFunction]}
           onPermalinkPress={[MockFunction]}
           textStyles={
@@ -1194,6 +1197,7 @@ exports[`channel_info_header should match snapshot when GM and hasGuests 1`] = `
               },
             }
           }
+          disableAtChannelMentionHighlight={true}
           onChannelLinkPress={[MockFunction]}
           onPermalinkPress={[MockFunction]}
           textStyles={
@@ -1510,6 +1514,7 @@ exports[`channel_info_header should match snapshot when is group constrained 1`]
               },
             }
           }
+          disableAtChannelMentionHighlight={true}
           onChannelLinkPress={[MockFunction]}
           onPermalinkPress={[MockFunction]}
           textStyles={
@@ -1876,6 +1881,7 @@ exports[`channel_info_header should match snapshot when public channel and hasGu
               },
             }
           }
+          disableAtChannelMentionHighlight={true}
           onChannelLinkPress={[MockFunction]}
           onPermalinkPress={[MockFunction]}
           textStyles={

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -213,6 +213,7 @@ export default class ChannelInfoHeader extends React.PureComponent {
                                     blockStyles={blockStyles}
                                     value={header}
                                     onChannelLinkPress={popToRoot}
+                                    disableAtChannelMentionHighlight={true}
                                 />
                             </View>
                         </TouchableHighlight>


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-mobile/pull/3975 was merged a bit prematurely since I was still doing a UX review with @michaelgamble but I forgot to add a UX review label

- This is a small follow up to disable channel mention highlights in the channel info header section.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22622

#### Checklist
- [x] Updated unit tests
- [x] Has UI changes

#### Device Information
This PR was tested on: iOS 11

#### Screenshots
![Screen Shot 2020-03-04 at 12 40 08 PM](https://user-images.githubusercontent.com/3207297/75907799-f4593580-5e16-11ea-9239-19b00c37078f.png)
