### PR TITLE
MM-29965 Fix at_mention autocomplete selection bug

### DIFF
--- a/app/components/autocomplete/at_mention/at_mention.js
+++ b/app/components/autocomplete/at_mention/at_mention.js
@@ -63,19 +63,8 @@ export default class AtMention extends PureComponent {
         if (matchTerm === null) {
             this.props.onResultCountChange(0);
             this.setState({
-                mentionComplete: false,
                 sections: [],
             });
-            this.props.onResultCountChange(0);
-            return;
-        }
-
-        if (this.state.mentionComplete) {
-            // Mention has been completed. Hide autocomplete.
-            this.setState({
-                sections: [],
-            });
-
             this.props.onResultCountChange(0);
             return;
         }
@@ -203,7 +192,9 @@ export default class AtMention extends PureComponent {
         }
 
         onChangeText(completedDraft);
-        this.setState({mentionComplete: true});
+        this.setState({
+            sections: [],
+        });
     };
 
     renderSectionHeader = ({section}) => {
@@ -255,8 +246,8 @@ export default class AtMention extends PureComponent {
 
     render() {
         const {maxListHeight, theme, nestedScrollEnabled} = this.props;
-        const {mentionComplete, sections} = this.state;
-        if (sections.length === 0 || mentionComplete) {
+        const {sections} = this.state;
+        if (sections.length === 0) {
             // If we are not in an active state or the mention has been completed return null so nothing is rendered
             // other components are not blocked.
             return null;

--- a/app/components/autocomplete/at_mention/at_mention.js
+++ b/app/components/autocomplete/at_mention/at_mention.js
@@ -61,11 +61,9 @@ export default class AtMention extends PureComponent {
 
         // Not invoked, render nothing.
         if (matchTerm === null) {
-            this.props.onResultCountChange(0);
             this.setState({
                 sections: [],
             });
-            this.props.onResultCountChange(0);
             return;
         }
 
@@ -93,6 +91,12 @@ export default class AtMention extends PureComponent {
             });
 
             this.props.onResultCountChange(sections.reduce((total, section) => total + section.data.length, 0));
+        }
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevState.sections.length !== this.state.sections.length && this.state.sections.length === 0) {
+            this.props.onResultCountChange(0);
         }
     }
 

--- a/detox/e2e/test/autocomplete/at_mention.e2e.js
+++ b/detox/e2e/test/autocomplete/at_mention.e2e.js
@@ -168,7 +168,7 @@ describe('Autocomplete', () => {
         await expect(element(by.id(`autocomplete.at_mention.item.${user.id}`))).not.toExist();
     });
 
-    it('should be able to select at mention multiple times', async () => {
+    it('MM-T3409_11 should be able to select at mention multiple times', async () => {
         // # Type "@" to activate at mention autocomplete
         await expect(element(by.id('autocomplete.at_mention.list'))).not.toExist();
         await postInput.typeText('@');

--- a/detox/e2e/test/autocomplete/at_mention.e2e.js
+++ b/detox/e2e/test/autocomplete/at_mention.e2e.js
@@ -168,7 +168,7 @@ describe('Autocomplete', () => {
         await expect(element(by.id(`autocomplete.at_mention.item.${user.id}`))).not.toExist();
     });
 
-    it('should display suggestions in sequence', async () => {
+    it('should be able to select at mention multiple times', async () => {
         // # Type "@" to activate at mention autocomplete
         await expect(element(by.id('autocomplete.at_mention.list'))).not.toExist();
         await postInput.typeText('@');

--- a/detox/e2e/test/autocomplete/at_mention.e2e.js
+++ b/detox/e2e/test/autocomplete/at_mention.e2e.js
@@ -167,4 +167,24 @@ describe('Autocomplete', () => {
         // * Expect at mention autocomplete not to contain associated user suggestion
         await expect(element(by.id(`autocomplete.at_mention.item.${user.id}`))).not.toExist();
     });
+
+    it('should display suggestions in sequence', async () => {
+        // # Type "@" to activate at mention autocomplete
+        await expect(element(by.id('autocomplete.at_mention.list'))).not.toExist();
+        await postInput.typeText('@');
+        await expect(element(by.id('autocomplete.at_mention.list'))).toExist();
+
+        // # Type username
+        await postInput.typeText(user.username);
+
+        // # Tap user
+        await element(by.id(`autocomplete.at_mention.item.${user.id}`)).tap();
+
+        // * expect mention autocomplete to dissappear
+        await expect(element(by.id('autocomplete.at_mention.list'))).not.toExist();
+
+        // # Type "@" again to re-activate mention autocomplete
+        await postInput.typeText('@');
+        await expect(element(by.id('autocomplete.at_mention.list'))).toExist();
+    });
 });


### PR DESCRIPTION
#### Summary
This PR fixes an issue with being able to select `@` mentions multiple times in the same post draft and adds an E2E test to prevent the same issue from happening in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29965

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 11 (Simulator)
* Pixel 3a XL (Simulator)
