### PR TITLE
Bump upload timeout to 1 min

### DIFF
--- a/app/components/post_draft/uploads/upload_item/upload_item.js
+++ b/app/components/post_draft/uploads/upload_item/upload_item.js
@@ -151,7 +151,7 @@ export default class UploadItem extends PureComponent {
 
         const certificate = await mattermostBucket.getPreference('cert');
         const options = {
-            timeout: 10000,
+            timeout: 60000,
             certificate,
         };
         this.uploadPromise = RNFetchBlob.config(options).fetch('POST', Client4.getFilesRoute(), headers, data);


### PR DESCRIPTION
#### Summary
There have been reports the when the antivirus plugin is enabled the files upload are failing due to timing out, this PR is bumping the timeout to help determine if that is the actual cause.

Based on this convo: https://community.mattermost.com/private-core/pl/onw9nyodzid13e8gf3oxe63tde this PR solves the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25561