### PR TITLE
MM-25792 Ensure previous state is cleared when logout

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2925,41 +2925,6 @@ SOFTWARE.
 
 ---
 
-## redux-reset
-
-This product contains 'redux-reset' by Wang Zixiao.
-
-Gives redux the ability to reset the state
-
-* HOMEPAGE:
-  * https://github.com/wwayne/redux-reset
-
-* LICENSE: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Wang Zixiao
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 ## redux-thunk
 
 This product contains 'redux-thunk' by Dan Abramov.

--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -145,7 +145,7 @@ export function purgeOfflineStore() {
 
         dispatch({
             type: General.OFFLINE_STORE_PURGE,
-            state: getStateForReset(initialState, currentState),
+            data: getStateForReset(initialState, currentState),
         });
 
         EventEmitter.emit(NavigationTypes.RESTART_APP);

--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -167,7 +167,6 @@ class GlobalEventHandler {
 
         removeAppCredentials();
         deleteFileCache();
-        await this.resetState();
         resetMomentLocale();
 
         // TODO: Handle when multi-server support is added
@@ -327,7 +326,7 @@ class GlobalEventHandler {
 
             return Store.redux.dispatch({
                 type: General.OFFLINE_STORE_PURGE,
-                state: newState,
+                data: newState,
             });
         } catch (e) {
             // clear error

--- a/app/mm-redux/types/module.d.ts
+++ b/app/mm-redux/types/module.d.ts
@@ -3,4 +3,3 @@
 declare module 'gfycat-sdk';
 declare module 'remote-redux-devtools';
 declare module 'redux-action-buffer';
-declare module 'redux-reset';

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -5,11 +5,11 @@ import AsyncStorage from '@react-native-community/async-storage';
 import * as redux from 'redux';
 import {createPersistoid, createTransform, persistReducer, persistStore, Persistor, PersistConfig} from 'redux-persist';
 import {createBlacklistFilter} from 'redux-persist-transform-filter';
-import reduxReset from 'redux-reset';
 import DeviceInfo from 'react-native-device-info';
 
 import {General} from '@mm-redux/constants';
 import serviceReducer from '@mm-redux/reducers';
+import {GenericAction} from '@mm-redux/types/actions';
 import {GlobalState} from '@mm-redux/types/store';
 
 import initialState from '@store/initial_state';
@@ -183,7 +183,15 @@ export default function configureStore(storage: any, preloadedState: any = {}, o
 
     const persistConfig: PersistConfig<GlobalState> = Object.assign({}, defaultConfig, optionalConfig);
     const baseState: any = Object.assign({}, initialState, preloadedState);
-    const rootReducer: any = createReducer(serviceReducer as any, appReducer as any);
+    const baseReducer: any = createReducer(serviceReducer as any, appReducer as any);
+    const rootReducer: any = (state: GlobalState, action: GenericAction) => {
+        if (action.type === General.OFFLINE_STORE_PURGE) {
+            // eslint-disable-next-line no-underscore-dangle
+            delete action.data._persist;
+            return baseReducer(action.data, action as any);
+        }
+        return baseReducer(state as any, action as any);
+    };
     const persistedReducer = persistReducer({...persistConfig}, rootReducer);
     const options: ClientOptions = Object.assign({}, defaultOptions, optionalOptions);
 
@@ -194,7 +202,6 @@ export default function configureStore(storage: any, preloadedState: any = {}, o
             redux.applyMiddleware(
                 ...createMiddlewares(options),
             ),
-            reduxReset(General.OFFLINE_STORE_PURGE),
         ),
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19877,11 +19877,6 @@
         "lodash.unset": "^4.5.2"
       }
     },
-    "redux-reset": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/redux-reset/-/redux-reset-0.3.0.tgz",
-      "integrity": "sha1-q4B5W0ENWyhomYbqxAy4R6ac0BI="
-    },
     "redux-thunk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "redux-batched-actions": "0.5.0",
     "redux-persist": "6.0.0",
     "redux-persist-transform-filter": "0.0.20",
-    "redux-reset": "0.3.0",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "rn-fetch-blob": "0.12.0",

--- a/packager/moduleNames.js
+++ b/packager/moduleNames.js
@@ -828,7 +828,6 @@ module.exports = [
     'node_modules/redux-persist/lib/persistStore.js',
     'node_modules/redux-persist/lib/purgeStoredState.js',
     'node_modules/redux-persist/lib/stateReconciler/autoMergeLevel1.js',
-    'node_modules/redux-reset/lib/index.js',
     'node_modules/redux/lib/redux.js',
     'node_modules/requires-port/index.js',
     'node_modules/reselect/lib/index.js',

--- a/packager/modulePaths.js
+++ b/packager/modulePaths.js
@@ -825,7 +825,6 @@ module.exports = [
     './node_modules/node_modules/redux-persist/lib/persistStore.js',
     './node_modules/node_modules/redux-persist/lib/purgeStoredState.js',
     './node_modules/node_modules/redux-persist/lib/stateReconciler/autoMergeLevel1.js',
-    './node_modules/node_modules/redux-reset/lib/index.js',
     './node_modules/node_modules/redux/lib/redux.js',
     './node_modules/node_modules/requires-port/index.js',
     './node_modules/node_modules/reselect/lib/index.js',


### PR DESCRIPTION
#### Summary
Make sure previous redux state is cleared when you logout from a server so there is no conflicting data or data that  does not belong when you switch servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25792