### PR TITLE
On change, Group mentions are updated in autocomplete

### DIFF
--- a/app/components/autocomplete/at_mention/at_mention.js
+++ b/app/components/autocomplete/at_mention/at_mention.js
@@ -57,7 +57,7 @@ export default class AtMention extends PureComponent {
     }
 
     componentWillReceiveProps(nextProps) {
-        const {inChannel, outChannel, teamMembers, isSearch, matchTerm, requestStatus} = nextProps;
+        const {groups, inChannel, outChannel, teamMembers, isSearch, matchTerm, requestStatus} = nextProps;
 
         // Not invoked, render nothing.
         if (matchTerm === null) {
@@ -96,8 +96,13 @@ export default class AtMention extends PureComponent {
         }
 
         // Server request is complete
-        if (requestStatus !== RequestStatus.STARTED &&
-            (inChannel !== this.props.inChannel || outChannel !== this.props.outChannel || teamMembers !== this.props.teamMembers)) {
+        if (
+            groups !== this.props.groups ||
+                (
+                    requestStatus !== RequestStatus.STARTED &&
+                    (inChannel !== this.props.inChannel || outChannel !== this.props.outChannel || teamMembers !== this.props.teamMembers)
+                )
+        ) {
             const sections = this.buildSections(nextProps);
             this.setState({
                 sections,

--- a/app/mm-redux/selectors/entities/groups.ts
+++ b/app/mm-redux/selectors/entities/groups.ts
@@ -75,7 +75,7 @@ export const getAssociatedGroupsForReference = reselect.createSelector(
         }
         return groupsForReference;
     },
-    getCurrentUserLocale,
+    (state: GlobalState) => getCurrentUserLocale(state),
     (groupsForReference, locale) => {
         return groupsForReference.sort((groupA: Group, groupB: Group) => groupA.name.localeCompare(groupB.name, locale));
     },

--- a/app/mm-redux/selectors/entities/groups.ts
+++ b/app/mm-redux/selectors/entities/groups.ts
@@ -76,7 +76,7 @@ export const getAssociatedGroupsForReference = reselect.createSelector(
         return groupsForReference;
     },
     (state: GlobalState) => getCurrentUserLocale(state),
-    (groupsForReference, locale) => {
+    (groupsForReference: Array<Group>, locale: string) => {
         return groupsForReference.sort((groupA: Group, groupB: Group) => groupA.name.localeCompare(groupB.name, locale));
     },
 );
@@ -84,7 +84,7 @@ export const getAssociatedGroupsForReference = reselect.createSelector(
 export const searchAssociatedGroupsForReferenceLocal = reselect.createSelector(
     (state: GlobalState, term: string, teamId: string, channelId: string) => getAssociatedGroupsForReference(state, teamId, channelId),
     (state: GlobalState, term: string) => term,
-    (groups, term) => {
+    (groups: Array<Group>, term: string) => {
         if (!groups || groups.length === 0) {
             return emptyList;
         }

--- a/app/mm-redux/selectors/entities/groups.ts
+++ b/app/mm-redux/selectors/entities/groups.ts
@@ -57,34 +57,41 @@ export function getGroupMembers(state: GlobalState, id: string) {
     return groupMemberData.members;
 }
 
-export function searchAssociatedGroupsForReferenceLocal(state: GlobalState, term: string, teamId: string, channelId: string): Array<Group> {
-    const groups = getAssociatedGroupsForReference(state, teamId, channelId);
-    if (!groups || groups.length === 0) {
-        return emptyList;
-    }
-    const filteredGroups = filterGroupsMatchingTerm(groups, term);
-    return filteredGroups;
-}
+export const getAssociatedGroupsForReference = reselect.createSelector(
+    (state: GlobalState, teamId: string, channelId: string) => {
+        const team = getTeam(state, teamId);
+        const channel = getChannel(state, channelId);
+        let groupsForReference = [];
+        if (team && team.group_constrained && channel && channel.group_constrained) {
+            const groupsFromChannel = getGroupsAssociatedToChannelForReference(state, channelId);
+            const groupsFromTeam = getGroupsAssociatedToTeamForReference(state, teamId);
+            groupsForReference = groupsFromChannel.concat(groupsFromTeam.filter((item) => groupsFromChannel.indexOf(item) < 0));
+        } else if (team && team.group_constrained) {
+            groupsForReference = getGroupsAssociatedToTeamForReference(state, teamId);
+        } else if (channel && channel.group_constrained) {
+            groupsForReference = getGroupsAssociatedToChannelForReference(state, channelId);
+        } else {
+            groupsForReference = getAllAssociatedGroupsForReference(state);
+        }
+        return groupsForReference;
+    },
+    getCurrentUserLocale,
+    (groupsForReference, locale) => {
+        return groupsForReference.sort((groupA: Group, groupB: Group) => groupA.name.localeCompare(groupB.name, locale));
+    },
+);
 
-export function getAssociatedGroupsForReference(state: GlobalState, teamId: string, channelId: string): Array<Group> {
-    const team = getTeam(state, teamId);
-    const channel = getChannel(state, channelId);
-    const locale = getCurrentUserLocale(state);
-
-    let groupsForReference = [];
-    if (team && team.group_constrained && channel && channel.group_constrained) {
-        const groupsFromChannel = getGroupsAssociatedToChannelForReference(state, channelId);
-        const groupsFromTeam = getGroupsAssociatedToTeamForReference(state, teamId);
-        groupsForReference = groupsFromChannel.concat(groupsFromTeam.filter((item) => groupsFromChannel.indexOf(item) < 0));
-    } else if (team && team.group_constrained) {
-        groupsForReference = getGroupsAssociatedToTeamForReference(state, teamId);
-    } else if (channel && channel.group_constrained) {
-        groupsForReference = getGroupsAssociatedToChannelForReference(state, channelId);
-    } else {
-        groupsForReference = getAllAssociatedGroupsForReference(state);
-    }
-    return groupsForReference.sort((groupA: Group, groupB: Group) => groupA.name.localeCompare(groupB.name, locale));
-}
+export const searchAssociatedGroupsForReferenceLocal = reselect.createSelector(
+    (state: GlobalState, term: string, teamId: string, channelId: string) => getAssociatedGroupsForReference(state, teamId, channelId),
+    (state: GlobalState, term: string) => term,
+    (groups, term) => {
+        if (!groups || groups.length === 0) {
+            return emptyList;
+        }
+        const filteredGroups = filterGroupsMatchingTerm(groups, term);
+        return filteredGroups;
+    },
+);
 
 export const getAssociatedGroupsForReferenceMap = reselect.createSelector(
     getAssociatedGroupsForReference,


### PR DESCRIPTION
#### Summary
This PR updates the group names shown in the autocomplete when there is any change in the group data.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26785

#### Checklist
- [x] Re-build autocomplete section when group data prop has been changed

#### Device Information
This PR was tested on: iPhone 11 (Simulator)