### PR TITLE
[MM-24451] Handle setting previousVersion on logout and clearing data

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -280,6 +280,7 @@ class GlobalEventHandler {
                         app: {
                             build: DeviceInfo.getBuildNumber(),
                             version: DeviceInfo.getVersion(),
+                            previousVersion: state.app?.previousVersion || DeviceInfo.getVersion(),
                         },
                     },
                 },

--- a/app/reducers/app/previousVersion.js
+++ b/app/reducers/app/previousVersion.js
@@ -1,6 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export default function previousVersion(state = '') {
+import DeviceInfo from 'react-native-device-info';
+
+import {UserTypes} from 'mattermost-redux/action_types';
+
+export default function previousVersion(state = '', action) {
+    switch (action.type) {
+    case UserTypes.LOGIN:
+        return state || DeviceInfo.getVersion();
+    }
     return state;
 }

--- a/app/reducers/app/previousVersion.js
+++ b/app/reducers/app/previousVersion.js
@@ -1,14 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import DeviceInfo from 'react-native-device-info';
-
-import {UserTypes} from 'mattermost-redux/action_types';
-
-export default function previousVersion(state = '', action) {
-    switch (action.type) {
-    case UserTypes.LOGIN:
-        return state || DeviceInfo.getVersion();
-    }
+export default function previousVersion(state = '') {
     return state;
 }

--- a/app/store/utils.js
+++ b/app/store/utils.js
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import merge from 'deepmerge';
-import DeviceInfo from 'react-native-device-info';
 
 function transformFromSet(incoming) {
     const state = {...incoming};

--- a/app/store/utils.js
+++ b/app/store/utils.js
@@ -67,6 +67,7 @@ export function waitForHydration(store, callback) {
 }
 
 export function getStateForReset(initialState, currentState) {
+    const {app} = currentState;
     const {currentUserId} = currentState.entities.users;
     const currentUserProfile = currentState.entities.users.profiles[currentUserId];
     const {currentTeamId} = currentState.entities.teams;
@@ -78,10 +79,7 @@ export function getStateForReset(initialState, currentState) {
     });
 
     const resetState = merge(initialState, {
-        app: {
-            build: DeviceInfo.getBuildNumber(),
-            version: DeviceInfo.getVersion(),
-        },
+        app,
         entities: {
             users: {
                 currentUserId,

--- a/app/store/utils.test.js
+++ b/app/store/utils.test.js
@@ -20,6 +20,11 @@ describe('getStateForReset', () => {
     const otherUserId = 'other-user-id';
     const currentTeamId = 'current-team-id';
     const currentState = {
+        app: {
+            build: 'build',
+            version: 'version',
+            previousVersion: 'previousVersion',
+        },
         entities: {
             users: {
                 currentUserId,
@@ -75,5 +80,11 @@ describe('getStateForReset', () => {
         const themeKeys = preferenceKeys.filter((key) => key.startsWith('theme--'));
         expect(themeKeys.length).not.toEqual(0);
         expect(themeKeys.length).toEqual(preferenceKeys.length);
+    });
+
+    it('should keep app', () => {
+        const resetState = getStateForReset(initialState, currentState);
+        const {app} = resetState;
+        expect(app).toStrictEqual(currentState.app);
     });
 });


### PR DESCRIPTION
#### Summary
Because `previousVersion` was not set until state was persited and because persisting is not triggered when placing the app in the background using backspace, when `launchApp` ran on returning the app to the foreground the version validation was provided a null `previousVersion` causing a logout. Likewise when clearing data, `previousVersion` was unset so the former scenario would occur on backspace. We now ensure `previousVersion` is set on logout if it was previously not set and is kept when clearing data.

Note: These changes will be applied to https://github.com/mattermost/mattermost-mobile/pull/4197 for master/1.31.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24451

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Mi A3, Android 9