### PR TITLE
[MM-24899] Update control icon style

### DIFF
--- a/app/components/video_controls.js
+++ b/app/components/video_controls.js
@@ -106,17 +106,15 @@ export default class VideoControls extends PureComponent {
         });
     };
 
-    getPlayerStateIcon = (playerState) => {
+    getControlIconAndAspectRatio = (playerState) => {
         switch (playerState) {
-        case PLAYER_STATE.PAUSED:
-            return playImage;
         case PLAYER_STATE.PLAYING:
-            return pauseImage;
+            return {icon: pauseImage, aspectRatio: 0.83};
         case PLAYER_STATE.ENDED:
-            return replayImage;
+            return {icon: replayImage, aspectRatio: 1.17};
         }
 
-        return playImage;
+        return {icon: playImage, aspectRatio: 0.83};
     };
 
     handleAppStateChange = (nextAppState) => {
@@ -216,16 +214,16 @@ export default class VideoControls extends PureComponent {
     };
 
     setPlayerControls = (playerState) => {
-        const icon = this.getPlayerStateIcon(playerState);
+        const {icon, aspectRatio} = this.getControlIconAndAspectRatio(playerState);
         const pressAction = playerState === PLAYER_STATE.ENDED ? this.onReplay : this.onPause;
         return (
             <TouchableOpacity
-                style={[styles.playButton, {backgroundColor: this.props.mainColor}]}
+                style={[styles.controlButton, {backgroundColor: this.props.mainColor}]}
                 onPress={pressAction}
             >
                 <FastImage
                     source={icon}
-                    style={styles.playIcon}
+                    style={[styles.controlIcon, {aspectRatio}]}
                 />
             </TouchableOpacity>
         );
@@ -288,7 +286,7 @@ const styles = StyleSheet.create({
     timeRow: {
         alignSelf: 'stretch',
     },
-    playButton: {
+    controlButton: {
         justifyContent: 'center',
         alignItems: 'center',
         width: 50,
@@ -297,15 +295,8 @@ const styles = StyleSheet.create({
         borderWidth: 1.5,
         borderColor: 'rgba(255,255,255,0.5)',
     },
-    playIcon: {
-        width: 22,
-        height: 22,
-        resizeMode: 'contain',
-    },
-    replayIcon: {
-        width: 25,
+    controlIcon: {
         height: 20,
-        resizeMode: 'stretch',
     },
     progressContainer: {
         position: 'absolute',


### PR DESCRIPTION
#### Summary
Defining just `height` and `aspectRatio` fixes the cut-off issues with the play and replay icons.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24899

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* Android 9 emulator
* iPhone SE

#### Screenshots
![play](https://user-images.githubusercontent.com/3208014/82614434-b26d9f00-9b7c-11ea-965c-2915fbd4956d.png)
![pause](https://user-images.githubusercontent.com/3208014/82614439-b4376280-9b7c-11ea-90f8-e14a877eccb0.png)
![replay](https://user-images.githubusercontent.com/3208014/82614442-b6012600-9b7c-11ea-9b31-dd9314f39f99.png)
