### PR TITLE
[MM-27294] Allow returning to Channel screen without resetting the navigation root

### DIFF
--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -223,24 +223,25 @@ export async function popToRoot() {
     }
 }
 
-export async function popDismissToChannel() {
+export async function popDismissToRoot() {
     const componentId = EphemeralStore.getNavigationTopComponentId();
     if (componentId === CHANNEL_SCREEN || EphemeralStore.allNavigationComponentIds.length <= 1) {
         return;
     }
 
     try {
-        await Navigation.pop(componentId);
+        await popToRoot();
     } catch (error) {
         // Do nothing
     }
+
     try {
-        await dismissModal();
+        await dismissAllModals();
     } catch (error) {
-        // Do thing
+        // Do nothing
     }
 
-    popDismissToChannel();
+    await popDismissToRoot();
 }
 
 export function showModal(name, title, passProps = {}, options = {}) {

--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -11,7 +11,7 @@ import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import EphemeralStore from '@store/ephemeral_store';
 import Store from '@store/store';
 
-export const CHANNEL_SCREEN = 'Channel';
+const CHANNEL_SCREEN = 'Channel';
 
 function getThemeFromState() {
     const state = Store.redux?.getState() || {};

--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -11,7 +11,7 @@ import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import EphemeralStore from '@store/ephemeral_store';
 import Store from '@store/store';
 
-const CHANNEL_SCREEN = 'Channel';
+export const CHANNEL_SCREEN = 'Channel';
 
 function getThemeFromState() {
     const state = Store.redux?.getState() || {};
@@ -221,6 +221,26 @@ export async function popToRoot() {
         // RNN returns a promise rejection if there are no screens
         // atop the root screen to pop. We'll do nothing in this case.
     }
+}
+
+export async function popDismissToChannel() {
+    const componentId = EphemeralStore.getNavigationTopComponentId();
+    if (componentId === CHANNEL_SCREEN || EphemeralStore.allNavigationComponentIds.length <= 1) {
+        return;
+    }
+
+    try {
+        await Navigation.pop(componentId);
+    } catch (error) {
+        // Do nothing
+    }
+    try {
+        await dismissModal();
+    } catch (error) {
+        // Do thing
+    }
+
+    popDismissToChannel();
 }
 
 export function showModal(name, title, passProps = {}, options = {}) {

--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -223,27 +223,6 @@ export async function popToRoot() {
     }
 }
 
-export async function popDismissToRoot() {
-    const componentId = EphemeralStore.getNavigationTopComponentId();
-    if (componentId === CHANNEL_SCREEN || EphemeralStore.allNavigationComponentIds.length <= 1) {
-        return;
-    }
-
-    try {
-        await popToRoot();
-    } catch (error) {
-        // Do nothing
-    }
-
-    try {
-        await dismissAllModals();
-    } catch (error) {
-        // Do nothing
-    }
-
-    await popDismissToRoot();
-}
-
 export function showModal(name, title, passProps = {}, options = {}) {
     const theme = getThemeFromState();
     const defaultOptions = {

--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -7,9 +7,11 @@ import merge from 'deepmerge';
 
 import {Preferences} from '@mm-redux/constants';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
+import EventEmmiter from '@mm-redux/utils/event_emitter';
 
 import EphemeralStore from '@store/ephemeral_store';
 import Store from '@store/store';
+import {NavigationTypes} from '@constants';
 
 const CHANNEL_SCREEN = 'Channel';
 
@@ -217,6 +219,7 @@ export async function popToRoot() {
 
     try {
         await Navigation.popToRoot(componentId);
+        EventEmmiter.emit(NavigationTypes.NAVIGATION_POP_TO_ROOT);
     } catch (error) {
         // RNN returns a promise rejection if there are no screens
         // atop the root screen to pop. We'll do nothing in this case.

--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -219,11 +219,17 @@ export async function popToRoot() {
 
     try {
         await Navigation.popToRoot(componentId);
-        EventEmmiter.emit(NavigationTypes.NAVIGATION_POP_TO_ROOT);
     } catch (error) {
         // RNN returns a promise rejection if there are no screens
         // atop the root screen to pop. We'll do nothing in this case.
     }
+}
+
+export async function dismissAllModalsAndPopToRoot() {
+    await dismissAllModals();
+    await popToRoot();
+
+    EventEmmiter.emit(NavigationTypes.NAVIGATION_DISMISS_AND_POP_TO_ROOT);
 }
 
 export function showModal(name, title, passProps = {}, options = {}) {

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -481,49 +481,4 @@ describe('@actions/navigation', () => {
         await NavigationActions.dismissOverlay(topComponentId);
         expect(dismissOverlay).toHaveBeenCalledWith(topComponentId);
     });
-
-    describe('popDismissToRoot', () => {
-        const popToRoot = jest.spyOn(Navigation, 'popToRoot');
-        const dismissAllModals = jest.spyOn(Navigation, 'dismissAllModals');
-
-        it('should return early if top componentId is channel', async () => {
-            EphemeralStore.getNavigationTopComponentId.mockReturnValueOnce(NavigationActions.CHANNEL_SCREEN);
-
-            await NavigationActions.popDismissToRoot();
-            expect(popToRoot).not.toHaveBeenCalled();
-            expect(dismissAllModals).not.toHaveBeenCalled();
-        });
-
-        it('should return early if there is 1 or less navigation components in the stack', async () => {
-            EphemeralStore.allNavigationComponentIds = ['A'];
-
-            await NavigationActions.popDismissToRoot();
-            expect(popToRoot).not.toHaveBeenCalled();
-            expect(dismissAllModals).not.toHaveBeenCalled();
-
-            EphemeralStore.allNavigationComponentIds = [];
-
-            await NavigationActions.popDismissToRoot();
-            expect(popToRoot).not.toHaveBeenCalled();
-            expect(dismissAllModals).not.toHaveBeenCalled();
-        });
-
-        it('should call pop and dismissModal then call itself until the channel screen is reached', async () => {
-            EphemeralStore.allNavigationComponentIds = ['A', 'B', NavigationActions.CHANNEL_SCREEN];
-
-            // getNavigationTopComponentId is called twice times per
-            // popDismissToChannel call that doesn't return early:
-            // once by popDismissToRoot and once by popToRoot
-            EphemeralStore.getNavigationTopComponentId.
-                mockReturnValueOnce('A').
-                mockReturnValueOnce('A').
-                mockReturnValueOnce('B').
-                mockReturnValueOnce('B').
-                mockReturnValueOnce(NavigationActions.CHANNEL_SCREEN);
-
-            await NavigationActions.popDismissToRoot();
-            expect(popToRoot).toHaveBeenCalledTimes(2);
-            expect(dismissAllModals).toHaveBeenCalledTimes(2);
-        });
-    });
 });

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -480,4 +480,54 @@ describe('@actions/navigation', () => {
         await NavigationActions.dismissOverlay(topComponentId);
         expect(dismissOverlay).toHaveBeenCalledWith(topComponentId);
     });
+
+    describe('popDismissToChannel', () => {
+        const pop = jest.spyOn(Navigation, 'pop');
+        const dismissModal = jest.spyOn(Navigation, 'dismissModal');
+
+        it('should return early if top componentId is channel', async () => {
+            EphemeralStore.getNavigationTopComponentId.mockReturnValueOnce(NavigationActions.CHANNEL_SCREEN);
+
+            await NavigationActions.popDismissToChannel();
+            expect(pop).not.toHaveBeenCalled();
+            expect(dismissModal).not.toHaveBeenCalled();
+        });
+
+        it('should return early if there is 1 or less navigation components in the stack', async () => {
+            EphemeralStore.allNavigationComponentIds = ['A'];
+
+            await NavigationActions.popDismissToChannel();
+            expect(pop).not.toHaveBeenCalled();
+            expect(dismissModal).not.toHaveBeenCalled();
+
+            EphemeralStore.allNavigationComponentIds = [];
+
+            await NavigationActions.popDismissToChannel();
+            expect(pop).not.toHaveBeenCalled();
+            expect(dismissModal).not.toHaveBeenCalled();
+        });
+
+        it('should call pop and dismissModal then call itself until the channel screen is reached', async () => {
+            EphemeralStore.hasModalsOpened = jest.fn(() => {
+                return true;
+            });
+            EphemeralStore.allNavigationComponentIds = ['A', 'B', NavigationActions.CHANNEL_SCREEN];
+
+            // getNavigationTopComponentId is called twice times per
+            // popDismissToChannel call that doesn't return early:
+            // once by popDismissToChannel and once by dismissModal
+            EphemeralStore.getNavigationTopComponentId.
+                mockReturnValueOnce('A').
+                mockReturnValueOnce('A');
+            EphemeralStore.getNavigationTopComponentId.
+                mockReturnValueOnce('B').
+                mockReturnValueOnce('B');
+            EphemeralStore.getNavigationTopComponentId.
+                mockReturnValueOnce(NavigationActions.CHANNEL_SCREEN);
+
+            await NavigationActions.popDismissToChannel();
+            expect(pop).toHaveBeenCalledTimes(2);
+            expect(dismissModal).toHaveBeenCalledTimes(2);
+        });
+    });
 });

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -7,11 +7,14 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import merge from 'deepmerge';
 
+import EventEmitter from '@mm-redux/utils/event_emitter';
+
 import * as NavigationActions from '@actions/navigation';
 import Preferences from '@mm-redux/constants/preferences';
 import EphemeralStore from '@store/ephemeral_store';
 import intitialState from '@store/initial_state';
 import Store from '@store/store';
+import {NavigationTypes} from '@constants';
 
 jest.unmock('@actions/navigation');
 jest.mock('@store/ephemeral_store', () => ({
@@ -220,11 +223,13 @@ describe('@actions/navigation', () => {
         expect(pop).toHaveBeenCalledWith(otherComponentId);
     });
 
-    test('popToRoot should call Navigation.popToRoot', async () => {
+    test('popToRoot should call Navigation.popToRoot and emit event', async () => {
         const popToRoot = jest.spyOn(Navigation, 'popToRoot');
+        EventEmitter.emit = jest.fn();
 
         await NavigationActions.popToRoot();
         expect(popToRoot).toHaveBeenCalledWith(topComponentId);
+        expect(EventEmitter.emit).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_POP_TO_ROOT);
     });
 
     test('showModal should call Navigation.showModal', () => {

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -223,13 +223,11 @@ describe('@actions/navigation', () => {
         expect(pop).toHaveBeenCalledWith(otherComponentId);
     });
 
-    test('popToRoot should call Navigation.popToRoot and emit event', async () => {
+    test('popToRoot should call Navigation.popToRoot', async () => {
         const popToRoot = jest.spyOn(Navigation, 'popToRoot');
-        EventEmitter.emit = jest.fn();
 
         await NavigationActions.popToRoot();
         expect(popToRoot).toHaveBeenCalledWith(topComponentId);
-        expect(EventEmitter.emit).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_POP_TO_ROOT);
     });
 
     test('showModal should call Navigation.showModal', () => {
@@ -484,5 +482,16 @@ describe('@actions/navigation', () => {
 
         await NavigationActions.dismissOverlay(topComponentId);
         expect(dismissOverlay).toHaveBeenCalledWith(topComponentId);
+    });
+
+    test('dismissAllModalsAndPopToRoot should call Navigation.dismissAllModals, Navigation.popToRoot, and emit event', async () => {
+        const dismissAllModals = jest.spyOn(Navigation, 'dismissAllModals');
+        const popToRoot = jest.spyOn(Navigation, 'popToRoot');
+        EventEmitter.emit = jest.fn();
+
+        await NavigationActions.dismissAllModalsAndPopToRoot();
+        expect(dismissAllModals).toHaveBeenCalled();
+        expect(popToRoot).toHaveBeenCalledWith(topComponentId);
+        expect(EventEmitter.emit).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_DISMISS_AND_POP_TO_ROOT);
     });
 });

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -17,7 +17,6 @@ jest.unmock('@actions/navigation');
 jest.mock('@store/ephemeral_store', () => ({
     getNavigationTopComponentId: jest.fn(),
     clearNavigationComponents: jest.fn(),
-    clearNavigationModals: jest.fn(),
     addNavigationModal: jest.fn(),
     hasModalsOpened: jest.fn().mockReturnValue(true),
 }));

--- a/app/actions/navigation/index.test.js
+++ b/app/actions/navigation/index.test.js
@@ -17,6 +17,7 @@ jest.unmock('@actions/navigation');
 jest.mock('@store/ephemeral_store', () => ({
     getNavigationTopComponentId: jest.fn(),
     clearNavigationComponents: jest.fn(),
+    clearNavigationModals: jest.fn(),
     addNavigationModal: jest.fn(),
     hasModalsOpened: jest.fn().mockReturnValue(true),
 }));
@@ -481,53 +482,48 @@ describe('@actions/navigation', () => {
         expect(dismissOverlay).toHaveBeenCalledWith(topComponentId);
     });
 
-    describe('popDismissToChannel', () => {
-        const pop = jest.spyOn(Navigation, 'pop');
-        const dismissModal = jest.spyOn(Navigation, 'dismissModal');
+    describe('popDismissToRoot', () => {
+        const popToRoot = jest.spyOn(Navigation, 'popToRoot');
+        const dismissAllModals = jest.spyOn(Navigation, 'dismissAllModals');
 
         it('should return early if top componentId is channel', async () => {
             EphemeralStore.getNavigationTopComponentId.mockReturnValueOnce(NavigationActions.CHANNEL_SCREEN);
 
-            await NavigationActions.popDismissToChannel();
-            expect(pop).not.toHaveBeenCalled();
-            expect(dismissModal).not.toHaveBeenCalled();
+            await NavigationActions.popDismissToRoot();
+            expect(popToRoot).not.toHaveBeenCalled();
+            expect(dismissAllModals).not.toHaveBeenCalled();
         });
 
         it('should return early if there is 1 or less navigation components in the stack', async () => {
             EphemeralStore.allNavigationComponentIds = ['A'];
 
-            await NavigationActions.popDismissToChannel();
-            expect(pop).not.toHaveBeenCalled();
-            expect(dismissModal).not.toHaveBeenCalled();
+            await NavigationActions.popDismissToRoot();
+            expect(popToRoot).not.toHaveBeenCalled();
+            expect(dismissAllModals).not.toHaveBeenCalled();
 
             EphemeralStore.allNavigationComponentIds = [];
 
-            await NavigationActions.popDismissToChannel();
-            expect(pop).not.toHaveBeenCalled();
-            expect(dismissModal).not.toHaveBeenCalled();
+            await NavigationActions.popDismissToRoot();
+            expect(popToRoot).not.toHaveBeenCalled();
+            expect(dismissAllModals).not.toHaveBeenCalled();
         });
 
         it('should call pop and dismissModal then call itself until the channel screen is reached', async () => {
-            EphemeralStore.hasModalsOpened = jest.fn(() => {
-                return true;
-            });
             EphemeralStore.allNavigationComponentIds = ['A', 'B', NavigationActions.CHANNEL_SCREEN];
 
             // getNavigationTopComponentId is called twice times per
             // popDismissToChannel call that doesn't return early:
-            // once by popDismissToChannel and once by dismissModal
+            // once by popDismissToRoot and once by popToRoot
             EphemeralStore.getNavigationTopComponentId.
                 mockReturnValueOnce('A').
-                mockReturnValueOnce('A');
-            EphemeralStore.getNavigationTopComponentId.
+                mockReturnValueOnce('A').
                 mockReturnValueOnce('B').
-                mockReturnValueOnce('B');
-            EphemeralStore.getNavigationTopComponentId.
+                mockReturnValueOnce('B').
                 mockReturnValueOnce(NavigationActions.CHANNEL_SCREEN);
 
-            await NavigationActions.popDismissToChannel();
-            expect(pop).toHaveBeenCalledTimes(2);
-            expect(dismissModal).toHaveBeenCalledTimes(2);
+            await NavigationActions.popDismissToRoot();
+            expect(popToRoot).toHaveBeenCalledTimes(2);
+            expect(dismissAllModals).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -12,7 +12,7 @@ import * as PostListUtils from '@mm-redux/utils/post_list';
 
 import CombinedUserActivityPost from 'app/components/combined_user_activity_post';
 import Post from 'app/components/post';
-import {DeepLinkTypes, ListTypes} from 'app/constants';
+import {DeepLinkTypes, ListTypes, NavigationTypes} from '@constants';
 import mattermostManaged from 'app/mattermost_managed';
 import {makeExtraData} from 'app/utils/list_view';
 import {changeOpacity} from 'app/utils/theme';
@@ -105,6 +105,7 @@ export default class PostList extends PureComponent {
         const {actions, deepLinkURL, highlightPostId, initialIndex} = this.props;
 
         EventEmitter.on('scroll-to-bottom', this.handleSetScrollToBottom);
+        EventEmitter.on(NavigationTypes.NAVIGATION_POP_TO_ROOT, this.handleClosePermalink);
 
         // Invoked when hitting a deep link and app is not already running.
         if (deepLinkURL) {
@@ -149,6 +150,7 @@ export default class PostList extends PureComponent {
 
     componentWillUnmount() {
         EventEmitter.off('scroll-to-bottom', this.handleSetScrollToBottom);
+        EventEmitter.off(NavigationTypes.NAVIGATION_POP_TO_ROOT, this.handleClosePermalink);
 
         this.resetPostList();
     }

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -105,7 +105,7 @@ export default class PostList extends PureComponent {
         const {actions, deepLinkURL, highlightPostId, initialIndex} = this.props;
 
         EventEmitter.on('scroll-to-bottom', this.handleSetScrollToBottom);
-        EventEmitter.on(NavigationTypes.NAVIGATION_POP_TO_ROOT, this.handleClosePermalink);
+        EventEmitter.on(NavigationTypes.NAVIGATION_DISMISS_AND_POP_TO_ROOT, this.handleClosePermalink);
 
         // Invoked when hitting a deep link and app is not already running.
         if (deepLinkURL) {
@@ -150,7 +150,7 @@ export default class PostList extends PureComponent {
 
     componentWillUnmount() {
         EventEmitter.off('scroll-to-bottom', this.handleSetScrollToBottom);
-        EventEmitter.off(NavigationTypes.NAVIGATION_POP_TO_ROOT, this.handleClosePermalink);
+        EventEmitter.off(NavigationTypes.NAVIGATION_DISMISS_AND_POP_TO_ROOT, this.handleClosePermalink);
 
         this.resetPostList();
     }

--- a/app/components/post_list/post_list.test.js
+++ b/app/components/post_list/post_list.test.js
@@ -5,8 +5,10 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import Preferences from '@mm-redux/constants/preferences';
+import EventEmitter from '@mm-redux/utils/event_emitter';
 
 import * as NavigationActions from 'app/actions/navigation';
+import {NavigationTypes} from '@constants';
 import PostList from './post_list';
 
 jest.useFakeTimers();
@@ -120,5 +122,37 @@ describe('PostList', () => {
         });
 
         expect(instance.loadToFillContent).toHaveBeenCalledTimes(1);
+    });
+
+    test('should register listeners on componentDidMount', () => {
+        const wrapper = shallow(
+            <PostList {...baseProps}/>,
+        );
+        const instance = wrapper.instance();
+        instance.handleSetScrollToBottom = jest.fn();
+        instance.handleClosePermalink = jest.fn();
+        EventEmitter.on = jest.fn();
+
+        expect(EventEmitter.on).not.toHaveBeenCalled();
+        instance.componentDidMount();
+        expect(EventEmitter.on).toHaveBeenCalledTimes(2);
+        expect(EventEmitter.on).toHaveBeenCalledWith('scroll-to-bottom', instance.handleSetScrollToBottom);
+        expect(EventEmitter.on).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_POP_TO_ROOT, instance.handleClosePermalink);
+    });
+
+    test('should remove listeners on componentWillUnmount', () => {
+        const wrapper = shallow(
+            <PostList {...baseProps}/>,
+        );
+        const instance = wrapper.instance();
+        instance.handleSetScrollToBottom = jest.fn();
+        instance.handleClosePermalink = jest.fn();
+        EventEmitter.off = jest.fn();
+
+        expect(EventEmitter.off).not.toHaveBeenCalled();
+        instance.componentWillUnmount();
+        expect(EventEmitter.off).toHaveBeenCalledTimes(2);
+        expect(EventEmitter.off).toHaveBeenCalledWith('scroll-to-bottom', instance.handleSetScrollToBottom);
+        expect(EventEmitter.off).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_POP_TO_ROOT, instance.handleClosePermalink);
     });
 });

--- a/app/components/post_list/post_list.test.js
+++ b/app/components/post_list/post_list.test.js
@@ -137,7 +137,7 @@ describe('PostList', () => {
         instance.componentDidMount();
         expect(EventEmitter.on).toHaveBeenCalledTimes(2);
         expect(EventEmitter.on).toHaveBeenCalledWith('scroll-to-bottom', instance.handleSetScrollToBottom);
-        expect(EventEmitter.on).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_POP_TO_ROOT, instance.handleClosePermalink);
+        expect(EventEmitter.on).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_DISMISS_AND_POP_TO_ROOT, instance.handleClosePermalink);
     });
 
     test('should remove listeners on componentWillUnmount', () => {
@@ -153,6 +153,6 @@ describe('PostList', () => {
         instance.componentWillUnmount();
         expect(EventEmitter.off).toHaveBeenCalledTimes(2);
         expect(EventEmitter.off).toHaveBeenCalledWith('scroll-to-bottom', instance.handleSetScrollToBottom);
-        expect(EventEmitter.off).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_POP_TO_ROOT, instance.handleClosePermalink);
+        expect(EventEmitter.off).toHaveBeenCalledWith(NavigationTypes.NAVIGATION_DISMISS_AND_POP_TO_ROOT, instance.handleClosePermalink);
     });
 });

--- a/app/constants/navigation.js
+++ b/app/constants/navigation.js
@@ -10,7 +10,7 @@ const NavigationTypes = keyMirror({
     RESTART_APP: null,
     NAVIGATION_ERROR_TEAMS: null,
     NAVIGATION_SHOW_OVERLAY: null,
-    NAVIGATION_POP_TO_ROOT: null,
+    NAVIGATION_DISMISS_AND_POP_TO_ROOT: null,
     CLOSE_MAIN_SIDEBAR: null,
     MAIN_SIDEBAR_DID_CLOSE: null,
     MAIN_SIDEBAR_DID_OPEN: null,

--- a/app/constants/navigation.js
+++ b/app/constants/navigation.js
@@ -10,6 +10,7 @@ const NavigationTypes = keyMirror({
     RESTART_APP: null,
     NAVIGATION_ERROR_TEAMS: null,
     NAVIGATION_SHOW_OVERLAY: null,
+    NAVIGATION_POP_TO_ROOT: null,
     CLOSE_MAIN_SIDEBAR: null,
     MAIN_SIDEBAR_DID_CLOSE: null,
     MAIN_SIDEBAR_DID_OPEN: null,

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -16,7 +16,8 @@ import {
     goToScreen,
     dismissModal,
     setButtons,
-    popDismissToRoot,
+    dismissAllModals,
+    popToRoot,
 } from '@actions/navigation';
 import Config from '@assets/config';
 import FormattedTime from '@components/formatted_time';
@@ -216,7 +217,8 @@ export default class UserProfile extends PureComponent {
                 },
             );
         } else {
-            popDismissToRoot();
+            await dismissAllModals();
+            await popToRoot();
         }
     };
 

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -16,8 +16,7 @@ import {
     goToScreen,
     dismissModal,
     setButtons,
-    dismissAllModals,
-    popToRoot,
+    dismissAllModalsAndPopToRoot,
 } from '@actions/navigation';
 import Config from '@assets/config';
 import FormattedTime from '@components/formatted_time';
@@ -217,8 +216,7 @@ export default class UserProfile extends PureComponent {
                 },
             );
         } else {
-            await dismissAllModals();
-            await popToRoot();
+            dismissAllModalsAndPopToRoot();
         }
     };
 

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -16,6 +16,7 @@ import {
     goToScreen,
     dismissModal,
     setButtons,
+    popDismissToChannel,
 } from '@actions/navigation';
 import Config from '@assets/config';
 import FormattedTime from '@components/formatted_time';
@@ -215,7 +216,7 @@ export default class UserProfile extends PureComponent {
                 },
             );
         } else {
-            this.close();
+            popDismissToChannel();
         }
     };
 

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -16,7 +16,7 @@ import {
     goToScreen,
     dismissModal,
     setButtons,
-    popDismissToChannel,
+    popDismissToRoot,
 } from '@actions/navigation';
 import Config from '@assets/config';
 import FormattedTime from '@components/formatted_time';
@@ -216,7 +216,7 @@ export default class UserProfile extends PureComponent {
                 },
             );
         } else {
-            popDismissToChannel();
+            popDismissToRoot();
         }
     };
 


### PR DESCRIPTION
#### Summary
When pressing `Send Message` from the UserProfile screen, we only closed the modal. If you had navigated to the UserProfile screen from anywhere other than the Channel screen, you were not redirected to the Channel screen. Because the navigation stack can include both screens and modals, we now dismiss all modals and then pop to the root component. Also, the PostList component now calls `handleClosePermalink` when we pop to the root component. This will reset the `selectFocusedPostId` and set `showingPermalink` to false if a focused postId was set and `showingPermalink` was true.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27294

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iOS 13 simulator
* Android Q emulator