### PR TITLE
[MM-23490] Save state to file via async middleware vs store subscription

### DIFF
--- a/app/initial_state.js
+++ b/app/initial_state.js
@@ -139,7 +139,6 @@ const state = {
         root: {
             deepLinkURL: '',
             hydrationComplete: false,
-            purge: false,
         },
         selectServer: {
             serverUrl: Config.DefaultServerUrl,

--- a/app/reducers/views/root.js
+++ b/app/reducers/views/root.js
@@ -26,17 +26,7 @@ function hydrationComplete(state = false, action) {
     }
 }
 
-function purge(state = false, action) {
-    switch (action.type) {
-    case General.OFFLINE_STORE_PURGE:
-        return true;
-    default:
-        return state;
-    }
-}
-
 export default combineReducers({
     deepLinkURL,
     hydrationComplete,
-    purge,
 });

--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -1,17 +1,89 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Platform} from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 
 import {ViewTypes} from 'app/constants';
 import initialState from 'app/initial_state';
+import {throttle} from 'app/utils/general';
+
+import mattermostBucket from 'app/mattermost_bucket';
 
 import {
     captureException,
     LOGGER_JAVASCRIPT_WARNING,
 } from 'app/utils/sentry';
 
-export function messageRetention(store) {
+const SAVE_STATE_ACTIONS = [
+    'CONNECTION_CHANGED',
+    'DATA_CLEANUP',
+    'LOGIN',
+    'Offline/STATUS_CHANGED',
+    'persist/REHYDRATE',
+    'RECEIVED_APP_STATE',
+    'WEBSOCKET_CLOSED',
+    'WEBSOCKET_SUCCESS',
+];
+
+// This middleware stores key parts of state entities into a file (in the App Group container) on certain actions.
+// iOS only. Allows the share extension to work, without having access available to the redux store object.
+// Remove this middleware if/when state is moved to a persisted solution.
+const saveShareExtensionState = (store) => {
+    return (next) => (action) => {
+        if (SAVE_STATE_ACTIONS.includes(action.type)) {
+            throttle(saveStateToFile(store));
+        }
+        return next(action);
+    };
+};
+
+const saveStateToFile = async (store) => {
+    if (Platform.OS === 'ios') {
+        const state = store.getState();
+        if (state.entities) {
+            const channelsInTeam = {...state.entities.channels.channelsInTeam};
+            Object.keys(channelsInTeam).forEach((teamId) => {
+                channelsInTeam[teamId] = Array.from(channelsInTeam[teamId]);
+            });
+
+            const profilesInChannel = {...state.entities.users.profilesInChannel};
+            Object.keys(profilesInChannel).forEach((channelId) => {
+                profilesInChannel[channelId] = Array.from(profilesInChannel[channelId]);
+            });
+
+            let url;
+            if (state.entities.users.currentUserId) {
+                url = state.entities.general.credentials.url || state.views.selectServer.serverUrl;
+            }
+
+            const entities = {
+                ...state.entities,
+                general: {
+                    ...state.entities.general,
+                    credentials: {
+                        url,
+                    },
+                },
+                channels: {
+                    ...state.entities.channels,
+                    channelsInTeam,
+                },
+                users: {
+                    ...state.entities.users,
+                    profilesInChannel,
+                    profilesNotInTeam: [],
+                    profilesWithoutTeam: [],
+                    profilesNotInChannel: [],
+                },
+            };
+
+            mattermostBucket.writeToFile('entities', JSON.stringify(entities));
+        }
+    }
+};
+
+const messageRetention = (store) => {
     return (next) => (action) => {
         if (action.type === 'persist/REHYDRATE') {
             const {app} = action.payload;
@@ -55,7 +127,7 @@ export function messageRetention(store) {
 
         return next(action);
     };
-}
+};
 
 function resetStateForNewVersion(action) {
     const {payload} = action;
@@ -433,4 +505,10 @@ function removePendingPost(pendingPostIds, id) {
     if (pendingIndex !== -1) {
         pendingPostIds.splice(pendingIndex, 1);
     }
+}
+
+export const middlewares = [messageRetention];
+
+if (Platform.OS === 'ios') {
+    middlewares.push(saveShareExtensionState);
 }

--- a/app/store/middleware.test.js
+++ b/app/store/middleware.test.js
@@ -14,7 +14,7 @@ import {
 } from 'app/store/middleware';
 
 describe('messageRetention', () => {
-    const messageRetention = middlewares[0];
+    const messageRetention = middlewares()[0];
 
     describe('should chain the same incoming action type', () => {
         const actions = [

--- a/app/store/middleware.test.js
+++ b/app/store/middleware.test.js
@@ -10,10 +10,12 @@ import {
     cleanUpPostsInChannel,
     cleanUpState,
     getAllFromPostsInChannel,
-    messageRetention,
+    middlewares,
 } from 'app/store/middleware';
 
 describe('messageRetention', () => {
+    const messageRetention = middlewares[0];
+
     describe('should chain the same incoming action type', () => {
         const actions = [
             {

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {batchActions} from 'redux-batched-actions';
-import {Platform} from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import {createBlacklistFilter} from 'redux-persist-transform-filter';
 import {createTransform, persistStore} from 'redux-persist';
@@ -15,13 +14,10 @@ import EventEmitter from '@mm-redux/utils/event_emitter';
 
 import {NavigationTypes, ViewTypes} from 'app/constants';
 import appReducer from 'app/reducers';
-import {throttle} from 'app/utils/general';
 import {getSiteUrl, setSiteUrl} from 'app/utils/image_cache_manager';
 import {createSentryMiddleware} from 'app/utils/sentry/middleware';
 
-import mattermostBucket from 'app/mattermost_bucket';
-
-import {messageRetention} from './middleware';
+import {middlewares} from './middleware';
 import {createThunkMiddleware} from './thunk';
 import {transformSet, getStateForReset} from './utils';
 
@@ -151,51 +147,6 @@ export default function configureAppStore(initialState) {
 
             let purging = false;
 
-            // for iOS write the entities to a shared file
-            if (Platform.OS === 'ios') {
-                store.subscribe(throttle(() => {
-                    const state = store.getState();
-                    if (state.entities) {
-                        const channelsInTeam = {...state.entities.channels.channelsInTeam};
-                        Object.keys(channelsInTeam).forEach((teamId) => {
-                            channelsInTeam[teamId] = Array.from(channelsInTeam[teamId]);
-                        });
-
-                        const profilesInChannel = {...state.entities.users.profilesInChannel};
-                        Object.keys(profilesInChannel).forEach((channelId) => {
-                            profilesInChannel[channelId] = Array.from(profilesInChannel[channelId]);
-                        });
-
-                        let url;
-                        if (state.entities.users.currentUserId) {
-                            url = state.entities.general.credentials.url || state.views.selectServer.serverUrl;
-                        }
-
-                        const entities = {
-                            ...state.entities,
-                            general: {
-                                ...state.entities.general,
-                                credentials: {
-                                    url,
-                                },
-                            },
-                            channels: {
-                                ...state.entities.channels,
-                                channelsInTeam,
-                            },
-                            users: {
-                                ...state.entities.users,
-                                profilesInChannel,
-                                profilesNotInTeam: [],
-                                profilesWithoutTeam: [],
-                                profilesNotInChannel: [],
-                            },
-                        };
-                        mattermostBucket.writeToFile('entities', JSON.stringify(entities));
-                    }
-                }, 1000));
-            }
-
             // check to see if the logout request was successful
             store.subscribe(async () => {
                 const state = store.getState();
@@ -273,7 +224,7 @@ export default function configureAppStore(initialState) {
         additionalMiddleware: [
             createThunkMiddleware(),
             createSentryMiddleware(),
-            messageRetention,
+            ...middlewares,
         ],
         enableThunk: false, // We override the default thunk middleware
     };

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -1,25 +1,21 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {batchActions} from 'redux-batched-actions';
 import AsyncStorage from '@react-native-community/async-storage';
 import {createBlacklistFilter} from 'redux-persist-transform-filter';
 import {createTransform, persistStore} from 'redux-persist';
 
-import {ErrorTypes, GeneralTypes} from '@mm-redux/action_types';
 import {General} from '@mm-redux/constants';
 import {getConfig} from '@mm-redux/selectors/entities/general';
 import configureStore from '@mm-redux/store';
-import EventEmitter from '@mm-redux/utils/event_emitter';
 
-import {NavigationTypes, ViewTypes} from 'app/constants';
 import appReducer from 'app/reducers';
 import {getSiteUrl, setSiteUrl} from 'app/utils/image_cache_manager';
 import {createSentryMiddleware} from 'app/utils/sentry/middleware';
 
 import {middlewares} from './middleware';
 import {createThunkMiddleware} from './thunk';
-import {transformSet, getStateForReset} from './utils';
+import {transformSet} from './utils';
 
 function getAppReducer() {
     return require('../../app/reducers'); // eslint-disable-line global-require
@@ -46,188 +42,140 @@ const setTransforms = [
     ...rolesSetTransform,
 ];
 
+const viewsBlackListFilter = createBlacklistFilter(
+    'views',
+    ['extension', 'root'],
+);
+
+const typingBlackListFilter = createBlacklistFilter(
+    'entities',
+    ['typing'],
+);
+
+const channelViewBlackList = {loading: true, refreshing: true, loadingPosts: true, retryFailed: true, loadMorePostsVisible: true};
+const channelViewBlackListFilter = createTransform(
+    (inboundState) => {
+        const channel = {};
+
+        for (const channelKey of Object.keys(inboundState.channel)) {
+            if (!channelViewBlackList[channelKey]) {
+                channel[channelKey] = inboundState.channel[channelKey];
+            }
+        }
+
+        return {
+            ...inboundState,
+            channel,
+        };
+    },
+    null,
+    {whitelist: ['views']}, // Only run this filter on the views state (or any other entry that ends up being named views)
+);
+
+const emojiBlackList = {nonExistentEmoji: true};
+const emojiBlackListFilter = createTransform(
+    (inboundState) => {
+        const emojis = {};
+
+        for (const emojiKey of Object.keys(inboundState.emojis)) {
+            if (!emojiBlackList[emojiKey]) {
+                emojis[emojiKey] = inboundState.emojis[emojiKey];
+            }
+        }
+
+        return {
+            ...inboundState,
+            emojis,
+        };
+    },
+    null,
+    {whitelist: ['entities']}, // Only run this filter on the entities state (or any other entry that ends up being named entities)
+);
+
+const setTransformer = createTransform(
+    (inboundState, key) => {
+        if (key === 'entities') {
+            const state = {...inboundState};
+            for (const prop in state) {
+                if (state.hasOwnProperty(prop)) {
+                    state[prop] = transformSet(state[prop], setTransforms);
+                }
+            }
+
+            return state;
+        }
+
+        return inboundState;
+    },
+    (outboundState, key) => {
+        if (key === 'entities') {
+            const state = {...outboundState};
+            for (const prop in state) {
+                if (state.hasOwnProperty(prop)) {
+                    state[prop] = transformSet(state[prop], setTransforms, false);
+                }
+            }
+
+            return state;
+        }
+
+        return outboundState;
+    },
+);
+
+const persistConfig = {
+    effect: (effect, action) => {
+        if (typeof effect !== 'function') {
+            throw new Error('Offline Action: effect must be a function.');
+        } else if (!action.meta.offline.commit) {
+            throw new Error('Offline Action: commit action must be present.');
+        }
+
+        return effect();
+    },
+    persist: (store, options) => {
+        const persistor = persistStore(store, {storage: AsyncStorage, ...options}, () => {
+            store.dispatch({
+                type: General.STORE_REHYDRATION_COMPLETE,
+            });
+        });
+
+        store.subscribe(async () => {
+            const state = store.getState();
+            const config = getConfig(state);
+
+            if (getSiteUrl() !== config?.SiteURL) {
+                setSiteUrl(config.SiteURL);
+            }
+        });
+
+        return persistor;
+    },
+    persistOptions: {
+        autoRehydrate: {
+            log: false,
+        },
+        blacklist: ['device', 'navigation', 'offline', 'requests'],
+        debounce: 500,
+        transforms: [
+            setTransformer,
+            viewsBlackListFilter,
+            typingBlackListFilter,
+            channelViewBlackListFilter,
+            emojiBlackListFilter,
+        ],
+    },
+};
+
 export default function configureAppStore(initialState) {
-    const viewsBlackListFilter = createBlacklistFilter(
-        'views',
-        ['extension', 'root'],
-    );
-
-    const typingBlackListFilter = createBlacklistFilter(
-        'entities',
-        ['typing'],
-    );
-
-    const channelViewBlackList = {loading: true, refreshing: true, loadingPosts: true, retryFailed: true, loadMorePostsVisible: true};
-    const channelViewBlackListFilter = createTransform(
-        (inboundState) => {
-            const channel = {};
-
-            for (const channelKey of Object.keys(inboundState.channel)) {
-                if (!channelViewBlackList[channelKey]) {
-                    channel[channelKey] = inboundState.channel[channelKey];
-                }
-            }
-
-            return {
-                ...inboundState,
-                channel,
-            };
-        },
-        null,
-        {whitelist: ['views']}, // Only run this filter on the views state (or any other entry that ends up being named views)
-    );
-
-    const emojiBlackList = {nonExistentEmoji: true};
-    const emojiBlackListFilter = createTransform(
-        (inboundState) => {
-            const emojis = {};
-
-            for (const emojiKey of Object.keys(inboundState.emojis)) {
-                if (!emojiBlackList[emojiKey]) {
-                    emojis[emojiKey] = inboundState.emojis[emojiKey];
-                }
-            }
-
-            return {
-                ...inboundState,
-                emojis,
-            };
-        },
-        null,
-        {whitelist: ['entities']}, // Only run this filter on the entities state (or any other entry that ends up being named entities)
-    );
-
-    const setTransformer = createTransform(
-        (inboundState, key) => {
-            if (key === 'entities') {
-                const state = {...inboundState};
-                for (const prop in state) {
-                    if (state.hasOwnProperty(prop)) {
-                        state[prop] = transformSet(state[prop], setTransforms);
-                    }
-                }
-
-                return state;
-            }
-
-            return inboundState;
-        },
-        (outboundState, key) => {
-            if (key === 'entities') {
-                const state = {...outboundState};
-                for (const prop in state) {
-                    if (state.hasOwnProperty(prop)) {
-                        state[prop] = transformSet(state[prop], setTransforms, false);
-                    }
-                }
-
-                return state;
-            }
-
-            return outboundState;
-        },
-    );
-
-    const offlineOptions = {
-        effect: (effect, action) => {
-            if (typeof effect !== 'function') {
-                throw new Error('Offline Action: effect must be a function.');
-            } else if (!action.meta.offline.commit) {
-                throw new Error('Offline Action: commit action must be present.');
-            }
-
-            return effect();
-        },
-        persist: (store, options) => {
-            const persistor = persistStore(store, {storage: AsyncStorage, ...options}, () => {
-                store.dispatch({
-                    type: General.STORE_REHYDRATION_COMPLETE,
-                });
-            });
-
-            let purging = false;
-
-            // check to see if the logout request was successful
-            store.subscribe(async () => {
-                const state = store.getState();
-                const config = getConfig(state);
-
-                if (getSiteUrl() !== config?.SiteURL) {
-                    setSiteUrl(config.SiteURL);
-                }
-
-                if (state.views.root.purge && !purging) {
-                    purging = true;
-
-                    await persistor.purge();
-
-                    const resetState = getStateForReset(initialState, state);
-
-                    store.dispatch(batchActions([
-                        {
-                            type: General.OFFLINE_STORE_RESET,
-                            data: resetState,
-                        },
-                        {
-                            type: ErrorTypes.RESTORE_ERRORS,
-                            data: [...state.errors],
-                        },
-                        {
-                            type: GeneralTypes.RECEIVED_APP_DEVICE_TOKEN,
-                            data: state.entities.general.deviceToken,
-                        },
-                        {
-                            type: GeneralTypes.RECEIVED_APP_CREDENTIALS,
-                            data: {
-                                url: state.entities.general.credentials.url,
-                            },
-                        },
-                        {
-                            type: ViewTypes.SERVER_URL_CHANGED,
-                            serverUrl: state.entities.general.credentials.url || state.views.selectServer.serverUrl,
-                        },
-                        {
-                            type: GeneralTypes.RECEIVED_SERVER_VERSION,
-                            data: state.entities.general.serverVersion,
-                        },
-                        {
-                            type: General.STORE_REHYDRATION_COMPLETE,
-                        },
-                    ], 'BATCH_FOR_RESTART'));
-
-                    setTimeout(() => {
-                        purging = false;
-                        EventEmitter.emit(NavigationTypes.RESTART_APP);
-                    }, 500);
-                }
-            });
-
-            return persistor;
-        },
-        persistOptions: {
-            autoRehydrate: {
-                log: false,
-            },
-            blacklist: ['device', 'navigation', 'offline', 'requests'],
-            debounce: 500,
-            transforms: [
-                setTransformer,
-                viewsBlackListFilter,
-                typingBlackListFilter,
-                channelViewBlackListFilter,
-                emojiBlackListFilter,
-            ],
-        },
-    };
-
     const clientOptions = {
         additionalMiddleware: [
             createThunkMiddleware(),
             createSentryMiddleware(),
-            ...middlewares,
+            ...middlewares(persistConfig),
         ],
         enableThunk: false, // We override the default thunk middleware
     };
 
-    return configureStore(initialState, appReducer, offlineOptions, getAppReducer, clientOptions);
+    return configureStore(initialState, appReducer, persistConfig, getAppReducer, clientOptions);
 }


### PR DESCRIPTION
#### Summary

Currently for iOS, a subset of store state is saved to an on-device file, so that the Share Extension can have access to information it needs (teams and channels) to function.

This file saving would happen via a store subscription which triggers a file save for every dispatched action. By moving this logic to a middleware function, when this function gets invoked is now limited to a configurable set of action dispatches. (e.g. `LOGIN`, `CONNECTION_CHANGED`, `WEBSOCKET_SUCCESS`), etc.

#### Ticket Link
* [MM-23490](https://mattermost.atlassian.net/browse/MM-23490)
* [MM-23493](https://mattermost.atlassian.net/browse/MM-23493) (merged via #4069 )

#### Device Information
This PR was tested on:

* iPhone 11 (Simulator)
* Android 10 (OnePlus 5 device)

---

### Notes & Observations

* [persistor function in store.js](https://github.com/mattermost/mattermost-mobile/blob/master/app/store/store.js#L145-L255) has less responsibilities now, and more aligned with its core purpose (offline persistence). Cache saving is now treated as a side-effect.

* In existing solution, file writes were triggered with every state change, and the [function call throttle](https://github.com/mattermost/mattermost-mobile/blob/master/app/store/store.js#L156) was effective, but was also preventing most-recent writes from happening if within the 1 second window. Therefore, the file write was dependent on being subsequently re-triggered by an action that may have  had no connection with teams, channels or users (what's relevant to the share extension).

Now, file write attempts are limited to the following key state actions:
```
    CONNECTION_CHANGED
    DATA_CLEANUP
    LOGIN
    Offline/STATUS_CHANGED
    persist/REHYDRATE
    RECEIVED_APP_STATE
    WEBSOCKET_CLOSED
    WEBSOCKET_SUCCESS
```

@enahum : I'm not thrilled with this "solution" for limiting file writes by specific actions. I'd definitely consider firing the new middleware on every action if that makes more sense, and ensures a most up-to-date state cache file? This will be even more relevant with upcoming batching effort of websocket actions and the resulting `BATCHED_ACTIONS` action that would obfuscate the individual websocket action names.

* This middleware could be quickly removed if/when the app moves to persisted state management.

---

**QA Notes**
Functionality in PR #4069 was based on this PR and has been merged in, covering functionality for both Jira tickets listed above.