### PR TITLE
[MM-24427] Check canPost permissions for v5.22+

### DIFF
--- a/app/components/post_textbox/index.js
+++ b/app/components/post_textbox/index.js
@@ -30,7 +30,7 @@ import PostTextbox from './post_textbox';
 
 const MAX_MESSAGE_LENGTH = 4000;
 
-function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state, ownProps) {
     const currentDraft = ownProps.rootId ? getThreadDraft(state, ownProps.rootId) : getCurrentChannelDraft(state);
     const config = getConfig(state);
 
@@ -50,17 +50,19 @@ function mapStateToProps(state, ownProps) {
     const currentChannelStats = getCurrentChannelStats(state);
     const currentChannelMembersCount = currentChannelStats?.member_count || 0; // eslint-disable-line camelcase
     const isTimezoneEnabled = config?.ExperimentalTimezone === 'true';
-    const canPost = haveIChannelPermission(
-        state,
-        {
-            channel: currentChannel.id,
-            team: currentChannel.team_id,
-            permission: Permissions.CREATE_POST,
-        },
-    );
 
+    let canPost = true;
     let useChannelMentions = true;
     if (isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)) {
+        canPost = haveIChannelPermission(
+            state,
+            {
+                channel: currentChannel.id,
+                team: currentChannel.team_id,
+                permission: Permissions.CREATE_POST,
+            },
+        );
+
         useChannelMentions = haveIChannelPermission(
             state,
             {

--- a/app/components/post_textbox/index.test.js
+++ b/app/components/post_textbox/index.test.js
@@ -1,0 +1,100 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Permissions} from '@mm-redux/constants';
+import * as channelSelectors from '@mm-redux/selectors/entities/channels';
+import * as userSelectors from '@mm-redux/selectors/entities/users';
+import * as generalSelectors from '@mm-redux/selectors/entities/general';
+import * as preferenceSelectors from '@mm-redux/selectors/entities/preferences';
+import * as roleSelectors from '@mm-redux/selectors/entities/roles';
+import * as deviceSelectors from '@selectors/device';
+
+import {isMinimumServerVersion} from '@mm-redux/utils/helpers';
+
+import {mapStateToProps} from './index';
+
+jest.mock('./post_textbox', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+channelSelectors.getCurrentChannel = jest.fn().mockReturnValue({});
+channelSelectors.isCurrentChannelReadOnly = jest.fn();
+channelSelectors.getCurrentChannelStats = jest.fn();
+userSelectors.getStatusForUserId = jest.fn();
+generalSelectors.canUploadFilesOnMobile = jest.fn();
+preferenceSelectors.getTheme = jest.fn();
+roleSelectors.haveIChannelPermission = jest.fn();
+deviceSelectors.isLandscape = jest.fn();
+
+describe('mapStateToProps', () => {
+    const baseState = {
+        entities: {
+            general: {
+                config: {},
+                serverVersion: '',
+            },
+            users: {
+                currentUserId: '',
+            },
+            channels: {
+                currentChannelId: '',
+            },
+            preferences: {
+                myPreferences: {},
+            },
+        },
+        views: {
+            channel: {
+                drafts: {},
+            },
+        },
+        requests: {
+            files: {
+                uploadFiles: {
+                    status: '',
+                },
+            },
+        },
+    };
+
+    const baseOwnProps = {};
+
+    test('haveIChannelPermission is not called when isMinimumServerVersion is not 5.22v', () => {
+        const state = {...baseState};
+        state.entities.general.serverVersion = '5.21';
+
+        mapStateToProps(state, baseOwnProps);
+        expect(isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)).toBe(false);
+
+        expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
+            channel: undefined,
+            team: undefined,
+            permission: Permissions.CREATE_POST,
+        });
+
+        expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
+            channel: undefined,
+            permission: Permissions.USE_CHANNEL_MENTIONS,
+        });
+    });
+
+    test('haveIChannelPermission is called when isMinimumServerVersion is 5.22v', () => {
+        const state = {...baseState};
+        state.entities.general.serverVersion = '5.22';
+
+        mapStateToProps(state, baseOwnProps);
+        expect(isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)).toBe(true);
+
+        expect(roleSelectors.haveIChannelPermission).toHaveBeenCalledWith(state, {
+            channel: undefined,
+            team: undefined,
+            permission: Permissions.CREATE_POST,
+        });
+
+        expect(roleSelectors.haveIChannelPermission).toHaveBeenCalledWith(state, {
+            channel: undefined,
+            permission: Permissions.USE_CHANNEL_MENTIONS,
+        });
+    });
+});

