### PR TITLE
MM-30185 Fix bad permalink reference for saved posts screen

### DIFF
--- a/app/screens/flagged_posts/flagged_posts.js
+++ b/app/screens/flagged_posts/flagged_posts.js
@@ -112,9 +112,10 @@ export default class FlaggedPosts extends PureComponent {
     keyExtractor = (item) => item;
 
     previewPost = (post) => {
+        const {showPermalink} = this.props.actions;
         Keyboard.dismiss();
 
-        this.showPermalinkView(post.id, false);
+        showPermalink(this.context.intl, '', post.id, false);
     };
 
     renderEmpty = () => {


### PR DESCRIPTION
#### Summary
With the permalink refactor the function to open the permalink view from the save posts screens was missed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30185