### PR TITLE
DOPS-90 fix folder for iOS simulator CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,6 +368,31 @@ jobs:
       - save:
           filename: "Mattermost-unsigned.ipa"
 
+  build-ios-simulator:
+    executor: ios
+    steps:
+      - checkout:
+          path: ~/mattermost-mobile
+      - ruby-setup
+      - npm-dependencies
+      - pods-dependencies
+      - assets
+      - fastlane-dependencies:
+          for: ios
+      - run:
+          working_directory: fastlane
+          name: Run fastlane to build unsigned x86_64 iOS app for iPhone simulator
+          no_output_timeout: 30m
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install watchman
+            bundle exec fastlane ios simulator
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - mattermost-mobile/Mattermost-simulator-x86_64.app.zip
+      - save:
+          filename: "Mattermost-simulator-x86_64.app.zip"
+
   deploy-android-release:
     executor:
       name: android
@@ -548,6 +573,16 @@ workflows:
               only: /^v(\d+\.)(\d+\.)(\d+)(.*)?$/
             branches:
               only: unsigned
+      - build-ios-simulator:
+          context: mattermost-mobile-unsigned
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - /^build-\d+$/
+                - /^build-ios-\d+$/
+                - /^build-ios-beta-\d+$/
                 
       - github-release:
           context: mattermost-mobile-unsigned

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -358,8 +358,8 @@ platform :ios do
     replace_assets
 
     sh 'cd ../ios && xcodebuild -workspace Mattermost.xcworkspace -scheme Mattermost -arch x86_64 -sdk iphonesimulator -configuration Release -parallelizeTargets -derivedDataPath ../build-ios ENABLE_BITCODE=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENABLE_BITCODE=NO'
-    sh 'cd ../ios/Build/Products/Release-iphonesimulator && zip -r Mattermost-simulator-x86_64.app.zip Mattermost.app'
-    sh 'mv ../ios/Build/Products/Release-iphonesimulator/Mattermost-simulator-x86_64.app.zip ../'
+    sh 'cd ../build-ios/Build/Products/Release-iphonesimulator && zip -r Mattermost-simulator-x86_64.app.zip Mattermost.app'
+    sh 'mv ../build-ios/Build/Products/Release-iphonesimulator/Mattermost-simulator-x86_64.app.zip ../'
     upload_file_to_s3({
       :os_type => "iOS",
       :file => "Mattermost-simulator-x86_64.app.zip"


### PR DESCRIPTION
#### Summary
Fix by correcting the output build. I realized that my build preference is different from the default value. That's why my original commit didn't work.

I'm requesting to include this to release-1.34.

Ref: https://github.com/mattermost/mattermost-mobile/pull/4605/files

Jira ticket - https://mattermost.atlassian.net/browse/DOPS-90