### PR TITLE
MM-25832 Prevent permalink view from loading posts multiple times

### DIFF
--- a/app/mm-redux/client/client4.ts
+++ b/app/mm-redux/client/client4.ts
@@ -3126,6 +3126,7 @@ export class ClientError extends Error {
     intl: { defaultMessage: string; id: string } | { defaultMessage: string; id: string } | { id: string; defaultMessage: string; values: any } | { id: string; defaultMessage: string };
     server_error_id: any;
     status_code: any;
+    details: Error;
     constructor(baseUrl: string, data: any) {
         super(data.message + ': ' + cleanUrlForLogging(baseUrl, data.url));
 
@@ -3134,6 +3135,7 @@ export class ClientError extends Error {
         this.intl = data.intl;
         this.server_error_id = data.server_error_id;
         this.status_code = data.status_code;
+        this.details = data.details;
 
         // Ensure message is treated as a property of this class when object spreading. Without this,
         // copying the object by using `{...error}` would not include the message.

--- a/app/screens/permalink/__snapshots__/permalink.test.js.snap
+++ b/app/screens/permalink/__snapshots__/permalink.test.js.snap
@@ -120,62 +120,12 @@ exports[`Permalink should match snapshot 1`] = `
           ]
         }
       >
-        <Connect(PostList)
-          currentUserId="current_user_id"
-          highlightPinnedOrFlagged={false}
-          highlightPostId="focused_post_id"
-          indicateNewMessages={false}
-          isSearchResult={false}
-          lastPostIndex={-1}
-          lastViewedAt={0}
-          onHashtagPress={[Function]}
-          onPermalinkPress={[Function]}
-          onPostPress={[Function]}
-          postIds={
-            Array [
-              "post_id_1",
-              "focused_post_id",
-              "post_id_3",
-            ]
-          }
-          renderReplies={true}
-          shouldRenderReplyButton={false}
+        <Loading
+          color="#3d3c40"
+          size="large"
+          style={Object {}}
         />
       </View>
-      <ForwardRef
-        onPress={[Function]}
-        style={
-          Array [
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#166de0",
-              "flexDirection": "row",
-              "height": 43,
-              "justifyContent": "center",
-              "paddingRight": 16,
-              "width": "100%",
-            },
-            Object {
-              "borderBottomLeftRadius": 6,
-              "borderBottomRightRadius": 6,
-            },
-          ]
-        }
-      >
-        <FormattedText
-          defaultMessage=""
-          defautMessage="Jump to recent messages"
-          id="mobile.search.jump"
-          style={
-            Object {
-              "color": "#ffffff",
-              "fontSize": 15,
-              "fontWeight": "600",
-              "textAlignVertical": "center",
-            }
-          }
-        />
-      </ForwardRef>
     </withAnimatable(View)>
   </View>
 </Connect(SafeAreaIos)>

--- a/app/screens/permalink/__snapshots__/permalink.test.js.snap
+++ b/app/screens/permalink/__snapshots__/permalink.test.js.snap
@@ -120,12 +120,62 @@ exports[`Permalink should match snapshot 1`] = `
           ]
         }
       >
-        <Loading
-          color="#3d3c40"
-          size="large"
-          style={Object {}}
+        <Connect(PostList)
+          currentUserId="current_user_id"
+          highlightPinnedOrFlagged={false}
+          highlightPostId="focused_post_id"
+          indicateNewMessages={false}
+          isSearchResult={false}
+          lastPostIndex={-1}
+          lastViewedAt={0}
+          onHashtagPress={[Function]}
+          onPermalinkPress={[Function]}
+          onPostPress={[Function]}
+          postIds={
+            Array [
+              "post_id_1",
+              "focused_post_id",
+              "post_id_3",
+            ]
+          }
+          renderReplies={true}
+          shouldRenderReplyButton={false}
         />
       </View>
+      <ForwardRef
+        onPress={[Function]}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#166de0",
+              "flexDirection": "row",
+              "height": 43,
+              "justifyContent": "center",
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            Object {
+              "borderBottomLeftRadius": 6,
+              "borderBottomRightRadius": 6,
+            },
+          ]
+        }
+      >
+        <FormattedText
+          defaultMessage=""
+          defautMessage="Jump to recent messages"
+          id="mobile.search.jump"
+          style={
+            Object {
+              "color": "#ffffff",
+              "fontSize": 15,
+              "fontWeight": "600",
+              "textAlignVertical": "center",
+            }
+          }
+        />
+      </ForwardRef>
     </withAnimatable(View)>
   </View>
 </Connect(SafeAreaIos)>

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -15,27 +15,24 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import {Navigation} from 'react-native-navigation';
 
