### PR TITLE
[MM-25831] Fix timing issue with cancelPing

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -313,10 +313,6 @@ export default class SelectServer extends PureComponent {
             error: null,
         });
 
-        const serverUrl = await this.getUrl(url, !retryWithHttp);
-        Client4.setUrl(serverUrl);
-        handleServerUrlChanged(serverUrl);
-
         let cancel = false;
         this.cancelPing = () => {
             cancel = true;
@@ -328,6 +324,10 @@ export default class SelectServer extends PureComponent {
 
             this.cancelPing = null;
         };
+
+        const serverUrl = await this.getUrl(url, !retryWithHttp);
+        Client4.setUrl(serverUrl);
+        handleServerUrlChanged(serverUrl);
 
         try {
             const result = await getPing();


### PR DESCRIPTION
#### Summary

With `getUrl` recently [becoming async](https://github.com/mattermost/mattermost-mobile/commit/293470ff#diff-60b06b1c4aab028b96d9b207e84000c6R316), the global definition of the cancelPing function wasn't being made available in time for use by other functions (e.g. `handleSslProblem` and `handleConnect`)

#### Ticket Link

[MM-25831](https://mattermost.atlassian.net/browse/MM-25831)

#### Device Information
This PR was tested on: 
* iPhone 11 device
