### PR TITLE
[MM-23893] No need to subtract delivered notifications from badge count

### DIFF
--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -214,7 +214,6 @@ class PushNotification {
             }
 
             if (ids.length) {
-                badgeCount -= ids.length;
                 NotificationsIOS.removeDeliveredNotifications(ids);
             }
 

--- a/app/push_notifications/push_notifications.ios.test.js
+++ b/app/push_notifications/push_notifications.ios.test.js
@@ -2,11 +2,14 @@
 // See LICENSE.txt for license information.
 
 import NotificationsIOS from 'react-native-notifications';
+
+import * as ViewSelectors from 'app/selectors/views';
+
 import PushNotification from './push_notifications.ios';
 
 jest.mock('react-native-notifications', () => {
     let badgesCount = 0;
-    let deliveredNotifications = {};
+    let deliveredNotifications = [];
 
     return {
         getBadgesCount: jest.fn((callback) => callback(badgesCount)),
@@ -89,5 +92,30 @@ describe('PushNotification', () => {
         expect(NotificationsIOS.setBadgesCount).toHaveBeenCalledWith(0);
         expect(cancelAllLocalNotifications).toHaveBeenCalled();
         expect(NotificationsIOS.cancelAllLocalNotifications).toHaveBeenCalled();
+    });
+
+    it('clearChannelNotifications should set app badge number from to delivered notification count when redux store is not set', () => {
+        PushNotification.reduxStore = null;
+        const setApplicationIconBadgeNumber = jest.spyOn(PushNotification, 'setApplicationIconBadgeNumber');
+        const deliveredNotifications = [{identifier: 1}, {identifier: 2}];
+        NotificationsIOS.setDeliveredNotifications(deliveredNotifications);
+
+        PushNotification.clearChannelNotifications();
+        expect(setApplicationIconBadgeNumber).toHaveBeenCalledWith(deliveredNotifications.length);
+    });
+
+    it('clearChannelNotifications should set app badge number from redux store when set', () => {
+        PushNotification.reduxStore = {
+            getState: jest.fn(),
+        };
+        const setApplicationIconBadgeNumber = jest.spyOn(PushNotification, 'setApplicationIconBadgeNumber');
+        const deliveredNotifications = [{identifier: 1}, {identifier: 2}];
+        NotificationsIOS.setDeliveredNotifications(deliveredNotifications);
+
+        const stateBadgeCount = 2 * deliveredNotifications.length;
+        ViewSelectors.getBadgeCount = jest.fn().mockReturnValue(stateBadgeCount);
+
+        PushNotification.clearChannelNotifications();
+        expect(setApplicationIconBadgeNumber).toHaveBeenCalledWith(stateBadgeCount);
     });
 });


### PR DESCRIPTION
#### Summary
The badge count is set to the number of delivered notifications first. If the redux store is set, then the badge count is overridden with the value from state so there is no need to subtract the delivered count.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23893

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 7, iOS 13