### PR TITLE
[MM-28706] revert ordering change for `in:` auto-suggest search

### DIFF
--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -91,12 +91,13 @@ export default class ChannelMention extends PureComponent {
         myMembers !== this.props.myMembers)) {
             const sections = [];
             if (isSearch) {
-                if (directAndGroupMessages.length) {
+                if (publicChannels.length) {
                     sections.push({
-                        id: t('suggestion.search.direct'),
-                        defaultMessage: 'Direct Messages',
-                        data: directAndGroupMessages,
-                        key: 'directAndGroupMessages',
+                        id: t('suggestion.search.public'),
+                        defaultMessage: 'Public Channels',
+                        data: publicChannels.filter((cId) => myMembers[cId]),
+                        key: 'publicChannels',
+                        hideLoadingIndicator: true,
                     });
                 }
 
@@ -110,13 +111,12 @@ export default class ChannelMention extends PureComponent {
                     });
                 }
 
-                if (publicChannels.length) {
+                if (directAndGroupMessages.length) {
                     sections.push({
-                        id: t('suggestion.search.public'),
-                        defaultMessage: 'Public Channels',
-                        data: publicChannels.filter((cId) => myMembers[cId]),
-                        key: 'publicChannels',
-                        hideLoadingIndicator: true,
+                        id: t('suggestion.search.direct'),
+                        defaultMessage: 'Direct Messages',
+                        data: directAndGroupMessages,
+                        key: 'directAndGroupMessages',
                     });
                 }
             } else {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
- Revert ordering change for `in:` auto-suggest search after user feedback. The ordering now is Public Channels, Private Channels, and finally DMs and GMs.
This PR only fixes ordering. Further search improvements are planned in https://mattermost.atlassian.net/browse/MM-26805
 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-28706
- The Jira ticket above reverts the changes in https://mattermost.atlassian.net/browse/MM-27540 (Parent: https://mattermost.atlassian.net/browse/MM-15477) which was implemented in https://github.com/mattermost/mattermost-mobile/pull/4704

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 
Android Emulator - Pixel 3 XL running Android 11



#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->
![Screenshot_1600425394](https://user-images.githubusercontent.com/1779129/93589486-7e8b7480-f9ca-11ea-840e-362f05369782.png)