### PR TITLE
SSO: Rebuild the server url without query string and/or hash

### DIFF
--- a/app/screens/sso/sso.js
+++ b/app/screens/sso/sso.js
@@ -114,10 +114,11 @@ class SSO extends PureComponent {
         // Check whether we need to set a sub-path
         parsedUrl.set('pathname', original.pathname || '');
 
-        parsedUrl.set('query', '');
-        Client4.setUrl(parsedUrl.href);
+        // Rebuild the server url without query string and/or hash
+        const url = `${parsedUrl.origin}${parsedUrl.pathname}`;
+        Client4.setUrl(url);
 
-        CookieManager.get(parsedUrl.href, true).then((res) => {
+        CookieManager.get(url, true).then((res) => {
             const mmtoken = res.MMAUTHTOKEN;
             const csrf = res.MMCSRF;
             const token = typeof mmtoken === 'object' ? mmtoken.value : mmtoken;


### PR DESCRIPTION
#### Summary
There have been reports of people unable to login using GitLab SSO. For SSO login attempts we were removing any potential query strings from the final url so they are not included as part of the server base url used for API calls.

Based on a small investigation it could be that GitLab not only appends query strings but also a hash as part of the redirect_uri, this hash in case it is present is not being explicitly removed.

With this PR, we attempt to fix this by reconstructing the base url using the base origin and the pathname in case that the mattermost server is hosted on a subpath

#### Ticket Link
Potentially Resolves: https://github.com/mattermost/mattermost-mobile/issues/4712