### PR TITLE
Disable camelcase check

### DIFF
--- a/app/components/post_body/post_body.js
+++ b/app/components/post_body/post_body.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint-disable camelcase */
+
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {


### PR DESCRIPTION
Fix for the failing eslint check found on https://github.com/mattermost/mattermost-mobile/pull/4152. Will manually cherry pick this along with the change from that PR.