### PR TITLE
[MM-22859] Check for null imageConfig

### DIFF
--- a/patches/react-native-image-picker+2.0.0.patch
+++ b/patches/react-native-image-picker+2.0.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModule.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModule.java
-index ef62bed..7379605 100644
+index ef62bed..7a363af 100644
 --- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModule.java
 +++ b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModule.java
 @@ -49,6 +49,7 @@ import java.io.InputStream;
@@ -37,7 +37,7 @@ index ef62bed..7379605 100644
      else
      {
        requestCode = REQUEST_LAUNCH_IMAGE_CAPTURE;
-       cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);      
+       cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
 -
 -      final File original = createNewFile(reactContext, this.options, false);
 -      imageConfig = imageConfig.withOriginalFile(original);
@@ -86,7 +86,21 @@ index ef62bed..7379605 100644
      }
  
      final ReadExifResult result = readExifInterface(responseHelper, imageConfig);
-@@ -551,7 +556,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
+@@ -481,6 +486,13 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
+     else
+     {
+       imageConfig = getResizedImage(reactContext, this.options, imageConfig, initialWidth, initialHeight, requestCode);
++      if (imageConfig == null)
++      {
++        responseHelper.invokeError(callback, "Could not read image");
++        callback = null;
++        return;
++      }
++
+       if (imageConfig.resized == null)
+       {
+         removeUselessFiles(requestCode, imageConfig);
+@@ -551,7 +563,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
    {
      return callback == null || (cameraCaptureURI == null && requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE)
              || (requestCode != REQUEST_LAUNCH_IMAGE_CAPTURE && requestCode != REQUEST_LAUNCH_IMAGE_LIBRARY
@@ -96,7 +110,7 @@ index ef62bed..7379605 100644
    }
  
    private void updatedResultResponse(@Nullable final Uri uri,
-@@ -571,22 +577,23 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
+@@ -571,22 +584,23 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                                     @NonNull final Callback callback,
                                     @NonNull final int requestCode)
    {
@@ -130,7 +144,7 @@ index ef62bed..7379605 100644
      if (!permissionsGranted)
      {
        final Boolean dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA);
-@@ -641,7 +648,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
+@@ -641,7 +655,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
              PERMISSIONS = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
              break;
            case REQUEST_PERMISSIONS_FOR_CAMERA:
@@ -139,7 +153,7 @@ index ef62bed..7379605 100644
              break;
            default:
              PERMISSIONS = new String[]{};
-@@ -781,4 +788,22 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
+@@ -781,4 +795,22 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
        videoDurationLimit = options.getInt("durationLimit");
      }
    }


### PR DESCRIPTION
#### Summary
Added a null check on `imageConfig` as [`getResizedImage` can return null](https://github.com/react-native-community/react-native-image-picker/blob/v2.0.0/android/src/main/java/com/imagepicker/utils/MediaUtils.java#L104). There's an [open issue](https://github.com/react-native-community/react-native-image-picker/issues/1278) for this on react-native-image-picker.

Cannot reproduce the crash so not adding QA review.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22859

#### Device Information
This PR was tested on:
* Android Q emulator