### PR TITLE
MM-25929 Decouple id-loaded retries from regular notification run

### DIFF
--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -14,17 +14,17 @@ class NotificationService: UNNotificationServiceExtension {
       let ackId = bestAttemptContent.userInfo["ack_id"]
       let type = bestAttemptContent.userInfo["type"]
       let postId = bestAttemptContent.userInfo["post_id"]
-      let idLoaded = bestAttemptContent.userInfo["id_loaded"] ?? false
+      let idLoaded = (bestAttemptContent.userInfo["id_loaded"] ?? false) as! Bool
 
       UploadSession.shared.notificationReceipt(
         notificationId: ackId,
         receivedAt: Date().millisecondsSince1970,
         type: type,
         postId: postId,
-        idLoaded: idLoaded as! Bool
+        idLoaded: idLoaded
       ) { data, error in
-        if (idLoaded as! Bool) {
-          guard let data = data, error == nil else {
+        guard let data = data, error == nil else {
+          if (idLoaded) {
             self.sendFailed = true;
             let fibonacciBackoffsInSeconds = [1.0, 2.0, 3.0, 5.0, 8.0]
             for backoffInSeconds in fibonacciBackoffsInSeconds {
@@ -34,7 +34,7 @@ class NotificationService: UNNotificationServiceExtension {
                   receivedAt: Date().millisecondsSince1970,
                   type: type,
                   postId: postId,
-                  idLoaded: idLoaded as! Bool
+                  idLoaded: idLoaded
                 ) { data, error in
                   guard let data = data, error == nil else {
                     self.sendFailed = true;
@@ -51,10 +51,10 @@ class NotificationService: UNNotificationServiceExtension {
                 break
               }
             }
-            return
           }
-          self.processResponse(data: data, bestAttemptContent: bestAttemptContent, contentHandler: contentHandler)
+          return
         }
+        self.processResponse(data: data, bestAttemptContent: bestAttemptContent, contentHandler: contentHandler)
       }
     }
   }


### PR DESCRIPTION
#### Summary

Bug found in #4302 that delayed delivery/receipt of normal (non id-loaded) iOS push notifications. Response handling was happening within the guard block for id-loaded messages.

#### Ticket Link

* [MM-25929](https://mattermost.atlassian.net/browse/MM-25929)

#### Device Information
This PR was tested on:
* iPhone 11 device
