### PR TITLE
Wait for hydration before app launch

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -56,8 +56,8 @@ const launchApp = (credentials) => {
     ]);
 
     const store = Store.redux;
-    if (credentials) {
-        waitForHydration(store, async () => {
+    waitForHydration(store, async () => {
+        if (credentials) {
             const {previousVersion} = store.getState().app;
             const valid = validatePreviousVersion(previousVersion);
             if (valid) {
@@ -69,10 +69,10 @@ const launchApp = (credentials) => {
                 captureJSException(error, false, store);
                 store.dispatch(logout());
             }
-        });
-    } else {
-        resetToSelectServer(emmProvider.allowOtherServers);
-    }
+        } else {
+            resetToSelectServer(emmProvider.allowOtherServers);
+        }
+    });
 
     telemetry.startSinceLaunch(['start:splash_screen']);
     EphemeralStore.appStarted = true;


### PR DESCRIPTION
#### Summary
Make sure the redux store has been hydrated before switching to the start screen.

Test:
App should open and take you to either the channel screen if you are signed in or  to the server url screen.
If previously connected to a server when opening the app the previous server url should be in the input box on the server url screen.

Do test on first install and app upgrades.

#### Ticket Link
Based on https://community.mattermost.com/core/pl/bdx8nidq4fnijr69fzjjt13frc