### PR TITLE
Change 'mobile.more_dms.start' in 'i18n/ja.json'

### DIFF
--- a/assets/base/i18n/ja.json
+++ b/assets/base/i18n/ja.json
@@ -267,7 +267,7 @@
   "mobile.more_dms.add_more": "あと{remaining, number}人のユーザーを追加できます",
   "mobile.more_dms.cannot_add_more": "これ以上ユーザーを追加できません",
   "mobile.more_dms.one_more": "あと1ユーザー追加できます",
-  "mobile.more_dms.start": "先頭",
+  "mobile.more_dms.start": "開始",
   "mobile.more_dms.title": "新しい会話",
   "mobile.more_dms.you": "@{username} - あなた",
   "mobile.notice_mobile_link": "モバイルアプリ",


### PR DESCRIPTION
### Summary

An unnatural Japanese word was found, so it was fixed.
'先頭' means 'head' or 'first'.
I think the '開始' is more accurate.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->