### PR TITLE
[MM-25344] Catch ClassCastException

### DIFF
--- a/patches/react-native-navigation+6.4.0.patch
+++ b/patches/react-native-navigation+6.4.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
-index 260ed81..52b53d8 100644
+index 260ed81..f719679 100644
 --- a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
 +++ b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
 @@ -56,14 +56,18 @@ public class NavigationModule extends ReactContextBaseJavaModule {
@@ -26,6 +26,21 @@ index 260ed81..52b53d8 100644
 +                } catch (ClassCastException e) {
 +                    // The most current activity is not a NavigationActivity
 +                }
+             }
+         });
+     }
+@@ -196,8 +200,12 @@ public class NavigationModule extends ReactContextBaseJavaModule {
+ 
+     protected void handle(Runnable task) {
+         UiThread.post(() -> {
+-            if (getCurrentActivity() != null && !activity().isFinishing()) {
+-                task.run();
++            try {
++                if (getCurrentActivity() != null && !activity().isFinishing()) {
++                    task.run();
++                }
++            } catch (ClassCastException e) {
++                // The most current activity is not a NavigationActivity
              }
          });
      }


### PR DESCRIPTION
#### Summary
The navigation library attempts to cast the current activity to class NavigationActivity but fails when the current activity is the ShareActivity. This change catches the exception so the app doesn't crash. A separate [ticket](https://mattermost.atlassian.net/browse/MM-25416) was opened to fix push notifications not displayed while the share extension is open.

Note for QA: this only needs to be tested for Android.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25344

#### Checklist

#### Device Information
This PR was tested on:
* Android 9 emulator