### PR TITLE
Disable loadUnreadChannelPosts

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -30,7 +30,7 @@ import {getChannelByName as selectChannelByName} from '@mm-redux/utils/channel_u
 import EventEmitter from '@mm-redux/utils/event_emitter';
 
 import {loadSidebarDirectMessagesProfiles} from '@actions/helpers/channels';
-import {getPosts, getPostsBefore, getPostsSince, getPostThread, loadUnreadChannelPosts} from '@actions/views/post';
+import {getPosts, getPostsBefore, getPostsSince, getPostThread} from '@actions/views/post';
 import {INSERT_TO_COMMENT, INSERT_TO_DRAFT} from '@constants/post_textbox';
 import {getChannelReachable} from '@selectors/channel';
 import telemetry from '@telemetry';
@@ -654,7 +654,8 @@ export function loadChannelsForTeam(teamId, skipDispatch = false) {
                 // Fetch needed profiles from channel creators and direct channels
                 dispatch(loadSidebar(data));
 
-                dispatch(loadUnreadChannelPosts(data.channels, data.channelMembers));
+                // Uncomment once we want to enable this feature
+                // dispatch(loadUnreadChannelPosts(data.channels, data.channelMembers));
             }
         }
 


### PR DESCRIPTION
This feature may be causing problems in 1.31. Once cherry-picked into 1.31 we'll push another beta build.

We need to take a closer look at the following before we enable again:
* Server rate-limiting
* Should we queue requests?
* If queued, how do we handle a user switching to an unread channel prior to the queued pre-fetch request being called?
* Should we set a minimum delta since last websocket connection before pre-fetching?