### PR TITLE
[MM-22632] Set vertical padding for SlashSuggestionItemi

### DIFF
--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
@@ -51,7 +51,7 @@ export default class SlashSuggestionItem extends PureComponent {
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         row: {
-            height: 55,
+            minHeight: 55,
             justifyContent: 'center',
             paddingHorizontal: 8,
             backgroundColor: theme.centerChannelBg,

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
@@ -51,7 +51,7 @@ export default class SlashSuggestionItem extends PureComponent {
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         row: {
-            minHeight: 55,
+            paddingVertical: 8,
             justifyContent: 'center',
             paddingHorizontal: 8,
             backgroundColor: theme.centerChannelBg,


### PR DESCRIPTION
#### Summary
Replace SlashSuggestionItem's `height` with `paddingVertical`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22632

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone 7, iOS 13

#### Screenshots
| Before  | After|
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/3208014/78701730-5b598680-78bc-11ea-9164-0d28f27f6cad.PNG)  | ![IMG_0381](https://user-images.githubusercontent.com/3208014/78711359-b2b32300-78cb-11ea-86c9-092ab1c103f9.PNG)  |
