### PR TITLE
[MM-24639] Set rehydrated values to true on store cleanup.

### DIFF
--- a/app/store/middlewares/helpers.js
+++ b/app/store/middlewares/helpers.js
@@ -136,7 +136,7 @@ export function cleanUpState(payload, keepCurrent = false) {
 
     nextState.views.root = {
         // eslint-disable-next-line no-underscore-dangle
-        hydrationComplete: !nextState._persist,
+        hydrationComplete: true,
     };
 
     // eslint-disable-next-line no-underscore-dangle

--- a/app/store/middlewares/helpers.js
+++ b/app/store/middlewares/helpers.js
@@ -136,7 +136,7 @@ export function cleanUpState(payload, keepCurrent = false) {
 
     nextState.views.root = {
         // eslint-disable-next-line no-underscore-dangle
-        hydrationComplete: true,
+        hydrationComplete: payload?.views?.root?.hydrationComplete || !nextState._persist,
     };
 
     // eslint-disable-next-line no-underscore-dangle

--- a/app/store/middlewares/helpers.js
+++ b/app/store/middlewares/helpers.js
@@ -134,9 +134,13 @@ export function cleanUpState(payload, keepCurrent = false) {
         nextEntities.posts.pendingPostIds = nextPendingPostIds;
     }
 
-    nextState.views.root = {
-        // eslint-disable-next-line no-underscore-dangle
-        hydrationComplete: payload?.views?.root?.hydrationComplete || !nextState._persist,
+    nextState.views = {
+        ...nextState.views,
+        root: {
+            ...nextState.views?.root,
+            // eslint-disable-next-line no-underscore-dangle
+            hydrationComplete: nextState.views?.root?.hydrationComplete || !nextState._persist,
+        },
     };
 
     // eslint-disable-next-line no-underscore-dangle

--- a/app/store/middlewares/middleware.test.js
+++ b/app/store/middlewares/middleware.test.js
@@ -7,8 +7,10 @@ import DeviceInfo from 'react-native-device-info';
 
 import assert from 'assert';
 import {REHYDRATE} from 'redux-persist';
+import merge from 'deepmerge';
 
 import {ViewTypes} from '@constants';
+import initialState from '@store/initial_state';
 import {
     cleanUpPostsInChannel,
     cleanUpState,
@@ -347,6 +349,26 @@ describe('cleanUpState', () => {
 
         expect(result.entities.posts.pendingPostIds).toEqual([]);
         expect(result.entities.posts.postsInChannel.channel1).toEqual([{order: ['post1', 'post2'], recent: true}]);
+    });
+
+    test('should set rehydration values to true', () => {
+        const state = merge(initialState, {
+            // eslint-disable-next-line no-underscore-dangle
+            _persist: {
+                rehydrated: false,
+            },
+            views: {
+                root: {
+                    hydrationComplete: false,
+                },
+            },
+        });
+
+        const result = cleanUpState(state);
+
+        
+        expect(result._persist.rehydrated).toBe(true); // eslint-disable-line no-underscore-dangle
+        expect(result.views.root.hydrationComplete).toBe(true);
     });
 });
 

--- a/app/store/middlewares/middleware.test.js
+++ b/app/store/middlewares/middleware.test.js
@@ -351,23 +351,60 @@ describe('cleanUpState', () => {
         expect(result.entities.posts.postsInChannel.channel1).toEqual([{order: ['post1', 'post2'], recent: true}]);
     });
 
-    test('should set rehydration values to true', () => {
+    test('should always set _persist.rehydrated to true', () => {
+        const persistValues = [
+            null,
+            {},
+            {rehydrated: false},
+            {rehydrated: true},
+        ];
+
+        for (let i = 0; i < persistValues.length; i++) {
+            const _persist = persistValues[i]; // eslint-disable-line no-underscore-dangle
+            const state = merge(initialState, {
+                // eslint-disable-next-line no-underscore-dangle
+                _persist,
+            });
+
+            const result = cleanUpState(state);
+            expect(result._persist.rehydrated).toBe(true); // eslint-disable-line no-underscore-dangle
+        }
+    });
+
+    test('should set views.root.hydrationComplete to true when previous views.root.hydrationComplete is true', () => {
         const state = merge(initialState, {
-            // eslint-disable-next-line no-underscore-dangle
-            _persist: {
-                rehydrated: false,
-            },
             views: {
                 root: {
-                    hydrationComplete: false,
+                    hydrationComplete: true,
                 },
             },
         });
 
         const result = cleanUpState(state);
-
-        expect(result._persist.rehydrated).toBe(true); // eslint-disable-line no-underscore-dangle
         expect(result.views.root.hydrationComplete).toBe(true);
+    });
+
+    test('should set views.root.hydrationComplete to !_persist when previous views.root.hydrationComplete is falsy', () => {
+        const persistValues = [true, false];
+        const viewsValues = [
+            {},
+            {root: {}},
+            {root: {hydrationComplete: false}},
+        ];
+
+        for (let i = 0; i < persistValues.length; i++) {
+            const _persist = persistValues[i]; // eslint-disable-line no-underscore-dangle
+            for (let j = 0; j < viewsValues.length; j++) {
+                const views = viewsValues[j];
+                const state = merge(initialState, {
+                    _persist,
+                    views,
+                });
+
+                const result = cleanUpState(state);
+                expect(result.views.root.hydrationComplete).toBe(!_persist); // eslint-disable-line no-underscore-dangle
+            }
+        }
     });
 });
 

--- a/app/store/middlewares/middleware.test.js
+++ b/app/store/middlewares/middleware.test.js
@@ -366,7 +366,6 @@ describe('cleanUpState', () => {
 
         const result = cleanUpState(state);
 
-        
         expect(result._persist.rehydrated).toBe(true); // eslint-disable-line no-underscore-dangle
         expect(result.views.root.hydrationComplete).toBe(true);
     });


### PR DESCRIPTION
#### Summary
Cleanup was setting `views.root.hydrationComplete` to false and it remained so on returning the app to the foreground because `persist/REHYDRATE` is only fired on app launch from an exited state. When a push notification returned the app to the foreground it waited for rehydration which never happened.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24639

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
Mi A3, Android 9