### PR TITLE
MM-21368 Notify user when editing message that's too long

### DIFF
--- a/app/components/post_draft/index.js
+++ b/app/components/post_draft/index.js
@@ -14,17 +14,16 @@ import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {getCurrentUserId, getStatusForUserId} from '@mm-redux/selectors/entities/users';
 import {getChannelTimezones} from '@mm-redux/actions/channels';
 
-import {executeCommand} from 'app/actions/views/command';
-import {addReactionToLatestPost} from 'app/actions/views/emoji';
-import {handleClearFiles, handleClearFailedFiles, initUploadFiles} from 'app/actions/views/file_upload';
-import {getCurrentChannelDraft, getThreadDraft} from 'app/selectors/views';
-import {getChannelMembersForDm} from 'app/selectors/channel';
-import {getAllowedServerMaxFileSize} from 'app/utils/file';
-import {isLandscape} from 'app/selectors/device';
+import {executeCommand} from '@actions/views/command';
+import {addReactionToLatestPost} from '@actions/views/emoji';
+import {handleClearFiles, handleClearFailedFiles, initUploadFiles} from '@actions/views/file_upload';
+import {MAX_MESSAGE_LENGTH_FALLBACK} from '@constants/post_draft';
+import {getCurrentChannelDraft, getThreadDraft} from '@selectors/views';
+import {getChannelMembersForDm} from '@selectors/channel';
+import {getAllowedServerMaxFileSize} from '@utils/file';
+import {isLandscape} from '@selectors/device';
 
 import PostDraft from './post_draft';
