### PR TITLE
[MM-29216] Don't allow sharing of files if file uploads are disabled

### DIFF
--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -276,6 +276,7 @@
   "mobile.file_upload.browse": "Browse Files",
   "mobile.file_upload.camera_photo": "Take Photo",
   "mobile.file_upload.camera_video": "Take Video",
+  "mobile.file_upload.disabled": "File uploads from mobile are disabled. Please contact your System Admin for more details.",
   "mobile.file_upload.library": "Photo Library",
   "mobile.file_upload.max_warning": "Uploads limited to 5 files maximum.",
   "mobile.file_upload.unsupportedMimeType": "Only BMP, JPG or PNG images may be used for profile pictures.",

--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -97,7 +97,7 @@ class ShareViewController: SLComposeServiceViewController {
     } else if store.getCurrentTeamId() == "" || store.getMyTeams().count == 0 {
       showErrorMessage(title: "", message: "You must belong to a team before you can share files.", VC: self)
     } else if !canUploadFiles {
-      showErrorMessage(title: "", message: "File uploads are disabled from mobile. Please contact your System Admin for more details.", VC: self)
+      showErrorMessage(title: "", message: "File uploads from mobile are disabled. Please contact your System Admin for more details.", VC: self)
     } else {
       extractDataFromContext()
     }

