### PR TITLE
MM-25434 Fix switch team badge cut off

### DIFF
--- a/app/components/sidebars/main/channels_list/channels_list.js
+++ b/app/components/sidebars/main/channels_list/channels_list.js
@@ -135,7 +135,7 @@ export default class ChannelsList extends PureComponent {
                     backgroundColor='transparent'
                     inputHeight={33}
                     inputStyle={searchBarInput}
-                    containerStyle={styles.flex}
+                    containerStyle={styles.searchBar}
                     placeholderTextColor={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
                     tintColorSearch={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
                     tintColorDelete={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
@@ -173,9 +173,6 @@ export default class ChannelsList extends PureComponent {
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
-        flex: {
-            flex: 1,
-        },
         above: {
             backgroundColor: theme.mentionBg,
             top: 40,
@@ -228,6 +225,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             left: 10,
             right: 10,
             top: 10,
+        },
+        searchBar: {
+            flex: 1,
+            overflow: 'visible',
         },
         searchContainer: {
             flex: 1,


### PR DESCRIPTION
#### Summary
The overflow hidden added to prevent the `Cancel` button to be displayed in the search bar on iOS while in landscape cause this little regression

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25434

#### Screenshots
![image](https://user-images.githubusercontent.com/6757047/82685411-2615b780-9c22-11ea-970b-73afabc82289.png)
