### PR TITLE
MM-32183 Fix in-app notification + Android ack

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostCredentialsHelper.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostCredentialsHelper.java
@@ -37,6 +37,11 @@ public class MattermostCredentialsHelper {
         HashMap<String, String> asyncStorageResults = asyncStorage.multiGet(asyncStorageKeys);
         String serverUrl = asyncStorageResults.get(CURRENT_SERVER_URL);
         final WritableMap options = Arguments.createMap();
+        // KeyChain module fails authenticationPrompt is not set
+        final WritableMap authPrompt = Arguments.createMap();
+        authPrompt.putString("title", "Authenticate to retrieve secret");
+        authPrompt.putString("cancel", "Cancel");
+        options.putMap("authenticationPrompt", authPrompt);
         options.putString("service", serverUrl);
 
         keychainModule.getGenericPasswordForOptions(options, promise);

--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostCredentialsHelper.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostCredentialsHelper.java
@@ -37,7 +37,7 @@ public class MattermostCredentialsHelper {
         HashMap<String, String> asyncStorageResults = asyncStorage.multiGet(asyncStorageKeys);
         String serverUrl = asyncStorageResults.get(CURRENT_SERVER_URL);
         final WritableMap options = Arguments.createMap();
-        // KeyChain module fails authenticationPrompt is not set
+        // KeyChain module fails if `authenticationPrompt` is not set
         final WritableMap authPrompt = Arguments.createMap();
         authPrompt.putString("title", "Authenticate to retrieve secret");
         authPrompt.putString("cancel", "Cancel");

--- a/app/screens/notification/index.tsx
+++ b/app/screens/notification/index.tsx
@@ -7,6 +7,7 @@ import * as Animatable from 'react-native-animatable';
 import {Navigation} from 'react-native-navigation';
 import {PanGestureHandler} from 'react-native-gesture-handler';
 import {useDispatch} from 'react-redux';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {popToRoot, dismissAllModals, dismissOverlay} from '@actions/navigation';
 import {loadFromPushNotification} from '@actions/views/root';
@@ -44,6 +45,7 @@ const initialAnimation: SlideAnimation = {
 
 const Notification = ({componentId, notification}: NotificationProps) => {
     const [animation, setAnimation] = useState<SlideAnimation>(initialAnimation);
+    const insets = useSafeAreaInsets();
     const dispatch = useDispatch();
     const dismissTimerRef = useRef<NodeJS.Timeout | null>(null);
     const tapped = useRef<boolean>(false);
@@ -121,7 +123,7 @@ const Notification = ({componentId, notification}: NotificationProps) => {
         >
             <Animatable.View
                 duration={250}
-                style={styles.container}
+                style={[styles.container, {height: styles.container.height + (insets.top / 2), paddingTop: (insets.top / 2)}]}
                 useNativeDriver={true}
                 animation={animation}
                 testID='in_app_notification.screen'
@@ -190,7 +192,7 @@ const styles = StyleSheet.create({
         marginLeft: 10,
         ...Platform.select({
             android: {
-                marginTop: 17,
+                marginTop: 5,
                 height: 50,
             },
             ios: {

--- a/patches/react-native-navigation+7.8.1.patch
+++ b/patches/react-native-navigation+7.8.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
-index 3bfbc0b..cdb0d05 100644
+index 2d8f1ba..708f130 100644
 --- a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
 +++ b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
 @@ -55,14 +55,18 @@ public class NavigationModule extends ReactContextBaseJavaModule {
@@ -29,7 +29,7 @@ index 3bfbc0b..cdb0d05 100644
              }
          });
      }
-@@ -196,8 +200,12 @@ public class NavigationModule extends ReactContextBaseJavaModule {
+@@ -201,8 +205,12 @@ public class NavigationModule extends ReactContextBaseJavaModule {
  
      protected void handle(Runnable task) {
          UiThread.post(() -> {
@@ -44,11 +44,34 @@ index 3bfbc0b..cdb0d05 100644
              }
          });
      }
+diff --git a/node_modules/react-native-navigation/lib/ios/RNNOverlayWindow.m b/node_modules/react-native-navigation/lib/ios/RNNOverlayWindow.m
+index 815e1c6..a35a087 100644
+--- a/node_modules/react-native-navigation/lib/ios/RNNOverlayWindow.m
++++ b/node_modules/react-native-navigation/lib/ios/RNNOverlayWindow.m
+@@ -1,5 +1,7 @@
+ #import "RNNOverlayWindow.h"
+ #import "RNNReactView.h"
++#import <react-native-safe-area-context/RNCSafeAreaView.h>
++#import <react-native-safe-area-context/RNCSafeAreaProvider.h>
+ 
+ @implementation RNNOverlayWindow
+ 
+@@ -7,7 +9,9 @@ - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+     UIView *hitTestResult = [super hitTest:point withEvent:event];
+ 
+     if ([hitTestResult isKindOfClass:[UIWindow class]] ||
+-        [hitTestResult.subviews.firstObject isKindOfClass:RNNReactView.class]) {
++        [hitTestResult.subviews.firstObject isKindOfClass:RNNReactView.class] ||
++        [hitTestResult isKindOfClass:[RNCSafeAreaView class]] ||
++        [hitTestResult isKindOfClass:[RNCSafeAreaProvider class]]) {
+         return nil;
+     }
+ 
 diff --git a/node_modules/react-native-navigation/lib/ios/RNNViewLocation.m b/node_modules/react-native-navigation/lib/ios/RNNViewLocation.m
-index f5187d9..d97e766 100644
+index 6b9981d..f725701 100644
 --- a/node_modules/react-native-navigation/lib/ios/RNNViewLocation.m
 +++ b/node_modules/react-native-navigation/lib/ios/RNNViewLocation.m
-@@ -32,11 +32,7 @@ - (CGFloat)getClippedCornerRadius:(UIView *)view {
+@@ -31,11 +31,7 @@ - (CGFloat)getClippedCornerRadius:(UIView *)view {
  
  - (CATransform3D)getTransform:(UIView *)view {
      if (view) {


### PR DESCRIPTION
#### Summary
The in-app overlay was conflicting with RNSafeAreaContext thus once the in-app notification was shown, gestures outside the overlay were not captured, this PR applies a patch to the overlay in the nav library and also fixes a couple of styles.

On top of that the Keychain manager required a couple of options in order to actually retrieve the session token from the native side on Android.

Tests: It would be good to test notifications with id loaded on Android to ensure the device is able to retrieve the session token and use it to get the actual message from the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32183

#### Device Information
Android 11 Pixel 4
iOS 14.3 iPhone XS & 12