### PR TITLE
MM-25809 - Fixed rendering code blocks when starting with 4 spaces

### DIFF
--- a/app/components/post_draft/post_draft.js
+++ b/app/components/post_draft/post_draft.js
@@ -141,7 +141,7 @@ export default class PostDraft extends PureComponent {
                 channel_id: channelId,
                 root_id: rootId,
                 parent_id: rootId,
-                message: value.trim(),
+                message: value,
             };
 
             createPost(post, postFiles);


### PR DESCRIPTION
#### Summary

Removed unnecessary trim before creating the post that was preventing displaying as code blocks when the text was preceded with 4 spaces. 
 
#### Ticket Link
[MM-25809](https://mattermost.atlassian.net/browse/MM-25809)

#### Device Information
This PR was tested on: iOS simulator.

#### Related PR
Issue originally introduced in: https://github.com/mattermost/mattermost-mobile/pull/4122
