### PR TITLE
[MM-24583] Add find_replace_string for MMKVStorage

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -436,6 +436,12 @@ platform :ios do
         new_string: app_group_id
     )
 
+    find_replace_string(
+        path_to_file: './node_modules/react-native-mmkv-storage/ios/MMKVStorage.m',
+        old_string: 'group.com.mattermost.rnbeta',
+        new_string: app_group_id
+    )
+
     update_app_group_identifiers(
         entitlements_file: './ios/MattermostShare/MattermostShare.entitlements',
         app_group_identifiers: [app_group_id]

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -550,7 +550,7 @@ SPEC CHECKSUMS:
   jail-monkey: d7c5048b2336f22ee9c9e0efa145f1f917338ea9
   libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
   MMKV: 7bb6c30f9ff2ea45bc2398c86e66dd1cb63cfe20
-  MMKVCore: f455d4bf01bb5257511c1062fdbc3d7ebdec216b
+  MMKVCore: f1e0aad4fc330e7cbfbdff16720017bf0973db5a
   Permission-Camera: 8f0e5decca5f28f70f28a8dc31f012c9bad40ad8
   Permission-PhotoLibrary: b209bf23b784c9e1409a57d81c6d11ab1d3079c1
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035


### PR DESCRIPTION
#### Summary
`group.com.mattermost.rnbeta` needs to be replaced with the provided `app_group_id` in MMKVStorage.m

This change does take effect with test builds so QA will need to test on a release build.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24583