### PR TITLE
don't hide developer setup installation errors

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -5,9 +5,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     gem install bundler --version 2.1.4
   fi
   echo "Installing Gems"
-  npm run ios-gems &> /dev/null
+  npm run ios-gems
   echo "Getting Cocoapods dependencies"
-  npm run pod-install &> /dev/null
+  npm run pod-install
 fi
 
 ASSETS=$(node scripts/generate-assets.js)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
I finally received the hardware to get setup on OSX. Setting up my dev environment didn't show me any errors, but I was getting strange ios simulator errors. After poking around a bit it, turns out my dev setup was broken (note: Xcode 12.2 does not work, you'll see `ruby/config.h` not found errors. Xcode 11.7 works). The install errors were masked because both stdout and stderr had been redirected to `/dev/null`. I've removed the redirect. The output is more verbose, but atleast we know if the setup completes successfully. 
