### PR TITLE
MM-27354 Progressive image loading

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
       android:installLocation="auto"
       android:networkSecurityConfig="@xml/network_security_config"
       android:requestLegacyExternalStorage="true"
+      android:usesCleartextTraffic="true"
     >
         <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
         <meta-data android:name="android.content.APP_RESTRICTIONS"

--- a/app/components/file_attachment_list/__snapshots__/file_attachment_list.test.js.snap
+++ b/app/components/file_attachment_list/__snapshots__/file_attachment_list.test.js.snap
@@ -52,6 +52,7 @@ exports[`FileAttachmentList should match snapshot with a single image file 1`] =
           }
         }
         id="fileId"
+        inViewPort={false}
         index={0}
         isSingleImage={true}
         onCaptureRef={[Function]}
@@ -144,6 +145,7 @@ exports[`FileAttachmentList should match snapshot with combination of image and 
           }
         }
         id="fileId"
+        inViewPort={false}
         index={0}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -215,6 +217,7 @@ exports[`FileAttachmentList should match snapshot with combination of image and 
           }
         }
         id="otherFileId"
+        inViewPort={false}
         index={1}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -276,6 +279,7 @@ exports[`FileAttachmentList should match snapshot with combination of image and 
         }
       }
       id="fileId"
+      inViewPort={false}
       index={0}
       isSingleImage={false}
       onCaptureRef={[Function]}
@@ -367,6 +371,7 @@ exports[`FileAttachmentList should match snapshot with four image files 1`] = `
           }
         }
         id="fileId"
+        inViewPort={false}
         index={0}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -438,6 +443,7 @@ exports[`FileAttachmentList should match snapshot with four image files 1`] = `
           }
         }
         id="otherFileId"
+        inViewPort={false}
         index={1}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -509,6 +515,7 @@ exports[`FileAttachmentList should match snapshot with four image files 1`] = `
           }
         }
         id="thirdFileId"
+        inViewPort={false}
         index={2}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -580,6 +587,7 @@ exports[`FileAttachmentList should match snapshot with four image files 1`] = `
           }
         }
         id="fourthFileId"
+        inViewPort={false}
         index={3}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -672,6 +680,7 @@ exports[`FileAttachmentList should match snapshot with more than four image file
           }
         }
         id="fileId"
+        inViewPort={false}
         index={0}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -743,6 +752,7 @@ exports[`FileAttachmentList should match snapshot with more than four image file
           }
         }
         id="otherFileId"
+        inViewPort={false}
         index={1}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -814,6 +824,7 @@ exports[`FileAttachmentList should match snapshot with more than four image file
           }
         }
         id="thirdFileId"
+        inViewPort={false}
         index={2}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -885,6 +896,7 @@ exports[`FileAttachmentList should match snapshot with more than four image file
           }
         }
         id="fourthFileId"
+        inViewPort={false}
         index={3}
         isSingleImage={false}
         nonVisibleImagesCount={2}
@@ -958,6 +970,7 @@ exports[`FileAttachmentList should match snapshot with non-image attachment 1`] 
         }
       }
       id="fileId"
+      inViewPort={false}
       index={0}
       isSingleImage={false}
       onCaptureRef={[Function]}
@@ -1049,6 +1062,7 @@ exports[`FileAttachmentList should match snapshot with three image files 1`] = `
           }
         }
         id="fileId"
+        inViewPort={false}
         index={0}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -1120,6 +1134,7 @@ exports[`FileAttachmentList should match snapshot with three image files 1`] = `
           }
         }
         id="otherFileId"
+        inViewPort={false}
         index={1}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -1191,6 +1206,7 @@ exports[`FileAttachmentList should match snapshot with three image files 1`] = `
           }
         }
         id="thirdFileId"
+        inViewPort={false}
         index={2}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -1283,6 +1299,7 @@ exports[`FileAttachmentList should match snapshot with two image files 1`] = `
           }
         }
         id="fileId"
+        inViewPort={false}
         index={0}
         isSingleImage={false}
         onCaptureRef={[Function]}
@@ -1354,6 +1371,7 @@ exports[`FileAttachmentList should match snapshot with two image files 1`] = `
           }
         }
         id="otherFileId"
+        inViewPort={false}
         index={1}
         isSingleImage={false}
         onCaptureRef={[Function]}

