### PR TITLE
MM-22181 Backoff retries for ID-loaded push notification messages

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -26,6 +26,9 @@ import com.mattermost.react_native_interface.ResolvePromise;
 public class ReceiptDelivery {
     static final String CURRENT_SERVER_URL = "@currentServerUrl";
 
+    private static int reRequestCount = 0;
+    private static final int[] FIBONACCI_BACKOFFS = new int[] { 0, 1, 2, 3, 5, 8 };
+
     public static void send(Context context, final String ackId, final String postId, final String type, final boolean isIdLoaded, ResolvePromise promise) {
         final ReactApplicationContext reactApplicationContext = new ReactApplicationContext(context);
 
@@ -95,26 +98,39 @@ public class ReceiptDelivery {
                     .post(body)
                     .build();
 
-            try {
-                Response response = client.newCall(request).execute();
-                String responseBody = response.body().string();
-                if (response.code() != 200 || !isIdLoaded) {
-                    throw new Exception(responseBody);
-                }
-                JSONObject jsonResponse = new JSONObject(responseBody);
-                Bundle bundle = new Bundle();
-                String keys[] = new String[] {"post_id", "category", "message", "team_id", "channel_id", "channel_name", "type", "sender_id", "sender_name", "version"};
-                for (int i = 0; i < keys.length; i++) {
-                    String key = keys[i];
-                    if (jsonResponse.has(key)) {
-                        bundle.putString(key, jsonResponse.getString(key));
-                    }
-                }
-                promise.resolve(bundle);
-            } catch (Exception e) {
-                Log.e("ReactNative", "Receipt delivery failed to send");
-                promise.reject("Receipt delivery failure", e.toString());
+            makeServerRequest(client, request, isIdLoaded, promise);
+        }
+    }
+
+    private static void makeServerRequest(OkHttpClient client, Request request, Boolean isIdLoaded, ResolvePromise promise) {
+        try {
+            Response response = client.newCall(request).execute();
+            String responseBody = response.body().string();
+            if (response.code() != 200 || !isIdLoaded) {
+                throw new Exception(responseBody);
             }
+            JSONObject jsonResponse = new JSONObject(responseBody);
+            Bundle bundle = new Bundle();
+            String keys[] = new String[]{"post_id", "category", "message", "team_id", "channel_id", "channel_name", "type", "sender_id", "sender_name", "version"};
+            for (int i = 0; i < keys.length; i++) {
+                String key = keys[i];
+                if (jsonResponse.has(key)) {
+                    bundle.putString(key, jsonResponse.getString(key));
+                }
+            }
+            promise.resolve(bundle);
+        } catch (Exception e) {
+            Log.e("ReactNative", "Receipt delivery failed to send");
+            try {
+                reRequestCount++;
+                if (reRequestCount < FIBONACCI_BACKOFFS.length) {
+                    Log.e("ReactNative", "Retry attempt " + reRequestCount + " with backoff delay: " + FIBONACCI_BACKOFFS[reRequestCount] + " seconds");
+                    Thread.sleep(FIBONACCI_BACKOFFS[reRequestCount] * 1000);
+                    makeServerRequest(client, request, isIdLoaded, promise);
+                }
+            } catch(InterruptedException ie) {}
+
+            promise.reject("Receipt delivery failure", e.toString());
         }
     }
 }

--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -98,11 +98,11 @@ public class ReceiptDelivery {
                     .post(body)
                     .build();
 
-            makeServerRequest(client, request, isIdLoaded, promise);
+            makeServerRequest(client, request, isIdLoaded, reRequestCount, promise);
         }
     }
 
