### PR TITLE
[MM-30994] tweak emoji search options for better results

### DIFF
--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.js
@@ -21,9 +21,7 @@ const EMOJI_REGEX = /(^|\s|^\+|^-)(:([^:\s]*))$/i;
 const EMOJI_REGEX_WITHOUT_PREFIX = /\B(:([^:\s]*))$/i;
 const FUSE_OPTIONS = {
     shouldSort: false,
-    threshold: 0.3,
-    location: 0,
-    distance: 10,
+    ignoreLocation: true,
     includeMatches: true,
     findAllMatches: true,
 };

--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.test.js
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.test.js
@@ -46,9 +46,10 @@ describe('components/autocomplete/emoji_suggestion', () => {
     });
 
     test('searchEmojis should return the right values on fuse', () => {
-        const output1 = ['100', '1234', '1st_place_medal', '+1', '-1', 'u7121'];
+        const output1 = ['100', '1234', '1st_place_medal', '+1', '-1', 'clock1', 'clock10', 'clock1030', 'clock11', 'clock1130', 'clock12', 'clock1230', 'clock130', 'rage1', 'u7121', 'u7981'];
         const output2 = ['+1'];
-        const output3 = ['-1'];
+        const output3 = ['-1', 'e-mail', 'non-potable_water'];
+        const output4 = ['checkered_flag', 'ballot_box_with_check', 'heavy_check_mark', 'white_check_mark'];
 
         const wrapper = shallowWithIntl(<EmojiSuggestion {...baseProps}/>);
         wrapper.instance().searchEmojis('');
@@ -70,6 +71,12 @@ describe('components/autocomplete/emoji_suggestion', () => {
         jest.runAllTimers();
         setTimeout(() => {
             expect(wrapper.state('dataSource')).toEqual(output3);
+        }, 100);
+
+        wrapper.instance().searchEmojis('check');
+        jest.runAllTimers();
+        setTimeout(() => {
+            expect(wrapper.state('dataSource')).toEqual(output4);
         }, 100);
     });
 });

--- a/app/components/emoji_picker/emoji_picker.test.js
+++ b/app/components/emoji_picker/emoji_picker.test.js
@@ -25,9 +25,7 @@ describe('components/emoji_picker/emoji_picker.ios', () => {
     const emojisBySection = selectEmojisBySection(state);
     const options = {
         shouldSort: false,
-        threshold: 0.3,
-        location: 0,
-        distance: 10,
+        ignoreLocation: true,
         includeMatches: true,
         findAllMatches: true,
     };
@@ -74,7 +72,7 @@ describe('components/emoji_picker/emoji_picker.ios', () => {
 
     test('searchEmojis should return the right values on fuse', async () => {
         const input = '1';
-        const output = ['100', '1234', '1st_place_medal', '+1', '-1', 'u7121'];
+        const output = ['100', '1234', '1st_place_medal', '+1', '-1', 'clock1', 'clock10', 'clock1030', 'clock11', 'clock1130', 'clock12', 'clock1230', 'clock130', 'rage1', 'u7121', 'u7981'];
 
         const wrapper = shallowWithIntl(<EmojiPicker {...baseProps}/>);
         const result = wrapper.instance().searchEmojis(input);

--- a/app/components/emoji_picker/index.js
+++ b/app/components/emoji_picker/index.js
@@ -19,9 +19,7 @@ function mapStateToProps(state) {
     const emojis = selectEmojisByName(state);
     const options = {
         shouldSort: false,
-        threshold: 0.3,
-        location: 0,
-        distance: 10,
+        ignoreLocation: true,
         includeMatches: true,
         findAllMatches: true,
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
- Tweak emoji search options for better results. We drop the location and threshold options in favour of matching anywhere in the emoji alias string. For smaller search terms there will more results returned but the general ordering does not change (i.e. low confidence results will still be lower in the list, and usually beyond the start scroll limit of the flat list).
For longer search terms we will have better results. I dont think there are any performance regressions - according to `app/utils/emojis.js` there are only about 1447 emojis.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-30994
- 
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 
- ios emulator running ios 13.7

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->

**Before**
![Simulator Screen Shot - iPhone 11 - 2021-01-15 at 18 26 12](https://user-images.githubusercontent.com/1779129/104729994-4cfb9d80-575f-11eb-991d-7701d5e95efa.png)


**After**
![Simulator Screen Shot - iPhone 11 - 2021-01-15 at 18 12 50](https://user-images.githubusercontent.com/1779129/104730009-5258e800-575f-11eb-903f-7c3f695b24a0.png)