-
-const MAX_MESSAGE_LENGTH = 4000;
 
 export function mapStateToProps(state, ownProps) {
     const currentDraft = ownProps.rootId ? getThreadDraft(state, ownProps.rootId) : getCurrentChannelDraft(state);
@@ -81,7 +80,7 @@ export function mapStateToProps(state, ownProps) {
         files: currentDraft.files,
         isLandscape: isLandscape(state),
         isTimezoneEnabled,
-        maxMessageLength: (config && parseInt(config.MaxPostSize || 0, 10)) || MAX_MESSAGE_LENGTH,
+        maxMessageLength: (config && parseInt(config.MaxPostSize || 0, 10)) || MAX_MESSAGE_LENGTH_FALLBACK,
         maxFileSize: getAllowedServerMaxFileSize(config),
         membersCount,
         theme: getTheme(state),

--- a/app/constants/post_draft.js
+++ b/app/constants/post_draft.js
@@ -1,11 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export const MAX_FILE_COUNT = 5;
-export const IS_REACTION_REGEX = /(^\+:([^:\s]*):)$/i;
-export const INSERT_TO_DRAFT = 'insert_to_draft';
-export const INSERT_TO_COMMENT = 'insert_to_comment';
-export const ICON_SIZE = 24;
 export const ACCESSORIES_CONTAINER_NATIVE_ID = 'channelAccessoriesContainer';
 export const CHANNEL_POST_TEXTBOX_CURSOR_CHANGE = 'onChannelTextBoxCursorChange';
 export const CHANNEL_POST_TEXTBOX_VALUE_CHANGE = 'onChannelTextBoxValueChange';
+export const ICON_SIZE = 24;
+export const INSERT_TO_COMMENT = 'insert_to_comment';
+export const INSERT_TO_DRAFT = 'insert_to_draft';
+export const IS_REACTION_REGEX = /(^\+:([^:\s]*):)$/i;
+export const MAX_FILE_COUNT = 5;
+export const MAX_MESSAGE_LENGTH_FALLBACK = 4000;

--- a/app/screens/edit_post/index.js
+++ b/app/screens/edit_post/index.js
@@ -5,18 +5,23 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {editPost} from '@mm-redux/actions/posts';
+import {getConfig} from '@mm-redux/selectors/entities/general';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 
-import {getDimensions, isLandscape} from 'app/selectors/device';
+import {MAX_MESSAGE_LENGTH_FALLBACK} from '@constants/post_draft';
+import {getDimensions, isLandscape} from '@selectors/device';
 
 import EditPost from './edit_post';
 
 function mapStateToProps(state, ownProps) {
+    const config = getConfig(state);
+
     return {
         ...getDimensions(state),
+        isLandscape: isLandscape(state),
+        maxMessageLength: (config && parseInt(config.MaxPostSize || 0, 10)) || MAX_MESSAGE_LENGTH_FALLBACK,
         post: ownProps.post,
         theme: getTheme(state),
-        isLandscape: isLandscape(state),
     };
 }
 

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -300,6 +300,7 @@
   "mobile.markdown.link.copy_url": "Copy URL",
   "mobile.mention.copy_mention": "Copy Mention",
   "mobile.message_length.message": "Your current message is too long. Current character count: {count}/{max}",
+  "mobile.message_length.message_multiline": "Your current message is too long.\nCurrent character count: {count}/{max}",
   "mobile.message_length.title": "Message Length",
   "mobile.more_dms.add_more": "You can add {remaining, number} more users",
   "mobile.more_dms.cannot_add_more": "You cannot add more users",

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -26,15 +26,15 @@ import {Client4} from '@mm-redux/client';
 import {Preferences} from '@mm-redux/constants';
 import {getFormattedFileSize, lookupMimeType} from '@mm-redux/utils/file_utils';
 
-import Loading from 'app/components/loading';
-import PaperPlane from 'app/components/post_draft/quick_actions/send_action/paper_plane';
-import {MAX_FILE_COUNT} from 'app/constants/post_draft';
-import {getCurrentServerUrl, getAppCredentials} from 'app/init/credentials';
+import Loading from '@components/loading';
+import PaperPlane from '@components/post_draft/quick_actions/send_action/paper_plane';
+import {MAX_FILE_COUNT, MAX_MESSAGE_LENGTH_FALLBACK} from '@constants/post_draft';
+import {getCurrentServerUrl, getAppCredentials} from '@init/credentials';
+import {getExtensionFromMime} from '@utils/file';
+import {setCSRFFromCookie} from '@utils/security';
+import {preventDoubleTap} from '@utils/tap';
+import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import mattermostManaged from 'app/mattermost_managed';
-import {getExtensionFromMime} from 'app/utils/file';
-import {setCSRFFromCookie} from 'app/utils/security';
-import {preventDoubleTap} from 'app/utils/tap';
-import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
 
 import {
     ExcelSvg,
@@ -59,7 +59,6 @@ const extensionSvg = {
 };
 const ShareExtension = NativeModules.MattermostShare;
 const INPUT_HEIGHT = 150;
-const MAX_MESSAGE_LENGTH = 4000;
 
 export default class ExtensionPost extends PureComponent {
     static propTypes = {
@@ -386,7 +385,7 @@ export default class ExtensionPost extends PureComponent {
         const {currentUserId} = this.props;
         const {formatMessage} = this.context.intl;
 
-        if (value.length > MAX_MESSAGE_LENGTH) {
+        if (value.length > MAX_MESSAGE_LENGTH_FALLBACK) {
             Alert.alert(
                 formatMessage({
                     id: 'mobile.share_extension.too_long_title',
@@ -397,7 +396,7 @@ export default class ExtensionPost extends PureComponent {
                     defaultMessage: 'Character count: {count}/{max}',
                 }, {
                     count: value.length,
-                    max: MAX_MESSAGE_LENGTH,
+                    max: MAX_MESSAGE_LENGTH_FALLBACK,
                 }),
             );
         } else {
@@ -588,7 +587,7 @@ export default class ExtensionPost extends PureComponent {
 
     renderMessageLengthRemaining = () => {
         const {value} = this.state;
-        const messageLengthRemaining = MAX_MESSAGE_LENGTH - value.length;
+        const messageLengthRemaining = MAX_MESSAGE_LENGTH_FALLBACK - value.length;
 
         if (value.length === 0) {
             return null;


### PR DESCRIPTION
#### Summary

When editing a post that's too long (above allowed message length limit)

* Disable 'Save' button to prevent edits from being posted
* Display error message specific to the message size and allows max, instead of the current, default "Invalid Message" error.

#### Ticket Link

[MM-21368](https://mattermost.atlassian.net/browse/MM-21368)

#### Checklist
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 
* Android 10 emulator (Nexus 3)
* iPhone 11 simulator

#### Screenshots

<img width="428" alt="Screen Shot 2020-05-29 at 14 05 27" src="https://user-images.githubusercontent.com/887849/83286132-d00eba00-a1b5-11ea-9ef8-bb6706662cc9.png">
