### PR TITLE
[MM-30976] fix viewing/joining archived channels using channel links

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -224,7 +224,7 @@ export function handleSelectChannelByName(channelName, teamName, errorHandler) {
         const {teams: currentTeams, currentTeamId} = state.entities.teams;
         const currentTeam = currentTeams[currentTeamId];
         const currentTeamName = currentTeam?.name;
-        const response = await dispatch(getChannelByNameAndTeamName(teamName || currentTeamName, channelName));
+        const response = await dispatch(getChannelByNameAndTeamName(teamName || currentTeamName, channelName, true));
         const {error, data: channel} = response;
         const currentChannelId = getCurrentChannelId(state);
 

--- a/app/actions/views/channel.test.js
+++ b/app/actions/views/channel.test.js
@@ -150,6 +150,7 @@ describe('Actions.Views.Channel', () => {
     channelSelectors.getMyChannelMember = jest.fn(() => ({data: {member: {}}}));
 
     const appChannelSelectors = require('app/selectors/channel');
+    const getChannelReachableOriginal = appChannelSelectors.getChannelReachable;
     appChannelSelectors.getChannelReachable = jest.fn(() => true);
 
     test('handleSelectChannelByName success', async () => {
@@ -230,6 +231,60 @@ describe('Actions.Views.Channel', () => {
 
         const joinedChannel = storeActions.some((action) => action.type === 'MOCK_JOIN_CHANNEL' && action.data.channel.id === 'channel-id-3');
         expect(joinedChannel).toBe(true);
+    });
+
+    test('handleSelectChannelByName select archived channel with ExperimentalViewArchivedChannels enabled', async () => {
+        const archivedChannelStoreObj = {...storeObj};
+        archivedChannelStoreObj.entities.general.config.ExperimentalViewArchivedChannels = 'true';
+        store = mockStore(archivedChannelStoreObj);
+
+        appChannelSelectors.getChannelReachable = getChannelReachableOriginal;
+        actions.getChannelByNameAndTeamName = jest.fn(() => {
+            return {
+                type: MOCK_RECEIVE_CHANNEL_TYPE,
+                data: {id: 'channel-id-3', name: 'channel-id-3', display_name: 'Test Channel', type: General.OPEN_CHANNEL, delete_at: 100},
+            };
+        });
+        channelSelectors.getChannelByName = jest.fn(() => {
+            return {
+                data: {id: 'channel-id-3', name: 'channel-id-3', display_name: 'Test Channel', type: General.OPEN_CHANNEL, delete_at: 100},
+            };
+        });
+        const errorHandler = jest.fn();
+
+        await store.dispatch(handleSelectChannelByName('channel-id-3', currentTeamName, errorHandler));
+
+        const storeActions = store.getActions();
+        const receivedChannel = storeActions.some((action) => action.type === MOCK_RECEIVE_CHANNEL_TYPE);
+        expect(receivedChannel).toBe(true);
+        expect(errorHandler).not.toBeCalled();
+    });
+
+    test('handleSelectChannelByName select archived channel with ExperimentalViewArchivedChannels disabled', async () => {
+        const noArchivedChannelStoreObj = {...storeObj};
+        noArchivedChannelStoreObj.entities.general.config.ExperimentalViewArchivedChannels = 'false';
+        store = mockStore(noArchivedChannelStoreObj);
+
+        appChannelSelectors.getChannelReachable = getChannelReachableOriginal;
+        actions.getChannelByNameAndTeamName = jest.fn(() => {
+            return {
+                type: MOCK_RECEIVE_CHANNEL_TYPE,
+                data: {id: 'channel-id-3', name: 'channel-id-3', display_name: 'Test Channel', type: General.OPEN_CHANNEL, delete_at: 100},
+            };
+        });
+        channelSelectors.getChannelByName = jest.fn(() => {
+            return {
+                data: {id: 'channel-id-3', name: 'channel-id-3', display_name: 'Test Channel', type: General.OPEN_CHANNEL, delete_at: 100},
+            };
+        });
+        const errorHandler = jest.fn();
+
+        await store.dispatch(handleSelectChannelByName('channel-id-3', currentTeamName, errorHandler));
+
+        const storeActions = store.getActions();
+        const receivedChannel = storeActions.some((action) => action.type === MOCK_RECEIVE_CHANNEL_TYPE);
+        expect(receivedChannel).toBe(true);
+        expect(errorHandler).toBeCalled();
     });
 
     test('loadPostsIfNecessaryWithRetry for the first time', async () => {

--- a/app/selectors/channel.js
+++ b/app/selectors/channel.js
@@ -6,6 +6,8 @@ import {createSelector} from 'reselect';
 import {getCurrentUserId, getUser} from '@mm-redux/selectors/entities/users';
 import {getChannelByName} from '@mm-redux/selectors/entities/channels';
 import {getTeamByName} from '@mm-redux/selectors/entities/teams';
+import {getConfig} from '@mm-redux/selectors/entities/general';
+import {isArchivedChannel} from '@mm-redux/utils/channel_utils';
 
 const getOtherUserIdForDm = createSelector(
     (state, channel) => channel,
@@ -46,5 +48,15 @@ const getChannel = (state, channelName) => getChannelByName(state, channelName);
 export const getChannelReachable = createSelector(
     getTeam,
     getChannel,
-    (team, channel) => team && channel,
+    getConfig,
+    (team, channel, config) => {
+        if (!(team && channel)) {
+            return false;
+        }
+        const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
+        if (isArchivedChannel(channel) && !viewArchivedChannels) {
+            return false;
+        }
+        return true;
+    },
 );


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
- Fix viewing/joining archived channels using channel links. Include all channels in query for channels, and respect the `ExperimentalViewArchivedChannels` setting

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-30976

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 
- Android and ios emulators.

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->