### PR TITLE
[MM-25749] Add command autocomplete support for mobile

### DIFF
--- a/app/components/autocomplete/slash_suggestion/command_autocomplete/command_autocomplete.js
+++ b/app/components/autocomplete/slash_suggestion/command_autocomplete/command_autocomplete.js
@@ -1,0 +1,455 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const AUTOCOMPLETE_ARG = {
+    TEXT: 'TextInput',
+    STATIC_LIST: 'StaticList',
+    DYNAMIC_LIST: 'DynamicList',
+};
+
+export default class CommandAutocomplete {
+    constructor(updateDynamicAutocompleteSuggestions) {
+        this.updateDynamicAutocompleteSuggestions = updateDynamicAutocompleteSuggestions;
+    }
+
+    getSuggestions = (commands, dynamicArguments, inputParsed, inputToBeParsed) => {
+        if (!commands) {
+            return [];
+        }
+        let suggestions = [];
+        const index = inputToBeParsed.indexOf(' ');
+        if (index === -1) {// no space in input
+            for (let i = 0; i < commands.length; i++) {
+                if (commands[i].Trigger.startsWith(inputToBeParsed.toLowerCase())) {
+                    const s = {
+                        Complete: inputParsed + commands[i].Trigger,
+                        Suggestion: commands[i].Trigger,
+                        Description: commands[i].HelpText,
+                        Hint: commands[i].Hint,
+                    };
+                    suggestions.push(s);
+                }
+            }
+            return suggestions;
+        }
+        for (let i = 0; i < commands.length; i++) {
+            if (commands[i].Trigger !== inputToBeParsed.substring(0, index).toLowerCase()) {
+                continue;
+            }
+            const toBeParsed = inputToBeParsed.substring(index + 1);
+            const parsed = inputParsed + inputToBeParsed.substring(0, index + 1);
+            if (!commands[i].Arguments || commands[i].Arguments.length === 0) {
+                // Seek recursively in subcommands
+                const subSuggestions = this.getSuggestions(commands[i].SubCommands, dynamicArguments, parsed, toBeParsed);
+                suggestions = suggestions.concat(subSuggestions);
+                continue;
+            }
+            const {
+                found: parsedFound,
+                suggestions: parsedSuggestions,
+            } = this.parseArguments(commands[i].Arguments, dynamicArguments, parsed, toBeParsed);
+            if (parsedFound) {
+                suggestions = suggestions.concat(parsedSuggestions);
+            }
+        }
+        return suggestions;
+    }
+
+    parseArguments = (args, dynamicArguments, parsed, toBeParsed) => {
+        let suggestions = [];
+        if (!args || args.length === 0) {
+            return {
+                found: false,
+                parsed,
+                toBeParsed,
+                suggestions: [],
+            };
+        }
+        if (args[0].Required) {
+            const {
+                found: parsedFound,
+                parsed: changedParsed,
+                toBeParsed: changedToBeParsed,
+                suggestions: parsedSuggestions,
+            } = this.parseArgument(args[0], dynamicArguments, parsed, toBeParsed);
+            if (parsedFound) {
+                suggestions = suggestions.concat(parsedSuggestions);
+                return {
+                    found: true,
+                    parsed: changedParsed,
+                    toBeParsed: changedToBeParsed,
+                    suggestions,
+                };
+            }
+            return this.parseArguments(args.slice(1), dynamicArguments, changedParsed, changedToBeParsed);
+        }
+
+        // Handling optional arguments. Optional argument can be inputted or not,
+        // so we have to pase both cases recursively and output combined suggestions.
+        const parsedArgument = this.parseArgument(args[0], dynamicArguments, parsed, toBeParsed);
+        let {
+            found: foundWithOptional,
+            parsed: changedParsedWithOptional,
+            toBeParsed: changedToBeParsedWithOptional,
+        } = parsedArgument;
+        const {suggestions: suggestionsWithOptional} = parsedArgument;
+        if (foundWithOptional) {
+            suggestions = suggestions.concat(suggestionsWithOptional);
+        } else {
+            const {
+                found: foundWithOptionalRest,
+                parsed: changedParsedWithOptionalRest,
+                toBeParsed: changedToBeParsedWithOptionalRest,
+                suggestions: suggestionsWithOptionalRest,
+            } = this.parseArguments(args.slice(1), dynamicArguments, changedParsedWithOptional, changedToBeParsedWithOptional);
+            if (foundWithOptionalRest) {
+                suggestions = suggestions.concat(suggestionsWithOptionalRest);
+            }
+            foundWithOptional = foundWithOptionalRest;
+            changedParsedWithOptional = changedParsedWithOptionalRest;
+            changedToBeParsedWithOptional = changedToBeParsedWithOptionalRest;
+        }
+
+        const {
+            found: foundWithoutOptional,
+            parsed: changedParsedWithoutOptional,
+            toBeParsed: changedToBeParsedWithoutOptional,
+            suggestions: suggestionsWithoutOptional,
+        } = this.parseArguments(args.slice(1), dynamicArguments, parsed, toBeParsed);
+        if (foundWithoutOptional) {
+            suggestions = suggestions.concat(suggestionsWithoutOptional);
+        }
+
+        // if suggestions were found we can return them
+        if (foundWithOptional || foundWithoutOptional) {
+            return {
+                found: true,
+                parsed: parsed + toBeParsed,
+                toBeParsed: '',
+                suggestions,
+            };
+        }
+
+        // no suggestions found yet, check if optional argument was inputted
+        if (changedParsedWithOptional !== parsed && changedToBeParsedWithOptional !== toBeParsed) {
+            return {
+                found: false,
+                parsed: changedParsedWithOptional,
+                toBeParsed: changedToBeParsedWithOptional,
+                suggestions,
+            };
+        }
+
+        // no suggestions and optional argument was not inputted
+        return {
+            found: foundWithoutOptional,
+            parsed: changedParsedWithoutOptional,
+            toBeParsed: changedToBeParsedWithoutOptional,
+            suggestions,
+        };
+    }
+
+    parseArgument = (arg, dynamicArguments, parsed, toBeParsed) => {
+        let suggestions = [];
+        let localParsed = parsed;
+        let localToBeParsed = toBeParsed;
+
+        if (!arg) {
+            return {
+                found: false,
+                parsed: localParsed,
+                toBeParsed: localToBeParsed,
+                suggestions: [],
+            };
+        }
+        if (arg.Name !== '') { //Parse the --name first
+            const {
+                found,
+                parsed: changedParsed,
+                toBeParsed: changedToBeParsed,
+                suggestion,
+            } = this.parseNamedArgument(arg, localParsed, localToBeParsed);
+            if (found) {
+                suggestions.push(suggestion);
+                return {
+                    found: true,
+                    parsed: changedParsed,
+                    toBeParsed: changedToBeParsed,
+                    suggestions,
+                };
+            }
+            if (changedToBeParsed === '') {
+                return {
+                    found: true,
+                    parsed: changedParsed,
+                    toBeParsed: changedToBeParsed,
+                    suggestions,
+                };
+            }
+            if (changedToBeParsed === ' ') {
+                localToBeParsed = '';
+            } else {
+                localToBeParsed = changedToBeParsed;
+            }
+            localParsed = changedParsed;
+        }
+
+        if (arg.Type === AUTOCOMPLETE_ARG.TEXT) {
+            const {
+                found,
+                parsed: changedParsed,
+                toBeParsed: changedToBeParsed,
+                suggestion,
+            } = this.parseInputTextArgument(arg, localParsed, localToBeParsed);
+            if (found) {
+                suggestions.push(suggestion);
+                return {
+                    found: true,
+                    parsed: changedParsed,
+                    toBeParsed: changedToBeParsed,
+                    suggestions,
+                };
+            }
+            localParsed = changedParsed;
+            localToBeParsed = changedToBeParsed;
+        } else if (arg.Type === AUTOCOMPLETE_ARG.STATIC_LIST) {
+            const {
+                found,
+                parsed: changedParsed,
+                toBeParsed: changedToBeParsed,
+                suggestions: staticListSuggestions,
+            } = this.parseStaticListArgument(arg, localParsed, localToBeParsed);
+            if (found) {
+                suggestions = suggestions.concat(staticListSuggestions);
+                return {
+                    found: true,
+                    parsed: changedParsed,
+                    toBeParsed: changedToBeParsed,
+                    suggestions,
+                };
+            }
+            localParsed = changedParsed;
+            localToBeParsed = changedToBeParsed;
+        } else if (arg.Type === AUTOCOMPLETE_ARG.DYNAMIC_LIST) {
+            const {
+                found,
+                parsed: changedParsed,
+                toBeParsed: changedToBeParsed,
+                suggestions: dynamicListSuggestions,
+            } = this.getDynamicListArgument(arg, dynamicArguments, localParsed, localToBeParsed);
+            if (found) {
+                suggestions = suggestions.concat(dynamicListSuggestions);
+                return {
+                    found: true,
+                    parsed: changedParsed,
+                    toBeParsed: changedToBeParsed,
+                    suggestions,
+                };
+            }
+            localParsed = changedParsed;
+            localToBeParsed = changedToBeParsed;
+        }
+
+        return {
+            found: false,
+            parsed: localParsed,
+            toBeParsed: localToBeParsed,
+            suggestions,
+        };
+    }
+
+    parseNamedArgument = (arg, parsed, toBeParsed) => {
+        if (!arg) {
+            return {
+                found: false,
+                parsed,
+                toBeParsed,
+                suggestion: {},
+            };
+        }
+        let inp = toBeParsed;
+        if (toBeParsed.startsWith(' ')) {
+            inp = toBeParsed.substring(1);
+        }
+        const namedArg = '--' + arg.Name;
+        if (inp === '') { //The user has not started typing the argument.
+            return {
+                found: true,
+                parsed: parsed + toBeParsed,
+                toBeParsed: '',
+                suggestion: {Complete: parsed + toBeParsed + namedArg + ' ', Suggestion: namedArg, Hint: '', Description: arg.HelpText},
+            };
+        }
+        if (namedArg.toLowerCase().startsWith(inp.toLowerCase())) {
+            return {
+                found: true,
+                parsed: parsed + toBeParsed,
+                toBeParsed: '',
+                suggestion: {Complete: parsed + toBeParsed + namedArg.substring(inp.length) + ' ', Suggestion: namedArg, Hint: '', Description: arg.HelpText},
+            };
+        }
+
+        if (!inp.toLowerCase().startsWith(namedArg.toLowerCase() + ' ')) {
+            return {
+                found: false,
+                parsed: parsed + toBeParsed,
+                toBeParsed: '',
+                suggestion: {},
+            };
+        }
+        if (inp.toLowerCase() === namedArg.toLowerCase() + ' ') {
+            return {
+                found: false,
+                parsed: parsed + namedArg + ' ',
+                toBeParsed: ' ',
+                suggestion: {},
+            };
+        }
+
+        return {
+            found: false,
+            parsed: parsed + namedArg + ' ',
+            toBeParsed: inp.substring(namedArg.length + 1),
+            suggestion: {},
+        };
+    }
+
+    parseInputTextArgument = (arg, parsed, toBeParsed) => {
+        if (!arg || !arg.Data) {
+            return {
+                found: false,
+                parsed,
+                toBeParsed,
+                suggestion: {},
+            };
+        }
+        let inp = toBeParsed;
+        if (toBeParsed.startsWith(' ')) {
+            inp = toBeParsed.slice(1);
+        }
+        const a = arg.Data;
+        if (inp === '') { //The user has not started typing the argument.
+            return {
+                found: true,
+                parsed: parsed + toBeParsed,
+                toBeParsed: '',
+                suggestion: {Complete: parsed + toBeParsed, Suggestion: '', Hint: a.Hint, Description: arg.HelpText},
+            };
+        }
+        if (inp[0] === '"') { //input with multiple words
+            const indexOfSecondQuote = inp.slice(1).indexOf('"');
+            if (indexOfSecondQuote === -1) { //typing of the multiple word argument is not finished
+                return {
+                    found: true,
+                    parsed: parsed + toBeParsed,
+                    toBeParsed: '',
+                    suggestion: {Complete: parsed + toBeParsed, Suggestion: '', Hint: a.Hint, Description: arg.HelpText},
+                };
+            }
+
+            // this argument is typed already
+            let offset = 2;
+            if (inp.length > indexOfSecondQuote + 2 && inp[indexOfSecondQuote + 2] === ' ') {
+                offset++;
+            }
+            return {
+                found: false,
+                parsed: parsed + inp.substring(0, indexOfSecondQuote + offset),
+                toBeParsed: inp.substring(indexOfSecondQuote + offset),
+                suggestion: {},
+            };
+        }
+
+        // input with a single word
+        const index = inp.indexOf(' ');
+        if (index === -1) { // typing of the single word argument is not finished
+            return {
+                found: true,
+                parsed: parsed + toBeParsed,
+                toBeParsed: '',
+                suggestion: {Complete: parsed + toBeParsed, Suggestion: '', Hint: a.Hint, Description: arg.HelpText},
+            };
+        }
+
+        // single word argument already typed
+        return {
+            found: false,
+            parsed: parsed + inp.substring(0, index + 1),
+            toBeParsed: inp.substring(index + 1),
+            suggestion: {},
+        };
+    }
+
+    parseStaticListArgument = (arg, parsed, toBeParsed) => {
+        if (!arg || !arg.Data || !arg.Data.PossibleArguments) {
+            return {
+                found: false,
+                parsed,
+                toBeParsed,
+                suggestion: [],
+            };
+        }
+        return this.parseListItems(arg.Data.PossibleArguments, parsed, toBeParsed);
+    }
+
+    getDynamicListArgument = (arg, dynamicArguments, parsed, toBeParsed) => {
+        if (!arg || !arg.Data) {
+            return {
+                found: false,
+                parsed,
+                toBeParsed,
+                suggestion: [],
+            };
+        }
+        const dynamicArg = arg.Data;
+        const autocompleteItems = dynamicArguments[dynamicArg.FetchURL];
+        this.updateDynamicAutocompleteSuggestions(dynamicArg.FetchURL, parsed, toBeParsed);
+
+        return this.parseListItems(autocompleteItems, parsed, toBeParsed);
+    }
+
+    parseListItems = (items, parsed, toBeParsed) => {
+        if (!items) {
+            return {
+                found: false,
+                parsed,
+                toBeParsed,
+                suggestions: [],
+            };
+        }
+        let inp = toBeParsed;
+        if (toBeParsed.startsWith(' ')) {
+            inp = toBeParsed.slice(1);
+        }
+        const suggestions = [];
+        let maxPrefix = '';
+        for (let i = 0; i < items.length; i++) {
+            if (inp.toLowerCase().startsWith(items[i].Item.toLowerCase() + ' ') && maxPrefix.length < items[i].Item.length + 1) {
+                maxPrefix = items[i].Item + ' ';
+            }
+        }
+
+        if (maxPrefix !== '') { //typing of an argument finished
+            return {
+                found: false,
+                parsed: parsed + inp.substring(0, maxPrefix.length),
+                toBeParsed: inp.substring(maxPrefix.length),
+                suggestions: [],
+            };
+        }
+
+        // user has not finished typing static argument
+        for (let i = 0; i < items.length; i++) {
+            if (items[i].Item.toLowerCase().startsWith(inp.toLowerCase())) {
+                suggestions.push({Complete: parsed + items[i].Item, Suggestion: items[i].Item, Hint: items[i].Hint, Description: items[i].HelpText});
+            }
+        }
+
+        return {
+            found: true,
+            parsed: parsed + toBeParsed,
+            toBeParsed: '',
+            suggestions,
+        };
+    }
+}

