### PR TITLE
[MM-30697, MM-30699] Detox/E2E: Add e2e for MM-T3273 and MM-T3228

### DIFF
--- a/app/screens/edit_post/__snapshots__/edit_post.test.js.snap
+++ b/app/screens/edit_post/__snapshots__/edit_post.test.js.snap
@@ -65,7 +65,7 @@ exports[`EditPost should match snapshot 1`] = `
               },
             ]
           }
-          testID="edit_post.input"
+          testID="edit_post.message.input"
           underlineColorAndroid="transparent"
         />
       </View>

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -267,7 +267,7 @@ export default class EditPost extends PureComponent {
                         {displayError}
                         <View style={[inputContainerStyle, {height}]}>
                             <TextInputWithLocalizedPlaceholder
-                                testID='edit_post.input'
+                                testID='edit_post.message.input'
                                 ref={this.messageRef}
                                 value={message}
                                 blurOnSubmit={false}

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -47,12 +47,13 @@ export default class EditPost extends PureComponent {
 
     leftButton = {
         id: 'close-edit-post',
-        testID: 'edit_post.close',
+        testID: 'close.edit_post.button',
     };
 
     rightButton = {
         id: 'edit-post',
         showAsAction: 'always',
+        testID: 'edit_post.save.button',
     };
 
     constructor(props, context) {

--- a/detox/e2e/support/ui/screen/edit_post.js
+++ b/detox/e2e/support/ui/screen/edit_post.js
@@ -8,12 +8,14 @@ class EditPostScreen {
     testID = {
         editPostScreen: 'edit_post.screen',
         editPostInput: 'edit_post.input',
-        editPostClose: 'edit_post.close',
+        editPostSaveButton: 'edit_post.save.button',
+        closeEditPostButton: 'close.edit_post.button',
     }
 
     editPostScreen = element(by.id(this.testID.editPostScreen));
     editPostInput = element(by.id(this.testID.editPostInput));
-    editPostClose = element(by.id(this.testID.editPostClose));
+    editPostSaveButton = element(by.id(this.testID.editPostSaveButton));
+    closeEditPostButton = element(by.id(this.testID.closeEditPostButton));
 
     toBeVisible = async () => {
         if (isAndroid()) {

--- a/detox/e2e/support/ui/screen/edit_post.js
+++ b/detox/e2e/support/ui/screen/edit_post.js
@@ -7,15 +7,15 @@ import {isAndroid} from '@support/utils';
 class EditPostScreen {
     testID = {
         editPostScreen: 'edit_post.screen',
-        editPostInput: 'edit_post.input',
-        editPostSaveButton: 'edit_post.save.button',
         closeEditPostButton: 'close.edit_post.button',
+        messageInput: 'edit_post.message.input',
+        saveButton: 'edit_post.save.button',
     }
 
     editPostScreen = element(by.id(this.testID.editPostScreen));
-    editPostInput = element(by.id(this.testID.editPostInput));
-    editPostSaveButton = element(by.id(this.testID.editPostSaveButton));
     closeEditPostButton = element(by.id(this.testID.closeEditPostButton));
+    messageInput = element(by.id(this.testID.messageInput));
+    saveButton = element(by.id(this.testID.saveButton));
 
     toBeVisible = async () => {
         if (isAndroid()) {

--- a/detox/e2e/test/autocomplete/edit_post.e2e.js
+++ b/detox/e2e/test/autocomplete/edit_post.e2e.js
@@ -50,11 +50,14 @@ describe('Autocomplete', () => {
         await EditPostScreen.open();
 
         const {atMentionSuggestionList} = Autocomplete;
-        const {editPostInput, closeEditPostButton} = EditPostScreen;
+        const {
+            closeEditPostButton,
+            messageInput,
+        } = EditPostScreen;
 
         // # Open autocomplete
         await expect(atMentionSuggestionList).not.toExist();
-        await editPostInput.typeText(' @');
+        await messageInput.typeText(' @');
 
         // * Expect at_mention autocomplete to render
         await expect(atMentionSuggestionList).toExist();

--- a/detox/e2e/test/smoke_test/logout.e2e.js
+++ b/detox/e2e/test/smoke_test/logout.e2e.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {SettingsSidebar} from '@support/ui/component';
+import {
+    ChannelScreen,
+    SelectServerScreen,
+} from '@support/ui/screen';
+import {Setup} from '@support/server_api';
+
+describe('Logout', () => {
+    beforeAll(async () => {
+        const {user} = await Setup.apiInit();
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    it('MM-T3273 should be able to log out', async () => {
+        await ChannelScreen.openSettingsSidebar();
+        await SettingsSidebar.tapLogoutAction();
+        await SelectServerScreen.toBeVisible();
+    });
+});

--- a/detox/e2e/test/smoke_test/message_edit.e2e.js
+++ b/detox/e2e/test/smoke_test/message_edit.e2e.js
@@ -40,8 +40,8 @@ describe('Message Edit', () => {
             postMessage,
         } = ChannelScreen;
         const {
-            editPostInput,
-            editPostSaveButton,
+            messageInput,
+            saveButton,
         } = EditPostScreen;
 
         // # Post a message
@@ -55,8 +55,8 @@ describe('Message Edit', () => {
 
         // # Edit post and save
         const additionalText = ' additional text';
-        await editPostInput.typeText(additionalText);
-        await editPostSaveButton.tap();
+        await messageInput.typeText(additionalText);
+        await saveButton.tap();
 
         // * Verify post is edited
         await ChannelScreen.toBeVisible();

--- a/detox/e2e/test/smoke_test/message_edit.e2e.js
+++ b/detox/e2e/test/smoke_test/message_edit.e2e.js
@@ -7,7 +7,6 @@
 // - Use element testID when selecting an element. Create one if none.
 // *******************************************************************
 
-import {Autocomplete} from '@support/ui/component';
 import {
     ChannelScreen,
     EditPostScreen,
@@ -18,7 +17,7 @@ import {
     Setup,
 } from '@support/server_api';
 
-describe('Autocomplete', () => {
+describe('Message Edit', () => {
     let testChannel;
 
     beforeAll(async () => {
@@ -34,11 +33,16 @@ describe('Autocomplete', () => {
         await ChannelScreen.logout();
     });
 
-    it('MM-T3391 should render autocomplete in post edit screen', async () => {
+    it('MM-T3228 should be able to edit a message and save', async () => {
         const {
+            getPostListPostItem,
             openPostOptionsFor,
             postMessage,
         } = ChannelScreen;
+        const {
+            editPostInput,
+            editPostSaveButton,
+        } = EditPostScreen;
 
         // # Post a message
         const testMessage = Date.now().toString();
@@ -49,17 +53,14 @@ describe('Autocomplete', () => {
         await openPostOptionsFor(post.id, testMessage);
         await EditPostScreen.open();
 
-        const {atMentionSuggestionList} = Autocomplete;
-        const {editPostInput, closeEditPostButton} = EditPostScreen;
+        // # Edit post and save
+        const additionalText = ' additional text';
+        await editPostInput.typeText(additionalText);
+        await editPostSaveButton.tap();
 
-        // # Open autocomplete
-        await expect(atMentionSuggestionList).not.toExist();
-        await editPostInput.typeText(' @');
-
-        // * Expect at_mention autocomplete to render
-        await expect(atMentionSuggestionList).toExist();
-
-        // # Close edit post screen
-        await closeEditPostButton.tap();
+        // * Verify post is edited
+        await ChannelScreen.toBeVisible();
+        const {postListPostItem} = await getPostListPostItem(post.id, `${testMessage}${additionalText} (edited)`);
+        await expect(postListPostItem).toBeVisible();
     });
 });


### PR DESCRIPTION
#### Summary
- Added tests for MM-T3273 and MM-T3228 in
    - `smoke_test/message_edit.e2e.js` 
    - `smoke_test/logout.e2e.js`
- Added/updated testIDs

#### Ticket Link
JIRA tickets:
- https://mattermost.atlassian.net/browse/MM-30697
- https://mattermost.atlassian.net/browse/MM-30699
TM4J Cases:
- [MM-T3273](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T3273)
- [MM-T3228](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T3228)

![Screen Shot 2021-01-29 at 8 43 29 AM](https://user-images.githubusercontent.com/487991/106302708-25e8a580-620e-11eb-8148-fac9243b77db.png)
![Screen Shot 2021-01-29 at 8 43 55 AM](https://user-images.githubusercontent.com/487991/106302709-26813c00-620e-11eb-8e49-7358d548b1ef.png)

