### PR TITLE
[MM-24346] Android - Loosen SSL for bad/problem server SSL certificates

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainApplication.java
@@ -71,6 +71,7 @@ private final ReactNativeHost mReactNativeHost =
       // packages.add(new MyReactNativePackage());
       packages.add(new RNNotificationsPackage(MainApplication.this));
       packages.add(new RNPasteableTextInputPackage());
+      packages.add(new MattermostWebSocketPackage());
       packages.add(
         new TurboReactPackage() {
               @Override

--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostWebSocketModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostWebSocketModule.java
@@ -1,0 +1,484 @@
+package com.mattermost.rnbeta;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.ReactConstants;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.network.ForwardingCookieHandler;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+
+@ReactModule(name = MattermostWebSocketModule.NAME, hasConstants = false)
+public final class MattermostWebSocketModule extends ReactContextBaseJavaModule {
+
+    public static final String TAG = MattermostWebSocketModule.class.getSimpleName();
+    public static final String NAME = "MattermostWebSocketModule";
+
+    private final Map<Integer, WebSocket> mWebSocketConnections = new ConcurrentHashMap<>();
+    private final Map<Integer, ContentHandler> mContentHandlers = new ConcurrentHashMap<>();
+
+    private ForwardingCookieHandler mCookieHandler;
+
+    private static ReactApplicationContext reactContext;
+
+    public MattermostWebSocketModule(ReactApplicationContext context) {
+        super(context);
+        reactContext = context;
+
+        mCookieHandler = new ForwardingCookieHandler(context);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    public interface ContentHandler {
+      void onMessage(String text, WritableMap params);
+
+      void onMessage(ByteString byteString, WritableMap params);
+    }
+
+    public void setContentHandler(final int id, final ContentHandler contentHandler) {
+        if (contentHandler != null) {
+            mContentHandlers.put(id, contentHandler);
+        } else {
+            mContentHandlers.remove(id);
+        }
+    }
+
+    private void sendEvent(String eventName, WritableMap params) {
+        ReactApplicationContext reactApplicationContext = this.reactContext;
+
+        if (reactApplicationContext != null) {
+            reactApplicationContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(eventName, params);
+        }
+    }
+
+    @ReactMethod
+    public void connect(
+        final String url,
+        @Nullable final ReadableArray protocols,
+        @Nullable final ReadableMap options,
+        final double socketID) {
+
+        final int id = (int) socketID;
+
+        boolean trustSSL = false;
+        if (options != null && options.hasKey("trustSSL")) {
+            trustSSL = options.getBoolean("trustSSL");
+        }
+
+        OkHttpClient client = new OkHttpClient();
+
+        if (trustSSL) {
+            // Check if explicit request has been made for using an unsafe trust manager (e.g. SSL is relaxed)
+            client = getUnsafeOkHttpClient().build();
+        } else {
+            // Default, secure trust manager for connection validation.
+            client = new OkHttpClient.Builder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
+                .build();
+        }
+
+        Request.Builder builder = new Request.Builder().tag(id).url(url);
+
+        String cookie = getCookie(url);
+        if (cookie != null) {
+            builder.addHeader("Cookie", cookie);
+        }
+
+        boolean hasOriginHeader = false;
+
+        if (options != null
+            && options.hasKey("headers")
+            && options.getType("headers").equals(ReadableType.Map)) {
+
+            ReadableMap headers = options.getMap("headers");
+            ReadableMapKeySetIterator iterator = headers.keySetIterator();
+
+            while (iterator.hasNextKey()) {
+                String key = iterator.nextKey();
+                if (ReadableType.String.equals(headers.getType(key))) {
+                if (key.equalsIgnoreCase("origin")) {
+                    hasOriginHeader = true;
+                }
+
+                builder.addHeader(key, headers.getString(key));
+                } else {
+                    if (key != "trustSSL") {
+                        FLog.w(ReactConstants.TAG, "Ignoring: requested " + key + ", value not a string");
+                    }
+                }
+            }
+        }
+
+        if (!hasOriginHeader) {
+            builder.addHeader("origin", getDefaultOrigin(url));
+        }
+
+        if (protocols != null && protocols.size() > 0) {
+            StringBuilder protocolsValue = new StringBuilder("");
+            for (int i = 0; i < protocols.size(); i++) {
+                String v = protocols.getString(i).trim();
+                if (!v.isEmpty() && !v.contains(",")) {
+                    protocolsValue.append(v);
+                    protocolsValue.append(",");
+                }
+            }
+            if (protocolsValue.length() > 0) {
+                protocolsValue.replace(protocolsValue.length() - 1, protocolsValue.length(), "");
+                builder.addHeader("Sec-WebSocket-Protocol", protocolsValue.toString());
+            }
+        }
+
+        client.newWebSocket(
+            builder.build(),
+            new WebSocketListener() {
+
+                @Override
+                public void onOpen(WebSocket webSocket, Response response) {
+                    mWebSocketConnections.put(id, webSocket);
+                    WritableMap params = Arguments.createMap();
+                    params.putInt("id", id);
+                    params.putString("protocol", response.header("Sec-WebSocket-Protocol", ""));
+                    sendEvent("websocketOpen", params);
+                }
+
+                @Override
+                public void onClosing(WebSocket websocket, int code, String reason) {
+                    websocket.close(code, reason);
+                }
+
+                @Override
+                public void onClosed(WebSocket webSocket, int code, String reason) {
+                    WritableMap params = Arguments.createMap();
+                    params.putInt("id", id);
+                    params.putInt("code", code);
+                    params.putString("reason", reason);
+                    sendEvent("websocketClosed", params);
+                }
+
+                @Override
+                public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+                    notifyWebSocketFailed(id, t.getMessage());
+                }
+
+                @Override
+                public void onMessage(WebSocket webSocket, String text) {
+                    WritableMap params = Arguments.createMap();
+                    params.putInt("id", id);
+                    params.putString("type", "text");
+
+                    ContentHandler contentHandler = mContentHandlers.get(id);
+                    if (contentHandler != null) {
+                        contentHandler.onMessage(text, params);
+                    } else {
+                        params.putString("data", text);
+                    }
+                    sendEvent("websocketMessage", params);
+                }
+
+                @Override
+                public void onMessage(WebSocket webSocket, ByteString bytes) {
+                    WritableMap params = Arguments.createMap();
+                    params.putInt("id", id);
+                    params.putString("type", "binary");
+
+                    ContentHandler contentHandler = mContentHandlers.get(id);
+                    if (contentHandler != null) {
+                        contentHandler.onMessage(bytes, params);
+                    } else {
+                        String text = bytes.base64();
+
+                        params.putString("data", text);
+                    }
+                    sendEvent("websocketMessage", params);
+                }
+            });
+
+        // Trigger shutdown of the dispatcher's executor so this process can exit cleanly
+        client.dispatcher().executorService().shutdown();
+    }
+
+    @ReactMethod
+    public void send(String message, double socketID) {
+        final int id = (int) socketID;
+        WebSocket client = mWebSocketConnections.get(id);
+        if (client == null) {
+            // This is a programmer error -- display development warning
+            WritableMap params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putString("message", "client is null");
+            sendEvent("websocketFailed", params);
+            params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putInt("code", 0);
+            params.putString("reason", "client is null");
+            sendEvent("websocketClosed", params);
+            mWebSocketConnections.remove(id);
+            mContentHandlers.remove(id);
+            return;
+        }
+        try {
+            client.send(message);
+        } catch (Exception e) {
+            notifyWebSocketFailed(id, e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void close(double code, String reason, double socketID) {
+        int id = (int) socketID;
+        WebSocket client = mWebSocketConnections.get(id);
+        if (client == null) {
+            // WebSocket is already closed
+            // Don't do anything, mirror the behaviour on web
+            return;
+        }
+
+        try {
+            client.close((int) code, reason);
+            mWebSocketConnections.remove(id);
+            mContentHandlers.remove(id);
+        } catch (Exception e) {
+            FLog.e(ReactConstants.TAG, "Could not close WebSocket connection for id " + id, e);
+        }
+    }
+
+    @ReactMethod
+    public void sendBinary(String base64String, double socketID) {
+        final int id = (int) socketID;
+        WebSocket client = mWebSocketConnections.get(id);
+        if (client == null) {
+            // This is a programmer error -- display development warning
+            WritableMap params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putString("message", "client is null");
+            sendEvent("websocketFailed", params);
+            params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putInt("code", 0);
+            params.putString("reason", "client is null");
+            sendEvent("websocketClosed", params);
+            mWebSocketConnections.remove(id);
+            mContentHandlers.remove(id);
+            return;
+        }
+        try {
+            client.send(ByteString.decodeBase64(base64String));
+        } catch (Exception e) {
+            notifyWebSocketFailed(id, e.getMessage());
+        }
+    }
+
+    public void sendBinary(ByteString byteString, int id) {
+        WebSocket client = mWebSocketConnections.get(id);
+        if (client == null) {
+            // This is a programmer error -- display development warning
+            WritableMap params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putString("message", "client is null");
+            sendEvent("websocketFailed", params);
+            params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putInt("code", 0);
+            params.putString("reason", "client is null");
+            sendEvent("websocketClosed", params);
+            mWebSocketConnections.remove(id);
+            mContentHandlers.remove(id);
+            return;
+        }
+        try {
+            client.send(byteString);
+        } catch (Exception e) {
+            notifyWebSocketFailed(id, e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void ping(double socketID) {
+        final int id = (int) socketID;
+        WebSocket client = mWebSocketConnections.get(id);
+        if (client == null) {
+            // This is a programmer error -- display development warning
+            WritableMap params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putString("message", "client is null");
+            sendEvent("websocketFailed", params);
+            params = Arguments.createMap();
+            params.putInt("id", id);
+            params.putInt("code", 0);
+            params.putString("reason", "client is null");
+            sendEvent("websocketClosed", params);
+            mWebSocketConnections.remove(id);
+            mContentHandlers.remove(id);
+            return;
+        }
+        try {
+            client.send(ByteString.EMPTY);
+        } catch (Exception e) {
+            notifyWebSocketFailed(id, e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void addListener(String eventName) {}
+
+    @ReactMethod
+    public void removeListeners(double count) {}
+
+    /**
+    * Get the cookie for a specific domain
+    *
+    * @param uri
+    * @return The cookie header or null if none is set
+    */
+    private String getCookie(String uri) {
+        try {
+            URI origin = new URI(getDefaultOrigin(uri));
+            Map<String, List<String>> cookieMap = mCookieHandler.get(origin, new HashMap());
+            List<String> cookieList = cookieMap.get("Cookie");
+
+            if (cookieList == null || cookieList.isEmpty()) {
+                return null;
+            }
+
+            return cookieList.get(0);
+        } catch (URISyntaxException | IOException e) {
+            throw new IllegalArgumentException("Unable to get cookie from " + uri);
+        }
+    }
+
+    private void notifyWebSocketFailed(int id, String message) {
+        WritableMap params = Arguments.createMap();
+        params.putInt("id", id);
+        params.putString("message", message);
+        sendEvent("websocketFailed", params);
+    }
+
+    /**
+    * Get the default HTTP(S) origin for a specific WebSocket URI
+    *
+    * @param uri
+    * @return A string of the endpoint converted to HTTP protocol (http[s]://host[:port])
+    */
+    private static String getDefaultOrigin(String uri) {
+        try {
+            String defaultOrigin;
+            String scheme = "";
+
+            URI requestURI = new URI(uri);
+            switch (requestURI.getScheme()) {
+                case "wss":
+                    scheme += "https";
+                    break;
+                case "ws":
+                    scheme += "http";
+                    break;
+                case "http":
+                case "https":
+                    scheme += requestURI.getScheme();
+                    break;
+                default:
+                    break;
+            }
+
+            if (requestURI.getPort() != -1) {
+                defaultOrigin =
+                    String.format("%s://%s:%s", scheme, requestURI.getHost(), requestURI.getPort());
+                } else {
+                defaultOrigin = String.format("%s://%s", scheme, requestURI.getHost());
+            }
+
+            return defaultOrigin;
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Unable to set " + uri + " as default origin header");
+        }
+    }
+
+    private static OkHttpClient.Builder getUnsafeOkHttpClient() {
+        try {
+            // Create a trust manager that does not validate certificate chains
+            final X509TrustManager x509TrustManager = getUnsafeTrustManager();
+
+            final TrustManager[] trustAllCerts = new TrustManager[]{ x509TrustManager };
+
+            // Install the all-trusting trust manager
+            final SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+            // Create an ssl socket factory with our all-trusting manager
+            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+
+            OkHttpClient.Builder builder = new OkHttpClient.Builder();
+            builder.sslSocketFactory(sslSocketFactory, x509TrustManager);
+            builder.hostnameVerifier(new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    return (session.getPeerHost().equalsIgnoreCase(hostname));
+                }
+            });
+
+            return builder;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static X509TrustManager getUnsafeTrustManager() {
+        return new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+            }
+
+            @Override
+            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+            }
+
+            @Override
+            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                return new java.security.cert.X509Certificate[]{};
+            }
+        };
+    }
+}

--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostWebSocketPackage.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostWebSocketPackage.java
@@ -1,0 +1,27 @@
+package com.mattermost.rnbeta;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MattermostWebSocketPackage implements ReactPackage {
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(
+                              ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new MattermostWebSocketModule(reactContext));
+
+        return modules;
+    }
+}

--- a/app/client/websocket.ts
+++ b/app/client/websocket.ts
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 import {Platform} from 'react-native';
+import {isTrustedHost} from 'app/utils/network';
+import {emptyFunction} from 'app/utils/general';
 
 const MAX_WEBSOCKET_FAILS = 7;
 const MIN_WEBSOCKET_RETRY_TIME = 3000; // 3 sec
@@ -87,7 +89,12 @@ class WebSocketClient {
                 return;
             }
 
-            this.conn = new WebSocket(connectionUrl, [], {headers: {origin}, ...(additionalOptions || {})});
+            const options = {headers: {origin}, trustSSL: false, ...(additionalOptions || {})};
+            if (isTrustedHost()) {
+                options.trustSSL = true;
+            }
+
+            this.conn = new WebSocket(connectionUrl, [], options);
             this.connectionUrl = connectionUrl;
             this.token = token;
 
@@ -204,7 +211,7 @@ class WebSocketClient {
         this.connectFailCount = 0;
         this.sequence = 1;
         if (this.conn && this.conn.readyState === WebSocket.OPEN) {
-            this.conn.onclose = () => {}; //eslint-disable-line no-empty-function
+            this.conn.onclose = emptyFunction;
             this.conn.close();
             this.conn = undefined;
             console.log('websocket closed'); //eslint-disable-line no-console

--- a/app/components/emoji/emoji.js
+++ b/app/components/emoji/emoji.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import FastImage from 'react-native-fast-image';
 
+import {isTrustedHost} from 'app/utils/network';
 import CustomPropTypes from 'app/constants/custom_prop_types';
 
 export default class Emoji extends React.PureComponent {
@@ -101,6 +102,7 @@ export default class Emoji extends React.PureComponent {
                 source={{uri: imageUrl}}
                 onError={this.onError}
                 resizeMode={FastImage.resizeMode.contain}
+                trustSSL={isTrustedHost()}
             />
         );
     }

--- a/app/components/message_attachments/attachment_thumbnail.js
+++ b/app/components/message_attachments/attachment_thumbnail.js
@@ -6,6 +6,8 @@ import {StyleSheet, View} from 'react-native';
 import PropTypes from 'prop-types';
 import FastImage from 'react-native-fast-image';
 
+import {isTrustedHost} from 'app/utils/network';
+
 export default class AttachmentThumbnail extends PureComponent {
     static propTypes = {
         url: PropTypes.string,
@@ -25,6 +27,7 @@ export default class AttachmentThumbnail extends PureComponent {
                     resizeMode='contain'
                     resizeMethod='scale'
                     style={style.image}
+                    trustSSL={isTrustedHost()}
                 />
             </View>
         );

--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -3,13 +3,15 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Image, Platform, View} from 'react-native';
+import {Platform, View} from 'react-native';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
+import FastImage from 'react-native-fast-image';
 
 import {Client4} from '@mm-redux/client';
 
 import UserStatus from 'app/components/user_status';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+import {isTrustedHost} from 'app/utils/network';
 
 import placeholder from 'assets/images/profile.jpg';
 
@@ -150,15 +152,16 @@ export default class ProfilePicture extends PureComponent {
             };
 
             image = (
-                <Image
+                <FastImage
                     key={pictureUrl}
                     style={{width: this.props.size, height: this.props.size, borderRadius: this.props.size / 2}}
                     source={source}
+                    trustSSL={isTrustedHost()}
                 />
             );
         } else {
             image = (
-                <Image
+                <FastImage
                     style={{width: this.props.size, height: this.props.size, borderRadius: this.props.size / 2}}
                     source={placeholder}
                 />

--- a/app/components/progressive_image/__snapshots__/progressive_image.test.js.snap
+++ b/app/components/progressive_image/__snapshots__/progressive_image.test.js.snap
@@ -27,6 +27,7 @@ exports[`ProgressiveImage should match snapshot 1`] = `
         undefined,
       ]
     }
+    trustSSL={false}
   />
   <ForwardRef(AnimatedComponentWrapper)
     style={

--- a/app/components/progressive_image/progressive_image.js
+++ b/app/components/progressive_image/progressive_image.js
@@ -3,13 +3,15 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Animated, Image, ImageBackground, Platform, View, StyleSheet} from 'react-native';
+import {Animated, ImageBackground, Platform, View, StyleSheet} from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 import {Client4} from '@mm-redux/client';
 
 import CustomPropTypes from 'app/constants/custom_prop_types';
 import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
+import {isTrustedHost} from 'app/utils/network';
+import EphemeralStore from 'app/store/ephemeral_store';
 
 const AnimatedImageBackground = Animated.createAnimatedComponent(ImageBackground);
 const AnimatedImage = Animated.createAnimatedComponent(FastImage);
@@ -135,7 +137,7 @@ export default class ProgressiveImage extends PureComponent {
             DefaultComponent = ImageBackground;
             ImageComponent = AnimatedImageBackground;
         } else {
-            DefaultComponent = Image;
+            DefaultComponent = FastImage;
             ImageComponent = AnimatedImage;
         }
 
@@ -151,6 +153,7 @@ export default class ProgressiveImage extends PureComponent {
                         resizeMode='center'
                         resizeMethod={resizeMethod}
                         onError={onError}
+                        trustSSL={isTrustedHost()}
                     >
                         {this.props.children}
                     </DefaultComponent>
@@ -164,6 +167,7 @@ export default class ProgressiveImage extends PureComponent {
                     onError={onError}
                     source={defaultSource}
                     style={[StyleSheet.absoluteFill, imageStyle]}
+                    trustSSL={isTrustedHost()}
                 >
                     {this.props.children}
                 </DefaultComponent>
@@ -199,6 +203,7 @@ export default class ProgressiveImage extends PureComponent {
                     style={[StyleSheet.absoluteFill, imageStyle]}
                     blurRadius={isImageReady ? null : 5}
                     onLoadEnd={this.loadFullImage}
+                    trustSSL={isTrustedHost()}
                 >
                     {this.props.children}
                 </ImageComponent>

--- a/app/components/progressive_image/progressive_image.test.js
+++ b/app/components/progressive_image/progressive_image.test.js
@@ -8,10 +8,6 @@ import Preferences from '@mm-redux/constants/preferences';
 
 import ProgressiveImage from './progressive_image';
 
-jest.mock('react-native-fast-image', () => ({
-    preload: jest.fn(),
-}));
-
 jest.useFakeTimers();
 
 describe('ProgressiveImage', () => {

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -5,6 +5,7 @@ import DeepLinkTypes from './deep_linking';
 import DeviceTypes from './device';
 import ListTypes from './list';
 import NavigationTypes from './navigation';
+import Network from './network';
 import Types from './types';
 import ViewTypes, {UpgradeTypes} from './view';
 import WebsocketEvents from './websocket';
@@ -14,8 +15,9 @@ export {
     DeviceTypes,
     ListTypes,
     NavigationTypes,
-    UpgradeTypes,
+    Network,
     Types,
+    UpgradeTypes,
     ViewTypes,
     WebsocketEvents,
 };

--- a/app/constants/network.js
+++ b/app/constants/network.js
@@ -1,0 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export default {
+    SSL_TRUSTLIST: '@sslTrustlist',
+};

--- a/app/init/fetch.js
+++ b/app/init/fetch.js
@@ -3,6 +3,7 @@
 
 import {Platform} from 'react-native';
 import DeviceInfo from 'react-native-device-info';
+import AsyncStorage from '@react-native-community/async-storage';
 import RNFetchBlob from 'rn-fetch-blob';
 import urlParse from 'url-parse';
 
@@ -11,11 +12,14 @@ import {ClientError, HEADER_X_VERSION_ID} from '@mm-redux/client/client4';
 import EventEmitter from '@mm-redux/utils/event_emitter';
 import {General} from '@mm-redux/constants';
 
+import {Network} from '@constants';
+import EphemeralStore from 'app/store/ephemeral_store';
 import mattermostBucket from 'app/mattermost_bucket';
 import mattermostManaged from 'app/mattermost_managed';
 import LocalConfig from 'assets/config';
 
 import {t} from 'app/utils/i18n';
+import {isTrustedHost} from 'app/utils/network';
 
 /* eslint-disable no-throw-literal */
 
@@ -144,10 +148,14 @@ Client4.doFetchWithResponse = async (url, options) => {
     });
 };
 
-const initFetchConfig = async () => {
+export const initFetchConfig = async () => {
+    EphemeralStore.trustedSslHost = await AsyncStorage.getItem(Network.SSL_TRUSTLIST);
+    const trustSSL = isTrustedHost();
+
     const fetchConfig = {
         auto: true,
         timeout: 5000, // Set the base timeout for every request to 5s
+        trusty: trustSSL,
     };
 
     try {

--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -42,6 +42,8 @@ import LocalConfig from 'assets/config';
 import {getAppCredentials, removeAppCredentials} from './credentials';
 import emmProvider from './emm_provider';
 
+import {initFetchConfig} from 'app/init/fetch';
+
 const {StatusBarManager} = NativeModules;
 const PROMPT_IN_APP_PIN_CODE_AFTER = 5 * 1000;
 
@@ -137,6 +139,10 @@ class GlobalEventHandler {
         }
 
         emmProvider.previousAppState = appState;
+
+        // Refresh fetch config to ensure that SSL enforcement/relaxation
+        // happens just as during server selection.
+        initFetchConfig();
     };
 
     onDeepLink = (event) => {

--- a/app/mattermost_websocket/index.js
+++ b/app/mattermost_websocket/index.js
@@ -1,0 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {NativeModules} from 'react-native';
+
+module.exports = NativeModules.MattermostWebSocket;

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -34,6 +34,7 @@ import {emptyFunction} from 'app/utils/general';
 import {calculateDimensions} from 'app/utils/images';
 import {t} from 'app/utils/i18n';
 import BottomSheet from 'app/utils/bottom_sheet';
+import {isTrustedHost} from 'app/utils/network';
 import {
     dismissModal,
     mergeNavigationOptions,
@@ -381,6 +382,7 @@ export default class ImagePreview extends PureComponent {
                     <FastImage
                         source={source}
                         style={imageStyle}
+                        trustSSL={isTrustedHost()}
                     />
                 </View>
             );

--- a/app/store/ephemeral_store.js
+++ b/app/store/ephemeral_store.js
@@ -15,6 +15,7 @@ class EphemeralStore {
             [ViewTypes.PORTRAIT]: null,
             [ViewTypes.LANDSCAPE]: null,
         };
+        this.trustedSslHost = null;
     }
 
     getNavigationTopComponentId = () => this.navigationComponentIdStack[0];

--- a/app/utils/network.js
+++ b/app/utils/network.js
@@ -9,6 +9,7 @@ import {Client4} from '@mm-redux/client';
 
 import mattermostBucket from 'app/mattermost_bucket';
 import mattermostManaged from 'app/mattermost_managed';
+import EphemeralStore from 'app/store/ephemeral_store';
 
 let certificate = '';
 let previousState;
@@ -82,4 +83,11 @@ export default function networkConnectionListener(onChange) {
     return {
         removeEventListener,
     };
+}
+
+export function isTrustedHost() {
+    const trustedHost = EphemeralStore.trustedSslHost;
+    const serverUrl = Client4.getUrl();
+
+    return (serverUrl === trustedHost);
 }

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -449,6 +449,8 @@
   "mobile.server_link.error.title": "Link Error",
   "mobile.server_link.unreachable_channel.error": "This link belongs to a deleted channel or to a channel to which you do not have access.",
   "mobile.server_link.unreachable_team.error": "This link belongs to a deleted team or to a team to which you do not have access.",
+  "mobile.server_ssl.error.text": "Problem with server's SSL certificate.\nDo you accept the risks and want to continue anyway?",
+  "mobile.server_ssl.error.title": "Server SSL Issue",
   "mobile.server_upgrade.button": "OK",
   "mobile.server_upgrade.description": "\nA server upgrade is required to use the Mattermost app. Please ask your System Administrator for details.\n",
   "mobile.server_upgrade.title": "Server upgrade required",

--- a/patches/react-native+0.62.2.patch
+++ b/patches/react-native+0.62.2.patch
@@ -53,6 +53,28 @@ index 5ef712c..d6f9082 100644
    },
    horizontallyInverted: {
      transform: [{scaleX: -1}],
+diff --git a/node_modules/react-native/Libraries/WebSocket/NativeWebSocketModule.js b/node_modules/react-native/Libraries/WebSocket/NativeWebSocketModule.js
+index c2ce1b5..a89d368 100644
+--- a/node_modules/react-native/Libraries/WebSocket/NativeWebSocketModule.js
++++ b/node_modules/react-native/Libraries/WebSocket/NativeWebSocketModule.js
+@@ -12,6 +12,7 @@
+ 
+ import type {TurboModule} from '../TurboModule/RCTExport';
+ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
++import Platform from '../Utilities/Platform';
+ 
+ export interface Spec extends TurboModule {
+   +connect: (
+@@ -30,6 +31,8 @@ export interface Spec extends TurboModule {
+   +removeListeners: (count: number) => void;
+ }
+ 
++const webSocketModule = (Platform.OS === 'android') ? 'MattermostWebSocketModule' : 'WebSocketModule';
++
+ export default (TurboModuleRegistry.getEnforcing<Spec>(
+-  'WebSocketModule',
++  webSocketModule,
+ ): Spec);
 diff --git a/node_modules/react-native/Libraries/WebSocket/RCTSRWebSocket.h b/node_modules/react-native/Libraries/WebSocket/RCTSRWebSocket.h
 index 1b17cff..70a59b6 100644
 --- a/node_modules/react-native/Libraries/WebSocket/RCTSRWebSocket.h
@@ -189,15 +211,23 @@ index b967c14..e24e926 100644
                          forKey:(__bridge id)kCFStreamPropertySSLSettings];
    }
 diff --git a/node_modules/react-native/Libraries/WebSocket/WebSocket.js b/node_modules/react-native/Libraries/WebSocket/WebSocket.js
-index a1679bd..9445e3e 100644
+index a1679bd..a21b71b 100644
 --- a/node_modules/react-native/Libraries/WebSocket/WebSocket.js
 +++ b/node_modules/react-native/Libraries/WebSocket/WebSocket.js
-@@ -92,7 +92,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
+@@ -85,14 +85,14 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
+   constructor(
+     url: string,
+     protocols: ?string | ?Array<string>,
+-    options: ?{headers?: {origin?: string, ...}, ...},
++    options: ?{headers?: {origin?: string}, trustSSL?: boolean},
+   ) {
+     super();
+     if (typeof protocols === 'string') {
        protocols = [protocols];
      }
  
 -    const {headers = {}, ...unrecognized} = options || {};
-+    const {headers = {}, certificate = {}, ...unrecognized} = options || {};
++    const {headers = {}, certificate = {}, trustSSL = false, ...unrecognized} = options || {};
  
      // Preserve deprecated backwards compatibility for the 'origin' option
      /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
@@ -206,7 +236,7 @@ index a1679bd..9445e3e 100644
      this._socketId = nextWebSocketId++;
      this._registerEvents();
 -    NativeWebSocketModule.connect(url, protocols, {headers}, this._socketId);
-+    NativeWebSocketModule.connect(url, protocols, {headers, certificate}, this._socketId);
++    NativeWebSocketModule.connect(url, protocols, {headers, certificate, trustSSL}, this._socketId);
    }
  
    get binaryType(): ?BinaryType {

--- a/patches/react-native-fast-image+8.1.5.patch
+++ b/patches/react-native-fast-image+8.1.5.patch
@@ -43,14 +43,237 @@ index 0000000..f2306f6
 +    }
 +}
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
-index 2214f04..bfb9895 100644
+index 2214f04..3ea65b7 100644
 --- a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
-@@ -45,6 +45,7 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
+@@ -31,6 +31,17 @@ import okio.ForwardingSource;
+ import okio.Okio;
+ import okio.Source;
+ 
++import java.security.cert.CertificateException;
++import java.security.cert.X509Certificate;
++
++import javax.net.ssl.HostnameVerifier;
++import javax.net.ssl.SSLContext;
++import javax.net.ssl.SSLSession;
++import javax.net.ssl.SSLSocketFactory;
++import javax.net.ssl.TrustManager;
++import javax.net.ssl.X509TrustManager;
++
++
+ @GlideModule
+ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
+ 
+@@ -45,23 +56,51 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
          OkHttpClient client = OkHttpClientProvider
                  .getOkHttpClient()
                  .newBuilder()
 +                .cookieJar(new FastImageCookieJar())
                  .addInterceptor(createInterceptor(progressListener))
                  .build();
++
          OkHttpUrlLoader.Factory factory = new OkHttpUrlLoader.Factory(client);
+         registry.replace(GlideUrl.class, InputStream.class, factory);
+     }
+ 
+     private static Interceptor createInterceptor(final ResponseProgressListener listener) {
+         return new Interceptor() {
++
++            private Response execute(Chain chain, Request request) throws IOException {
++                Response response = chain.proceed(request);
++                final String key = request.url().toString();
++                return response
++                    .newBuilder()
++                    .body(new OkHttpProgressResponseBody(key, response.body(), listener))
++                    .build();
++            }
++
+             @Override
+             public Response intercept(Chain chain) throws IOException {
+                 Request request = chain.request();
+-                Response response = chain.proceed(request);
++
+                 final String key = request.url().toString();
+-                return response
+-                        .newBuilder()
+-                        .body(new OkHttpProgressResponseBody(key, response.body(), listener))
+-                        .build();
++                final Boolean trustSsl = listener.isTrustSslEnabled(key);
++
++                if (trustSsl != null && trustSsl) {
++                    try {
++                        return execute(chain, request);
++                    } catch(javax.net.ssl.SSLHandshakeException ce) {
++                        OkHttpClient client = getUnsafeOkHttpClientBuilder()
++                            .cookieJar(new FastImageCookieJar())
++                            .addInterceptor(createInterceptor(listener))
++                            .build();
++
++                        Response response = client.newCall(request).execute();
++                        return response
++                                .newBuilder()
++                                .body(new OkHttpProgressResponseBody(key, response.body(), listener))
++                                .build();
++                    }
++                } else {
++                    return execute(chain, request);
++                }
+             }
+         };
+     }
+@@ -76,11 +115,13 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
+ 
+     private interface ResponseProgressListener {
+         void update(String key, long bytesRead, long contentLength);
++        Boolean isTrustSslEnabled(String key);
+     }
+ 
+     private static class DispatchingProgressListener implements ResponseProgressListener {
+         private final Map<String, FastImageProgressListener> LISTENERS = new WeakHashMap<>();
+         private final Map<String, Long> PROGRESSES = new HashMap<>();
++        private final Map<String, Boolean> TRUST_SSL = new HashMap<>();
+ 
+         private final Handler handler;
+ 
+@@ -91,10 +132,18 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
+         void forget(String key) {
+             LISTENERS.remove(key);
+             PROGRESSES.remove(key);
++            TRUST_SSL.remove(key);
+         }
+ 
+         void expect(String key, FastImageProgressListener listener) {
+             LISTENERS.put(key, listener);
++            TRUST_SSL.put(key, listener.getTrustSsl(key));
++        }
++
++        @Override
++        public Boolean isTrustSslEnabled(String key) {
++            // Note: Preloaded images don't go through FastImageProgressListener and aren't subject to custom OkHttpClient creation.
++            return TRUST_SSL.get(key);
+         }
+ 
+         @Override
+@@ -186,4 +235,49 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
+             };
+         }
+     }
++
++    private static OkHttpClient.Builder getUnsafeOkHttpClientBuilder() {
++        try {
++            // Create a trust manager that does not validate certificate chains
++            final X509TrustManager x509TrustManager = getUnsafeTrustManager();
++
++            final TrustManager[] trustAllCerts = new TrustManager[]{ x509TrustManager };
++
++            // Install the all-trusting trust manager
++            final SSLContext sslContext = SSLContext.getInstance("SSL");
++            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
++            // Create an ssl socket factory with our all-trusting manager
++            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
++
++            OkHttpClient.Builder builder = new OkHttpClient.Builder();
++            builder.sslSocketFactory(sslSocketFactory, x509TrustManager);
++            builder.hostnameVerifier(new HostnameVerifier() {
++                @Override
++                public boolean verify(String hostname, SSLSession session) {
++                    return (session.getPeerHost().equalsIgnoreCase(hostname));
++                }
++            });
++
++            return builder;
++        } catch (Exception e) {
++            throw new RuntimeException(e);
++        }
++    }
++
++    private static X509TrustManager getUnsafeTrustManager() {
++        return new X509TrustManager() {
++            @Override
++            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
++            }
++
++            @Override
++            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
++            }
++
++            @Override
++            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
++                return new java.security.cert.X509Certificate[]{};
++            }
++        };
++    }
+ }
+diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageProgressListener.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageProgressListener.java
+index 6cd5eb2..8845b82 100644
+--- a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageProgressListener.java
++++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageProgressListener.java
+@@ -11,4 +11,5 @@ public interface FastImageProgressListener {
+      */
+     float getGranularityPercentage();
+ 
++    Boolean getTrustSsl(String key);
+ }
+diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+index f97ec71..fe3a751 100644
+--- a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
++++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+@@ -81,7 +81,6 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
+         }
+ 
+         String key = glideUrl.toStringUrl();
+-        FastImageOkHttpProgressGlideModule.expect(key, this);
+         List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
+         if (viewsForKey != null && !viewsForKey.contains(view)) {
+             viewsForKey.add(view);
+@@ -89,6 +88,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
+             List<FastImageViewWithUrl> newViewsForKeys = new ArrayList<>(Collections.singletonList(view));
+             VIEWS_FOR_URLS.put(key, newViewsForKeys);
+         }
++        FastImageOkHttpProgressGlideModule.expect(key, this);
+ 
+         ThemedReactContext context = (ThemedReactContext) view.getContext();
+         RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
+@@ -125,6 +125,20 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
+         view.setScaleType(scaleType);
+     }
+ 
++    @ReactProp(name = "trustSSL")
++    public void setTrustSsl(FastImageViewWithUrl view, Boolean trustSsl) {
++        view.setTrustSsl(trustSsl);
++    }
++
++    @Override
++    public Boolean getTrustSsl(String key) {
++        List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
++        if (viewsForKey == null) {
++            return false;
++        }
++        return viewsForKey.get(0).getTrustSsl();
++    }
++
+     @Override
+     public void onDropViewInstance(FastImageViewWithUrl view) {
+         // This will cancel existing requests.
+diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+index 0b74d92..8e0d18a 100644
+--- a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
++++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+@@ -7,8 +7,17 @@ import com.bumptech.glide.load.model.GlideUrl;
+ 
+ class FastImageViewWithUrl extends ImageView {
+     public GlideUrl glideUrl;
++    Boolean trustSsl;
+ 
+     public FastImageViewWithUrl(Context context) {
+         super(context);
+     }
++
++    public void setTrustSsl(Boolean trustSsl) {
++        this.trustSsl = trustSsl;
++    }
++
++    public Boolean getTrustSsl() {
++        return this.trustSsl;
++    }
+ }

--- a/patches/rn-fetch-blob+0.12.0.patch
+++ b/patches/rn-fetch-blob+0.12.0.patch
@@ -119,10 +119,21 @@ index a4d7015..f430865 100644
       * List content of folder
       * @param path Target folder
 diff --git a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java b/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
-index a8abd71..ad273ce 100644
+index a8abd71..edbf851 100644
 --- a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
 +++ b/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
-@@ -407,6 +407,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
+@@ -233,7 +233,9 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
+             if (this.options.trusty) {
+                 clientBuilder = RNFetchBlobUtils.getUnsafeOkHttpClient(client);
+             } else {
+-                clientBuilder = client.newBuilder();
++                // Uses default trust manager for connection validation.
++                // Emits warning if SSL problem encountered, for user acceptance/rejection.
++                clientBuilder = RNFetchBlobUtils.getRelaxedOkHttpClient(client);
+             }
+ 
+             // wifi only, need ACCESS_NETWORK_STATE permission
+@@ -407,6 +409,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                                  extended = new RNFetchBlobFileResp(
                                          RNFetchBlob.RCTContext,
                                          taskId,
@@ -130,7 +141,7 @@ index a8abd71..ad273ce 100644
                                          originalResponse.body(),
                                          destPath,
                                          options.overwrite);
-@@ -556,16 +557,13 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
+@@ -556,16 +559,13 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                              return;
                          }
                          try {
@@ -151,7 +162,7 @@ index a8abd71..ad273ce 100644
                              if(responseFormat == ResponseFormat.UTF8) {
                                  String utf8 = new String(b);
                                  callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_UTF8, utf8);
-@@ -591,7 +589,19 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
+@@ -591,7 +591,19 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
  //                    ignored.printStackTrace();
                  }
  
@@ -172,6 +183,129 @@ index a8abd71..ad273ce 100644
  
                  if(rnFetchBlobFileResp != null && !rnFetchBlobFileResp.isDownloadComplete()){
                      callback.invoke("Download interrupted.", null);
+diff --git a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java b/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
+index ab35fdd..14ff403 100644
+--- a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
++++ b/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
+@@ -6,12 +6,17 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
+ 
+ import java.security.MessageDigest;
+ import java.security.cert.CertificateException;
++import java.security.cert.X509Certificate;
++import java.security.KeyStore;
++import java.security.NoSuchAlgorithmException;
++import java.security.KeyStoreException;
+ 
+ import javax.net.ssl.HostnameVerifier;
+ import javax.net.ssl.SSLContext;
+ import javax.net.ssl.SSLSession;
+ import javax.net.ssl.SSLSocketFactory;
+ import javax.net.ssl.TrustManager;
++import javax.net.ssl.TrustManagerFactory;
+ import javax.net.ssl.X509TrustManager;
+ 
+ import okhttp3.OkHttpClient;
+@@ -53,23 +58,72 @@ public class RNFetchBlobUtils {
+                 .emit(RNFetchBlobConst.EVENT_MESSAGE, args);
+     }
+ 
+-    public static OkHttpClient.Builder getUnsafeOkHttpClient(OkHttpClient client) {
++    // Uses default, secure trust manager for connection validation.
++    // Emits warning if SSL problem encountered.
++    public static OkHttpClient.Builder getRelaxedOkHttpClient(OkHttpClient client) {
+         try {
+-            // Create a trust manager that does not validate certificate chains
++            final X509TrustManager defaultTrustManager = getDefaultTrustManager();
++
+             final X509TrustManager x509TrustManager = new X509TrustManager() {
+                 @Override
+-                public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
++                public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                 }
+ 
+                 @Override
+-                public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
++                public void checkServerTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
++                    try {
++                        defaultTrustManager.checkServerTrusted(chain, authType);
++                    } catch(CertificateException ce) {
++                        emitWarningEvent("RNFetchBlob custom: Server presented problem with SSL handshake.");
++                    }
+                 }
+ 
+                 @Override
+-                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+-                    return new java.security.cert.X509Certificate[]{};
++                public X509Certificate[] getAcceptedIssuers() {
++                    return new X509Certificate[]{};
+                 }
+             };
++
++            final TrustManager[] trustManagers = new TrustManager[]{x509TrustManager};
++
++            final SSLContext sslContext = SSLContext.getInstance("SSL");
++            sslContext.init(null, trustManagers, new java.security.SecureRandom());
++
++            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
++
++            OkHttpClient.Builder builder = client.newBuilder();
++            builder.sslSocketFactory(sslSocketFactory, x509TrustManager);
++            builder.hostnameVerifier(new HostnameVerifier() {
++                @Override
++                public boolean verify(String hostname, SSLSession session) {
++                    return (session.getPeerHost().equalsIgnoreCase(hostname));
++                }
++            });
++
++            return builder;
++        } catch (Exception e) {
++            throw new RuntimeException(e);
++        }
++    }
++
++    public static X509TrustManager getDefaultTrustManager() throws NoSuchAlgorithmException, KeyStoreException {
++        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
++        trustManagerFactory.init((KeyStore) null); // Using null here initialises the TrustManagerFactory with the default trust store.
++
++        X509TrustManager defaultTrustManager = null;
++        for (TrustManager tm : trustManagerFactory.getTrustManagers()) {
++            if (tm instanceof X509TrustManager) {
++                defaultTrustManager = (X509TrustManager) tm;
++            }
++        }
++        return defaultTrustManager;
++    }
++
++    public static OkHttpClient.Builder getUnsafeOkHttpClient(OkHttpClient client) {
++        try {
++            // Create a trust manager that does not validate certificate chains
++            final X509TrustManager x509TrustManager = getUnsafeTrustManager();
++
+             final TrustManager[] trustAllCerts = new TrustManager[]{ x509TrustManager };
+ 
+             // Install the all-trusting trust manager
+@@ -92,4 +146,21 @@ public class RNFetchBlobUtils {
+             throw new RuntimeException(e);
+         }
+     }
++
++    public static X509TrustManager getUnsafeTrustManager() {
++        return new X509TrustManager() {
++            @Override
++            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
++            }
++
++            @Override
++            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
++            }
++
++            @Override
++            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
++                return new java.security.cert.X509Certificate[]{};
++            }
++        };
++    }
+ }
 diff --git a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java b/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
 index 2470eef..4e92989 100644
 --- a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java


### PR DESCRIPTION
#### Summary

Some server installations use internally-trusted SSL certificates that fail standard SSL handshakes, and therefore prevent the Mattermost mobile client from connecting.

Per [MM-18642](https://mattermost.atlassian.net/browse/MM-18642), the user is now given the option to explicitly accept and trust the host being connected to, now being aware of the security implications of this explicit trust. The intention is to mimic similar behaviour on the mobile client as the "trust and acceptance at your own risk" functionality common in web browsers.

This is the Android pull request. iOS behaviour should remain unchanged.

#### Ticket Link

* [MM-18642](https://mattermost.atlassian.net/browse/MM-18642)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
* Android 10 emulator (device testing pending)
* iPhone 11 simulator (device testing pending)

#### Screenshots

<img width="300" alt="Loosen SSL Alert" src="https://user-images.githubusercontent.com/887849/79680033-8196f480-81e1-11ea-9470-1bd04b586e36.png">

---

**Technical Notes**

* `fetch` on HTTP requests does an additional check for whether the host is part of the SSL Trust List (currently stored in ASyncStorage, soon to be in MMKV). This uses [`rn-fetch-blob` 's `trusty` flag](https://github.com/joltup/rn-fetch-blob#self-signed-ssl-server).

* This PR introduces a Mattermost `WebSocket` module, adapted from the RN version (from 0.62.2)

* File attachment images are not preloaded (in `FastImage`) is the host uses an explicitly-trusted, loosened SSL certificate because of the [underlying implementation](https://github.com/DylanVann/react-native-fast-image/blob/master/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java#L38-L51) of `Glide.preload()` not allowing injection of a custom `OkHttpClient`.

---

**TODO**
- [ ] fix memory leak in test run (local and CircleCI)
- [ ] device testing
- [ ] test against wildcard certificates and hostnames registered as SANs on certificate
- [ ] new tests
- [ ] test scenarios described in #4119 
