### PR TITLE
MM-22318 Fix autocomplete selection char code for native emojis

### DIFF
--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -129,7 +129,11 @@ export default class EmojiSuggestion extends PureComponent {
 
             const emojiData = getEmojiByName(emoji);
             if (emojiData?.filename && !BuiltInEmojis.includes(emojiData.filename)) {
-                completedDraft = emojiPart.replace(EMOJI_REGEX_WITHOUT_PREFIX, String.fromCodePoint(parseInt(emojiData.filename, 16)));
+                const codeArray = emojiData.filename.split('-');
+                const code = codeArray.reduce((acc, c) => {
+                    return acc + String.fromCodePoint(parseInt(c, 16));
+                }, '');
+                completedDraft = emojiPart.replace(EMOJI_REGEX_WITHOUT_PREFIX, `${code} `);
             } else {
                 completedDraft = emojiPart.replace(EMOJI_REGEX_WITHOUT_PREFIX, `${prefix}${emoji}: `);
             }


### PR DESCRIPTION
#### Summary
When using the autocomplete for emojis the `codePoint` mapping was wrongly implemented thus some emojis were incorrectly rendered like (man/woman shrug, flags, and a few others), this PR corrects the parsing

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22318
Fixes: #4039 