### PR TITLE
Fix isDateLine function to check for null and undefined

### DIFF
--- a/app/mm-redux/utils/post_list.test.js
+++ b/app/mm-redux/utils/post_list.test.js
@@ -836,6 +836,8 @@ describe('makeCombineUserActivityPosts', () => {
 
 describe('isDateLine', () => {
     test('should correctly identify date line items', () => {
+        expect(isDateLine(undefined)).toBe(false);
+        expect(isDateLine(null)).toBe(false);
         expect(isDateLine('')).toBe(false);
         expect(isDateLine('date')).toBe(false);
         expect(isDateLine('date-')).toBe(true);

--- a/app/mm-redux/utils/post_list.ts
+++ b/app/mm-redux/utils/post_list.ts
@@ -182,7 +182,7 @@ export function isStartOfNewMessages(item: string) {
 }
 
 export function isDateLine(item: string) {
-    return Boolean(item && item.startsWith(DATE_LINE));
+    return Boolean(item?.startsWith(DATE_LINE));
 }
 
 export function getDateForDateLine(item: string) {

--- a/app/mm-redux/utils/post_list.ts
+++ b/app/mm-redux/utils/post_list.ts
@@ -114,7 +114,7 @@ export function makeFilterPostsAndAddSeparators() {
 
             // Flip it back to newest to oldest
             return out.reverse();
-        }
+        },
     );
 }
 
@@ -182,7 +182,7 @@ export function isStartOfNewMessages(item: string) {
 }
 
 export function isDateLine(item: string) {
-    return item.startsWith(DATE_LINE);
+    return Boolean(item && item.startsWith(DATE_LINE));
 }
 
 export function getDateForDateLine(item: string) {
@@ -290,7 +290,7 @@ export function makeGenerateCombinedPost() {
                 user_id: '',
                 metadata: {},
             };
-        }
+        },
     );
 }
 


### PR DESCRIPTION
#### Summary
The `isDateLine` was not taking into account that the item could be `null` or `undefined` causing this issues https://github.com/mattermost/mattermost-mobile/pull/4093#pullrequestreview-391542323 found by @josephbaylon who thought they are related to the other PR where in fact this issue was introduced by #4129 and missed during QA Review.
