### PR TITLE
[MM-23162] Remove unnecessary dimension and orientation dispatches

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -189,16 +189,26 @@ class GlobalEventHandler {
 
     onOrientationChange = (dimensions) => {
         if (this.store) {
-            const {dispatch} = this.store;
+            const {dispatch, getState} = this.store;
+            const deviceState = getState().device;
+
             if (DeviceInfo.isTablet()) {
                 dispatch(setDeviceAsTablet());
             }
 
             const {height, width} = dimensions.window;
             const orientation = height > width ? 'PORTRAIT' : 'LANDSCAPE';
+            const savedOrientation = deviceState?.orientation;
+            const savedDimension = deviceState?.dimension;
 
-            dispatch(setDeviceOrientation(orientation));
-            dispatch(setDeviceDimensions(height, width));
+            if (orientation !== savedOrientation) {
+                dispatch(setDeviceOrientation(orientation));
+            }
+
+            if (height !== savedDimension?.deviceHeight ||
+                width !== savedDimension?.deviceWidth) {
+                dispatch(setDeviceDimensions(height, width));
+            }
         }
     };
 


### PR DESCRIPTION
#### Summary

`setDeviceOrientation` and `setDeviceDimensions` used to get called on any navigation change (e.g. modal launches) and triggered multiple needless dispatches.

#### Ticket Link
[MM-23162](https://mattermost.atlassian.net/browse/MM-23162)

#### Device Information
This PR was tested on: Android 11 (OnePlus 5)
