### PR TITLE
Give a enough warning when archiving a channel

### DIFF
--- a/app/screens/channel_info/archive/archive.tsx
+++ b/app/screens/channel_info/archive/archive.tsx
@@ -67,7 +67,7 @@ export default class Archive extends PureComponent<ArchiveProps> {
         const title = {id: t('mobile.channel_info.alertTitleDeleteChannel'), defaultMessage: 'Archive {term}'};
         const message = {
             id: t('mobile.channel_info.alertMessageDeleteChannel'),
-            defaultMessage: 'Are you sure you want to archive the {term} {name}?',
+            defaultMessage: 'This will make its contents inaccessible for all users. Are you sure you want to archive the {term} {name}?',
         };
         const onPressAction = async () => {
             const result = await deleteChannel(channelId);

--- a/app/screens/channel_info/archive/archive.tsx
+++ b/app/screens/channel_info/archive/archive.tsx
@@ -67,7 +67,7 @@ export default class Archive extends PureComponent<ArchiveProps> {
         const title = {id: t('mobile.channel_info.alertTitleDeleteChannel'), defaultMessage: 'Archive {term}'};
         const message = {
             id: t('mobile.channel_info.alertMessageDeleteChannel'),
-            defaultMessage: 'This will make its contents inaccessible for all users. Are you sure you want to archive the {term} {name}?',
+            defaultMessage: 'This will make its contents inaccessible for all users.\n\nAre you sure you want to archive the {term} {name}?',
         };
         const onPressAction = async () => {
             const result = await deleteChannel(channelId);

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -170,7 +170,7 @@
   "mobile.camera_video_permission_denied_title": "{applicationName} would like to access your camera",
   "mobile.channel_drawer.search": "Jump to...",
   "mobile.channel_info.alertMessageConvertChannel": "When you convert {displayName} to a private channel, history and membership are preserved. Publicly shared files remain accessible to anyone with the link. Membership in a private channel is by invitation only.\n\nThe change is permanent and cannot be undone.\n\nAre you sure you want to convert {displayName} to a private channel?",
-  "mobile.channel_info.alertMessageDeleteChannel": "This will make its contents inaccessible for all users. Are you sure you want to archive the {term} {name}?",
+  "mobile.channel_info.alertMessageDeleteChannel": "This will make its contents inaccessible for all users.\n\nAre you sure you want to archive the {term} {name}?",
   "mobile.channel_info.alertMessageLeaveChannel": "Are you sure you want to leave the {term} {name}?",
   "mobile.channel_info.alertMessageUnarchiveChannel": "Are you sure you want to unarchive the {term} {name}?",
   "mobile.channel_info.alertNo": "No",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -170,7 +170,7 @@
   "mobile.camera_video_permission_denied_title": "{applicationName} would like to access your camera",
   "mobile.channel_drawer.search": "Jump to...",
   "mobile.channel_info.alertMessageConvertChannel": "When you convert {displayName} to a private channel, history and membership are preserved. Publicly shared files remain accessible to anyone with the link. Membership in a private channel is by invitation only.\n\nThe change is permanent and cannot be undone.\n\nAre you sure you want to convert {displayName} to a private channel?",
-  "mobile.channel_info.alertMessageDeleteChannel": "Are you sure you want to archive the {term} {name}?",
+  "mobile.channel_info.alertMessageDeleteChannel": "This will make its contents inaccessible for all users. Are you sure you want to archive the {term} {name}?",
   "mobile.channel_info.alertMessageLeaveChannel": "Are you sure you want to leave the {term} {name}?",
   "mobile.channel_info.alertMessageUnarchiveChannel": "Are you sure you want to unarchive the {term} {name}?",
   "mobile.channel_info.alertNo": "No",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Archiving a channel in Mattermost is actually stronger than it sounds.
It will remove the channel from the user interface, and the contents
cannot be viewed, shared, or searched out of the box.
https://docs.mattermost.com/help/getting-started/organizing-conversations.html#archiving-a-channel

Let's give a enough warning similar to the web version.


#### Ticket Link

Closes: #4806

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
Moto G7 Plus, Android 10

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->
[current]

![Screenshot_20201222-132645](https://user-images.githubusercontent.com/4356209/102850224-4168cf80-445c-11eb-89fa-e691ee1c3023.png)

[proposed]

![Screenshot_20210105-191223](https://user-images.githubusercontent.com/4356209/103647365-89304080-4f9e-11eb-9303-779faaba1165.png)


