### PR TITLE
Revert "Disable loadUnreadChannelPosts (#4245)"

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -30,7 +30,7 @@ import {getChannelByName as selectChannelByName} from '@mm-redux/utils/channel_u
 import EventEmitter from '@mm-redux/utils/event_emitter';
 
 import {loadSidebarDirectMessagesProfiles} from '@actions/helpers/channels';
-import {getPosts, getPostsBefore, getPostsSince, getPostThread} from '@actions/views/post';
+import {getPosts, getPostsBefore, getPostsSince, getPostThread, loadUnreadChannelPosts} from '@actions/views/post';
 import {INSERT_TO_COMMENT, INSERT_TO_DRAFT} from '@constants/post_textbox';
 import {getChannelReachable} from '@selectors/channel';
 import telemetry from '@telemetry';
@@ -654,8 +654,7 @@ export function loadChannelsForTeam(teamId, skipDispatch = false) {
                 // Fetch needed profiles from channel creators and direct channels
                 dispatch(loadSidebar(data));
 
-                // Uncomment once we want to enable this feature
-                // dispatch(loadUnreadChannelPosts(data.channels, data.channelMembers));
+                dispatch(loadUnreadChannelPosts(data.channels, data.channelMembers));
             }
         }
 


### PR DESCRIPTION
This reverts commit 8de77754ef398488db22d31e6027bea058f4ea6f.

Reverting due to banner issue being caused by a missed [cherry-pick](https://github.com/mattermost/mattermost-mobile/pull/4090) to 1.31.