### PR TITLE
MM-30101 Match channel specific global notification preference

### DIFF
--- a/app/screens/channel_notification_preference/channel_notification_preference.android.js
+++ b/app/screens/channel_notification_preference/channel_notification_preference.android.js
@@ -23,7 +23,7 @@ export default class ChannelNotificationPreferenceAndroid extends ChannelNotific
                 label: intl.formatMessage({
                     id: element.id,
                     defaultMessage: element.defaultMessage,
-                }),
+                }, element.labelValues),
                 value: element.value,
                 checked: element.checked,
             };

--- a/app/screens/channel_notification_preference/channel_notification_preference.ios.js
+++ b/app/screens/channel_notification_preference/channel_notification_preference.ios.js
@@ -46,6 +46,7 @@ export default class ChannelNotificationPreferenceIos extends ChannelNotificatio
                                             <FormattedText
                                                 id={item.id}
                                                 defaultMessage={item.defaultMessage}
+                                                values={item.labelValues}
                                             />
                                         )}
                                         action={this.handlePress}

--- a/app/screens/channel_notification_preference/channel_notification_preference.test.js
+++ b/app/screens/channel_notification_preference/channel_notification_preference.test.js
@@ -6,7 +6,7 @@ import {ViewTypes} from '@constants';
 import Preferences from '@mm-redux/constants/preferences';
 import SectionItem from '@screens/settings/section_item';
 
