### PR TITLE
[MM-18642] Ensure SSL exception is thrown for bad servers

### DIFF
--- a/patches/rn-fetch-blob+0.12.0.patch
+++ b/patches/rn-fetch-blob+0.12.0.patch
@@ -194,7 +194,7 @@ index a8abd71..9078855 100644
                  if(rnFetchBlobFileResp != null && !rnFetchBlobFileResp.isDownloadComplete()){
                      callback.invoke("Download interrupted.", null);
 diff --git a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java b/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
-index ab35fdd..69f4b49 100644
+index ab35fdd..60465a0 100644
 --- a/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
 +++ b/node_modules/rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
 @@ -6,12 +6,16 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -233,7 +233,7 @@ index ab35fdd..69f4b49 100644
      }
  
      public static OkHttpClient.Builder getUnsafeOkHttpClient(OkHttpClient client) {
-@@ -92,4 +98,59 @@ public class RNFetchBlobUtils {
+@@ -92,4 +98,60 @@ public class RNFetchBlobUtils {
              throw new RuntimeException(e);
          }
      }
@@ -255,6 +255,7 @@ index ab35fdd..69f4b49 100644
 +                        defaultTrustManager.checkServerTrusted(chain, authType);
 +                    } catch(CertificateException ce) {
 +                        emitWarningEvent("RNFetchBlob custom: Server presented problem with SSL handshake.", RNFetchBlobConst.EVENT_SSL_TRUST_MESSAGE);
++                        throw ce;
 +                    }
 +                }
 +


### PR DESCRIPTION
#### Summary

Without the explicitly thrown exception, the TLS handshake never exits cleanly as it should.

Context: [see conversation](https://community.mattermost.com/private-core/pl/36cp76j5g3r7z8hre1pr8hfhmy)

#### Ticket Link

* [MM-18642](https://mattermost.atlassian.net/browse/MM-18642)

#### Device Information
This PR was tested on: Android 10 emulator
