### PR TITLE
MM-25670 perform search when hitting Enter on HW keyboard

### DIFF
--- a/app/components/post_draft/post_input/post_input.js
+++ b/app/components/post_draft/post_input/post_input.js
@@ -10,6 +10,7 @@ import HWKeyboardEvent from 'react-native-hw-keyboard-event';
 import PasteableTextInput from '@components/pasteable_text_input';
 import {INSERT_TO_COMMENT, INSERT_TO_DRAFT} from '@constants/post_draft';
 import EventEmitter from '@mm-redux/utils/event_emitter';
+import EphemeralStore from '@store/ephemeral_store';
 import {t} from '@utils/i18n';
 import {switchKeyboardForCodeBlocks} from '@utils/markdown';
 import {changeOpacity, makeStyleSheetFromTheme, getKeyboardAppearanceFromTheme} from '@utils/theme';
@@ -17,6 +18,7 @@ import {changeOpacity, makeStyleSheetFromTheme, getKeyboardAppearanceFromTheme} 
 const {RNTextInputReset} = NativeModules;
 const INPUT_LINE_HEIGHT = 20;
 const HW_SHIFT_ENTER_TEXT = Platform.OS === 'ios' ? '\n' : '';
+const HW_EVENT_IN_SCREEN = ['Channel', 'Thread'];
 
 export default class PostInput extends PureComponent {
     static contextTypes = {
@@ -160,13 +162,15 @@ export default class PostInput extends PureComponent {
     };
 
     handleHardwareEnterPress = (keyEvent) => {
-        switch (keyEvent.pressedKey) {
-        case 'enter':
-            this.props.onSend();
-            break;
-        case 'shift-enter':
-            this.handleInsertTextToDraft(HW_SHIFT_ENTER_TEXT);
-            break;
+        if (HW_EVENT_IN_SCREEN.includes(EphemeralStore.getNavigationTopComponentId())) {
+            switch (keyEvent.pressedKey) {
+            case 'enter':
+                this.props.onSend();
+                break;
+            case 'shift-enter':
+                this.handleInsertTextToDraft(HW_SHIFT_ENTER_TEXT);
+                break;
+            }
         }
     }
 

--- a/app/screens/search/search.js
+++ b/app/screens/search/search.js
@@ -15,29 +15,31 @@ import {
 } from 'react-native';
 import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import {Navigation} from 'react-native-navigation';
+import HWKeyboardEvent from 'react-native-hw-keyboard-event';
 
+import {goToScreen, showModalOverCurrentContext, dismissModal} from '@actions/navigation';
+import Autocomplete from '@components/autocomplete';
+import KeyboardLayout from '@components/layout/keyboard_layout';
+import DateHeader from '@components/post_list/date_header';
+import FormattedText from '@components/formatted_text';
+import Loading from '@components/loading';
+import PostListRetry from '@components/post_list_retry';
+import PostSeparator from '@components/post_separator';
+import SearchBar from '@components/search_bar';
+import StatusBar from '@components/status_bar';
+import {paddingHorizontal as padding} from '@components/safe_area_view/iphone_x_spacing';
+import {ListTypes} from '@constants';
 import {debounce} from '@mm-redux/actions/helpers';
 import {isDateLine, getDateForDateLine} from '@mm-redux/utils/post_list';
-
-import Autocomplete from 'app/components/autocomplete';
-import KeyboardLayout from 'app/components/layout/keyboard_layout';
-import DateHeader from 'app/components/post_list/date_header';
-import FormattedText from 'app/components/formatted_text';
-import Loading from 'app/components/loading';
-import PostListRetry from 'app/components/post_list_retry';
-import PostSeparator from 'app/components/post_separator';
-import SearchBar from 'app/components/search_bar';
-import StatusBar from 'app/components/status_bar';
-import {paddingHorizontal as padding} from 'app/components/safe_area_view/iphone_x_spacing';
-import {ListTypes} from 'app/constants';
-import mattermostManaged from 'app/mattermost_managed';
-import {preventDoubleTap} from 'app/utils/tap';
-import {goToScreen, showModalOverCurrentContext, dismissModal} from 'app/actions/navigation';
+import EphemeralStore from '@store/ephemeral_store';
+import {preventDoubleTap} from '@utils/tap';
 import {
     changeOpacity,
     makeStyleSheetFromTheme,
     getKeyboardAppearanceFromTheme,
-} from 'app/utils/theme';
+} from '@utils/theme';
+
+import mattermostManaged from 'app/mattermost_managed';
 
 import ChannelDisplayName from './channel_display_name';
 import Modifier, {MODIFIER_LABEL_HEIGHT} from './modifier';
@@ -107,6 +109,7 @@ export default class Search extends PureComponent {
 
     componentDidMount() {
         this.navigationEventListener = Navigation.events().bindComponent(this);
+        HWKeyboardEvent.onHWKeyPressed(this.handleHardwareEnterPress);
 
         if (this.props.initialValue) {
             this.search(this.props.initialValue);
@@ -148,6 +151,20 @@ export default class Search extends PureComponent {
                     });
                 }
             }, 250);
+        }
+    }
+
+    componentWillUnmount() {
+        HWKeyboardEvent.removeOnHWKeyPressed();
+    }
+
+    handleHardwareEnterPress = (keyEvent) => {
+        if (EphemeralStore.getNavigationTopComponentId() === 'Search') {
+            switch (keyEvent.pressedKey) {
+            case 'enter':
+                this.search(this.state.value);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Adds the ability to press the Enter key in a Hardware keyboard to perform a search.

Testing notes: Have a text entered in the input box in the center channel and then go to the search screen without previously sent the message in the center channel, perform a search by pressing the Enter key, message in the center channel should remain in the input box.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25670