### PR TITLE
Fix ChannelLoader prop warning

### DIFF
--- a/app/components/channel_loader/channel_loader.js
+++ b/app/components/channel_loader/channel_loader.js
@@ -42,7 +42,7 @@ export default class ChannelLoader extends PureComponent {
         style: CustomPropTypes.Style,
         theme: PropTypes.object.isRequired,
         height: PropTypes.number,
-        retryLoad: PropTypes.func.isRequired,
+        retryLoad: PropTypes.func,
     };
 
     constructor(props) {
@@ -75,8 +75,10 @@ export default class ChannelLoader extends PureComponent {
     }
 
     componentDidMount() {
-        this.stillLoadingTimeout = setTimeout(this.showIndicator, 10000);
-        this.retryLoadInterval = setInterval(this.props.retryLoad, 10000);
+        if (this.props.retryLoad) {
+            this.stillLoadingTimeout = setTimeout(this.showIndicator, 10000);
+            this.retryLoadInterval = setInterval(this.props.retryLoad, 10000);
+        }
     }
 
     componentWillUnmount() {

--- a/app/components/channel_loader/channel_loader.test.js
+++ b/app/components/channel_loader/channel_loader.test.js
@@ -14,7 +14,6 @@ describe('ChannelLoader', () => {
     const baseProps = {
         channelIsLoading: true,
         theme: Preferences.THEMES.default,
-        retryLoad: jest.fn(),
     };
 
     test('should match snapshot', () => {
@@ -23,15 +22,26 @@ describe('ChannelLoader', () => {
     });
 
     test('should call setTimeout and setInterval for showIndicator and retryLoad on mount', () => {
-        const wrapper = shallow(<ChannelLoader {...baseProps}/>);
-        const instance = wrapper.instance();
+        shallow(<ChannelLoader {...baseProps}/>);
+        expect(setTimeout).not.toHaveBeenCalled();
+        expect(setInterval).not.toHaveBeenCalled();
 
+        const props = {
+            ...baseProps,
+            retryLoad: jest.fn(),
+        };
+        const wrapper = shallow(<ChannelLoader {...props}/>);
+        const instance = wrapper.instance();
         expect(setTimeout).toHaveBeenCalledWith(instance.showIndicator, 10000);
-        expect(setInterval).toHaveBeenCalledWith(baseProps.retryLoad, 10000);
+        expect(setInterval).toHaveBeenCalledWith(props.retryLoad, 10000);
     });
 
     test('should clear timer and interval on unmount', () => {
-        const wrapper = shallow(<ChannelLoader {...baseProps}/>);
+        const props = {
+            ...baseProps,
+            retryLoad: jest.fn(),
+        }
+        const wrapper = shallow(<ChannelLoader {...props}/>);
         const instance = wrapper.instance();
         instance.componentWillUnmount();
 

--- a/app/components/channel_loader/channel_loader.test.js
+++ b/app/components/channel_loader/channel_loader.test.js
@@ -40,7 +40,7 @@ describe('ChannelLoader', () => {
         const props = {
             ...baseProps,
             retryLoad: jest.fn(),
-        }
+        };
         const wrapper = shallow(<ChannelLoader {...props}/>);
         const instance = wrapper.instance();
         instance.componentWillUnmount();


### PR DESCRIPTION
#### Summary
Fix for warning:
`Failed prop type: The prop type "retryLoad" is marked as required in "ChannelLoader", but it's value is undefined`

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone 11 simulator