### PR TITLE
[MM-24891] [MM-24572] Add ability to specify default value when role not found for selector

### DIFF
--- a/app/components/autocomplete/at_mention/index.js
+++ b/app/components/autocomplete/at_mention/index.js
@@ -34,6 +34,7 @@ function mapStateToProps(state, ownProps) {
             {
                 channel: currentChannelId,
                 permission: Permissions.USE_CHANNEL_MENTIONS,
+                default: true,
             },
         );
     }

--- a/app/components/post_draft/index.js
+++ b/app/components/post_draft/index.js
@@ -55,6 +55,7 @@ export function mapStateToProps(state, ownProps) {
                 channel: currentChannel.id,
                 team: currentChannel.team_id,
                 permission: Permissions.CREATE_POST,
+                default: true,
             },
         );
 
@@ -63,6 +64,7 @@ export function mapStateToProps(state, ownProps) {
             {
                 channel: currentChannel.id,
                 permission: Permissions.USE_CHANNEL_MENTIONS,
+                default: true,
             },
         );
     }

--- a/app/components/post_draft/index.test.js
+++ b/app/components/post_draft/index.test.js
@@ -71,11 +71,13 @@ describe('mapStateToProps', () => {
             channel: undefined,
             team: undefined,
             permission: Permissions.CREATE_POST,
+            default: true,
         });
 
         expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
             channel: undefined,
             permission: Permissions.USE_CHANNEL_MENTIONS,
+            default: true,
         });
     });
 
@@ -90,11 +92,13 @@ describe('mapStateToProps', () => {
             channel: undefined,
             team: undefined,
             permission: Permissions.CREATE_POST,
+            default: true,
         });
 
         expect(roleSelectors.haveIChannelPermission).toHaveBeenCalledWith(state, {
             channel: undefined,
             permission: Permissions.USE_CHANNEL_MENTIONS,
+            default: true,
         });
     });
 });

--- a/app/components/reactions/index.js
+++ b/app/components/reactions/index.js
@@ -43,6 +43,7 @@ function makeMapStateToProps() {
                 team: teamId,
                 channel: channelId,
                 permission: Permissions.ADD_REACTION,
+                default: true,
             });
 
             if (reactions) {
@@ -54,6 +55,7 @@ function makeMapStateToProps() {
                 team: teamId,
                 channel: channelId,
                 permission: Permissions.REMOVE_REACTION,
+                default: true,
             });
         }
 

