### PR TITLE
Fix post in channel batching order

### DIFF
--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -86,16 +86,16 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
             const posts = Object.values(data.posts);
             const actions = [];
 
-            if (posts?.length || !postForChannel) {
-                actions.push(receivedPostsInChannel(data, channelId, page === 0, data.prev_post_id === ''));
-            }
-
             if (posts?.length) {
                 actions.push(receivedPosts(data));
                 const additional = await dispatch(getPostsAdditionalDataBatch(posts));
                 if (additional.data.length) {
                     actions.push(...additional.data);
                 }
+            }
+
+            if (posts?.length || !postForChannel) {
+                actions.push(receivedPostsInChannel(data, channelId, page === 0, data.prev_post_id === ''));
             }
 
             dispatch(batchActions(actions, 'BATCH_GET_POSTS'));

--- a/app/store/utils.js
+++ b/app/store/utils.js
@@ -69,12 +69,7 @@ export function getStateForReset(initialState, currentState) {
     const {currentUserId} = currentState.entities.users;
     const currentUserProfile = currentState.entities.users.profiles[currentUserId];
     const {currentTeamId} = currentState.entities.teams;
-    const myPreferences = {...currentState.entities.preferences.myPreferences};
-    Object.keys(myPreferences).forEach((key) => {
-        if (!key.startsWith('theme--')) {
-            Reflect.deleteProperty(myPreferences, key);
-        }
-    });
+    const preferences = currentState.entities.preferences;
 
     const resetState = merge(initialState, {
         entities: {
@@ -87,9 +82,7 @@ export function getStateForReset(initialState, currentState) {
             teams: {
                 currentTeamId,
             },
-            preferences: {
-                myPreferences,
-            },
+            preferences,
         },
     });
 

--- a/app/store/utils.test.js
+++ b/app/store/utils.test.js
@@ -73,7 +73,6 @@ describe('getStateForReset', () => {
         const {myPreferences} = resetState.entities.preferences;
         const preferenceKeys = Object.keys(myPreferences);
         const themeKeys = preferenceKeys.filter((key) => key.startsWith('theme--'));
-        expect(themeKeys.length).not.toEqual(0);
-        expect(themeKeys.length).toEqual(preferenceKeys.length);
+        expect(themeKeys.length).toEqual(2);
     });
 });


### PR DESCRIPTION
#### Summary
With the batching of actions we adding to the `receivedPostsInChannel` before `receivedPosts` and this caused the reducers to fail as `receivedPostsInChannel` actually depends on the `receivedPosts` reducer to be executed first.

Batching actions are performed in sequence following the order they were added to the batch

This PR also preserves all the preferences when resetting the cache so there are no missing profiles to load in the sidebar. (The profiles for GM's won't load until this PR #4087 gets merged)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23669

Note: This is the PR for the `master` branch