### PR TITLE
MM-31491 Set Tablet orientation explicitly to all

### DIFF
--- a/app/actions/navigation/index.js
+++ b/app/actions/navigation/index.js
@@ -15,7 +15,7 @@ import Store from '@store/store';
 
 Navigation.setDefaultOptions({
     layout: {
-        orientation: [DeviceTypes.IS_TABLET ? undefined : 'portrait'],
+        orientation: [DeviceTypes.IS_TABLET ? 'all' : 'portrait'],
     },
 });
 


### PR DESCRIPTION
#### Summary
When we changed the navigation to lock the orientation to portrait, for tablets it was set as `undefined` but the navigation library is not handling the `undefined` value gracefully thus causing a crash, by setting the orientation explicitly to `all` everything works as it should.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31491