### PR TITLE
[MM-24706] Use cache only for http URIs

### DIFF
--- a/app/screens/image_preview/__snapshots__/image_preview.test.js.snap
+++ b/app/screens/image_preview/__snapshots__/image_preview.test.js.snap
@@ -186,14 +186,10 @@ exports[`ImagePreview should match snapshot 1`] = `
         }
         style={
           Object {
-            "bottom": 0,
             "justifyContent": "flex-end",
-            "left": 0,
             "maxHeight": 64,
             "paddingBottom": 0,
             "paddingHorizontal": 24,
-            "position": "absolute",
-            "right": 0,
           }
         }
       >

--- a/app/screens/image_preview/__snapshots__/image_preview.test.js.snap
+++ b/app/screens/image_preview/__snapshots__/image_preview.test.js.snap
@@ -194,6 +194,8 @@ exports[`ImagePreview should match snapshot 1`] = `
         }
       >
         <Text
+          ellipsizeMode="tail"
+          numberOfLines={2}
           style={
             Object {
               "color": "white",

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -313,7 +313,11 @@ export default class ImagePreview extends PureComponent {
                     colors={['transparent', '#000000']}
                     pointerEvents='none'
                 >
-                    <Text style={style.filename}>
+                    <Text
+                        style={style.filename}
+                        numberOfLines={2}
+                        ellipsizeMode='tail'
+                    >
                         {(files[index] && files[index].caption) || ''}
                     </Text>
                 </LinearGradient>

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -645,10 +645,6 @@ const style = StyleSheet.create({
         width: '100%',
     },
     footer: {
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        right: 0,
         maxHeight: 64,
         justifyContent: 'flex-end',
         paddingHorizontal: 24,

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -375,7 +375,11 @@ export default class ImagePreview extends PureComponent {
             const flattenStyle = StyleSheet.flatten(style);
             const calculatedDimensions = calculateDimensions(height, width, deviceWidth, deviceHeight - statusBar);
             const imageStyle = {...flattenStyle, ...calculatedDimensions};
-            const src = {...source, cache: FastImage.cacheControl.cacheOnly};
+
+            let src = {...source};
+            if (src.uri.startsWith('http')) {
+                src.cache = FastImage.cacheControl.cacheOnly;
+            }
 
             return (
                 <View style={[style, {justifyContent: 'center', alignItems: 'center'}]}>

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -376,7 +376,7 @@ export default class ImagePreview extends PureComponent {
             const calculatedDimensions = calculateDimensions(height, width, deviceWidth, deviceHeight - statusBar);
             const imageStyle = {...flattenStyle, ...calculatedDimensions};
 
-            let src = {...source};
+            const src = {...source};
             if (src.uri.startsWith('http')) {
                 src.cache = FastImage.cacheControl.cacheOnly;
             }

--- a/app/screens/image_preview/image_preview.js
+++ b/app/screens/image_preview/image_preview.js
@@ -376,15 +376,10 @@ export default class ImagePreview extends PureComponent {
             const calculatedDimensions = calculateDimensions(height, width, deviceWidth, deviceHeight - statusBar);
             const imageStyle = {...flattenStyle, ...calculatedDimensions};
 
-            const src = {...source};
-            if (src.uri.startsWith('http')) {
-                src.cache = FastImage.cacheControl.cacheOnly;
-            }
-
             return (
                 <View style={[style, {justifyContent: 'center', alignItems: 'center'}]}>
                     <FastImage
-                        source={src}
+                        source={source}
                         style={imageStyle}
                     />
                 </View>

--- a/app/screens/image_preview/image_preview.test.js
+++ b/app/screens/image_preview/image_preview.test.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {TouchableOpacity} from 'react-native';
+import FastImage from 'react-native-fast-image';
 
 // import RNFetchBlob from 'rn-fetch-blob';
 
@@ -115,6 +116,49 @@ describe('ImagePreview', () => {
                 },
             },
         );
+    });
+
+    test('renderImageComponent uses cache only for http URI', () => {
+        const wrapper = shallow(
+            <ImagePreview
+                {...baseProps}
+            />,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+        const instance = wrapper.instance();
+
+        const imageProps = {
+            style: {},
+            source: {uri: 'http://uri'},
+        };
+        const imageDimensions = {height: 100, widht: 100};
+        const component = instance.renderImageComponent(imageProps, imageDimensions);
+        
+        const fastImageProps = component.props.children.props;
+        expect(fastImageProps.source).toStrictEqual({
+            ...imageProps.source,
+            cache: FastImage.cacheControl.cacheOnly,
+        });
+    });
+
+    test('renderImageComponent does not use cache for non http URI', () => {
+        const wrapper = shallow(
+            <ImagePreview
+                {...baseProps}
+            />,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+        const instance = wrapper.instance();
+
+        const imageProps = {
+            style: {},
+            source: {uri: 'file:///uri'},
+        };
+        const imageDimensions = {height: 100, widht: 100};
+        const component = instance.renderImageComponent(imageProps, imageDimensions);
+        
+        const fastImageProps = component.props.children.props;
+        expect(fastImageProps.source).toStrictEqual(imageProps.source);
     });
 
     //     test('should show bottom sheet when showDownloadOptionsIOS is called for existing video', async () => {

--- a/app/screens/image_preview/image_preview.test.js
+++ b/app/screens/image_preview/image_preview.test.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {TouchableOpacity} from 'react-native';
-import FastImage from 'react-native-fast-image';
 
 // import RNFetchBlob from 'rn-fetch-blob';
 
@@ -116,49 +115,6 @@ describe('ImagePreview', () => {
                 },
             },
         );
-    });
-
-    test('renderImageComponent uses cache only for http URI', () => {
-        const wrapper = shallow(
-            <ImagePreview
-                {...baseProps}
-            />,
-            {context: {intl: {formatMessage: jest.fn()}}},
-        );
-        const instance = wrapper.instance();
-
-        const imageProps = {
-            style: {},
-            source: {uri: 'http://uri'},
-        };
-        const imageDimensions = {height: 100, widht: 100};
-        const component = instance.renderImageComponent(imageProps, imageDimensions);
-
-        const fastImageProps = component.props.children.props;
-        expect(fastImageProps.source).toStrictEqual({
-            ...imageProps.source,
-            cache: FastImage.cacheControl.cacheOnly,
-        });
-    });
-
-    test('renderImageComponent does not use cache for non http URI', () => {
-        const wrapper = shallow(
-            <ImagePreview
-                {...baseProps}
-            />,
-            {context: {intl: {formatMessage: jest.fn()}}},
-        );
-        const instance = wrapper.instance();
-
-        const imageProps = {
-            style: {},
-            source: {uri: 'file:///uri'},
-        };
-        const imageDimensions = {height: 100, widht: 100};
-        const component = instance.renderImageComponent(imageProps, imageDimensions);
-
-        const fastImageProps = component.props.children.props;
-        expect(fastImageProps.source).toStrictEqual(imageProps.source);
     });
 
     //     test('should show bottom sheet when showDownloadOptionsIOS is called for existing video', async () => {

--- a/app/screens/image_preview/image_preview.test.js
+++ b/app/screens/image_preview/image_preview.test.js
@@ -133,7 +133,7 @@ describe('ImagePreview', () => {
         };
         const imageDimensions = {height: 100, widht: 100};
         const component = instance.renderImageComponent(imageProps, imageDimensions);
-        
+
         const fastImageProps = component.props.children.props;
         expect(fastImageProps.source).toStrictEqual({
             ...imageProps.source,
@@ -156,7 +156,7 @@ describe('ImagePreview', () => {
         };
         const imageDimensions = {height: 100, widht: 100};
         const component = instance.renderImageComponent(imageProps, imageDimensions);
-        
+
         const fastImageProps = component.props.children.props;
         expect(fastImageProps.source).toStrictEqual(imageProps.source);
     });


### PR DESCRIPTION
#### Summary
Since local images are not cached FastImage could not find the image. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24706

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Mi A3, Android 9
* iPhone simulator