### PR TITLE
MM-30286 Detox/E2E: Add e2e test for MM-T3235

### DIFF
--- a/app/screens/permalink/__snapshots__/permalink.test.js.snap
+++ b/app/screens/permalink/__snapshots__/permalink.test.js.snap
@@ -5,7 +5,6 @@ exports[`Permalink should match snapshot 1`] = `
   backgroundColor="transparent"
   excludeHeader={true}
   footerColor="transparent"
-  testID="permalink.screen"
 >
   <View
     style={
@@ -14,6 +13,7 @@ exports[`Permalink should match snapshot 1`] = `
         "marginTop": 20,
       }
     }
+    testID="permalink.screen"
   >
     <withAnimatable(View)
       animation="zoomIn"

--- a/app/screens/permalink/permalink.js
+++ b/app/screens/permalink/permalink.js
@@ -329,12 +329,12 @@ export default class Permalink extends PureComponent {
 
         return (
             <SafeAreaView
-                testID='permalink.screen'
                 backgroundColor='transparent'
                 excludeHeader={true}
                 footerColor='transparent'
             >
                 <View
+                    testID='permalink.screen'
                     style={style.container}
                 >
                     <Animatable.View
@@ -381,6 +381,7 @@ export default class Permalink extends PureComponent {
                             onPress={this.handlePress}
                         >
                             <FormattedText
+                                testID='permalink.search.jump'
                                 id='mobile.search.jump'
                                 defautMessage='Jump to recent messages'
                                 style={style.jump}

--- a/detox/e2e/support/server_api/channel.js
+++ b/detox/e2e/support/server_api/channel.js
@@ -82,7 +82,7 @@ export const apiAddUserToChannel = async (userId, channelId) => {
  * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1members~1{user_id}/delete
  * @param {string} channelId - The channel ID
  * @param {string} userId - The user ID to be removed from channel
- * @return {Object} returns status on success or {error, status} on error
+ * @return {Object} returns {status} on success or {error, status} on error
  */
 export const apiDeleteUserFromChannel = async (channelId, userId) => {
     try {
@@ -90,7 +90,7 @@ export const apiDeleteUserFromChannel = async (channelId, userId) => {
             `/api/v4/channels/${channelId}/members/${userId}`,
         );
 
-        return response;
+        return {status: response.status};
     } catch (err) {
         return getResponseFromError(err);
     }

--- a/detox/e2e/support/ui/screen/index.js
+++ b/detox/e2e/support/ui/screen/index.js
@@ -16,6 +16,7 @@ import MoreDirectMessagesScreen from './more_direct_messages';
 import NotificationScreen from './notification';
 import NotificationSettingsMobileScreen from './notification_settings_mobile';
 import NotificationSettingsScreen from './notification_settings';
+import PermalinkScreen from './permalink';
 import PinnedMessagesScreen from './pinned_messages';
 import RecentMentionsScreen from './recent_mentions';
 import SavedMessagesScreen from './saved_messages';
@@ -41,6 +42,7 @@ export {
     NotificationScreen,
     NotificationSettingsMobileScreen,
     NotificationSettingsScreen,
+    PermalinkScreen,
     PinnedMessagesScreen,
     RecentMentionsScreen,
     SavedMessagesScreen,

--- a/detox/e2e/support/ui/screen/permalink.js
+++ b/detox/e2e/support/ui/screen/permalink.js
@@ -8,9 +8,11 @@ class PermalinkScreen {
     testID = {
         permalinkScreenPrefix: 'permalink.',
         permalinkScreen: 'permalink.screen',
+        searchJump: 'permalink.search.jump',
     }
 
     permalinkScreen = element(by.id(this.testID.permalinkScreen));
+    searchJump = element(by.id(this.testID.searchJump));
 
     postList = new PostList(this.testID.permalinkScreenPrefix);
 
@@ -28,6 +30,18 @@ class PermalinkScreen {
 
     getPostMessageAtIndex = (index) => {
         return this.postList.getPostMessageAtIndex(index);
+    }
+
+    toBeVisible = async () => {
+        await expect(this.permalinkScreen).toBeVisible();
+
+        return this.permalinkScreen;
+    }
+
+    jumpToRecentMessages = async () => {
+        // # Jump to recent messages
+        await this.searchJump.tap();
+        await expect(this.permalinkScreen).not.toBeVisible();
     }
 
     hasLongPostMessage = async (postMessage) => {

--- a/detox/e2e/test/smoke_test/search.e2e.js
+++ b/detox/e2e/test/smoke_test/search.e2e.js
@@ -10,6 +10,7 @@
 import {Autocomplete} from '@support/ui/component';
 import {
     ChannelScreen,
+    PermalinkScreen,
     SearchScreen,
     ThreadScreen,
 } from '@support/ui/screen';
@@ -42,39 +43,9 @@ describe('Search', () => {
 
     it('MM-T3236 search on sender, select from autocomplete, reply from search results', async () => {
         const testMessage = Date.now().toString();
-        const {
-            searchFromModifier,
-            searchFromSection,
-            searchInput,
-        } = SearchScreen;
 
-        // # Post a message
-        await ChannelScreen.postMessage(testMessage);
-
-        // # Open search screen
-        await SearchScreen.open();
-
-        // # Tap "from:" modifier
-        await searchInput.clearText();
-        await searchFromSection.tap();
-
-        // # Type beginning of search term
-        const searchTerm = testUser.first_name;
-        await searchInput.typeText(searchTerm);
-
-        // # Select user from autocomplete
-        await expect(atMentionSuggestionList).toExist();
-        const userAtMentionAutocomplete = await Autocomplete.getAtMentionItem(testUser.id);
-        await userAtMentionAutocomplete.tap();
-
-        // # Search user
-        await searchInput.tapReturnKey();
-        await expect(atMentionSuggestionList).not.toExist();
-
-        // * Verify recent search item is displayed
-        const searchTerms = `${searchFromModifier} ${testUser.username}`;
-        const recentSearchItem = await SearchScreen.getRecentSearchItem(searchTerms);
-        await expect(recentSearchItem).toBeVisible();
+        // # Post message and search on sender
+        await postMessageAndSearchFrom(testMessage, testUser, atMentionSuggestionList);
 
         // * Verify search result post has the message
         const lastPost = await Post.apiGetLastPostInChannel(testChannel.id);
@@ -101,4 +72,88 @@ describe('Search', () => {
         await ThreadScreen.back();
         await SearchScreen.cancel();
     });
+
+    it('MM-T3235 search on text, jump to result', async () => {
+        const testMessage = Date.now().toString();
+
+        // # Post message and search on text
+        await postMessageAndSearchText(testMessage);
+
+        // # Open permalink from search result post item
+        const lastPost = await Post.apiGetLastPostInChannel(testChannel.id);
+        const {searchResultPostItem} = await SearchScreen.getSearchResultPostItem(lastPost.post.id, testMessage);
+        await expect(searchResultPostItem).toBeVisible();
+        searchResultPostItem.tap();
+
+        // * Verify permalink post list has the message
+        PermalinkScreen.toBeVisible();
+        const {postListPostItem: permalinkPostItem} = await PermalinkScreen.getPostListPostItem(lastPost.post.id, testMessage);
+        await waitFor(permalinkPostItem).toBeVisible();
+
+        // # Jump to recent messages
+        PermalinkScreen.jumpToRecentMessages();
+
+        // * Verify user is on channel where message is posted
+        ChannelScreen.toBeVisible();
+        await expect(ChannelScreen.channelNavBarTitle).toHaveText(testChannel.display_name);
+        const {postListPostItem: channelPostItem} = await ChannelScreen.getPostListPostItem(lastPost.post.id, testMessage);
+        await expect(channelPostItem).toBeVisible();
+    });
 });
+
+async function postMessageAndSearchFrom(testMessage, testUser, atMentionSuggestionList) {
+    const {
+        searchFromModifier,
+        searchFromSection,
+        searchInput,
+    } = SearchScreen;
+
+    // # Post a message
+    await ChannelScreen.postMessage(testMessage);
+
+    // # Open search screen
+    await SearchScreen.open();
+
+    // # Tap "from:" modifier
+    await searchInput.clearText();
+    await searchFromSection.tap();
+
+    // # Type beginning of search term
+    const searchTerm = testUser.first_name;
+    await searchInput.typeText(searchTerm);
+
+    // # Select user from autocomplete
+    await expect(atMentionSuggestionList).toExist();
+    const userAtMentionAutocomplete = await Autocomplete.getAtMentionItem(testUser.id);
+    await userAtMentionAutocomplete.tap();
+
+    // # Search user
+    await searchInput.tapReturnKey();
+    await expect(atMentionSuggestionList).not.toExist();
+
+    // * Verify recent search item is displayed
+    const searchTerms = `${searchFromModifier} ${testUser.username}`;
+    const recentSearchItem = await SearchScreen.getRecentSearchItem(searchTerms);
+    await expect(recentSearchItem).toBeVisible();
+}
+
+async function postMessageAndSearchText(testMessage) {
+    const {searchInput} = SearchScreen;
+
+    // # Post a message
+    await ChannelScreen.postMessage(testMessage);
+
+    // # Open search screen
+    await SearchScreen.open();
+
+    // # Type beginning of search term
+    await searchInput.clearText();
+    await searchInput.typeText(testMessage);
+
+    // # Search text
+    await searchInput.tapReturnKey();
+
+    // * Verify recent search item is displayed
+    const recentSearchItem = await SearchScreen.getRecentSearchItem(testMessage);
+    await expect(recentSearchItem).toBeVisible();
+}


### PR DESCRIPTION
#### Summary
- Added test for MM-T3235 in `smoke_test/search.e2e.js`
- Pulled out some functions for readability

Notes:
1. Created this PR on top of https://github.com/mattermost/mattermost-mobile/pull/4990 as I needed existing components and screens in there.

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-30286
TM4J Cases:
- [MM-T3235](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T3235)

![Screen Shot 2020-12-07 at 9 51 17 AM](https://user-images.githubusercontent.com/487991/101386255-c4d9cc80-3871-11eb-82fe-98aca5260a03.png)
