### PR TITLE
[MM-23708] Send HW key pressed event only when a HW keyboard is connected

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
@@ -2,16 +2,29 @@ package com.mattermost.rnbeta;
 
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import android.view.KeyEvent;
+import android.content.res.Configuration;
 
 import com.reactnativenavigation.NavigationActivity;
-import android.view.KeyEvent;
 import com.github.emilioicai.hwkeyboardevent.HWKeyboardEventModule;
 
 public class MainActivity extends NavigationActivity {
+    private boolean HWKeyboardConnected = false;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.launch_screen);
+        setHWKeyboardConnected();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        if (newConfig.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO) {
+            HWKeyboardConnected = true;
+        } else if (newConfig.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_YES) {
+            HWKeyboardConnected = false;
+        }
     }
 
     /*
@@ -21,11 +34,15 @@ public class MainActivity extends NavigationActivity {
     */
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (event.getKeyCode() == KeyEvent.KEYCODE_ENTER && event.getAction() == KeyEvent.ACTION_UP) {
+        if (HWKeyboardConnected && event.getKeyCode() == KeyEvent.KEYCODE_ENTER && event.getAction() == KeyEvent.ACTION_UP) {
             String keyPressed = event.isShiftPressed() ? "shift-enter" : "enter";
             HWKeyboardEventModule.getInstance().keyPressed(keyPressed);
             return true;
         }
         return super.dispatchKeyEvent(event);
     };
+
+    private void setHWKeyboardConnected() {
+        HWKeyboardConnected = getResources().getConfiguration().keyboard == Configuration.KEYBOARD_QWERTY;
+    }
 }

--- a/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.java
@@ -20,6 +20,8 @@ public class MainActivity extends NavigationActivity {
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
         if (newConfig.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO) {
             HWKeyboardConnected = true;
         } else if (newConfig.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_YES) {

--- a/app/components/post_textbox/post_textbox_base.js
+++ b/app/components/post_textbox/post_textbox_base.js
@@ -53,6 +53,7 @@ import {
 const {RNTextInputReset} = NativeModules;
 const INPUT_LINE_HEIGHT = 20;
 const EXTRA_INPUT_PADDING = 3;
+const HW_SHIFT_ENTER_TEXT = Platform.OS === 'ios' ? '\n' : '';
 
 export default class PostTextBoxBase extends PureComponent {
     static propTypes = {
@@ -387,7 +388,7 @@ export default class PostTextBoxBase extends PureComponent {
         switch (keyEvent.pressedKey) {
         case 'enter': this.handleSendMessage();
             break;
-        case 'shift-enter': this.handleInsertTextToDraft('\n');
+        case 'shift-enter': this.handleInsertTextToDraft(HW_SHIFT_ENTER_TEXT);
         }
     }
 


### PR DESCRIPTION
#### Summary
There have been reports of messages being submitted on Android when pressing enter on a virtual keyboard. We now check if and when a HW keyboard is connected and only send the press event when connected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23708

#### Device Information
This PR was tested on:
* Mi A3, Android 9 with BT keyboard
* iPhone 7, iOS 13 with BT keyboard