-import {General} from '@mm-redux/constants';
-import EventEmitter from '@mm-redux/utils/event_emitter';
-import {getLastPostIndex} from '@mm-redux/utils/post_list';
-
-import FormattedText from 'app/components/formatted_text';
-import Loading from 'app/components/loading';
-import PostList from 'app/components/post_list';
-import PostListRetry from 'app/components/post_list_retry';
-import SafeAreaView from 'app/components/safe_area_view';
-import {marginHorizontal as margin} from 'app/components/safe_area_view/iphone_x_spacing';
-
-import {preventDoubleTap} from 'app/utils/tap';
-import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
-
 import {
     resetToChannel,
     goToScreen,
     dismissModal,
     dismissAllModals,
     popToRoot,
-} from 'app/actions/navigation';
+} from '@actions/navigation';
+import FormattedText from '@components/formatted_text';
+import Loading from '@components/loading';
+import PostList from '@components/post_list';
+import PostListRetry from '@components/post_list_retry';
+import SafeAreaView from '@components/safe_area_view';
+import {marginHorizontal as margin} from '@components/safe_area_view/iphone_x_spacing';
+import {General} from '@mm-redux/constants';
+import EventEmitter from '@mm-redux/utils/event_emitter';
+import {getLastPostIndex} from '@mm-redux/utils/post_list';
+import {preventDoubleTap} from '@utils/tap';
+import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
 Animatable.initializeRegistryWithDefinitions({
     growOut: {
@@ -76,7 +73,6 @@ export default class Permalink extends PureComponent {
         isPermalink: PropTypes.bool,
         myMembers: PropTypes.object.isRequired,
         onClose: PropTypes.func,
-        onPress: PropTypes.func,
         postIds: PropTypes.array,
         theme: PropTypes.object.isRequired,
         isLandscape: PropTypes.bool.isRequired,
@@ -84,7 +80,6 @@ export default class Permalink extends PureComponent {
     };
 
     static defaultProps = {
-        onPress: () => true,
         postIds: [],
     };
 
@@ -92,50 +87,10 @@ export default class Permalink extends PureComponent {
         intl: intlShape.isRequired,
     };
 
-    static getDerivedStateFromProps(nextProps, prevState) {
-        const newState = {};
-        if (nextProps.focusedPostId !== prevState.focusedPostIdState) {
-            newState.focusedPostIdState = nextProps.focusedPostId;
-        }
-
-        if (nextProps.channelId && nextProps.channelId !== prevState.channelIdState) {
-            newState.channelIdState = nextProps.channelId;
-        }
-
-        if (nextProps.channelName && nextProps.channelName !== prevState.channelNameState) {
-            newState.channelNameState = nextProps.channelName;
-        }
-
-        if (nextProps.postIds && nextProps.postIds.length > 0 && nextProps.postIds !== prevState.postIdsState) {
-            newState.postIdsState = nextProps.postIds;
-        }
-
-        if (nextProps.focusedPostId !== prevState.focusedPostIdState) {
-            let loading = true;
-            if (nextProps.postIds && nextProps.postIds.length >= 10) {
-                loading = false;
-            }
-
-            newState.loading = loading;
-        }
-
-        if (Object.keys(newState).length === 0) {
-            return null;
-        }
-
-        return newState;
-    }
-
     constructor(props) {
         super(props);
 
-        const {
-            postIds,
-            channelId,
-            channelName,
-            focusedPostId,
-            error,
-        } = props;
+        const {error, postIds} = props;
         let loading = true;
 
         if (postIds && postIds.length >= 10) {
@@ -143,14 +98,10 @@ export default class Permalink extends PureComponent {
         }
 
         this.state = {
-            title: channelName,
+            title: '',
             loading,
             error: error || '',
             retry: false,
-            channelIdState: channelId,
-            channelNameState: channelName,
-            focusedPostIdState: focusedPostId,
-            postIdsState: postIds,
         };
     }
 
@@ -159,14 +110,14 @@ export default class Permalink extends PureComponent {
 
         this.mounted = true;
 
-        if (this.state.loading) {
-            this.loadPosts(this.props);
+        if (this.state.loading && this.props.focusedPostId) {
+            this.loadPosts();
         }
     }
 
     componentDidUpdate() {
-        if (this.state.loading) {
-            this.loadPosts(this.props);
+        if (this.state.loading && this.props.focusedPostId) {
+            this.loadPosts();
         }
     }
 
@@ -225,23 +176,17 @@ export default class Permalink extends PureComponent {
     };
 
     handlePress = () => {
-        const {channelIdState} = this.state;
-
         if (this.viewRef) {
             this.viewRef.growOut().then(() => {
-                this.jumpToChannel(channelIdState);
+                this.jumpToChannel(this.props.channelId);
             });
         }
     };
 
     jumpToChannel = async (channelId) => {
         if (channelId) {
-            const {actions, channelTeamId, currentTeamId, onClose} = this.props;
-            const currentChannelId = this.props.channelId;
-            const {
-                handleSelectChannel,
-                handleTeamChange,
-            } = actions;
+            const {actions, channelId: currentChannelId, channelTeamId, currentTeamId, onClose} = this.props;
+            const {handleSelectChannel, handleTeamChange} = actions;
 
             actions.selectPost('');
 
@@ -269,16 +214,22 @@ export default class Permalink extends PureComponent {
         }
     };
 
-    loadPosts = async (props) => {
+    loadPosts = async () => {
         const {intl} = this.context;
-        const {actions, channelId, currentUserId, focusedPostId, isPermalink, postIds} = props;
+        const {actions, channelId, currentUserId, focusedPostId, isPermalink, postIds} = this.props;
         const {formatMessage} = intl;
         let focusChannelId = channelId;
+
+        if (this.mounted) {
+            this.setState({loading: false});
+        }
 
         if (focusedPostId) {
             const post = await actions.getPostThread(focusedPostId, false);
             if (post.error && (!postIds || !postIds.length)) {
-                if (this.mounted && isPermalink && post.error.message.toLowerCase() !== 'network request failed') {
+                const error = post.error.message.toLowerCase() === 'network request failed';
+                const connectionError = post.error.details?.message?.toLowerCase() === 'could not connect to the server.';
+                if (this.mounted && isPermalink && !error && !connectionError) {
                     this.setState({
                         error: formatMessage({
                             id: 'permalink.error.access',
@@ -290,7 +241,7 @@ export default class Permalink extends PureComponent {
                         }),
                     });
                 } else if (this.mounted) {
-                    this.setState({error: post.error.message, retry: true});
+                    this.setState({error: post.error.message, retry: true, loading: false});
                 }
 
                 return;
@@ -308,17 +259,12 @@ export default class Permalink extends PureComponent {
             }
 
             await actions.getPostsAround(focusChannelId, focusedPostId, 10);
-
-            if (this.mounted) {
-                this.setState({loading: false});
-            }
         }
     };
 
     retry = () => {
         if (this.mounted) {
             this.setState({loading: true, error: null, retry: false});
-            this.loadPosts(this.props);
         }
     };
 
@@ -340,19 +286,8 @@ export default class Permalink extends PureComponent {
     };
 
     render() {
-        const {
-            currentUserId,
-            focusedPostId,
-            theme,
-            isLandscape,
-        } = this.props;
-        const {
-            error,
-            retry,
-            loading,
-            postIdsState,
-            title,
-        } = this.state;
+        const {channelName, currentUserId, focusedPostId, isLandscape, postIds, theme} = this.props;
+        const {error, loading, retry, title} = this.state;
         const style = getStyleSheet(theme);
 
         let postList;
@@ -384,8 +319,8 @@ export default class Permalink extends PureComponent {
                     onHashtagPress={this.handleHashtagPress}
                     onPermalinkPress={this.handlePermalinkPress}
                     onPostPress={this.goToThread}
-                    postIds={postIdsState}
-                    lastPostIndex={Platform.OS === 'android' ? getLastPostIndex(postIdsState) : -1}
+                    postIds={postIds}
+                    lastPostIndex={Platform.OS === 'android' ? getLastPostIndex(postIds) : -1}
                     currentUserId={currentUserId}
                     lastViewedAt={0}
                     highlightPinnedOrFlagged={false}
@@ -430,7 +365,7 @@ export default class Permalink extends PureComponent {
                                     style={style.title}
                                 >
                                     {this.archivedIcon()}
-                                    {title}
+                                    {title || channelName}
                                 </Text>
                             </View>
                         </View>

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -270,6 +270,7 @@ export default class Permalink extends PureComponent {
 
     retry = () => {
         if (this.mounted) {
+            this.initialLoad = false;
             this.setState({loading: true, error: null, retry: false});
         }
     };

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -111,12 +111,13 @@ export default class Permalink extends PureComponent {
         this.mounted = true;
 
         if (this.state.loading && this.props.focusedPostId) {
+            this.initialLoad = true;
             this.loadPosts();
         }
     }
 
     componentDidUpdate() {
-        if (this.state.loading && this.props.focusedPostId) {
+        if (this.state.loading && this.props.focusedPostId && !this.initialLoad) {
             this.loadPosts();
         }
     }
@@ -220,7 +221,7 @@ export default class Permalink extends PureComponent {
         const {formatMessage} = intl;
         let focusChannelId = channelId;
 
-        if (this.mounted) {
+        if (this.mounted && !this.initialLoad) {
             this.setState({loading: false});
         }
 
@@ -259,6 +260,11 @@ export default class Permalink extends PureComponent {
             }
 
             await actions.getPostsAround(focusChannelId, focusedPostId, 10);
+
+            if (this.initialLoad) {
+                this.initialLoad = false;
+                this.setState({loading: false});
+            }
         }
     };
 
@@ -320,7 +326,7 @@ export default class Permalink extends PureComponent {
                     onPermalinkPress={this.handlePermalinkPress}
                     onPostPress={this.goToThread}
                     postIds={postIds}
-                    lastPostIndex={Platform.OS === 'android' ? getLastPostIndex(postIds) : -1}
+                    lastPostIndex={Platform.OS === 'android' ? getLastPostIndex(postIds || []) : -1}
                     currentUserId={currentUserId}
                     lastViewedAt={0}
                     highlightPinnedOrFlagged={false}

--- a/app/screens/permalink/permalink.test.js
+++ b/app/screens/permalink/permalink.test.js
@@ -34,7 +34,6 @@ describe('Permalink', () => {
         isPermalink: true,
         myMembers: {},
         onClose: jest.fn(),
-        onPress: jest.fn(),
         postIds: ['post_id_1', 'focused_post_id', 'post_id_3'],
         theme: Preferences.THEMES.default,
         componentId: 'component-id',
@@ -62,8 +61,7 @@ describe('Permalink', () => {
 
         wrapper.instance().loadPosts = jest.fn();
         wrapper.instance().retry();
-        expect(wrapper.instance().loadPosts).toHaveBeenCalledTimes(2);
-        expect(wrapper.instance().loadPosts).toBeCalledWith(baseProps);
+        expect(wrapper.instance().loadPosts).toHaveBeenCalledTimes(1);
     });
 
     test('should call handleClose on onNavigatorEvent(backPress)', () => {
@@ -75,44 +73,5 @@ describe('Permalink', () => {
         wrapper.instance().handleClose = jest.fn();
         wrapper.instance().navigationButtonPressed({buttonId: 'backPress'});
         expect(wrapper.instance().handleClose).toHaveBeenCalledTimes(1);
-    });
-
-    test('should match state', () => {
-        const wrapper = shallow(
-            <Permalink {...baseProps}/>,
-            {context: {intl: {formatMessage: jest.fn()}}},
-        );
-
-        expect(wrapper.state('channelIdState')).toEqual(baseProps.channelId);
-        expect(wrapper.state('channelNameState')).toEqual(baseProps.channelName);
-        expect(wrapper.state('focusedPostIdState')).toEqual(baseProps.focusedPostId);
-        expect(wrapper.state('postIdsState')).toEqual(baseProps.postIds);
-
-        wrapper.setProps({channelId: ''});
-        expect(wrapper.state('channelIdState')).toEqual(baseProps.channelId);
-        wrapper.setProps({channelId: null});
-        expect(wrapper.state('channelIdState')).toEqual(baseProps.channelId);
-        wrapper.setProps({channelId: 'new_channel_id'});
-        expect(wrapper.state('channelIdState')).toEqual('new_channel_id');
-
-        wrapper.setProps({channelName: ''});
-        expect(wrapper.state('channelNameState')).toEqual(baseProps.channelName);
-        wrapper.setProps({channelName: null});
-        expect(wrapper.state('channelNameState')).toEqual(baseProps.channelName);
-        wrapper.setProps({channelName: 'new_channel_name'});
-        expect(wrapper.state('channelNameState')).toEqual('new_channel_name');
-
-        wrapper.setProps({focusedPostId: 'new_focused_post_id'});
-        expect(wrapper.state('focusedPostIdState')).toEqual('new_focused_post_id');
-
-        wrapper.setProps({postIds: []});
-        expect(wrapper.state('postIdsState')).toEqual(baseProps.postIds);
-        wrapper.setProps({postIds: ['post_id_1', 'focused_post_id']});
-        expect(wrapper.state('postIdsState')).toEqual(['post_id_1', 'focused_post_id']);
-
-        wrapper.setProps({postIds: baseProps.postIds, focusedPostId: baseProps.focusedPostId});
-        expect(wrapper.state('loading')).toEqual(true);
-        wrapper.setProps({postIds: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'], focusedPostId: 'new_focused_post_id'});
-        expect(wrapper.state('loading')).toEqual(false);
     });
 });


### PR DESCRIPTION
#### Summary
The Permalink view was using `getDerivedStateFromProps` lifecycle which wasn't needed as well as having two other issues:
1. Channel name was not present at times as the title was not being update with prop changes
2. Posts were being loaded multiple times (~4-5 times) when the view loaded as well as when retrying.

On this PR we removed the unnecessary lifecycle as well as we load post once as needed.

Test 1: Open a permalink from the same team.
Test 2: Open a permalink from a different team that you **have** loaded
Test 3: Open a permalink from a different team that you **have not** loaded
Test 4: Reset cache -> go to the channel with a permalink -> Disconnect from internet -> Open permalink -> Connect to internet -> Tap Retry

#### Ticket Link
Found while trying to reproduce https://mattermost.atlassian.net/browse/MM-25832