--- a/app/components/autocomplete/slash_suggestion/command_autocomplete/command_autocomplete.test.js
+++ b/app/components/autocomplete/slash_suggestion/command_autocomplete/command_autocomplete.test.js
@@ -1,0 +1,823 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import CommandAutocomplete, {AUTOCOMPLETE_ARG} from './command_autocomplete';
+
+describe('components/autocomplete/slash_suggestions/command_autocomplete', () => {
+    const commandAutocomplete = new CommandAutocomplete(null);
+
+    test('should parse input text argument', () => {
+        const argument = {
+            Name: '', //positional
+            HelpText: 'some_help',
+            Type: AUTOCOMPLETE_ARG.TEXT,
+            Data: {Hint: 'hint', Pattern: 'pat'},
+        };
+
+        let found;
+        let suggestion;
+        ({found, suggestion} = commandAutocomplete.parseInputTextArgument(argument, '', ''));
+        expect(found).toEqual(true);
+        expect(suggestion).toEqual({Complete: '', Suggestion: '', Hint: 'hint', Description: 'some_help'});
+
+        ({found, suggestion} = commandAutocomplete.parseInputTextArgument(argument, '', ' '));
+        expect(found).toEqual(true);
+        expect(suggestion).toEqual({Complete: ' ', Suggestion: '', Hint: 'hint', Description: 'some_help'});
+
+        ({found, suggestion} = commandAutocomplete.parseInputTextArgument(argument, '', 'abc'));
+        expect(found).toEqual(true);
+        expect(suggestion).toEqual({Complete: 'abc', Suggestion: '', Hint: 'hint', Description: 'some_help'});
+
+        ({found, suggestion} = commandAutocomplete.parseInputTextArgument(argument, '', '"abc dfd df '));
+        expect(found).toEqual(true);
+        expect(suggestion).toEqual({Complete: '"abc dfd df ', Suggestion: '', Hint: 'hint', Description: 'some_help'});
+
+        let parsed;
+        let toBeParsed;
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseInputTextArgument(argument, '', 'abc efg '));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('abc ');
+        expect(toBeParsed).toEqual('efg ');
+
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseInputTextArgument(argument, '', 'abc '));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('abc ');
+        expect(toBeParsed).toEqual('');
+
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseInputTextArgument(argument, '', '"abc def" abc'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('"abc def" ');
+        expect(toBeParsed).toEqual('abc');
+
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseInputTextArgument(argument, '', '"abc def"'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('"abc def"');
+        expect(toBeParsed).toEqual('');
+    });
+
+    test('should parse static list arguments', () => {
+        const items = {
+            Hint: '[hint]',
+            Item: 'on',
+            HelpText: 'help',
+        };
+        const argument = {
+            Name: '', //positional
+            HelpText: 'some_help',
+            Type: AUTOCOMPLETE_ARG.STATIC_LIST,
+            Data: {PossibleArguments: [items]},
+        };
+        let found;
+        let suggestions;
+        ({found, suggestions} = commandAutocomplete.parseStaticListArgument(argument, '', ''));
+        expect(found).toEqual(true);
+        expect(suggestions).toEqual([{Complete: 'on', Suggestion: 'on', Hint: '[hint]', Description: 'help'}]);
+
+        ({found, suggestions} = commandAutocomplete.parseStaticListArgument(argument, '', 'o'));
+        expect(found).toEqual(true);
+        expect(suggestions).toEqual([{Complete: 'on', Suggestion: 'on', Hint: '[hint]', Description: 'help'}]);
+
+        let parsed;
+        let toBeParsed;
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseStaticListArgument(argument, '', 'on '));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('on ');
+        expect(toBeParsed).toEqual('');
+
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseStaticListArgument(argument, '', 'on some'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('on ');
+        expect(toBeParsed).toEqual('some');
+
+        argument.Data.PossibleArguments.push({Hint: '[hint]', Item: 'off', HelpText: 'help'});
+
+        ({found, suggestions} = commandAutocomplete.parseStaticListArgument(argument, '', 'o'));
+        expect(found).toEqual(true);
+        expect(suggestions).toEqual([{Complete: 'on', Suggestion: 'on', Hint: '[hint]', Description: 'help'}, {Complete: 'off', Suggestion: 'off', Hint: '[hint]', Description: 'help'}]);
+
+        ({found, suggestions} = commandAutocomplete.parseStaticListArgument(argument, '', 'off'));
+        expect(found).toEqual(true);
+        expect(suggestions).toEqual([{Complete: 'off', Suggestion: 'off', Hint: '[hint]', Description: 'help'}]);
+
+        ({found, suggestions} = commandAutocomplete.parseStaticListArgument(argument, '', 'o some'));
+        expect(found).toEqual(true);
+        expect(suggestions).toEqual([]);
+
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseStaticListArgument(argument, '', 'off some'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('off ');
+        expect(toBeParsed).toEqual('some');
+
+        argument.Data.PossibleArguments.push({Hint: '[hint]', Item: 'onon', HelpText: 'help'});
+
+        ({found, suggestions} = commandAutocomplete.parseStaticListArgument(argument, '', 'on'));
+        expect(found).toEqual(true);
+        expect(suggestions).toEqual([{Complete: 'on', Suggestion: 'on', Hint: '[hint]', Description: 'help'}, {Complete: 'onon', Suggestion: 'onon', Hint: '[hint]', Description: 'help'}]);
+
+        ({found, suggestions} = commandAutocomplete.parseStaticListArgument(argument, 'bla ', 'ono'));
+        expect(found).toEqual(true);
+        expect(suggestions).toEqual([{Complete: 'bla onon', Suggestion: 'onon', Hint: '[hint]', Description: 'help'}]);
+
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseStaticListArgument(argument, '', 'on some'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('on ');
+        expect(toBeParsed).toEqual('some');
+
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseStaticListArgument(argument, '', 'onon some'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('onon ');
+        expect(toBeParsed).toEqual('some');
+    });
+
+    test('should parse static list arguments', () => {
+        const argument = {
+            Name: 'name', //named
+            HelpText: 'some_help',
+            Type: AUTOCOMPLETE_ARG.TEXT,
+            Data: {Hint: 'hint', Pattern: 'pat'},
+        };
+
+        let found;
+        let suggestion;
+        ({found, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', ''));
+        expect(found).toEqual(true);
+        expect(suggestion).toEqual({Complete: '--name ', Suggestion: '--name', Hint: '', Description: 'some_help'});
+
+        ({found, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', ' '));
+        expect(found).toEqual(true);
+        expect(suggestion).toEqual({Complete: ' --name ', Suggestion: '--name', Hint: '', Description: 'some_help'});
+
+        let parsed;
+        let toBeParsed;
+        ({found, parsed, toBeParsed} = commandAutocomplete.parseNamedArgument(argument, '', 'abc'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('abc');
+        expect(toBeParsed).toEqual('');
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', '-'));
+        expect(found).toEqual(true);
+        expect(parsed).toEqual('-');
+        expect(toBeParsed).toEqual('');
+        expect(suggestion).toEqual({Complete: '--name ', Suggestion: '--name', Hint: '', Description: 'some_help'});
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', ' -'));
+        expect(found).toEqual(true);
+        expect(parsed).toEqual(' -');
+        expect(toBeParsed).toEqual('');
+        expect(suggestion).toEqual({Complete: ' --name ', Suggestion: '--name', Hint: '', Description: 'some_help'});
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', '--name'));
+        expect(found).toEqual(true);
+        expect(parsed).toEqual('--name');
+        expect(toBeParsed).toEqual('');
+        expect(suggestion).toEqual({Complete: '--name ', Suggestion: '--name', Hint: '', Description: 'some_help'});
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', '--name bla'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('--name ');
+        expect(toBeParsed).toEqual('bla');
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', '--name bla gla'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('--name ');
+        expect(toBeParsed).toEqual('bla gla');
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', '--name "bla gla"'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('--name ');
+        expect(toBeParsed).toEqual('"bla gla"');
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', '--name "bla gla" '));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('--name ');
+        expect(toBeParsed).toEqual('"bla gla" ');
+
+        ({found, parsed, toBeParsed, suggestion} = commandAutocomplete.parseNamedArgument(argument, '', 'bla'));
+        expect(found).toEqual(false);
+        expect(parsed).toEqual('bla');
+        expect(toBeParsed).toEqual('');
+    });
+
+    test('should autocomplete command with optional args', () => {
+        const command = createCommandWithOptionalArgs();
+        let suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'comm');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: command.Trigger,
+            Suggestion: command.Trigger,
+            Hint: '',
+            Description: command.HelpText,
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command ');
+        expect(suggestions).toHaveLength(4);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand1',
+            Suggestion: 'subcommand1',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand2',
+            Suggestion: 'subcommand2',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[2]).toEqual({
+            Complete: 'command subcommand3',
+            Suggestion: 'subcommand3',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[3]).toEqual({
+            Complete: 'command subcommand4',
+            Suggestion: 'subcommand4',
+            Hint: '',
+            Description: 'help1',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand1 ');
+        expect(suggestions).toHaveLength(2);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand1 item1',
+            Suggestion: 'item1',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand1 item2',
+            Suggestion: 'item2',
+            Hint: '',
+            Description: '',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand1 item1 ');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand1 item1 --name2 ',
+            Suggestion: '--name2',
+            Hint: '',
+            Description: 'arg2',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand1 item1 --name2 bla');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand1 item1 --name2 bla',
+            Suggestion: '',
+            Hint: '',
+            Description: 'arg2',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand2 ');
+        expect(suggestions).toHaveLength(2);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand2 --name1 ',
+            Suggestion: '--name1',
+            Hint: '',
+            Description: 'arg1',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand2 ',
+            Suggestion: '',
+            Hint: '',
+            Description: 'arg2',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand2 -');
+        expect(suggestions).toHaveLength(2);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand2 --name1 ',
+            Suggestion: '--name1',
+            Hint: '',
+            Description: 'arg1',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand2 -',
+            Suggestion: '',
+            Hint: '',
+            Description: 'arg2',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand2 --name1 ');
+        expect(suggestions).toHaveLength(3);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand2 --name1 item1',
+            Suggestion: 'item1',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand2 --name1 item2',
+            Suggestion: 'item2',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[2]).toEqual({
+            Complete: 'command subcommand2 --name1 ',
+            Suggestion: '',
+            Hint: '',
+            Description: 'arg3',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand2 --name1 item');
+        expect(suggestions).toHaveLength(3);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand2 --name1 item1',
+            Suggestion: 'item1',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand2 --name1 item2',
+            Suggestion: 'item2',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[2]).toEqual({
+            Complete: 'command subcommand2 --name1 item',
+            Suggestion: '',
+            Hint: '',
+            Description: 'arg3',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand2 --name1 item1 ');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand2 --name1 item1 ',
+            Suggestion: '',
+            Hint: '',
+            Description: 'arg2',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand2 --name1 item1 bla ');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand2 --name1 item1 bla ',
+            Suggestion: '',
+            Hint: '',
+            Description: 'arg3',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand2 --name1 item1 bla bla ');
+        expect(suggestions).toHaveLength(0);
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand3 ');
+        expect(suggestions).toHaveLength(3);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand3 --name1 ',
+            Suggestion: '--name1',
+            Hint: '',
+            Description: 'arg1',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand3 --name2 ',
+            Suggestion: '--name2',
+            Hint: '',
+            Description: 'arg2',
+        });
+        expect(suggestions[2]).toEqual({
+            Complete: 'command subcommand3 --name3 ',
+            Suggestion: '--name3',
+            Hint: '',
+            Description: 'arg3',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand3 --name');
+        expect(suggestions).toHaveLength(3);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand3 --name1 ',
+            Suggestion: '--name1',
+            Hint: '',
+            Description: 'arg1',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand3 --name2 ',
+            Suggestion: '--name2',
+            Hint: '',
+            Description: 'arg2',
+        });
+        expect(suggestions[2]).toEqual({
+            Complete: 'command subcommand3 --name3 ',
+            Suggestion: '--name3',
+            Hint: '',
+            Description: 'arg3',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand3 --name1 ');
+        expect(suggestions).toHaveLength(2);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand3 --name1 item1',
+            Suggestion: 'item1',
+            Hint: '',
+            Description: '',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand3 --name1 item2',
+            Suggestion: 'item2',
+            Hint: '',
+            Description: '',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand4 ');
+        expect(suggestions).toHaveLength(2);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand4 item1',
+            Suggestion: 'item1',
+            Hint: '(optional)',
+            Description: 'help3',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'command subcommand4 ',
+            Suggestion: '',
+            Hint: 'message',
+            Description: 'help4',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([command], {}, '', 'command subcommand4 item1 ');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'command subcommand4 item1 ',
+            Suggestion: '',
+            Hint: 'message',
+            Description: 'help4',
+        });
+    });
+
+    test('should autocomplete jira command', () => {
+        const jira = createJiraAutocompleteData();
+        let suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'ji');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: jira.Trigger,
+            Suggestion: jira.Trigger,
+            Hint: jira.Hint,
+            Description: jira.HelpText,
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira crea');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira create',
+            Suggestion: 'create',
+            Hint: '[issue text]',
+            Description: 'Create a new Issue',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira c');
+        expect(suggestions).toHaveLength(2);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira connect',
+            Suggestion: 'connect',
+            Hint: '[url]',
+            Description: 'Connect',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'jira create',
+            Suggestion: 'create',
+            Hint: '[issue text]',
+            Description: 'Create a new Issue',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira create ');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira create ',
+            Suggestion: '',
+            Hint: '[text]',
+            Description: 'This text',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira create some');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira create some',
+            Suggestion: '',
+            Hint: '[text]',
+            Description: 'This text',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira create some text');
+        expect(suggestions).toHaveLength(0);
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira create "some text');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira create "some text',
+            Suggestion: '',
+            Hint: '[text]',
+            Description: 'This text',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'invalid command');
+        expect(suggestions).toHaveLength(0);
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira settings notifications O');
+        expect(suggestions).toHaveLength(2);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira settings notifications On',
+            Suggestion: 'On',
+            Hint: 'Turn notifications on',
+            Description: '',
+        });
+        expect(suggestions[1]).toEqual({
+            Complete: 'jira settings notifications Off',
+            Suggestion: 'Off',
+            Hint: 'Turn notifications off',
+            Description: '',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira ');
+        expect(suggestions).toHaveLength(9);
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira create "some issue text');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira create "some issue text',
+            Suggestion: '',
+            Hint: '[text]',
+            Description: 'This text',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira timezone ');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira timezone --zone ',
+            Suggestion: '--zone',
+            Hint: '',
+            Description: 'Set timezone',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira timezone --');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira timezone --zone ',
+            Suggestion: '--zone',
+            Hint: '',
+            Description: 'Set timezone',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira timezone --zone ');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira timezone --zone ',
+            Suggestion: '',
+            Hint: '[UTC+07:00]',
+            Description: 'Set timezone',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira timezone --zone bla');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toEqual({
+            Complete: 'jira timezone --zone bla',
+            Suggestion: '',
+            Hint: '[UTC+07:00]',
+            Description: 'Set timezone',
+        });
+
+        suggestions = commandAutocomplete.getSuggestions([jira], {}, '', 'jira timezone bla');
+        expect(suggestions).toHaveLength(0);
+    });
+
+    test('should autocomplete for multiple commands', () => {
+        const commandA = {
+            Trigger: 'commandA',
+            Hint: '',
+            HelpText: '',
+            Arguments: [],
+            SubCommands: [],
+        };
+        const commandB = {
+            Trigger: 'commandB',
+            Hint: '',
+            HelpText: '',
+            Arguments: [],
+            SubCommands: [],
+        };
+
+        const commandC = {
+            Trigger: 'commandC',
+            Hint: '',
+            HelpText: '',
+            Arguments: [],
+            SubCommands: [],
+        };
+        const suggestions = commandAutocomplete.getSuggestions([commandA, commandB, commandC], {}, '', 'comm');
+        expect(suggestions).toHaveLength(3);
+        expect(suggestions[0].Complete).toEqual('commandA');
+        expect(suggestions[1].Complete).toEqual('commandB');
+        expect(suggestions[2].Complete).toEqual('commandC');
+    });
+});
+
+function createCommandWithOptionalArgs() {
+    return {
+        Trigger: 'command',
+        Hint: '',
+        HelpText: '',
+        Arguments: [],
+        SubCommands: [{
+            Trigger: 'subcommand1',
+            Hint: '',
+            HelpText: '',
+            Arguments: [{
+                Name: '',
+                HelpText: 'arg1',
+                Type: AUTOCOMPLETE_ARG.STATIC_LIST,
+                Required: true,
+                Data: {PossibleArguments: [{Item: 'item1', Hint: '', HelpText: ''}, {Item: 'item2', Hint: '', HelpText: ''}]},
+            }, {
+                Name: 'name2',
+                HelpText: 'arg2',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: false,
+                Data: {Hint: '', Pattern: ''},
+            }],
+            SubCommands: [],
+        }, {
+            Trigger: 'subcommand2',
+            Hint: '',
+            HelpText: '',
+            Arguments: [{
+                Name: 'name1',
+                HelpText: 'arg1',
+                Type: AUTOCOMPLETE_ARG.STATIC_LIST,
+                Required: false,
+                Data: {PossibleArguments: [{Item: 'item1', Hint: '', HelpText: ''}, {Item: 'item2', Hint: '', HelpText: ''}]},
+            }, {
+                Name: '',
+                HelpText: 'arg2',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: true,
+                Data: {Hint: '', Pattern: ''},
+            }, {
+                Name: '',
+                HelpText: 'arg3',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: true,
+                Data: {Hint: '', Pattern: ''},
+            }],
+            SubCommands: [],
+        }, {
+            Trigger: 'subcommand3',
+            Hint: '',
+            HelpText: '',
+            Arguments: [{
+                Name: 'name1',
+                HelpText: 'arg1',
+                Type: AUTOCOMPLETE_ARG.STATIC_LIST,
+                Required: false,
+                Data: {PossibleArguments: [{Item: 'item1', Hint: '', HelpText: ''}, {Item: 'item2', Hint: '', HelpText: ''}]},
+            }, {
+                Name: 'name2',
+                HelpText: 'arg2',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: false,
+                Data: {Hint: '', Pattern: ''},
+            }, {
+                Name: 'name3',
+                HelpText: 'arg3',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: false,
+                Data: {Hint: '', Pattern: ''},
+            }],
+            SubCommands: [],
+        }, {
+            Trigger: 'subcommand4',
+            Hint: '',
+            HelpText: 'help1',
+            Arguments: [{
+                Name: '',
+                HelpText: 'help2',
+                Type: AUTOCOMPLETE_ARG.STATIC_LIST,
+                Required: false,
+                Data: {PossibleArguments: [{Item: 'item1', Hint: '(optional)', HelpText: 'help3'}]},
+            }, {
+                Name: '',
+                HelpText: 'help4',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: true,
+                Data: {Hint: 'message', Pattern: ''},
+            }],
+            SubCommands: [],
+        }],
+    };
+}
+
+function createJiraAutocompleteData() {
+    return {
+        Trigger: 'jira',
+        Hint: '[command]',
+        HelpText: 'Available commands:',
+        Arguments: [],
+        SubCommands: [{
+            Trigger: 'connect',
+            Hint: '[url]',
+            HelpText: 'Connect',
+            Arguments: [],
+            SubCommands: [],
+        }, {
+            Trigger: 'disconnect',
+            Hint: '',
+            HelpText: 'Disconnect',
+            Arguments: [],
+            SubCommands: [],
+        }, {
+            Trigger: 'assign',
+            Hint: '[issue]',
+            HelpText: 'Change the assignee',
+            Arguments: [{
+                Name: '',
+                HelpText: 'List of issues',
+                Type: AUTOCOMPLETE_ARG.DYNAMIC_LIST,
+                Required: true,
+                Data: {FetchURL: '/url/issue-key'},
+            }, {
+                Name: '',
+                HelpText: 'List of assignees',
+                Type: AUTOCOMPLETE_ARG.DYNAMIC_LIST,
+                Required: true,
+                Data: {FetchURL: '/url/assignee'},
+            }],
+            SubCommands: [],
+        }, {
+            Trigger: 'create',
+            Hint: '[issue text]',
+            HelpText: 'Create a new Issue',
+            Arguments: [{
+                Name: '',
+                HelpText: 'This text',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: true,
+                Data: {Hint: '[text]', Pattern: ''},
+            }],
+            SubCommands: [],
+        }, {
+            Trigger: 'transition',
+            Hint: '[issue]',
+            HelpText: 'Change the state',
+            Arguments: [{
+                Name: '',
+                HelpText: 'List of issues',
+                Type: AUTOCOMPLETE_ARG.DYNAMIC_LIST,
+                Required: true,
+                Data: {FetchURL: '/url/issue-key'},
+            }, {
+                Name: '',
+                HelpText: 'List of states',
+                Type: AUTOCOMPLETE_ARG.DYNAMIC_LIST,
+                Required: true,
+                Data: {FetchURL: '/url/states'},
+            }],
+            SubCommands: [],
+        }, {
+            Trigger: 'subscribe',
+            Hint: '',
+            HelpText: 'Configure the Jira',
+            Arguments: [],
+            SubCommands: [],
+        }, {
+            Trigger: 'view',
+            Hint: '[issue]',
+            HelpText: 'View the details',
+            Arguments: [{
+                Name: '',
+                HelpText: 'List of issues',
+                Type: AUTOCOMPLETE_ARG.DYNAMIC_LIST,
+                Required: true,
+                Data: {FetchURL: '/url/issue-key'},
+            }],
+            SubCommands: [],
+        }, {
+            Trigger: 'settings',
+            Hint: '',
+            HelpText: 'Update your user settings',
+            Arguments: [],
+            SubCommands: [{
+                Trigger: 'notifications',
+                Hint: '[on/off]',
+                HelpText: 'Turn notifications on or off',
+                Arguments: [{
+                    Name: '',
+                    HelpText: 'arg1',
+                    Type: AUTOCOMPLETE_ARG.STATIC_LIST,
+                    Required: false,
+                    Data: {PossibleArguments: [{Item: 'On', Hint: 'Turn notifications on', HelpText: ''}, {Item: 'Off', Hint: 'Turn notifications off', HelpText: ''}]},
+                }],
+                SubCommands: [],
+            }],
+        }, {
+            Trigger: 'timezone',
+            Hint: '',
+            HelpText: 'Update your timezone',
+            Arguments: [{
+                Name: 'zone',
+                HelpText: 'Set timezone',
+                Type: AUTOCOMPLETE_ARG.TEXT,
+                Required: true,
+                Data: {Hint: '[UTC+07:00]', Pattern: ''},
+            }],
+            SubCommands: [],
+        }],
+    };
+}

--- a/app/components/autocomplete/slash_suggestion/index.js
+++ b/app/components/autocomplete/slash_suggestion/index.js
@@ -5,8 +5,8 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 
-import {getAutocompleteCommands} from '@mm-redux/actions/integrations';
-import {getAutocompleteCommandsList} from '@mm-redux/selectors/entities/integrations';
+import {getAutocompleteCommands, getDynamicAutocompleteSuggestions} from '@mm-redux/actions/integrations';
+import {getAutocompleteCommandsList, getDynamicArguments} from '@mm-redux/selectors/entities/integrations';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from '@mm-redux/selectors/entities/teams';
 import {isLandscape} from 'app/selectors/device';
@@ -32,6 +32,7 @@ function mapStateToProps(state) {
         currentTeamId: getCurrentTeamId(state),
         theme: getTheme(state),
         isLandscape: isLandscape(state),
+        dynamicArguments: getDynamicArguments(state),
     };
 }
 
@@ -39,6 +40,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getAutocompleteCommands,
+            getDynamicAutocompleteSuggestions,
         }, dispatch),
     };
 }

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
@@ -15,13 +15,14 @@ export default class SlashSuggestionItem extends PureComponent {
         hint: PropTypes.string,
         onPress: PropTypes.func.isRequired,
         theme: PropTypes.object.isRequired,
-        trigger: PropTypes.string,
+        suggestion: PropTypes.string,
+        complete: PropTypes.string,
         isLandscape: PropTypes.bool.isRequired,
     };
 
     completeSuggestion = () => {
-        const {onPress, trigger} = this.props;
-        onPress(trigger);
+        const {onPress, complete} = this.props;
+        onPress(complete);
     };
 
     render() {
@@ -29,7 +30,7 @@ export default class SlashSuggestionItem extends PureComponent {
             description,
             hint,
             theme,
-            trigger,
+            suggestion,
             isLandscape,
         } = this.props;
 
@@ -41,7 +42,7 @@ export default class SlashSuggestionItem extends PureComponent {
                 style={[style.row, padding(isLandscape)]}
                 type={'opacity'}
             >
-                <Text style={style.suggestionName}>{`/${trigger} ${hint}`}</Text>
+                <Text style={style.suggestionName}>{`/${suggestion} ${hint}`}</Text>
                 <Text style={style.suggestionDescription}>{description}</Text>
             </TouchableWithFeedback>
         );

--- a/app/mm-redux/action_types/integrations.ts
+++ b/app/mm-redux/action_types/integrations.ts
@@ -15,6 +15,7 @@ export default keyMirror({
     RECEIVED_COMMANDS: null,
     RECEIVED_COMMAND_TOKEN: null,
     DELETED_COMMAND: null,
+    RECEIVED_DYNAMIC_SUGGESTIONS: null,
     RECEIVED_OAUTH_APP: null,
     RECEIVED_OAUTH_APPS: null,
     DELETED_OAUTH_APP: null,

--- a/app/mm-redux/actions/integrations.ts
+++ b/app/mm-redux/actions/integrations.ts
@@ -381,3 +381,22 @@ export function submitInteractiveDialog(submission: DialogSubmission): ActionFun
         return {data};
     };
 }
+
+export function getDynamicAutocompleteSuggestions(url: string, parsed: string, toBeParsed: string, teamId: string): ActionFunc {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        let data: any = null;
+        try {
+            data = await Client4.dynamicAutocompleteSuggestions(url, parsed, toBeParsed, teamId);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            dispatch(logError(error));
+            return {error};
+        }
+        dispatch({
+            type: IntegrationTypes.RECEIVED_DYNAMIC_SUGGESTIONS,
+            data,
+            id: url,
+        });
+        return {data};
+    };
+}

--- a/app/mm-redux/client/client4.ts
+++ b/app/mm-redux/client/client4.ts
@@ -2810,6 +2810,14 @@ export default class Client4 {
         );
     };
 
