### PR TITLE
MM-24498 Fixing padding of SearchBar in Search screen

### DIFF
--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -706,6 +706,17 @@ export default class Search extends PureComponent {
             fontSize: 15,
         };
 
+        const paddingRes = padding(isLandscape);
+        if (paddingRes) {
+            // Without this the default paddingLeft in style.header
+            // overrides the paddingHorizontal value gotten from padding(isLandscape)
+            paddingRes.paddingLeft = null;
+
+            if (isLandscape) {
+                paddingRes.paddingTop = 10;
+            }
+        }
+
         return (
             <SafeAreaView
                 excludeHeader={isLandscape && DeviceTypes.IS_IPHONE_WITH_INSETS}
@@ -713,7 +724,7 @@ export default class Search extends PureComponent {
             >
                 <KeyboardLayout>
                     <StatusBar/>
-                    <View style={[style.header, padding(isLandscape)]}>
+                    <View style={[style.header, paddingRes]}>
                         <SearchBar
                             ref={this.setSearchBarRef}
                             placeholder={intl.formatMessage({id: 'search_bar.search', defaultMessage: 'Search'})}


### PR DESCRIPTION
#### Summary
This PR fixes a bug where the searchbar rendered incorrectly on iPhone X on landscape mode.
Note: This PR should not change anything on the Android side of things

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24498

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: 
* iPhone X (simulator)
* Google Pixel 3XL (simulator)

#### Screenshots
Before:
<img width="886" alt="image" src="https://user-images.githubusercontent.com/29700158/80183878-97bf0d80-8644-11ea-98db-6719933e8fe6.png">

After: 
<img width="884" alt="image" src="https://user-images.githubusercontent.com/29700158/80183842-883fc480-8644-11ea-906a-20091a47bf10.png">
