### PR TITLE
MM-30475 [v2] watermelondb default schema

### DIFF
--- a/app/constants/database.ts
+++ b/app/constants/database.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export enum MM_TABLES {
+    APP= 'app',
+    GLOBAL= 'global',
+    SERVERS= 'servers',
+}

--- a/app/constants/database.ts
+++ b/app/constants/database.ts
@@ -1,8 +1,44 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export enum MM_TABLES {
-    APP= 'app',
-    GLOBAL= 'global',
-    SERVERS= 'servers',
-}
+export const MM_TABLES = {
+    DEFAULT: {
+        APP: 'app',
+        GLOBAL: 'global',
+        SERVERS: 'servers',
+    },
+    SERVER: {
+        CHANNEL: 'Channel',
+        CHANNEL_INFO: 'ChannelInfo',
+        CHANNEL_MEMBERSHIP: 'ChannelMembership',
+        CUSTOM_EMOJI: 'CustomEmoji',
+        DRAFT: 'Draft',
+        FILE: 'File',
+        GROUP: 'Group',
+        GROUPS_IN_CHANNEL: 'GroupsInChannel',
+        GROUPS_IN_TEAM: 'GroupsInTeam',
+        GROUP_MEMBERSHIP: 'GroupMembership',
+        MY_CHANNEL: 'MyChannel',
+        MY_CHANNEL_SETTINGS: 'MyChannelSettings',
+        MY_TEAM: 'MyTeam',
+        POST: 'Post',
+        POSTS_IN_CHANNEL: 'PostsInChannel',
+        POSTS_IN_THREAD: 'PostsInThread',
+        POST_METADATA: 'PostMetadata',
+        PREFERENCE: 'Preference',
+        REACTION: 'Reaction',
+        ROLE: 'Role',
+        SLASH_COMMAND: 'SlashCommand',
+        SYSTEM: 'System',
+        TEAM: 'Team',
+        TEAM_CHANNEL_HISTORY: 'TeamChannelHistory',
+        TEAM_MEMBERSHIP: 'TeamMembership',
+        TEAM_SEARCH_HISTORY: 'TeamSearchHistory',
+        TERMS_OF_SERVICE: 'TermsOfService',
+        USER: 'User',
+    },
+};
+
+export default {
+    MM_TABLES,
+};

--- a/app/database/default/migration/index.ts
+++ b/app/database/default/migration/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {schemaMigrations} from '@nozbe/watermelondb/Schema/migrations';
+
+// NOTE : To implement migration, please follow this document
+// https://nozbe.github.io/WatermelonDB/Advanced/Migrations.html
+
+export default schemaMigrations({migrations: []});

