### PR TITLE
[MM-24201] List joinable teams alphabetically

### DIFF
--- a/app/screens/select_team/index.js
+++ b/app/screens/select_team/index.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 
 import {getTeams, addUserToTeam} from '@mm-redux/actions/teams';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
-import {getJoinableTeams} from '@mm-redux/selectors/entities/teams';
+import {getSortedJoinableTeams} from '@mm-redux/selectors/entities/teams';
 import {getCurrentUser} from '@mm-redux/selectors/entities/users';
 
 import {logout} from 'app/actions/views/user';
@@ -25,7 +25,7 @@ function mapStateToProps(state) {
         currentUserIsGuest,
         isLandscape: isLandscape(state),
         teamsRequest: state.requests.teams.getTeams,
-        teams: getJoinableTeams(state),
+        teams: getSortedJoinableTeams(state, currentUser.locale),
         theme: getTheme(state),
     };
 }


### PR DESCRIPTION

#### Summary

Listing of available teams to join was not sorted alphabetically, but was based on team creation date/time.

Now the list is alphabetized, and matches webapp behaviour.

#### Ticket Link

* [MM-24201](https://mattermost.atlassian.net/browse/MM-24201)

#### Device Information
This PR was tested on: iPhone 11 Simulator

#### Screenshots

**Before**

<img width="500" alt="Joinable teams (unsorted)" src="https://user-images.githubusercontent.com/887849/83078361-d125d700-a04f-11ea-9db4-fb727468832b.png">

**After**

<img width="500" alt="Joinable teams (sorted)" src="https://user-images.githubusercontent.com/887849/83078366-d6832180-a04f-11ea-8613-4d0f8ee5cde1.png">