--- a/app/components/file_attachment_list/file_attachment.js
+++ b/app/components/file_attachment_list/file_attachment.js
@@ -35,6 +35,7 @@ export default class FileAttachment extends PureComponent {
         wrapperWidth: PropTypes.number,
         isSingleImage: PropTypes.bool,
         nonVisibleImagesCount: PropTypes.number,
+        inViewPort: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -143,6 +144,7 @@ export default class FileAttachment extends PureComponent {
             onLongPress,
             isSingleImage,
             nonVisibleImagesCount,
+            inViewPort,
         } = this.props;
         const {data} = file;
         const style = getStyleSheet(theme);
@@ -165,6 +167,7 @@ export default class FileAttachment extends PureComponent {
                         theme={theme}
                         isSingleImage={isSingleImage}
                         imageDimensions={imageDimensions}
+                        inViewPort={inViewPort}
                     />
                     {this.renderMoreImagesOverlay(nonVisibleImagesCount, theme)}
                 </TouchableWithFeedback>

--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -40,6 +40,7 @@ export default class FileAttachmentImage extends PureComponent {
         isSingleImage: PropTypes.bool,
         imageDimensions: PropTypes.object,
         backgroundColor: PropTypes.string,
+        inViewPort: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -78,6 +79,8 @@ export default class FileAttachmentImage extends PureComponent {
         } else if (file.id) {
             imageProps.thumbnailUri = Client4.getFileThumbnailUrl(file.id);
             imageProps.imageUri = Client4.getFilePreviewUrl(file.id);
+            imageProps.miniPreview = file.mini_preview;
+            imageProps.inViewPort = this.props.inViewPort;
         }
         return imageProps;
     };

--- a/app/components/file_attachment_list/file_attachment_image.js
+++ b/app/components/file_attachment_list/file_attachment_image.js
@@ -77,9 +77,12 @@ export default class FileAttachmentImage extends PureComponent {
         if (file.localPath) {
             imageProps.defaultSource = {uri: file.localPath};
         } else if (file.id) {
-            imageProps.thumbnailUri = Client4.getFileThumbnailUrl(file.id);
+            if (file.mini_preview && file.mime_type) {
+                imageProps.thumbnailUri = `data:${file.mime_type};base64,${file.mini_preview}`;
+            } else {
+                imageProps.thumbnailUri = Client4.getFileThumbnailUrl(file.id);
+            }
             imageProps.imageUri = Client4.getFilePreviewUrl(file.id);
-            imageProps.miniPreview = file.mini_preview;
             imageProps.inViewPort = this.props.inViewPort;
         }
         return imageProps;

--- a/app/components/file_attachment_list/file_attachment_list.js
+++ b/app/components/file_attachment_list/file_attachment_list.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, View, DeviceEventEmitter} from 'react-native';
 
 import ImageViewPort from '@components/image_viewport';
 import {Client4} from '@mm-redux/client';
@@ -33,12 +33,24 @@ export default class FileAttachmentList extends ImageViewPort {
 
     constructor(props) {
         super(props);
-
+        this.state = {
+            inViewPort: false,
+        };
         this.items = [];
         this.filesForGallery = this.getFilesForGallery(props);
 
         this.buildGalleryFiles().then((results) => {
             this.galleryFiles = results;
+        });
+    }
+
+    componentDidMount() {
+        this.onScrollEnd = DeviceEventEmitter.addListener('scrolled', (viewableItems) => {
+            if (this.props.postId in viewableItems) {
+                this.setState({
+                    inViewPort: true,
+                });
+            }
         });
     }
 
@@ -48,6 +60,12 @@ export default class FileAttachmentList extends ImageViewPort {
             this.buildGalleryFiles().then((results) => {
                 this.galleryFiles = results;
             });
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.onScrollEnd && this.onScrollEnd.remove) {
+            this.onScrollEnd.remove();
         }
     }
 
@@ -165,6 +183,7 @@ export default class FileAttachmentList extends ImageViewPort {
                         isSingleImage={isSingleImage}
                         nonVisibleImagesCount={nonVisibleImagesCount}
                         wrapperWidth={getViewPortWidth(isReplyPost, this.hasPermanentSidebar())}
+                        inViewPort={this.state.inViewPort}
                     />
                 </View>
             );

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Alert, FlatList, Platform, RefreshControl, StyleSheet} from 'react-native';
+import {Alert, DeviceEventEmitter, FlatList, Platform, RefreshControl, StyleSheet} from 'react-native';
 import {intlShape} from 'react-intl';
 
 import {Posts} from '@mm-redux/constants';
@@ -454,7 +454,13 @@ export default class PostList extends PureComponent {
         if (!this.onViewableItemsChangedListener || !viewableItems.length || this.props.deepLinkURL) {
             return;
         }
-
+        const viewableItemsMap = viewableItems.reduce((acc, {item, isViewable}) => {
+            if (isViewable) {
+                acc[item] = true;
+            }
+            return acc;
+        }, {});
+        DeviceEventEmitter.emit('scrolled', viewableItemsMap);
         this.onViewableItemsChangedListener(viewableItems);
     }
 

--- a/app/components/progressive_image/__snapshots__/progressive_image.test.js.snap
+++ b/app/components/progressive_image/__snapshots__/progressive_image.test.js.snap
@@ -102,6 +102,7 @@ exports[`ProgressiveImage should match snapshot for Image 1`] = `
         },
       ]
     }
+    testID="thumbnail"
   />
   <ForwardRef(AnimatedComponentWrapper)
     onError={[MockFunction]}
@@ -128,6 +129,7 @@ exports[`ProgressiveImage should match snapshot for Image 1`] = `
         },
       ]
     }
