### PR TITLE
DOPS-90 Add build for iPhone simulator to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,6 +368,31 @@ jobs:
       - save:
           filename: "Mattermost-unsigned.ipa"
 
+  build-ios-iphonesimulator:
+    executor: ios
+    steps:
+      - checkout:
+          path: ~/mattermost-mobile
+      - ruby-setup
+      - npm-dependencies
+      - pods-dependencies
+      - assets
+      - fastlane-dependencies:
+          for: ios
+      - run:
+          working_directory: fastlane
+          name: Run fastlane to build unsigned x86_64 iOS app for iPhone simulator
+          no_output_timeout: 30m
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install watchman
+            bundle exec fastlane ios iphonesimulator
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - mattermost-mobile/Mattermost-simulator-x86_64.app.zip
+      - save:
+          filename: "Mattermost-simulator-x86_64.app.zip"
+
   deploy-android-release:
     executor:
       name: android
@@ -548,11 +573,23 @@ workflows:
               only: /^v(\d+\.)(\d+\.)(\d+)(.*)?$/
             branches:
               only: unsigned
+      - build-ios-iphonesimulator:
+          context: mattermost-mobile-unsigned
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v(\d+\.)(\d+\.)(\d+)(.*)?$/
+            only:
+                - unsigned
+                - /^iphonesimulator-.*/
+                
       - github-release:
           context: mattermost-mobile-unsigned
           requires:
             - build-android-unsigned
             - build-ios-unsigned
+            - build-ios-iphonesimulator
           filters:
             tags:
               only: /^v(\d+\.)(\d+\.)(\d+)(.*)?$/

--- a/Makefile
+++ b/Makefile
@@ -188,13 +188,7 @@ unsigned-ios: stop pre-build check-style ## Build an unsigned version of the iOS
 ios-sim-x86_64: stop pre-build check-style ## Build an unsigned x86_64 version of the iOS app for iPhone simulator
 	$(call start_packager)
 	@echo "Building unsigned x86_64 iOS app for iPhone simulator"
-	@cd fastlane && NODE_ENV=production bundle exec fastlane ios unsigned
-	@mkdir -p build-ios
-	@cd ios/ && xcodebuild -workspace Mattermost.xcworkspace/ -scheme Mattermost -arch x86_64 -sdk iphonesimulator -configuration Release -parallelizeTargets -resultBundlePath ../build-ios/result -derivedDataPath ../build-ios/ ENABLE_BITCODE=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENABLE_BITCODE=NO
-	@cd build-ios/Build/Products/Release-iphonesimulator/ && zip -r Mattermost-simulator-x86_64.app.zip Mattermost.app/
-	@mv build-ios/Build/Products/Release-iphonesimulator/Mattermost-simulator-x86_64.app.zip .
-	@rm -rf build-ios/
-	@cd fastlane && bundle exec fastlane upload_file_to_s3 file:Mattermost-simulator-x86_64.app.zip os_type:iOS
+	@cd fastlane && NODE_ENV=production bundle exec fastlane ios iphonesimulator
 	$(call stop_packager)
 
 unsigned-android: stop pre-build check-style prepare-android-build ## Build an unsigned version of the Android app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -294,7 +294,7 @@ lane :github do
       name: "Mobile Version #{version}",
       tag_name: tag,
       description: changelog,
-      upload_assets: ["./Mattermost-unsigned.ipa", "./Mattermost-unsigned.apk"],
+      upload_assets: ["./Mattermost-unsigned.ipa", "./Mattermost-unsigned.apk", "./Mattermost-simulator-x86_64.app.zip],
       is_draft: true
     )
   end
@@ -344,6 +344,26 @@ platform :ios do
     sh 'cd ../build-ios/ && mkdir -p Payload && cp -R Build/Products/Release-iphoneos/Mattermost.app Payload/ && zip -r Mattermost-unsigned.ipa Payload/'
     sh 'mv ../build-ios/Mattermost-unsigned.ipa ../'
     sh 'rm -rf ../build-ios/'
+  end
+
+  lane :iphonesimulator do
+    UI.success('Building iOS app for simulator')
+
+    ENV['APP_NAME'] = 'Mattermost'
+    ENV['REPLACE_ASSETS'] = 'true'
+    ENV['BUILD_FOR_RELEASE'] = 'true'
+    ENV['APP_SCHEME'] = 'mattermost-mobile'
+
+    update_identifiers
+    replace_assets
+
+    sh 'cd ../ios && xcodebuild -workspace Mattermost.xcworkspace -scheme Mattermost -arch x86_64 -sdk iphonesimulator -configuration Release -parallelizeTargets -derivedDataPath ../build-ios ENABLE_BITCODE=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENABLE_BITCODE=NO'
+    sh 'cd ../ios/Build/Products/Release-iphonesimulator && zip -r Mattermost-simulator-x86_64.app.zip Mattermost.app'
+    upload_file_to_s3({
+      :os_type => "iOS",
+      :file => "Mattermost-simulator-x86_64.app.zip"
+    })
+	  sh 'mv ../ios/Build/Products/Release-iphonesimulator/Mattermost-simulator-x86_64.app.zip ../'
   end
 
   lane :update_identifiers do


### PR DESCRIPTION
#### Summary
iOS build for iPhone simulator is primarily used for RainforestQA and will eventually consume for in-house mobile UI automation. This PR includes build steps to build and ability to include in Github release.

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/DOPS-90
