### PR TITLE
Show arrows in calendar

### DIFF
--- a/app/components/autocomplete/date_suggestion/date_suggestion.js
+++ b/app/components/autocomplete/date_suggestion/date_suggestion.js
@@ -165,8 +165,8 @@ const getDateFontSize = () => {
 };
 
 const calendarTheme = memoizeResult((theme) => ({
-    arrowHeight: 13,
-    arrowWidth: 8,
+    arrowHeight: Platform.select({ios: 13, android: 26}),
+    arrowWidth: Platform.select({ios: 8, android: 22}),
     calendarBackground: theme.centerChannelBg,
     monthTextColor: changeOpacity(theme.centerChannelColor, 0.8),
     dayTextColor: theme.centerChannelColor,

--- a/app/components/autocomplete/date_suggestion/date_suggestion.js
+++ b/app/components/autocomplete/date_suggestion/date_suggestion.js
@@ -165,6 +165,8 @@ const getDateFontSize = () => {
 };
 
 const calendarTheme = memoizeResult((theme) => ({
+    arrowHeight: 13,
+    arrowWidth: 8,
     calendarBackground: theme.centerChannelBg,
     monthTextColor: changeOpacity(theme.centerChannelColor, 0.8),
     dayTextColor: theme.centerChannelColor,


### PR DESCRIPTION
#### Summary
With the update to  react-native-calendars passing the width & height of the arrows is now mandatory, if not set arrows are not visible.

Test: In the calendar showed in the search screen, arrows should be visible and working