### PR TITLE
MM-26185 Fix unhandled error when logging out from the select team screen

### DIFF
--- a/app/screens/select_team/index.js
+++ b/app/screens/select_team/index.js
@@ -5,6 +5,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getTeams, addUserToTeam} from '@mm-redux/actions/teams';
+import {General} from '@mm-redux/constants';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {getSortedJoinableTeams} from '@mm-redux/selectors/entities/teams';
 import {getCurrentUser} from '@mm-redux/selectors/entities/users';
@@ -19,13 +20,14 @@ import SelectTeam from './select_team.js';
 function mapStateToProps(state) {
     const currentUser = getCurrentUser(state);
     const currentUserIsGuest = isGuest(currentUser);
+    const locale = currentUser?.locale || General.DEFAULT_LOCALE;
 
     return {
         currentUserId: currentUser && currentUser.id,
         currentUserIsGuest,
         isLandscape: isLandscape(state),
         teamsRequest: state.requests.teams.getTeams,
-        teams: getSortedJoinableTeams(state, currentUser.locale),
+        teams: getSortedJoinableTeams(state, locale),
         theme: getTheme(state),
     };
 }


### PR DESCRIPTION
#### Summary
When the user logins and do not belong to any team the select team screen  shows, if the user decides to logout from this screen there was an unhandled error as the `currentUser` is no longer set.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26185