### PR TITLE
MM-26638 MM-26656 await when dismissing post options modal

### DIFF
--- a/app/screens/post_options/post_options.js
+++ b/app/screens/post_options/post_options.js
@@ -56,7 +56,7 @@ export default class PostOptions extends PureComponent {
     };
 
     close = async (cb) => {
-        dismissModal();
+        await dismissModal();
 
         if (typeof cb === 'function') {
             requestAnimationFrame(cb);
@@ -260,7 +260,7 @@ export default class PostOptions extends PureComponent {
                 onEmojiPress: this.handleAddReactionToPost,
             };
 
-            this.close(() => showModal(screen, title, passProps));
+            this.closeWithAnimation(() => showModal(screen, title, passProps));
         });
     };
 
@@ -362,7 +362,7 @@ export default class PostOptions extends PureComponent {
                 closeButton: source,
             };
 
-            this.close(() => showModal(screen, title, passProps));
+            this.closeWithAnimation(() => showModal(screen, title, passProps));
         });
     };
 


### PR DESCRIPTION
#### Summary
When the keyboard was previously opened there seems to be a race condition of some sort causing the newly "opened" screen to get closed immediately. By awaiting until the modal is dismissed, the new screens opens and remains opened.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26638
https://mattermost.atlassian.net/browse/MM-26656