-    private static void makeServerRequest(OkHttpClient client, Request request, Boolean isIdLoaded, ResolvePromise promise) {
+    private static void makeServerRequest(OkHttpClient client, Request request, Boolean isIdLoaded, int reRequestCount, ResolvePromise promise) {
         try {
             Response response = client.newCall(request).execute();
             String responseBody = response.body().string();
@@ -119,7 +119,6 @@ public class ReceiptDelivery {
                 }
             }
             promise.resolve(bundle);
-            reRequestCount = 0;
         } catch (Exception e) {
             Log.e("ReactNative", "Receipt delivery failed to send");
             try {
@@ -127,7 +126,7 @@ public class ReceiptDelivery {
                 if (reRequestCount < FIBONACCI_BACKOFFS.length) {
                     Log.i("ReactNative", "Retry attempt " + reRequestCount + " with backoff delay: " + FIBONACCI_BACKOFFS[reRequestCount] + " seconds");
                     Thread.sleep(FIBONACCI_BACKOFFS[reRequestCount] * 1000);
-                    makeServerRequest(client, request, isIdLoaded, promise);
+                    makeServerRequest(client, request, isIdLoaded, reRequestCount, promise);
                 }
             } catch(InterruptedException ie) {}
 

--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -119,12 +119,13 @@ public class ReceiptDelivery {
                 }
             }
             promise.resolve(bundle);
+            reRequestCount = 0;
         } catch (Exception e) {
             Log.e("ReactNative", "Receipt delivery failed to send");
             try {
                 reRequestCount++;
                 if (reRequestCount < FIBONACCI_BACKOFFS.length) {
-                    Log.e("ReactNative", "Retry attempt " + reRequestCount + " with backoff delay: " + FIBONACCI_BACKOFFS[reRequestCount] + " seconds");
+                    Log.i("ReactNative", "Retry attempt " + reRequestCount + " with backoff delay: " + FIBONACCI_BACKOFFS[reRequestCount] + " seconds");
                     Thread.sleep(FIBONACCI_BACKOFFS[reRequestCount] * 1000);
                     makeServerRequest(client, request, isIdLoaded, promise);
                 }

--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -26,7 +26,6 @@ import com.mattermost.react_native_interface.ResolvePromise;
 public class ReceiptDelivery {
     static final String CURRENT_SERVER_URL = "@currentServerUrl";
 
-    private static int reRequestCount = 0;
     private static final int[] FIBONACCI_BACKOFFS = new int[] { 0, 1, 2, 3, 5, 8 };
 
     public static void send(Context context, final String ackId, final String postId, final String type, final boolean isIdLoaded, ResolvePromise promise) {
@@ -98,7 +97,7 @@ public class ReceiptDelivery {
                     .post(body)
                     .build();
 
-            makeServerRequest(client, request, isIdLoaded, reRequestCount, promise);
+            makeServerRequest(client, request, isIdLoaded, 0, promise);
         }
     }
 

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -5,6 +5,7 @@ class NotificationService: UNNotificationServiceExtension {
   
   var contentHandler: ((UNNotificationContent) -> Void)?
   var bestAttemptContent: UNMutableNotificationContent?
+  var sendFailed = false;
   
   override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
     self.contentHandler = contentHandler
@@ -14,38 +15,69 @@ class NotificationService: UNNotificationServiceExtension {
       let type = bestAttemptContent.userInfo["type"]
       let postId = bestAttemptContent.userInfo["post_id"]
       let idLoaded = bestAttemptContent.userInfo["id_loaded"] ?? false
+
       UploadSession.shared.notificationReceipt(
         notificationId: ackId,
-        receivedAt: Date().millisencondsSince1970,
+        receivedAt: Date().millisecondsSince1970,
         type: type,
         postId: postId,
         idLoaded: idLoaded as! Bool
       ) { data, error in
         if (idLoaded as! Bool) {
           guard let data = data, error == nil else {
-            return
-          }
-
-          let json = try? JSONSerialization.jsonObject(with: data) as! [String: Any]
-          if let json = json {
-            if let message = json["message"] as? String {
-              bestAttemptContent.body = message
-            }
-            if let channelName = json["channel_name"] as? String {
-              bestAttemptContent.title = channelName
-            }
-
-            let userInfoKeys = ["channel_name", "team_id", "sender_id", "root_id", "override_username", "override_icon_url", "from_webhook"]
-            for key in userInfoKeys {
-              if let value = json[key] as? String {
-                bestAttemptContent.userInfo[key] = value
+            self.sendFailed = true;
+            let fibonacciBackoffsInSeconds = [1.0, 2.0, 3.0, 5.0, 8.0]
+            for backoffInSeconds in fibonacciBackoffsInSeconds {
+              let timer = Timer.scheduledTimer(withTimeInterval: backoffInSeconds, repeats: false) { timer in
+                UploadSession.shared.notificationReceipt(
+                  notificationId: ackId,
+                  receivedAt: Date().millisecondsSince1970,
+                  type: type,
+                  postId: postId,
+                  idLoaded: idLoaded as! Bool
+                ) { data, error in
+                  guard let data = data, error == nil else {
+                    self.sendFailed = true;
+                    return
+                  }
+                  self.processResponse(data: data, bestAttemptContent: bestAttemptContent, contentHandler: contentHandler)
+                }
+              }
+              
+              if (self.sendFailed) {
+                self.sendFailed = false
+                timer.fire()
+              } else {
+                break
               }
             }
+            return
           }
+          self.processResponse(data: data, bestAttemptContent: bestAttemptContent, contentHandler: contentHandler)
         }
-
-        contentHandler(bestAttemptContent)
       }
+    }
+  }
+
+  func processResponse(data: Data, bestAttemptContent: UNMutableNotificationContent, contentHandler: ((UNNotificationContent) -> Void)?) {
+    let json = try? JSONSerialization.jsonObject(with: data) as! [String: Any]
+    if let json = json {
+      if let message = json["message"] as? String {
+        bestAttemptContent.body = message
+      }
+      if let channelName = json["channel_name"] as? String {
+        bestAttemptContent.title = channelName
+      }
+
+      let userInfoKeys = ["channel_name", "team_id", "sender_id", "root_id", "override_username", "override_icon_url", "from_webhook"]
+      for key in userInfoKeys {
+        if let value = json[key] as? String {
+          bestAttemptContent.userInfo[key] = value
+        }
+      }
+    }
+    if let contentHandler = contentHandler {
+      contentHandler(bestAttemptContent)
     }
   }
   
@@ -60,7 +92,7 @@ class NotificationService: UNNotificationServiceExtension {
 }
 
 extension Date {
-  var millisencondsSince1970: Int {
+  var millisecondsSince1970: Int {
     return Int((self.timeIntervalSince1970 * 1000.0).rounded())
   }
   


### PR DESCRIPTION
#### Summary

When an attempt to retrieve push notification message payload from server fails, initiate subsequent retry attempts using the following request backoff schedule (Fibonacci).

0 seconds to attempt 1 (original try)
1 seconds to attempt 2
2 seconds to attempt 3
3 seconds to attempt 4
5 seconds to attempt 5
8 seconds to attempt 6

6 attempts in ~20 seconds, not including response latency for each failure.

#### Ticket Link

* [MM-22181](https://mattermost.atlassian.net/browse/MM-22181)

#### Device Information
This PR was tested on:
* Android 10 (OnePlus 5 device)
* iPhone 11 device
