### PR TITLE
MM-26827 Add ShowFullName property

### DIFF
--- a/app/mm-redux/types/config.ts
+++ b/app/mm-redux/types/config.ts
@@ -151,6 +151,7 @@ export type Config = {
     SendEmailNotifications: string;
     SendPushNotifications: string;
     ShowEmailAddress: string;
+    ShowFullName: string;
     SiteName: string;
     SiteURL: string;
     SQLDriverName: string;

--- a/app/screens/user_profile/__snapshots__/user_profile.test.js.snap
+++ b/app/screens/user_profile/__snapshots__/user_profile.test.js.snap
@@ -163,66 +163,6 @@ exports[`user_profile should match snapshot 1`] = `
             ]
           }
         >
-          test
-        </Text>
-      </View>
-      <View>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": undefined,
-                "fontSize": 13,
-                "fontWeight": "600",
-                "marginBottom": 10,
-                "marginTop": 25,
-                "textTransform": "uppercase",
-              },
-              null,
-            ]
-          }
-        />
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#3d3c40",
-                "fontSize": 15,
-              },
-              null,
-            ]
-          }
-        >
-          fake
-        </Text>
-      </View>
-      <View>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": undefined,
-                "fontSize": 13,
-                "fontWeight": "600",
-                "marginBottom": 10,
-                "marginTop": 25,
-                "textTransform": "uppercase",
-              },
-              null,
-            ]
-          }
-        />
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#3d3c40",
-                "fontSize": 15,
-              },
-              null,
-            ]
-          }
-        >
           nick
         </Text>
       </View>

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -300,8 +300,8 @@ export default class UserProfile extends PureComponent {
 
         return (
             <View style={style.content}>
-                {this.buildDisplayBlock('first_name')}
-                {this.buildDisplayBlock('last_name')}
+                {this.props.config.ShowFullName === 'true' && this.buildDisplayBlock('first_name')}
+                {this.props.config.ShowFullName === 'true' && this.buildDisplayBlock('last_name')}
                 {this.props.config.ShowEmailAddress === 'true' && this.buildDisplayBlock('email')}
                 {this.buildDisplayBlock('nickname')}
                 {this.buildDisplayBlock('position')}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Adds the `ShowFullName` property to be used by the mobile app the same way `ShowEmailAddress` is being used for the user profile view. `ShowFullName` property is being used to control whether or not to display the `first_name` and `last_name` in profile view based on the system console settings.

Tested on iOS simulator. First and last name fields are displayed/hidden as expected, just like the `ShowEmailAddress` property.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Related to: 
- PR in mattermost-server [#14189](https://github.com/mattermost/mattermost-server/pull/14189)
- PR in mattermost-mobile [#4092](https://github.com/mattermost/mattermost-mobile/pull/4092)

JIRA: https://mattermost.atlassian.net/browse/MM-26827

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates