### PR TITLE
MM-25694 Disallow profile picture update is set by LDAP

### DIFF
--- a/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
+++ b/app/screens/edit_profile/__snapshots__/edit_profile.test.js.snap
@@ -10,92 +10,12 @@ exports[`edit_profile should match snapshot 1`] = `
     }
   }
 >
-  <ProfilePictureButton
-    blurTextBox={[Function]}
-    browseFileTypes="public.image"
-    canBrowseVideoLibrary={false}
-    canTakeVideo={false}
-    currentUser={
-      Object {
-        "email": "dwight@schrutefarms.com",
-        "first_name": "Dwight",
-        "last_name": "Schrute",
-        "nickname": "Dragon",
-        "position": "position",
-        "username": "ieatbeets",
-      }
-    }
-    maxFileSize={20971520}
-    onShowFileSizeWarning={[Function]}
-    onShowUnsupportedMimeTypeWarning={[Function]}
-    removeProfileImage={[Function]}
-    theme={
-      Object {
-        "awayIndicator": "#ffbc42",
-        "buttonBg": "#166de0",
-        "buttonColor": "#ffffff",
-        "centerChannelBg": "#ffffff",
-        "centerChannelColor": "#3d3c40",
-        "codeTheme": "github",
-        "dndIndicator": "#f74343",
-        "errorTextColor": "#fd5960",
-        "linkColor": "#2389d7",
-        "mentionBg": "#ffffff",
-        "mentionBj": "#ffffff",
-        "mentionColor": "#145dbf",
-        "mentionHighlightBg": "#ffe577",
-        "mentionHighlightLink": "#166de0",
-        "newMessageSeparator": "#ff8800",
-        "onlineIndicator": "#06d6a0",
-        "sidebarBg": "#145dbf",
-        "sidebarHeaderBg": "#1153ab",
-        "sidebarHeaderTextColor": "#ffffff",
-        "sidebarText": "#ffffff",
-        "sidebarTextActiveBorder": "#579eff",
-        "sidebarTextActiveColor": "#ffffff",
-        "sidebarTextHoverBg": "#4578bf",
-        "sidebarUnreadText": "#ffffff",
-        "type": "Mattermost",
-      }
-    }
-    uploadFiles={[Function]}
-    validMimeTypes={
-      Array [
-        "image/jpeg",
-        "image/jpeg",
-        "image/jpg",
-        "image/jp_",
-        "application/jpg",
-        "application/x-jpg",
-        "image/pjpeg",
-        "image/pipeg",
-        "image/vnd.swiftview-jpeg",
-        "image/x-xbitmap",
-        "image/png",
-        "application/png",
-        "application/x-png",
-        "image/bmp",
-        "image/x-bmp",
-        "image/x-bitmap",
-        "image/x-xbitmap",
-        "image/x-win-bitmap",
-        "image/x-windows-bmp",
-        "image/ms-bmp",
-        "image/x-ms-bmp",
-        "application/bmp",
-        "application/x-bmp",
-        "application/x-win-bitmap",
-      ]
-    }
-    wrapper={true}
-  >
-    <Connect(ProfilePicture)
-      edit={true}
-      imageUri={null}
-      size={150}
-      statusBorderWidth={6}
-      statusSize={40}
-    />
-  </ProfilePictureButton>
+  <Connect(ProfilePicture)
+    edit={false}
+    imageUri={null}
+    size={150}
+    statusBorderWidth={6}
+    statusSize={40}
+  />
 </View>
 `;