--- a/app/mm-redux/selectors/entities/roles.test.js
+++ b/app/mm-redux/selectors/entities/roles.test.js
@@ -180,14 +180,14 @@ describe('Selectors.Roles', () => {
     });
 
     it('should return my team permissions on getMyTeamPermissions', () => {
-        const {permissions, roleFound} = Selectors.getMyTeamPermissions(testState, {team: team1.id})
+        const {permissions, roleFound} = Selectors.getMyTeamPermissions(testState, {team: team1.id});
         const expectedPermissions = new Set(['user_role2', 'team1_role1']);
         assert.deepEqual(permissions, expectedPermissions);
         assert.equal(roleFound, true);
     });
 
     it('should return system permissions on getMyTeamPermissions when team not found', () => {
-        const {permissions, roleFound} = Selectors.getMyTeamPermissions(testState, {team: team4.id})
+        const {permissions, roleFound} = Selectors.getMyTeamPermissions(testState, {team: team4.id});
         const expectedPermissions = new Set(['user_role2']);
         assert.deepEqual(permissions, expectedPermissions);
         assert.equal(roleFound, false);
@@ -198,6 +198,12 @@ describe('Selectors.Roles', () => {
         assert.equal(Selectors.haveITeamPermission(testState, {team: team1.id, permission: 'team1_role1'}), true);
         assert.equal(Selectors.haveITeamPermission(testState, {team: team1.id, permission: 'team2_role2'}), false);
         assert.equal(Selectors.haveITeamPermission(testState, {team: team1.id, permission: 'invalid_permission'}), false);
+    });
+
+    it('should return default if role not found in state on haveITeamPermission for team scoped permission', () => {
+        assert.equal(Selectors.haveITeamPermission(testState, {team: team4.id, permission: 'any_permission', default: true}), true);
+        assert.equal(Selectors.haveITeamPermission(testState, {team: team4.id, permission: 'any_permission', default: false}), false);
+        assert.equal(Selectors.haveITeamPermission(testState, {team: team1.id, permission: 'user_role2'}), true);
     });
 
     it('should return my team permission on getMyCurrentTeamPermissions', () => {
@@ -241,6 +247,13 @@ describe('Selectors.Roles', () => {
         assert.equal(Selectors.haveIChannelPermission(testState, {team: team1.id, channel: channel1.id, permission: 'team2_role2'}), false);
         assert.equal(Selectors.haveIChannelPermission(testState, {team: team1.id, channel: channel1.id, permission: 'channel_a_role1'}), true);
         assert.equal(Selectors.haveIChannelPermission(testState, {team: team1.id, channel: channel1.id, permission: 'channel_b_role1'}), false);
+    });
+
+    it('should return default if role not found in state on haveIChannelPermission for channel scoped permission', () => {
+        assert.equal(Selectors.haveIChannelPermission(testState, {team: team1.id, channel: channel13.id, permission: 'any_permission', default: true}), true);
+        assert.equal(Selectors.haveIChannelPermission(testState, {team: team1.id, channel: channel13.id, permission: 'any_permission', default: false}), false);
+        assert.equal(Selectors.haveIChannelPermission(testState, {team: team1.id, channel: channel13.id, permission: 'user_role2'}), true);
+        assert.equal(Selectors.haveIChannelPermission(testState, {team: team1.id, channel: channel13.id, permission: 'team1_role1'}), true);
     });
 
     it('should return if i have a channel permission on haveICurrentChannelPermission', () => {

--- a/app/mm-redux/selectors/entities/roles.ts
+++ b/app/mm-redux/selectors/entities/roles.ts
@@ -79,7 +79,7 @@ export const getMyCurrentTeamPermissions = reselect.createSelector(
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
-                    roleFound = true
+                    roleFound = true;
                 }
             }
         }

--- a/app/mm-redux/selectors/entities/roles.ts
+++ b/app/mm-redux/selectors/entities/roles.ts
@@ -179,7 +179,7 @@ export const haveITeamPermission = reselect.createSelector(
     ({permissions, roleFound}, options) => {
         const hasPermission = permissions.has(options.permission);
         if (roleFound) {
-            return permissions.has(options.permission);
+            return hasPermission;
         }
         return options.default === true || hasPermission;
     },
@@ -191,7 +191,7 @@ export const haveIChannelPermission = reselect.createSelector(
     ({permissions, roleFound}, options) => {
         const hasPermission = permissions.has(options.permission);
         if (roleFound) {
-            return permissions.has(options.permission);
+            return hasPermission;
         }
         return options.default === true || hasPermission;
     },
@@ -203,7 +203,7 @@ export const haveICurrentTeamPermission = reselect.createSelector(
     ({permissions, roleFound}, options) => {
         const hasPermission = permissions.has(options.permission);
         if (roleFound) {
-            return permissions.has(options.permission);
+            return hasPermission;
         }
         return options.default === true || hasPermission;
     },
@@ -215,7 +215,7 @@ export const haveICurrentChannelPermission = reselect.createSelector(
     ({permissions, roleFound}, options) => {
         const hasPermission = permissions.has(options.permission);
         if (roleFound) {
-            return permissions.has(options.permission);
+            return hasPermission;
         }
         return options.default === true || hasPermission;
     },

--- a/app/mm-redux/selectors/entities/roles.ts
+++ b/app/mm-redux/selectors/entities/roles.ts
@@ -1,15 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import * as reselect from 'reselect';
-import {getCurrentUser, getCurrentChannelId} from '@mm-redux/selectors/entities/common';
+import {getCurrentChannelId} from '@mm-redux/selectors/entities/common';
 import {getTeamMemberships, getCurrentTeamId} from './teams';
 import * as types from '@mm-redux/types';
 import {getMySystemPermissions, getMySystemRoles, getRoles, PermissionsOptions} from '@mm-redux/selectors/entities/roles_helpers';
 import {GlobalState} from '@mm-redux/types/store';
 import {Dictionary} from '@mm-redux/types/utilities';
 import {Role} from '@mm-redux/types/roles';
-import {Channel} from '@mm-redux/types/channels';
-import {Team} from '@mm-redux/types/teams';
 
 export {getMySystemPermissions, getMySystemRoles, getRoles};
 
@@ -73,20 +71,22 @@ export const getMyCurrentTeamPermissions = reselect.createSelector(
     getMySystemPermissions,
     getCurrentTeamId,
     (myTeamRoles, roles, systemPermissions, teamId) => {
-        const permissions = new Set();
+        const permissions = new Set<string>();
+        let roleFound = false;
         if (myTeamRoles[teamId]) {
             for (const roleName of myTeamRoles[teamId]) {
                 if (roles[roleName]) {
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
+                    roleFound = true
                 }
             }
         }
         for (const permission of systemPermissions) {
             permissions.add(permission);
         }
-        return permissions;
+        return {permissions, roleFound};
     },
 );
 
@@ -95,21 +95,23 @@ export const getMyCurrentChannelPermissions = reselect.createSelector(
     getRoles,
     getMyCurrentTeamPermissions,
     getCurrentChannelId,
-    (myChannelRoles, roles, teamPermissions, channelId) => {
-        const permissions = new Set();
+    (myChannelRoles, roles, {permissions: teamPermissions, roleFound: teamRoleFound}, channelId) => {
+        const permissions = new Set<string>();
+        let roleFound = false;
         if (myChannelRoles[channelId]) {
             for (const roleName of myChannelRoles[channelId]) {
                 if (roles[roleName]) {
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
+                    roleFound = true && teamRoleFound;
                 }
             }
         }
         for (const permission of teamPermissions) {
             permissions.add(permission);
         }
-        return permissions;
+        return {permissions, roleFound};
     },
 );
 
@@ -119,20 +121,22 @@ export const getMyTeamPermissions = reselect.createSelector(
     getMySystemPermissions,
     (state: GlobalState, options: PermissionsOptions) => options.team,
     (myTeamRoles, roles, systemPermissions, teamId) => {
-        const permissions = new Set();
+        const permissions = new Set<string>();
+        let roleFound = false;
         if (myTeamRoles[teamId!]) {
             for (const roleName of myTeamRoles[teamId!]) {
                 if (roles[roleName]) {
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
+                    roleFound = true;
                 }
             }
         }
         for (const permission of systemPermissions) {
             permissions.add(permission);
         }
-        return permissions;
+        return {permissions, roleFound};
     },
 );
 
@@ -141,21 +145,23 @@ export const getMyChannelPermissions = reselect.createSelector(
     getRoles,
     getMyTeamPermissions,
     (state, options: PermissionsOptions) => options.channel,
-    (myChannelRoles, roles, teamPermissions, channelId) => {
-        const permissions = new Set();
+    (myChannelRoles, roles, {permissions: teamPermissions, roleFound: teamRoleFound}, channelId) => {
+        const permissions = new Set<string>();
+        let roleFound = false;
         if (myChannelRoles[channelId!]) {
             for (const roleName of myChannelRoles[channelId!]) {
                 if (roles[roleName]) {
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
+                    roleFound = true && teamRoleFound;
                 }
             }
         }
         for (const permission of teamPermissions) {
             permissions.add(permission);
         }
-        return permissions;
+        return {permissions, roleFound};
     },
 );
 
@@ -169,32 +175,48 @@ export const haveISystemPermission = reselect.createSelector(
 
 export const haveITeamPermission = reselect.createSelector(
     getMyTeamPermissions,
-    (state, options) => options.permission,
-    (permissions, permission) => {
-        return permissions.has(permission);
+    (state, options) => options,
+    ({permissions, roleFound}, options) => {
+        const hasPermission = permissions.has(options.permission);
+        if (roleFound) {
+            return permissions.has(options.permission);
+        }
+        return options.default === true || hasPermission;
     },
 );
 
 export const haveIChannelPermission = reselect.createSelector(
     getMyChannelPermissions,
-    (state, options) => options.permission,
-    (permissions, permission) => {
-        return permissions.has(permission);
+    (state, options) => options,
+    ({permissions, roleFound}, options) => {
+        const hasPermission = permissions.has(options.permission);
+        if (roleFound) {
+            return permissions.has(options.permission);
+        }
+        return options.default === true || hasPermission;
     },
 );
 
 export const haveICurrentTeamPermission = reselect.createSelector(
     getMyCurrentTeamPermissions,
-    (state: GlobalState, options: PermissionsOptions) => options.permission,
-    (permissions, permission) => {
-        return permissions.has(permission);
+    (state: GlobalState, options: PermissionsOptions) => options,
+    ({permissions, roleFound}, options) => {
+        const hasPermission = permissions.has(options.permission);
+        if (roleFound) {
+            return permissions.has(options.permission);
+        }
+        return options.default === true || hasPermission;
     },
 );
 
 export const haveICurrentChannelPermission = reselect.createSelector(
     getMyCurrentChannelPermissions,
-    (state: GlobalState, options: PermissionsOptions) => options.permission,
-    (permissions, permission) => {
-        return permissions.has(permission);
+    (state: GlobalState, options: PermissionsOptions) => options,
+    ({permissions, roleFound}, options) => {
+        const hasPermission = permissions.has(options.permission);
+        if (roleFound) {
+            return permissions.has(options.permission);
+        }
+        return options.default === true || hasPermission;
     },
 );

--- a/app/mm-redux/selectors/entities/roles_helpers.ts
+++ b/app/mm-redux/selectors/entities/roles_helpers.ts
@@ -9,6 +9,7 @@ export type PermissionsOptions = {
     channel?: string;
     team?: string;
     permission: string;
+    default?: boolean;
 };
 
 export function getRoles(state: GlobalState) {

--- a/app/screens/post_options/index.js
+++ b/app/screens/post_options/index.js
@@ -65,6 +65,7 @@ export function makeMapStateToProps() {
                     channel: post.channel_id,
                     team: channel.team_id,
                     permission: Permissions.CREATE_POST,
+                    default: true,
                 },
             );
         }
@@ -74,6 +75,7 @@ export function makeMapStateToProps() {
                 team: currentTeamId,
                 channel: post.channel_id,
                 permission: Permissions.ADD_REACTION,
+                default: true,
             });
         }
 

--- a/app/screens/post_options/index.test.js
+++ b/app/screens/post_options/index.test.js
@@ -156,6 +156,7 @@ describe('makeMapStateToProps', () => {
             channel: undefined,
             team: undefined,
             permission: Permissions.CREATE_POST,
+            default: true,
         });
     });
 
@@ -176,6 +177,7 @@ describe('makeMapStateToProps', () => {
             channel: undefined,
             team: undefined,
             permission: Permissions.CREATE_POST,
+            default: true,
         });
     });
 });


### PR DESCRIPTION
#### Summary
- Currently if the roles for a channel or team are not loaded into the state then any permission check that requires those roles returns false, so setting any kind of default beforehand is pointless since it just gets overridden to be false by the permission check

- This PR adds an optional attribute to the `PermissionsOptions` parameter passed in to all permission checks to specify a default in the case where the roles for the specified resource (team or channel) do not exist.

- Not sure what the best way to test this is but, I just modified the code to think there were no roles in the state and then ensured that the default values are honoured.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24891
- https://mattermost.atlassian.net/browse/MM-24572

#### Checklist
- [x] Added or updated unit tests (required for all new features)
~Has UI changes~
~Includes text changes and localization file updates~

#### Device Information
This PR was tested on:
- iPhone 11 Simulator
