### PR TITLE
MM-26490 Dismiss keyboard when closing more dms / channels / create channel

### DIFF
--- a/app/screens/create_channel/create_channel.js
+++ b/app/screens/create_channel/create_channel.js
@@ -110,6 +110,7 @@ export default class CreateChannel extends PureComponent {
     }
 
     close = (goBack = false) => {
+        Keyboard.dismiss();
         if (goBack) {
             popTopScreen();
         } else {

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -4,7 +4,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
-import {Platform, View, Text} from 'react-native';
+import {Keyboard, Platform, View, Text} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import {Navigation} from 'react-native-navigation';
 
@@ -162,6 +162,7 @@ export default class MoreChannels extends PureComponent {
     };
 
     close = () => {
+        Keyboard.dismiss();
         dismissModal();
     };
 

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -4,7 +4,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {intlShape} from 'react-intl';
-import {Platform, View} from 'react-native';
+import {Keyboard, Platform, View} from 'react-native';
 import {Navigation} from 'react-native-navigation';
 
 import {debounce} from '@mm-redux/actions/helpers';
@@ -114,6 +114,7 @@ export default class MoreDirectMessages extends PureComponent {
     }
 
     close = () => {
+        Keyboard.dismiss();
         dismissModal();
     };
 


### PR DESCRIPTION
#### Summary
When dismissing the screen to add a DM/Group join a Public Channel or create a public/private channel if the keyboard is opened cause of having set the focus on any input field, the keyboard now dismisses when closing the screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26490
Fixes: https://github.com/mattermost/mattermost-mobile/issues/4471