### PR TITLE
[MM-26635] Don't set state.inputValue in constructor

### DIFF
--- a/app/components/post_draft/quick_actions/quick_actions.js
+++ b/app/components/post_draft/quick_actions/quick_actions.js
@@ -41,7 +41,7 @@ export default class QuickActions extends PureComponent {
         super(props);
 
         this.state = {
-            inputValue: props.initialValue,
+            inputValue: '',
             atDisabled: props.readonly,
             slashDisabled: props.readonly,
         };


### PR DESCRIPTION
#### Summary
There's no need to set `state.inputValue` from props in the constructor. It's sufficient to handle `inputValue` changes in `componentDidUpdate`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26635

#### Device Information
This PR was tested on:
* iOS 13 simulator
* Android Q emulator