### PR TITLE
[MM-30243] Execute completion handler on main queue

### DIFF
--- a/ios/Mattermost/RNNotificationEventHandler+HandleReplyAction.m
+++ b/ios/Mattermost/RNNotificationEventHandler+HandleReplyAction.m
@@ -102,7 +102,9 @@ NSString *const ReplyActionID = @"REPLY_ACTION";
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:[notifications count]];
   }];
 
-  completionHandler();
+  dispatch_async(dispatch_get_main_queue(), ^{
+    completionHandler();
+  });
 }
 
 - (void) handleReplyFailure:(NSString *)channelId completionHandler:(void (^)(void))completionHandler {
@@ -124,7 +126,9 @@ NSString *const ReplyActionID = @"REPLY_ACTION";
   };
   [notificationCenter sendLocalNotification:notification withId:id];
 
-  completionHandler();
+  dispatch_async(dispatch_get_main_queue(), ^{
+    completionHandler();
+  });
 }
 
 #pragma mark - Method Swizzling


### PR DESCRIPTION
#### Summary
The completion handler in our swizzled method should run on the main queue like in the [original method](https://github.com/wix/react-native-notifications/blob/master/lib/ios/RNNotificationsStore.m#L50)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30243

#### Device Information
This PR was tested on:
* iPhone SE, iOS 14.1