### PR TITLE
[MM-25781] Don't retry nor use response message on 401

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -106,8 +106,14 @@ public class ReceiptDelivery {
             Response response = client.newCall(request).execute();
             String responseBody = response.body().string();
             if (response.code() != 200) {
+                if (response.code() == 401) {
+                    promise.reject("Receipt delivery failure", "Unauthorized");
+                    return;
+                }
+
                 throw new Exception(responseBody);
             }
+
             JSONObject jsonResponse = new JSONObject(responseBody);
             Bundle bundle = new Bundle();
             String keys[] = new String[]{"post_id", "category", "message", "team_id", "channel_id", "channel_name", "type", "sender_id", "sender_name", "version"};

--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -106,8 +106,21 @@ public class ReceiptDelivery {
             Response response = client.newCall(request).execute();
             String responseBody = response.body().string();
             if (response.code() != 200) {
-                if (response.code() == 401) {
+                switch (response.code()) {
+                    case 302:
+                    promise.reject("Receipt delivery failure", "StatusFound");
+                    return;
+                    case 400:
+                    promise.reject("Receipt delivery failure", "StatusBadRequest");
+                    return;
+                    case 401:
                     promise.reject("Receipt delivery failure", "Unauthorized");
+                    return;
+                    case 500:
+                    promise.reject("Receipt delivery failure", "StatusInternalServerError");
+                    return;
+                    case 501:
+                    promise.reject("Receipt delivery failure", "StatusNotImplemented");
                     return;
                 }
 

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -23,7 +23,12 @@ class NotificationService: UNNotificationServiceExtension {
         receivedAt: receivedAt,
         type: type,
         postId: postId,
-        idLoaded: idLoaded) { data, error in
+        idLoaded: idLoaded) { data, response, error in
+          if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 401 {
+            contentHandler(self.bestAttemptContent!)
+            return
+          }
+
           guard let data = data, error == nil else {
             if (idLoaded) {
               // Receipt retrieval failed. Kick off retries.

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -15,6 +15,7 @@ class NotificationService: UNNotificationServiceExtension {
 
     func fetchReceipt(notificationId: String, receivedAt: Int, type: String, postId: String, idLoaded: Bool ) -> Void {
       if (self.retryIndex >= fibonacciBackoffsInSeconds.count) {
+        contentHandler(self.bestAttemptContent!)
         return
       }
 

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -25,7 +25,7 @@ class NotificationService: UNNotificationServiceExtension {
         type: type,
         postId: postId,
         idLoaded: idLoaded) { data, response, error in
-          if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 401 {
+          if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
             contentHandler(self.bestAttemptContent!)
             return
           }

--- a/ios/UploadAttachments/UploadAttachments/UploadSession.swift
+++ b/ios/UploadAttachments/UploadAttachments/UploadSession.swift
@@ -130,10 +130,10 @@ import os.log
     }
 
     public func notificationReceipt(notificationId: Any?, receivedAt: Int, type: Any?) {
-        notificationReceipt(notificationId:notificationId, receivedAt:receivedAt, type:type, postId:nil, idLoaded: false, completion:{_, _ in})
+        notificationReceipt(notificationId:notificationId, receivedAt:receivedAt, type:type, postId:nil, idLoaded:false, completion:{_, _, _ in})
     }
 
-    public func notificationReceipt(notificationId: Any?, receivedAt: Int, type: Any?, postId: Any? = nil, idLoaded: Bool, completion: @escaping (Data?, Error?) -> Void) {
+    public func notificationReceipt(notificationId: Any?, receivedAt: Int, type: Any?, postId: Any? = nil, idLoaded: Bool, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
         if (notificationId != nil) {
             let store = StoreManager.shared() as StoreManager
             let entities = store.getEntities(true)
@@ -162,8 +162,8 @@ import os.log
                     request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
                     request.httpBody = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted)
 
-                    let task = URLSession(configuration: .ephemeral).dataTask(with: request) { data, _, error in
-                        completion(data, error)
+                    let task = URLSession(configuration: .ephemeral).dataTask(with: request) { data, response, error in
+                        completion(data, response, error)
                     }
                     task.resume()
                 }


### PR DESCRIPTION
#### Summary
These changes ensure that we don't retry failed ID-loaded requests if the server response code is 401. For iOS we also prevent the 401 response message from overriding the default ID-loaded message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25781

#### Device Information
This PR was tested on:
* iPhone SE, iOS 13
* Android Q emulator