### PR TITLE
Do not preload images with FastImage

### DIFF
--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -7,7 +7,6 @@ import {
     View,
     StyleSheet,
 } from 'react-native';
-import FastImage from 'react-native-fast-image';
 
 import brokenImageIcon from '@assets/images/icons/brokenimage.png';
 import ProgressiveImage from '@components/progressive_image';
@@ -49,29 +48,9 @@ export default class FileAttachmentImage extends PureComponent {
         resizeMethod: 'resize',
     };
 
-    constructor(props) {
-        super(props);
-
-        const {file} = props;
-        if (file && file.id && !file.localPath) {
-            const headers = Client4.getOptions({}).headers;
-
-            const preloadImages = [
-                {uri: Client4.getFileThumbnailUrl(file.id), headers},
-                {uri: Client4.getFileUrl(file.id), headers},
-            ];
-
-            if (isGif(file)) {
-                preloadImages.push({uri: Client4.getFilePreviewUrl(file.id), headers});
-            }
-
-            FastImage.preload(preloadImages);
-        }
-
-        this.state = {
-            failed: false,
-        };
-    }
+    state = {
+        failed: false,
+    };
 
     boxPlaceholder = () => {
         if (this.props.isSingleImage) {

--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -77,7 +77,6 @@ export default class MarkdownImage extends ImageViewPort {
             uri = EphemeralStore.currentServerUrl + uri;
         }
 
-        FastImage.preload([{uri}]);
         return uri;
     };
 

--- a/app/components/message_attachments/attachment_author.js
+++ b/app/components/message_attachments/attachment_author.js
@@ -16,14 +16,6 @@ export default class AttachmentAuthor extends PureComponent {
         theme: PropTypes.object.isRequired,
     };
 
-    constructor(props) {
-        super(props);
-
-        if (props.icon) {
-            FastImage.preload([{uri: props.icon}]);
-        }
-    }
-
     openLink = () => {
         const {link} = this.props;
         if (link && Linking.canOpenURL(link)) {

--- a/app/components/message_attachments/attachment_footer.js
+++ b/app/components/message_attachments/attachment_footer.js
@@ -17,14 +17,6 @@ export default class AttachmentFooter extends PureComponent {
         theme: PropTypes.object.isRequired,
     };
 
-    constructor(props) {
-        super(props);
-
-        if (props.icon) {
-            FastImage.preload([{uri: props.icon}]);
-        }
-    }
-
     render() {
         const {
             text,

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -110,8 +110,6 @@ export default class PostAttachmentOpenGraph extends PureComponent {
             dimensions = calculateDimensions(ogImage.height, ogImage.width, this.getViewPostWidth());
         }
 
-        FastImage.preload([{uri: imageUrl}]);
-
         return {
             hasImage: true,
             ...dimensions,

--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -61,7 +61,6 @@ export default class ProfilePicture extends PureComponent {
             this.setImageURL(imageUri);
         } else if (user) {
             const uri = Client4.getProfilePictureUrl(user.id, user.last_picture_update);
-            FastImage.preload([{uri, headers: Client4.getOptions({}).headers}]);
 
             this.setImageURL(uri);
             this.clearProfileImageUri();
@@ -102,7 +101,6 @@ export default class ProfilePicture extends PureComponent {
 
             if (nextUrl && url !== nextUrl) {
                 // empty function is so that promise unhandled is not triggered in dev mode
-                FastImage.preload([{uri: nextUrl, headers: Client4.getOptions({}).headers}]);
                 this.setImageURL(nextUrl);
                 this.clearProfileImageUri();
             }

--- a/app/components/progressive_image/progressive_image.test.js
+++ b/app/components/progressive_image/progressive_image.test.js
@@ -8,10 +8,6 @@ import Preferences from '@mm-redux/constants/preferences';
 
 import ProgressiveImage from './progressive_image';
 
-jest.mock('react-native-fast-image', () => ({
-    preload: jest.fn(),
-}));
-
 jest.useFakeTimers();
 
 describe('ProgressiveImage', () => {

--- a/app/components/team_icon/team_icon.js
+++ b/app/components/team_icon/team_icon.js
@@ -54,7 +54,6 @@ export default class TeamIcon extends React.PureComponent {
 
     preloadTeamIcon = (teamId, lastIconUpdate) => {
         const uri = Client4.getTeamIconUrl(teamId, lastIconUpdate);
-        FastImage.preload([{uri, headers: Client4.getOptions({}).headers}]);
         this.setImageURL(uri);
     };
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -119,13 +119,6 @@ jest.mock('react-native-device-info', () => {
     };
 });
 
-jest.mock('react-native-fast-image', () => {
-    const FastImage = jest.requireActual('react-native-fast-image').default;
-    FastImage.preload = jest.fn();
-
-    return FastImage;
-});
-
 jest.mock('rn-fetch-blob', () => ({
     fs: {
         dirs: {


### PR DESCRIPTION
#### Summary
When FastImage or Glide failed to create the source for the image to preload it crashes the app as there is no error handler baked in any of those libraries.

The fact remains that there is no much benefit in preloading the images while the image component is being mounted as chances are that the request has not yet finished and the image cached before the FastImage component attempts to get the image, so in the end the request is made again.

This PR removes the preloading of images.

Smoke test around images should be perform and there should not be any changes in the way it behaves.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25347

Fixes: https://github.com/mattermost/mattermost-mobile/issues/4310