### PR TITLE
Downgrade SDWebImage

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -297,9 +297,9 @@ PODS:
     - React
   - RNVectorIcons (6.6.0):
     - React
-  - SDWebImage (5.6.1):
-    - SDWebImage/Core (= 5.6.1)
-  - SDWebImage/Core (5.6.1)
+  - SDWebImage (5.5.2):
+    - SDWebImage/Core (= 5.5.2)
+  - SDWebImage/Core (5.5.2)
   - SDWebImageWebPCoder (0.4.1):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.5)
@@ -557,7 +557,7 @@ SPEC CHECKSUMS:
   RNSentry: 86baf0c87120cd5eb491d073989f8cbc1a2174c6
   RNSVG: 7e16ddfc6e00d5aa69c9eb83e699bcce5dcb85d4
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
-  SDWebImage: 7edb9c3ea661e77a66661f7f044de8c1b55d1120
+  SDWebImage: 4d5c027c935438f341ed33dbac53ff9f479922ca
   SDWebImageWebPCoder: 36f8f47bd9879a8aea6044765c1351120fd8e3a8
   Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
   Swime: d7b2c277503b6cea317774aedc2dce05613f8b0b


### PR DESCRIPTION
#### Summary
With SDWebImage v5.6.1 I get the following error on latest master:
```
[!] CocoaPods could not find compatible versions for pod "SDWebImage":
  In snapshot (Podfile.lock):
    SDWebImage (= 5.6.1, ~> 5.0)

  In Podfile:
    RNFastImage (from `../node_modules/react-native-fast-image`) was resolved to 8.1.5, which depends on
      SDWebImage (~> 5.0)

It seems like you've changed the constraints of dependency `SDWebImage` inside your development pod `RNFastImage`.
You should run `pod update SDWebImage` to apply changes you've made.
```