### PR TITLE
MM-30858 fix: follow config to show the option to copy file public link

### DIFF
--- a/app/screens/gallery/footer/index.tsx
+++ b/app/screens/gallery/footer/index.tsx
@@ -50,7 +50,7 @@ const Footer = forwardRef<FooterRef, FooterProps>((props: FooterProps, ref) => {
             const message = formatMessage({id: 'mobile.public_link.copied', defaultMessage: 'Public link copied'});
             const res = await Client4.getFilePublicLink(props.file.id);
             Clipboard.setString(res.link);
-            showToast(message, undefined, callback);
+            showToast(message, 100, callback);
         } catch (e) {
             // eslint-disable-next-line no-console
             console.log('An error occurred, we should show a different toast', e);

--- a/app/screens/gallery/footer/summary/actions/actions.tsx
+++ b/app/screens/gallery/footer/summary/actions/actions.tsx
@@ -40,7 +40,7 @@ const Actions = (props: ActionsProps) => {
         };
     }, []);
 
-    let linkActionVisible = !props.file.id.startsWith('uid');
+    let linkActionVisible = !props.file.id.startsWith('uid') && props.enablePublicLink;
     if (managedConfig?.copyPasteProtection === 'true') {
         linkActionVisible = false;
     }

--- a/app/screens/gallery/footer/summary/actions/index.ts
+++ b/app/screens/gallery/footer/summary/actions/index.ts
@@ -3,15 +3,18 @@
 
 import {connect} from 'react-redux';
 
-import {canDownloadFilesOnMobile} from '@mm-redux/selectors/entities/general';
+import {canDownloadFilesOnMobile, getConfig} from '@mm-redux/selectors/entities/general';
 
 import type {GlobalState} from '@mm-redux/types/store';
 
 import Actions from './actions';
 
 function mapStateToProps(state: GlobalState) {
+    const config = getConfig(state);
+
     return {
         canDownloadFiles: canDownloadFilesOnMobile(state),
+        enablePublicLink: config?.EnablePublicLink === 'true',
     };
 }
 

--- a/types/screens/gallery.d.ts
+++ b/types/screens/gallery.d.ts
@@ -21,6 +21,7 @@ export interface ActionProps {
 
 export interface ActionsProps {
     canDownloadFiles: boolean;
+    enablePublicLink: boolean;
     downloadAction: ActionCallback;
     file: FileInfo;
     linkAction: ActionCallback;


### PR DESCRIPTION
#### Summary
Take into the server config `EnablePublicLink ` to show or hide the option to copy the file public link, this option also follows the EMM setting for `copyAndPasteProtection` and only applies to files attached to posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30858