### PR TITLE
[MM-27132] Fix groups not actually being highlighted for self on mobile

### DIFF
--- a/app/components/at_mention/at_mention.js
+++ b/app/components/at_mention/at_mention.js
@@ -162,7 +162,7 @@ export default class AtMention extends React.PureComponent {
         } else {
             const group = this.getGroupFromMentionName();
             if (group.allow_reference) {
-                highlighted = mentionKeys.some((item) => item.key === group.name);
+                highlighted = mentionKeys.some((item) => item.key === `@${group.name}`);
                 isMention = true;
                 mention = group.name;
                 suffix = this.props.mentionName.substring(group.name.length);


### PR DESCRIPTION
#### Summary
- Not sure how this happened - or how this ever actually worked... since mentionKeys is of the format `@groupname` and `getGroupFromMentionName()` returns the actual name without the `@` prepended. 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27132

#### Device Information
- Tested on iPhone 11 sim 

![Screen Shot 2020-09-08 at 1 10 04 PM](https://user-images.githubusercontent.com/3207297/92507211-9dbd2180-f1d4-11ea-887a-ce16668aa483.png)
