### PR TITLE
[MM-27313] Define registerTypingAnimation in Thread screen

### DIFF
--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -102,7 +102,7 @@ export default class ChannelPostList extends PureComponent {
 
     goToThread = (post) => {
         telemetry.start(['post_list:thread']);
-        const {actions, channelId, registerTypingAnimation} = this.props;
+        const {actions, channelId} = this.props;
         const rootId = (post.root_id || post.id);
 
         Keyboard.dismiss();
@@ -114,7 +114,6 @@ export default class ChannelPostList extends PureComponent {
         const passProps = {
             channelId,
             rootId,
-            registerTypingAnimation,
         };
 
         requestAnimationFrame(() => {

--- a/app/screens/thread/__snapshots__/thread.ios.test.js.snap
+++ b/app/screens/thread/__snapshots__/thread.ios.test.js.snap
@@ -70,21 +70,7 @@ exports[`thread should match snapshot, has root post 1`] = `
       channelId="channel_id"
       channelIsArchived={false}
       cursorPositionEvent="onThreadTextBoxCursorChange"
-      registerTypingAnimation={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              [Function],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": [MockFunction],
-            },
-          ],
-        }
-      }
+      registerTypingAnimation={[Function]}
       rootId="root_id"
       valueEvent="onThreadTextBoxValueChange"
     />

--- a/app/screens/thread/thread.android.js
+++ b/app/screens/thread/thread.android.js
@@ -24,7 +24,6 @@ export default class ThreadAndroid extends ThreadBase {
             rootId,
             channelIsArchived,
             theme,
-            registerTypingAnimation,
         } = this.props;
 
         let content;
@@ -49,7 +48,7 @@ export default class ThreadAndroid extends ThreadBase {
                         channelIsArchived={channelIsArchived}
                         rootId={rootId}
                         screenId={this.props.componentId}
-                        registerTypingAnimation={registerTypingAnimation}
+                        registerTypingAnimation={this.registerTypingAnimation}
                     />
                 </>
             );

--- a/app/screens/thread/thread.ios.js
+++ b/app/screens/thread/thread.ios.js
@@ -37,7 +37,6 @@ export default class ThreadIOS extends ThreadBase {
             rootId,
             channelIsArchived,
             theme,
-            registerTypingAnimation,
         } = this.props;
 
         let content;
@@ -84,7 +83,7 @@ export default class ThreadIOS extends ThreadBase {
                         rootId={rootId}
                         screenId={this.props.componentId}
                         valueEvent={THREAD_POST_TEXTBOX_VALUE_CHANGE}
-                        registerTypingAnimation={registerTypingAnimation}
+                        registerTypingAnimation={this.registerTypingAnimation}
                     />
                 </KeyboardTrackingView>
             );

--- a/app/screens/thread/thread.ios.test.js
+++ b/app/screens/thread/thread.ios.test.js
@@ -6,8 +6,10 @@ import {shallow} from 'enzyme';
 
 import Preferences from '@mm-redux/constants/preferences';
 import {General, RequestStatus} from '@mm-redux/constants';
+import EventEmitter from '@mm-redux/utils/event_emitter';
 
 import PostList from 'app/components/post_list';
+import {TYPING_VISIBLE} from '@constants/post_draft';
 
 import ThreadIOS from './thread.ios';
 
@@ -30,9 +32,6 @@ describe('thread', () => {
         postIds: ['root_id', 'post_id_1', 'post_id_2'],
         channelIsArchived: false,
         threadLoadingStatus: {status: RequestStatus.STARTED},
-        registerTypingAnimation: jest.fn(() => {
-            return jest.fn();
-        }),
     };
 
     test('should match snapshot, has root post', () => {
@@ -80,11 +79,21 @@ describe('thread', () => {
             {context: {intl: {formatMessage: jest.fn()}}},
         );
         const instance = wrapper.instance();
+        instance.registerTypingAnimation = jest.fn(() => {
+            return jest.fn();
+        });
+        instance.bottomPaddingAnimation = jest.fn();
+        instance.runTypingAnimations = jest.fn();
+        EventEmitter.on = jest.fn();
+        EventEmitter.off = jest.fn();
 
-        expect(baseProps.registerTypingAnimation).toHaveBeenCalledTimes(1);
+        instance.componentDidMount();
+        expect(instance.registerTypingAnimation).toHaveBeenCalledWith(instance.bottomPaddingAnimation);
         expect(instance.removeTypingAnimation).not.toHaveBeenCalled();
+        expect(EventEmitter.on).toHaveBeenCalledWith(TYPING_VISIBLE, instance.runTypingAnimations);
 
-        wrapper.unmount();
-        expect(instance.removeTypingAnimation).toHaveBeenCalledTimes(1);
+        instance.componentWillUnmount();
+        expect(instance.removeTypingAnimation).toHaveBeenCalled();
+        expect(EventEmitter.off).toHaveBeenCalledWith(TYPING_VISIBLE, instance.runTypingAnimations);
     });
 });


### PR DESCRIPTION
#### Summary
`registerTypingAnimation` was passed to the Thread screen through props from ChannelPostList, however, this is not the only way to access the Thread screen. Defining `registerTypingAnimation` in the Thread screen as well allows for the typing animations to be registered from children components when navigating to the Thread screen from any other way other than ChannelPostList (ie, permalink in search results).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27313

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iOS 13 simulator
* Android Q emulator