### PR TITLE
Detox/E2E: Fix CustomDetoxEnvironment constructor args

### DIFF
--- a/detox/e2e/environment.js
+++ b/detox/e2e/environment.js
@@ -8,8 +8,8 @@ const {
 } = require('detox/runners/jest-circus');
 
 class CustomDetoxEnvironment extends DetoxCircusEnvironment {
-    constructor(config) {
-        super(config);
+    constructor(config, context) {
+        super(config, context);
 
         this.initTimeout = 300000;
 


### PR DESCRIPTION
- Fix CustomDetoxEnvironment constructor args due to upgrade

This only fixes the error Jesse experienced.  I'll address other failures in a separate PR once I'm able to run the whole suite