### PR TITLE
MM-25695 Select channel when switching teams if available

### DIFF
--- a/app/actions/helpers/channels.ts
+++ b/app/actions/helpers/channels.ts
@@ -4,11 +4,11 @@
 import {ChannelTypes, PreferenceTypes, RoleTypes, UserTypes} from '@mm-redux/action_types';
 import {Client4} from '@mm-redux/client';
 import {General, Preferences} from '@mm-redux/constants';
-import {getCurrentChannelId} from '@mm-redux/selectors/entities/channels';
+import {getCurrentChannelId, getRedirectChannelNameForTeam, getChannelsNameMapInTeam} from '@mm-redux/selectors/entities/channels';
 import {getConfig} from '@mm-redux/selectors/entities/general';
 import {getMyPreferences} from '@mm-redux/selectors/entities/preferences';
 import {getCurrentUserId, getUsers, getUserIdsInChannels} from '@mm-redux/selectors/entities/users';
-import {getUserIdFromChannelName, isAutoClosed} from '@mm-redux/utils/channel_utils';
+import {getChannelByName as selectChannelByName, getUserIdFromChannelName, isAutoClosed} from '@mm-redux/utils/channel_utils';
 import {getPreferenceKey} from '@mm-redux/utils/preference_utils';
 
 import {ActionResult, GenericAction} from '@mm-redux/types/actions';
@@ -279,6 +279,43 @@ export async function getAddedDmUsersIfNecessary(state: GlobalState, preferences
     }
 
     return actions;
+}
+
+export function lastChannelIdForTeam(state: GlobalState, teamId: string): string {
+    const {channels, myMembers} = state.entities.channels;
+    const {currentUserId} = state.entities.users;
+    const {myPreferences} = state.entities.preferences;
+    const lastChannelForTeam = state.views.team.lastChannelForTeam[teamId];
+    const lastChannelId = lastChannelForTeam && lastChannelForTeam.length ? lastChannelForTeam[0] : '';
+    const lastChannel = channels[lastChannelId];
+
+    const isDMVisible = lastChannel && lastChannel.type === General.DM_CHANNEL &&
+            isDirectChannelVisible(currentUserId, myPreferences, lastChannel);
+
+    const isGMVisible = lastChannel && lastChannel.type === General.GM_CHANNEL &&
+        isGroupChannelVisible(myPreferences, lastChannel);
+
+    if (
+        myMembers[lastChannelId] &&
+        lastChannel &&
+        (lastChannel.team_id === teamId || isDMVisible || isGMVisible)
+    ) {
+        return lastChannelId;
+    }
+
+    // Fallback to default channel
+    const channelsInTeam = getChannelsNameMapInTeam(state, teamId);
+    const channel = selectChannelByName(channelsInTeam, getRedirectChannelNameForTeam(state, teamId));
+
+    if (channel) {
+        return channel.id;
+    }
+
+    // Handle case when the default channel cannot be found
+    // so we need to get the first available channel of the team
+    const teamChannels = Object.values(channelsInTeam);
+    const firstChannel = teamChannels.length ? teamChannels[0].id : '';
+    return firstChannel;
 }
 
 function fetchDirectMessageProfileIfNeeded(state: GlobalState, channel: Channel, channelMembers: Array<ChannelMembership>, profilesInChannel: Array<string>) {

--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -29,7 +29,7 @@ import {getTeamByName} from '@mm-redux/selectors/entities/teams';
 import {getChannelByName as selectChannelByName, getChannelsIdForTeam} from '@mm-redux/utils/channel_utils';
 import EventEmitter from '@mm-redux/utils/event_emitter';
 
-import {loadSidebarDirectMessagesProfiles} from '@actions/helpers/channels';
+import {lastChannelIdForTeam, loadSidebarDirectMessagesProfiles} from '@actions/helpers/channels';
 import {getPosts, getPostsBefore, getPostsSince, getPostThread, loadUnreadChannelPosts} from '@actions/views/post';
 import {INSERT_TO_COMMENT, INSERT_TO_DRAFT} from '@constants/post_draft';
 import {getChannelReachable} from '@selectors/channel';
@@ -136,29 +136,9 @@ export function loadThreadIfNecessary(rootId) {
 export function selectInitialChannel(teamId) {
     return (dispatch, getState) => {
         const state = getState();
-        const {channels, myMembers} = state.entities.channels;
-        const {currentUserId} = state.entities.users;
-        const {myPreferences} = state.entities.preferences;
-        const lastChannelForTeam = state.views.team.lastChannelForTeam[teamId];
-        const lastChannelId = lastChannelForTeam && lastChannelForTeam.length ? lastChannelForTeam[0] : '';
-        const lastChannel = channels[lastChannelId];
+        const channelId = lastChannelIdForTeam(state, teamId);
 
-        const isDMVisible = lastChannel && lastChannel.type === General.DM_CHANNEL &&
-            isDirectChannelVisible(currentUserId, myPreferences, lastChannel);
-
-        const isGMVisible = lastChannel && lastChannel.type === General.GM_CHANNEL &&
-            isGroupChannelVisible(myPreferences, lastChannel);
-
-        if (
-            myMembers[lastChannelId] &&
-            lastChannel &&
-            (lastChannel.team_id === teamId || isDMVisible || isGMVisible)
-        ) {
-            dispatch(handleSelectChannel(lastChannelId));
-            return;
-        }
-
-        dispatch(selectDefaultChannel(teamId));
+        dispatch(handleSelectChannel(channelId));
     };
 }
 

--- a/app/mm-redux/types/store.ts
+++ b/app/mm-redux/types/store.ts
@@ -64,6 +64,7 @@ export type GlobalState = {
         roles: RolesRequestsStatuses;
         jobs: JobsRequestsStatuses;
     };
+    views: any;
     websocket: {
         connected: boolean;
         lastConnectAt: number;


### PR DESCRIPTION
#### Summary
Currently when switching teams, the selected channel is empty, which shows the channel loader until the team channels are fetched from the server and the initial channel gets selected. This PR helps to select the channel  in advance when switching teams if we already have them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25695