### PR TITLE
MM-31114 fix: regression for in: autocomplete modifier in search screen

### DIFF
--- a/app/components/autocomplete/channel_mention_item/channel_mention_item.js
+++ b/app/components/autocomplete/channel_mention_item/channel_mention_item.js
@@ -94,7 +94,7 @@ const ChannelMentionItem = (props) => {
         component = (
             <TouchableWithFeedback
                 key={channelId}
-                onPress={this.completeMention}
+                onPress={completeMention}
                 style={margins}
                 underlayColor={changeOpacity(theme.buttonBg, 0.08)}
                 type={'native'}


### PR DESCRIPTION
#### Summary
When the autocomplete/channel_mention_item was refactored as a functional component we missed to change the onPress handler

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31114