### PR TITLE
MM-27527 Allow swipe to close the sidebar after search is cancelled

### DIFF
--- a/app/components/sidebars/main/main_sidebar.ios.js
+++ b/app/components/sidebars/main/main_sidebar.ios.js
@@ -50,7 +50,7 @@ export default class MainSidebarIOS extends MainSidebarBase {
         if (this.state.drawerOpened && this.drawerRef?.current) {
             this.drawerRef.current.closeDrawer();
         } else if (this.drawerSwiper && DeviceTypes.IS_TABLET) {
-            this.resetDrawer(true);
+            this.resetDrawer();
         }
     };
 

--- a/app/components/sidebars/main/main_sidebar_base.js
+++ b/app/components/sidebars/main/main_sidebar_base.js
@@ -156,6 +156,9 @@ export default class MainSidebarBase extends Component {
 
     onSearchEnds = () => {
         this.setState({searching: false});
+        if (this.drawerRef?.current) {
+            this.drawerRef.current.canClose = true;
+        }
     };
 
     onSearchStart = () => {


### PR DESCRIPTION
#### Summary
When filtering the sidebar is cancelled the flag to allow the sidebar to be closed by a swipe was not included in the cancel handler.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27527