### PR TITLE
[MM-25348] Send event to JS only if React initialized

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -172,7 +172,9 @@ public class CustomPushNotification extends PushNotification {
             break;
         }
 
-        notifyReceivedToJS();
+        if (mAppLifecycleFacade.isReactInitialized()) {
+            notifyReceivedToJS();
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Summary
PushNotification's `digestNotification` does not call `sendEventToJS` if the ReactContext is not initialized so I added a check in our `onReceived()` function as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25348

#### Device Information
This PR was tested on:
* MiA3, Android 10