### PR TITLE
[MM-25002] Ensure currentChannel set

### DIFF
--- a/app/components/post_draft/index.js
+++ b/app/components/post_draft/index.js
@@ -48,7 +48,7 @@ export function mapStateToProps(state, ownProps) {
 
     let canPost = true;
     let useChannelMentions = true;
-    if (isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)) {
+    if (currentChannel && isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)) {
         canPost = haveIChannelPermission(
             state,
             {

--- a/app/components/post_draft/index.test.js
+++ b/app/components/post_draft/index.test.js
@@ -101,4 +101,25 @@ describe('mapStateToProps', () => {
             default: true,
         });
     });
+
+    test('haveIChannelPermission is not called when isMinimumServerVersion is 5.22v but currentChannel is null', () => {
+        channelSelectors.getCurrentChannel = jest.fn().mockReturnValue(null);
+
+        const state = {...baseState};
+        state.entities.general.serverVersion = '5.22';
+
+        mapStateToProps(state, baseOwnProps);
+        expect(isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)).toBe(true);
+
+        expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
+            channel: undefined,
+            team: undefined,
+            permission: Permissions.CREATE_POST,
+        });
+
+        expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
+            channel: undefined,
+            permission: Permissions.USE_CHANNEL_MENTIONS,
+        });
+    });
 });


### PR DESCRIPTION
#### Summary
When removed from the channel you are viewing, `currentChannel` can be null when the PostDraft component re-renders and the permission checks can throw an error when attempting to access `currentChannel` properties.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25002

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android 9 emulator