### PR TITLE
Fix unhandled exception when current user is not defined

### DIFF
--- a/app/components/post_draft/index.js
+++ b/app/components/post_draft/index.js
@@ -68,12 +68,19 @@ export function mapStateToProps(state, ownProps) {
         );
     }
 
+    const channelId = ownProps.channelId || (currentChannel ? currentChannel.id : '');
+
+    let channelIsReadOnly = false;
+    if (currentUserId && channelId) {
+        channelIsReadOnly = isCurrentChannelReadOnly(state) || false;
+    }
+
     return {
         canPost,
         channelDisplayName: state.views.channel.displayName || (currentChannel ? currentChannel.display_name : ''),
-        channelId: ownProps.channelId || (currentChannel ? currentChannel.id : ''),
+        channelId,
         channelIsArchived: ownProps.channelIsArchived || (currentChannel ? currentChannel.delete_at !== 0 : false),
-        channelIsReadOnly: isCurrentChannelReadOnly(state) || false,
+        channelIsReadOnly,
         currentUserId,
         deactivatedChannel,
         enableConfirmNotificationsToChannel,

--- a/app/mm-redux/selectors/entities/users.ts
+++ b/app/mm-redux/selectors/entities/users.ts
@@ -92,7 +92,7 @@ export function getUserByEmail(state: GlobalState, email: $Email<UserProfile>): 
 export const isCurrentUserSystemAdmin: (a: GlobalState) => boolean = createSelector(
     getCurrentUser,
     (user) => {
-        const roles = user.roles || '';
+        const roles = user?.roles || '';
         return isSystemAdmin(roles);
     },
 );

--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -67,9 +67,9 @@ function mapStateToProps(state) {
     const favoriteChannels = getSortedFavoriteChannelIds(state);
     const isCurrent = currentChannel.id === state.entities.channels.currentChannelId;
     const isFavorite = favoriteChannels && favoriteChannels.indexOf(currentChannel.id) > -1;
-    const roles = getCurrentUserRoles(state);
+    const roles = getCurrentUserRoles(state) || '';
     const {serverVersion} = state.entities.general;
-    let canManageUsers = currentChannel.hasOwnProperty('id') ? canManageChannelMembers(state) : false;
+    let canManageUsers = currentChannel.id ? canManageChannelMembers(state) : false;
     if (currentChannel.group_constrained) {
         canManageUsers = false;
     }
@@ -96,7 +96,11 @@ function mapStateToProps(state) {
     const isChannelAdmin = checkIsChannelAdmin(roles);
     const isSystemAdmin = checkIsSystemAdmin(roles);
 
-    const channelIsReadOnly = isCurrentChannelReadOnly(state);
+    let channelIsReadOnly = false;
+    if (currentUserId && currentChannel.id) {
+        channelIsReadOnly = isCurrentChannelReadOnly(state) || false;
+    }
+
     const canEditChannel = !channelIsReadOnly && showManagementOptions(state, config, license, currentChannel, isAdmin, isSystemAdmin, isChannelAdmin);
     const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
 


### PR DESCRIPTION
#### Summary
The selector for `isCurrentChannelReadOnly` relies on the currentUser being set, when this selector runs while logging out, the currentUser will be `undefined` leading to an unhandled exception.

No test needed: This only adds defensive code.

#### Ticket Link
TBD