### PR TITLE
MM-23176 Fix crash due to scrollToIndex out of range

### DIFF
--- a/app/components/post_list/__snapshots__/post_list.test.js.snap
+++ b/app/components/post_list/__snapshots__/post_list.test.js.snap
@@ -41,6 +41,7 @@ exports[`PostList setting channel deep link 1`] = `
   onEndReachedThreshold={2}
   onLayout={[Function]}
   onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
   onScrollToIndexFailed={[Function]}
   refreshControl={
     <RefreshControl
@@ -108,6 +109,7 @@ exports[`PostList setting permalink deep link 1`] = `
   onEndReachedThreshold={2}
   onLayout={[Function]}
   onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
   onScrollToIndexFailed={[Function]}
   refreshControl={
     <RefreshControl
@@ -175,6 +177,7 @@ exports[`PostList should match snapshot 1`] = `
   onEndReachedThreshold={2}
   onLayout={[Function]}
   onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
   onScrollToIndexFailed={[Function]}
   refreshControl={
     <RefreshControl


### PR DESCRIPTION
#### Summary
This PR fixes a race condition that cause the postList to try and scroll to an index of a previous visited channel when switching quickly between them, thus the index did not exist and was out of range and the app crashed.

The fix consist of two things:
1. Cancel all pending requestAnimationFrames and timeouts when the channel is switched
2. Avoid trying to jump to the new line message indicator if there was a scrolling interaction

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23176