### PR TITLE
MM-22683 use override_username on commented on post header

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -290,7 +290,7 @@ export default class Post extends PureComponent {
             postHeader = (
                 <PostHeader
                     post={post}
-                    commentedOnUserId={commentedOnPost && commentedOnPost.user_id}
+                    commentedOnPost={commentedOnPost}
                     createAt={post.create_at}
                     isSearchResult={isSearchResult}
                     shouldRenderReplyButton={shouldRenderReplyButton}

--- a/app/components/post_header/index.js
+++ b/app/components/post_header/index.js
@@ -8,7 +8,7 @@ import {makeGetCommentCountForPost} from '@mm-redux/selectors/entities/posts';
 import {getBool, getTeammateNameDisplaySetting, getTheme} from '@mm-redux/selectors/entities/preferences';
 import {isTimezoneEnabled} from '@mm-redux/selectors/entities/timezone';
 import {getUser, getCurrentUser} from '@mm-redux/selectors/entities/users';
-import {isPostPendingOrFailed, isSystemMessage} from '@mm-redux/utils/post_utils';
+import {isPostPendingOrFailed, isSystemMessage, isFromWebhook} from '@mm-redux/utils/post_utils';
 import {getUserCurrentTimezone} from '@mm-redux/utils/timezone_utils';
 import {displayUsername} from '@mm-redux/utils/user_utils';
 import {getConfig} from '@mm-redux/selectors/entities/general';
@@ -24,21 +24,31 @@ function makeMapStateToProps() {
     return function mapStateToProps(state, ownProps) {
         const config = getConfig(state);
         const post = ownProps.post;
-        const commentedOnUser = getUser(state, ownProps.commentedOnUserId);
+        const commentedOnPost = ownProps.commentedOnPost;
+        const commentedOnUserId = commentedOnPost?.user_id;
+        const commentedOnUser = commentedOnUserId ? getUser(state, commentedOnUserId) : null;
         const user = getUser(state, post.user_id) || {};
         const currentUser = getCurrentUser(state);
         const teammateNameDisplay = getTeammateNameDisplaySetting(state);
         const militaryTime = getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time');
         const enableTimezone = isTimezoneEnabled(state);
         const userTimezone = enableTimezone ? getUserCurrentTimezone(currentUser.timezone) : '';
+        let commentedOnDisplayName = '';
+        if (commentedOnUserId) {
+            if (isFromWebhook(commentedOnPost) && commentedOnPost.props.override_username) {
+                commentedOnDisplayName = commentedOnPost.props.override_username;
+            } else {
+                commentedOnDisplayName = displayUsername(commentedOnUser, teammateNameDisplay);
+            }
+        }
 
         return {
-            commentedOnDisplayName: ownProps.commentedOnUserId ? displayUsername(commentedOnUser, teammateNameDisplay) : '',
+            commentedOnDisplayName,
             commentCount: getCommentCountForPost(state, {post}),
             createAt: post.create_at,
             displayName: displayUsername(user, teammateNameDisplay),
             enablePostUsernameOverride: config.EnablePostUsernameOverride === 'true',
-            fromWebHook: post?.props?.from_webhook === 'true', // eslint-disable-line camelcase
+            fromWebHook: isFromWebhook(post),
             militaryTime,
             isPendingOrFailedPost: isPostPendingOrFailed(post),
             isSystemMessage: isSystemMessage(post),

--- a/app/mm-redux/utils/post_utils.ts
+++ b/app/mm-redux/utils/post_utils.ts
@@ -30,7 +30,7 @@ export function isMeMessage(post: Post): boolean {
 }
 
 export function isFromWebhook(post: Post): boolean {
-    return post.props && post.props.from_webhook;
+    return post.props && post.props.from_webhook === 'true';
 }
 
 export function isPostEphemeral(post: Post): boolean {


### PR DESCRIPTION
#### Summary
When a user commented on a post by an integration the `Commented on` header was showing the creator's name instead of the `override_username` prop for that integration, this PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22683
