### PR TITLE
MM-25782 improve channel member reducer speed to sync memberships

### DIFF
--- a/app/mm-redux/reducers/entities/channels.ts
+++ b/app/mm-redux/reducers/entities/channels.ts
@@ -370,12 +370,15 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
 
         // Remove existing channel memberships when the user is no longer a member
         if (sync) {
-            current.forEach((member: ChannelMembership) => {
-                const id = member.channel_id;
-                if (channelMembers.find((cm: ChannelMembership) => cm.channel_id !== id && teamChannels.includes(id))) {
-                    delete nextState[id];
-                    hasNewValues = true;
-                }
+            const memberIds = channelMembers.map((cm: ChannelMembership) => cm.channel_id);
+            const removedMembers = current.filter((cm: ChannelMembership) => {
+                const id = cm.channel_id;
+                return !memberIds.includes(id) && teamChannels.includes(id);
+            });
+
+            removedMembers.forEach((member: ChannelMembership) => {
+                delete nextState[member.channel_id];
+                hasNewValues = true;
             });
         }
 


### PR DESCRIPTION
#### Summary
The current reducer implementation for channel members was too slow as it was looping through all the current channel memberships to determine if some of them needed to be removed as the user was no longer a member of that channel.

The change now consist in determine if there are memberships to be removed first by filtering the current memberships with those returned by the server and then loop through them.

The issue being fixed is more noticeable when you have a large amount of channels ad multiple teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25782