### PR TITLE
[MM-29275]: Remove first char of slash cmd autocomplete suggestion text, only if it is a top-level command

### DIFF
--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
@@ -37,6 +37,11 @@ export default class SlashSuggestionItem extends PureComponent {
 
         const style = getStyleFromTheme(theme);
 
+        let suggestionText = suggestion;
+        if (suggestionText[0] === '/') {
+            suggestionText = suggestionText.substring(1);
+        }
+
         return (
             <TouchableWithFeedback
                 onPress={this.completeSuggestion}
@@ -54,7 +59,7 @@ export default class SlashSuggestionItem extends PureComponent {
                         />
                     </View>
                     <View style={style.suggestionContainer}>
-                        <Text style={style.suggestionName}>{`${suggestion.substring(1)} ${hint}`}</Text>
+                        <Text style={style.suggestionName}>{`${suggestionText} ${hint}`}</Text>
                         <Text
                             ellipsizeMode='tail'
                             numberOfLines={1}

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.js
@@ -32,13 +32,14 @@ export default class SlashSuggestionItem extends PureComponent {
             hint,
             theme,
             suggestion,
+            complete,
             isLandscape,
         } = this.props;
 
         const style = getStyleFromTheme(theme);
 
         let suggestionText = suggestion;
-        if (suggestionText[0] === '/') {
+        if (suggestionText[0] === '/' && complete.split(' ').length === 1) {
             suggestionText = suggestionText.substring(1);
         }
 


### PR DESCRIPTION
#### Summary

In a recent PR https://github.com/mattermost/mattermost-mobile/pull/4531 , the display of slash command suggestions is changed. The first character is removed in order to get rid of the preceding slash on each suggestion. However with subcommands and command args, the first letter is not always a slash. This results in incomplete suggesitons like `iew` for `jira view`.

This PR makes it so the char is checked to be a slash first. In order to know if a given suggestion is for a command (and not a subcommand or argument), we can check if `item.complete` is only one word. This is the full value of the suggestion. For example `jira` versus `jira view`.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-29275

#### Screenshots

-----

Before

<img width="400px" src="https://user-images.githubusercontent.com/6913320/95053018-d231d980-06bd-11eb-8c73-5c5eb2d33196.png"/>

-----

After

<img width="400px" src="https://user-images.githubusercontent.com/6913320/95052893-ab73a300-06bd-11eb-9e14-968bb7eca6df.png"/>

-----

Top level command looks correct before and after this PR's change

<img width="400px" src="https://user-images.githubusercontent.com/6913320/95053184-1329ee00-06be-11eb-8b8f-f57e83bf89e4.png"/>
