### PR TITLE
MM-23341 Fix message failed banner when posting first message

### DIFF
--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -10,6 +10,8 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import store from 'app/store';
 import EphemeralStore from 'app/store/ephemeral_store';
 
+const CHANNEL_SCREEN = 'Channel';
+
 function getThemeFromState() {
     const state = store.getState();
 
@@ -24,8 +26,8 @@ export function resetToChannel(passProps = {}) {
     const stack = {
         children: [{
             component: {
-                id: 'Channel',
-                name: 'Channel',
+                id: CHANNEL_SCREEN,
+                name: CHANNEL_SCREEN,
                 passProps,
                 options: {
                     layout: {
@@ -397,10 +399,8 @@ export function closeMainSideMenu() {
         return;
     }
 
-    const componentId = EphemeralStore.getNavigationTopComponentId();
-
     Keyboard.dismiss();
-    Navigation.mergeOptions(componentId, {
+    Navigation.mergeOptions(CHANNEL_SCREEN, {
         sideMenu: {
             left: {visible: false},
         },
@@ -412,9 +412,7 @@ export function enableMainSideMenu(enabled, visible = true) {
         return;
     }
 
-    const componentId = EphemeralStore.getNavigationTopComponentId();
-
-    Navigation.mergeOptions(componentId, {
+    Navigation.mergeOptions(CHANNEL_SCREEN, {
         sideMenu: {
             left: {enabled, visible},
         },
@@ -426,10 +424,8 @@ export function openSettingsSideMenu() {
         return;
     }
 
-    const componentId = EphemeralStore.getNavigationTopComponentId();
-
     Keyboard.dismiss();
-    Navigation.mergeOptions(componentId, {
+    Navigation.mergeOptions(CHANNEL_SCREEN, {
         sideMenu: {
             right: {visible: true},
         },
@@ -441,10 +437,8 @@ export function closeSettingsSideMenu() {
         return;
     }
 
-    const componentId = EphemeralStore.getNavigationTopComponentId();
-
     Keyboard.dismiss();
-    Navigation.mergeOptions(componentId, {
+    Navigation.mergeOptions(CHANNEL_SCREEN, {
         sideMenu: {
             right: {visible: false},
         },

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -48,6 +48,7 @@ import {INSERT_TO_COMMENT, INSERT_TO_DRAFT} from 'app/constants/post_textbox';
 import {getChannelReachable} from 'app/selectors/channel';
 import telemetry from 'app/telemetry';
 import {isDirectChannelVisible, isGroupChannelVisible, isDirectMessageVisible, isGroupMessageVisible, isDirectChannelAutoClosed} from 'app/utils/channels';
+import {isPendingPost} from 'app/utils/general';
 import {buildPreference} from 'app/utils/preferences';
 
 import {getPosts, getPostsBefore, getPostsSince, getPostThread} from './post';
@@ -658,7 +659,7 @@ export function increasePostVisibility(channelId, postId) {
             return true;
         }
 
-        if (postId.startsWith(currentUserId)) {
+        if (isPendingPost(postId, currentUserId)) {
             // This is the first created post in the channel
             return true;
         }

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -647,6 +647,7 @@ export function increasePostVisibility(channelId, postId) {
     return async (dispatch, getState) => {
         const state = getState();
         const {loadingPosts} = state.views.channel;
+        const currentUserId = getCurrentUserId(state);
 
         if (loadingPosts[channelId]) {
             return true;
@@ -654,6 +655,11 @@ export function increasePostVisibility(channelId, postId) {
 
         if (!postId) {
             // No posts are visible, so the channel is empty
+            return true;
+        }
+
+        if (postId.startsWith(currentUserId)) {
+            // This is the first created post in the channel
             return true;
         }
 

--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -80,19 +80,21 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
             const data = await Client4.getPosts(channelId, page, perPage);
             const posts = Object.values(data.posts);
 
-            if (posts?.length) {
-                const actions = [
-                    receivedPosts(data),
-                    receivedPostsInChannel(data, channelId, page === 0, data.prev_post_id === ''),
-                ];
+            // Even if the request does not return any posts we'll dispatch the actions
+            // so the block for postsInChannel gets created
+            const actions = [
+                receivedPosts(data),
+                receivedPostsInChannel(data, channelId, page === 0, data.prev_post_id === ''),
+            ];
 
+            if (posts?.length) {
                 const additional = await dispatch(getPostsAdditionalDataBatch(posts));
                 if (additional.length) {
                     actions.push(...additional);
                 }
-
-                dispatch(batchActions(actions));
             }
+
+            dispatch(batchActions(actions));
 
             return {data};
         } catch (error) {

--- a/app/components/sidebars/main/main_sidebar_base.js
+++ b/app/components/sidebars/main/main_sidebar_base.js
@@ -151,7 +151,7 @@ export default class MainSidebarBase extends Component {
             return;
         }
 
-        this.selectChannel(result.data.channel || result.data, currentChannelId, false);
+        this.selectChannel(result.data.channel || result.data, currentChannelId, true);
     };
 
     onSearchEnds = () => {

--- a/app/components/sidebars/main/main_sidebar_base.js
+++ b/app/components/sidebars/main/main_sidebar_base.js
@@ -151,7 +151,7 @@ export default class MainSidebarBase extends Component {
             return;
         }
 
-        this.selectChannel(result.data.channel || result.data, currentChannelId, true);
+        this.selectChannel(result.data.channel || result.data, currentChannelId, false);
     };
 
     onSearchEnds = () => {

--- a/app/utils/general.js
+++ b/app/utils/general.js
@@ -78,3 +78,7 @@ export function throttle(fn, limit, ...args) {
         }
     };
 }
+
+export function isPendingPost(postId, userId) {
+    return postId.startsWith(userId);
+}


### PR DESCRIPTION
#### Summary
On a new DM/GM channel there are no posts when the channel is initially created and when posting a new message this was triggering loading more messages so it fills the screen, the problem here is that it was attempting to load previous messages with a `pending_post_id`.

On this PR we are not calling `getPostsBefore` if the fist post in the list is a pending post.

Also a few other regression fixes:
* When opening a DM/GM on Android the sidebar was not closing.
* When creating a new channel on Android the sidebar was not closing.
* When fetching for posts in a channel the first time we were not dispatching the `receivedPostInChannel` action and this caused the block for recent posts not being created.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23341

Note: Marked for 1.30 as this is had 4 regressions.