### PR TITLE
MM-25562 Fix dismiss reaction list crash

### DIFF
--- a/app/components/slide_up_panel/slide_up_panel.js
+++ b/app/components/slide_up_panel/slide_up_panel.js
@@ -221,7 +221,7 @@ export default class SlideUpPanel extends PureComponent {
 
     scrollToTop = () => {
         if (this.scrollViewRef?.current) {
-            this.scrollViewRef.current._component.scrollTo({ //eslint-disable-line no-underscore-dangle
+            this.scrollViewRef.current.scrollTo({
                 x: 0,
                 y: 0,
                 animated: false,

--- a/app/screens/reaction_list/index.js
+++ b/app/screens/reaction_list/index.js
@@ -19,7 +19,7 @@ function makeMapStateToProps() {
     const getProfilesByIdsAndUsernames = makeGetProfilesByIdsAndUsernames();
 
     return function mapStateToProps(state, ownProps) {
-        const reactions = getReactionsForPostSelector(state, ownProps.postId);
+        const reactions = getReactionsForPostSelector(state, ownProps.postId) || undefined;
         const allUserIds = getUniqueUserIds(reactions);
 
         return {

--- a/app/utils/error_handling.js
+++ b/app/utils/error_handling.js
@@ -1,27 +1,22 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {
-    Alert,
-} from 'react-native';
 
-import {
-    setJSExceptionHandler,
-    setNativeExceptionHandler,
-} from 'react-native-exception-handler';
+import {Alert} from 'react-native';
+import {setJSExceptionHandler, setNativeExceptionHandler} from 'react-native-exception-handler';
 
+import {dismissAllModals} from '@actions/navigation';
+import {purgeOfflineStore} from '@actions/views/root';
+import {close as closeWebSocket} from '@actions/websocket';
+import {DEFAULT_LOCALE, getTranslations} from '@i18n';
 import {Client4} from '@mm-redux/client';
 import {logError} from '@mm-redux/actions/errors';
-import {close as closeWebSocket} from '@actions/websocket';
-
-import {purgeOfflineStore} from 'app/actions/views/root';
-import {DEFAULT_LOCALE, getTranslations} from 'app/i18n';
-import {t} from 'app/utils/i18n';
+import {t} from '@utils/i18n';
 import {
     captureException,
     captureJSException,
     initializeSentry,
     LOGGER_NATIVE,
-} from 'app/utils/sentry';
+} from '@utils/sentry';
 
 class JavascriptAndNativeErrorHandler {
     initializeErrorHandling = (store) => {
@@ -63,7 +58,9 @@ class JavascriptAndNativeErrorHandler {
                 translations[t('mobile.error_handler.description')],
                 [{
                     text: translations[t('mobile.error_handler.button')],
-                    onPress: () => {
+                    onPress: async () => {
+                        await dismissAllModals();
+
                         // purge the store
                         dispatch(purgeOfflineStore());
                     },


### PR DESCRIPTION
#### Summary
Applies to both iOS and Android. Fixes the Relaunch Alert and the crash when swiping the reaction list from the top to half way.

Note: Also dismissing all the modals when tapping on the Alert `Relaunch` option. <- no need to test this

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25562