### PR TITLE
MM-27607 Fix filter undefined when searching profiles

### DIFF
--- a/app/screens/channel_add_members/channel_add_members.js
+++ b/app/screens/channel_add_members/channel_add_members.js
@@ -276,7 +276,11 @@ export default class ChannelAddMembers extends PureComponent {
         const options = {not_in_channel_id: currentChannelId, team_id: currentTeamId, group_constrained: currentChannelGroupConstrained};
         this.setState({loading: true});
 
-        actions.searchProfiles(term.toLowerCase(), options).then(({data}) => {
+        actions.searchProfiles(term.toLowerCase(), options).then((results) => {
+            let data = [];
+            if (results.data) {
+                data = results.data;
+            }
             this.setState({searchResults: data, loading: false});
         });
     };

--- a/app/screens/channel_members/channel_members.js
+++ b/app/screens/channel_members/channel_members.js
@@ -307,7 +307,11 @@ export default class ChannelMembers extends PureComponent {
         const options = {in_channel_id: currentChannelId};
         this.setState({loading: true});
 
-        actions.searchProfiles(term.toLowerCase(), options).then(({data}) => {
+        actions.searchProfiles(term.toLowerCase(), options).then((results) => {
+            let data = [];
+            if (results.data) {
+                data = results.data;
+            }
             this.setState({searchResults: data, loading: false});
         });
     };

--- a/app/screens/more_dms/more_dms.js
+++ b/app/screens/more_dms/more_dms.js
@@ -279,20 +279,24 @@ export default class MoreDirectMessages extends PureComponent {
         }
     };
 
-    searchProfiles = (term) => {
+    searchProfiles = async (term) => {
         const lowerCasedTerm = term.toLowerCase();
         const {actions, currentTeamId, restrictDirectMessage} = this.props;
         this.setState({loading: true});
+        let results;
 
         if (restrictDirectMessage) {
-            actions.searchProfiles(lowerCasedTerm).then(({data}) => {
-                this.setState({searchResults: data, loading: false});
-            });
+            results = await actions.searchProfiles(lowerCasedTerm);
         } else {
-            actions.searchProfiles(lowerCasedTerm, {team_id: currentTeamId}).then(({data}) => {
-                this.setState({searchResults: data, loading: false});
-            });
+            results = await actions.searchProfiles(lowerCasedTerm, {team_id: currentTeamId});
         }
+
+        let data = [];
+        if (results.data) {
+            data = results.data;
+        }
+
+        this.setState({searchResults: data, loading: false});
     };
 
     startConversation = async (selectedId) => {

--- a/app/screens/selector_screen/selector_screen.js
+++ b/app/screens/selector_screen/selector_screen.js
@@ -215,7 +215,11 @@ export default class SelectorScreen extends PureComponent {
         const {actions} = this.props;
         this.setState({loading: true});
 
-        actions.searchProfiles(term.toLowerCase()).then(({data}) => {
+        actions.searchProfiles(term.toLowerCase()).then((results) => {
+            let data = [];
+            if (results.data) {
+                data = results.data;
+            }
             this.setState({searchResults: data, loading: false});
         });
     };


### PR DESCRIPTION
#### Summary
When searching for user profiles the code assumed that results were being returned. If the network request failed for any reason, results are `undefined`, now this use case is handled.

Affected: 
* New conversation (+ sign for Direct Messages sidebar)
* Add channel member
* Interactive dialog user selector

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27607
