### PR TITLE
MM-24451 Set prev app version to current on logout/reset cache

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -279,7 +279,7 @@ class GlobalEventHandler {
                 app: {
                     build: DeviceInfo.getBuildNumber(),
                     version: DeviceInfo.getVersion(),
-                    previousVersion: state.app?.previousVersion || DeviceInfo.getVersion(),
+                    previousVersion: DeviceInfo.getVersion(),
                 },
                 entities: {
                     ...initialState.entities,

--- a/app/store/utils.js
+++ b/app/store/utils.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import merge from 'deepmerge';
+import DeviceInfo from 'react-native-device-info';
 
 function transformFromSet(incoming) {
     const state = {...incoming};
@@ -80,7 +81,10 @@ export function getStateForReset(initialState, currentState) {
     const preferences = currentState.entities.preferences;
 
     const resetState = merge(initialState, {
-        app,
+        app: {
+            ...app,
+            previousVersion: DeviceInfo.getVersion(),
+        },
         entities: {
             general: currentState.entities.general,
             users: {

--- a/app/store/utils.test.js
+++ b/app/store/utils.test.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import DeviceInfo from 'react-native-device-info';
+
 import initialState from '@store/initial_state';
 import {getStateForReset} from '@store/utils';
 
@@ -21,8 +23,8 @@ describe('getStateForReset', () => {
     const currentTeamId = 'current-team-id';
     const currentState = {
         app: {
-            build: 'build',
-            version: 'version',
+            build: DeviceInfo.getBuildNumber(),
+            version: DeviceInfo.getVersion(),
             previousVersion: 'previousVersion',
         },
         entities: {
@@ -86,9 +88,9 @@ describe('getStateForReset', () => {
         expect(themeKeys.length).toEqual(2);
     });
 
-    it('should keep app', () => {
+    it('should set previous version as current', () => {
         const resetState = getStateForReset(initialState, currentState);
         const {app} = resetState;
-        expect(app).toStrictEqual(currentState.app);
+        expect(app.previousVersion).toStrictEqual(currentState.app.version);
     });
 });


### PR DESCRIPTION
#### Summary
Set the previous version of the app to the current one once the user is logged out or when deleting documents & data.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24451