### PR TITLE
[MM-24026] Set back button color

### DIFF
--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -44,6 +44,7 @@ export function resetToChannel(passProps = {}) {
                         },
                         backButton: {
                             visible: false,
+                            color: theme.sidebarHeaderTextColor,
                         },
                     },
                 },

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -53,6 +53,7 @@ describe('app/actions/navigation', () => {
                                     height: 0,
                                     backButton: {
                                         visible: false,
+                                        color: theme.sidebarHeaderTextColor,
                                     },
                                     background: {
                                         color: theme.sidebarHeaderBg,


### PR DESCRIPTION
#### Summary
`topBar.backButton.color` is needed in the root screen so that it applies that color in transitions back to the screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24026

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 7, iOS 13