### PR TITLE
[MM-27132] Handle group mention keys for group synced channels and teams 

### DIFF
--- a/app/components/at_mention/index.js
+++ b/app/components/at_mention/index.js
@@ -9,7 +9,7 @@ import {getAllUserMentionKeys} from '@mm-redux/selectors/entities/search';
 
 import {getTeammateNameDisplaySetting, getTheme} from '@mm-redux/selectors/entities/preferences';
 
-import {getGroupsByName} from '@mm-redux/selectors/entities/groups';
+import {getAllGroupsForReferenceByName} from '@mm-redux/selectors/entities/groups';
 
 import AtMention from './at_mention';
 
@@ -19,7 +19,7 @@ function mapStateToProps(state, ownProps) {
         usersByUsername: getUsersByUsername(state),
         mentionKeys: ownProps.mentionKeys || getAllUserMentionKeys(state),
         teammateNameDisplay: getTeammateNameDisplaySetting(state),
-        groupsByName: getGroupsByName(state),
+        groupsByName: getAllGroupsForReferenceByName(state),
     };
 }
 

--- a/app/components/autocomplete/at_mention/index.js
+++ b/app/components/autocomplete/at_mention/index.js
@@ -37,6 +37,7 @@ function mapStateToProps(state, ownProps) {
             state,
             {
                 channel: currentChannelId,
+                team: currentTeamId,
                 permission: Permissions.USE_CHANNEL_MENTIONS,
                 default: true,
             },
@@ -57,7 +58,7 @@ function mapStateToProps(state, ownProps) {
         outChannel = filterMembersNotInChannel(state, matchTerm);
     }
 
-    if (haveIChannelPermission(state, {channel: currentChannelId, permission: Permissions.USE_GROUP_MENTIONS, default: true}) && hasLicense && isMinimumServerVersion(state.entities.general.serverVersion, 5, 24)) {
+    if (haveIChannelPermission(state, {channel: currentChannelId, team: currentTeamId, permission: Permissions.USE_GROUP_MENTIONS, default: true}) && hasLicense && isMinimumServerVersion(state.entities.general.serverVersion, 5, 24)) {
         if (matchTerm) {
             groups = searchAssociatedGroupsForReferenceLocal(state, matchTerm, currentTeamId, currentChannelId);
         } else {

--- a/app/components/autocomplete/at_mention/index.js
+++ b/app/components/autocomplete/at_mention/index.js
@@ -57,7 +57,7 @@ function mapStateToProps(state, ownProps) {
         outChannel = filterMembersNotInChannel(state, matchTerm);
     }
 
-    if (haveIChannelPermission(state, {channel: currentChannelId, permission: Permissions.USE_GROUP_MENTIONS, default: false}) && hasLicense && isMinimumServerVersion(state.entities.general.serverVersion, 5, 24)) {
+    if (haveIChannelPermission(state, {channel: currentChannelId, permission: Permissions.USE_GROUP_MENTIONS, default: true}) && hasLicense && isMinimumServerVersion(state.entities.general.serverVersion, 5, 24)) {
         if (matchTerm) {
             groups = searchAssociatedGroupsForReferenceLocal(state, matchTerm, currentTeamId, currentChannelId);
         } else {

--- a/app/components/autocomplete/at_mention/index.js
+++ b/app/components/autocomplete/at_mention/index.js
@@ -57,7 +57,7 @@ function mapStateToProps(state, ownProps) {
         outChannel = filterMembersNotInChannel(state, matchTerm);
     }
 
-    if (hasLicense && isMinimumServerVersion(state.entities.general.serverVersion, 5, 24)) {
+    if (haveIChannelPermission(state, {channel: currentChannelId, permission: Permissions.USE_GROUP_MENTIONS, default: false}) && hasLicense && isMinimumServerVersion(state.entities.general.serverVersion, 5, 24)) {
         if (matchTerm) {
             groups = searchAssociatedGroupsForReferenceLocal(state, matchTerm, currentTeamId, currentChannelId);
         } else {

--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -33,6 +33,7 @@ const POST_TIMEOUT = 20000;
 export function makeMapStateToProps() {
     const memoizeHasEmojisOnly = memoizeResult((message, customEmojis) => hasEmojisOnly(message, customEmojis));
     const getReactionsForPost = makeGetReactionsForPost();
+    const getMentionKeysForPost = makeGetMentionKeysForPost();
 
     return (state, ownProps) => {
         const post = ownProps.post;
@@ -104,7 +105,7 @@ export function makeMapStateToProps() {
             isEmojiOnly,
             shouldRenderJumboEmoji,
             theme: getTheme(state),
-            mentionKeys: makeGetMentionKeysForPost(state, channel, postProps?.disable_group_highlight, postProps?.mentionHighlightDisabled),
+            mentionKeys: getMentionKeysForPost(state, channel, postProps?.disable_group_highlight, postProps?.mentionHighlightDisabled),
             canDelete,
             ...getDimensions(state),
         };

--- a/app/components/post_body/index.js
+++ b/app/components/post_body/index.js
@@ -104,7 +104,7 @@ export function makeMapStateToProps() {
             isEmojiOnly,
             shouldRenderJumboEmoji,
             theme: getTheme(state),
-            mentionKeys: makeGetMentionKeysForPost(state, postProps?.disable_group_highlight, postProps?.mentionHighlightDisabled),
+            mentionKeys: makeGetMentionKeysForPost(state, channel, postProps?.disable_group_highlight, postProps?.mentionHighlightDisabled),
             canDelete,
             ...getDimensions(state),
         };

--- a/app/components/post_draft/draft_input/index.js
+++ b/app/components/post_draft/draft_input/index.js
@@ -47,6 +47,7 @@ export function mapStateToProps(state, ownProps) {
             state,
             {
                 channel: channel.id,
+                team: channel.team_id,
                 permission: Permissions.USE_CHANNEL_MENTIONS,
                 default: true,
             },
@@ -60,6 +61,7 @@ export function mapStateToProps(state, ownProps) {
                 channel: channel.id,
                 team: channel.team_id,
                 permission: Permissions.USE_GROUP_MENTIONS,
+                default: true,
             },
         );
 

--- a/app/mm-redux/selectors/entities/groups.ts
+++ b/app/mm-redux/selectors/entities/groups.ts
@@ -167,12 +167,9 @@ export const getAssociatedGroupsByName: (state: GlobalState, teamID: string, cha
     (groups) => {
         const groupsByName: Dictionary<Group> = {};
 
-        for (const id in groups) {
-            if (groups.hasOwnProperty(id)) {
-                const group = groups[id];
-                groupsByName[group.name] = group;
-            }
-        }
+        Object.values(groups).forEach((group) => {
+            groupsByName[group.name] = group;
+        });
 
         return groupsByName;
     },
@@ -183,12 +180,9 @@ export const getAllGroupsForReferenceByName: (state: GlobalState) => NameMappedO
     (groups) => {
         const groupsByName: Dictionary<Group> = {};
 
-        for (const id in groups) {
-            if (groups.hasOwnProperty(id)) {
-                const group = groups[id];
-                groupsByName[group.name] = group;
-            }
-        }
+        Object.values(groups).forEach((group) => {
+            groupsByName[group.name] = group;
+        });
 
         return groupsByName;
     },

--- a/app/mm-redux/selectors/entities/roles.ts
+++ b/app/mm-redux/selectors/entities/roles.ts
@@ -156,7 +156,7 @@ export const getMyChannelPermissions = reselect.createSelector(
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
-                    roleFound = true && (teamRoleFound || teamId === undefined);
+                    roleFound = true && (teamRoleFound || !teamId);
                 }
             }
         }

--- a/app/mm-redux/selectors/entities/roles.ts
+++ b/app/mm-redux/selectors/entities/roles.ts
@@ -144,8 +144,10 @@ export const getMyChannelPermissions = reselect.createSelector(
     getMyChannelRoles,
     getRoles,
     getMyTeamPermissions,
-    (state, options: PermissionsOptions) => options.channel,
-    (myChannelRoles, roles, {permissions: teamPermissions, roleFound: teamRoleFound}, channelId) => {
+    (state, options: PermissionsOptions) => options,
+    (myChannelRoles, roles, {permissions: teamPermissions, roleFound: teamRoleFound}, options: PermissionsOptions) => {
+        const channelId = options.channel;
+        const teamId = options.team;
         const permissions = new Set<string>();
         let roleFound = false;
         if (myChannelRoles[channelId!]) {
@@ -154,7 +156,7 @@ export const getMyChannelPermissions = reselect.createSelector(
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
-                    roleFound = true && teamRoleFound;
+                    roleFound = true && (teamRoleFound || teamId === undefined);
                 }
             }
         }

--- a/app/mm-redux/selectors/entities/roles.ts
+++ b/app/mm-redux/selectors/entities/roles.ts
@@ -104,7 +104,7 @@ export const getMyCurrentChannelPermissions = reselect.createSelector(
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
-                    roleFound = true && teamRoleFound;
+                    roleFound = teamRoleFound;
                 }
             }
         }
@@ -156,7 +156,7 @@ export const getMyChannelPermissions = reselect.createSelector(
                     for (const permission of roles[roleName].permissions) {
                         permissions.add(permission);
                     }
-                    roleFound = true && (teamRoleFound || !teamId);
+                    roleFound = teamRoleFound || !teamId;
                 }
             }
         }

--- a/app/mm-redux/selectors/entities/search.test.js
+++ b/app/mm-redux/selectors/entities/search.test.js
@@ -66,37 +66,101 @@ describe('Selectors.Search', () => {
     });
 
     describe('makeGetMentionKeysForPost', () => {
-        it('should return all mentionKeys', () => {
-            const postProps = {
-                disable_group_highlight: false,
-                mentionHighlightDisabled: false,
-            };
-            const state = {
-                entities: {
-                    users: {
-                        currentUserId: 'a123',
-                        profiles: {
-                            a123: {
-                                username: 'a123',
-                                notify_props: {
-                                    channel: 'true',
-                                },
-                            },
-                        },
-                    },
-                    groups: {
-                        myGroups: {
-                            developers: {
-                                id: 123,
-                                name: 'developers',
-                                allow_reference: true,
-                                delete_at: 0,
+        const group = {
+            id: 123,
+            name: 'developers',
+            allow_reference: true,
+            delete_at: 0,
+        };
+
+        const group2 = {
+            id: 1234,
+            name: 'developers2',
+            allow_reference: true,
+            delete_at: 0,
+        };
+
+        const channel1 = {...TestHelper.fakeChannelWithId(team1.id), group_constrained: true};
+        const channel2 = {...TestHelper.fakeChannelWithId(team1.id), group_constrained: false};
+
+        const state = {
+            entities: {
+                users: {
+                    currentUserId: 'a123',
+                    profiles: {
+                        a123: {
+                            username: 'a123',
+                            notify_props: {
+                                channel: 'true',
                             },
                         },
                     },
                 },
+                groups: {
+                    syncables: {},
+                    members: {},
+                    groups: {
+                        [group.name]: group,
+                        [group2.name]: group2,
+                    },
+                    myGroups: {
+                        [group.name]: group,
+                        [group2.name]: group2,
+                    },
+                },
+                teams: {
+                    teams: {
+                        [team1.id]: team1,
+                    },
+                    groupsAssociatedToTeam: {
+                        [team1.id]: {ids: []},
+                    },
+                },
+                channels: {
+                    channels: {
+                        [channel1.id]: channel1,
+                        [channel2.id]: channel2,
+                    },
+                    groupsAssociatedToChannel: {
+                        [channel1.id]: {ids: [group.id]},
+                        [channel2.id]: {ids: []},
+                    },
+                },
+                general: {
+                    config: {},
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+            },
+        };
+
+        it('should return all mentionKeys for post if null channel given', () => {
+            const postProps = {
+                disable_group_highlight: false,
+                mentionHighlightDisabled: false,
             };
-            const results = Selectors.makeGetMentionKeysForPost(state, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = Selectors.makeGetMentionKeysForPost(state, null, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}, {key: '@developers2'}];
+            assert.deepEqual(results, expected);
+        });
+
+        it('should return all mentionKeys for post made in non group constrained channel', () => {
+            const postProps = {
+                disable_group_highlight: false,
+                mentionHighlightDisabled: false,
+            };
+            const results = Selectors.makeGetMentionKeysForPost(state, channel2, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}, {key: '@developers2'}];
+            assert.deepEqual(results, expected);
+        });
+
+        it('should return mentionKeys for post made in group constrained channel', () => {
+            const postProps = {
+                disable_group_highlight: false,
+                mentionHighlightDisabled: false,
+            };
+            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}];
             assert.deepEqual(results, expected);
         });
@@ -106,32 +170,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: true,
                 mentionHighlightDisabled: false,
             };
-            const state = {
-                entities: {
-                    users: {
-                        currentUserId: 'a123',
-                        profiles: {
-                            a123: {
-                                username: 'a123',
-                                notify_props: {
-                                    channel: 'true',
-                                },
-                            },
-                        },
-                    },
-                    groups: {
-                        myGroups: {
-                            developers: {
-                                id: 123,
-                                name: 'developers',
-                                allow_reference: true,
-                                delete_at: 0,
-                            },
-                        },
-                    },
-                },
-            };
-            const results = Selectors.makeGetMentionKeysForPost(state, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}];
             assert.deepEqual(results, expected);
         });
@@ -141,32 +180,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: false,
                 mentionHighlightDisabled: true,
             };
-            const state = {
-                entities: {
-                    users: {
-                        currentUserId: 'a123',
-                        profiles: {
-                            a123: {
-                                username: 'a123',
-                                notify_props: {
-                                    channel: 'true',
-                                },
-                            },
-                        },
-                    },
-                    groups: {
-                        myGroups: {
-                            developers: {
-                                id: 123,
-                                name: 'developers',
-                                allow_reference: true,
-                                delete_at: 0,
-                            },
-                        },
-                    },
-                },
-            };
-            const results = Selectors.makeGetMentionKeysForPost(state, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@a123'}, {key: '@developers'}];
             assert.deepEqual(results, expected);
         });
@@ -176,32 +190,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: true,
                 mentionHighlightDisabled: true,
             };
-            const state = {
-                entities: {
-                    users: {
-                        currentUserId: 'a123',
-                        profiles: {
-                            a123: {
-                                username: 'a123',
-                                notify_props: {
-                                    channel: 'true',
-                                },
-                            },
-                        },
-                    },
-                    groups: {
-                        myGroups: {
-                            developers: {
-                                id: 123,
-                                name: 'developers',
-                                allow_reference: true,
-                                delete_at: 0,
-                            },
-                        },
-                    },
-                },
-            };
-            const results = Selectors.makeGetMentionKeysForPost(state, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@a123'}];
             assert.deepEqual(results, expected);
         });

--- a/app/mm-redux/selectors/entities/search.test.js
+++ b/app/mm-redux/selectors/entities/search.test.js
@@ -65,7 +65,7 @@ describe('Selectors.Search', () => {
         assert.deepEqual(Selectors.getAllUserMentionKeys(state), [{key: 'First', caseSensitive: true}, {key: '@user'}, {key: '@I-AM-THE-BEST!'}, {key: '@Do-you-love-me?'}]);
     });
 
-    describe('makeGetMentionKeysForPost', () => {
+    describe('getMentionKeysForPost', () => {
         const group = {
             id: 123,
             name: 'developers',
@@ -135,12 +135,14 @@ describe('Selectors.Search', () => {
             },
         };
 
+        const getMentionKeysForPost = Selectors.makeGetMentionKeysForPost();
+
         it('should return all mentionKeys for post if null channel given', () => {
             const postProps = {
                 disable_group_highlight: false,
                 mentionHighlightDisabled: false,
             };
-            const results = Selectors.makeGetMentionKeysForPost(state, null, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = getMentionKeysForPost(state, null, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}, {key: '@developers2'}];
             assert.deepEqual(results, expected);
         });
@@ -150,7 +152,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: false,
                 mentionHighlightDisabled: false,
             };
-            const results = Selectors.makeGetMentionKeysForPost(state, channel2, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = getMentionKeysForPost(state, channel2, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}, {key: '@developers2'}];
             assert.deepEqual(results, expected);
         });
@@ -160,7 +162,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: false,
                 mentionHighlightDisabled: false,
             };
-            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = getMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}];
             assert.deepEqual(results, expected);
         });
@@ -170,7 +172,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: true,
                 mentionHighlightDisabled: false,
             };
-            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = getMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}];
             assert.deepEqual(results, expected);
         });
