### PR TITLE
[MM-27483] Fetch channel and member when loading from push notification

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -6,7 +6,7 @@ import {batchActions} from 'redux-batched-actions';
 import {NavigationTypes, ViewTypes} from '@constants';
 import {analytics} from '@init/analytics.ts';
 import {ChannelTypes, GeneralTypes, TeamTypes} from '@mm-redux/action_types';
-import {fetchMyChannelsAndMembers} from '@mm-redux/actions/channels';
+import {fetchMyChannelsAndMembers, getChannelAndMyMember} from '@mm-redux/actions/channels';
 import {getDataRetentionPolicy} from '@mm-redux/actions/general';
 import {receivedNewPost} from '@mm-redux/actions/posts';
 import {getMyTeams, getMyTeamMembers} from '@mm-redux/actions/teams';
@@ -102,6 +102,8 @@ export function loadFromPushNotification(notification) {
 export function handleSelectTeamAndChannel(teamId, channelId) {
     return async (dispatch, getState) => {
         const dt = Date.now();
+        await dispatch(getChannelAndMyMember(channelId));
+
         const state = getState();
         const {channels, currentChannelId, myMembers} = state.entities.channels;
         const {currentTeamId} = state.entities.teams;

--- a/app/components/post_list/more_messages_button/more_messages_button.js
+++ b/app/components/post_list/more_messages_button/more_messages_button.js
@@ -115,6 +115,7 @@ export default class MoreMessageButton extends React.PureComponent {
         // In this case we want to manually call onViewableItemsChanged with the stored
         // viewableItems.
         if (unreadCount > prevProps.unreadCount && prevProps.unreadCount === 0) {
+            this.uncancel();
             this.onViewableItemsChanged(this.viewableItems);
         }
 

--- a/app/components/post_list/more_messages_button/more_messages_button.test.js
+++ b/app/components/post_list/more_messages_button/more_messages_button.test.js
@@ -207,22 +207,26 @@ describe('MoreMessagesButton', () => {
             expect(instance.showMoreText).toHaveBeenCalledWith(10);
         });
 
-        test('componentDidUpdate should call onViewableItemsChanged when the unreadCount increases from 0', () => {
+        test('componentDidUpdate should call uncancel and onViewableItemsChanged when the unreadCount increases from 0', () => {
             const wrapper = shallowWithIntl(
                 <MoreMessagesButton {...baseProps}/>,
             );
             const instance = wrapper.instance();
+            instance.uncancel = jest.fn();
             instance.onViewableItemsChanged = jest.fn();
             instance.viewableItems = [{index: 1}];
 
             wrapper.setProps({unreadCount: 0});
+            expect(instance.uncancel).not.toHaveBeenCalled();
             expect(instance.onViewableItemsChanged).not.toHaveBeenCalled();
 
             wrapper.setProps({unreadCount: 1});
+            expect(instance.uncancel).toHaveBeenCalledTimes(1);
             expect(instance.onViewableItemsChanged).toHaveBeenCalledTimes(1);
             expect(instance.onViewableItemsChanged).toHaveBeenCalledWith(instance.viewableItems);
 
             wrapper.setProps({unreadCount: 2});
+            expect(instance.uncancel).toHaveBeenCalledTimes(1);
             expect(instance.onViewableItemsChanged).toHaveBeenCalledTimes(1);
         });
 


### PR DESCRIPTION
#### Summary
When loading from a push notification we need to fetch the latest channel and member from the server in order to have the latest counts from which to calculate the unread message count.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27483


#### Device Information
This PR was tested on:
* iPhone SE, iOS 13