### PR TITLE
[MM-26855] Ensure More Messages button works as expected when app is launched from a push notification

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -16,7 +16,7 @@ import EventEmitter from '@mm-redux/utils/event_emitter';
 import initialState from '@store/initial_state';
 import {getStateForReset} from '@store/utils';
 
-import {markChannelViewedAndRead} from './channel';
+import {markAsViewedAndReadBatch} from './channel';
 
 export function startDataCleanup() {
     return async (dispatch, getState) => {
@@ -107,7 +107,7 @@ export function handleSelectTeamAndChannel(teamId, channelId) {
         const {currentTeamId} = state.entities.teams;
         const channel = channels[channelId];
         const member = myMembers[channelId];
-        const actions = [];
+        const actions = markAsViewedAndReadBatch(state, channelId);
 
         // when the notification is from a team other than the current team
         if (teamId !== currentTeamId) {
@@ -124,8 +124,6 @@ export function handleSelectTeamAndChannel(teamId, channelId) {
                     teamId: channel.team_id || currentTeamId,
                 },
             });
-
-            dispatch(markChannelViewedAndRead(channelId));
         }
 
         if (actions.length) {

--- a/app/components/post_list/more_messages_button/index.js
+++ b/app/components/post_list/more_messages_button/index.js
@@ -3,6 +3,8 @@
 
 import {connect} from 'react-redux';
 
+import {resetUnreadMessageCount} from '@actions/views/channel';
+
 import MoreMessagesButton from './more_messages_button';
 
 function mapStateToProps(state, ownProps) {
@@ -18,4 +20,8 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-export default connect(mapStateToProps)(MoreMessagesButton);
+const mapDispatchToProps = {
+    resetUnreadMessageCount,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(MoreMessagesButton);

--- a/app/components/post_list/more_messages_button/more_messages_button.js
+++ b/app/components/post_list/more_messages_button/more_messages_button.js
@@ -262,13 +262,10 @@ export default class MoreMessageButton extends React.PureComponent {
     showMoreText = (readCount) => {
         const moreCount = this.props.unreadCount - readCount;
 
-        if (moreCount <= 0) {
-            this.cancel(true);
-            return;
+        if (moreCount > 0) {
+            const moreText = this.moreText(moreCount);
+            this.setState({moreText}, this.show);
         }
-
-        const moreText = this.moreText(moreCount);
-        this.setState({moreText}, this.show);
     }
 
     getReadCount = (lastViewableIndex) => {

--- a/app/components/post_list/more_messages_button/more_messages_button.test.js
+++ b/app/components/post_list/more_messages_button/more_messages_button.test.js
@@ -774,21 +774,19 @@ describe('MoreMessagesButton', () => {
             jest.clearAllMocks();
         });
 
-        it('should force cancel when props.unreadCount - readCount is <= 0', () => {
+        it('should not set moreText when props.unreadCount - readCount is <= 0', () => {
             let readCount = props.unreadCount + 1;
             instance.showMoreText(readCount);
-            expect(instance.cancel).toHaveBeenCalledTimes(1);
-            expect(instance.cancel.mock.calls[0][0]).toBe(true);
             expect(instance.moreText).not.toHaveBeenCalled();
             expect(instance.setState).not.toHaveBeenCalled();
 
             readCount = props.unreadCount;
             instance.showMoreText(readCount);
-            expect(instance.cancel).toHaveBeenCalledTimes(2);
-            expect(instance.cancel.mock.calls[1][0]).toBe(true);
+            expect(instance.moreText).not.toHaveBeenCalled();
+            expect(instance.setState).not.toHaveBeenCalled();
         });
 
-        it('should set moreTextd when props.unreadCount - readCount is > 0', () => {
+        it('should set moreText when props.unreadCount - readCount is > 0', () => {
             const moreCount = 1;
             const readCount = props.unreadCount - moreCount;
             instance.showMoreText(readCount);

--- a/app/components/post_list/more_messages_button/more_messages_button.test.js
+++ b/app/components/post_list/more_messages_button/more_messages_button.test.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Animated} from 'react-native';
+import {Animated, AppState} from 'react-native';
 import {shallowWithIntl} from 'test/intl-test-helper';
 
 import Preferences from '@mm-redux/constants/preferences';
@@ -28,6 +28,7 @@ describe('MoreMessagesButton', () => {
         manuallyUnread: false,
         newMessageLineIndex: 0,
         scrollToIndex: jest.fn(),
+        resetUnreadMessageCount: jest.fn(),
         registerViewableItemsListener: jest.fn(() => {
             return jest.fn();
         }),
@@ -54,12 +55,16 @@ describe('MoreMessagesButton', () => {
     });
 
     describe('lifecycle methods', () => {
-        test('componentDidMount should register indicator visibility listener, viewable items listener, and scroll end index listener', () => {
+        AppState.addEventListener = jest.fn();
+        AppState.removeEventListener = jest.fn();
+
+        test('componentDidMount should register app state listener, indicator visibility listener, viewable items listener, and scroll end index listener', () => {
             EventEmitter.on = jest.fn();
             const wrapper = shallowWithIntl(
                 <MoreMessagesButton {...baseProps}/>,
             );
             const instance = wrapper.instance();
+            instance.onAppStateChange = jest.fn();
             instance.onIndicatorBarVisible = jest.fn();
             instance.onViewableItemsChanged = jest.fn();
             instance.onScrollEndIndex = jest.fn();
@@ -69,6 +74,7 @@ describe('MoreMessagesButton', () => {
             // have not yet been mocked so we call componentDidMount again.
             instance.componentDidMount();
 
+            expect(AppState.addEventListener).toHaveBeenCalledWith('change', instance.onAppStateChange);
             expect(EventEmitter.on).toHaveBeenCalledWith(ViewTypes.INDICATOR_BAR_VISIBLE, instance.onIndicatorBarVisible);
             expect(baseProps.registerViewableItemsListener).toHaveBeenCalledWith(instance.onViewableItemsChanged);
             expect(instance.removeViewableItemsListener).toBeDefined();
@@ -76,18 +82,20 @@ describe('MoreMessagesButton', () => {
             expect(instance.removeScrollEndIndexListener).toBeDefined();
         });
 
-        test('componentWillUnmount should remove the indicator bar visible listener, the viewable items listener, the scroll end index listener, and clear all timers', () => {
+        test('componentWillUnmount should remove the app state listener, the indicator bar visible listener, the viewable items listener, the scroll end index listener, and clear all timers', () => {
             jest.useFakeTimers();
             EventEmitter.off = jest.fn();
             const wrapper = shallowWithIntl(
                 <MoreMessagesButton {...baseProps}/>,
             );
             const instance = wrapper.instance();
+            instance.onAppStateChange = jest.fn();
             instance.onIndicatorBarVisible = jest.fn();
             instance.removeViewableItemsListener = jest.fn();
             instance.removeScrollEndIndexListener = jest.fn();
 
             instance.componentWillUnmount();
+            expect(AppState.removeEventListener).toHaveBeenCalledWith('change', instance.onAppStateChange);
             expect(EventEmitter.off).toHaveBeenCalledWith(ViewTypes.INDICATOR_BAR_VISIBLE, instance.onIndicatorBarVisible);
             expect(instance.removeViewableItemsListener).toHaveBeenCalled();
             expect(instance.removeScrollEndIndexListener).toHaveBeenCalled();
@@ -216,6 +224,52 @@ describe('MoreMessagesButton', () => {
 
             wrapper.setProps({unreadCount: 2});
             expect(instance.onViewableItemsChanged).toHaveBeenCalledTimes(1);
+        });
+
+        test('componentDidUpdate should call hide when the unreadCount decreases to 0', () => {
+            const wrapper = shallowWithIntl(
+                <MoreMessagesButton {...baseProps}/>,
+            );
+            const instance = wrapper.instance();
+            instance.hide = jest.fn();
+            instance.viewableItems = [{index: 1}];
+
+            wrapper.setProps({unreadCount: 2});
+            expect(instance.hide).not.toHaveBeenCalled();
+
+            wrapper.setProps({unreadCount: 1});
+            expect(instance.hide).not.toHaveBeenCalled();
+
+            wrapper.setProps({unreadCount: 0});
+            expect(instance.hide).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('onAppStateChange', () => {
+        it('should call resetUnreadMessageCount when app state is not active', () => {
+            const wrapper = shallowWithIntl(
+                <MoreMessagesButton {...baseProps}/>,
+            );
+            const instance = wrapper.instance();
+
+            let appState = 'active';
+            instance.onAppStateChange(appState);
+            expect(baseProps.resetUnreadMessageCount).not.toHaveBeenCalled();
+
+            appState = 'inactive';
+            instance.onAppStateChange(appState);
+            expect(baseProps.resetUnreadMessageCount).toHaveBeenCalledTimes(1);
+            expect(baseProps.resetUnreadMessageCount).toHaveBeenCalledWith(baseProps.channelId);
+
+            appState = 'background';
+            instance.onAppStateChange(appState);
+            expect(baseProps.resetUnreadMessageCount).toHaveBeenCalledTimes(2);
+            expect(baseProps.resetUnreadMessageCount).toHaveBeenCalledWith(baseProps.channelId);
+
+            appState = '';
+            instance.onAppStateChange(appState);
+            expect(baseProps.resetUnreadMessageCount).toHaveBeenCalledTimes(3);
+            expect(baseProps.resetUnreadMessageCount).toHaveBeenCalledWith(baseProps.channelId);
         });
     });
 
@@ -566,18 +620,6 @@ describe('MoreMessagesButton', () => {
             const viewableItems = [{index: 0}, {index: 1}];
 
             wrapper.setProps({newMessageLineIndex: 0});
-            instance.onViewableItemsChanged(viewableItems);
-            expect(clearTimeout).not.toHaveBeenCalled();
-
-            wrapper.setProps({newMessageLineIndex: -1});
-            instance.onViewableItemsChanged(viewableItems);
-            expect(clearTimeout).not.toHaveBeenCalled();
-        });
-
-        it('should return early when unreadCount is 0', () => {
-            const viewableItems = [{index: 0}, {index: 1}];
-
-            wrapper.setProps({newMessageLineIndex: 1, unreadCount: 0});
             instance.onViewableItemsChanged(viewableItems);
             expect(clearTimeout).not.toHaveBeenCalled();
 

--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -34,7 +34,6 @@ export default class ChannelBase extends PureComponent {
             selectDefaultTeam: PropTypes.func.isRequired,
             selectInitialChannel: PropTypes.func.isRequired,
             recordLoadTime: PropTypes.func.isRequired,
-            resetUnreadMessageCount: PropTypes.func.isRequired,
         }).isRequired,
         componentId: PropTypes.string.isRequired,
         currentChannelId: PropTypes.string,
@@ -90,7 +89,6 @@ export default class ChannelBase extends PureComponent {
         }
 
         if (currentChannelId) {
-            actions.resetUnreadMessageCount(this.props.currentChannelId);
             PushNotifications.clearChannelNotifications(currentChannelId);
             requestAnimationFrame(() => {
                 actions.getChannelStats(currentChannelId);

--- a/app/screens/channel/channel_base.test.js
+++ b/app/screens/channel/channel_base.test.js
@@ -27,7 +27,6 @@ describe('ChannelBase', () => {
             recordLoadTime: jest.fn(),
             selectDefaultTeam: jest.fn(),
             selectInitialChannel: jest.fn(),
-            resetUnreadMessageCount: jest.fn(),
         },
         componentId: channelBaseComponentId,
         theme: Preferences.THEMES.default,

--- a/app/screens/channel/index.js
+++ b/app/screens/channel/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {loadChannelsForTeam, selectInitialChannel, resetUnreadMessageCount} from '@actions/views/channel';
+import {loadChannelsForTeam, selectInitialChannel} from '@actions/views/channel';
 import {recordLoadTime} from '@actions/views/root';
 import {selectDefaultTeam} from '@actions/views/select_team';
 import {ViewTypes} from '@constants';
@@ -52,7 +52,6 @@ function mapDispatchToProps(dispatch) {
             selectDefaultTeam,
             selectInitialChannel,
             recordLoadTime,
-            resetUnreadMessageCount,
         }, dispatch),
     };
 }


### PR DESCRIPTION

#### Summary
Resetting of the unread count was previously done on MoreMessages mount. This was to ensure that the unread count was reset if you exited the app and re-launched it in the same channel. This didn't work well when launching the app from a push notification so we now reset the unread count when the app becomes inactive. Other changes include hiding the more messages button when the unread count decreases to 0 and not using an unreadCount of 0 to return early in `onViewableItemsChanged` as the `(newMessageLineIndex <= 0 || viewableItems.length === 0 || this.disableViewableItems)` condition is sufficient.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26855

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Android Q emulator