### PR TITLE
[MM-25350] Hide 'Select Team' title on modal when server error occurs

### DIFF
--- a/app/components/root/root.js
+++ b/app/components/root/root.js
@@ -61,10 +61,10 @@ export default class Root extends PureComponent {
             setTimeout(this.errorTeamsList, 200);
             return;
         }
-        this.navigateToTeamsPage('ErrorTeamsList');
+        this.navigateToTeamsPage('ErrorTeamsList', true);
     }
 
-    navigateToTeamsPage = (screen) => {
+    navigateToTeamsPage = (screen, error = false) => {
         const {currentUrl, theme} = this.props;
         const {intl} = this.providerRef.getChildContext();
 
@@ -93,7 +93,10 @@ export default class Root extends PureComponent {
             };
         }
 
-        const title = intl.formatMessage({id: 'mobile.routes.selectTeam', defaultMessage: 'Select Team'});
+        let title = '';
+        if (!error) {
+            title = intl.formatMessage({id: 'mobile.routes.selectTeam', defaultMessage: 'Select Team'});
+        }
 
         resetToTeams(screen, title, passProps, options);
     }


### PR DESCRIPTION
#### Summary

| **Old** | **New** |
| --- | --- |
| <img width="373" alt="Old" src="https://user-images.githubusercontent.com/887849/84390292-b6b23880-abcd-11ea-8eb5-3b76032d7f62.png"> | <img width="373" alt="New" src="https://user-images.githubusercontent.com/887849/84390163-93878900-abcd-11ea-842e-43e35fe41fc9.png"> |

#### Ticket Link

* [MM-25350](https://mattermost.atlassian.net/browse/MM-25350)

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on: iPhone 11 Simulator

#### Additional Notes

When the device is offline, the error message that renders is not "Something Went Wrong", but "Device is not connected to Internet. Please try again". The navigation screen setups for the "offline" message is entirely different from the "server response error" and are not affected by this PR. The code changes here only apply when the device is online and the server exhibits some problem in responding.