### PR TITLE
[MM-24501] Load all (including joinable) teams when resetting app state

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -18,6 +18,7 @@ import LocalConfig from '@assets/config';
 import {NavigationTypes, ViewTypes} from '@constants';
 import {getTranslations, resetMomentLocale} from '@i18n';
 import {setAppState, setServerVersion} from '@mm-redux/actions/general';
+import {getTeams} from '@mm-redux/actions/teams';
 import {autoUpdateTimezone} from '@mm-redux/actions/timezone';
 import {close as closeWebSocket} from '@actions/websocket';
 import {Client4} from '@mm-redux/client';
@@ -234,6 +235,7 @@ class GlobalEventHandler {
         const user = getUser(state, currentUserId);
 
         await dispatch(loadConfigAndLicense());
+        await dispatch(getTeams());
         await dispatch(loadMe(user));
 
         const window = Dimensions.get('window');

--- a/app/mm-redux/actions/teams.ts
+++ b/app/mm-redux/actions/teams.ts
@@ -132,7 +132,7 @@ export function getTeams(page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, i
             });
         }
 
-        dispatch(batchActions(actions));
+        dispatch(batchActions(actions, 'BATCH_GET_TEAMS'));
 
         return {data};
     };
@@ -164,7 +164,7 @@ export function searchTeams(term: string, page?: number, perPage?: number): Acti
             {
                 type: TeamTypes.GET_TEAMS_SUCCESS,
             },
-        ]));
+        ], 'BATCH_SEARCH_TEAMS'));
 
         return {data: response};
     };
@@ -203,7 +203,7 @@ export function createTeam(team: Team): ActionFunc {
                 type: TeamTypes.SELECT_TEAM,
                 data: created.id,
             },
-        ]));
+        ], 'BATCH_CREATE_TEAM'));
         dispatch(loadRolesIfNeeded(member.roles.split(' ')));
 
         return {data: created};
@@ -237,7 +237,7 @@ export function deleteTeam(teamId: string): ActionFunc {
             },
         );
 
-        dispatch(batchActions(actions));
+        dispatch(batchActions(actions, 'BATCH_DELETE_TEAM'));
 
         return {data: true};
     };
@@ -482,7 +482,7 @@ export function addUsersToTeam(teamId: string, userIds: Array<string>): ActionFu
                 type: TeamTypes.RECEIVED_MEMBERS_IN_TEAM,
                 data: members,
             },
-        ]));
+        ], 'BATCH_ADD_USERS_TO_TEAM'));
 
         return {data: members};
     };
@@ -512,7 +512,7 @@ export function addUsersToTeamGracefully(teamId: string, userIds: Array<string>)
                 type: TeamTypes.RECEIVED_MEMBERS_IN_TEAM,
                 data: members,
             },
-        ]));
+        ], 'BATCH_ADD_USERS_TO_TEAM_GRACEFULLY'));
 
         return {data: result};
     };
@@ -566,7 +566,7 @@ export function removeUserFromTeam(teamId: string, userId: string): ActionFunc {
             }
         }
 
-        dispatch(batchActions(actions));
+        dispatch(batchActions(actions, 'BATCH_REMOVE_USER_FROM_TEAM'));
 
         return {data: true};
     };


### PR DESCRIPTION
## Summary

When the app restarts after a state reset, the subsequent `loadMe` only fetches a user's already-joined teams, which doesn't populate `state.entities.teams.teams` with the entire set of teams available, including potentially joinable teams.

#### Ticket Link

[MM-24501](https://mattermost.atlassian.net/browse/MM-24501)

Fixes https://github.com/mattermost/mattermost-mobile/issues/4209

#### Device Information
This PR was tested on:
* iPhone 11 Simulator 
* Android 10 emulator (Nexus 3)