--- a/app/database/default/models/app.ts
+++ b/app/database/default/models/app.ts
@@ -7,7 +7,7 @@ import field from '@nozbe/watermelondb/decorators/field';
 import date from '@nozbe/watermelondb/decorators/date';
 
 export default class App extends Model {
-    static table = MM_TABLES.APP
+    static table = MM_TABLES.DEFAULT.APP
 
     @field('app_id') appId!: string
     @field('build_number') buildNumber!: string

--- a/app/database/default/models/app.ts
+++ b/app/database/default/models/app.ts
@@ -4,12 +4,11 @@
 import {Model} from '@nozbe/watermelondb';
 import {MM_TABLES} from '@constants/database';
 import field from '@nozbe/watermelondb/decorators/field';
-import date from '@nozbe/watermelondb/decorators/date';
 
 export default class App extends Model {
     static table = MM_TABLES.DEFAULT.APP
 
     @field('build_number') buildNumber!: string
-    @date('created_at') createdAt!: Date
-    @field('version_number') unreadCount!: string
+    @field('created_at') createdAt!: number
+    @field('version_number') versionNumber!: string
 }

--- a/app/database/default/models/app.ts
+++ b/app/database/default/models/app.ts
@@ -9,7 +9,6 @@ import date from '@nozbe/watermelondb/decorators/date';
 export default class App extends Model {
     static table = MM_TABLES.DEFAULT.APP
 
-    @field('app_id') appId!: string
     @field('build_number') buildNumber!: string
     @date('created_at') createdAt!: Date
     @field('version_number') unreadCount!: string

--- a/app/database/default/models/app.ts
+++ b/app/database/default/models/app.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Model} from '@nozbe/watermelondb';
+import {MM_TABLES} from '@constants/database';
+import field from '@nozbe/watermelondb/decorators/field';
+import date from '@nozbe/watermelondb/decorators/date';
+
+export default class App extends Model {
+    static table = MM_TABLES.APP
+
+    @field('app_id') appId!: string
+    @field('build_number') buildNumber!: string
+    @date('created_at') createdAt!: Date
+    @field('version_number') unreadCount!: string
+}

--- a/app/database/default/models/global.ts
+++ b/app/database/default/models/global.ts
@@ -7,10 +7,8 @@ import field from '@nozbe/watermelondb/decorators/field';
 import json from '@nozbe/watermelondb/decorators/json';
 
 export default class Global extends Model {
-    static table = MM_TABLES.GLOBAL
+    static table = MM_TABLES.DEFAULT.GLOBAL
 
     @field('name') name!: string
-
-    //TODO : implement a better sanitizer callback for the 'value' field
-    @json('value', (rawJson) => rawJson) value!: Object
+    @json('value', (rawJson) => rawJson) value!: string[]
 }

--- a/app/database/default/models/global.ts
+++ b/app/database/default/models/global.ts
@@ -10,6 +10,7 @@ export default class Global extends Model {
     static table = MM_TABLES.GLOBAL
 
     @field('name') name!: string
+
     //TODO : implement a better sanitizer callback for the 'value' field
     @json('value', (rawJson) => rawJson) value!: Object
 }

--- a/app/database/default/models/global.ts
+++ b/app/database/default/models/global.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Model} from '@nozbe/watermelondb';
+import {MM_TABLES} from '@constants/database';
+import field from '@nozbe/watermelondb/decorators/field';
+import json from '@nozbe/watermelondb/decorators/json';
+
+export default class Global extends Model {
+    static table = MM_TABLES.GLOBAL
+
+    @field('name') name!: string
+    //TODO : implement a better sanitizer callback for the 'value' field
+    @json('value', (rawJson) => rawJson) value!: Object
+}

--- a/app/database/default/models/global.ts
+++ b/app/database/default/models/global.ts
@@ -10,5 +10,9 @@ export default class Global extends Model {
     static table = MM_TABLES.DEFAULT.GLOBAL
 
     @field('name') name!: string
+
+    // TODO : add TS definitions to sanitizer function signature.
+
+    // TODO : atm, the return type for 'value' is string[].  However, this return type can change to string/number/etc.  A broader definition will need to be applied and this return type updated accordingly.
     @json('value', (rawJson) => rawJson) value!: string[]
 }

--- a/app/database/default/models/server.ts
+++ b/app/database/default/models/server.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {Model} from '@nozbe/watermelondb';
+import field from '@nozbe/watermelondb/decorators/field';
+
+import {MM_TABLES} from '@constants/database';
+
+export default class Server extends Model {
+    static table = MM_TABLES.SERVERS
+
+    @field('db_path') dbPath!: string
+    @field('display_name') displayName!: string
+    @field('mention_count') mentionCount!: number
+    @field('unread_count') unreadCount!: number
+    @field('url') url!: string
+}

