### PR TITLE
[MM-26972] Ignore pagination when loading group data

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -616,7 +616,7 @@ function loadGroupData() {
                     } else {
                         const [getAllGroupsAssociatedToChannelsInTeam, getGroups] = await Promise.all([ //eslint-disable-line no-await-in-loop
                             Client4.getAllGroupsAssociatedToChannelsInTeam(team.id, true),
-                            Client4.getGroups(true),
+                            Client4.getGroups(true, 0, 0),
                         ]);
 
                         if (getAllGroupsAssociatedToChannelsInTeam.groups) {

--- a/app/mm-redux/client/client4.ts
+++ b/app/mm-redux/client/client4.ts
@@ -2850,9 +2850,9 @@ export default class Client4 {
         );
     };
 
-    getGroups = async (filterAllowReference = false) => {
+    getGroups = async (filterAllowReference = false, page = 0, perPage = PER_PAGE_DEFAULT) => {
         return this.doFetch(
-            `${this.getBaseRoute()}/groups${buildQueryString({filter_allow_reference: filterAllowReference})}`,
+            `${this.getBaseRoute()}/groups${buildQueryString({filter_allow_reference: filterAllowReference, page, per_page: perPage})}`,
             {method: 'get'},
         );
     };


### PR DESCRIPTION
#### Summary
- Skips pagination when calling `getGroups` in the `loadGroupData` fn to load _all_ groups instead of just the first 60 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-26972

#### Screenshots
- 60+ Groups loaded 
![Screen Shot 2020-08-04 at 7 12 58 PM](https://user-images.githubusercontent.com/3207297/89354324-86938d00-d686-11ea-9c63-7881c1ff7283.png)

#### Device Information
- Tested on iOS simulator
