### PR TITLE
MM-30695 Detox/E2E: Add e2e for MM-T3218

### DIFF
--- a/detox/e2e/test/smoke_test/message_reply.e2e.js
+++ b/detox/e2e/test/smoke_test/message_reply.e2e.js
@@ -57,6 +57,7 @@ describe('Message Reply', () => {
         ({post: replyPost} = await Post.apiGetLastPostInChannel(testChannel.id));
         ({postListPostItem: replyPostItem} = await ThreadScreen.getPostListPostItem(replyPost.id, replyMessage));
         await expect(replyPostItem).toBeVisible();
+        await replyPostItem.tap();
 
         // * Verify reply post is displayed in main channel
         await ThreadScreen.back();

--- a/detox/e2e/test/smoke_test/message_reply.e2e.js
+++ b/detox/e2e/test/smoke_test/message_reply.e2e.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {
+    ChannelScreen,
+    ThreadScreen,
+} from '@support/ui/screen';
+import {
+    Channel,
+    Post,
+    Setup,
+} from '@support/server_api';
+
+describe('Message Reply', () => {
+    let testChannel;
+    let parentPost;
+    let parentPostItem;
+    let replyPost;
+    let replyPostItem;
+
+    beforeAll(async () => {
+        const {team, user} = await Setup.apiInit();
+
+        const {channel} = await Channel.apiGetChannelByName(team.name, 'town-square');
+        testChannel = channel;
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    it('MM-T3218 should be able to post a reply to a message', async () => {
+        // # Post a message
+        const parentMessage = Date.now().toString();
+        await ChannelScreen.postMessage(parentMessage);
+
+        // * Verify parent post is displayed in reply thread
+        ({post: parentPost} = await Post.apiGetLastPostInChannel(testChannel.id));
+        await ChannelScreen.openReplyThreadFor(parentPost.id, parentMessage);
+        ({postListPostItem: parentPostItem} = await ThreadScreen.getPostListPostItem(parentPost.id, parentMessage));
+        await expect(parentPostItem).toBeVisible();
+
+        // # Post a reply
+        const replyMessage = `reply to ${parentMessage}`;
+        await ThreadScreen.postMessage(replyMessage);
+
+        // * Verify reply post appears after parent post in reply thread
+        ({post: replyPost} = await Post.apiGetLastPostInChannel(testChannel.id));
+        ({postListPostItem: replyPostItem} = await ThreadScreen.getPostListPostItem(replyPost.id, replyMessage));
+        await expect(replyPostItem).toBeVisible();
+
+        // * Verify reply post is displayed in main channel
+        await ThreadScreen.back();
+        await ChannelScreen.toBeVisible();
+        await expect(element(by.text(replyMessage))).toBeVisible();
+    });
+});


### PR DESCRIPTION
#### Summary
- Added `smoke_test/message_reply.e2e.js` for MM-T3218

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-30695
TM4J Cases:
- [MM-T3218](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T3218)

![Screen Shot 2021-01-25 at 3 30 44 PM](https://user-images.githubusercontent.com/487991/105779145-9481e680-5f22-11eb-89d3-5ccc95dfeae3.png)