+    testID="highResImage"
   />
 </ForwardRef(AnimatedComponentWrapper)>
 `;

--- a/app/components/progressive_image/__snapshots__/progressive_image.test.js.snap
+++ b/app/components/progressive_image/__snapshots__/progressive_image.test.js.snap
@@ -102,7 +102,7 @@ exports[`ProgressiveImage should match snapshot for Image 1`] = `
         },
       ]
     }
-    testID="thumbnail"
+    testID="progressive_image.thumbnail"
   />
   <ForwardRef(AnimatedComponentWrapper)
     onError={[MockFunction]}
@@ -129,7 +129,7 @@ exports[`ProgressiveImage should match snapshot for Image 1`] = `
         },
       ]
     }
-    testID="highResImage"
+    testID="progressive_image.highResImage"
   />
 </ForwardRef(AnimatedComponentWrapper)>
 `;

--- a/app/components/progressive_image/progressive_image.js
+++ b/app/components/progressive_image/progressive_image.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Animated, ImageBackground, Image, View, StyleSheet} from 'react-native';
+import {Animated, ImageBackground, Image, Platform, View, StyleSheet} from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 import thumb from '@assets/images/thumb.png';
@@ -152,7 +152,7 @@ export default class ProgressiveImage extends PureComponent {
                         StyleSheet.absoluteFill,
                         imageStyle,
                     ]}
-                    blurRadius={0.4}
+                    blurRadius={Platform.OS === 'android' ? 0.4 : 1}
                     testID='progressive_image.miniPreview'
                 >
                     {this.props.children}

