### PR TITLE
[MM-21582] Parse payload safely to report Sentry exception with needed information

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -194,8 +194,12 @@ public class ShareModule extends ReactContextBaseJavaModule {
         JSONObject json = new JSONObject();
         try {
             json.put("user_id", data.getString("currentUserId"));
-            json.put("channel_id", data.getString("channelId"));
-            json.put("message", data.getString("value"));
+            if (data.hasKey("channel_id")) {
+                json.put("channel_id", data.getString("channelId"));
+            }
+            if (data.hasKey("value")) {
+                json.put("message", data.getString("value"));
+            }
         } catch (JSONException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
#### Summary
Users are hitting legitimate exceptions when using the Android Share extension.

However, in some cases where the channel ID isn't available from the user's actions that triggered the exception, the Sentry error reporting message payload can't be successfully formed and it bombs.

This commit allows Sentry's payload to be successfully formed, so that we can now see the actual underlying exception (with its associated user data) in Sentry. The single, catch-all `NoSuchKeyException` should now stop, and be replaced by a few new Sentry exception reports to analyze and tackle individually.

#### Ticket Link
* [MM-21582](https://mattermost.atlassian.net/browse/MM-21582)

#### Device Information
This PR was tested on: Android 10 (OnePlus 5 device)