--- a/app/database/default/models/server.ts
+++ b/app/database/default/models/server.ts
@@ -6,7 +6,7 @@ import field from '@nozbe/watermelondb/decorators/field';
 import {MM_TABLES} from '@constants/database';
 
 export default class Server extends Model {
-    static table = MM_TABLES.SERVERS
+    static table = MM_TABLES.DEFAULT.SERVERS
 
     @field('db_path') dbPath!: string
     @field('display_name') displayName!: string

--- a/app/database/default/schema/index.ts
+++ b/app/database/default/schema/index.ts
@@ -7,29 +7,29 @@ export const defaultSchema: AppSchema = appSchema({
     version: 1,
     tables: [
         tableSchema({
-            name: MM_TABLES.SERVERS,
+            name: MM_TABLES.DEFAULT.APP,
             columns: [
-                {name: 'db_path', type: 'string'},
-                {name: 'display_name', type: 'string', isIndexed: true},
-                {name: 'mention_count', type: 'number'},
-                {name: 'unread_count', type: 'number'},
-                {name: 'url', type: 'string'},
-            ],
-        }),
-        tableSchema({
-            name: MM_TABLES.APP,
-            columns: [
-                {name: 'app_id', type: 'string', isIndexed: true}, // to avoid name conflict with id column ?
+                {name: 'app_id', type: 'string', isIndexed: true},
                 {name: 'build_number', type: 'string'},
                 {name: 'created_at', type: 'number'},
                 {name: 'version_number', type: 'string'},
             ],
         }),
         tableSchema({
-            name: MM_TABLES.GLOBAL,
+            name: MM_TABLES.DEFAULT.GLOBAL,
             columns: [
                 {name: 'name', type: 'string', isIndexed: true},
                 {name: 'value', type: 'string'},
+            ],
+        }),
+        tableSchema({
+            name: MM_TABLES.DEFAULT.SERVERS,
+            columns: [
+                {name: 'db_path', type: 'string'},
+                {name: 'display_name', type: 'string', isIndexed: true},
+                {name: 'mention_count', type: 'number'},
+                {name: 'unread_count', type: 'number'},
+                {name: 'url', type: 'string'},
             ],
         }),
     ],

--- a/app/database/default/schema/index.ts
+++ b/app/database/default/schema/index.ts
@@ -9,7 +9,6 @@ export const defaultSchema: AppSchema = appSchema({
         tableSchema({
             name: MM_TABLES.DEFAULT.APP,
             columns: [
-                {name: 'app_id', type: 'string', isIndexed: true},
                 {name: 'build_number', type: 'string'},
                 {name: 'created_at', type: 'number'},
                 {name: 'version_number', type: 'string'},

--- a/app/database/default/schema/index.ts
+++ b/app/database/default/schema/index.ts
@@ -25,10 +25,10 @@ export const defaultSchema: AppSchema = appSchema({
             name: MM_TABLES.DEFAULT.SERVERS,
             columns: [
                 {name: 'db_path', type: 'string'},
-                {name: 'display_name', type: 'string', isIndexed: true},
+                {name: 'display_name', type: 'string'},
                 {name: 'mention_count', type: 'number'},
                 {name: 'unread_count', type: 'number'},
-                {name: 'url', type: 'string'},
+                {name: 'url', type: 'string', isIndexed: true},
             ],
         }),
     ],

--- a/app/database/default/schema/index.ts
+++ b/app/database/default/schema/index.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {AppSchema, appSchema, tableSchema} from '@nozbe/watermelondb';
+import {MM_TABLES} from '@constants/database';
+
+export const defaultSchema: AppSchema = appSchema({
+    version: 1,
+    tables: [
+        tableSchema({
+            name: MM_TABLES.SERVERS,
+            columns: [
+                {name: 'db_path', type: 'string'},
+                {name: 'display_name', type: 'string', isIndexed: true},
+                {name: 'mention_count', type: 'number'},
+                {name: 'unread_count', type: 'number'},
+                {name: 'url', type: 'string'},
+            ],
+        }),
+        tableSchema({
+            name: MM_TABLES.APP,
+            columns: [
+                {name: 'app_id', type: 'string', isIndexed: true}, // to avoid name conflict with id column ?
+                {name: 'build_number', type: 'string'},
+                {name: 'created_at', type: 'number'},
+                {name: 'version_number', type: 'string'},
+            ],
+        }),
+        tableSchema({
+            name: MM_TABLES.GLOBAL,
+            columns: [
+                {name: 'name', type: 'string', isIndexed: true},
+                {name: 'value', type: 'string'},
+            ],
+        }),
+    ],
+});

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -741,11 +741,11 @@ SPEC CHECKSUMS:
   UMReactNativeAdapter: 2c175f151cfe5ff011ced7bc79ccb08bf124f6c3
   UMSensorsInterface: 1df848f22690ccd23a821777f00df230fe5a28e3
   UMTaskManagerInterface: dfc62edf51844ae87dafc1fe849b594871fda1e5
-  WatermelonDB: 553035ef459ca26be2dbb5a73b183d1976c47a35
+  WatermelonDB: 0aa53ec3f017fd52cd953ad6e69e4eec36c04044
   XCDYouTubeKit: 79baadb0560673a67c771eba45f83e353fd12c1f
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YoutubePlayer-in-WKWebView: af2f5929fc78882d94bfdfeea999b661b78d9717
 
 PODFILE CHECKSUM: 93ddf37519d321c69692a52e0a30c3e7fb27b0e0
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5965,6 +5965,13 @@
         "rambdax": "2.15.0",
         "rxjs": "^6.5.3",
         "sql-escape-string": "^1.1.0"
+      },
+      "dependencies": {
+        "lokijs": {
+          "version": "npm:@nozbe/lokijs@1.5.10-wmelon3",
+          "resolved": "https://registry.npmjs.org/@nozbe/lokijs/-/lokijs-1.5.10-wmelon3.tgz",
+          "integrity": "sha512-yfuj/SzYiVVn0e3OP8vjcbekumUR62Df90deG8uH7+5nqJqTLe4HkEzlmwJfss9UE0K8PsTQLACFOUq/2aAJ2A=="
+        }
       }
     },
     "@nozbe/with-observables": {
@@ -22742,11 +22749,6 @@
           }
         }
       }
-    },
-    "lokijs": {
-      "version": "npm:@nozbe/lokijs@1.5.10-wmelon3",
-      "resolved": "https://registry.npmjs.org/@nozbe/lokijs/-/lokijs-1.5.10-wmelon3.tgz",
-      "integrity": "sha512-yfuj/SzYiVVn0e3OP8vjcbekumUR62Df90deG8uH7+5nqJqTLe4HkEzlmwJfss9UE0K8PsTQLACFOUq/2aAJ2A=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "experimentalDecorators": true,
         "target": "esnext",
         "lib": [
             "es6"

--- a/types/database/app.d.ts
+++ b/types/database/app.d.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {Model} from '@nozbe/watermelondb';
+export default class App extends Model {
+    static table: string;
+    appId: string;
+    buildNumber: string;
+    createdAt: Date;
+    unreadCount: string;
+}

--- a/types/database/app.d.ts
+++ b/types/database/app.d.ts
@@ -3,7 +3,7 @@
 import {Model} from '@nozbe/watermelondb';
 export default class App extends Model {
     static table: string;
-    appId: string;
+
     buildNumber: string;
     createdAt: Date;
     unreadCount: string;

--- a/types/database/app.d.ts
+++ b/types/database/app.d.ts
@@ -3,8 +3,7 @@
 import {Model} from '@nozbe/watermelondb';
 export default class App extends Model {
     static table: string;
-
     buildNumber: string;
-    createdAt: Date;
-    unreadCount: string;
+    createdAt: number;
+    versionNumber: string;
 }

--- a/types/database/global.d.ts
+++ b/types/database/global.d.ts
@@ -4,5 +4,7 @@ import {Model} from '@nozbe/watermelondb';
 export default class Global extends Model {
     static table: string;
     name: string;
-    value: Object;
+
+    // TODO : atm, the return type for 'value' is string[].  However, this return type can change to string/number/etc.  A broader definition will need to be applied and this return type updated accordingly.
+    value: string[];
 }

--- a/types/database/global.d.ts
+++ b/types/database/global.d.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {Model} from '@nozbe/watermelondb';
+export default class Global extends Model {
+    static table: string;
+    name: string;
+    value: Object;
+}

--- a/types/database/server.d.ts
+++ b/types/database/server.d.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {Model} from '@nozbe/watermelondb';
+export default class Server extends Model {
+    static table: string;
+    dbPath: string;
+    displayName: string;
+    mentionCount: number;
+    unreadCount: number;
+    url: string;
+}


### PR DESCRIPTION
#### Summary
This PR lays the foundation for the default schema that will be used on our storage layer.
It currently comprises of three entities; namely 'app', 'global' and 'server' and an empty migration object for the time being.

This PR is all about Model definition and it does not include unit tests.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30475
