### PR TITLE
[MM-23135] Remove double-handling of toggle switch state

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -90,18 +90,12 @@ export default class ChannelInfo extends PureComponent {
         };
     }
 
-    static getDerivedStateFromProps(nextProps, state) {
-        if (state.isFavorite !== nextProps.isFavorite ||
-            state.isMuted !== nextProps.isChannelMuted ||
-            state.ignoreChannelMentions !== nextProps.ignoreChannelMentions) {
-            return {
-                isFavorite: nextProps.isFavorite,
-                isMuted: nextProps.isChannelMuted,
-                ignoreChannelMentions: nextProps.ignoreChannelMentions,
-            };
-        }
-
-        return null;
+    static getDerivedStateFromProps(props) {
+        return {
+            isFavorite: props.isFavorite,
+            isMuted: props.isChannelMuted,
+            ignoreChannelMentions: props.ignoreChannelMentions,
+        };
     }
 
     componentDidMount() {
@@ -356,7 +350,6 @@ export default class ChannelInfo extends PureComponent {
         const {isFavorite, actions, currentChannel} = this.props;
         const {favoriteChannel, unfavoriteChannel} = actions;
         const toggleFavorite = isFavorite ? unfavoriteChannel : favoriteChannel;
-        this.setState({isFavorite: !isFavorite});
         toggleFavorite(currentChannel.id);
     });
 
@@ -378,7 +371,6 @@ export default class ChannelInfo extends PureComponent {
             mark_unread: isChannelMuted ? 'all' : 'mention',
         };
 
-        this.setState({isMuted: !isChannelMuted});
         updateChannelNotifyProps(currentUserId, currentChannel.id, opts);
     });
 
@@ -390,7 +382,6 @@ export default class ChannelInfo extends PureComponent {
             ignore_channel_mentions: ignoreChannelMentions ? Users.IGNORE_CHANNEL_MENTIONS_OFF : Users.IGNORE_CHANNEL_MENTIONS_ON,
         };
 
-        this.setState({ignoreChannelMentions: !ignoreChannelMentions});
         updateChannelNotifyProps(currentUserId, currentChannel.id, opts);
     });
 


### PR DESCRIPTION
#### Summary

Whether the Mute, Favorite, Ignore toggles are set on or off is already being governed by the parent controlling component. Whenever any of their respective states change, the parent updates the child's props, and the toggle switches re-render with the correct switch settings in props anyway.

`getDerivedStateFromProps` is called on component creation and then whenever the parent component's state is updated and a re-render of all children is triggered, **regardless of whether the props are different from before **

The `this.setState` in each of the toggle switch handlers was already taking care of keeping component state healthy. With `getDerivedStateFromProps`, state was being "double-managed" resulting in toggle switches sometimes jumping between on and off, well after it was touched.

#### Ticket Link

* https://mattermost.atlassian.net/browse/MM-23135

#### Device Information
This PR was tested on: Android 10 (OnePlus 5 device)

#### Screenshots

**Old (jumping switches)**
<img width="275" alt="old" src="https://user-images.githubusercontent.com/887849/76338796-f66c3a00-62d7-11ea-8d83-5b63d0f3d01c.gif">

**New**

<img width="275" alt="new" src="https://user-images.githubusercontent.com/887849/76338784-f3714980-62d7-11ea-86df-c3bb6030f067.gif">
