### PR TITLE
Avoid throwing when purging

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -187,7 +187,7 @@ export default function configureStore(storage: any, preloadedState: any = {}, o
     const rootReducer: any = (state: GlobalState, action: GenericAction) => {
         if (action.type === General.OFFLINE_STORE_PURGE) {
             // eslint-disable-next-line no-underscore-dangle
-            if (action?.data?._persist) {
+            if (action.data?._persist) {
                 delete action?.data?._persist;
             }
             return baseReducer(action.data, action as any);

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -187,7 +187,9 @@ export default function configureStore(storage: any, preloadedState: any = {}, o
     const rootReducer: any = (state: GlobalState, action: GenericAction) => {
         if (action.type === General.OFFLINE_STORE_PURGE) {
             // eslint-disable-next-line no-underscore-dangle
-            delete action.data._persist;
+            if (action?.data?._persist) {
+                delete action?.data?._persist;
+            }
             return baseReducer(action.data, action as any);
         }
         return baseReducer(state as any, action as any);
@@ -230,7 +232,7 @@ export default function configureStore(storage: any, preloadedState: any = {}, o
 
             store.dispatch({
                 type: General.OFFLINE_STORE_PURGE,
-                state,
+                data: state,
             });
 
             console.log('HYDRATED FROM v4', storeKeys); // eslint-disable-line no-console


### PR DESCRIPTION
#### Summary
This PR fixes a bug when opening the app was causing an "Unexpected Error" because of a failed migration as the action executed after the migration did not include `data` but `state` as the action payload property.

#### Ticket Link
TBD