### PR TITLE
[MM-24029] Fix date re-selection on search bar

### DIFF
--- a/app/components/autocomplete/date_suggestion/date_suggestion.js
+++ b/app/components/autocomplete/date_suggestion/date_suggestion.js
@@ -60,13 +60,21 @@ export default class DateSuggestion extends PureComponent {
     completeMention = (day) => {
         const mention = day.dateString;
         const {cursorPosition, onChangeText, value} = this.props;
-        const mentionPart = value.substring(0, cursorPosition);
+
+        // Substring to first space after current cursor position.
+        // If there is none, cursor is at the end of the date segment already.
+        let dateSegmentEnd = value.indexOf(' ', cursorPosition);
+        if (dateSegmentEnd === -1) {
+            dateSegmentEnd = cursorPosition;
+        }
+        const mentionPart = value.substring(0, dateSegmentEnd);
+
         const flags = mentionPart.match(ALL_SEARCH_FLAGS_REGEX);
         const currentFlag = flags[flags.length - 1];
         let completedDraft = mentionPart.replace(DATE_MENTION_SEARCH_REGEX, `${currentFlag} ${mention} `);
 
-        if (value.length > cursorPosition) {
-            completedDraft += value.substring(cursorPosition);
+        if (value.length > dateSegmentEnd) {
+            completedDraft += value.substring(dateSegmentEnd + 1); // accounting for extra space character
         }
 
         onChangeText(completedDraft, true);


### PR DESCRIPTION
#### Summary

Picking a new date string (tapping a date on the autocomplete calendar) to replace an already populated date string in the search bar, leaves the search text garbled. This was because of incorrect handling of the tap cursor position in the search box.

#### Ticket Link

[MM-24029](https://mattermost.atlassian.net/browse/MM-24029)

#### Device Information
This PR was tested on: Android 10 emulator (Nexus 3)

#### Screenshots

**Before**

<img width="300" alt="Before" src="https://user-images.githubusercontent.com/887849/83208440-0b64a680-a12c-11ea-8a93-5d37d54633db.gif"> 

**After**

<img width="300" alt="After" src="https://user-images.githubusercontent.com/887849/83208474-27684800-a12c-11ea-89ca-249847a22b46.gif"> 

