### PR TITLE
[MM-25794] Ensure state teams and members are up-to-date

### DIFF
--- a/share_extension/android/index.js
+++ b/share_extension/android/index.js
@@ -58,7 +58,7 @@ export default class ShareApp extends PureComponent {
     initTeamAndChannel = async ({dispatch, getState}) => {
         await dispatch(getMyTeams());
         await dispatch(getMyTeamMembers());
-        
+
         const {myMembers} = getState().entities.teams;
         if (Object.keys(myMembers).length === 0) {
             dispatch(selectTeam(''));

--- a/share_extension/android/index.js
+++ b/share_extension/android/index.js
@@ -5,6 +5,10 @@ import React, {PureComponent} from 'react';
 import {Provider} from 'react-redux';
 import {IntlProvider} from 'react-intl';
 
+import {getMyTeams, getMyTeamMembers, selectTeam} from '@mm-redux/actions/teams';
+
+import {selectDefaultTeam} from '@actions/views/select_team';
+import {selectDefaultChannel, loadChannelsForTeam} from '@actions/views/channel';
 import {getTranslations} from '@i18n';
 import {getCurrentLocale} from '@selectors/i18n';
 import configureStore from '@store';
@@ -44,12 +48,28 @@ export default class ShareApp extends PureComponent {
         if (MMKVStorage) {
             configureStore(MMKVStorage);
         }
-        waitForHydration(Store.redux, () => {
-            const {dispatch, getState} = Store.redux;
-            const {currentTeamId} = getState().entities.teams;
-            dispatch(extensionSelectTeamId(currentTeamId));
+        waitForHydration(Store.redux, async () => {
+            await this.initTeamAndChannel(Store.redux);
+
             this.setState({init: true});
         });
+    }
+
+    initTeamAndChannel = async ({dispatch, getState}) => {
+        await dispatch(getMyTeams());
+        await dispatch(getMyTeamMembers());
+        
+        const {myMembers} = getState().entities.teams;
+        if (Object.keys(myMembers).length === 0) {
+            dispatch(selectTeam(''));
+            dispatch(extensionSelectTeamId(''));
+        } else {
+            await dispatch(selectDefaultTeam());
+            const {currentTeamId} = getState().entities.teams;
+            await dispatch(loadChannelsForTeam(currentTeamId));
+            await dispatch(selectDefaultChannel(currentTeamId));
+            dispatch(extensionSelectTeamId(currentTeamId));
+        }
     }
 
     render() {


### PR DESCRIPTION
#### Summary
With the mobile app open and when leaving the last team from another client, the mobile app's `currentTeamId` is not unset so the Share extension still loads data for that team. Also, because you can leave/join channels through another client while the mobile app is not running, the Share extension will not have up-to-date team and membership data to use if opened first.

With these changes, the Share extension dispatches `getMyTeams` and `getMyTeamMembers` to update the state then handles selection of a default team and channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25794

#### Device Information
This PR was tested on:
* Android 10 emulator