### PR TITLE
[MM-28040] Make OAUTH services not able edit FULL NAME

### DIFF
--- a/app/screens/edit_profile/index.js
+++ b/app/screens/edit_profile/index.js
@@ -18,10 +18,12 @@ function mapStateToProps(state, ownProps) {
     const {auth_service: service} = ownProps.currentUser;
 
     const firstNameDisabled = (service === 'ldap' && config.LdapFirstNameAttributeSet === 'true') ||
-        (service === 'saml' && config.SamlFirstNameAttributeSet === 'true');
+        (service === 'saml' && config.SamlFirstNameAttributeSet === 'true') ||
+        (['gitlab', 'google', 'office365'].includes(service));
 
     const lastNameDisabled = (service === 'ldap' && config.LdapLastNameAttributeSet === 'true') ||
-        (service === 'saml' && config.SamlLastNameAttributeSet === 'true');
+        (service === 'saml' && config.SamlLastNameAttributeSet === 'true') ||
+        (['gitlab', 'google', 'office365'].includes(service));
 
     const nicknameDisabled = (service === 'ldap' && config.LdapNicknameAttributeSet === 'true') ||
         (service === 'saml' && config.SamlNicknameAttributeSet === 'true');


### PR DESCRIPTION
#### Summary
<!--
A brief description of what this pull request does.
-->
Editing full names is allowed if a user logins via an OAUTH service (gitlab google office365). We want to not allow them edit their full name (similar to LDAP and SAML).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-28040