--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -95,6 +95,7 @@ export default class EditProfile extends PureComponent {
         lastNameDisabled: PropTypes.bool.isRequired,
         nicknameDisabled: PropTypes.bool.isRequired,
         positionDisabled: PropTypes.bool.isRequired,
+        profilePictureDisabled: PropTypes.bool.isRequired,
         theme: PropTypes.object.isRequired,
         commandType: PropTypes.string.isRequired,
         isLandscape: PropTypes.bool.isRequired,
@@ -504,6 +505,7 @@ export default class EditProfile extends PureComponent {
     renderProfilePicture = () => {
         const {
             currentUser,
+            profilePictureDisabled,
             theme,
         } = this.props;
 
@@ -514,6 +516,25 @@ export default class EditProfile extends PureComponent {
 
         const style = getStyleSheet(theme);
         const uri = profileImage ? profileImage.uri : null;
+        const profilePicture = (
+            <ProfilePicture
+                userId={currentUser.id}
+                size={150}
+                statusBorderWidth={6}
+                statusSize={40}
+                edit={!profilePictureDisabled}
+                imageUri={uri}
+                profileImageRemove={profileImageRemove}
+            />
+        );
+
+        if (profilePictureDisabled) {
+            return (
+                <View style={style.top}>
+                    {profilePicture}
+                </View>
+            );
+        }
 
         return (
             <View style={style.top}>
@@ -532,15 +553,7 @@ export default class EditProfile extends PureComponent {
                     onShowUnsupportedMimeTypeWarning={this.onShowUnsupportedMimeTypeWarning}
                     validMimeTypes={VALID_MIME_TYPES}
                 >
-                    <ProfilePicture
-                        userId={currentUser.id}
-                        size={150}
-                        statusBorderWidth={6}
-                        statusSize={40}
-                        edit={true}
-                        imageUri={uri}
-                        profileImageRemove={profileImageRemove}
-                    />
+                    {profilePicture}
                 </ProfilePictureButton>
             </View>
         );

--- a/app/screens/edit_profile/edit_profile.test.js
+++ b/app/screens/edit_profile/edit_profile.test.js
@@ -32,6 +32,7 @@ describe('edit_profile', () => {
         lastNameDisabled: true,
         nicknameDisabled: true,
         positionDisabled: true,
+        profilePictureDisabled: true,
         theme: Preferences.THEMES.default,
         currentUser: {
             first_name: 'Dwight',
@@ -58,6 +59,7 @@ describe('edit_profile', () => {
         const wrapper = shallow(
             <EditProfile
                 {...baseProps}
+                profilePictureDisabled={false}
             />,
             {context: {intl: {formatMessage: jest.fn()}}},
         );

--- a/app/screens/edit_profile/index.js
+++ b/app/screens/edit_profile/index.js
@@ -26,12 +26,12 @@ function mapStateToProps(state, ownProps) {
     const nicknameDisabled = (service === 'ldap' && config.LdapNicknameAttributeSet === 'true') ||
         (service === 'saml' && config.SamlNicknameAttributeSet === 'true');
 
-    let positionDisabled = false;
-    if (isMinimumServerVersion(serverVersion, 5, 12)) {
-        positionDisabled = (service === 'ldap' && config.LdapPositionAttributeSet === 'true') ||
-            (service === 'saml' && config.SamlPositionAttributeSet === 'true');
-    } else {
-        positionDisabled = (service === 'ldap' || service === 'saml') && config.PositionAttribute === 'true';
+    const positionDisabled = (service === 'ldap' && config.LdapPositionAttributeSet === 'true') ||
+        (service === 'saml' && config.SamlPositionAttributeSet === 'true');
+
+    let profilePictureDisabled = false;
+    if (isMinimumServerVersion(serverVersion, 5, 24)) {
+        profilePictureDisabled = (service === 'ldap' || service === 'saml') && config.LdapPictureAttributeSet === 'true';
     }
 
     return {
@@ -39,6 +39,7 @@ function mapStateToProps(state, ownProps) {
         lastNameDisabled,
         nicknameDisabled,
         positionDisabled,
+        profilePictureDisabled,
         theme: getTheme(state),
         isLandscape: isLandscape(state),
     };


### PR DESCRIPTION
#### Summary
Do not allow the user to update their profile picture if the account is using LDAP or SAML to login and the profile picture attribute is set

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25694