### PR TITLE
MM-31705 allow file local path to use multiple dots

### DIFF
--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -283,7 +283,24 @@ export const hashCode = (str) => {
 export function getLocalFilePathFromFile(dir, file) {
     if (dir) {
         if (file?.name) {
-            const [filename, extension] = file.name.split('.');
+            let extension = file.extension;
+            let filename = file.name;
+
+            if (!extension) {
+                extension = getExtensionFromMime(file.mime_type);
+            }
+
+            if (extension && filename.includes(`.${extension}`)) {
+                filename = filename.replace(`.${extension}`, '');
+            } else {
+                const fileParts = file.name.split('.');
+
+                if (fileParts.length > 1) {
+                    extension = fileParts.pop();
+                    filename = fileParts.join('.');
+                }
+            }
+
             return `${dir}/${filename}-${hashCode(file.id)}.${extension}`;
         } else if (file?.id && file?.extension) {
             return `${dir}/${file.id}.${file.extension}`;

--- a/app/utils/file.test.js
+++ b/app/utils/file.test.js
@@ -118,12 +118,23 @@ describe('getExtensionFromContentDisposition', () => {
     it('should return the path for the document file', () => {
         const file = {
             id: generateId(),
-            name: 'Some other doocument.txt',
+            name: 'Some other document.txt',
             extension: 'txt',
         };
 
         const localFile = getLocalPath(file);
         const [filename] = file.name.split('.');
         expect(localFile).toBe(`${DeviceTypes.DOCUMENTS_PATH}/${filename}-${hashCode(file.id)}.${file.extension}`);
+    });
+
+    it('should return the path for the document file including multiple dots in the filename', () => {
+        const file = {
+            id: generateId(),
+            name: 'Some.other.document.txt',
+            extension: 'txt',
+        };
+        const expectedFilename = 'Some.other.document';
+        const localFile = getLocalPath(file);
+        expect(localFile).toBe(`${DeviceTypes.DOCUMENTS_PATH}/${expectedFilename}-${hashCode(file.id)}.${file.extension}`);
     });
 });


### PR DESCRIPTION
#### Summary
When a file was being shared and its filename contained multiple dots (including the extension) the file wasn't being able to preview as we split the filename without considering multiple dots and the extension was wrongly  set.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31705