### PR TITLE
MM-26749 Fix race condition when open from PN

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -133,7 +133,7 @@ export function handleSelectTeamAndChannel(teamId, channelId) {
         }
 
         // eslint-disable-next-line no-console
-        console.log('channel switch from push notification to', channel?.display_name, (Date.now() - dt), 'ms');
+        console.log('channel switch from push notification to', channel?.display_name || channel?.id, (Date.now() - dt), 'ms');
     };
 }
 

--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -13,7 +13,6 @@ import {getMyTeams, getMyTeamMembers} from '@mm-redux/actions/teams';
 import {Client4} from '@mm-redux/client';
 import {General} from '@mm-redux/constants';
 import EventEmitter from '@mm-redux/utils/event_emitter';
-import EphemeralStore from '@store/ephemeral_store';
 import initialState from '@store/initial_state';
 import {getStateForReset} from '@store/utils';
 
@@ -133,9 +132,8 @@ export function handleSelectTeamAndChannel(teamId, channelId) {
             dispatch(batchActions(actions, 'BATCH_SELECT_TEAM_AND_CHANNEL'));
         }
 
-        EphemeralStore.setStartFromNotification(false);
-
-        console.log('channel switch from push notification to', channel?.display_name, (Date.now() - dt), 'ms'); //eslint-disable-line
+        // eslint-disable-next-line no-console
+        console.log('channel switch from push notification to', channel?.display_name, (Date.now() - dt), 'ms');
     };
 }
 

--- a/app/init/push_notifications.js
+++ b/app/init/push_notifications.js
@@ -39,8 +39,8 @@ class PushNotificationUtils {
         this.replyNotificationData = null;
     }
 
-    configure = () => {
-        PushNotifications.configure({
+    configure = async () => {
+        return PushNotifications.configure({
             onRegister: this.onRegisterDevice,
             onNotification: this.onPushNotification,
             onReply: this.onPushNotificationReply,

--- a/app/init/push_notifications.js
+++ b/app/init/push_notifications.js
@@ -50,8 +50,6 @@ class PushNotificationUtils {
     };
 
     loadFromNotification = async (notification) => {
-        // Set appStartedFromPushNotification to avoid channel screen to call selectInitialChannel
-        EphemeralStore.setStartFromNotification(true);
         await Store.redux.dispatch(loadFromPushNotification(notification));
 
         // if we have a componentId means that the app is already initialized

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -63,6 +63,8 @@ const launchApp = (credentials) => {
             if (valid) {
                 store.dispatch(loadMe());
                 await globalEventHandler.configureAnalytics();
+                // eslint-disable-next-line no-console
+                console.log('Launch app in Channel screen');
                 resetToChannel({skipMetrics: true});
             } else {
                 const error = new Error(`Previous app version "${previousVersion}" is invalid.`);

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -29,15 +29,15 @@ import {captureJSException} from '@utils/sentry';
 
 const init = async () => {
     const credentials = await getAppCredentials();
-    const MMKVStorage = await getStorage();
-
-    const {store} = configureStore(MMKVStorage);
     if (EphemeralStore.appStarted) {
         launchApp(credentials);
         return;
     }
 
-    pushNotifications.configure();
+    const MMKVStorage = await getStorage();
+    const {store} = configureStore(MMKVStorage);
+
+    await pushNotifications.configure();
     globalEventHandler.configure({
         launchApp,
     });

--- a/app/push_notifications/push_notifications.android.js
+++ b/app/push_notifications/push_notifications.android.js
@@ -31,6 +31,7 @@ class PushNotification {
 
         NotificationsAndroid.setNotificationOpenedListener((notification) => {
             if (notification) {
+                EphemeralStore.setStartFromNotification(true);
                 const data = notification.getData();
                 this.handleNotification(data, true);
             }
@@ -65,7 +66,7 @@ class PushNotification {
                     if (notification) {
                         const data = notification.getData();
                         if (data) {
-                            EphemeralStore.appStartedFromPushNotification = true;
+                            EphemeralStore.setStartFromNotification(true);
                             this.handleNotification(data, true);
                         }
                     }

--- a/app/push_notifications/push_notifications.ios.js
+++ b/app/push_notifications/push_notifications.ios.js
@@ -51,7 +51,12 @@ class PushNotification {
 
         this.requestNotificationReplyPermissions();
 
-        if (options.popInitialNotification) {
+        return new Promise((resolve) => {
+            if (!options.popInitialNotification) {
+                resolve();
+                return;
+            }
+
             NotificationsIOS.getInitialNotification().
                 then((notification) => {
                     if (notification) {
@@ -64,8 +69,11 @@ class PushNotification {
                 }).
                 catch((err) => {
                     console.log('iOS getInitialNotifiation() failed', err); //eslint-disable-line no-console
+                }).
+                finally(() => {
+                    resolve();
                 });
-        }
+        });
     }
 
     requestNotificationReplyPermissions = () => {

--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -184,7 +184,11 @@ export default class ChannelBase extends PureComponent {
 
     loadChannels = (teamId) => {
         const {loadChannelsForTeam, selectInitialChannel} = this.props.actions;
-        if (!EphemeralStore.getStartFromNotification()) {
+        if (EphemeralStore.getStartFromNotification()) {
+            // eslint-disable-next-line no-console
+            console.log('Switch to channel from a push notification');
+            EphemeralStore.setStartFromNotification(false);
+        } else {
             loadChannelsForTeam(teamId).then((result) => {
                 if (result?.error) {
                     this.setState({channelsRequestFailed: true});


### PR DESCRIPTION
#### Summary
Currently there is a race condition when loading the channel from the push notification finishes before loading the channel screen and so because the `EphemeralStore` flag for **startFromNotification**  is set to false before it reaches the ` loadChannels` methods we are switching back to the "last" channel you were in.

This was happening for both Android and iOS and reproducing is not consistent hence the race condition.
Happened on:
* Opening the app from cold start
* With the app in the background and receiving a notification on different team than the current one visible in the app.

In this PR we set the flag after the channel screen has been loaded instead of doing that at the action level.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26749