### PR TITLE
MM-26946 Handle invalid YouTube links

### DIFF
--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -391,7 +391,11 @@ export default class PostBodyAdditionalContent extends ImageViewPort {
             getViewPortWidth(this.props.isReplyPost, this.hasPermanentSidebar()),
         );
 
-        const imgUrl = Object.keys(this.props.metadata.images)[0] || `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+        let imgUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+        if (this.props.metadata?.images) {
+            imgUrl = Object.keys(this.props.metadata.images)[0];
+        }
+
         return (
             <TouchableWithFeedback
                 style={[styles.imageContainer, {height: dimensions.height}]}

--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -391,9 +391,14 @@ export default class PostBodyAdditionalContent extends ImageViewPort {
             getViewPortWidth(this.props.isReplyPost, this.hasPermanentSidebar()),
         );
 
-        let imgUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+        let imgUrl;
         if (this.props.metadata?.images) {
             imgUrl = Object.keys(this.props.metadata.images)[0];
+        }
+
+        if (!imgUrl) {
+            // Fallback to default YouTube thumbnail if available
+            imgUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
         }
 
         return (


### PR DESCRIPTION
#### Summary
When posting an invalid YouTube link, the metadata of the post is present but there is no image metadata in it, as we were relying  on the presence of the images metadata the app gets an unhandled exception leading it to become unusable until the link is corrected or the post deleted.

This PR handles the scenario where the YouTube link is invalid. As the link is invalid the thumbnail of the video will be blank.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26946