### PR TITLE
MM-25510 Increase post options long press delay to 200ms

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -312,7 +312,7 @@ export default class Post extends PureComponent {
                 <TouchableWithFeedback
                     onPress={this.handlePress}
                     onLongPress={this.showPostOptions}
-                    delayLongPress={250}
+                    delayLongPress={200}
                     underlayColor={changeOpacity(theme.centerChannelColor, 0.1)}
                     cancelTouchOnPanning={true}
                 >

--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -312,7 +312,7 @@ export default class Post extends PureComponent {
                 <TouchableWithFeedback
                     onPress={this.handlePress}
                     onLongPress={this.showPostOptions}
-                    delayLongPress={100}
+                    delayLongPress={250}
                     underlayColor={changeOpacity(theme.centerChannelColor, 0.1)}
                     cancelTouchOnPanning={true}
                 >


### PR DESCRIPTION
#### Summary
The post menu is showing by long pressing a post. The long press seemed to be very short and felt too sensitive, by increasing it to 200ms it feels much better UX.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25510