### PR TITLE
Automated cherry pick of #4131

### DIFF
--- a/app/components/post_body/__snapshots__/system_message_helpers.test.js.snap
+++ b/app/components/post_body/__snapshots__/system_message_helpers.test.js.snap
@@ -21,13 +21,11 @@ exports[`renderSystemMessage uses renderer for Channel Header update 1`] = `
 `;
 
 exports[`renderSystemMessage uses renderer for Channel Purpose update 1`] = `
-<Connect(Markdown)
-  baseTextStyle={Object {}}
-  disableAtChannelMentionHighlight={true}
-  onPostPress={[MockFunction]}
-  textStyles={Object {}}
-  value="{username} updated the channel purpose from: {oldPurpose} to: {newPurpose}"
-/>
+<Text
+  style={Object {}}
+>
+  {username} updated the channel purpose from: {oldPurpose} to: {newPurpose}
+</Text>
 `;
 
 exports[`renderSystemMessage uses renderer for OLD archived channel without a username 1`] = `

--- a/app/components/post_body/system_message_helpers.js
+++ b/app/components/post_body/system_message_helpers.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {Text} from 'react-native';
 import {Posts} from '@mm-redux/constants';
 import Markdown from 'app/components/markdown';
 import {t} from 'app/utils/i18n';
@@ -14,9 +15,17 @@ const renderUsername = (value = '') => {
     return value;
 };
 
-const renderMessage = (postBodyProps, styles, intl, localeHolder, values) => {
+const renderMessage = (postBodyProps, styles, intl, localeHolder, values, skipMarkdown = false) => {
     const {onPress} = postBodyProps;
     const {messageStyle, textStyles} = styles;
+
+    if (skipMarkdown) {
+        return (
+            <Text style={messageStyle}>
+                {intl.formatMessage(localeHolder, values)}
+            </Text>
+        );
+    }
 
     return (
         <Markdown
@@ -94,7 +103,7 @@ const renderPurposeChangeMessage = (postBodyProps, styles, intl) => {
             };
 
             values = {username, oldPurpose, newPurpose};
-            return renderMessage(postBodyProps, styles, intl, localeHolder, values);
+            return renderMessage(postBodyProps, styles, intl, localeHolder, values, true);
         }
 
         localeHolder = {
@@ -103,7 +112,7 @@ const renderPurposeChangeMessage = (postBodyProps, styles, intl) => {
         };
 
         values = {username, oldPurpose, newPurpose};
-        return renderMessage(postBodyProps, styles, intl, localeHolder, values);
+        return renderMessage(postBodyProps, styles, intl, localeHolder, values, true);
     } else if (postProps.old_purpose) {
         localeHolder = {
             id: t('mobile.system_message.update_channel_purpose_message.removed'),
@@ -111,7 +120,7 @@ const renderPurposeChangeMessage = (postBodyProps, styles, intl) => {
         };
 
         values = {username, oldPurpose, newPurpose};
-        return renderMessage(postBodyProps, styles, intl, localeHolder, values);
+        return renderMessage(postBodyProps, styles, intl, localeHolder, values, true);
     }
 
     return null;

--- a/app/components/post_body/system_message_helpers.test.js
+++ b/app/components/post_body/system_message_helpers.test.js
@@ -1,8 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import * as SystemMessageHelpers from './system_message_helpers';
+import renderer from 'react-test-renderer';
 import {Posts} from '@mm-redux/constants';
+
+import * as SystemMessageHelpers from './system_message_helpers';
 
 const basePostBodyProps = {
     postProps: {
@@ -62,7 +64,9 @@ describe('renderSystemMessage', () => {
         };
 
         const renderedMessage = SystemMessageHelpers.renderSystemMessage(postBodyProps, mockStyles, mockIntl);
-        expect(renderedMessage).toMatchSnapshot();
+        const tree = renderer.create(renderedMessage).toJSON();
+        expect(tree).toMatchSnapshot();
+        expect(tree.type).toEqual('Text');
     });
 
     test('uses renderer for archived channel', () => {


### PR DESCRIPTION
Cherry pick of #4131 on release-1.31.

- #4131: MM-22043 Render Channel purpose message without markdown

/cc  @enahum