### PR TITLE
[MM-22181] Retry ID loaded push notification fetch

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -195,6 +195,7 @@ android {
     packagingOptions {
         // Make sure libjsc.so does not packed in APK
         exclude "**/libjsc.so"
+        pickFirst "META-INF/DEPENDENCIES"
     }
 }
 
@@ -240,6 +241,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.firebase:firebase-messaging:17.3.4'
+    implementation 'com.google.http-client:google-http-client:1.34.2'
+    implementation 'com.google.api-client:google-api-client-jackson2:1.30.4'
     implementation project(':react-native-document-picker')
     implementation project(':react-native-keychain')
     implementation project(':react-native-doc-viewer')

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -54,6 +54,7 @@ public class CustomPushNotification extends PushNotification {
 
     private NotificationChannel mHighImportanceChannel;
     private NotificationChannel mMinImportanceChannel;
+    private ReceiptDelivery mReceiptDelivery;
 
     private static Map<String, Integer> channelIdToNotificationCount = new HashMap<String, Integer>();
     private static Map<String, List<Bundle>> channelIdToNotification = new HashMap<String, List<Bundle>>();
@@ -64,6 +65,7 @@ public class CustomPushNotification extends PushNotification {
     public CustomPushNotification(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
         this.context = context;
+        mReceiptDelivery = new ReceiptDelivery();
         createNotificationChannels();
     }
 
@@ -529,7 +531,7 @@ public class CustomPushNotification extends PushNotification {
     }
 
     private void notificationReceiptDelivery(String ackId, String postId, String type, boolean isIdLoaded, ResolvePromise promise) {
-        ReceiptDelivery.send(context, ackId, postId, type, isIdLoaded, promise);
+        mReceiptDelivery.send(context, ackId, postId, type, isIdLoaded, promise);
     }
 
     private void createNotificationChannels() {

--- a/android/app/src/main/java/com/mattermost/rnbeta/HttpClient.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/HttpClient.java
@@ -1,0 +1,69 @@
+package com.mattermost.rnbeta;
+
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.ExponentialBackOff;
+
+import java.io.IOException;
+
+public class HttpClient {
+    private HttpRequestFactory mRequestFactory;
+
+    static HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+    static JsonFactory JSON_FACTORY = new JacksonFactory();
+
+    public HttpClient() {
+        this(false);
+    }
+
+    public HttpClient(Boolean withExponentialBackoff) {
+        mRequestFactory = HTTP_TRANSPORT.createRequestFactory(
+            (HttpRequest request) -> {
+              request.setParser(new JsonObjectParser(JSON_FACTORY));
+
+              HttpHeaders headers = request.getHeaders();
+              headers.setContentType("application/json");
+              request.setHeaders(headers);
+
+              if (withExponentialBackoff) {
+                  ExponentialBackOff backoff = buildExponentialBackoff();
+                  request.setUnsuccessfulResponseHandler(
+                      new HttpBackOffUnsuccessfulResponseHandler(backoff));
+              }
+          }
+        );
+    }
+
+    protected ExponentialBackOff buildExponentialBackoff() {
+        return new ExponentialBackOff.Builder()
+            .setInitialIntervalMillis(500)
+            .setMaxElapsedTimeMillis(900000)
+            .setMaxIntervalMillis(6000)
+            .setMultiplier(1.5)
+            .setRandomizationFactor(0.5)
+            .build();
+    }
+
+    protected HttpResponse post(String url, String authorization, String bodyString) throws IOException {
+        ByteArrayContent body = ByteArrayContent.fromString("application/json", bodyString);
+        HttpRequest request = mRequestFactory.buildPostRequest(
+            new GenericUrl(url), body);
+
+        HttpHeaders headers = request.getHeaders();
+        headers.setAuthorization(authorization);
+        request.setHeaders(headers);
+
+        return request.execute();
+    }
+}


### PR DESCRIPTION
#### Summary
WIP. Android done, iOS to do.

I'm using the [default `ExponentialBackoff` config](https://github.com/googleapis/google-http-java-client/blob/c39e63cf577df3538e5330c220c9692f0210b3af/google-http-client/src/main/java/com/google/api/client/util/ExponentialBackOff.java#L48) which produces up to 11 retries with the intervals listed in the link. 

I tested by updating the server to keep a count of the requests coming in and returning a 500 response for the first 9 requests. On the 10th retry the contents of the push notification were successfully received by the device. I then updated the server to return a 500 response for all requests and verified that the retries stopped at the 10th/11th request and the device received the generic push notification message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22181

#### Device Information
This PR was tested on:
* Mi A3, Android 9