### PR TITLE
[MM-27576] Check for undefined channel

### DIFF
--- a/app/components/post_draft/draft_input/index.js
+++ b/app/components/post_draft/draft_input/index.js
@@ -53,7 +53,7 @@ export function mapStateToProps(state, ownProps) {
         );
     }
 
-    if (isMinimumServerVersion(state.entities.general.serverVersion, 5, 24) && license && license.IsLicensed === 'true') {
+    if (channel && isMinimumServerVersion(state.entities.general.serverVersion, 5, 24) && license && license.IsLicensed === 'true') {
         useGroupMentions = haveIChannelPermission(
             state,
             {


### PR DESCRIPTION
#### Summary
Only check for `USE_GROUP_MENTIONS` when channel is defined.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27576

#### Device Information
This PR was tested on:
* iPhone SE, iOS 13.5.1