### PR TITLE
Ensure postProps is not null/undefined

### DIFF
--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -80,8 +80,8 @@ export function makeMapStateToProps() {
         const customEmojis = getCustomEmojisByName(state);
         const {isEmojiOnly, shouldRenderJumboEmoji} = memoizeHasEmojisOnly(post.message, customEmojis);
         const systemMessage = isSystemMessage(post);
-        const postProps = post.props;
-        if (systemMessage && !post.props?.username) {
+        const postProps = post.props || {};
+        if (systemMessage && !postProps.username) {
             const owner = getUser(state, post.user_id);
             postProps.username = owner?.username || '';
         }

--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -62,7 +62,7 @@ export default class PostBody extends PureComponent {
         onPermalinkPress: PropTypes.func,
         onPress: PropTypes.func,
         post: PropTypes.object.isRequired,
-        postProps: PropTypes.object,
+        postProps: PropTypes.object.isRequired,
         postType: PropTypes.string,
         replyBarStyle: PropTypes.array,
         showAddReaction: PropTypes.bool,
@@ -79,6 +79,7 @@ export default class PostBody extends PureComponent {
         onPress: emptyFunction,
         replyBarStyle: [],
         message: '',
+        postProps: {},
     };
 
     static contextTypes = {
@@ -193,21 +194,23 @@ export default class PostBody extends PureComponent {
         });
     };
 
-    renderAddChannelMember = (style, messageStyle, textStyles) => {
+    renderAddChannelMember = (messageStyle, textStyles) => {
         const {onPress, postProps} = this.props;
 
         if (!PostAddChannelMember) {
             PostAddChannelMember = require('app/components/post_add_channel_member').default;
         }
 
-        let userIds = postProps.add_channel_member.not_in_channel_user_ids;
-        let usernames = postProps.add_channel_member.not_in_channel_usernames;
+        const postId = postProps.add_channel_member.post_id;
+        const noGroupsUsernames = postProps.add_channel_member?.not_in_groups_usernames;
+        let userIds = postProps.add_channel_member?.not_in_channel_user_ids;
+        let usernames = postProps.add_channel_member?.not_in_channel_usernames;
 
         if (!userIds) {
-            userIds = postProps.add_channel_member.user_ids;
+            userIds = postProps.add_channel_member?.user_ids;
         }
         if (!usernames) {
-            usernames = postProps.add_channel_member.usernames;
+            usernames = postProps.add_channel_member?.usernames;
         }
 
         return (
@@ -215,10 +218,10 @@ export default class PostBody extends PureComponent {
                 baseTextStyle={messageStyle}
                 onPostPress={onPress}
                 textStyles={textStyles}
-                postId={postProps.add_channel_member.post_id}
+                postId={postId}
                 userIds={userIds}
                 usernames={usernames}
-                noGroupsUsernames={postProps.add_channel_member.not_in_groups_usernames}
+                noGroupsUsernames={noGroupsUsernames}
             />
         );
     };
@@ -368,7 +371,7 @@ export default class PostBody extends PureComponent {
                 />
             );
         } else if (isPostAddChannelMember) {
-            messageComponent = this.renderAddChannelMember(style, messageStyle, textStyles);
+            messageComponent = this.renderAddChannelMember(messageStyle, textStyles);
         } else if (postType === Posts.POST_TYPES.COMBINED_USER_ACTIVITY) {
             const {allUserIds, allUsernames, messageData} = postProps.user_activity;
             messageComponent = (


### PR DESCRIPTION
#### Summary
Changes made in https://github.com/mattermost/mattermost-mobile/commit/6667962e1f7946549ad383f6c3d0e989f7d8121f introduced the possibility of `postProps` being undefined. We now default `postProps` to and empty object to avoid crashes when accessing `postProps` properties. 