### PR TITLE
MM-26667 Set EMM username as the initial loginId

### DIFF
--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -297,7 +297,8 @@ export default class Login extends PureComponent {
     setEmmUsernameIfAvailable = async () => {
         const managedConfig = await mattermostManaged.getConfig();
         if (managedConfig?.username && this.loginRef.current) {
-            this.loginRef.current.setNativeProps({text: managedConfig?.username});
+            this.loginRef.current.setNativeProps({text: managedConfig.username});
+            this.loginId = managedConfig.username;
         }
     }
 


### PR DESCRIPTION
#### Summary
When the username is being set by an EMM provider the TextInput value was being set but not the local variable used to set the username before executing the login flow, this PR makes sure both values are set


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26667