### PR TITLE
[MM-24061] Bring back channel sidebar hamburger icon for tablets

### DIFF
--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.js
@@ -70,6 +70,14 @@ export default class ChannelNavBar extends PureComponent {
         }
     };
 
+    drawerButtonVisible = () => {
+        if (DeviceTypes.IS_TABLET && Platform.OS === 'ios') {
+            return false;
+        }
+
+        return (!this.state.permanentSidebar || !this.state.isSplitView);
+    };
+
     render() {
         const {isLandscape, onPress, theme} = this.props;
         const {openMainSidebar, openSettingsSidebar} = this.props;
@@ -99,16 +107,11 @@ export default class ChannelNavBar extends PureComponent {
             break;
         }
 
-        let drawerButtonVisible = false;
-        if (!this.state.permanentSidebar || !this.state.isSplitView) {
-            drawerButtonVisible = true;
-        }
-
         return (
             <View style={[style.header, padding(isLandscape), {height}]}>
                 <ChannelDrawerButton
                     openSidebar={openMainSidebar}
-                    visible={drawerButtonVisible}
+                    visible={this.drawerButtonVisible()}
                 />
                 <ChannelTitle
                     onPress={onPress}

--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.js
@@ -100,7 +100,7 @@ export default class ChannelNavBar extends PureComponent {
         }
 
         let drawerButtonVisible = false;
-        if (!DeviceTypes.IS_TABLET || this.state.isSplitView || !this.state.permanentSidebar) {
+        if (!this.state.permanentSidebar || !this.state.isSplitView) {
             drawerButtonVisible = true;
         }
 

--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.js
@@ -71,11 +71,11 @@ export default class ChannelNavBar extends PureComponent {
     };
 
     drawerButtonVisible = () => {
-        if (DeviceTypes.IS_TABLET && Platform.OS === 'ios') {
-            return false;
+        if (Platform.OS === 'android') {
+            return true;
         }
 
-        return (!this.state.permanentSidebar || !this.state.isSplitView);
+        return (!DeviceTypes.IS_TABLET || this.state.isSplitView || !this.state.permanentSidebar);
     };
 
     render() {

--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.test.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.test.js
@@ -87,10 +87,12 @@ describe('ChannelNavBar', () => {
         expect(wrapper.instance().drawerButtonVisible()).toBe(true);
     });
 
-    test('drawerButtonVisible appears for iOS tablets', () => {
+    test('drawerButtonVisible appears for iOS tablets with PermanentSidebar at default false, and not in splitview', () => {
         const wrapper = shallow(
             <ChannelNavBar {...baseProps}/>,
         );
+
+        wrapper.setState({permanentSidebar: false, isSplitView: false});
 
         DeviceTypes.IS_TABLET = true;
         Platform.OS = 'ios';

--- a/app/screens/channel/channel_nav_bar/channel_nav_bar.test.js
+++ b/app/screens/channel/channel_nav_bar/channel_nav_bar.test.js
@@ -2,15 +2,19 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {Platform} from 'react-native';
 import {shallow} from 'enzyme';
 
 import Preferences from '@mm-redux/constants/preferences';
 
-import {DeviceTypes} from 'app/constants';
+import {DeviceTypes} from '@constants';
 
 import ChannelNavBar from './channel_nav_bar';
 
 jest.mock('react-intl');
+jest.mock('app/mattermost_managed', () => ({
+    isRunningInSplitView: jest.fn().mockResolvedValue(false),
+}));
 
 describe('ChannelNavBar', () => {
     const baseProps = {
@@ -48,5 +52,75 @@ describe('ChannelNavBar', () => {
         await wrapper.instance().handlePermanentSidebar();
 
         expect(wrapper.state('permanentSidebar')).toBeDefined();
+    });
+
+    test('drawerButtonVisible appears for android tablets', () => {
+        const wrapper = shallow(
+            <ChannelNavBar {...baseProps}/>,
+        );
+
+        DeviceTypes.IS_TABLET = true;
+        Platform.OS = 'android';
+
+        expect(wrapper.instance().drawerButtonVisible()).toBe(true);
+    });
+
+    test('drawerButtonVisible appears for android phones', () => {
+        const wrapper = shallow(
+            <ChannelNavBar {...baseProps}/>,
+        );
+
+        DeviceTypes.IS_TABLET = false;
+        Platform.OS = 'android';
+
+        expect(wrapper.instance().drawerButtonVisible()).toBe(true);
+    });
+
+    test('drawerButtonVisible appears for iOS phones', () => {
+        const wrapper = shallow(
+            <ChannelNavBar {...baseProps}/>,
+        );
+
+        DeviceTypes.IS_TABLET = false;
+        Platform.OS = 'ios';
+
+        expect(wrapper.instance().drawerButtonVisible()).toBe(true);
+    });
+
+    test('drawerButtonVisible appears for iOS tablets', () => {
+        const wrapper = shallow(
+            <ChannelNavBar {...baseProps}/>,
+        );
+
+        DeviceTypes.IS_TABLET = true;
+        Platform.OS = 'ios';
+
+        expect(wrapper.instance().drawerButtonVisible()).toBe(true);
+    });
+
+    test('drawerButtonVisible does not appear for iOS tablets with permanentSidebar enabled', () => {
+        const wrapper = shallow(
+            <ChannelNavBar {...baseProps}/>,
+        );
+
+        wrapper.setState({permanentSidebar: true});
+
+        DeviceTypes.IS_TABLET = true;
+        Platform.OS = 'ios';
+
+        expect(wrapper.instance().drawerButtonVisible()).toBe(false);
+    });
+
+    test('drawerButtonVisible appears for iOS tablets with splitview enabled', () => {
+        const wrapper = shallow(
+            <ChannelNavBar {...baseProps}/>,
+        );
+
+        wrapper.setState({isSplitView: true});
+
+        DeviceTypes.IS_TABLET = true;
+        Platform.OS = 'ios';
+
+        expect(wrapper.instance().drawerButtonVisible()).toBe(true);
     });
 });


### PR DESCRIPTION
#### Summary

Hamburger menu to show on Android when:
* "persistent sidebar" setting is not on (or)
* device is not using split view for multiple apps

Hamburger icon to not show on iPads, just as before.

#### Ticket Link

* [MM-24061](https://mattermost.atlassian.net/browse/MM-24061)

#### Device Information

This PR was tested on: 
* Android 9 tablet emulator (Nexus 3)
* Android 10 device (OnePlus 5)
* iPad Pro Simulator

#### Screenshots
**Before**
<img width="289" alt="Screen Shot 2020-04-28 at 09 37 58" src="https://user-images.githubusercontent.com/887849/80488912-75bfd680-8935-11ea-912b-37b321047c74.png">

**After**
<img width="357" alt="Screen Shot 2020-04-28 at 09 36 59" src="https://user-images.githubusercontent.com/887849/80488933-7c4e4e00-8935-11ea-805e-32817f857fdf.png">


