### PR TITLE
MM-23493 Move app cache purge from store subscription to middleware

### DIFF
--- a/app/initial_state.js
+++ b/app/initial_state.js
@@ -143,7 +143,6 @@ const state = {
         root: {
             deepLinkURL: '',
             hydrationComplete: false,
-            purge: false,
         },
         selectServer: {
             serverUrl: Config.DefaultServerUrl,

--- a/app/reducers/views/root.js
+++ b/app/reducers/views/root.js
@@ -26,17 +26,7 @@ function hydrationComplete(state = false, action) {
     }
 }
 
-function purge(state = false, action) {
-    switch (action.type) {
-    case General.OFFLINE_STORE_PURGE:
-        return true;
-    default:
-        return state;
-    }
-}
-
 export default combineReducers({
     deepLinkURL,
     hydrationComplete,
-    purge,
 });

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import initialState from 'app/initial_state';
 import configureAppStore from './store';
 
-const store = configureAppStore(initialState);
+const store = configureAppStore();
 
 export default store;

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,8 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import initialState from 'app/initial_state';
 import configureAppStore from './store';
 
-const store = configureAppStore();
+const store = configureAppStore(initialState);
 
 export default store;

--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -3,12 +3,22 @@
 
 import {Platform} from 'react-native';
 import DeviceInfo from 'react-native-device-info';
+import {batchActions} from 'redux-batched-actions';
+import AsyncStorage from '@react-native-community/async-storage';
+import {purgeStoredState} from 'redux-persist';
 
-import {ViewTypes} from 'app/constants';
+import {NavigationTypes, ViewTypes} from 'app/constants';
 import initialState from 'app/initial_state';
 import {throttle} from 'app/utils/general';
 
+import {General} from 'mattermost-redux/constants';
+import {ErrorTypes, GeneralTypes} from 'mattermost-redux/action_types';
+import EventEmitter from 'mattermost-redux/utils/event_emitter';
+
+import {persistConfig} from 'app/store/store';
 import mattermostBucket from 'app/mattermost_bucket';
+
+import {getStateForReset} from './utils';
 
 import {
     captureException,
@@ -41,6 +51,7 @@ const saveShareExtensionState = (store) => {
 const saveStateToFile = async (store) => {
     if (Platform.OS === 'ios') {
         const state = store.getState();
+
         if (state.entities) {
             const channelsInTeam = {...state.entities.channels.channelsInTeam};
             Object.keys(channelsInTeam).forEach((teamId) => {
@@ -81,6 +92,55 @@ const saveStateToFile = async (store) => {
             mattermostBucket.writeToFile('entities', JSON.stringify(entities));
         }
     }
+};
+
+const purgeAppCache = (store) => {
+    return (next) => (action) => {
+        if (action.type === General.OFFLINE_STORE_PURGE) {
+            purgeStoredState({...persistConfig, storage: AsyncStorage});
+
+            const state = store.getState();
+            const resetState = getStateForReset(initialState, state);
+
+            store.dispatch(batchActions([
+                {
+                    type: General.OFFLINE_STORE_RESET,
+                    data: resetState,
+                },
+                {
+                    type: ErrorTypes.RESTORE_ERRORS,
+                    data: [...state.errors],
+                },
+                {
+                    type: GeneralTypes.RECEIVED_APP_DEVICE_TOKEN,
+                    data: state.entities.general.deviceToken,
+                },
+                {
+                    type: GeneralTypes.RECEIVED_APP_CREDENTIALS,
+                    data: {
+                        url: state.entities.general.credentials.url,
+                    },
+                },
+                {
+                    type: ViewTypes.SERVER_URL_CHANGED,
+                    serverUrl: state.entities.general.credentials.url || state.views.selectServer.serverUrl,
+                },
+                {
+                    type: GeneralTypes.RECEIVED_SERVER_VERSION,
+                    data: state.entities.general.serverVersion,
+                },
+                {
+                    type: General.STORE_REHYDRATION_COMPLETE,
+                },
+            ], 'BATCH_FOR_RESTART'));
+
+            setTimeout(() => {
+                EventEmitter.emit(NavigationTypes.RESTART_APP);
+            }, 500);
+        }
+
+        return next(action);
+    };
 };
 
 const messageRetention = (store) => {
@@ -498,7 +558,7 @@ function removePendingPost(pendingPostIds, id) {
     }
 }
 
-export const middlewares = [messageRetention];
+export const middlewares = [messageRetention, purgeAppCache];
 
 if (Platform.OS === 'ios') {
     middlewares.push(saveShareExtensionState);

--- a/app/store/middleware.test.js
+++ b/app/store/middleware.test.js
@@ -14,7 +14,7 @@ import {
 } from 'app/store/middleware';
 
 describe('messageRetention', () => {
-    const messageRetention = middlewares[0];
+    const messageRetention = middlewares()[0];
 
     describe('should chain the same incoming action type', () => {
         const actions = [

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -9,7 +9,6 @@ import {General} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import configureStore from 'mattermost-redux/store';
 
-import initialState from 'app/initial_state';
 import appReducer from 'app/reducers';
 import {getSiteUrl, setSiteUrl} from 'app/utils/image_cache_manager';
 import {createSentryMiddleware} from 'app/utils/sentry/middleware';
@@ -168,7 +167,7 @@ const persistConfig = {
     },
 };
 
-export default function configureAppStore() {
+export default function configureAppStore(initialState) {
     const clientOptions = {
         additionalMiddleware: [
             createThunkMiddleware(),

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -124,7 +124,7 @@ const setTransformer = createTransform(
     },
 );
 
-export const persistConfig = {
+const persistConfig = {
     effect: (effect, action) => {
         if (typeof effect !== 'function') {
             throw new Error('Offline Action: effect must be a function.');

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -1,25 +1,22 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {batchActions} from 'redux-batched-actions';
 import AsyncStorage from '@react-native-community/async-storage';
 import {createBlacklistFilter} from 'redux-persist-transform-filter';
 import {createTransform, persistStore} from 'redux-persist';
 
-import {ErrorTypes, GeneralTypes} from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import configureStore from 'mattermost-redux/store';
-import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
-import {NavigationTypes, ViewTypes} from 'app/constants';
+import initialState from 'app/initial_state';
 import appReducer from 'app/reducers';
 import {getSiteUrl, setSiteUrl} from 'app/utils/image_cache_manager';
 import {createSentryMiddleware} from 'app/utils/sentry/middleware';
 
 import {middlewares} from './middleware';
 import {createThunkMiddleware} from './thunk';
-import {transformSet, getStateForReset} from './utils';
+import {transformSet} from './utils';
 
 function getAppReducer() {
     return require('../../app/reducers'); // eslint-disable-line global-require
@@ -46,180 +43,132 @@ const setTransforms = [
     ...rolesSetTransform,
 ];
 
-export default function configureAppStore(initialState) {
-    const viewsBlackListFilter = createBlacklistFilter(
-        'views',
-        ['extension', 'login', 'root'],
-    );
+const viewsBlackListFilter = createBlacklistFilter(
+    'views',
+    ['extension', 'login', 'root'],
+);
 
-    const typingBlackListFilter = createBlacklistFilter(
-        'entities',
-        ['typing'],
-    );
+const typingBlackListFilter = createBlacklistFilter(
+    'entities',
+    ['typing'],
+);
 
-    const channelViewBlackList = {loading: true, refreshing: true, loadingPosts: true, retryFailed: true, loadMorePostsVisible: true};
-    const channelViewBlackListFilter = createTransform(
-        (inboundState) => {
-            const channel = {};
+const channelViewBlackList = {loading: true, refreshing: true, loadingPosts: true, retryFailed: true, loadMorePostsVisible: true};
+const channelViewBlackListFilter = createTransform(
+    (inboundState) => {
+        const channel = {};
 
-            for (const channelKey of Object.keys(inboundState.channel)) {
-                if (!channelViewBlackList[channelKey]) {
-                    channel[channelKey] = inboundState.channel[channelKey];
+        for (const channelKey of Object.keys(inboundState.channel)) {
+            if (!channelViewBlackList[channelKey]) {
+                channel[channelKey] = inboundState.channel[channelKey];
+            }
+        }
+
+        return {
+            ...inboundState,
+            channel,
+        };
+    },
+    null,
+    {whitelist: ['views']}, // Only run this filter on the views state (or any other entry that ends up being named views)
+);
+
+const emojiBlackList = {nonExistentEmoji: true};
+const emojiBlackListFilter = createTransform(
+    (inboundState) => {
+        const emojis = {};
+
+        for (const emojiKey of Object.keys(inboundState.emojis)) {
+            if (!emojiBlackList[emojiKey]) {
+                emojis[emojiKey] = inboundState.emojis[emojiKey];
+            }
+        }
+
+        return {
+            ...inboundState,
+            emojis,
+        };
+    },
+    null,
+    {whitelist: ['entities']}, // Only run this filter on the entities state (or any other entry that ends up being named entities)
+);
+
+const setTransformer = createTransform(
+    (inboundState, key) => {
+        if (key === 'entities') {
+            const state = {...inboundState};
+            for (const prop in state) {
+                if (state.hasOwnProperty(prop)) {
+                    state[prop] = transformSet(state[prop], setTransforms);
                 }
             }
 
-            return {
-                ...inboundState,
-                channel,
-            };
-        },
-        null,
-        {whitelist: ['views']}, // Only run this filter on the views state (or any other entry that ends up being named views)
-    );
+            return state;
+        }
 
-    const emojiBlackList = {nonExistentEmoji: true};
-    const emojiBlackListFilter = createTransform(
-        (inboundState) => {
-            const emojis = {};
-
-            for (const emojiKey of Object.keys(inboundState.emojis)) {
-                if (!emojiBlackList[emojiKey]) {
-                    emojis[emojiKey] = inboundState.emojis[emojiKey];
+        return inboundState;
+    },
+    (outboundState, key) => {
+        if (key === 'entities') {
+            const state = {...outboundState};
+            for (const prop in state) {
+                if (state.hasOwnProperty(prop)) {
+                    state[prop] = transformSet(state[prop], setTransforms, false);
                 }
             }
 
-            return {
-                ...inboundState,
-                emojis,
-            };
-        },
-        null,
-        {whitelist: ['entities']}, // Only run this filter on the entities state (or any other entry that ends up being named entities)
-    );
+            return state;
+        }
 
-    const setTransformer = createTransform(
-        (inboundState, key) => {
-            if (key === 'entities') {
-                const state = {...inboundState};
-                for (const prop in state) {
-                    if (state.hasOwnProperty(prop)) {
-                        state[prop] = transformSet(state[prop], setTransforms);
-                    }
-                }
+        return outboundState;
+    },
+);
 
-                return state;
-            }
+export const persistConfig = {
+    effect: (effect, action) => {
+        if (typeof effect !== 'function') {
+            throw new Error('Offline Action: effect must be a function.');
+        } else if (!action.meta.offline.commit) {
+            throw new Error('Offline Action: commit action must be present.');
+        }
 
-            return inboundState;
-        },
-        (outboundState, key) => {
-            if (key === 'entities') {
-                const state = {...outboundState};
-                for (const prop in state) {
-                    if (state.hasOwnProperty(prop)) {
-                        state[prop] = transformSet(state[prop], setTransforms, false);
-                    }
-                }
-
-                return state;
-            }
-
-            return outboundState;
-        },
-    );
-
-    const offlineOptions = {
-        effect: (effect, action) => {
-            if (typeof effect !== 'function') {
-                throw new Error('Offline Action: effect must be a function.');
-            } else if (!action.meta.offline.commit) {
-                throw new Error('Offline Action: commit action must be present.');
-            }
-
-            return effect();
-        },
-        persist: (store, options) => {
-            const persistor = persistStore(store, {storage: AsyncStorage, ...options}, () => {
-                store.dispatch({
-                    type: General.STORE_REHYDRATION_COMPLETE,
-                });
+        return effect();
+    },
+    persist: (store, options) => {
+        const persistor = persistStore(store, {storage: AsyncStorage, ...options}, () => {
+            store.dispatch({
+                type: General.STORE_REHYDRATION_COMPLETE,
             });
+        });
 
-            let purging = false;
+        store.subscribe(async () => {
+            const state = store.getState();
+            const config = getConfig(state);
 
-            // check to see if the logout request was successful
-            store.subscribe(async () => {
-                const state = store.getState();
-                const config = getConfig(state);
+            if (getSiteUrl() !== config?.SiteURL) {
+                setSiteUrl(config.SiteURL);
+            }
+        });
 
-                if (getSiteUrl() !== config?.SiteURL) {
-                    setSiteUrl(config.SiteURL);
-                }
-
-                if (state.views.root.purge && !purging) {
-                    purging = true;
-
-                    await persistor.purge();
-
-                    const resetState = getStateForReset(initialState, state);
-
-                    store.dispatch(batchActions([
-                        {
-                            type: General.OFFLINE_STORE_RESET,
-                            data: resetState,
-                        },
-                        {
-                            type: ErrorTypes.RESTORE_ERRORS,
-                            data: [...state.errors],
-                        },
-                        {
-                            type: GeneralTypes.RECEIVED_APP_DEVICE_TOKEN,
-                            data: state.entities.general.deviceToken,
-                        },
-                        {
-                            type: GeneralTypes.RECEIVED_APP_CREDENTIALS,
-                            data: {
-                                url: state.entities.general.credentials.url,
-                            },
-                        },
-                        {
-                            type: ViewTypes.SERVER_URL_CHANGED,
-                            serverUrl: state.entities.general.credentials.url || state.views.selectServer.serverUrl,
-                        },
-                        {
-                            type: GeneralTypes.RECEIVED_SERVER_VERSION,
-                            data: state.entities.general.serverVersion,
-                        },
-                        {
-                            type: General.STORE_REHYDRATION_COMPLETE,
-                        },
-                    ], 'BATCH_FOR_RESTART'));
-
-                    setTimeout(() => {
-                        purging = false;
-                        EventEmitter.emit(NavigationTypes.RESTART_APP);
-                    }, 500);
-                }
-            });
-
-            return persistor;
+        return persistor;
+    },
+    persistOptions: {
+        autoRehydrate: {
+            log: false,
         },
-        persistOptions: {
-            autoRehydrate: {
-                log: false,
-            },
-            blacklist: ['device', 'navigation', 'offline', 'requests'],
-            debounce: 500,
-            transforms: [
-                setTransformer,
-                viewsBlackListFilter,
-                typingBlackListFilter,
-                channelViewBlackListFilter,
-                emojiBlackListFilter,
-            ],
-        },
-    };
+        blacklist: ['device', 'navigation', 'offline', 'requests'],
+        debounce: 500,
+        transforms: [
+            setTransformer,
+            viewsBlackListFilter,
+            typingBlackListFilter,
+            channelViewBlackListFilter,
+            emojiBlackListFilter,
+        ],
+    },
+};
 
+export default function configureAppStore() {
     const clientOptions = {
         additionalMiddleware: [
             createThunkMiddleware(),
@@ -229,5 +178,6 @@ export default function configureAppStore(initialState) {
         enableThunk: false, // We override the default thunk middleware
     };
 
-    return configureStore(initialState, appReducer, offlineOptions, getAppReducer, clientOptions);
+    // return configureStore(initialState, appReducer, offlineOptions, getAppReducer, clientOptions);
+    return configureStore(initialState, appReducer, persistConfig, getAppReducer, clientOptions);
 }

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -173,11 +173,10 @@ export default function configureAppStore() {
         additionalMiddleware: [
             createThunkMiddleware(),
             createSentryMiddleware(),
-            ...middlewares,
+            ...middlewares(persistConfig),
         ],
         enableThunk: false, // We override the default thunk middleware
     };
 
-    // return configureStore(initialState, appReducer, offlineOptions, getAppReducer, clientOptions);
     return configureStore(initialState, appReducer, persistConfig, getAppReducer, clientOptions);
 }


### PR DESCRIPTION
#### Summary

_This PR merges into branch `MM-23490/state-cache-middleware`._

Exposes persistence configuration as a static reference, so that cache purging can be invoked on demand anywhere else in the codebase.

While middleware still may not be the best spot for this singular "action" (purge cache), existing functionality reacting to `OFFLINE_STORE_PURGE` is maintained.

Aso removes the need for `state.views.root.purge` to exist in the state tree.

#### Ticket Link
* [MM-23493](https://mattermost.atlassian.net/browse/MM-23493)

#### Device Information
This PR was tested on: 
* iPhone 11 Simulator
* Android 10 (OnePlus 5 device)

#### Screenshots

Same as existing functionality. Cache size goes to 0 bytes.

**Before**
<img width="250" alt="Screen Shot 2020-03-24 at 00 24 13" src="https://user-images.githubusercontent.com/887849/77385101-f05d6b00-6d65-11ea-97a6-ad9bce0fc570.png">

**After**
<img width="250" alt="Screen Shot 2020-03-24 at 00 24 28" src="https://user-images.githubusercontent.com/887849/77385074-e0458b80-6d65-11ea-9c9f-3c2886077dd6.png">

---

**Notes**
* [middleware.js](https://github.com/mattermost/mattermost-mobile/blob/MM-23493/cache-purge-action/app/store/middleware.js) could now use some refactoring to split the one monolith file out into importable, individual middleware functions. To do in a future ticket.
