### PR TITLE
Ensure receivedPosts runs first

### DIFF
--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -465,7 +465,10 @@ export function loadUnreadChannelPosts(channels, channelMembers) {
 
         console.log(`Fetched ${posts.length} posts from ${promises.length} unread channels`); //eslint-disable-line no-console
         if (posts.length) {
-            actions.push(receivedPosts({posts}));
+            // receivedPosts should be the first action dispatched as
+            // receivedPostsSince and receivedPostsInChannel reducers are
+            // dependent on it.
+            actions.unshift(receivedPosts({posts}));
             const additional = await dispatch(getPostsAdditionalDataBatch(posts));
             if (additional.data.length) {
                 actions.push(...additional.data);

--- a/app/actions/views/post.test.js
+++ b/app/actions/views/post.test.js
@@ -83,18 +83,16 @@ describe('Actions.Views.Post', () => {
         const actionTypes = store.getActions()[0].payload.map((action) => action.type);
 
         // Actions dispatched:
+        // RECEIVED_POSTS once and first, with all channel posts combined.
         // RECEIVED_POSTS_IN_CHANNEL and RECEIVED_POSTS_FOR_CHANNEL_AT_TIME for each channel.
-        // RECEIVED_POSTS once, with all channel posts combined.
         expect(actionTypes.length).toBe((2 * channels.length) + 1);
+        expect(actionTypes[0]).toEqual(PostTypes.RECEIVED_POSTS);
 
         const receivedPostsInChannelActions = actionTypes.filter((type) => type === PostTypes.RECEIVED_POSTS_IN_CHANNEL);
         expect(receivedPostsInChannelActions.length).toBe(channels.length);
 
         const receivedPostsForChannelAtTimeActions = actionTypes.filter((type) => type === ViewTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME);
         expect(receivedPostsForChannelAtTimeActions.length).toBe(channels.length);
-
-        const receivedPosts = actionTypes.filter((type) => type === 'RECEIVED_POSTS');
-        expect(receivedPosts.length).toBe(1);
     });
 
     test('loadUnreadChannelPosts dispatches actions for unread channels with postIds in channel', async () => {
@@ -122,18 +120,16 @@ describe('Actions.Views.Post', () => {
         const actionTypes = store.getActions()[0].payload.map((action) => action.type);
 
         // Actions dispatched:
+        // RECEIVED_POSTS once and first, with all channel posts combined.
         // RECEIVED_POSTS_SINCE and RECEIVED_POSTS_FOR_CHANNEL_AT_TIME for each channel.
-        // RECEIVED_POSTS once, with all channel posts combined.
         expect(actionTypes.length).toBe((2 * channels.length) + 1);
+        expect(actionTypes[0]).toEqual(PostTypes.RECEIVED_POSTS);
 
         const receivedPostsInChannelActions = actionTypes.filter((type) => type === PostTypes.RECEIVED_POSTS_SINCE);
         expect(receivedPostsInChannelActions.length).toBe(channels.length);
 
         const receivedPostsForChannelAtTimeActions = actionTypes.filter((type) => type === ViewTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME);
         expect(receivedPostsForChannelAtTimeActions.length).toBe(channels.length);
-
-        const receivedPosts = actionTypes.filter((type) => type === PostTypes.RECEIVED_POSTS);
-        expect(receivedPosts.length).toBe(1);
     });
 
     test('loadUnreadChannelPosts dispatches additional actions for unread channels', async () => {
@@ -168,20 +164,18 @@ describe('Actions.Views.Post', () => {
         const actionTypes = store.getActions()[0].payload.map((action) => action.type);
 
         // Actions dispatched:
+        // RECEIVED_POSTS once and first, with all channel posts combined.
         // RECEIVED_POSTS_SINCE and RECEIVED_POSTS_FOR_CHANNEL_AT_TIME for each channel.
-        // RECEIVED_POSTS once, with all channel posts combined.
         // RECEIVED_PROFILES_LIST twice, once for getProfilesByIds and once for getProfilesByUsernames
         // RECEIVED_STATUSES for getStatusesByIds
         expect(actionTypes.length).toBe((2 * channels.length) + 4);
+        expect(actionTypes[0]).toEqual(PostTypes.RECEIVED_POSTS);
 
         const receivedPostsInChannelActions = actionTypes.filter((type) => type === PostTypes.RECEIVED_POSTS_SINCE);
         expect(receivedPostsInChannelActions.length).toBe(channels.length);
 
         const receivedPostsForChannelAtTimeActions = actionTypes.filter((type) => type === ViewTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME);
         expect(receivedPostsForChannelAtTimeActions.length).toBe(channels.length);
-
-        const receivedPosts = actionTypes.filter((type) => type === PostTypes.RECEIVED_POSTS);
-        expect(receivedPosts.length).toBe(1);
 
         const receivedProfiles = actionTypes.filter((type) => type === UserTypes.RECEIVED_PROFILES_LIST);
         expect(receivedProfiles.length).toBe(2);


### PR DESCRIPTION
#### Summary
`RECEIVED_POSTS` and `RECEIVED_POSTS_IN_CHANNEL` rely on [nextPosts](https://github.com/mattermost/mattermost-mobile/blob/62fd36127659d89f4af12d1fe174de187457ae6b/app/mm-redux/reducers/entities/posts.ts#L1174-L1175) being computed by `RECEIVED_POSTS` so we need to ensure that `receivedPosts` is dispatched first.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24793

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Mi A3, Android 9