### PR TITLE
Update camera-roll dependency

### DIFF
--- a/app/screens/image_preview/downloader.ios.js
+++ b/app/screens/image_preview/downloader.ios.js
@@ -200,7 +200,7 @@ export default class Downloader extends PureComponent {
             tension: 8,
             friction: 5,
         }).start(async () => {
-            await CameraRoll.saveToCameraRoll(videoPath, 'video');
+            await CameraRoll.save(videoPath, {type: 'video'});
             this.props.onDownloadSuccess();
             InteractionManager.runAfterInteractions(() => {
                 this.setState({force: false, isVideo: false});
@@ -281,7 +281,7 @@ export default class Downloader extends PureComponent {
             let path = res.path();
 
             if (saveToCameraRoll) {
-                path = await CameraRoll.saveToCameraRoll(path, 'photo'); /* eslint-disable-line require-atomic-updates */
+                path = await CameraRoll.save(path, {type: 'photo'});
             }
 
             if (this.mounted) {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -208,7 +208,7 @@ PODS:
     - React-cxxreact (= 0.63.1)
     - React-jsi (= 0.63.1)
   - React-jsinspector (0.63.1)
-  - react-native-cameraroll (1.6.2):
+  - react-native-cameraroll (4.0.0):
     - React
   - react-native-cookies (3.2.0):
     - React
@@ -608,7 +608,7 @@ SPEC CHECKSUMS:
   React-jsi: b32a31da32e030f30bbf9a8d3a9c8325df9e793f
   React-jsiexecutor: 7ab9cdcdd18d57652fb041f8a147fe9658d4e00a
   React-jsinspector: 2e28bb487e42dda6c94dbfa0c648d1343767a0fb
-  react-native-cameraroll: 94bec91c68b94ac946c61b497b594bb38692c41b
+  react-native-cameraroll: 7c2e22b5a8e8f30fc6d5566c942b225ca7129752
   react-native-cookies: 854d59c4135c70b92a02ca4930e68e4e2eb58150
   react-native-document-picker: d694111879537cec2c258a1dcd2243d9df746824
   react-native-hw-keyboard-event: b517cefb8d5c659a38049c582de85ff43337dc53

--- a/package-lock.json
+++ b/package-lock.json
@@ -5301,9 +5301,9 @@
       }
     },
     "@react-native-community/cameraroll": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-1.6.2.tgz",
-      "integrity": "sha512-5R/2Tpi7APoNBDmRV23OcRIN9YiaRMJAHrXkGDpj7jVo2yQpJCCrARnZ9qhJ9dYEMybdP/XhXI1vVjuad5xqNQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-4.0.0.tgz",
+      "integrity": "sha512-ZqzWbNHklgq/sPUmlDgi/SvfbkIVKNYXhcDGRcabXRsX9aIyNEX2dk2fkCSJoKWqBF8uSUnVznonpTP3TlwdyQ=="
     },
     "@react-native-community/cli-debugger-ui": {
       "version": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "7.10.4",
     "@react-native-community/async-storage": "1.10.1",
-    "@react-native-community/cameraroll": "1.6.2",
+    "@react-native-community/cameraroll": "4.0.0",
     "@react-native-community/clipboard": "1.2.3",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/netinfo": "5.8.1",


### PR DESCRIPTION
#### Summary
This dependency is used to save images / videos to the camera roll in the  device.