### PR TITLE
Fix post in channel batching order (release-1.30)

### DIFF
--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -84,16 +84,16 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
             const posts = Object.values(data.posts);
             const actions = [];
 
-            if (posts?.length || !postForChannel) {
-                actions.push(receivedPostsInChannel(data, channelId, page === 0, data.prev_post_id === ''));
-            }
-
             if (posts?.length) {
                 actions.push(receivedPosts(data));
                 const additional = await dispatch(getPostsAdditionalDataBatch(posts));
                 if (additional.length) {
                     actions.push(...additional);
                 }
+            }
+
+            if (posts?.length || !postForChannel) {
+                actions.push(receivedPostsInChannel(data, channelId, page === 0, data.prev_post_id === ''));
             }
 
             dispatch(batchActions(actions));


### PR DESCRIPTION
#### Summary
With the batching of actions we adding to the `receivedPostsInChannel` before `receivedPosts` and this caused the reducers to fail as `receivedPostsInChannel` actually depends on the `receivedPosts` reducer to be executed first.

Batching actions are performed in sequence following the order they were added to the batch

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23669

Note: This is the PR for the `release-1.30` branch