### PR TITLE
MM-24451 Set prev app version to current on logout/reset cache

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -280,7 +280,7 @@ class GlobalEventHandler {
                         app: {
                             build: DeviceInfo.getBuildNumber(),
                             version: DeviceInfo.getVersion(),
-                            previousVersion: state.app?.previousVersion || DeviceInfo.getVersion(),
+                            previousVersion: DeviceInfo.getVersion(),
                         },
                     },
                 },

--- a/app/store/utils.js
+++ b/app/store/utils.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import merge from 'deepmerge';
+import DeviceInfo from 'react-native-device-info';
 
 function transformFromSet(incoming) {
     const state = {...incoming};
@@ -78,7 +79,10 @@ export function getStateForReset(initialState, currentState) {
     });
 
     const resetState = merge(initialState, {
-        app,
+        app: {
+            ...app,
+            previousVersion: DeviceInfo.getVersion(),
+        },
         entities: {
             users: {
                 currentUserId,

--- a/app/store/utils.test.js
+++ b/app/store/utils.test.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import DeviceInfo from 'react-native-device-info';
+
 import initialState from 'app/initial_state';
 import {getStateForReset} from 'app/store/utils';
 
@@ -21,8 +23,8 @@ describe('getStateForReset', () => {
     const currentTeamId = 'current-team-id';
     const currentState = {
         app: {
-            build: 'build',
-            version: 'version',
+            build: DeviceInfo.getBuildNumber(),
+            version: DeviceInfo.getVersion(),
             previousVersion: 'previousVersion',
         },
         entities: {
@@ -82,9 +84,9 @@ describe('getStateForReset', () => {
         expect(themeKeys.length).toEqual(preferenceKeys.length);
     });
 
-    it('should keep app', () => {
+    it('should set previous version as current', () => {
         const resetState = getStateForReset(initialState, currentState);
         const {app} = resetState;
-        expect(app).toStrictEqual(currentState.app);
+        expect(app.previousVersion).toStrictEqual(currentState.app.version);
     });
 });


### PR DESCRIPTION
#### Summary
Set the previous version of the app to the current one once the user is logged out or when deleting documents & data.

There is going to be a separate PR for master/1.31

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24451