### PR TITLE
MM-23234 Prefer mobile-defined state actions

### DIFF
--- a/app/components/network_indicator/index.js
+++ b/app/components/network_indicator/index.js
@@ -4,13 +4,13 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {stopPeriodicStatusUpdates, startPeriodicStatusUpdates, logout} from 'mattermost-redux/actions/users';
+import {stopPeriodicStatusUpdates, startPeriodicStatusUpdates} from 'mattermost-redux/actions/users';
 import {init as initWebSocket, close as closeWebSocket} from 'mattermost-redux/actions/websocket';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
 import {connection} from 'app/actions/device';
 import {markChannelViewedAndReadOnReconnect, setChannelRetryFailed} from 'app/actions/views/channel';
-import {setCurrentUserStatusOffline} from 'app/actions/views/user';
+import {setCurrentUserStatusOffline, logout} from 'app/actions/views/user';
 import {getConnection, isLandscape} from 'app/selectors/device';
 
 import NetworkIndicator from './network_indicator';

--- a/app/screens/error_teams_list/index.js
+++ b/app/screens/error_teams_list/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {logout, loadMe} from 'mattermost-redux/actions/users';
+import {logout, loadMe} from 'app/actions/views/user';
 import {connection} from 'app/actions/device';
 import {selectDefaultTeam} from 'app/actions/views/select_team';
 

--- a/app/screens/select_team/index.js
+++ b/app/screens/select_team/index.js
@@ -5,11 +5,11 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getTeams, addUserToTeam, joinTeam} from 'mattermost-redux/actions/teams';
-import {logout} from 'mattermost-redux/actions/users';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getJoinableTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
+import {logout} from 'app/actions/views/user';
 import {handleTeamChange} from 'app/actions/views/select_team';
 import {isLandscape} from 'app/selectors/device';
 import {isGuest} from 'app/utils/users';

--- a/app/screens/terms_of_service/index.js
+++ b/app/screens/terms_of_service/index.js
@@ -4,9 +4,10 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {getTermsOfService, logout, updateMyTermsOfServiceStatus} from 'mattermost-redux/actions/users';
+import {getTermsOfService, updateMyTermsOfServiceStatus} from 'mattermost-redux/actions/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {logout} from 'app/actions/views/user';
 
 import TermsOfService from './terms_of_service.js';
 


### PR DESCRIPTION
#### Summary

Unify usage to one set of defined dispatch actions in codebase, instead of a mix of (almost) identical actions defined in `mattermost-mobile` and `mattermost-redux` .

#### Ticket Link
As part of investigation done for [MM-23234](https://mattermost.atlassian.net/browse/MM-23234)

#### Device Information
This PR was tested on:

* iPhone 11 Simulator
* Android 10 (OnePlus 5 device)
