### PR TITLE
[MM-22237] Fix text capitalization

### DIFF
--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -63,7 +63,7 @@
 	<key>NSCalendarsUsageDescription</key>
 	<string>Share contacts in your Mattermost instance</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Take a Photo or Video and upload it to your mattermost instance</string>
+	<string>Take a Photo or Video and upload it to your Mattermost instance</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Send your current location to your Mattermost instance</string>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
#### Summary
Change 'mattermost' to 'Mattermost' on iOS camera permissions alert text.

#### Ticket Link
[MM-22237](https://mattermost.atlassian.net/browse/MM-22237)

#### Checklist
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone 11 Simulator

#### Screenshots

<img width="373" alt="Text capitalization" src="https://user-images.githubusercontent.com/887849/76894750-7ad93280-686d-11ea-83b2-5dd629a6df7a.png">
