### PR TITLE
MM-26722 check for switchKeyboardForCodeBlocks only on iOS 12+

### DIFF
--- a/app/utils/markdown.js
+++ b/app/utils/markdown.js
@@ -184,22 +184,25 @@ export function escapeRegex(text) {
 }
 
 export function switchKeyboardForCodeBlocks(value, cursorPosition) {
-    const regexForCodeBlock = /^```$(.*?)^```$|^```$(.*)/gms;
+    if (Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 12) {
+        const regexForCodeBlock = /^```$(.*?)^```$|^```$(.*)/gms;
 
-    const matches = [];
-    let nextMatch;
-    while ((nextMatch = regexForCodeBlock.exec(value)) !== null) {
-        matches.push({
-            startOfMatch: regexForCodeBlock.lastIndex - nextMatch[0].length,
-            endOfMatch: regexForCodeBlock.lastIndex + 1,
-        });
+        const matches = [];
+        let nextMatch;
+        while ((nextMatch = regexForCodeBlock.exec(value)) !== null) {
+            matches.push({
+                startOfMatch: regexForCodeBlock.lastIndex - nextMatch[0].length,
+                endOfMatch: regexForCodeBlock.lastIndex + 1,
+            });
+        }
+
+        const cursorIsInsideCodeBlock = matches.some((match) => cursorPosition >= match.startOfMatch && cursorPosition <= match.endOfMatch);
+
+        // 'email-address' keyboardType prevents iOS emdash autocorrect
+        if (cursorIsInsideCodeBlock) {
+            return 'email-address';
+        }
     }
 
-    const cursorIsInsideCodeBlock = matches.some((match) => cursorPosition >= match.startOfMatch && cursorPosition <= match.endOfMatch);
-
-    // 'email-address' keyboardType prevents iOS emdash autocorrect
-    if (cursorIsInsideCodeBlock) {
-        return 'email-address';
-    }
     return 'default';
 }

--- a/app/utils/markdown.test.js
+++ b/app/utils/markdown.test.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Platform} from 'react-native';
 import {switchKeyboardForCodeBlocks} from './markdown';
 
 describe('switchKeyboardForCodeBlocks', () => {
@@ -66,4 +67,12 @@ describe('switchKeyboardForCodeBlocks', () => {
             expect(switchKeyboardForCodeBlocks(testCase.value, testCase.cursorPosition)).toEqual(testCase.expected);
         });
     }
+});
+
+describe('switchKeyboardForCodeBlocks for iOS 11', () => {
+    it('Should return default keyboard', () => {
+        Platform.Version = 11;
+        expect(switchKeyboardForCodeBlocks('```\ntest\n```test', 12)).toEqual('default');
+        Platform.Version = 12;
+    });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -94,7 +94,11 @@ jest.doMock('react-native', () => {
     };
 
     return Object.setPrototypeOf({
-        Platform,
+        Platform: {
+            ...Platform,
+            OS: 'ios',
+            Version: 12,
+        },
         StyleSheet,
         ViewPropTypes,
         PermissionsAndroid,


### PR DESCRIPTION
#### Summary
The JSC that ships with iOS 11 or below does not support the regex to verify if the user is typing inside a code block. This PR disables the feature for iOS below v12

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26722

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator running 11.2