### PR TITLE
[MM-26489] No need to decode file URI on Android

### DIFF
--- a/app/components/post_draft/quick_actions/file_quick_action/index.js
+++ b/app/components/post_draft/quick_actions/file_quick_action/index.js
@@ -13,7 +13,6 @@ import Permissions from 'react-native-permissions';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {ICON_SIZE} from '@constants/post_draft';
 import {changeOpacity} from '@utils/theme';
-import {encodeLonePercentSymbols} from '@utils/file';
 
 const ShareExtension = NativeModules.MattermostShare;
 
@@ -69,8 +68,10 @@ export default class FileQuickAction extends PureComponent {
                     }
                 }
 
-                // Decode file uri to get the actual path
-                res.uri = decodeURIComponent(encodeLonePercentSymbols(res.uri));
+                if (Platform.OS === 'ios') {
+                    // Decode file uri to get the actual path
+                    res.uri = decodeURIComponent(res.uri);
+                }
 
                 this.props.onUploadFiles([res]);
             } catch (error) {

--- a/app/components/post_draft/quick_actions/file_quick_action/index.js
+++ b/app/components/post_draft/quick_actions/file_quick_action/index.js
@@ -13,6 +13,7 @@ import Permissions from 'react-native-permissions';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {ICON_SIZE} from '@constants/post_draft';
 import {changeOpacity} from '@utils/theme';
+import {encodeLonePercentSymbols} from '@utils/file';
 
 const ShareExtension = NativeModules.MattermostShare;
 
@@ -69,7 +70,7 @@ export default class FileQuickAction extends PureComponent {
                 }
 
                 // Decode file uri to get the actual path
-                res.uri = decodeURIComponent(res.uri);
+                res.uri = decodeURIComponent(encodeLonePercentSymbols(res.uri));
 
                 this.props.onUploadFiles([res]);
             } catch (error) {

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -263,7 +263,3 @@ export function getExtensionFromContentDisposition(contentDisposition) {
 
     return null;
 }
-
-export function encodeLonePercentSymbols(uri) {
-    return uri.replace(/%(?![0-9a-fA-F]{2})/g, '%25');
-}

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -263,3 +263,7 @@ export function getExtensionFromContentDisposition(contentDisposition) {
 
     return null;
 }
+
+export function encodeLonePercentSymbols(uri) {
+    return uri.replace(/%(?![0-9a-fA-F]{2})/g, '%25');
+}

--- a/app/utils/file.test.js
+++ b/app/utils/file.test.js
@@ -1,7 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {generateId, getLocalFilePathFromFile, getExtensionFromContentDisposition} from 'app/utils/file';
+import {
+    generateId,
+    getLocalFilePathFromFile,
+    getExtensionFromContentDisposition,
+    encodeLonePercentSymbols,
+} from 'app/utils/file';
 
 describe('getExtensionFromContentDisposition', () => {
     it('should return the extracted the extension', () => {
@@ -73,5 +78,24 @@ describe('getExtensionFromContentDisposition', () => {
         };
         const localFile = getLocalFilePathFromFile('Videos', {data});
         expect(localFile).toBeNull();
+    });
+});
+
+describe('encodeLonePercentSymbols', () => {
+    it('should not encode % chars used for encoding', () => {
+        const encodingChars = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'c', 'd', 'e', 'f'];
+        for (let i = 0; i < encodingChars.length; i++) {
+            for (let j = 0; j < encodingChars.length; j++) {
+                const str = `test%${encodingChars[i]}${encodingChars[j]}`;
+                const result = encodeLonePercentSymbols(str);
+                expect(result).toEqual(str);
+            }
+        }
+    });
+
+    it('should encode % chars not used for encoding', () => {
+        const str = 'test%%20%21%AZ%';
+        const result = encodeLonePercentSymbols(str);
+        expect(result).toEqual('test%25%20%21%25AZ%25');
     });
 });

--- a/app/utils/file.test.js
+++ b/app/utils/file.test.js
@@ -5,7 +5,6 @@ import {
     generateId,
     getLocalFilePathFromFile,
     getExtensionFromContentDisposition,
-    encodeLonePercentSymbols,
 } from 'app/utils/file';
 
 describe('getExtensionFromContentDisposition', () => {
@@ -78,24 +77,5 @@ describe('getExtensionFromContentDisposition', () => {
         };
         const localFile = getLocalFilePathFromFile('Videos', {data});
         expect(localFile).toBeNull();
-    });
-});
-
-describe('encodeLonePercentSymbols', () => {
-    it('should not encode % chars used for encoding', () => {
-        const encodingChars = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'c', 'd', 'e', 'f'];
-        for (let i = 0; i < encodingChars.length; i++) {
-            for (let j = 0; j < encodingChars.length; j++) {
-                const str = `test%${encodingChars[i]}${encodingChars[j]}`;
-                const result = encodeLonePercentSymbols(str);
-                expect(result).toEqual(str);
-            }
-        }
-    });
-
-    it('should encode % chars not used for encoding', () => {
-        const str = 'test%%20%21%AZ%';
-        const result = encodeLonePercentSymbols(str);
-        expect(result).toEqual('test%25%20%21%25AZ%25');
     });
 });


### PR DESCRIPTION
#### Summary
There's no need to use `decodeURIComponent` on Android.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26489

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* Mi A3, Android 9
* iPhone SE, iOS 13