### PR TITLE
Wrap screen in gestureHandlerRootHOC

### DIFF
--- a/app/screens/index.js
+++ b/app/screens/index.js
@@ -52,7 +52,7 @@ export function registerScreens(store, Provider) {
     Navigation.registerComponent('MFA', () => wrapper(require('app/screens/mfa').default), () => require('app/screens/mfa').default);
     Navigation.registerComponent('MoreChannels', () => wrapper(require('app/screens/more_channels').default), () => require('app/screens/more_channels').default);
     Navigation.registerComponent('MoreDirectMessages', () => wrapper(require('app/screens/more_dms').default), () => require('app/screens/more_dms').default);
-    Navigation.registerComponent('Notification', () => wrapper(require('app/screens/notification').default), () => require('app/screens/notification').default);
+    Navigation.registerComponent('Notification', () => gestureHandlerRootHOC(wrapper(require('app/screens/notification').default)), () => require('app/screens/notification').default);
     Navigation.registerComponent('NotificationSettings', () => wrapper(require('app/screens/settings/notification_settings').default), () => require('app/screens/settings/notification_settings').default);
     Navigation.registerComponent('NotificationSettingsAutoResponder', () => wrapper(require('app/screens/settings/notification_settings_auto_responder').default), () => require('app/screens/settings/notification_settings_auto_responder').default);
     Navigation.registerComponent('NotificationSettingsEmail', () => wrapper(require('app/screens/settings/notification_settings_email').default), () => require('app/screens/settings/notification_settings_email').default);


### PR DESCRIPTION
#### Summary
Swipe to dismiss works fine in iOS but on Android it requires the Notification screen to be [wrapped in gestureHandlerRootHOC](https://software-mansion.github.io/react-native-gesture-handler/docs/getting-started.html#with-wix-react-native-navigation-https-githubcom-wix-react-native-navigation).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23053

#### Device Information
This PR was tested on:
* Mi A3, Android 9
* iPhone 7, iOS 13