### PR TITLE
[MM-23780] Correctly add additional actions when loading unread channel posts

### DIFF
--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -467,8 +467,8 @@ export function loadUnreadChannelPosts(channels, channelMembers) {
         if (posts.length) {
             actions.push(receivedPosts({posts}));
             const additional = await dispatch(getPostsAdditionalDataBatch(posts));
-            if (additional.length) {
-                actions.push(...additional);
+            if (additional.data.length) {
+                actions.push(...additional.data);
             }
 
             dispatch(batchActions(actions));


### PR DESCRIPTION
#### Summary
A typo in https://github.com/mattermost/mattermost-mobile/pull/4078 prevented `RECEIVED_PROFILES_LIST` and `RECEIVED_STATUSES` actions from being dispatched when loading unread channel posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23780

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android Q emulator