### PR TITLE
[MM-22582] Fix mute channel switch lag

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -89,6 +89,10 @@ export default class ChannelInfo extends PureComponent {
     }
 
     static getDerivedStateFromProps(nextProps, state) {
+        if (state.ownUpdate) {
+            return {ownUpdate: false};
+        }
+
         if (state.isFavorite !== nextProps.isFavorite ||
             state.isMuted !== nextProps.isChannelMuted ||
             state.ignoreChannelMentions !== nextProps.ignoreChannelMentions) {
@@ -348,7 +352,7 @@ export default class ChannelInfo extends PureComponent {
         const {isFavorite, actions, currentChannel} = this.props;
         const {favoriteChannel, unfavoriteChannel} = actions;
         const toggleFavorite = isFavorite ? unfavoriteChannel : favoriteChannel;
-        this.setState({isFavorite: !isFavorite});
+        this.setState({isFavorite: !isFavorite, ownUpdate: true});
         toggleFavorite(currentChannel.id);
     });
 
@@ -370,7 +374,7 @@ export default class ChannelInfo extends PureComponent {
             mark_unread: isChannelMuted ? 'all' : 'mention',
         };
 
-        this.setState({isMuted: !isChannelMuted});
+        this.setState({isMuted: !isChannelMuted, ownUpdate: true});
         updateChannelNotifyProps(currentUserId, currentChannel.id, opts);
     });
 
@@ -382,7 +386,7 @@ export default class ChannelInfo extends PureComponent {
             ignore_channel_mentions: ignoreChannelMentions ? Users.IGNORE_CHANNEL_MENTIONS_OFF : Users.IGNORE_CHANNEL_MENTIONS_ON,
         };
 
-        this.setState({ignoreChannelMentions: !ignoreChannelMentions});
+        this.setState({ignoreChannelMentions: !ignoreChannelMentions, ownUpdate: true});
         updateChannelNotifyProps(currentUserId, currentChannel.id, opts);
     });
 

--- a/app/screens/channel_info/channel_info.test.js
+++ b/app/screens/channel_info/channel_info.test.js
@@ -201,4 +201,25 @@ describe('channel_info', () => {
         const render = instance.renderUnarchiveChannel();
         expect(render).toBeFalsy();
     });
+
+    test('handleFavorite, handleMuteChannel and handleIgnoreChannelMentions should persist state changes', async () => {
+        const props = Object.assign({}, baseProps);
+        const wrapper = shallow(
+            <ChannelInfo
+                {...props}
+            />,
+            {context: {intl: intlMock}},
+        );
+
+        const instance = wrapper.instance();
+
+        instance.handleFavorite();
+        expect(wrapper.state('isFavorite')).toBe(true);
+
+        instance.handleMuteChannel();
+        expect(wrapper.state('isMuted')).toBe(true);
+
+        instance.handleIgnoreChannelMentions();
+        expect(wrapper.state('ignoreChannelMentions')).toBe(true);
+    });
 });


### PR DESCRIPTION
#### Summary

When the user hits the mute channel switch, the animation and color change of the switch is laggy. This is due to the call to `setState` being overriden by props while we wait for the API call to complete.

Timeline of events when we toggle the setting:

- user hits `mute channel` switch
- `setState` is called
- [API call is kicked off](https://github.com/mattermost/mattermost-mobile/blob/4cd8d2ed5efb2071dba07128f97b07467d929460/app/mm-redux/actions/channels.ts#L369-L375)
- getDerivedStateFromProps is called
  - we see mismatch of state vs props on isMuted
  - [props takes precedence over state change](https://github.com/mattermost/mattermost-mobile/blob/4cd8d2ed5efb2071dba07128f97b07467d929460/app/screens/channel_info/channel_info.js#L91-L103), which makes the `setState` call reverted
- API call finishes
- [redux store is updated](https://github.com/mattermost/mattermost-mobile/blob/4cd8d2ed5efb2071dba07128f97b07467d929460/app/mm-redux/actions/channels.ts#L380-L391)
- props now say isMuted is true
- getDerivedStateFromProps is called
  - props takes precedence and state is set to match it

React did not used to call `getDerivedStateFromProps` on a call to `setState`. [This graph](https://projects.wojtekmaj.pl/react-lifecycle-methods-diagram) shows that React did not call `getDerivedStateFromProps` in version `16.3`, but began to do so in `^16.4`. This doesn't make sense because we are currently using `16.3.1`, and it is being called. I'm not sure how/why the `getDerivedStateFromProps` function is being called on `setState`.

As for the solution here, there are only 3 functions calling `setState` in the component:

- `handleFavorite`, which is currently not affected by this issue because redux is updated by the action before any api call, as an [optimistic action](https://github.com/mattermost/mattermost-mobile/blob/4cd8d2ed5efb2071dba07128f97b07467d929460/app/mm-redux/actions/channels.ts#L1389-L1399).
- `handleMuteChannel`, which does not have an optimistic redux update, as the eventual dispatched action is `RECEIVED_CHANNEL_PROPS`, which [triggers a re-sorting of channel sidebar](https://github.com/mattermost/mattermost-mobile/blob/ee4b85edcfee8316db08c31ec5b2a26afb343bd3/app/mm-redux/actions/channels.ts#L380-L390).
- `handleIgnoreChannelMentions` is in the same situation as `handleMuteChannel`

I'm applying the fix to `isFavorite` as well for consistency. I'm fine with removing the fix from there if it's deemed inappropriate.

Inspiration for this solution: https://stackoverflow.com/a/57208053/5755821

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-22582

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 
- iPhone 11 (13.5) 