### PR TITLE
[MM-22860] Override bestAttemptContent only when we have values

### DIFF
--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -26,18 +26,22 @@ class NotificationService: UNNotificationServiceExtension {
             return
           }
 
-          let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as! Dictionary<String,Any>
-          bestAttemptContent.title = json!["channel_name"] as! String
-          bestAttemptContent.body = json!["message"] as! String
+          let json = try? JSONSerialization.jsonObject(with: data) as! [String: Any]
+          if let json = json {
+            if let message = json["message"] as? String {
+              bestAttemptContent.body = message
+            }
+            if let channelName = json["channel_name"] as? String {
+              bestAttemptContent.title = channelName
+            }
 
-          bestAttemptContent.userInfo["channel_name"] = json!["channel_name"] as! String
-          bestAttemptContent.userInfo["team_id"] = json!["team_id"] as? String
-          bestAttemptContent.userInfo["sender_id"] = json!["sender_id"] as! String
-          bestAttemptContent.userInfo["sender_name"] = json!["sender_name"] as! String
-          bestAttemptContent.userInfo["root_id"] = json!["root_id"] as? String
-          bestAttemptContent.userInfo["override_username"] = json!["override_username"] as? String
-          bestAttemptContent.userInfo["override_icon_url"] = json!["override_icon_url"] as? String
-          bestAttemptContent.userInfo["from_webhook"] = json!["from_webhook"] as? String
+            let userInfoKeys = ["channel_name", "team_id", "sender_id", "root_id", "override_username", "override_icon_url", "from_webhook"]
+            for key in userInfoKeys {
+              if let value = json[key] as? String {
+                bestAttemptContent.userInfo[key] = value
+              }
+            }
+          }
         }
 
         contentHandler(bestAttemptContent)


### PR DESCRIPTION
#### Summary
The forced downcasting of channel name to type String is throwing an error. I'm not sure how this can happen as, from my understanding, the server always returns a non-empty string for the channel name for ID loaded push notifications. I've updated all the force downcasts to conditional ones and only set `bestAttemptContent` values when the downcast succeeds. I tested this by removing the channel ID from the server response and verified that the generic message is not displayed but instead the post message without the channel title.

I'm not adding QA review as I don't have repro steps.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22860

#### Device Information
This PR was tested on:
* iPhone 7, iOS 13

#### Screenshots
ID loaded push notification with message contents but no channel name:
![IMG_0272](https://user-images.githubusercontent.com/3208014/75932286-478db100-5e34-11ea-879e-f5f1d4d045a2.PNG)
