### PR TITLE
[MM-28276] Update react-native-elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18638,9 +18638,9 @@
       "integrity": "sha512-ZKGAa8ztQ7zA1eE95OCiNsI/Q6fiq1Q3es8MyOEakBkWcX9avWNYaJUrbv/8v80Vo4RzcNxsO3wT6a2hgfpz7A=="
     },
     "react-native-elements": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-2.3.0.tgz",
-      "integrity": "sha512-t6DIIzGPfgVUwS80cBz03PPRl625ffvJEIwRQjmfOpow5Ur8YyR+b0+UzZfBtvq35lUbznNSe0Z3dNFTm13AbA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-2.3.2.tgz",
+      "integrity": "sha512-HygYYmq8JYjk/YYiUwr/64qT64H2xlPBz0JnkGTQwvnnyXZrfkHFopw8rLWCupv3iLLPDzVohvPs0Z5HLdonSQ==",
       "requires": {
         "@types/react-native-vector-icons": "^6.4.5",
         "color": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native-cookies": "github:mattermost/react-native-cookies#b35bafc388ae09c83bd875e887daf6a0755e0b40",
     "react-native-device-info": "5.6.5",
     "react-native-document-picker": "3.5.4",
-    "react-native-elements": "2.3.0",
+    "react-native-elements": "2.3.2",
     "react-native-exception-handler": "2.10.8",
     "react-native-fast-image": "8.3.2",
     "react-native-file-viewer": "2.1.1",


### PR DESCRIPTION
#### Summary
The `placeholderTextColor` prop was not applied due to a bug in `react-native-elements` which was fixed with https://github.com/react-native-elements/react-native-elements/pull/2531

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28276

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested on:
* iOS 13 simulator

#### Screenshots
![Simulator Screen Shot - iPhone 11 - 2020-09-08 at 11 03 46](https://user-images.githubusercontent.com/3208014/92512036-0b605200-f1c3-11ea-989d-31e003d2c6ab.png)
