### PR TITLE
[MM-31216] iOS - Only set badge to 0 if there are no delivered notifications or it is forced

### DIFF
--- a/app/init/push_notifications.test.js
+++ b/app/init/push_notifications.test.js
@@ -58,12 +58,12 @@ describe('PushNotification', () => {
         });
     });
 
-    it('should clear all notifications', () => {
+    it('should clear all notifications', async () => {
         const setApplicationIconBadgeNumber = jest.spyOn(PushNotification, 'setApplicationIconBadgeNumber');
         const cancelAllLocalNotifications = jest.spyOn(PushNotification, 'cancelAllLocalNotifications');
 
         PushNotification.clearNotifications();
-        expect(setApplicationIconBadgeNumber).toHaveBeenCalledWith(0);
+        await expect(setApplicationIconBadgeNumber).toHaveBeenCalledWith(0, true);
         expect(Notifications.ios.setBadgeCount).toHaveBeenCalledWith(0);
         expect(cancelAllLocalNotifications).toHaveBeenCalled();
         expect(Notifications.cancelAllLocalNotifications).toHaveBeenCalled();
@@ -93,4 +93,18 @@ describe('PushNotification', () => {
         await PushNotification.clearChannelNotifications();
         expect(setApplicationIconBadgeNumber).toHaveBeenCalledWith(stateBadgeCount);
     });
+
+    test('setApplicationIconBadgeNumber should only set badge to 0 if there are no delivered notifications', async () => {
+        const setBadgeCount = jest.spyOn(Notifications.ios, 'setBadgeCount');
+
+        let deliveredNotifications = [{identifier: 1}];
+        Notifications.setDeliveredNotifications(deliveredNotifications);
+        await PushNotification.setApplicationIconBadgeNumber(0);
+        expect(setBadgeCount).not.toHaveBeenCalled();
+
+        deliveredNotifications = [];
+        Notifications.setDeliveredNotifications(deliveredNotifications);
+        await PushNotification.setApplicationIconBadgeNumber(0);
+        expect(setBadgeCount).toHaveBeenCalledWith(0);
+    })
 });

--- a/app/init/push_notifications.test.js
+++ b/app/init/push_notifications.test.js
@@ -106,5 +106,5 @@ describe('PushNotification', () => {
         Notifications.setDeliveredNotifications(deliveredNotifications);
         await PushNotification.setApplicationIconBadgeNumber(0);
         expect(setBadgeCount).toHaveBeenCalledWith(0);
-    })
+    });
 });

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -65,7 +65,7 @@ class PushNotifications {
     }
 
     clearNotifications = () => {
-        this.setApplicationIconBadgeNumber(0);
+        this.setApplicationIconBadgeNumber(0, true);
 
         // TODO: Only cancel the local notifications that belong to this server
         this.cancelAllLocalNotifications();
@@ -233,10 +233,13 @@ class PushNotifications {
         }
     };
 
-    setApplicationIconBadgeNumber = (value: number) => {
+    setApplicationIconBadgeNumber = async (value: number, force = false) => {
         if (Platform.OS === 'ios') {
             const count = value < 0 ? 0 : value;
-            Notifications.ios.setBadgeCount(count);
+            const notifications = await Notifications.ios.getDeliveredNotifications();
+            if (count === 0 && (force || notifications.length === 0)) {
+                Notifications.ios.setBadgeCount(count);
+            }
         }
     };
 


### PR DESCRIPTION
#### Summary
There's a scenario where, having 2+ push notifications and thus should have a badge count of 2+ when the app is launched via a push notification tap, the badge count is transitionally set to 0. This causes all push notifications to be cleared, losing any push notifications from other channels in the process. While the proper fix is to avoid this transitional setting of the badge count to 0 (and this fix will be part of v2), for v1 it is sufficient to only set the badge count to 0 in the case where there are no delivered push notifications. We can also force set the badge count to 0 by passing in a `force = true` param, as we'd do when logging out.

Note to QA: Please also test that all delivered push notifications are cleared when logging out.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31216

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone SE, iOS 14