### PR TITLE
Revert "MM-24113 Support 'leave' slash command (#4273)"

### DIFF
--- a/app/components/autocomplete/slash_suggestion/index.js
+++ b/app/components/autocomplete/slash_suggestion/index.js
@@ -14,7 +14,7 @@ import {isLandscape} from 'app/selectors/device';
 import SlashSuggestion from './slash_suggestion';
 
 // TODO: Remove when all below commands have been implemented
-const COMMANDS_TO_IMPLEMENT_LATER = ['collapse', 'expand', 'join', 'open', 'logout', 'msg', 'grpmsg'];
+const COMMANDS_TO_IMPLEMENT_LATER = ['collapse', 'expand', 'join', 'open', 'leave', 'logout', 'msg', 'grpmsg'];
 const NON_MOBILE_COMMANDS = ['rename', 'invite_people', 'shortcuts', 'search', 'help', 'settings', 'remove'];
 
 const COMMANDS_TO_HIDE_ON_MOBILE = [...COMMANDS_TO_IMPLEMENT_LATER, ...NON_MOBILE_COMMANDS];

--- a/app/screens/channel/channel.android.js
+++ b/app/screens/channel/channel.android.js
@@ -51,7 +51,6 @@ export default class ChannelAndroid extends ChannelBase {
                     <PostDraft
                         ref={this.postDraft}
                         screenId={this.props.componentId}
-                        key={this.props.currentChannelId}
                     />
                 </KeyboardLayout>
                 <NetworkIndicator/>


### PR DESCRIPTION
#### Summary

This reverts commit fd450f998824f366ad63017d09d176467ddc8132.
Per [conversation](https://github.com/mattermost/mattermost-mobile/pull/4273#issuecomment-625379784), the `/leave` command cannot be supported at this time because of the various cases that need to be explicitly considered on the client-side based on the server action/response.

#### Ticket Link

* [MM-24113](https://mattermost.atlassian.net/browse/MM-24113)
