### PR TITLE
[MM-22386] Get store data on init

### DIFF
--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -29,6 +29,15 @@ class ShareViewController: SLComposeServiceViewController {
   private var teamsVC: TeamsViewController = TeamsViewController()
   
   private var maxMessageSize: Int = 0
+  
+  required init?(coder aDecoder: NSCoder) {
+      super.init(coder: aDecoder)
+  
+      entities = store.getEntities(true) as [AnyHashable:Any]?
+      sessionToken = store.getToken()
+      serverURL = store.getServerUrl()
+      maxMessageSize = Int(store.getMaxPostSize())
+  }
 
   // MARK: - Lifecycle methods
   override func viewDidLoad() {
@@ -81,17 +90,12 @@ class ShareViewController: SLComposeServiceViewController {
   }
 
   func loadData() {
-    entities = store.getEntities(true) as [AnyHashable:Any]?
-    sessionToken = store.getToken()
-    serverURL = store.getServerUrl()
-    maxMessageSize = Int(store.getMaxPostSize())
-
-    extractDataFromContext()
-    
     if sessionToken == nil || serverURL == nil {
       showErrorMessage(title: "", message: "Authentication required: Please first login using the app.", VC: self)
     } else if store.getCurrentTeamId() == "" {
       showErrorMessage(title: "", message: "You must belong to a team before you can share files.", VC: self)
+    } else {
+      extractDataFromContext()
     }
   }
   


### PR DESCRIPTION
#### Summary
`isContentValid` is called before `viewDidLoad` so `maxMessageSize`, which is initalized to 0, is not yet set from the store value. This is fixed by getting the store data in the view controller's `init` function.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22386

#### Device Information
This PR was tested on:
* iPhone 7, iOS 13