### PR TITLE
MM-27982 Fix soft crash for edge emoji formatting

### DIFF
--- a/app/components/markdown/markdown_emoji/markdown_emoji.js
+++ b/app/components/markdown/markdown_emoji/markdown_emoji.js
@@ -38,6 +38,7 @@ export default class MarkdownEmoji extends PureComponent {
                 editedIndicator: this.renderEditedIndicator,
                 emoji: this.renderEmoji,
                 paragraph: this.renderParagraph,
+                document: this.renderParagraph,
                 text: this.renderText,
             },
         });
@@ -66,7 +67,7 @@ export default class MarkdownEmoji extends PureComponent {
     renderParagraph = ({children}) => {
         const style = getStyleSheet(this.props.theme);
         return (
-            <View style={style.block}>{children}</View>
+            <View style={style.block}><Text>{children}</Text></View>
         );
     };
 

--- a/app/utils/emoji_utils.js
+++ b/app/utils/emoji_utils.js
@@ -55,7 +55,7 @@ export function hasEmojisOnly(message, customEmojis) {
         return {isEmojiOnly: false, shouldRenderJumboEmoji: false};
     }
 
-    const chunks = message.trim().split(' ').filter((m) => m && m.length > 0);
+    const chunks = message.trim().replace(/\n/g, ' ').split(' ').filter((m) => m && m.length > 0);
 
     if (chunks.length === 0) {
         return {isEmojiOnly: false, shouldRenderJumboEmoji: false};

--- a/app/utils/emoji_utils.test.js
+++ b/app/utils/emoji_utils.test.js
@@ -64,6 +64,19 @@ describe('hasEmojisOnly with named emojis', () => {
         name: 'This should render a codeblock instead',
         message: '    :D',
         expected: {isEmojiOnly: false, shouldRenderJumboEmoji: false},
+    }, {
+        name: 'Mixed emojis with whitespace and newlines',
+        message: `:fire: 
+        :-)`,
+        expected: {isEmojiOnly: true, shouldRenderJumboEmoji: true},
+    }, {
+        name: 'Emojis with whitespace and newlines',
+        message: ':fire: \n:smile:',
+        expected: {isEmojiOnly: true, shouldRenderJumboEmoji: true},
+    }, {
+        name: 'Emojis with newlines',
+        message: ':fire:\n:smile:',
+        expected: {isEmojiOnly: true, shouldRenderJumboEmoji: true},
     }];
 
     const customEmojis = new Map([['valid_custom', 0]]);


### PR DESCRIPTION
#### Summary
For a specific message format that included emoji's only like hair on fire `:fire:<space>\n:-)` the CommonMark parser was handling it as a paragraph instead of text or emoji, and the paragraph renderer for the emoji markdown component did not include a `<Text>` wrapper on the children as any of the other markdown components.

The code causing the soft crash has been unchanged for the past 2 years with this commit https://github.com/mattermost/mattermost-mobile/commit/d8abeabd70e612c22a42c148b1e7085c14c33c23

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27982

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS and Android