### PR TITLE
[MM-23874] Always show expand button

### DIFF
--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -236,7 +236,7 @@ export default class MarkdownTable extends React.PureComponent {
         }
 
         let expandButton = null;
-        if (expandButtonOffset > 0 && (moreRight || moreBelow)) {
+        if (expandButtonOffset > 0) {
             expandButton = (
                 <TouchableWithFeedback
                     type={'opacity'}


### PR DESCRIPTION
#### Summary
Removed condition that `moreBelow` or `moreRight` not be null in order to show the expand button.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23874

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iOS 13 simulator