### PR TITLE
[MM-28884] Fix getPostThread import

### DIFF
--- a/app/screens/long_post/index.js
+++ b/app/screens/long_post/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {getPostThread} from '@actions/views/channel';
+import {getPostThread} from '@actions/views/post';
 import {selectPost} from '@mm-redux/actions/posts';
 import {makeGetChannel} from '@mm-redux/selectors/entities/channels';
 import {getPost} from '@mm-redux/selectors/entities/posts';


### PR DESCRIPTION
#### Summary
Import `getPostThread` from the correct module.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28884