### PR TITLE
MM-28450 Fix crash when posting at-mention that does not belong to the channel

### DIFF
--- a/app/components/at_mention/at_mention.js
+++ b/app/components/at_mention/at_mention.js
@@ -141,9 +141,9 @@ export default class AtMention extends React.PureComponent {
     render() {
         const {isSearchResult, mentionName, mentionStyle, onPostPress, teammateNameDisplay, textStyle, mentionKeys} = this.props;
         const {user} = this.state;
-        const {backgroundColor, ...styleText} = StyleSheet.flatten(textStyle);
         const mentionTextStyle = [];
 
+        let backgroundColor;
         let canPress = false;
         let highlighted;
         let isMention = false;
@@ -152,6 +152,13 @@ export default class AtMention extends React.PureComponent {
         let onPress;
         let suffix;
         let suffixElement;
+        let styleText;
+
+        if (textStyle) {
+            const {backgroundColor: bg, ...otherStyles} = StyleSheet.flatten(textStyle);
+            backgroundColor = bg;
+            styleText = otherStyles;
+        }
 
         if (user?.username) {
             suffix = this.props.mentionName.substring(user.username.length);


### PR DESCRIPTION
#### Summary
For the ephemeral message that gets posted to add mentioned users to the channel the `textStyle` was undefined and  deconstructing it was causing the crash.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28450