--- a/app/components/progressive_image/progressive_image.js
+++ b/app/components/progressive_image/progressive_image.js
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Animated, ImageBackground, View, StyleSheet} from 'react-native';
+import {Animated, ImageBackground, Image, View, StyleSheet} from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 import thumb from '@assets/images/thumb.png';
@@ -140,8 +140,10 @@ export default class ProgressiveImage extends PureComponent {
         let thumbnail;
         let image;
         if (thumbnailUri) {
+            const ImageElement = thumbnailUri.startsWith('data:') ? Image : ImageComponent;
+
             thumbnail = (
-                <ImageComponent
+                <ImageElement
                     resizeMode={resizeMode}
                     resizeMethod={resizeMethod}
                     onError={onError}
@@ -150,10 +152,11 @@ export default class ProgressiveImage extends PureComponent {
                         StyleSheet.absoluteFill,
                         imageStyle,
                     ]}
-                    testID='miniPreview'
+                    blurRadius={0.4}
+                    testID='progressive_image.miniPreview'
                 >
                     {this.props.children}
-                </ImageComponent>
+                </ImageElement>
             );
 
             if (showHighResImage) {
@@ -168,7 +171,7 @@ export default class ProgressiveImage extends PureComponent {
                             imageStyle,
                             {opacity}]
                         }
-                        testID='highResImage'
+                        testID='progressive_image.highResImage'
                         onLoadEnd={this.onLoadImageEnd}
                     >
                         {this.props.children}
@@ -183,7 +186,7 @@ export default class ProgressiveImage extends PureComponent {
                     onError={onError}
                     source={thumb}
                     style={[imageStyle, {tintColor: theme.centerChannelColor, opacity: defaultOpacity}]}
-                    testID='thumbnail'
+                    testID='progressive_image.thumbnail'
                 />
             );
 
@@ -195,7 +198,7 @@ export default class ProgressiveImage extends PureComponent {
                     source={{uri: imageUri}}
                     style={[StyleSheet.absoluteFill, imageStyle, {opacity}]}
                     onLoadEnd={this.onLoadImageEnd}
-                    testID='highResImage'
+                    testID='progressive_image.highResImage'
                 >
                     {this.props.children}
                 </ImageComponent>

--- a/app/components/progressive_image/progressive_image.test.js
+++ b/app/components/progressive_image/progressive_image.test.js
@@ -58,3 +58,46 @@ describe('ProgressiveImage', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });
+
+describe('MiniPreview', () => {
+    test('should show mini preview when supported & image not in viewport', () => {
+        const baseProps = {
+            isBackgroundImage: false,
+            imageUri: 'https://images.com/image.png',
+            onError: jest.fn(),
+            resizeMethod: 'auto',
+            resizeMode: 'contain',
+            theme: Preferences.THEMES.default,
+            tintDefaultSource: false,
+            defaultSource: null,
+            inViewPort: false,
+            miniPreview: 'somebase64data',
+            filename: 'file.png',
+        };
+        const wrapper = shallow(<ProgressiveImage {...baseProps}/>);
+        expect(wrapper.find({testID: 'miniPreview'}).length).toEqual(1);
+    });
+
+    test('should load and show high res image with animation when component comes into viewport', () => {
+        const baseProps = {
+            isBackgroundImage: false,
+            imageUri: 'https://images.com/image.png',
+            onError: jest.fn(),
+            resizeMethod: 'auto',
+            resizeMode: 'contain',
+            theme: Preferences.THEMES.default,
+            tintDefaultSource: false,
+            defaultSource: null,
+            inViewPort: false,
+            miniPreview: 'somebase64data',
+            filename: 'file.png',
+        };
+        const wrapper = shallow(<ProgressiveImage {...baseProps}/>);
+        const selectHighResImage = () => wrapper.find({testID: 'highResImage'});
+        expect(selectHighResImage().length).toEqual(0);
+        wrapper.setProps({
+            inViewPort: true,
+        });
+        expect(selectHighResImage().length).toEqual(1);
+    });
+});

--- a/app/components/progressive_image/progressive_image.test.js
+++ b/app/components/progressive_image/progressive_image.test.js
@@ -74,7 +74,7 @@ describe('MiniPreview', () => {
             thumbnailUri: 'somebase64data',
         };
         const wrapper = shallow(<ProgressiveImage {...baseProps}/>);
-        expect(wrapper.find({testID: 'miniPreview'}).length).toEqual(1);
+        expect(wrapper.find({testID: 'progressive_image.miniPreview'}).length).toEqual(1);
     });
 
     test('should load and show high res image with animation when component comes into viewport', () => {
@@ -91,7 +91,7 @@ describe('MiniPreview', () => {
             thumbnailUri: 'somebase64data',
         };
         const wrapper = shallow(<ProgressiveImage {...baseProps}/>);
-        const selectHighResImage = () => wrapper.find({testID: 'highResImage'});
+        const selectHighResImage = () => wrapper.find({testID: 'progressive_image.highResImage'});
         expect(selectHighResImage().length).toEqual(0);
         wrapper.setProps({
             inViewPort: true,

--- a/app/components/progressive_image/progressive_image.test.js
+++ b/app/components/progressive_image/progressive_image.test.js
@@ -71,8 +71,7 @@ describe('MiniPreview', () => {
             tintDefaultSource: false,
             defaultSource: null,
             inViewPort: false,
-            miniPreview: 'somebase64data',
-            filename: 'file.png',
+            thumbnailUri: 'somebase64data',
         };
         const wrapper = shallow(<ProgressiveImage {...baseProps}/>);
         expect(wrapper.find({testID: 'miniPreview'}).length).toEqual(1);
@@ -89,8 +88,7 @@ describe('MiniPreview', () => {
             tintDefaultSource: false,
             defaultSource: null,
             inViewPort: false,
-            miniPreview: 'somebase64data',
-            filename: 'file.png',
+            thumbnailUri: 'somebase64data',
         };
         const wrapper = shallow(<ProgressiveImage {...baseProps}/>);
         const selectHighResImage = () => wrapper.find({testID: 'highResImage'});


### PR DESCRIPTION
#### Summary
<!--
A brief description of what this pull request does.
-->
This PR loads the image progressively as the image comes into view-port instead of loading all the images on mount.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/15644

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests
- [x] Has UI changes

#### Device Information
This PR was tested on: Poco F1, Android 9