### PR TITLE
MM-28307 Fix display name in convert channel to private alert

### DIFF
--- a/app/screens/channel_info/convert_private/convert_private.tsx
+++ b/app/screens/channel_info/convert_private/convert_private.tsx
@@ -52,7 +52,7 @@ export default class ConvertPrivate extends PureComponent<ConvertPrivateProps> {
         } else {
             Alert.alert(
                 '',
-                formatMessage({id: t('mobile.channel_info.convert_success'), defaultMessage: '{displayName} is now a private channel.'}, displayName),
+                formatMessage({id: t('mobile.channel_info.convert_success'), defaultMessage: '{displayName} is now a private channel.'}, {displayName}),
             );
         }
     });


### PR DESCRIPTION
#### Summary
This PR fixes the Alert shown to the user once a channel was converted from public to private where the display name of the channel was not being applied to the translation string.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28307