@@ -180,7 +182,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: false,
                 mentionHighlightDisabled: true,
             };
-            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = getMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@a123'}, {key: '@developers'}];
             assert.deepEqual(results, expected);
         });
@@ -190,7 +192,7 @@ describe('Selectors.Search', () => {
                 disable_group_highlight: true,
                 mentionHighlightDisabled: true,
             };
-            const results = Selectors.makeGetMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
+            const results = getMentionKeysForPost(state, channel1, postProps.disable_group_highlight, postProps.mentionHighlightDisabled);
             const expected = [{key: '@a123'}];
             assert.deepEqual(results, expected);
         });

--- a/app/mm-redux/selectors/entities/search.ts
+++ b/app/mm-redux/selectors/entities/search.ts
@@ -26,23 +26,24 @@ export const getAllUserMentionKeys: (state: GlobalState) => UserMentionKey[] = r
     },
 );
 
-export const makeGetMentionKeysForPost: (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => UserMentionKey[] = reselect.createSelector(
-    getCurrentUserMentionKeys,
-    (state: GlobalState, channel: Channel) => (channel?.id ? getMyGroupMentionKeysForChannel(state, channel?.team_id, channel?.id) : getMyGroupMentionKeys(state)),
-    (state: GlobalState, channel: Channel, disableGroupHighlight: boolean) => disableGroupHighlight,
-    (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => mentionHighlightDisabled,
-    (mentionKeysWithoutGroups, groupMentionKeys, disableGroupHighlight = false, mentionHighlightDisabled = false) => {
-        let mentionKeys = mentionKeysWithoutGroups;
-        if (!disableGroupHighlight) {
-            mentionKeys = mentionKeys.concat(groupMentionKeys);
-        }
+export function makeGetMentionKeysForPost(): (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => UserMentionKey[] {
+    return reselect.createSelector(
+        getCurrentUserMentionKeys,
+        (state: GlobalState, channel: Channel) => (channel?.id ? getMyGroupMentionKeysForChannel(state, channel?.team_id, channel?.id) : getMyGroupMentionKeys(state)),
+        (state: GlobalState, channel: Channel, disableGroupHighlight: boolean) => disableGroupHighlight,
+        (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => mentionHighlightDisabled,
+        (mentionKeysWithoutGroups, groupMentionKeys, disableGroupHighlight = false, mentionHighlightDisabled = false) => {
+            let mentionKeys = mentionKeysWithoutGroups;
+            if (!disableGroupHighlight) {
+                mentionKeys = mentionKeys.concat(groupMentionKeys);
+            }
 
-        if (mentionHighlightDisabled) {
-            const CHANNEL_MENTIONS = ['@all', '@channel', '@here'];
-            mentionKeys = mentionKeys.filter((value) => !CHANNEL_MENTIONS.includes(value.key));
-        }
+            if (mentionHighlightDisabled) {
+                const CHANNEL_MENTIONS = ['@all', '@channel', '@here'];
+                mentionKeys = mentionKeys.filter((value) => !CHANNEL_MENTIONS.includes(value.key));
+            }
 
-        return mentionKeys;
-    },
-);
-
+            return mentionKeys;
+        },
+    );
+}

--- a/app/mm-redux/selectors/entities/search.ts
+++ b/app/mm-redux/selectors/entities/search.ts
@@ -3,9 +3,10 @@
 
 import * as reselect from 'reselect';
 import {GlobalState} from '@mm-redux/types/store';
+import {Channel} from '@mm-redux/types/channels';
 import {UserMentionKey} from './users';
 import {getCurrentUserMentionKeys} from '@mm-redux/selectors/entities/users';
-import {getCurrentUserGroupMentionKeys} from '@mm-redux/selectors/entities/groups';
+import {getMyGroupMentionKeys, getMyGroupMentionKeysForChannel} from '@mm-redux/selectors/entities/groups';
 
 import {getCurrentTeamId} from '@mm-redux/selectors/entities/teams';
 
@@ -19,21 +20,21 @@ export const getCurrentSearchForCurrentTeam = reselect.createSelector(
 
 export const getAllUserMentionKeys: (state: GlobalState) => UserMentionKey[] = reselect.createSelector(
     getCurrentUserMentionKeys,
-    (state: GlobalState) => getCurrentUserGroupMentionKeys(state),
+    (state: GlobalState) => getMyGroupMentionKeys(state),
     (userMentionKeys, groupMentionKeys) => {
         return userMentionKeys.concat(groupMentionKeys);
     },
 );
 
-export const makeGetMentionKeysForPost: (state: GlobalState, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => UserMentionKey[] = reselect.createSelector(
-    getAllUserMentionKeys,
+export const makeGetMentionKeysForPost: (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => UserMentionKey[] = reselect.createSelector(
     getCurrentUserMentionKeys,
-    (state: GlobalState, disableGroupHighlight: boolean) => disableGroupHighlight,
-    (state: GlobalState, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => mentionHighlightDisabled,
-    (allMentionKeys, mentionKeysWithoutGroups, disableGroupHighlight = false, mentionHighlightDisabled = false) => {
-        let mentionKeys = allMentionKeys;
-        if (disableGroupHighlight) {
-            mentionKeys = mentionKeysWithoutGroups;
+    (state: GlobalState, channel: Channel) => (channel?.id ? getMyGroupMentionKeysForChannel(state, channel?.team_id, channel?.id) : []),
+    (state: GlobalState, channel: Channel, disableGroupHighlight: boolean) => disableGroupHighlight,
+    (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => mentionHighlightDisabled,
+    (mentionKeysWithoutGroups, groupMentionKeys, disableGroupHighlight = false, mentionHighlightDisabled = false) => {
+        let mentionKeys = mentionKeysWithoutGroups;
+        if (!disableGroupHighlight) {
+            mentionKeys = mentionKeys.concat(groupMentionKeys);
         }
 
         if (mentionHighlightDisabled) {

--- a/app/mm-redux/selectors/entities/search.ts
+++ b/app/mm-redux/selectors/entities/search.ts
@@ -28,7 +28,7 @@ export const getAllUserMentionKeys: (state: GlobalState) => UserMentionKey[] = r
 
 export const makeGetMentionKeysForPost: (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => UserMentionKey[] = reselect.createSelector(
     getCurrentUserMentionKeys,
-    (state: GlobalState, channel: Channel) => (channel?.id ? getMyGroupMentionKeysForChannel(state, channel?.team_id, channel?.id) : []),
+    (state: GlobalState, channel: Channel) => (channel?.id ? getMyGroupMentionKeysForChannel(state, channel?.team_id, channel?.id) : getMyGroupMentionKeys(state)),
     (state: GlobalState, channel: Channel, disableGroupHighlight: boolean) => disableGroupHighlight,
     (state: GlobalState, channel: Channel, disableGroupHighlight: boolean, mentionHighlightDisabled: boolean) => mentionHighlightDisabled,
     (mentionKeysWithoutGroups, groupMentionKeys, disableGroupHighlight = false, mentionHighlightDisabled = false) => {


### PR DESCRIPTION
#### Summary
- Fixes a bug where a group (not synced to channel) is mentioned in a group synced channel but still shows as highlighted for the current user (if the user belongs in that group).


- Example: In this screenshot the user `board.one` is a member of `@board` _and_ `@executive`  however only `@board` group is synced to the current group constrained channel so only that group is being highlighted
![Screen Shot 2020-08-25 at 2 07 30 PM](https://user-images.githubusercontent.com/3207297/91211174-5450da80-e6dc-11ea-8b3a-07b917255e2e.png)


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27132

#### Checklist
- [x] Added or updated unit tests for `makeGetMentionKeysForPost`

#### Device Information
Tested on iPhone 11 Simulator  
