### PR TITLE
[MM-24463] Run message retention cleanup off of pre-existing state instead of a reconstructed "zero" state (1.30)

### DIFF
--- a/app/store/middleware.js
+++ b/app/store/middleware.js
@@ -4,7 +4,6 @@
 import DeviceInfo from 'react-native-device-info';
 
 import {ViewTypes} from 'app/constants';
-import initialState from 'app/initial_state';
 
 import {
     captureException,
@@ -20,7 +19,6 @@ export function messageRetention(store) {
             const build = DeviceInfo.getBuildNumber();
             const version = DeviceInfo.getVersion();
             const previousVersion = app?.version;
-            const previousBuild = app?.build;
 
             action.payload = {
                 ...action.payload,
@@ -33,11 +31,6 @@ export function messageRetention(store) {
 
             if (!entities || !views) {
                 return next(action);
-            }
-
-            if (previousVersion !== version || previousBuild !== build) {
-                // When a new version of the app has been detected
-                return next(resetStateForNewVersion(action));
             }
 
             // Keep only the last 60 messages for the last 5 viewed channels in each team
@@ -62,139 +55,6 @@ export function messageRetention(store) {
     };
 }
 
-function resetStateForNewVersion(action) {
-    const {payload} = action;
-    const lastChannelForTeam = getLastChannelForTeam(payload);
-
-    let general = initialState.entities.general;
-    if (payload.entities.general) {
-        general = payload.entities.general;
-    }
-
-    let teams = initialState.entities.teams;
-    if (payload.entities.teams) {
-        teams = {
-            currentTeamId: payload.entities.teams.currentTeamId,
-            teams: payload.entities.teams.teams,
-            myMembers: payload.entities.teams.myMembers,
-        };
-    }
-
-    let users = initialState.entities.users;
-    if (payload.entities.users) {
-        const currentUserId = payload.entities.users.currentUserId;
-        if (currentUserId) {
-            users = {
-                currentUserId,
-                profiles: {
-                    [currentUserId]: payload.entities.users.profiles[currentUserId],
-                },
-            };
-        }
-    }
-
-    let preferences = initialState.entities.preferences;
-    if (payload.entities.preferences) {
-        preferences = payload.entities.preferences;
-    }
-
-    let roles = initialState.entities.roles;
-    if (payload.entities.roles) {
-        roles = payload.entities.roles;
-    }
-
-    let search = initialState.entities.search;
-    if (payload.entities.search && payload.entities.search.recent) {
-        search = {
-            recent: payload.entities.search.recent,
-        };
-    }
-
-    let channelDrafts = initialState.views.channel.drafts;
-    if (payload.views.channel && payload.views.channel.drafts) {
-        channelDrafts = payload.views.channel.drafts;
-    }
-
-    let i18n = initialState.views.i18n;
-    if (payload.views.i18n) {
-        i18n = payload.views.i18n;
-    }
-
-    let lastTeamId = initialState.views.team.lastTeamId;
-    if (payload.views.team && payload.views.team.lastTeamId) {
-        lastTeamId = payload.views.team.lastTeamId;
-    }
-
-    const currentChannelId = lastChannelForTeam[lastTeamId] && lastChannelForTeam[lastTeamId].length ? lastChannelForTeam[lastTeamId][0] : '';
-    let channels = initialState.entities.channels;
-    if (payload.entities.channels && currentChannelId) {
-        channels = {
-            currentChannelId,
-            channels: {
-                [currentChannelId]: payload.entities.channels.channels[currentChannelId],
-            },
-            myMembers: {
-                [currentChannelId]: payload.entities.channels.myMembers[currentChannelId],
-            },
-        };
-    }
-
-    let threadDrafts = initialState.views.thread.drafts;
-    if (payload.views.thread && payload.views.thread.drafts) {
-        threadDrafts = payload.views.thread.drafts;
-    }
-
-    let selectServer = initialState.views.selectServer;
-    if (payload.views.selectServer) {
-        selectServer = payload.views.selectServer;
-    }
-
-    let recentEmojis = initialState.views.recentEmojis;
-    if (payload.views.recentEmojis) {
-        recentEmojis = payload.views.recentEmojis;
-    }
-
-    const nextState = {
-        app: {
-            ...payload.app,
-        },
-        entities: {
-            channels,
-            general,
-            teams,
-            users,
-            preferences,
-            search,
-            roles,
-        },
-        views: {
-            channel: {
-                drafts: channelDrafts,
-            },
-            i18n,
-            team: {
-                lastTeamId,
-                lastChannelForTeam,
-            },
-            thread: {
-                drafts: threadDrafts,
-            },
-            selectServer,
-            recentEmojis,
-        },
-        websocket: {
-            lastConnectAt: payload.websocket?.lastConnectAt,
-            lastDisconnectAt: payload.websocket?.lastDisconnectAt,
-        },
-    };
-
-    return {
-        type: action.type,
-        payload: nextState,
-        error: action.error,
-    };
-}
-
 function getLastChannelForTeam(payload) {
     const lastChannelForTeam = {...payload.views.team.lastChannelForTeam};
     const convertLastChannelForTeam = Object.values(lastChannelForTeam).some((value) => !Array.isArray(value));
@@ -209,11 +69,14 @@ function getLastChannelForTeam(payload) {
 }
 
 export function cleanUpState(action, keepCurrent = false) {
-    const {payload: resetPayload} = resetStateForNewVersion(action);
     const {payload} = action;
-    const {currentChannelId} = payload.entities.channels;
+    const nextState = Object.assign({}, payload);
 
-    const {lastChannelForTeam} = resetPayload.views.team;
+    const lastTeamId = payload.views?.team?.lastTeamId;
+
+    const lastChannelForTeam = getLastChannelForTeam(payload);
+    const currentChannelId = lastChannelForTeam[lastTeamId] && lastChannelForTeam[lastTeamId].length ? lastChannelForTeam[lastTeamId][0] : '';
+
     const nextEntities = {
         posts: {
             posts: {},
@@ -231,9 +94,9 @@ export function cleanUpState(action, keepCurrent = false) {
     };
 
     let retentionPeriod = 0;
-    if (resetPayload.entities.general && resetPayload.entities.general.dataRetentionPolicy &&
-        resetPayload.entities.general.dataRetentionPolicy.message_deletion_enabled) {
-        retentionPeriod = resetPayload.entities.general.dataRetentionPolicy.message_retention_cutoff;
+    if (payload.entities.general && payload.entities.general.dataRetentionPolicy &&
+        payload.entities.general.dataRetentionPolicy.message_deletion_enabled) {
+        retentionPeriod = payload.entities.general.dataRetentionPolicy.message_retention_cutoff;
     }
 
     const postIdsToKeep = [];
@@ -258,6 +121,12 @@ export function cleanUpState(action, keepCurrent = false) {
             postIdsToKeep.push(...flagged);
         }
     }
+
+    const nextSearch = {
+        ...payload.entities.search,
+        results: searchResults,
+        flagged: flaggedPosts,
+    };
 
     postIdsToKeep.forEach((postId) => {
         const post = payload.entities.posts.posts[postId];
@@ -317,38 +186,11 @@ export function cleanUpState(action, keepCurrent = false) {
         nextEntities.posts.pendingPostIds = nextPendingPostIds;
     }
 
-    const nextState = {
-        app: resetPayload.app,
-        entities: {
-            ...nextEntities,
-            channels: payload.entities.channels,
-            emojis: payload.entities.emojis,
-            general: resetPayload.entities.general,
-            preferences: resetPayload.entities.preferences,
-            search: {
-                ...resetPayload.entities.search,
-                results: searchResults,
-                flagged: flaggedPosts,
-            },
-            teams: resetPayload.entities.teams,
-            users: payload.entities.users,
-            roles: resetPayload.entities.roles,
-        },
-        views: {
-            announcement: payload.views.announcement,
-            ...resetPayload.views,
-            channel: {
-                ...resetPayload.views.channel,
-                ...payload.views.channel,
-            },
-        },
-        websocket: {
-            lastConnectAt: payload.websocket?.lastConnectAt,
-            lastDisconnectAt: payload.websocket?.lastDisconnectAt,
-        },
+    nextState.entities = {
+        ...nextState.entities,
+        ...nextEntities,
+        search: nextSearch,
     };
-
-    nextState.errors = payload.errors;
 
     return {
         type: action.type,


### PR DESCRIPTION
(**This is the PR for 1.30. Separate PR to follow for `master` and 1.31**)

#### Summary

Only posts in channels, searched posts and flag posts are recalculated (as per data retention policy, if applicable). The rest of state is cloned from existing state.

On a version upgrade, data cleanup gets run anyway.

#### Ticket Link

* [MM-24463](https://mattermost.atlassian.net/browse/MM-24463)

#### Device Information
This PR was tested on: OnePlus 5 (Android 10 device)
