### PR TITLE
Fixing improper padding of searchBar container

### DIFF
--- a/app/components/sidebars/main/channels_list/channels_list.js
+++ b/app/components/sidebars/main/channels_list/channels_list.js
@@ -228,6 +228,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         searchContainer: {
             flex: 1,
             flexDirection: 'row',
+            overflow: 'hidden',
             ...Platform.select({
                 android: {
                     marginBottom: 1,

--- a/app/components/sidebars/main/channels_list/channels_list.js
+++ b/app/components/sidebars/main/channels_list/channels_list.js
@@ -12,7 +12,7 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import SearchBar from 'app/components/search_bar';
 import {ViewTypes} from 'app/constants';
-import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
+import {paddingLeft as padding} from 'app/components/safe_area_view/iphone_x_spacing';
 import {
     changeOpacity,
     makeStyleSheetFromTheme,


### PR DESCRIPTION
#### Summary
This PR ensures that the search bar in the channels list renders properly in landscape mode  on Iphone X

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24444

#### Device Information
This PR was tested on:
* iPhone 11
* iPhone X

#### Screenshots
Before:
<img width="496" alt="Screen Shot 2020-04-23 at 3 07 48 PM" src="https://user-images.githubusercontent.com/29700158/80066097-43e5f300-8576-11ea-8e5c-9c2776a16857.png">

After: 
<img width="478" alt="Screen Shot 2020-04-23 at 3 08 01 PM" src="https://user-images.githubusercontent.com/29700158/80066122-4d6f5b00-8576-11ea-8abf-cafc95c6f380.png">
