### PR TITLE
[MM-24113] Support 'leave' slash command

### DIFF
--- a/app/components/autocomplete/slash_suggestion/index.js
+++ b/app/components/autocomplete/slash_suggestion/index.js
@@ -14,7 +14,7 @@ import {isLandscape} from 'app/selectors/device';
 import SlashSuggestion from './slash_suggestion';
 
 // TODO: Remove when all below commands have been implemented
-const COMMANDS_TO_IMPLEMENT_LATER = ['collapse', 'expand', 'join', 'open', 'leave', 'logout', 'msg', 'grpmsg'];
+const COMMANDS_TO_IMPLEMENT_LATER = ['collapse', 'expand', 'join', 'open', 'logout', 'msg', 'grpmsg'];
 const NON_MOBILE_COMMANDS = ['rename', 'invite_people', 'shortcuts', 'search', 'help', 'settings', 'remove'];
 
 const COMMANDS_TO_HIDE_ON_MOBILE = [...COMMANDS_TO_IMPLEMENT_LATER, ...NON_MOBILE_COMMANDS];

--- a/app/screens/channel/channel.android.js
+++ b/app/screens/channel/channel.android.js
@@ -51,6 +51,7 @@ export default class ChannelAndroid extends ChannelBase {
                     <PostDraft
                         ref={this.postDraft}
                         screenId={this.props.componentId}
+                        key={this.props.currentChannelId}
                     />
                 </KeyboardLayout>
                 <NetworkIndicator/>


### PR DESCRIPTION
#### Summary

Fixes crash on Android when attempting to redirect back to a read-only channel (default channel) after using the `/leave` command.

Also, enables official support of `leave` slash command. Added as auto-complete suggestion.

#### Ticket Link

* [MM-24113](https://mattermost.atlassian.net/browse/MM-24113)

#### Device Information
This PR was tested on:
* Android 10 device (OnePlus 5)
* iPhone 11 device