-import {shallowWithIntl} from 'test/intl-test-helper';
+import {shallowWithIntlMessages} from 'test/intl-test-helper';
 import ChannelNotificationPreference from './channel_notification_preference';
 
 function makeProps(pushNotificationLevel) {
@@ -15,6 +15,9 @@ function makeProps(pushNotificationLevel) {
             updateChannelNotifyProps: jest.fn(),
         },
         channelId: 'channel_id',
+        globalNotifyProps: {
+            push: 'mention',
+        },
         userId: 'user_id',
         notifyProps: {
             push: pushNotificationLevel,
@@ -25,7 +28,7 @@ function makeProps(pushNotificationLevel) {
 }
 
 function checkNotificationSelected(pushNotificationLevel, trueIdx) {
-    const wrapper = shallowWithIntl(
+    const wrapper = shallowWithIntlMessages(
         <ChannelNotificationPreference
             {...makeProps(pushNotificationLevel)}
         />,
@@ -52,7 +55,7 @@ describe('ChannelNotificationPreference', () => {
 
     test('should save on click', () => {
         const props = makeProps('default');
-        const wrapper = shallowWithIntl(
+        const wrapper = shallowWithIntlMessages(
             <ChannelNotificationPreference {...props}/>,
         );
 

--- a/app/screens/channel_notification_preference/channel_notification_preference_base.js
+++ b/app/screens/channel_notification_preference/channel_notification_preference_base.js
@@ -16,6 +16,7 @@ export default class ChannelNotificationPreferenceBase extends PureComponent {
             updateChannelNotifyProps: PropTypes.func.isRequired,
         }),
         channelId: PropTypes.string.isRequired,
+        globalNotifyProps: PropTypes.object.isRequired,
         isLandscape: PropTypes.bool.isRequired,
         notifyProps: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
@@ -35,25 +36,33 @@ export default class ChannelNotificationPreferenceBase extends PureComponent {
     }
 
     getItems = () => {
+        const {formatMessage} = this.context.intl;
+        const {globalNotifyProps} = this.props;
         const {notificationLevel} = this.state;
+        const defaultNotificationLevel = formatMessage({id: `channel_header.notificationPreference.${globalNotifyProps.push.toLowerCase()}`});
+
         return [{
             id: t('channel_notifications.preference.global_default'),
-            defaultMessage: 'Global default (Mentions)',
+            defaultMessage: 'Global default ({notifyLevel})',
+            labelValues: {notifyLevel: defaultNotificationLevel},
             value: ViewTypes.NotificationLevels.DEFAULT,
             checked: notificationLevel === ViewTypes.NotificationLevels.DEFAULT,
         }, {
             id: t('channel_notifications.preference.all_activity'),
             defaultMessage: 'For all activity',
+            labelValues: undefined,
             value: ViewTypes.NotificationLevels.ALL,
             checked: notificationLevel === ViewTypes.NotificationLevels.ALL,
         }, {
             id: t('channel_notifications.preference.only_mentions'),
             defaultMessage: 'Only mentions and direct messages',
+            labelValues: undefined,
             value: ViewTypes.NotificationLevels.MENTION,
             checked: notificationLevel === ViewTypes.NotificationLevels.MENTION,
         }, {
             id: t('channel_notifications.preference.never'),
             defaultMessage: 'Never',
+            labelValues: undefined,
             value: ViewTypes.NotificationLevels.NONE,
             checked: notificationLevel === ViewTypes.NotificationLevels.NONE,
         }];

--- a/app/screens/channel_notification_preference/channel_notification_preference_base.js
+++ b/app/screens/channel_notification_preference/channel_notification_preference_base.js
@@ -39,7 +39,7 @@ export default class ChannelNotificationPreferenceBase extends PureComponent {
         const {formatMessage} = this.context.intl;
         const {globalNotifyProps} = this.props;
         const {notificationLevel} = this.state;
-        const defaultNotificationLevel = formatMessage({id: `channel_header.notificationPreference.${globalNotifyProps.push.toLowerCase()}`});
+        const defaultNotificationLevel = formatMessage({id: `channel_header.notificationPreference.${globalNotifyProps?.push.toLowerCase()}`});
 
         return [{
             id: t('channel_notifications.preference.global_default'),

--- a/app/screens/channel_notification_preference/index.js
+++ b/app/screens/channel_notification_preference/index.js
@@ -4,16 +4,17 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {updateChannelNotifyProps} from '@mm-redux/actions/channels';
+import {getCurrentUser} from '@mm-redux/selectors/entities/users';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {isLandscape} from 'app/selectors/device';
 
 import ChannelNotificationPreference from './channel_notification_preference';
 
 function mapStateToProps(state) {
-    const theme = getTheme(state);
     return {
-        theme,
+        globalNotifyProps: getCurrentUser(state)?.notify_props,
         isLandscape: isLandscape(state),
+        theme: getTheme(state),
     };
 }
 

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -41,7 +41,7 @@
   "channel_notifications.ignoreChannelMentions.settings": "Ignore @channel, @here, @all",
   "channel_notifications.muteChannel.settings": "Mute channel",
   "channel_notifications.preference.all_activity": "For all activity",
-  "channel_notifications.preference.global_default": "Global default (Mentions)",
+  "channel_notifications.preference.global_default": "Global default ({notifyLevel})",
   "channel_notifications.preference.header": "Send Notifications",
   "channel_notifications.preference.never": "Never",
   "channel_notifications.preference.only_mentions": "Only mentions and direct messages",

--- a/test/intl-test-helper.js
+++ b/test/intl-test-helper.js
@@ -5,12 +5,23 @@ import React from 'react';
 import {IntlProvider, intlShape} from 'react-intl';
 import {mount, shallow} from 'enzyme';
 
+import {getTranslations} from '@i18n';
+
 const intlProvider = new IntlProvider({locale: 'en'}, {});
 const {intl} = intlProvider.getChildContext();
 
 export function shallowWithIntl(node, {context} = {}) {
     return shallow(React.cloneElement(node, {intl}), {
         context: Object.assign({}, context, {intl}),
+    });
+}
+
+export function shallowWithIntlMessages(node, {context} = {}) {
+    const provider = new IntlProvider({locale: 'en', messages: getTranslations('en')}, {});
+    const {intl: intlWithMessages} = provider.getChildContext();
+
+    return shallow(React.cloneElement(node, {intl: intlWithMessages}), {
+        context: Object.assign({}, context, {intl: intlWithMessages}),
     });
 }
 


### PR DESCRIPTION
#### Summary
reflect inherited the default notification preference for channel level notification preference.

Note: The preference updates real time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30101

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: Android & iOS