--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -56,14 +56,18 @@ export function makeMapStateToProps() {
         let {canDelete} = ownProps;
         let canFlag = true;
         let canPin = true;
-        const canPost = haveIChannelPermission(
-            state,
-            {
-                channel: post.channel_id,
-                team: channel.team_id,
-                permission: Permissions.CREATE_POST,
-            },
-        );
+
+        let canPost = true;
+        if (isMinimumServerVersion(serverVersion, 5, 22)) {
+            canPost = haveIChannelPermission(
+                state,
+                {
+                    channel: post.channel_id,
+                    team: channel.team_id,
+                    permission: Permissions.CREATE_POST,
+                },
+            );
+        }
 
         if (hasNewPermissions(state)) {
             canAddReaction = haveIChannelPermission(state, {

--- a/app/screens/post_options/index.test.js
+++ b/app/screens/post_options/index.test.js
@@ -2,11 +2,13 @@
 // See LICENSE.txt for license information.
 import {makeMapStateToProps} from './index';
 
+import {Permissions} from '@mm-redux/constants';
 import * as channelSelectors from '@mm-redux/selectors/entities/channels';
 import * as generalSelectors from '@mm-redux/selectors/entities/general';
 import * as userSelectors from '@mm-redux/selectors/entities/users';
 import * as commonSelectors from '@mm-redux/selectors/entities/common';
 import * as teamSelectors from '@mm-redux/selectors/entities/teams';
+import * as roleSelectors from '@mm-redux/selectors/entities/roles';
 import * as deviceSelectors from 'app/selectors/device';
 import * as preferencesSelectors from '@mm-redux/selectors/entities/preferences';
 import {isMinimumServerVersion} from '@mm-redux/utils/helpers';
@@ -26,6 +28,7 @@ teamSelectors.getCurrentTeamUrl = jest.fn();
 deviceSelectors.getDimensions = jest.fn();
 deviceSelectors.isLandscape = jest.fn();
 preferencesSelectors.getTheme = jest.fn();
+roleSelectors.haveIChannelPermission = jest.fn();
 
 describe('makeMapStateToProps', () => {
     const baseState = {
@@ -134,5 +137,45 @@ describe('makeMapStateToProps', () => {
         const props = mapStateToProps(state, baseOwnProps);
         expect(isMinimumServerVersion(state.entities.general.serverVersion, 5, 18)).toBe(false);
         expect(props.canMarkAsUnread).toBe(false);
+    });
+
+    test('haveIChannelPermission for canPost is not called when isMinimumServerVersion is not 5.22v', () => {
+        const state = {
+            entities: {
+                ...baseState.entities,
+                general: {
+                    serverVersion: '5.21',
+                },
+            },
+        };
+
+        const mapStateToProps = makeMapStateToProps();
+        mapStateToProps(state, baseOwnProps);
+        expect(isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)).toBe(false);
+        expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
+            channel: undefined,
+            team: undefined,
+            permission: Permissions.CREATE_POST,
+        });
+    });
+
+    test('haveIChannelPermission for canPost is called when isMinimumServerVersion is 5.22v', () => {
+        const state = {
+            entities: {
+                ...baseState.entities,
+                general: {
+                    serverVersion: '5.22',
+                },
+            },
+        };
+
+        const mapStateToProps = makeMapStateToProps();
+        mapStateToProps(state, baseOwnProps);
+        expect(isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)).toBe(true);
+        expect(roleSelectors.haveIChannelPermission).toHaveBeenCalledWith(state, {
+            channel: undefined,
+            team: undefined,
+            permission: Permissions.CREATE_POST,
+        });
     });
 });


### PR DESCRIPTION
#### Summary
Default `canPost` to true and apply permission check only for v5.22+ server versions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24427

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android 9 emulator