### PR TITLE
MM-27711 Play YouTube video using expanded link

### DIFF
--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -238,9 +238,10 @@ export default class PostBodyAdditionalContent extends ImageViewPort {
     };
 
     playYouTubeVideo = () => {
-        const {link} = this.props;
-        const videoId = getYouTubeVideoId(link);
-        const startTime = this.getYouTubeTime(link);
+        const {expandedLink, link} = this.props;
+        const videoLink = expandedLink || link;
+        const videoId = getYouTubeVideoId(videoLink);
+        const startTime = this.getYouTubeTime(videoLink);
 
         if (Platform.OS === 'ios') {
             YouTubeStandaloneIOS.
@@ -258,7 +259,7 @@ export default class PostBodyAdditionalContent extends ImageViewPort {
                     startTime,
                 }).catch(this.playYouTubeVideoError);
             } else {
-                Linking.openURL(link);
+                Linking.openURL(videoLink);
             }
         }
     };


### PR DESCRIPTION
#### Summary
Correctly plays a YouTube video when shared using a short link, to play the video we'll use the expanded link instead of the short link if available.

Test: short link as specified in the ticket and a regular link as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27711