### PR TITLE
Save draft when post input unmounts

### DIFF
--- a/app/components/post_draft/post_input/post_input.js
+++ b/app/components/post_draft/post_input/post_input.js
@@ -74,6 +74,8 @@ export default class PostInput extends PureComponent {
         if (Platform.OS === 'android') {
             Keyboard.removeListener('keyboardDidHide', this.handleAndroidKeyboard);
         }
+
+        this.changeDraft(this.getValue());
     }
 
     blur = () => {


### PR DESCRIPTION
#### Summary
Draft was only being saved when blurring the input, now it also saves when the component unmounts (leaving the thread screen while the input has focus)

#### Ticket Link
Original issue reported in the ticket is already fixed on master (can be verified with the app created by this PR)  https://mattermost.atlassian.net/browse/MM-28488?focusedCommentId=98071