--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -29,6 +29,7 @@ class ShareViewController: SLComposeServiceViewController {
   private var teamsVC: TeamsViewController = TeamsViewController()
   
   private var maxMessageSize: Int = 0
+  private var canUploadFiles: Bool = true
   
   required init?(coder aDecoder: NSCoder) {
       super.init(coder: aDecoder)
@@ -37,6 +38,7 @@ class ShareViewController: SLComposeServiceViewController {
       sessionToken = store.getToken()
       serverURL = store.getServerUrl()
       maxMessageSize = Int(store.getMaxPostSize())
+      canUploadFiles = store.getCanUploadFiles()
   }
 
   // MARK: - Lifecycle methods
@@ -94,6 +96,8 @@ class ShareViewController: SLComposeServiceViewController {
       showErrorMessage(title: "", message: "Authentication required: Please first login using the app.", VC: self)
     } else if store.getCurrentTeamId() == "" || store.getMyTeams().count == 0 {
       showErrorMessage(title: "", message: "You must belong to a team before you can share files.", VC: self)
+    } else if !canUploadFiles {
+      showErrorMessage(title: "", message: "File uploads are disabled from mobile. Please contact your System Admin for more details.", VC: self)
     } else {
       extractDataFromContext()
     }

--- a/ios/UploadAttachments/UploadAttachments/StoreManager.h
+++ b/ios/UploadAttachments/UploadAttachments/StoreManager.h
@@ -22,5 +22,6 @@
 -(NSArray *)getMyTeams;
 -(NSString *)getServerUrl;
 -(NSString *)getToken;
+-(BOOL)getCanUploadFiles;
 -(void)updateEntities:(NSString *)content;
 @end

--- a/ios/UploadAttachments/UploadAttachments/StoreManager.m
+++ b/ios/UploadAttachments/UploadAttachments/StoreManager.m
@@ -207,6 +207,21 @@
     return DEFAULT_SERVER_MAX_POST_SIZE;
 }
 
+-(BOOL)getCanUploadFiles {
+    NSDictionary *config = [self getConfig];
+    NSDictionary *license = [self getLicense];
+    if (config != nil && license != nil) {
+        NSString *enableFileAttachments = [config objectForKey:@"EnableFileAttachments"];
+        NSString *isLicensed = [license objectForKey:@"IsLicensed"];
+        NSString *compliance = [license objectForKey:@"Compliance"];
+        NSString *enableMobileFileUpload = [config objectForKey:@"EnableMobileFileUpload"];
+        return ![enableFileAttachments isEqual:@"false"] &&
+           ([isLicensed isEqual:@"false"] || [compliance isEqual:@"false"] || ![enableMobileFileUpload isEqual:@"false"]);
+    }
+      
+    return YES;
+}
+
 -(void)updateEntities:(NSString *)content {
     [self.bucket writeToFile:@"entities" content:content];
 }
@@ -270,6 +285,10 @@
 
 -(NSDictionary *)getConfig {
   return [[self.entities objectForKey:@"general"] objectForKey:@"config"];
+}
+
+-(NSDictionary *)getLicense {
+  return [[self.entities objectForKey:@"general"] objectForKey:@"license"];
 }
 
 -(NSDictionary *)getMyPreferences {

--- a/share_extension/android/extension_post/__snapshots__/extension_post.test.js.snap
+++ b/share_extension/android/extension_post/__snapshots__/extension_post.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`ExtensionPost should render file uploads disabled message when canUploadFiles is false 1`] = `null`;

--- a/share_extension/android/extension_post/__snapshots__/extension_post.test.js.snap
+++ b/share_extension/android/extension_post/__snapshots__/extension_post.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExtensionPost should render file uploads disabled message when canUploadFiles is false 1`] = `null`;

--- a/share_extension/android/extension_post/extension_post.js
+++ b/share_extension/android/extension_post/extension_post.js
@@ -66,6 +66,7 @@ export default class ExtensionPost extends PureComponent {
         channels: PropTypes.object.isRequired,
         currentUserId: PropTypes.string.isRequired,
         getTeamChannels: PropTypes.func.isRequired,
+        canUploadFiles: PropTypes.bool.isRequired,
         maxFileSize: PropTypes.number.isRequired,
         navigation: PropTypes.object.isRequired,
         teamId: PropTypes.string.isRequired,
@@ -377,7 +378,7 @@ export default class ExtensionPost extends PureComponent {
     };
 
     onClose = (data) => {
-        ShareExtension.close(data.nativeEvent ? null : data);
+        ShareExtension.close(data?.nativeEvent ? null : data);
     };
 
     onPost = () => {
@@ -555,6 +556,7 @@ export default class ExtensionPost extends PureComponent {
             delayPressIn={0}
             pressColorAndroid='rgba(0, 0, 0, .32)'
             onPress={this.onPost}
+            disabled={!this.props.canUploadFiles}
         >
             <View style={styles.left}>
                 <PaperPlane
@@ -623,6 +625,14 @@ export default class ExtensionPost extends PureComponent {
             });
 
             return this.renderErrorMessage(teamRequired);
+        }
+
+        if (!this.props.canUploadFiles) {
+            const uploadsDisabled = formatMessage({
+                id: 'mobile.file_upload.disabled',
+                defaultMessage: 'File uploads from mobile are disabled. Please contact your System Admin for more details.',
+            });
+            return this.renderErrorMessage(uploadsDisabled);
         }
 
         if (this.token && this.url) {

--- a/share_extension/android/extension_post/extension_post.test.js
+++ b/share_extension/android/extension_post/extension_post.test.js
@@ -71,7 +71,6 @@ describe('ExtensionPost', () => {
     test('should render file uploads disabled message when canUploadFiles is false', () => {
         wrapper.setState({loaded: true});
         wrapper.setProps({canUploadFiles: false});
-        expect(wrapper.getElement()).toMatchSnapshot();
         expect(instance.renderErrorMessage).toHaveBeenCalledWith('File uploads from mobile are disabled. Please contact your System Admin for more details.');
     });
 });

--- a/share_extension/android/extension_post/extension_post.test.js
+++ b/share_extension/android/extension_post/extension_post.test.js
@@ -24,6 +24,7 @@ describe('ExtensionPost', () => {
         channels: {},
         currentUserId: 'current-user-id',
         getTeamChannels: jest.fn(),
+        canUploadFiles: true,
         maxFileSize: 1024,
         navigation: {
             setOptions: jest.fn(),
@@ -39,6 +40,7 @@ describe('ExtensionPost', () => {
     );
 
     const instance = wrapper.instance();
+    instance.renderErrorMessage = jest.fn();
 
     const postMessage = (message) => {
         wrapper.setState({value: message});
@@ -64,5 +66,12 @@ describe('ExtensionPost', () => {
         postMessage(exactLengthMessage);
 
         expect(Alert.alert).not.toHaveBeenCalled();
+    });
+
+    test('should render file uploads disabled message when canUploadFiles is false', () => {
+        wrapper.setState({loaded: true});
+        wrapper.setProps({canUploadFiles: false});
+        expect(wrapper.getElement()).toMatchSnapshot();
+        expect(instance.renderErrorMessage).toHaveBeenCalledWith('File uploads from mobile are disabled. Please contact your System Admin for more details.');
     });
 });

--- a/share_extension/android/extension_post/index.js
+++ b/share_extension/android/extension_post/index.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 import {getAllChannels, getCurrentChannel, getDefaultChannel} from '@mm-redux/selectors/entities/channels';
 import {getCurrentTeamId} from '@mm-redux/selectors/entities/teams';
 import {getCurrentUserId} from '@mm-redux/selectors/entities/users';
-import {getConfig} from '@mm-redux/selectors/entities/general';
+import {getConfig, canUploadFilesOnMobile} from '@mm-redux/selectors/entities/general';
 
 import {getTeamChannels} from 'share_extension/android/actions';
 import {getAllowedServerMaxFileSize} from 'app/utils/file';
@@ -25,6 +25,7 @@ function mapStateToProps(state) {
         channelId: channel?.id,
         channels: getAllChannels(state),
         currentUserId: getCurrentUserId(state),
+        canUploadFiles: canUploadFilesOnMobile(state),
         maxFileSize: getAllowedServerMaxFileSize(config),
         teamId: getCurrentTeamId(state),
     };


### PR DESCRIPTION
#### Summary
Check to see if file uploads from mobile are disabled and if so show an error message.
QA: For iOS, please test all the scenarios in which [getCanUploadFiles](https://github.com/mattermost/mattermost-mobile/compare/MM-29216/share-ext-fix?expand=1#diff-d95e0ee731354c8e1142b425819d140aR218) can return false.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29216

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on:
* Mi A3, Android 10
* iOS 14 simulator

#### Screenshots
Android:
![android](https://user-images.githubusercontent.com/3208014/94864320-a4fcd700-03f0-11eb-8afc-cf1bf45295f8.jpg)

iOS:
![ios](https://user-images.githubusercontent.com/3208014/94864017-3455ba80-03f0-11eb-8aad-0b9e4b8f8b1b.png)
