### PR TITLE
MM-23014 Keep Android cache for vector icons

### DIFF
--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -55,7 +55,8 @@ export function generateId() {
     return 'uid' + id;
 }
 
-const dirsToExclude = ['Cache.db', 'WebKit', 'WebView'];
+const vectorIconsDir = 'vectorIcons';
+const dirsToExclude = ['Cache.db', 'WebKit', 'WebView', vectorIconsDir];
 async function getDirectorySize(fileStats) {
     if (fileStats?.length) {
         const total = await fileStats.reduce(async (previousPromise, stat) => {
@@ -93,8 +94,19 @@ export async function deleteFileCache() {
     const isCacheDir = await RNFetchBlob.fs.isDir(cacheDir);
     if (isCacheDir) {
         try {
-            await RNFetchBlob.fs.unlink(cacheDir);
-            await RNFetchBlob.fs.mkdir(cacheDir);
+            if (Platform.OS === 'ios') {
+                await RNFetchBlob.fs.unlink(cacheDir);
+                await RNFetchBlob.fs.mkdir(cacheDir);
+            } else {
+                const cacheStats = await RNFetchBlob.fs.lstat(RNFetchBlob.fs.dirs.CacheDir);
+                if (cacheStats?.length) {
+                    cacheStats.forEach((stat) => {
+                        if (!stat.path.includes(vectorIconsDir)) {
+                            RNFetchBlob.fs.unlink(stat.path);
+                        }
+                    });
+                }
+            }
         } catch (e) {
             // do nothing
         }

--- a/patches/react-native-vector-icons+6.6.0.patch
+++ b/patches/react-native-vector-icons+6.6.0.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/react-native-vector-icons/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java b/node_modules/react-native-vector-icons/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java
+index ddb740c..3738367 100755
+--- a/node_modules/react-native-vector-icons/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java
++++ b/node_modules/react-native-vector-icons/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java
+@@ -43,7 +43,8 @@ public class VectorIconsModule extends ReactContextBaseJavaModule {
+   public void getImageForFont(String fontFamily, String glyph, Integer fontSize, Integer color, Callback callback) {
+     Context context = getReactApplicationContext();
+     File cacheFolder = context.getCacheDir();
+-    String cacheFolderPath = cacheFolder.getAbsolutePath() + "/";
++    String cacheFolderPath = cacheFolder.getAbsolutePath() + "/vectorIcons/";
++    File vectorIconsFolder = new File(cacheFolderPath);
+ 
+     float scale = context.getResources().getDisplayMetrics().density;
+     String scaleSuffix = "@" + (scale == (int) scale ? Integer.toString((int) scale) : Float.toString(scale)) + "x";
+@@ -54,6 +55,10 @@ public class VectorIconsModule extends ReactContextBaseJavaModule {
+     String cacheFileUrl = "file://" + cacheFilePath;
+     File cacheFile = new File(cacheFilePath);
+ 
++    if (!vectorIconsFolder.exists()) {
++      vectorIconsFolder.mkdirs();
++    }
++
+     if(cacheFile.exists()) {
+       callback.invoke(null, cacheFileUrl);
+     } else {


### PR DESCRIPTION
#### Summary
Vector icons (as in the close icon) on Android are saved in the cache folder. When we logout / clear cache, the cache folder was completely removed.

With this PR we create a custom `vectorIcons` folder inside the cache folder and when cleaning that folder we will keep the `vectorIcons` so any previous cached icon will remain accessible.

The reason why it was not being regenerated unless you closed and re-opened the app is cause `react-native-vector-icons` keeps a list of "cached" files in a SET to avoid the need to hit the Native side.

iOS is unaffected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23014