### PR TITLE
Set previous app version on persist store migration

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -6,6 +6,7 @@ import * as redux from 'redux';
 import {createPersistoid, createTransform, persistReducer, persistStore, Persistor, PersistConfig} from 'redux-persist';
 import {createBlacklistFilter} from 'redux-persist-transform-filter';
 import reduxReset from 'redux-reset';
+import DeviceInfo from 'react-native-device-info';
 
 import {General} from '@mm-redux/constants';
 import serviceReducer from '@mm-redux/reducers';
@@ -200,12 +201,20 @@ export default function configureStore(storage: any, preloadedState: any = {}, o
 
     getStoredState().then(({storeKeys, restoredState}: V4Store) => {
         if (Object.keys(restoredState).length) {
+            const {app} = restoredState;
+            app.previousVersion = app.version;
+            app.build = DeviceInfo.getBuildNumber();
+            app.version = DeviceInfo.getVersion();
+
             const state = {
                 ...restoredState,
+                app: {
+                    ...app,
+                },
                 views: {
                     ...restoredState.views,
                     root: {
-                        hydrationComplete: true,
+                        hydrationComplete: false,
                     },
                 },
                 _persist: persistor.getState(),


### PR DESCRIPTION
Intro:
in 1.31 we upgraded the persistent store to use MMKV instead of AsyncStorage for performance reasons. 

What was happening:
- When the app is installed for the first time, there is no  previous version set for obvious reasons although the current version is set.
- When the upgrade happens, we run a store migration and in here the previous version was obviously empty as it is taken from the previous persisted store and this logs you out based on the condition that we have.

What is the fix:
Set the previous version of the app to the app version set in the persisted store during the migration, this will ensure that the right previous version is being set. **The migration only occurs once**

What is expected:
* Upgrading from 1.30.x to 1.31 should not be logged out no matter how many times the app was opened.
*  Upgrading from 1.28 to 1.31 should not be logged out if the app was opened at least 2-3 times
*  Upgrading from 1.29 should log you out regardless of the times you opened the app.