### PR TITLE
Cleanup fetch error & add details to sso

### DIFF
--- a/app/init/fetch.js
+++ b/app/init/fetch.js
@@ -89,6 +89,7 @@ Client4.doFetchWithResponse = async (url, options) => {
                 message: 'You need to use a valid client certificate in order to connect to this Mattermost server',
                 status_code: 401,
                 url,
+                details: err,
             });
         }
 
@@ -99,6 +100,7 @@ Client4.doFetchWithResponse = async (url, options) => {
                 defaultMessage: 'Received invalid response from the server.',
             },
             url,
+            details: err,
         });
     }
 
@@ -138,7 +140,7 @@ Client4.doFetchWithResponse = async (url, options) => {
     }
 
     throw new ClientError(Client4.getUrl(), {
-        message: `${msg} url = ${url}`,
+        message: msg,
         server_error_id: data.id,
         status_code: data.status_code,
         url,

--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -210,7 +210,15 @@ class SSO extends PureComponent {
 
     onLoadEndError = (e) => {
         console.warn('Failed to set store from local data', e); // eslint-disable-line no-console
-        this.setState({error: e.message});
+        let error = e.message;
+        if (e.details) {
+            error += `\n${e.details.message}`;
+        }
+
+        if (e.url) {
+            error += `\nURL: ${e.url}`;
+        }
+        this.setState({error});
     };
 
     scheduleSessionExpiredNotification = () => {


### PR DESCRIPTION
When receiving an error from the server, the url should not be shown in the error string.

Only in the SSO screen (no need to replicate this one) -> don't know how to... this is to help with a customer issue