### PR TITLE
MM-24446 Fix Crash on iOS with EMM enabled

### DIFF
--- a/app/mattermost_managed/mattermost-managed.android.js
+++ b/app/mattermost_managed/mattermost-managed.android.js
@@ -36,11 +36,12 @@ export default {
             listeners.splice(index, 1);
         }
     },
-    authenticate: () => {
+    authenticate: (opts) => {
         if (!LocalAuth) {
             LocalAuth = require('react-native-local-auth');
         }
-        return LocalAuth.auth;
+
+        return LocalAuth.auth(opts);
     },
     blurAppScreen: emptyFunction,
     appGroupIdentifier: null,

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -67,6 +67,10 @@ export default class SelectServer extends PureComponent {
         serverUrl: PropTypes.string.isRequired,
     };
 
+    static defaultProps = {
+        allowOtherServers: true,
+    };
+
     static contextTypes = {
         intl: intlShape.isRequired,
     };
@@ -159,11 +163,18 @@ export default class SelectServer extends PureComponent {
     };
 
     goToNextScreen = (screen, title, passProps = {}, navOptions = {}) => {
+        const {allowOtherServers} = this.props;
+        let visible = !LocalConfig.AutoSelectServerUrl;
+
+        if (!allowOtherServers) {
+            visible = false;
+        }
+
         const defaultOptions = {
-            popGesture: !LocalConfig.AutoSelectServerUrl,
+            popGesture: visible,
             topBar: {
-                visible: !LocalConfig.AutoSelectServerUrl,
-                height: LocalConfig.AutoSelectServerUrl ? 0 : null,
+                visible,
+                height: visible ? null : 0,
             },
         };
         const options = merge(defaultOptions, navOptions);

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -215,6 +215,8 @@ PODS:
     - React
   - react-native-image-picker (2.3.1):
     - React
+  - react-native-local-auth (1.6.0):
+    - React
   - react-native-mmkv-storage (0.3.1):
     - MMKV (= 1.1.0)
     - React
@@ -368,6 +370,7 @@ DEPENDENCIES:
   - react-native-document-picker (from `../node_modules/react-native-document-picker`)
   - react-native-hw-keyboard-event (from `../node_modules/react-native-hw-keyboard-event`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
+  - react-native-local-auth (from `../node_modules/react-native-local-auth`)
   - react-native-mmkv-storage (from `../node_modules/react-native-mmkv-storage`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-notifications (from `../node_modules/react-native-notifications`)
@@ -467,6 +470,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-hw-keyboard-event"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
+  react-native-local-auth:
+    :path: "../node_modules/react-native-local-auth"
   react-native-mmkv-storage:
     :path: "../node_modules/react-native-mmkv-storage"
   react-native-netinfo:
@@ -563,6 +568,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 6acd41af22988cf349848678fdaa294d4448478e
   react-native-hw-keyboard-event: b517cefb8d5c659a38049c582de85ff43337dc53
   react-native-image-picker: 668e72d0277dc8c12ae90e835507c1eddd2e4f85
+  react-native-local-auth: 359af242caa1e5c501ac9dfe33b1e238ad8f08c6
   react-native-mmkv-storage: d413e1e00b1f410a744e1d547a912a1f87e67260
   react-native-netinfo: 892a5130be97ff8bb69c523739c424a2ffc296d1
   react-native-notifications: 24706907104a0f00c35c4bde7e0ca76a50f730e1

--- a/patches/react-native-local-auth+1.6.0.patch
+++ b/patches/react-native-local-auth+1.6.0.patch
@@ -170,3 +170,29 @@ index 38b78f1..a47afea 100644
      } catch (Exception e) {
        authPromise.reject(E_FAILED_TO_SHOW_AUTH, e);
        authPromise = null;
+diff --git a/node_modules/react-native-local-auth/react-native-local-auth.podspec b/node_modules/react-native-local-auth/react-native-local-auth.podspec
+new file mode 100644
+index 0000000..5f9a6b4
+--- /dev/null
++++ b/node_modules/react-native-local-auth/react-native-local-auth.podspec
+@@ -0,0 +1,20 @@
++require "json"
++package = JSON.parse(File.read(File.join(__dir__, '/package.json')))
++
++Pod::Spec.new do |s|
++  s.name = package['name']
++  s.version = package['version']
++  s.summary = package['description']
++  s.description = package['description']
++  s.homepage = package['homepage']
++  s.license = package['license']
++  s.author = package['author']
++  s.source = { :git => 'https://github.com/tradle/react-native-local-auth.git' }
++
++  s.platform = :ios, '9.0'
++  s.ios.deployment_target = '9.0'
++
++  s.source_files = "*.{h,m}"
++
++  s.dependency 'React'
++end


### PR DESCRIPTION
#### Summary
This PR affects master and 1.31 and another PR will be submitted against 1.30

The react-native-local-auth library was not being linked for iOS and then when this functionality was requested the app crashed.

Also fixes Passcode authentication on Android that was not being triggered and finally fixes the header being present and allowing going back to the select server screen when EMM disallowed using other servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24446