### PR TITLE
MM-28295 Do not remove the Channel screen from the stack tracking

### DIFF
--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -13,8 +13,6 @@ import EphemeralStore from '@store/ephemeral_store';
 import Store from '@store/store';
 import {NavigationTypes} from '@constants';
 
-const CHANNEL_SCREEN = 'Channel';
-
 function getThemeFromState() {
     const state = Store.redux?.getState() || {};
 
@@ -29,8 +27,8 @@ export function resetToChannel(passProps = {}) {
     const stack = {
         children: [{
             component: {
-                id: CHANNEL_SCREEN,
-                name: CHANNEL_SCREEN,
+                id: NavigationTypes.CHANNEL_SCREEN,
+                name: NavigationTypes.CHANNEL_SCREEN,
                 passProps,
                 options: {
                     layout: {
@@ -427,7 +425,7 @@ export function closeMainSideMenu() {
     }
 
     Keyboard.dismiss();
-    Navigation.mergeOptions(CHANNEL_SCREEN, {
+    Navigation.mergeOptions(NavigationTypes.CHANNEL_SCREEN, {
         sideMenu: {
             left: {visible: false},
         },
@@ -439,7 +437,7 @@ export function enableMainSideMenu(enabled, visible = true) {
         return;
     }
 
-    Navigation.mergeOptions(CHANNEL_SCREEN, {
+    Navigation.mergeOptions(NavigationTypes.CHANNEL_SCREEN, {
         sideMenu: {
             left: {enabled, visible},
         },
@@ -452,7 +450,7 @@ export function openSettingsSideMenu() {
     }
 
     Keyboard.dismiss();
-    Navigation.mergeOptions(CHANNEL_SCREEN, {
+    Navigation.mergeOptions(NavigationTypes.CHANNEL_SCREEN, {
         sideMenu: {
             right: {visible: true},
         },
@@ -465,7 +463,7 @@ export function closeSettingsSideMenu() {
     }
 
     Keyboard.dismiss();
-    Navigation.mergeOptions(CHANNEL_SCREEN, {
+    Navigation.mergeOptions(NavigationTypes.CHANNEL_SCREEN, {
         sideMenu: {
             right: {visible: false},
         },

--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -86,6 +86,8 @@ export function resetToChannel(passProps = {}) {
 export function resetToSelectServer(allowOtherServers) {
     const theme = Preferences.THEMES.default;
 
+    EphemeralStore.clearNavigationComponents();
+
     Navigation.setRoot({
         root: {
             stack: {
@@ -147,6 +149,8 @@ export function resetToTeams(name, title, passProps = {}, options = {}) {
             },
         },
     };
+
+    EphemeralStore.clearNavigationComponents();
 
     Navigation.setRoot({
         root: {

--- a/app/constants/navigation.js
+++ b/app/constants/navigation.js
@@ -18,4 +18,6 @@ const NavigationTypes = keyMirror({
     BLUR_POST_DRAFT: null,
 });
 
+NavigationTypes.CHANNEL_SCREEN = 'Channel';
+
 export default NavigationTypes;

--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -124,7 +124,9 @@ export function componentDidAppearListener({componentId}) {
 }
 
 export function componentDidDisappearListener({componentId}) {
-    EphemeralStore.removeNavigationComponentId(componentId);
+    if (componentId !== NavigationTypes.CHANNEL_SCREEN) {
+        EphemeralStore.removeNavigationComponentId(componentId);
+    }
 
     if (componentId === 'MainSidebar') {
         EventEmitter.emit(NavigationTypes.MAIN_SIDEBAR_DID_CLOSE);

--- a/app/store/ephemeral_store.js
+++ b/app/store/ephemeral_store.js
@@ -58,7 +58,7 @@ class EphemeralStore {
 
     removeNavigationComponentId = (componentId) => {
         const index = this.navigationComponentIdStack.indexOf(componentId);
-        if (index > 0) {
+        if (index >= 0) {
             this.navigationComponentIdStack.splice(index, 1);
         }
     }


### PR DESCRIPTION
#### Summary
With #4777 we attempted to fix an issue on the Android navigation, but that introduced a second bug that was affecting both Android and iOS:

* Open the app in a channel that contains posts
* Tap a post the Thread opens
* Go back to the channel screen
* Long Press on a Post and close the post options
* Tap on the post  to go to the thread screen again

Observed:  Nothing happened after tapping the post again.
The same could be accomplished by
* switching teams
*  opening the search screen
* opening the channel info screen
*  opening the emoji picker
* opening the gallery
* Opening the reaction list
In fact it  was  happening when opening any modal from the channel screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28295