### PR TITLE
MM-22671: Pre-load channel posts with mentions or unreads

### DIFF
--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -36,9 +36,11 @@ export default class ChannelBase extends PureComponent {
             selectInitialChannel: PropTypes.func.isRequired,
             recordLoadTime: PropTypes.func.isRequired,
             getChannelStats: PropTypes.func.isRequired,
+            preFetchUnreadChannels: PropTypes.func.isRequired,
         }).isRequired,
         componentId: PropTypes.string.isRequired,
         currentChannelId: PropTypes.string,
+        unreadChannelIds: PropTypes.array,
         currentTeamId: PropTypes.string,
         isLandscape: PropTypes.bool,
         theme: PropTypes.object.isRequired,
@@ -202,7 +204,8 @@ export default class ChannelBase extends PureComponent {
     };
 
     loadChannels = (teamId) => {
-        const {loadChannelsForTeam, selectInitialChannel} = this.props.actions;
+        const {unreadChannelIds} = this.props;
+        const {loadChannelsForTeam, selectInitialChannel, preFetchUnreadChannels} = this.props.actions;
         if (!EphemeralStore.getStartFromNotification()) {
             loadChannelsForTeam(teamId).then((result) => {
                 if (result?.error) {
@@ -212,6 +215,10 @@ export default class ChannelBase extends PureComponent {
 
                 this.setState({channelsRequestFailed: false});
                 selectInitialChannel(teamId);
+
+                if (unreadChannelIds.length > 0) {
+                    preFetchUnreadChannels(unreadChannelIds);
+                }
             });
         }
     };

--- a/app/screens/channel/channel_base.test.js
+++ b/app/screens/channel/channel_base.test.js
@@ -27,6 +27,7 @@ describe('ChannelBase', () => {
             recordLoadTime: jest.fn(),
             selectDefaultTeam: jest.fn(),
             selectInitialChannel: jest.fn(),
+            preFetchUnreadChannels: jest.fn(),
         },
         componentId: channelBaseComponentId,
         theme: Preferences.THEMES.default,

--- a/app/screens/channel/index.js
+++ b/app/screens/channel/index.js
@@ -5,7 +5,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'mattermost-redux/actions/users';
-import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannelId, getUnreadChannelIds} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
@@ -14,6 +14,7 @@ import {getChannelStats} from 'mattermost-redux/actions/channels';
 import {
     loadChannelsForTeam,
     selectInitialChannel,
+    preFetchUnreadChannels,
 } from 'app/actions/views/channel';
 import {connection} from 'app/actions/device';
 import {recordLoadTime} from 'app/actions/views/root';
@@ -27,6 +28,7 @@ function mapStateToProps(state) {
     return {
         currentTeamId: getCurrentTeamId(state),
         currentChannelId: getCurrentChannelId(state),
+        unreadChannelIds: getUnreadChannelIds(state),
         isLandscape: isLandscape(state),
         theme: getTheme(state),
         showTermsOfService: shouldShowTermsOfService(state),
@@ -45,6 +47,7 @@ function mapDispatchToProps(dispatch) {
             recordLoadTime,
             startPeriodicStatusUpdates,
             stopPeriodicStatusUpdates,
+            preFetchUnreadChannels,
         }, dispatch),
     };
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR adds functionality to pre fetch posts for channels that are unread or have mentions (before the user actually clicks on the channel) to improve performance. The new `preFetchUnreadChannels` function follows `loadPostsIfNecessaryWithRetry` in overall structure but changes in order to await all post fetches, batch all the actions, and write to the state only once.

` preFetchUnreadChannels` is called after `loadChannelsForTeam` has finished as to not reduce performance of those network calls. As per the scope of this ticket, the pre fetch is called on app launch (or team switches) but ideally the same function can be used for other cases like a websocket reconnect or perhaps on a timer interval (like how user status ids are checked periodically). 


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA Ticket: https://mattermost.atlassian.net/browse/MM-22671 

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: moto g7 play (Android 9), iPhone 11 Simulator (iOS 13)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->
![prefetch](https://user-images.githubusercontent.com/20244930/76030837-55ead400-5eeb-11ea-98bd-b3078d0822e6.gif)
