### PR TITLE
Automated cherry pick of #4288

### DIFF
--- a/app/components/post_textbox/index.js
+++ b/app/components/post_textbox/index.js
@@ -53,7 +53,7 @@ export function mapStateToProps(state, ownProps) {
 
     let canPost = true;
     let useChannelMentions = true;
-    if (isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)) {
+    if (currentChannel && isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)) {
         canPost = haveIChannelPermission(
             state,
             {

--- a/app/components/post_textbox/index.test.js
+++ b/app/components/post_textbox/index.test.js
@@ -101,4 +101,25 @@ describe('mapStateToProps', () => {
             default: true,
         });
     });
+
+    test('haveIChannelPermission is not called when isMinimumServerVersion is 5.22v but currentChannel is null', () => {
+        channelSelectors.getCurrentChannel = jest.fn().mockReturnValue(null);
+
+        const state = {...baseState};
+        state.entities.general.serverVersion = '5.22';
+
+        mapStateToProps(state, baseOwnProps);
+        expect(isMinimumServerVersion(state.entities.general.serverVersion, 5, 22)).toBe(true);
+
+        expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
+            channel: undefined,
+            team: undefined,
+            permission: Permissions.CREATE_POST,
+        });
+
+        expect(roleSelectors.haveIChannelPermission).not.toHaveBeenCalledWith(state, {
+            channel: undefined,
+            permission: Permissions.USE_CHANNEL_MENTIONS,
+        });
+    });
 });


### PR DESCRIPTION
Cherry pick of #4288 on release-1.31.

- #4288: Ensure currentChannel set

/cc  @migbot