### PR TITLE
[MM-27824] Store value before resetting text input

### DIFF
--- a/app/components/post_draft/draft_input/draft_input.js
+++ b/app/components/post_draft/draft_input/draft_input.js
@@ -146,9 +146,12 @@ export default class DraftInput extends PureComponent {
         return messageLength > 0;
     };
 
-    doSubmitMessage = () => {
+    doSubmitMessage = (message = null) => {
         const {createPost, currentUserId, channelId, files, handleClearFiles, rootId} = this.props;
-        const value = this.input.current?.getValue() || '';
+        let value = message;
+        if (!value) {
+            value = this.input.current?.getValue() || '';
+        }
         const postFiles = files.filter((f) => !f.failed);
         const post = {
             user_id: currentUserId,
@@ -223,10 +226,10 @@ export default class DraftInput extends PureComponent {
             return;
         }
 
+        const value = this.input.current.getValue();
         this.input.current.resetTextInput();
 
         requestAnimationFrame(() => {
-            const value = this.input.current.getValue();
             if (!this.isSendButtonEnabled()) {
                 this.input.current.setValue(value);
                 return;
@@ -253,12 +256,12 @@ export default class DraftInput extends PureComponent {
                 const accept = () => {
                     // Remove only failed files
                     handleClearFailedFiles(channelId, rootId);
-                    this.sendMessage();
+                    this.sendMessage(value);
                 };
 
                 DraftUtils.alertAttachmentFail(formatMessage, accept, cancel);
             } else {
-                this.sendMessage();
+                this.sendMessage(value);
             }
         });
     }
@@ -303,8 +306,7 @@ export default class DraftInput extends PureComponent {
         this.input.current.changeDraft('');
     };
 
-    sendMessage = () => {
-        const value = this.input.current?.getValue() || '';
+    sendMessage = (value = '') => {
         const {channelMemberCountsByGroup, enableConfirmNotificationsToChannel, groupsWithAllowReference, membersCount, useGroupMentions, useChannelMentions} = this.props;
         const notificationsToChannel = enableConfirmNotificationsToChannel && useChannelMentions;
         const notificationsToGroups = enableConfirmNotificationsToChannel && useGroupMentions;
@@ -320,10 +322,10 @@ export default class DraftInput extends PureComponent {
             if (memberNotifyCount > 0) {
                 this.showSendToGroupsAlert(Array.from(groupMentionsSet), memberNotifyCount, channelTimezoneCount, value);
             } else {
-                this.doSubmitMessage();
+                this.doSubmitMessage(value);
             }
         } else {
-            this.doSubmitMessage();
+            this.doSubmitMessage(value);
         }
     };
 

--- a/app/components/post_draft/draft_input/draft_input.test.js
+++ b/app/components/post_draft/draft_input/draft_input.test.js
@@ -12,6 +12,8 @@ jest.mock('react-native-image-picker', () => ({
     launchCamera: jest.fn(),
 }));
 
+jest.useFakeTimers();
+
 describe('DraftInput', () => {
     const baseProps = {
         registerTypingAnimation: jest.fn(),
@@ -95,10 +97,12 @@ describe('DraftInput', () => {
                 getValue: () => message,
                 setValue: jest.fn(),
                 changeDraft: jest.fn(),
+                resetTextInput: jest.fn(),
             },
         };
 
-        instance.sendMessage();
+        instance.handleSendMessage();
+        jest.runOnlyPendingTimers();
         expect(Alert.alert).toBeCalled();
         expect(Alert.alert).toHaveBeenCalledWith('Confirm sending notifications to entire channel', expect.anything(), expect.anything());
     });
@@ -118,9 +122,11 @@ describe('DraftInput', () => {
                 getValue: () => message,
                 setValue: jest.fn(),
                 changeDraft: jest.fn(),
+                resetTextInput: jest.fn(),
             },
         };
-        instance.sendMessage();
+        instance.handleSendMessage();
+        jest.runOnlyPendingTimers();
         expect(Alert.alert).toBeCalled();
     });
 
@@ -139,10 +145,12 @@ describe('DraftInput', () => {
                 getValue: () => message,
                 setValue: jest.fn(),
                 changeDraft: jest.fn(),
+                resetTextInput: jest.fn(),
             },
         };
 
-        instance.sendMessage();
+        instance.handleSendMessage();
+        jest.runOnlyPendingTimers();
         expect(Alert.alert).not.toBeCalled();
     });
 
@@ -162,10 +170,12 @@ describe('DraftInput', () => {
                 getValue: () => message,
                 setValue: jest.fn(),
                 changeDraft: jest.fn(),
+                resetTextInput: jest.fn(),
             },
         };
 
-        instance.sendMessage();
+        instance.handleSendMessage();
+        jest.runOnlyPendingTimers();
         expect(Alert.alert).not.toHaveBeenCalled();
     });
 
@@ -185,10 +195,12 @@ describe('DraftInput', () => {
                 getValue: () => message,
                 setValue: jest.fn(),
                 changeDraft: jest.fn(),
+                resetTextInput: jest.fn(),
             },
         };
 
-        instance.sendMessage();
+        instance.handleSendMessage();
+        jest.runOnlyPendingTimers();
         expect(Alert.alert).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
#### Summary
Resetting the text input in `handleSendMessage` makes the value inaccessible later in `doSubmitMessage` when using dictation. We know assign the value to a variable before resetting the text input and pass this value down to `doSubmitMessage`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27824

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone SE