### PR TITLE
MM-28295 Android fix opening sidebar after closing setting screen

### DIFF
--- a/app/store/ephemeral_store.js
+++ b/app/store/ephemeral_store.js
@@ -58,7 +58,7 @@ class EphemeralStore {
 
     removeNavigationComponentId = (componentId) => {
         const index = this.navigationComponentIdStack.indexOf(componentId);
-        if (index >= 0) {
+        if (index > 0) {
             this.navigationComponentIdStack.splice(index, 1);
         }
     }


### PR DESCRIPTION
#### Summary
When the channel screen disappears into the background it gets removed from the stack, probably something got updated in the underlying navigation dependency that caused this change in behavior from 1.34

This PR avoids removing the Channel screen from the stack.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28295