### PR TITLE
MM-22975 Fix archive handle when server does not allow view archive channel

### DIFF
--- a/app/components/sidebars/main/channels_list/filtered_list/index.js
+++ b/app/components/sidebars/main/channels_list/filtered_list/index.js
@@ -26,6 +26,7 @@ import Config from 'assets/config';
 import FilteredList from './filtered_list';
 
 const DEFAULT_SEARCH_ORDER = ['unreads', 'dms', 'channels', 'members', 'nonmembers', 'archived'];
+const emptyArray = [];
 
 const pastDirectMessages = createSelector(
     getDirectShowPreferences,
@@ -98,15 +99,17 @@ const getGroupChannelMemberDetails = createSelector(
 
 function mapStateToProps(state) {
     const {currentUserId} = state.entities.users;
+    const config = getConfig(state);
 
     const profiles = getUsers(state);
     let teamProfiles = {};
-    const restrictDms = getConfig(state).RestrictDirectMessage !== General.RESTRICT_DIRECT_MESSAGE_ANY;
+    const restrictDms = config.RestrictDirectMessage !== General.RESTRICT_DIRECT_MESSAGE_ANY;
     if (restrictDms) {
         teamProfiles = getTeamProfiles(state);
     }
 
     const searchOrder = Config.DrawerSearchOrder ? Config.DrawerSearchOrder : DEFAULT_SEARCH_ORDER;
+    const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
 
     return {
         channels: getChannelsWithUnreadSection(state),
@@ -114,7 +117,7 @@ function mapStateToProps(state) {
         currentTeam: getCurrentTeam(state),
         currentUserId,
         otherChannels: getOtherChannels(state, false),
-        archivedChannels: getArchivedChannels(state),
+        archivedChannels: viewArchivedChannels ? getArchivedChannels(state) : emptyArray,
         groupChannelMemberDetails: getGroupChannelMemberDetails(state),
         profiles,
         teamProfiles,

--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -322,6 +322,13 @@ function lastChannelViewTime(state = {}, action) {
 function keepChannelIdAsUnread(state = null, action) {
     switch (action.type) {
     case ChannelTypes.SELECT_CHANNEL: {
+        if (!action.extra && action.data) {
+            return {
+                id: action.data,
+                hadMentions: false,
+            };
+        }
+
         const {channel, member} = action.extra;
 
         if (!member || !channel) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9974,8 +9974,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#260818380037a7e202f8f1a492ec1be1d44e44b0",
-      "from": "github:mattermost/mattermost-redux#260818380037a7e202f8f1a492ec1be1d44e44b0",
+      "version": "github:mattermost/mattermost-redux#38c456cfb6b7c900b8413f4f9d6e742d4236150f",
+      "from": "github:mattermost/mattermost-redux#38c456cfb6b7c900b8413f4f9d6e742d4236150f",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9974,8 +9974,8 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#0847d2fd8038e9cf626697b38e6ae9c441e8d1f6",
-      "from": "github:mattermost/mattermost-redux#0847d2fd8038e9cf626697b38e6ae9c441e8d1f6",
+      "version": "github:mattermost/mattermost-redux#260818380037a7e202f8f1a492ec1be1d44e44b0",
+      "from": "github:mattermost/mattermost-redux#260818380037a7e202f8f1a492ec1be1d44e44b0",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.1",
     "jsc-android": "241213.2.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#0847d2fd8038e9cf626697b38e6ae9c441e8d1f6",
+    "mattermost-redux": "github:mattermost/mattermost-redux#260818380037a7e202f8f1a492ec1be1d44e44b0",
     "mime-db": "1.43.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "intl": "1.2.5",
     "jail-monkey": "2.3.1",
     "jsc-android": "241213.2.0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#260818380037a7e202f8f1a492ec1be1d44e44b0",
+    "mattermost-redux": "github:mattermost/mattermost-redux#38c456cfb6b7c900b8413f4f9d6e742d4236150f",
     "mime-db": "1.43.0",
     "moment-timezone": "0.5.27",
     "prop-types": "15.7.2",


### PR DESCRIPTION
#### Summary
With the performance optimizations done for 1.29 a reducer that listened for `SELECT_CHANNEL` was expecting an `extra` property which is not set when a channel is deleted/archived, this PR handles that.

Also this PR requires https://github.com/mattermost/mattermost-redux/pull/1069 that addresses some WebSocket bugs related to this issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22934
https://mattermost.atlassian.net/browse/MM-22975