### PR TITLE
[MM-23483] Add backgroundColor to drawer content parent View

### DIFF
--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -412,8 +412,15 @@ const styles = StyleSheet.create({
     container: {
         height: HEIGHT,
         width: '100%',
-        zIndex: 9,
         position: 'absolute',
+        ...Platform.select({
+            android: {
+                elevation: 9,
+            },
+            ios: {
+                zIndex: 9,
+            },
+        }),
     },
     wrapper: {
         alignItems: 'center',

--- a/app/screens/channel/channel.android.js
+++ b/app/screens/channel/channel.android.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {View} from 'react-native';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
@@ -12,6 +12,7 @@ import InteractiveDialogController from 'app/components/interactive_dialog_contr
 import NetworkIndicator from 'app/components/network_indicator';
 import PostTextbox from 'app/components/post_textbox';
 import {NavigationTypes} from 'app/constants';
+import {makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import LocalConfig from 'assets/config';
 
@@ -38,6 +39,7 @@ export default class ChannelAndroid extends ChannelBase {
             return channelLoadingOrFailed;
         }
 
+        const style = getStyle(theme);
         const drawerContent = (
             <>
                 <NetworkIndicator/>
@@ -61,7 +63,7 @@ export default class ChannelAndroid extends ChannelBase {
 
         return (
             <>
-                <View style={style.flex}>
+                <View style={style.backdrop}>
                     {drawerContent}
                 </View>
                 <InteractiveDialogController
@@ -72,8 +74,12 @@ export default class ChannelAndroid extends ChannelBase {
     }
 }
 
-const style = StyleSheet.create({
+const getStyle = makeStyleSheetFromTheme((theme) => ({
     flex: {
         flex: 1,
     },
-});
+    backdrop: {
+        flex: 1,
+        backgroundColor: theme.centerChannelBg,
+    },
+}));

--- a/app/screens/channel/channel.android.js
+++ b/app/screens/channel/channel.android.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
@@ -12,7 +12,6 @@ import InteractiveDialogController from 'app/components/interactive_dialog_contr
 import NetworkIndicator from 'app/components/network_indicator';
 import PostTextbox from 'app/components/post_textbox';
 import {NavigationTypes} from 'app/constants';
-import {makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import LocalConfig from 'assets/config';
 
@@ -39,10 +38,8 @@ export default class ChannelAndroid extends ChannelBase {
             return channelLoadingOrFailed;
         }
 
-        const style = getStyle(theme);
         const drawerContent = (
             <>
-                <NetworkIndicator/>
                 <ChannelNavBar
                     openMainSidebar={this.openMainSidebar}
                     openSettingsSidebar={this.openSettingsSidebar}
@@ -57,13 +54,14 @@ export default class ChannelAndroid extends ChannelBase {
                         screenId={this.props.componentId}
                     />
                 </KeyboardLayout>
+                <NetworkIndicator/>
                 {LocalConfig.EnableMobileClientUpgrade && <ClientUpgradeListener/>}
             </>
         );
 
         return (
             <>
-                <View style={style.backdrop}>
+                <View style={style.flex}>
                     {drawerContent}
                 </View>
                 <InteractiveDialogController
@@ -74,12 +72,8 @@ export default class ChannelAndroid extends ChannelBase {
     }
 }
 
-const getStyle = makeStyleSheetFromTheme((theme) => ({
+const style = StyleSheet.create({
     flex: {
         flex: 1,
     },
-    backdrop: {
-        flex: 1,
-        backgroundColor: theme.centerChannelBg,
-    },
-}));
+});

--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.js
@@ -130,7 +130,14 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             flexDirection: 'row',
             justifyContent: 'flex-start',
             width: '100%',
-            zIndex: 10,
+            ...Platform.select({
+                android: {
+                    elevation: 10,
+                },
+                ios: {
+                    zIndex: 10,
+                },
+            }),
         },
     };
 });


### PR DESCRIPTION
#### Summary
The backgroundColor was removed from the drawer content's parent View component, however, this backgroundColor is needed to appropriately display the network indicator banner. iOS is not affected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23483

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Android 10 emulator

#### Screenshots
![Screenshot_1585013693](https://user-images.githubusercontent.com/3208014/77379102-06066c80-6d35-11ea-96d0-f3e252749318.png)

![Screenshot_1585013699](https://user-images.githubusercontent.com/3208014/77379104-07d03000-6d35-11ea-9bc0-1a4b7e077c02.png)
