### PR TITLE
MM-24446 Fix Crash on iOS with EMM enabled (1.30)

### DIFF
--- a/app/mattermost_managed/mattermost-managed.android.js
+++ b/app/mattermost_managed/mattermost-managed.android.js
@@ -36,11 +36,12 @@ export default {
             listeners.splice(index, 1);
         }
     },
-    authenticate: () => {
+    authenticate: (opts) => {
         if (!LocalAuth) {
             LocalAuth = require('react-native-local-auth');
         }
-        return LocalAuth.auth;
+
+        return LocalAuth.auth(opts);
     },
     blurAppScreen: emptyFunction,
     appGroupIdentifier: null,

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -67,6 +67,10 @@ export default class SelectServer extends PureComponent {
         serverUrl: PropTypes.string.isRequired,
     };
 
+    static defaultProps = {
+        allowOtherServers: true,
+    };
+
     static contextTypes = {
         intl: intlShape.isRequired,
     };
@@ -159,11 +163,18 @@ export default class SelectServer extends PureComponent {
     };
 
     goToNextScreen = (screen, title, passProps = {}, navOptions = {}) => {
+        const {allowOtherServers} = this.props;
+        let visible = !LocalConfig.AutoSelectServerUrl;
+
+        if (!allowOtherServers) {
+            visible = false;
+        }
+
         const defaultOptions = {
-            popGesture: !LocalConfig.AutoSelectServerUrl,
+            popGesture: visible,
             topBar: {
-                visible: !LocalConfig.AutoSelectServerUrl,
-                height: LocalConfig.AutoSelectServerUrl ? 0 : null,
+                visible,
+                height: visible ? null : 0,
             },
         };
         const options = merge(defaultOptions, navOptions);

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -212,6 +212,8 @@ PODS:
     - React
   - react-native-image-picker (2.3.1):
     - React
+  - react-native-local-auth (1.6.0):
+    - React
   - react-native-netinfo (4.4.0):
     - React
   - react-native-notifications (2.0.6):
@@ -338,6 +340,7 @@ DEPENDENCIES:
   - react-native-document-picker (from `../node_modules/react-native-document-picker`)
   - react-native-hw-keyboard-event (from `../node_modules/react-native-hw-keyboard-event`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
+  - react-native-local-auth (from `../node_modules/react-native-local-auth`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-notifications (from `../node_modules/react-native-notifications`)
   - react-native-passcode-status (from `../node_modules/react-native-passcode-status`)
@@ -434,6 +437,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-hw-keyboard-event"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
+  react-native-local-auth:
+    :path: "../node_modules/react-native-local-auth"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-notifications:
@@ -526,6 +531,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 0573c02d742d4bef38a5d16b5f039754cfa69888
   react-native-hw-keyboard-event: b517cefb8d5c659a38049c582de85ff43337dc53
   react-native-image-picker: 668e72d0277dc8c12ae90e835507c1eddd2e4f85
+  react-native-local-auth: 359af242caa1e5c501ac9dfe33b1e238ad8f08c6
   react-native-netinfo: 892a5130be97ff8bb69c523739c424a2ffc296d1
   react-native-notifications: d5cb54ef8bf3004dcb56c887650dea08ecbddee7
   react-native-passcode-status: 88c4f6e074328bc278bd127646b6c694ad5a530a

--- a/patches/react-native-local-auth+1.6.0.patch
+++ b/patches/react-native-local-auth+1.6.0.patch
@@ -1,3 +1,175 @@
+diff --git a/node_modules/react-native-local-auth/LocalAuth.android.js b/node_modules/react-native-local-auth/LocalAuth.android.js
+index 49242b4..8deada5 100644
+--- a/node_modules/react-native-local-auth/LocalAuth.android.js
++++ b/node_modules/react-native-local-auth/LocalAuth.android.js
+@@ -3,28 +3,63 @@
+  * @providesModule LocalAuth
+  * @flow
+  */
+-'use strict'
++'use strict';
+ 
+-import { createError } from './error'
+-import Errors from './data/errors'
+-import { NativeModules } from 'react-native'
++import { createError } from './error';
++import { NativeModules } from 'react-native';
+ 
+-const { RNLocalAuth } = NativeModules
++const { RNLocalAuth } = NativeModules;
+ 
+-module.exports = {
+-  hasTouchID() {
+-    return Promise.reject(createError('RCTTouchIDNotSupported'))
+-  },
+-
+-  isDeviceSecure() {
+-    return RNLocalAuth.isDeviceSecure()
+-  },
+-
+-  authenticate(opts) {
+-    return RNLocalAuth.authenticate(opts)
+-      .catch(err => {
+-        err.name = err.code
+-        throw err
+-      })
+-  }
++function performAuth(opts) {
++    return new Promise(async (resolve, reject) => {
++        try {
++            if (await RNLocalAuth.isInitialized()) {
++                RNLocalAuth.authenticate(opts).
++                then(() => resolve()).
++                catch((e) => {
++                  e.name = e.code;
++                  reject(e);
++                });
++            } else {
++                setTimeout(() => {
++                    resolve(performAuth(opts));
++                }, 1000);
++            }
++        } catch (err) {
++            reject(err);
++        }
++    });
++}
++
++function performAuthSkipInit(opts) {
++    return new Promise(async (resolve, reject) => {
++        try {
++            RNLocalAuth.authenticate(opts).
++            then(() => resolve()).
++            catch((e) => {
++                e.name = e.code;
++                reject(e);
++            });
++        } catch (err) {
++            reject(err);
++        }
++    });
+ }
++
++module.exports = {
++    hasTouchID() {
++        return Promise.reject(createError('RCTTouchIDNotSupported'))
++    },
++
++    isDeviceSecure() {
++        return RNLocalAuth.isDeviceSecure()
++    },
++
++    authenticate(opts) {
++        return performAuth(opts)
++    },
++
++    auth(opts) {
++        return performAuthSkipInit(opts);
++    }
++};
+\ No newline at end of file
+diff --git a/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java b/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java
+index 38b78f1..a47afea 100644
+--- a/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java
++++ b/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java
+@@ -6,6 +6,7 @@ import android.app.KeyguardManager;
+ import android.content.Intent;
+ import android.content.Context;
+ 
++import android.os.Bundle;
+ import com.facebook.react.bridge.ReactApplicationContext;
+ import com.facebook.react.bridge.ReactContextBaseJavaModule;
+ import com.facebook.react.bridge.ReactMethod;
+@@ -14,6 +15,8 @@ import com.facebook.react.bridge.ActivityEventListener;
+ import com.facebook.react.bridge.BaseActivityEventListener;
+ import com.facebook.react.bridge.ReadableMap;
+ 
++import java.util.Set;
++//import java.util.concurrent.CountDownLatch;
+ // source for main part from:
+ // https://github.com/googlesamples/android-ConfirmCredential/blob/master/Application/src/main/java/com/example/android/confirmcredential/MainActivity.java
+ 
+@@ -28,8 +31,24 @@ public class LocalAuthModule extends ReactContextBaseJavaModule {
+   private final ReactApplicationContext reactContext;
+   private KeyguardManager mKeyguardManager;
+   private Promise authPromise;
++  private boolean initialized = false;
+ 
+   private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
++    @Override
++    public void onNewIntent(Intent intent) {
++      if (!initialized) {
++        Bundle bundle = intent.getExtras();
++        if (bundle != null) {
++          Set<String> keys = bundle.keySet();
++
++          StringBuilder stringBuilder = new StringBuilder();
++          for (String key : keys) {
++            stringBuilder.append(key).append("=").append(bundle.get(key)).append("\n\r");
++            initialized = stringBuilder.toString().contains("screen=Root");
++          }
++        }
++      }
++    }
+     @Override
+     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+       if (requestCode != AUTH_REQUEST || authPromise == null) return;
+@@ -61,19 +80,21 @@ public class LocalAuthModule extends ReactContextBaseJavaModule {
+     promise.resolve(mKeyguardManager.isDeviceSecure());
+   }
+ 
++  @ReactMethod
++  public void isInitialized(final Promise promise) { promise.resolve(initialized);}
++
+   @ReactMethod
+   public void authenticate(ReadableMap map, final Promise promise) {
+     // Create the Confirm Credentials screen. You can customize the title and description. Or
+     // we will provide a generic one for you if you leave it null
+-    Activity currentActivity = getCurrentActivity();
+ 
+-    if (authPromise != null) {
+-      promise.reject(E_ONE_REQ_AT_A_TIME, "Activity doesn't exist");
++    if (getCurrentActivity() == null) {
++      promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "One auth request at a time");
+       return;
+     }
+ 
+-    if (currentActivity == null) {
+-      promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "One auth request at a time");
++    if (authPromise != null) {
++      promise.reject(E_ONE_REQ_AT_A_TIME, "Activity doesn't exist");
+       return;
+     }
+ 
+@@ -84,7 +105,7 @@ public class LocalAuthModule extends ReactContextBaseJavaModule {
+     String description = map.hasKey("description") ? map.getString("description") : null;
+     try {
+       final Intent authIntent = mKeyguardManager.createConfirmDeviceCredentialIntent(reason, description);
+-      currentActivity.startActivityForResult(authIntent, AUTH_REQUEST);
++      getCurrentActivity().startActivityForResult(authIntent, AUTH_REQUEST);
+     } catch (Exception e) {
+       authPromise.reject(E_FAILED_TO_SHOW_AUTH, e);
+       authPromise = null;
 diff --git a/node_modules/react-native-local-auth/react-native-local-auth.podspec b/node_modules/react-native-local-auth/react-native-local-auth.podspec
 new file mode 100644
 index 0000000..5f9a6b4

--- a/patches/react-native-local-auth+1.6.0.patch
+++ b/patches/react-native-local-auth+1.6.0.patch
@@ -1,172 +1,26 @@
-diff --git a/node_modules/react-native-local-auth/LocalAuth.android.js b/node_modules/react-native-local-auth/LocalAuth.android.js
-index 49242b4..8deada5 100644
---- a/node_modules/react-native-local-auth/LocalAuth.android.js
-+++ b/node_modules/react-native-local-auth/LocalAuth.android.js
-@@ -3,28 +3,63 @@
-  * @providesModule LocalAuth
-  * @flow
-  */
--'use strict'
-+'use strict';
- 
--import { createError } from './error'
--import Errors from './data/errors'
--import { NativeModules } from 'react-native'
-+import { createError } from './error';
-+import { NativeModules } from 'react-native';
- 
--const { RNLocalAuth } = NativeModules
-+const { RNLocalAuth } = NativeModules;
- 
--module.exports = {
--  hasTouchID() {
--    return Promise.reject(createError('RCTTouchIDNotSupported'))
--  },
--
--  isDeviceSecure() {
--    return RNLocalAuth.isDeviceSecure()
--  },
--
--  authenticate(opts) {
--    return RNLocalAuth.authenticate(opts)
--      .catch(err => {
--        err.name = err.code
--        throw err
--      })
--  }
-+function performAuth(opts) {
-+    return new Promise(async (resolve, reject) => {
-+        try {
-+            if (await RNLocalAuth.isInitialized()) {
-+                RNLocalAuth.authenticate(opts).
-+                then(() => resolve()).
-+                catch((e) => {
-+                  e.name = e.code;
-+                  reject(e);
-+                });
-+            } else {
-+                setTimeout(() => {
-+                    resolve(performAuth(opts));
-+                }, 1000);
-+            }
-+        } catch (err) {
-+            reject(err);
-+        }
-+    });
-+}
+diff --git a/node_modules/react-native-local-auth/react-native-local-auth.podspec b/node_modules/react-native-local-auth/react-native-local-auth.podspec
+new file mode 100644
+index 0000000..5f9a6b4
+--- /dev/null
++++ b/node_modules/react-native-local-auth/react-native-local-auth.podspec
+@@ -0,0 +1,20 @@
++require "json"
++package = JSON.parse(File.read(File.join(__dir__, '/package.json')))
 +
-+function performAuthSkipInit(opts) {
-+    return new Promise(async (resolve, reject) => {
-+        try {
-+            RNLocalAuth.authenticate(opts).
-+            then(() => resolve()).
-+            catch((e) => {
-+                e.name = e.code;
-+                reject(e);
-+            });
-+        } catch (err) {
-+            reject(err);
-+        }
-+    });
- }
++Pod::Spec.new do |s|
++  s.name = package['name']
++  s.version = package['version']
++  s.summary = package['description']
++  s.description = package['description']
++  s.homepage = package['homepage']
++  s.license = package['license']
++  s.author = package['author']
++  s.source = { :git => 'https://github.com/tradle/react-native-local-auth.git' }
 +
-+module.exports = {
-+    hasTouchID() {
-+        return Promise.reject(createError('RCTTouchIDNotSupported'))
-+    },
++  s.platform = :ios, '9.0'
++  s.ios.deployment_target = '9.0'
 +
-+    isDeviceSecure() {
-+        return RNLocalAuth.isDeviceSecure()
-+    },
++  s.source_files = "*.{h,m}"
 +
-+    authenticate(opts) {
-+        return performAuth(opts)
-+    },
-+
-+    auth(opts) {
-+        return performAuthSkipInit(opts);
-+    }
-+};
-\ No newline at end of file
-diff --git a/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java b/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java
-index 38b78f1..a47afea 100644
---- a/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java
-+++ b/node_modules/react-native-local-auth/android/src/main/java/io/tradle/reactlocalauth/LocalAuthModule.java
-@@ -6,6 +6,7 @@ import android.app.KeyguardManager;
- import android.content.Intent;
- import android.content.Context;
- 
-+import android.os.Bundle;
- import com.facebook.react.bridge.ReactApplicationContext;
- import com.facebook.react.bridge.ReactContextBaseJavaModule;
- import com.facebook.react.bridge.ReactMethod;
-@@ -14,6 +15,8 @@ import com.facebook.react.bridge.ActivityEventListener;
- import com.facebook.react.bridge.BaseActivityEventListener;
- import com.facebook.react.bridge.ReadableMap;
- 
-+import java.util.Set;
-+//import java.util.concurrent.CountDownLatch;
- // source for main part from:
- // https://github.com/googlesamples/android-ConfirmCredential/blob/master/Application/src/main/java/com/example/android/confirmcredential/MainActivity.java
- 
-@@ -28,8 +31,24 @@ public class LocalAuthModule extends ReactContextBaseJavaModule {
-   private final ReactApplicationContext reactContext;
-   private KeyguardManager mKeyguardManager;
-   private Promise authPromise;
-+  private boolean initialized = false;
- 
-   private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
-+    @Override
-+    public void onNewIntent(Intent intent) {
-+      if (!initialized) {
-+        Bundle bundle = intent.getExtras();
-+        if (bundle != null) {
-+          Set<String> keys = bundle.keySet();
-+
-+          StringBuilder stringBuilder = new StringBuilder();
-+          for (String key : keys) {
-+            stringBuilder.append(key).append("=").append(bundle.get(key)).append("\n\r");
-+            initialized = stringBuilder.toString().contains("screen=Root");
-+          }
-+        }
-+      }
-+    }
-     @Override
-     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-       if (requestCode != AUTH_REQUEST || authPromise == null) return;
-@@ -61,19 +80,21 @@ public class LocalAuthModule extends ReactContextBaseJavaModule {
-     promise.resolve(mKeyguardManager.isDeviceSecure());
-   }
- 
-+  @ReactMethod
-+  public void isInitialized(final Promise promise) { promise.resolve(initialized);}
-+
-   @ReactMethod
-   public void authenticate(ReadableMap map, final Promise promise) {
-     // Create the Confirm Credentials screen. You can customize the title and description. Or
-     // we will provide a generic one for you if you leave it null
--    Activity currentActivity = getCurrentActivity();
- 
--    if (authPromise != null) {
--      promise.reject(E_ONE_REQ_AT_A_TIME, "Activity doesn't exist");
-+    if (getCurrentActivity() == null) {
-+      promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "One auth request at a time");
-       return;
-     }
- 
--    if (currentActivity == null) {
--      promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "One auth request at a time");
-+    if (authPromise != null) {
-+      promise.reject(E_ONE_REQ_AT_A_TIME, "Activity doesn't exist");
-       return;
-     }
- 
-@@ -84,7 +105,7 @@ public class LocalAuthModule extends ReactContextBaseJavaModule {
-     String description = map.hasKey("description") ? map.getString("description") : null;
-     try {
-       final Intent authIntent = mKeyguardManager.createConfirmDeviceCredentialIntent(reason, description);
--      currentActivity.startActivityForResult(authIntent, AUTH_REQUEST);
-+      getCurrentActivity().startActivityForResult(authIntent, AUTH_REQUEST);
-     } catch (Exception e) {
-       authPromise.reject(E_FAILED_TO_SHOW_AUTH, e);
-       authPromise = null;
++  s.dependency 'React'
++end


### PR DESCRIPTION
#### Summary
This PR affects 1.30 and another PR exists for master/1.31

The react-native-local-auth library was not being linked for iOS and then when this functionality was requested the app crashed.

Also fixes Passcode authentication on Android that was not being triggered and finally fixes the header being present and allowing going back to the select server screen when EMM disallowed using other servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24446