### PR TITLE
MM-24964 select server url correctly animate error with keyboard

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -513,7 +513,9 @@ export default class SelectServer extends PureComponent {
                                     {buttonText}
                                 </Text>
                             </Button>
-                            <ErrorText error={error}/>
+                            <View>
+                                <ErrorText error={error}/>
+                            </View>
                         </View>
                     </TouchableWithoutFeedback>
                 </KeyboardAvoidingView>


### PR DESCRIPTION
#### Summary
Wrap the error inside a view so it animates along side the `KeyboardAvoidingView` in the select server url screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24964