### PR TITLE
[MM-25114] Handle MFA error in MFA screen

### DIFF
--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -25,7 +25,6 @@ import FormattedText from '@components/formatted_text';
 import {paddingHorizontal as padding} from '@components/safe_area_view/iphone_x_spacing';
 import StatusBar from '@components/status_bar';
 import {t} from '@utils/i18n';
-import {setMfaPreflightDone, getMfaPreflightDone} from '@utils/security';
 import {preventDoubleTap} from '@utils/tap';
 import {changeOpacity} from '@utils/theme';
 import tracker from '@utils/time_tracker';
@@ -68,7 +67,6 @@ export default class Login extends PureComponent {
     componentDidMount() {
         Dimensions.addEventListener('change', this.orientationDidChange);
 
-        setMfaPreflightDone(false);
         this.setEmmUsernameIfAvailable();
     }
 
@@ -92,7 +90,7 @@ export default class Login extends PureComponent {
         const loginId = this.loginId;
         const password = this.password;
 
-        goToScreen(screen, title, {onMfaComplete: this.checkLoginResponse, goToChannel: this.goToChannel, loginId, password});
+        goToScreen(screen, title, {goToChannel: this.goToChannel, loginId, password});
     };
 
     blur = () => {
@@ -181,9 +179,6 @@ export default class Login extends PureComponent {
         const errorId = error.server_error_id;
         if (!errorId) {
             return error.message;
-        }
-        if (mfaExpectedErrors.includes(errorId) && !getMfaPreflightDone()) {
-            return null;
         }
         if (
             errorId === 'store.sql_user.get_for_login.app_error' ||

--- a/app/screens/login/login.test.js
+++ b/app/screens/login/login.test.js
@@ -94,7 +94,6 @@ describe('Login', () => {
                 'Multi-factor Authentication',
                 {
                     goToChannel: wrapper.instance().goToChannel,
-                    onMfaComplete: wrapper.instance().checkLoginResponse,
                     loginId,
                     password,
                 },

--- a/app/screens/mfa/mfa.js
+++ b/app/screens/mfa/mfa.js
@@ -15,14 +15,12 @@ import {
 } from 'react-native';
 import Button from 'react-native-button';
 
-import {popTopScreen} from '@actions/navigation';
 import ErrorText from '@components/error_text';
 import FormattedText from '@components/formatted_text';
 import StatusBar from '@components/status_bar';
 import TextInputWithLocalizedPlaceholder from '@components/text_input_with_localized_placeholder';
 import {t} from '@utils/i18n';
 import {preventDoubleTap} from '@utils/tap';
-import {setMfaPreflightDone} from '@utils/security';
 
 import {GlobalStyles} from 'app/styles';
 
@@ -34,7 +32,6 @@ export default class Mfa extends PureComponent {
         goToChannel: PropTypes.func.isRequired,
         loginId: PropTypes.string.isRequired,
         password: PropTypes.string.isRequired,
-        onMfaComplete: PropTypes.func.isRequired,
     };
 
     constructor(props) {
@@ -79,7 +76,7 @@ export default class Mfa extends PureComponent {
     };
 
     submit = preventDoubleTap(() => {
-        const {actions, goToChannel, loginId, password, onMfaComplete} = this.props;
+        const {actions, goToChannel, loginId, password} = this.props;
         const {token} = this.state;
 
         Keyboard.dismiss();
@@ -94,16 +91,16 @@ export default class Mfa extends PureComponent {
             });
             return;
         }
-        setMfaPreflightDone(true);
+
         this.setState({isLoading: true});
         actions.login(loginId, password, token).then((result) => {
             this.setState({isLoading: false});
-            if (onMfaComplete(result)) {
-                goToChannel();
+            if (result.error) {
+                this.setState({error: result.error});
                 return;
             }
 
-            popTopScreen();
+            goToChannel();
         });
     });
 

--- a/app/utils/security.js
+++ b/app/utils/security.js
@@ -4,16 +4,6 @@
 import {Client4} from '@mm-redux/client';
 import CookieManager from '@react-native-community/cookies';
 
-let mfaPreflightDone = false;
-
-export function setMfaPreflightDone(state) {
-    mfaPreflightDone = state;
-}
-
-export function getMfaPreflightDone() {
-    return mfaPreflightDone;
-}
-
 export function setCSRFFromCookie(url) {
     return new Promise((resolve) => {
         CookieManager.get(url, false).then((cookies) => {


### PR DESCRIPTION
#### Summary
The crash was caused by the MFA screen calling the Login screen's `onMfaComplete` function, which attempted to push the MFA screen to the navigation stack again on error. I've removed `onMfaComplete` and instead now handle the error on the MFA screen itself.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25114

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android 9 emulator

#### Screenshots
![Screenshot_1589931495](https://user-images.githubusercontent.com/3208014/82389821-f718ff00-99f1-11ea-8cd7-6c71d38d3b3d.png)
