### PR TITLE
MM-25849 Android: Apply backoff & retry logic only for ID-loaded push notifications

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -105,7 +105,7 @@ public class ReceiptDelivery {
         try {
             Response response = client.newCall(request).execute();
             String responseBody = response.body().string();
-            if (response.code() != 200 || !isIdLoaded) {
+            if (response.code() != 200) {
                 throw new Exception(responseBody);
             }
             JSONObject jsonResponse = new JSONObject(responseBody);
@@ -120,14 +120,16 @@ public class ReceiptDelivery {
             promise.resolve(bundle);
         } catch (Exception e) {
             Log.e("ReactNative", "Receipt delivery failed to send");
-            try {
-                reRequestCount++;
-                if (reRequestCount < FIBONACCI_BACKOFFS.length) {
-                    Log.i("ReactNative", "Retry attempt " + reRequestCount + " with backoff delay: " + FIBONACCI_BACKOFFS[reRequestCount] + " seconds");
-                    Thread.sleep(FIBONACCI_BACKOFFS[reRequestCount] * 1000);
-                    makeServerRequest(client, request, isIdLoaded, reRequestCount, promise);
-                }
-            } catch(InterruptedException ie) {}
+            if (isIdLoaded) {
+                try {
+                    reRequestCount++;
+                    if (reRequestCount < FIBONACCI_BACKOFFS.length) {
+                        Log.i("ReactNative", "Retry attempt " + reRequestCount + " with backoff delay: " + FIBONACCI_BACKOFFS[reRequestCount] + " seconds");
+                        Thread.sleep(FIBONACCI_BACKOFFS[reRequestCount] * 1000);
+                        makeServerRequest(client, request, isIdLoaded, reRequestCount, promise);
+                    }
+                } catch(InterruptedException ie) {}    
+            }
 
             promise.reject("Receipt delivery failure", e.toString());
         }


### PR DESCRIPTION
#### Summary

Changes in #4302 piggy-backed on the existing [exception catching logic](https://github.com/mattermost/mattermost-mobile/pull/4302/files#diff-266cddcf80a6bc300b40cc922e7a659bL101-L102) to retry failed request (status != 200). However, the change applied retries for any type of push notification.

Android only.

#### Ticket Link
* [MM-25849](https://mattermost.atlassian.net/browse/MM-25849)

#### Device Information
This PR was tested on: Android 10 device (OnePlus 5)
