### PR TITLE
[MM-29300] Emit PASTE_FILES event only from last subscribed input

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/RNPasteableActionCallback.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/RNPasteableActionCallback.java
@@ -82,7 +82,12 @@ public class RNPasteableActionCallback implements ActionMode.Callback {
             return null;
         }
 
-        String text = item.getText().toString();
+        CharSequence chars = item.getText();
+        if (chars == null) {
+            return null;
+        }
+
+        String text = chars.toString(); 
         if (text.length() > 0) {
             return null;
         }

--- a/app/components/pasteable_text_input/index.js
+++ b/app/components/pasteable_text_input/index.js
@@ -27,7 +27,17 @@ export class PasteableTextInput extends React.PureComponent {
         }
     }
 
+    getLastSubscriptionKey = () => {
+        const subscriptions = OnPasteEventEmitter._subscriber._subscriptionsForType.onPaste?.filter((sub) => sub); // eslint-disable-line no-underscore-dangle
+        return subscriptions?.length && subscriptions[subscriptions.length - 1].key;
+    }
+
     onPaste = (event) => {
+        const lastSubscriptionKey = this.getLastSubscriptionKey();
+        if (this.subscription.key !== lastSubscriptionKey) {
+            return;
+        }
+
         let data = null;
         let error = null;
 

--- a/app/components/pasteable_text_input/index.test.js
+++ b/app/components/pasteable_text_input/index.test.js
@@ -12,6 +12,8 @@ import {PasteableTextInput} from './index';
 const nativeEventEmitter = new NativeEventEmitter();
 
 describe('PasteableTextInput', () => {
+    const emit = jest.spyOn(EventEmitter, 'emit');
+
     test('should render pasteable text input', () => {
         const onPaste = jest.fn();
         const text = 'My Text';
@@ -24,12 +26,11 @@ describe('PasteableTextInput', () => {
     test('should call onPaste props if native onPaste trigger', () => {
         const event = {someData: 'data'};
         const text = 'My Text';
-        const onPaste = jest.spyOn(EventEmitter, 'emit');
         shallow(
             <PasteableTextInput>{text}</PasteableTextInput>,
         );
         nativeEventEmitter.emit('onPaste', event);
-        expect(onPaste).toHaveBeenCalledWith(PASTE_FILES, null, event);
+        expect(emit).toHaveBeenCalledWith(PASTE_FILES, null, event);
     });
 
     test('should remove onPaste listener when unmount', () => {
@@ -42,5 +43,17 @@ describe('PasteableTextInput', () => {
         component.instance().subscription.remove = mockRemove;
         component.instance().componentWillUnmount();
         expect(mockRemove).toHaveBeenCalled();
+    });
+
+    test('should emit PASTE_FILES event only for last subscription', () => {
+        const component1 = shallow(<PasteableTextInput/>);
+        const instance1 = component1.instance();
+        const component2 = shallow(<PasteableTextInput/>);
+        const instance2 = component2.instance();
+
+        instance1.onPaste();
+        expect(emit).not.toHaveBeenCalled();
+        instance2.onPaste();
+        expect(emit).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
#### Summary
Even though we check the top screen ID when handling the `PASTE_FILES` event in the Upload component, a second `onPaste` event was emitted from the Channel screen which causes the Thread screen to emit a second `PASTE_FILES` event. We now only emit if the `onPaste` subscriber is the latest subscriber.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29300

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone SE, iOS 14
* Mi A3, Android 10