### PR TITLE
[MM-28465] Show share extension error if team count is 0

### DIFF
--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -92,7 +92,7 @@ class ShareViewController: SLComposeServiceViewController {
   func loadData() {
     if sessionToken == nil || serverURL == nil {
       showErrorMessage(title: "", message: "Authentication required: Please first login using the app.", VC: self)
-    } else if store.getCurrentTeamId() == "" {
+    } else if store.getCurrentTeamId() == "" || store.getMyTeams().count == 0 {
       showErrorMessage(title: "", message: "You must belong to a team before you can share files.", VC: self)
     } else {
       extractDataFromContext()


### PR DESCRIPTION
#### Summary
In the share extension the currentTeamId could still be set so we also check that the team count is 0 and how the error message if so.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28465

#### Device Information
This PR was tested on:
* iOS 13 simulator