### PR TITLE
[MM-28973] Prevent destructuring of undefined

### DIFF
--- a/app/reducers/views/channel.js
+++ b/app/reducers/views/channel.js
@@ -62,7 +62,7 @@ function handleSetTempUploadFileForPostDraft(state, action) {
 
     const tempFiles = action.clientIds.map((temp) => ({...temp, loading: true}));
     const files = [
-        ...state[action.channelId].files,
+        ...state[action.channelId]?.files || [],
         ...tempFiles,
     ];
 

--- a/app/reducers/views/thread.js
+++ b/app/reducers/views/thread.js
@@ -73,7 +73,7 @@ function handleSetTempUploadFilesForPostDraft(state, action) {
 
     const tempFiles = action.clientIds.map((temp) => ({...temp, loading: true}));
     const files = [
-        ...state[action.rootId].files,
+        ...state[action.rootId]?.files || [],
         ...tempFiles,
     ];
 


### PR DESCRIPTION
#### Summary
After purging the store `state.views.channel.drafts` is an empty object so destructuring `state[action.channelId].files` would throw an error. This is fixed by using a default empty array when `state[action.channelId]?.files` is undefined.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28973

#### Device Information
This PR was tested on:
* iOS 13 simulator