### PR TITLE
MM-31322: redirect permalink handler

### DIFF
--- a/app/actions/views/permalink.ts
+++ b/app/actions/views/permalink.ts
@@ -17,29 +17,32 @@ export function showPermalink(intl: typeof intlShape, teamName: string, postId: 
     return async (dispatch: DispatchFunc) => {
         const loadTeam = await dispatch(loadChannelsByTeamName(teamName, permalinkBadTeam.bind(null, intl)));
 
-        if (!loadTeam.error) {
-            Keyboard.dismiss();
-            dispatch(selectFocusedPostId(postId));
-
-            if (!showingPermalink) {
-                const screen = 'Permalink';
-                const passProps = {
-                    isPermalink: openAsPermalink,
-                    onClose: () => {
-                        dispatch(closePermalink());
-                    },
-                };
-
-                const options = {
-                    layout: {
-                        componentBackgroundColor: changeOpacity('#000', 0.2),
-                    },
-                };
-
-                showingPermalink = true;
-                showModalOverCurrentContext(screen, passProps, options);
-            }
+        if (loadTeam.error) {
+            return {};
         }
+
+        Keyboard.dismiss();
+        dispatch(selectFocusedPostId(postId));
+
+        if (!showingPermalink) {
+            const screen = 'Permalink';
+            const passProps = {
+                isPermalink: openAsPermalink,
+                onClose: () => {
+                    dispatch(closePermalink());
+                },
+            };
+
+            const options = {
+                layout: {
+                    componentBackgroundColor: changeOpacity('#000', 0.2),
+                },
+            };
+
+            showingPermalink = true;
+            showModalOverCurrentContext(screen, passProps, options);
+        }
+
         return {};
     };
 }

--- a/app/actions/views/permalink.ts
+++ b/app/actions/views/permalink.ts
@@ -15,10 +15,13 @@ export let showingPermalink = false;
 
 export function showPermalink(intl: typeof intlShape, teamName: string, postId: string, openAsPermalink = true) {
     return async (dispatch: DispatchFunc) => {
-        const loadTeam = await dispatch(loadChannelsByTeamName(teamName, permalinkBadTeam.bind(null, intl)));
+        // For the special, "_redirect" path, just use the currently selected team.
+        if (teamName !== '_redirect') {
+            const loadTeam = await dispatch(loadChannelsByTeamName(teamName, permalinkBadTeam.bind(null, intl)));
 
-        if (loadTeam.error) {
-            return {};
+            if (loadTeam.error) {
+                return {};
+            }
         }
 
         Keyboard.dismiss();

--- a/app/actions/views/permalink.ts
+++ b/app/actions/views/permalink.ts
@@ -17,32 +17,29 @@ export function showPermalink(intl: typeof intlShape, teamName: string, postId: 
     return async (dispatch: DispatchFunc) => {
         const loadTeam = await dispatch(loadChannelsByTeamName(teamName, permalinkBadTeam.bind(null, intl)));
 
-        if (loadTeam.error) {
-            return {};
+        if (!loadTeam.error) {
+            Keyboard.dismiss();
+            dispatch(selectFocusedPostId(postId));
+
+            if (!showingPermalink) {
+                const screen = 'Permalink';
+                const passProps = {
+                    isPermalink: openAsPermalink,
+                    onClose: () => {
+                        dispatch(closePermalink());
+                    },
+                };
+
+                const options = {
+                    layout: {
+                        componentBackgroundColor: changeOpacity('#000', 0.2),
+                    },
+                };
+
+                showingPermalink = true;
+                showModalOverCurrentContext(screen, passProps, options);
+            }
         }
-
-        Keyboard.dismiss();
-        dispatch(selectFocusedPostId(postId));
-
-        if (!showingPermalink) {
-            const screen = 'Permalink';
-            const passProps = {
-                isPermalink: openAsPermalink,
-                onClose: () => {
-                    dispatch(closePermalink());
-                },
-            };
-
-            const options = {
-                layout: {
-                    componentBackgroundColor: changeOpacity('#000', 0.2),
-                },
-            };
-
-            showingPermalink = true;
-            showModalOverCurrentContext(screen, passProps, options);
-        }
-
         return {};
     };
 }

--- a/app/actions/views/permalink.ts
+++ b/app/actions/views/permalink.ts
@@ -15,13 +15,10 @@ export let showingPermalink = false;
 
 export function showPermalink(intl: typeof intlShape, teamName: string, postId: string, openAsPermalink = true) {
     return async (dispatch: DispatchFunc) => {
-        // For the special, "_redirect" path, just use the currently selected team.
-        if (teamName !== '_redirect') {
-            const loadTeam = await dispatch(loadChannelsByTeamName(teamName, permalinkBadTeam.bind(null, intl)));
+        const loadTeam = await dispatch(loadChannelsByTeamName(teamName, permalinkBadTeam.bind(null, intl)));
 
-            if (loadTeam.error) {
-                return {};
-            }
+        if (loadTeam.error) {
+            return {};
         }
 
         Keyboard.dismiss();

--- a/app/components/markdown/markdown_link/index.js
+++ b/app/components/markdown/markdown_link/index.js
@@ -5,14 +5,18 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getConfig, getCurrentUrl} from '@mm-redux/selectors/entities/general';
+import {getCurrentTeam} from '@mm-redux/selectors/entities/teams';
 import {handleSelectChannelByName} from 'app/actions/views/channel';
 
 import MarkdownLink from './markdown_link';
 
 function mapStateToProps(state) {
+    const team = getCurrentTeam(state);
+
     return {
         serverURL: getCurrentUrl(state),
         siteURL: getConfig(state).SiteURL,
+        currentTeamName: team && team.name,
     };
 }
 

--- a/app/components/markdown/markdown_link/index.js
+++ b/app/components/markdown/markdown_link/index.js
@@ -11,12 +11,10 @@ import {handleSelectChannelByName} from 'app/actions/views/channel';
 import MarkdownLink from './markdown_link';
 
 function mapStateToProps(state) {
-    const team = getCurrentTeam(state);
-
     return {
         serverURL: getCurrentUrl(state),
         siteURL: getConfig(state).SiteURL,
-        currentTeamName: team && team.name,
+        currentTeamName: getCurrentTeam(state)?.name,
     };
 }
 

--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -15,7 +15,7 @@ import {getCurrentServerUrl} from '@init/credentials';
 import BottomSheet from '@utils/bottom_sheet';
 import {errorBadChannel} from '@utils/draft';
 import {preventDoubleTap} from '@utils/tap';
-import {matchDeepLink, normalizeProtocol, tryOpenURL} from '@utils/url';
+import {matchDeepLink, normalizeProtocol, tryOpenURL, PERMALINK_GENERIC_TEAM_NAME_REDIRECT} from '@utils/url';
 
 import mattermostManaged from 'app/mattermost_managed';
 
@@ -29,6 +29,7 @@ export default class MarkdownLink extends PureComponent {
         onPermalinkPress: PropTypes.func,
         serverURL: PropTypes.string,
         siteURL: PropTypes.string.isRequired,
+        currentTeamName: PropTypes.string,
     };
 
     static defaultProps = {
@@ -61,7 +62,11 @@ export default class MarkdownLink extends PureComponent {
                 const {intl} = this.context;
                 this.props.actions.handleSelectChannelByName(match.channelName, match.teamName, errorBadChannel.bind(null, intl));
             } else if (match.type === DeepLinkTypes.PERMALINK) {
-                onPermalinkPress(match.postId, match.teamName);
+                if (match.teamName === PERMALINK_GENERIC_TEAM_NAME_REDIRECT) {
+                    onPermalinkPress(match.postId, this.props.currentTeamName);
+                } else {
+                    onPermalinkPress(match.postId, match.teamName);
+                }
             }
         } else {
             const onError = () => {

--- a/app/components/post_list/index.js
+++ b/app/components/post_list/index.js
@@ -24,8 +24,6 @@ function makeMapStateToProps() {
             initialIndex = postIds.indexOf(ownProps.highlightPostId);
         }
 
-        const team = getCurrentTeam(state);
-
         return {
             deepLinkURL: state.views.root.deepLinkURL,
             postIds,
@@ -33,7 +31,7 @@ function makeMapStateToProps() {
             serverURL: getCurrentUrl(state),
             siteURL: getConfig(state).SiteURL,
             theme: getTheme(state),
-            currentTeamName: team && team.name,
+            getCurrentTeam(state)?.name,
         };
     };
 }

--- a/app/components/post_list/index.js
+++ b/app/components/post_list/index.js
@@ -31,7 +31,7 @@ function makeMapStateToProps() {
             serverURL: getCurrentUrl(state),
             siteURL: getConfig(state).SiteURL,
             theme: getTheme(state),
-            getCurrentTeam(state)?.name,
+            currentTeamName: getCurrentTeam(state)?.name,
         };
     };
 }

--- a/app/components/post_list/index.js
+++ b/app/components/post_list/index.js
@@ -8,6 +8,7 @@ import {closePermalink, showPermalink} from '@actions/views/permalink';
 import {getConfig, getCurrentUrl} from '@mm-redux/selectors/entities/general';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {makePreparePostIdsForPostList, START_OF_NEW_MESSAGES} from '@mm-redux/utils/post_list';
+import {getCurrentTeam} from '@mm-redux/selectors/entities/teams';
 
 import {handleSelectChannelByName, refreshChannelWithRetry} from 'app/actions/views/channel';
 import {setDeepLinkURL} from 'app/actions/views/root';
@@ -23,6 +24,8 @@ function makeMapStateToProps() {
             initialIndex = postIds.indexOf(ownProps.highlightPostId);
         }
 
+        const team = getCurrentTeam(state);
+
         return {
             deepLinkURL: state.views.root.deepLinkURL,
             postIds,
@@ -30,6 +33,7 @@ function makeMapStateToProps() {
             serverURL: getCurrentUrl(state),
             siteURL: getConfig(state).SiteURL,
             theme: getTheme(state),
+            currentTeamName: team && team.name,
         };
     };
 }

--- a/app/components/post_list/post_list.js
+++ b/app/components/post_list/post_list.js
@@ -16,7 +16,7 @@ import Post from 'app/components/post';
 import {DeepLinkTypes, ListTypes, NavigationTypes} from '@constants';
 import mattermostManaged from 'app/mattermost_managed';
 import {makeExtraData} from 'app/utils/list_view';
-import {matchDeepLink} from 'app/utils/url';
+import {matchDeepLink, PERMALINK_GENERIC_TEAM_NAME_REDIRECT} from 'app/utils/url';
 import telemetry from 'app/telemetry';
 
 import DateHeader from './date_header';
@@ -71,6 +71,7 @@ export default class PostList extends PureComponent {
         location: PropTypes.string,
         scrollViewNativeID: PropTypes.string,
         showMoreMessagesButton: PropTypes.bool,
+        currentTeamName: PropTypes.string,
     };
 
     static defaultProps = {
@@ -81,6 +82,7 @@ export default class PostList extends PureComponent {
         siteURL: '',
         postIds: [],
         showMoreMessagesButton: false,
+        currentTeamName: '',
     };
 
     static contextTypes = {
@@ -181,7 +183,7 @@ export default class PostList extends PureComponent {
     };
 
     handleDeepLink = (url) => {
-        const {serverURL, siteURL} = this.props;
+        const {serverURL, siteURL, currentTeamName} = this.props;
 
         const match = matchDeepLink(url, serverURL, siteURL);
 
@@ -190,7 +192,11 @@ export default class PostList extends PureComponent {
                 const {intl} = this.context;
                 this.props.actions.handleSelectChannelByName(match.channelName, match.teamName, errorBadChannel(intl));
             } else if (match.type === DeepLinkTypes.PERMALINK) {
-                this.handlePermalinkPress(match.postId, match.teamName);
+                if (match.teamName === PERMALINK_GENERIC_TEAM_NAME_REDIRECT) {
+                    this.handlePermalinkPress(match.postId, currentTeamName);
+                } else {
+                    this.handlePermalinkPress(match.postId, match.teamName);
+                }
             }
         } else {
             const {formatMessage} = this.context.intl;

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -102,6 +102,8 @@ export function getScheme(url) {
     return match && match[1];
 }
 
+export const PERMALINK_GENERIC_TEAM_NAME_REDIRECT = '_redirect';
+
 export function matchDeepLink(url, serverURL, siteURL) {
     if (!url || (!serverURL && !siteURL)) {
         return null;

--- a/detox/e2e/test/messaging/permalink.e2e.js
+++ b/detox/e2e/test/messaging/permalink.e2e.js
@@ -54,7 +54,7 @@ describe('Permalink', () => {
 
         // # Dismiss the permalink screen by jumping to recent messages
         await PermalinkScreen.jumpToRecentMessages();
-        
+
         // * Verify user is on channel where message is posted
         await expect(ChannelScreen.channelNavBarTitle).toHaveText(permalinkTargetChannel.display_name);
         const {postListPostItem: channelPostItem} = await ChannelScreen.getPostListPostItem(permalinkTargetPost.id, permalinkTargetPost.message);

--- a/detox/e2e/test/messaging/permalink.e2e.js
+++ b/detox/e2e/test/messaging/permalink.e2e.js
@@ -61,7 +61,7 @@ describe('Permalink', () => {
         await expect(channelPostItem).toBeVisible();
     };
 
-    it('[tm4j_id]_[step] should support _redirect to public channel post', async () => {
+    it('MM-T3805_1 should support _redirect to public channel post', async () => {
         // # Post a test message in a public channel
         const permalinkTargetMessage = 'post in Town Square';
         const permalinkTargetPost = await Post.apiCreatePost({
@@ -72,7 +72,7 @@ describe('Permalink', () => {
         await expectPermalinkTargetMessage(permalinkTargetPost.post, townSquareChannel);
     });
 
-    it('[tm4j_id]_[step] should support _redirect to DM post', async () => {
+    it('MM-T3805_2 should support _redirect to DM post', async () => {
         // # Post a test message in a DM
         const {user: dmOtherUser} = await User.apiCreateUser({prefix: 'testchannel-1'});
         const {channel: directMessageChannel} = await Channel.apiCreateDirectChannel([testUser.id, dmOtherUser.id]);

--- a/detox/e2e/test/messaging/permalink.e2e.js
+++ b/detox/e2e/test/messaging/permalink.e2e.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {MainSidebar} from '@support/ui/component';
+import {ChannelScreen, PermalinkScreen} from '@support/ui/screen';
+import {User, Setup, Channel, Post} from '@support/server_api';
+
+describe('Permalink', () => {
+    let testUser;
+    let testChannel;
+    let townSquareChannel;
+
+    beforeAll(async () => {
+        const {user, team, channel} = await Setup.apiInit();
+        testUser = user;
+        testChannel = channel;
+        ({channel: townSquareChannel} = await Channel.apiGetChannelByName(team.name, 'town-square'));
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    const expectPermalinkTargetMessage = async (permalinkTargetPost) => {
+        // # Post a message in the test channel referencing the given permalink.
+        const permalinkMessage = `[permalink](/_redirect/pl/${permalinkTargetPost.id})`;
+        await Post.apiCreatePost({
+            channelId: testChannel.id,
+            message: permalinkMessage,
+        });
+
+        // # Go to test channel
+        await ChannelScreen.openMainSidebar();
+        await MainSidebar.getChannelByDisplayName(testChannel.display_name).tap();
+        await ChannelScreen.toBeVisible();
+
+        // # Tap the channel permalink
+        element(by.text('permalink')).tap({x: 5, y: 10});
+
+        // * Verify permalink post list has the expected target message
+        await PermalinkScreen.toBeVisible();
+        const {postListPostItem: permalinkPostItem} = await PermalinkScreen.getPostListPostItem(permalinkTargetPost.id, permalinkTargetPost.message);
+        await waitFor(permalinkPostItem).toBeVisible();
+
+        // * Dismiss the permalink screen by jumping to recent messages
+        await PermalinkScreen.jumpToRecentMessages();
+    };
+
+    it('[tm4j_id]_[step] should support _redirect to public channel post', async () => {
+        // # Post a test message in a public channel
+        const permalinkTargetMessage = 'post in Town Square';
+        const permalinkTargetPost = await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: permalinkTargetMessage,
+        });
+
+        expectPermalinkTargetMessage(permalinkTargetPost.post);
+    });
+
+    it('[tm4j_id]_[step] should support _redirect to DM post', async () => {
+        // # Post a test message in a DM
+        const {user: dmOtherUser} = await User.apiCreateUser({prefix: 'testchannel-1'});
+        const {channel: directMessageChannel} = await Channel.apiCreateDirectChannel([testUser.id, dmOtherUser.id]);
+        const permalinkTargetMessage = 'post in DM';
+        const permalinkTargetPost = await Post.apiCreatePost({
+            channelId: directMessageChannel.id,
+            message: permalinkTargetMessage,
+        });
+
+        expectPermalinkTargetMessage(permalinkTargetPost.post);
+    });
+});


### PR DESCRIPTION
#### Summary
Some time ago, support for `_redirect` was added to the webapp permalink handler code. The exact semantics there effectively replaced it with the current team name, allowing the server to generate permalinks to DMs and GMs without having to know more context about the enduser and which teams they access.

This PR extends the mobile application to do same, though it works even better here, since it resolves non-DM and non-GM permalinks across team boundaries. We may revisit the webapp implementation to do same at some point, but all of this is only lightly used at present.

This is my first stab at writing a Detox test, though the Cypress familiarity made it relatively straightforward. Big thanks to @josephbaylon for various assists :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31322

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator