### PR TITLE
[MM-28006] Use substring over replaceFirst when removing sender name

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -534,7 +534,12 @@ public class CustomPushNotification extends PushNotification {
     }
 
     private String removeSenderNameFromMessage(String message, String senderName) {
-        return message.replaceFirst(senderName, "").replaceFirst(": ", "").trim();
+        Integer index = message.indexOf(senderName);
+        if (index == 0) {
+            message = message.substring(senderName.length());
+        }
+
+        return message.replaceFirst(": ", "").trim();
     }
 
     private void notificationReceiptDelivery(String ackId, String postId, String type, boolean isIdLoaded, ResolvePromise promise) {


### PR DESCRIPTION
#### Summary
The `senderName` may include special chars that are used in regex matching and so `replaceFirst` can throw an exception. To avoid this we now use `substring` to extract the message without the sender name.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28006


#### Device Information
This PR was tested on:
* Android 10 emulator