### PR TITLE
[MM-28074] Apply flex style only when list is empty

### DIFF
--- a/app/components/emoji_picker/__snapshots__/emoji_picker.test.js.snap
+++ b/app/components/emoji_picker/__snapshots__/emoji_picker.test.js.snap
@@ -8,7 +8,7 @@ exports[`components/emoji_picker/emoji_picker.ios should match snapshot 1`] = `
   <KeyboardAvoidingView
     behavior="padding"
     enabled={false}
-    keyboardVerticalOffset={50}
+    keyboardVerticalOffset={80}
     style={
       Object {
         "flex": 1,

--- a/app/components/emoji_picker/emoji_picker.ios.js
+++ b/app/components/emoji_picker/emoji_picker.ios.js
@@ -25,7 +25,7 @@ export default class EmojiPicker extends EmojiPickerBase {
 
         const shorten = DeviceTypes.IS_IPHONE_WITH_INSETS && isLandscape ? 6 : 2;
 
-        let keyboardOffset = DeviceTypes.IS_IPHONE_WITH_INSETS ? 50 : 30;
+        let keyboardOffset = DeviceTypes.IS_IPHONE_WITH_INSETS ? 80 : 60;
         if (isLandscape) {
             keyboardOffset = DeviceTypes.IS_IPHONE_WITH_INSETS ? 0 : 10;
         }

--- a/app/components/emoji_picker/emoji_picker_base.js
+++ b/app/components/emoji_picker/emoji_picker_base.js
@@ -251,6 +251,8 @@ export default class EmojiPicker extends PureComponent {
 
         let listComponent;
         if (searchTerm) {
+            const contentContainerStyle = filteredEmojis.length ? null : styles.flex;
+
             listComponent = (
                 <FlatList
                     data={filteredEmojis}
@@ -261,7 +263,7 @@ export default class EmojiPicker extends PureComponent {
                     pageSize={10}
                     renderItem={this.flatListRenderItem}
                     ListEmptyComponent={this.renderEmptyList}
-                    contentContainerStyle={styles.flex}
+                    contentContainerStyle={contentContainerStyle}
                     style={styles.flatList}
                 />
             );


### PR DESCRIPTION
#### Summary
Applied `flex: 1` style needed to properly center the `ListEmptyComponent` only when the list is empty. Also updated the `keyboardOffset` so that the last list item is not hidden behind the keyboard.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28074

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iPhone 11 simulator
* iPhone SE

#### Screenshots
Before:
![before](https://user-images.githubusercontent.com/3208014/91227349-39319b00-e6db-11ea-8ba1-8cad6b13585b.png)

After:
![after](https://user-images.githubusercontent.com/3208014/91227366-3df64f00-e6db-11ea-82db-0a4fe08ec96a.png)