+    dynamicAutocompleteSuggestions = (url: string, parsed: string, toBeParsed: string, teamId: string) => {
+        const encodedURL = encodeURIComponent(url);
+        return this.doFetch(
+            `${this.getTeamRoute(teamId)}/commands/dynamic_autocomplete_suggestions${buildQueryString({url: encodedURL, parsed, toBeParsed})}`,
+            {method: 'get'},
+        );
+    }
+
     // Groups
 
     linkGroupSyncable = async (groupID: string, syncableID: string, syncableType: string, patch: SyncablePatch) => {

--- a/app/mm-redux/reducers/entities/integrations.ts
+++ b/app/mm-redux/reducers/entities/integrations.ts
@@ -4,7 +4,7 @@
 import {combineReducers} from 'redux';
 import {IntegrationTypes, ChannelTypes} from '@mm-redux/action_types';
 import {GenericAction} from '@mm-redux/types/actions';
-import {Command, IncomingWebhook, OutgoingWebhook, OAuthApp} from '@mm-redux/types/integrations';
+import {Command, IncomingWebhook, OutgoingWebhook, OAuthApp, AutocompleteListItems} from '@mm-redux/types/integrations';
 import {Dictionary, IDMappedObjects} from '@mm-redux/types/utilities';
 
 function incomingHooks(state: IDMappedObjects<IncomingWebhook> = {}, action: GenericAction) {
@@ -159,6 +159,20 @@ function systemCommands(state: IDMappedObjects<Command> = {}, action: GenericAct
     }
 }
 
+function dynamicArguments(state: IDMappedObjects<AutocompleteListItems> = {}, action: GenericAction) {
+    switch (action.type) {
+    case IntegrationTypes.RECEIVED_DYNAMIC_SUGGESTIONS: {
+        const nextState = {...state};
+        if (action.data) {
+            nextState[action.id] = action.data;
+        }
+        return nextState;
+    }
+    default:
+        return state;
+    }
+}
+
 function oauthApps(state: IDMappedObjects<OAuthApp> = {}, action: GenericAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OAUTH_APPS: {
@@ -218,6 +232,9 @@ export default combineReducers({
 
     // object to represent built-in slash commands
     systemCommands,
+
+    // object to represent slash commands' dynamic arguments
+    dynamicArguments,
 
     // trigger ID for interactive dialogs
     dialogTriggerId,

--- a/app/mm-redux/selectors/entities/integrations.ts
+++ b/app/mm-redux/selectors/entities/integrations.ts
@@ -26,6 +26,10 @@ export function getSystemCommands(state: types.store.GlobalState) {
     return state.entities.integrations.systemCommands;
 }
 
+export function getDynamicArguments(state: types.store.GlobalState) {
+    return state.entities.integrations.dynamicArguments;
+}
+
 /**
  * get outgoing hooks in current team
  */

--- a/app/mm-redux/types/integrations.ts
+++ b/app/mm-redux/types/integrations.ts
@@ -52,6 +52,20 @@ export type Command = {
     'description': string;
     'url': string;
 };
+
+// AutocompleteListItem represents plugin slash command dynamic argument's single suggestion
+export type AutocompleteListItem = {
+    'Item': string;
+    'Hint': string;
+    'HelpText': string;
+};
+
+// AutocompleteListItems represents plugin slash command dynamic argument's all suggestions.
+// Relative url of the dynamic argument(including the plugin id) is stored in the id field.
+export type AutocompleteListItems = {
+    'id': string;
+    'items': AutocompleteListItem[];
+}
 export type OAuthApp = {
     'id': string;
     'creator_id': string;
@@ -71,6 +85,10 @@ export type IntegrationsState = {
     oauthApps: IDMappedObjects<OAuthApp>;
     systemCommands: IDMappedObjects<Command>;
     commands: IDMappedObjects<Command>;
+
+    // dynamicArguments is a map saving slash commands' dynamic argument suggestions.
+    // Arguments are fetched from the plugins, cached and updated lazily(on demand) after x seconds.
+    dynamicArguments: IDMappedObjects<AutocompleteListItems>;
 };
 export type DialogSubmission = {
     url: string;


### PR DESCRIPTION
#### Summary
This PR will add support of the slash command autocomplete on mobile.
For server v5.24 it will autocomplete static arguments
For server v5.26 will autocomplete dynamic's too
For older versions nothing will be changed.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-25749


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: iphone 11, OS 13.5

#### Screenshots
![Simulator Screen Shot - iPhone 11 - 2020-06-26 at 00 17 09](https://user-images.githubusercontent.com/2340127/85791359-baec6300-b742-11ea-85d1-e00bf18ee7e6.png)

#### Related PRs:
server - https://github.com/mattermost/mattermost-server/pull/14915
api - https://github.com/mattermost/mattermost-api-reference/pull/536