### PR TITLE
Fix Android Navbar tap events

### DIFF
--- a/app/components/network_indicator/network_indicator.js
+++ b/app/components/network_indicator/network_indicator.js
@@ -394,7 +394,10 @@ export default class NetworkIndicator extends PureComponent {
         }
 
         return (
-            <Animated.View style={[styles.container, {top: this.top, backgroundColor: background, opacity: this.state.opacity}]}>
+            <Animated.View
+                pointerEvents='none'
+                style={[styles.container, {top: this.top, backgroundColor: background, opacity: this.state.opacity}]}
+            >
                 <Animated.View style={styles.wrapper}>
                     <FormattedText
                         defaultMessage={defaultMessage}


### PR DESCRIPTION
#### Summary
With this PR #4067 the tap events on the Android Navbar to go to channel info, open the drawers and the search screen were not responding, this is because although not visible the Network Indicator component was capturing the panResponder.

