### PR TITLE
Fix infinite loop retrieving post files

### DIFF
--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -69,13 +69,11 @@ export default class FileAttachmentList extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.files !== this.props.files) {
-            this.filesForGallery = this.getFilesForGallery(this.props);
-            this.buildGalleryFiles().then((results) => {
-                this.galleryFiles = results;
-            });
-        }
-        if (this.props.files !== prevProps.files && this.props.files.length === 0) {
+        this.filesForGallery = this.getFilesForGallery(this.props);
+        this.buildGalleryFiles().then((results) => {
+            this.galleryFiles = results;
+        });
+        if (prevProps.files.length !== this.props.files.length) {
             this.loadFilesForPost();
         }
     }

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -69,11 +69,11 @@ export default class FileAttachmentList extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        this.filesForGallery = this.getFilesForGallery(this.props);
-        this.buildGalleryFiles().then((results) => {
-            this.galleryFiles = results;
-        });
         if (prevProps.files.length !== this.props.files.length) {
+            this.filesForGallery = this.getFilesForGallery(this.props);
+            this.buildGalleryFiles().then((results) => {
+                this.galleryFiles = results;
+            });
             this.loadFilesForPost();
         }
     }


### PR DESCRIPTION
<!-- Thank you for contributing to a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at another repository-specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Right now if all the attachments of a post are removed the component update code enters into an infinite loop because the comparison between arrays always returns false.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23907

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 

Nvidia Shield, Android 7

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->