### PR TITLE
[MM-31754] [MM-31756] Default to an empty channel object

### DIFF
--- a/app/components/sidebars/main/channels_list/channel_item/index.js
+++ b/app/components/sidebars/main/channels_list/channel_item/index.js
@@ -24,7 +24,7 @@ function makeMapStateToProps() {
     const getChannel = makeGetChannel();
 
     return (state, ownProps) => {
-        const channel = ownProps.channel || getChannel(state, {id: ownProps.channelId});
+        const channel = ownProps.channel || getChannel(state, {id: ownProps.channelId}) || {};
         const member = getMyChannelMember(state, channel.id);
         const currentUserId = getCurrentUserId(state);
         const channelDraft = getDraftForChannel(state, channel.id);


### PR DESCRIPTION
#### Summary
There's a race condition when state is set after leaving the current channel and selecting a default channel. The channel ID of the channel being left still exists in the sidebar but is not included when the ChannelItem component re-renders. I tried to batch the [`selectDefaultChannel` and `leaveChannelService` actions](https://github.com/mattermost/mattermost-mobile/blob/499c749a6fd90fa5cb3f42b9d86ea1cc1a5e5800/app/actions/views/channel.js#L487-L491) but that prevented the selected default channel from being loaded. Defaulting to an empty object is a quick fix for the crash and I'll open a [new ticket](https://mattermost.atlassian.net/browse/MM-31770) for a more thorough fix.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31754
https://mattermost.atlassian.net/browse/MM-31756

#### Device Information
This PR was tested on:
* iOS 14 simulator