### PR TITLE
MM-24093 Fix crash when system message does not contain a username in post props

### DIFF
--- a/app/components/post_body/__snapshots__/system_message_helpers.test.js.snap
+++ b/app/components/post_body/__snapshots__/system_message_helpers.test.js.snap
@@ -28,6 +28,16 @@ exports[`renderSystemMessage uses renderer for Channel Purpose update 1`] = `
 </Text>
 `;
 
+exports[`renderSystemMessage uses renderer for OLD archived channel without a username 1`] = `
+<Connect(Markdown)
+  baseTextStyle={Object {}}
+  disableAtChannelMentionHighlight={true}
+  onPostPress={[MockFunction]}
+  textStyles={Object {}}
+  value="{username} archived the channel"
+/>
+`;
+
 exports[`renderSystemMessage uses renderer for archived channel 1`] = `
 <Connect(Markdown)
   baseTextStyle={Object {}}

--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -7,7 +7,7 @@ import {General, Posts} from '@mm-redux/constants';
 import {getChannel, canManageChannelMembers, getCurrentChannelId} from '@mm-redux/selectors/entities/channels';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {getConfig, getLicense} from '@mm-redux/selectors/entities/general';
-import {getCurrentUserId, getCurrentUserRoles} from '@mm-redux/selectors/entities/users';
+import {getCurrentUserId, getCurrentUserRoles, getUser} from '@mm-redux/selectors/entities/users';
 import {getCurrentTeamId} from '@mm-redux/selectors/entities/teams';
 import {getCustomEmojisByName} from '@mm-redux/selectors/entities/emojis';
 import {makeGetReactionsForPost} from '@mm-redux/selectors/entities/posts';
@@ -79,10 +79,16 @@ export function makeMapStateToProps() {
 
         const customEmojis = getCustomEmojisByName(state);
         const {isEmojiOnly, shouldRenderJumboEmoji} = memoizeHasEmojisOnly(post.message, customEmojis);
+        const systemMessage = isSystemMessage(post);
+        const postProps = post.props;
+        if (systemMessage && !post.props?.username) {
+            const owner = getUser(state, post.user_id);
+            postProps.username = owner?.username || '';
+        }
 
         return {
             metadata: post.metadata,
-            postProps: post.props || {},
+            postProps,
             postType: post.type || '',
             fileIds: post.file_ids,
             hasBeenDeleted: post.state === Posts.POST_DELETED,
@@ -92,7 +98,7 @@ export function makeMapStateToProps() {
             isPending,
             isPostAddChannelMember,
             isPostEphemeral: isEphemeralPost,
-            isSystemMessage: isSystemMessage(post),
+            isSystemMessage: systemMessage,
             message: post.message,
             isEmojiOnly,
             shouldRenderJumboEmoji,

--- a/app/components/post_body/system_message_helpers.js
+++ b/app/components/post_body/system_message_helpers.js
@@ -7,8 +7,12 @@ import {Posts} from '@mm-redux/constants';
 import Markdown from 'app/components/markdown';
 import {t} from 'app/utils/i18n';
 
-const renderUsername = (value) => {
-    return (value[0] === '@') ? value : `@${value}`;
+const renderUsername = (value = '') => {
+    if (value) {
+        return (value[0] === '@') ? value : `@${value}`;
+    }
+
+    return value;
 };
 
 const renderMessage = (postBodyProps, styles, intl, localeHolder, values, skipMarkdown = false) => {

--- a/app/components/post_body/system_message_helpers.test.js
+++ b/app/components/post_body/system_message_helpers.test.js
@@ -82,6 +82,17 @@ describe('renderSystemMessage', () => {
         expect(renderedMessage).toMatchSnapshot();
     });
 
+    test('uses renderer for OLD archived channel without a username', () => {
+        const postBodyProps = {
+            ...basePostBodyProps,
+            postProps: {},
+            postType: Posts.POST_TYPES.CHANNEL_DELETED,
+        };
+
+        const renderedMessage = SystemMessageHelpers.renderSystemMessage(postBodyProps, mockStyles, mockIntl);
+        expect(renderedMessage).toMatchSnapshot();
+    });
+
     test('uses renderer for unarchived channel', () => {
         const postBodyProps = {
             ...basePostBodyProps,


### PR DESCRIPTION
#### Summary
On old system messages the post props did not have the username set, and when trying to render the post the app crashed.

The fix has two parts:
1. If the post is a system message and it does not have the username who originated the action set then we add the username from the post user_id
2. Handle the case when there is no username in the renderer of System Messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24093