### PR TITLE
[MM-27381] Fix autocomplete after cache delete

### DIFF
--- a/app/components/autocomplete/slash_suggestion/slash_suggestion.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion.js
@@ -51,7 +51,7 @@ export default class SlashSuggestion extends PureComponent {
     };
 
     componentWillReceiveProps(nextProps) {
-        if ((nextProps.value === this.props.value && nextProps.suggestions === this.props.suggestions) ||
+        if ((nextProps.value === this.props.value && nextProps.suggestions === this.props.suggestions && nextProps.commands === this.props.commands) ||
             nextProps.isSearch || nextProps.value.startsWith('//') || !nextProps.channelId) {
             return;
         }


### PR DESCRIPTION
#### Summary
This PR fixes autocomplete experience after deleted cache

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-27381


#### Checklist

#### Device Information
This PR was tested on: iOS sumulator
