### PR TITLE
MM-32254 Update CommonMark and fix handling of deeply nested Markdown

### DIFF
--- a/app/components/markdown/markdown.test.js
+++ b/app/components/markdown/markdown.test.js
@@ -33,4 +33,15 @@ describe('Markdown', () => {
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    test('MM-32254 should not crash when given string with deeply nested asterisks', () => {
+        const props = {
+            ...baseProps,
+            value: '**'.repeat(50) + 'test' + '**'.repeat(50) + 'test',
+        };
+
+        shallow(
+            <Markdown {...props}/>,
+        );
+    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12431,14 +12431,21 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "commonmark": {
-      "version": "github:mattermost/commonmark.js#f6ab98dede6ce4b4e7adea140ac77249bfb2d6ce",
-      "from": "github:mattermost/commonmark.js#f6ab98dede6ce4b4e7adea140ac77249bfb2d6ce",
+      "version": "github:mattermost/commonmark.js#d716e1c89e0a6721051df7bc74ad7683e1ae438f",
+      "from": "github:mattermost/commonmark.js#d716e1c89e0a6721051df7bc74ad7683e1ae438f",
       "requires": {
-        "entities": "~ 1.1.1",
-        "mdurl": "~ 1.0.1",
-        "minimist": "~ 1.2.0",
+        "entities": "~2.0",
+        "mdurl": "~1.0.1",
+        "minimist": ">=1.2.2",
         "string.prototype.repeat": "^0.2.0",
         "xregexp": "4.1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+        }
       }
     },
     "commonmark-react-renderer": {
@@ -13920,7 +13927,8 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "envinfo": {
       "version": "7.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12449,8 +12449,8 @@
       }
     },
     "commonmark-react-renderer": {
-      "version": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",
-      "from": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",
+      "version": "github:mattermost/commonmark-react-renderer#81af294317ebe19b5cc195d7fbc4f4a58177854c",
+      "from": "github:mattermost/commonmark-react-renderer#81af294317ebe19b5cc195d7fbc4f4a58177854c",
       "requires": {
         "in-publish": "^2.0.0",
         "lodash.assign": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sentry/react-native": "2.1.0",
     "analytics-react-native": "1.2.0",
     "commonmark": "github:mattermost/commonmark.js#d716e1c89e0a6721051df7bc74ad7683e1ae438f",
-    "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",
+    "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#81af294317ebe19b5cc195d7fbc4f4a58177854c",
     "core-js": "3.8.2",
     "deep-equal": "2.0.5",
     "deepmerge": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@rudderstack/rudder-sdk-react-native": "1.0.4",
     "@sentry/react-native": "2.1.0",
     "analytics-react-native": "1.2.0",
-    "commonmark": "github:mattermost/commonmark.js#f6ab98dede6ce4b4e7adea140ac77249bfb2d6ce",
+    "commonmark": "github:mattermost/commonmark.js#d716e1c89e0a6721051df7bc74ad7683e1ae438f",
     "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#3a2ac19cab725ad28b170fdc1d397dddedcf87eb",
     "core-js": "3.8.2",
     "deep-equal": "2.0.5",


### PR DESCRIPTION
This fixes an error that would occur when someone posts a message containing a large number of asterisks. This caused an error because the message would be parsed as a very deeply nested structure of bold/unbold tags which would cause us to cut off the rendering at a certain depth, and then the part of commonmark-react-renderer responsible for rendering bold/unbold would hit an error due to the Markdown tree only being partially rendered. The actual fix for that is here: https://github.com/mattermost/commonmark-react-renderer/commit/81af294317ebe19b5cc195d7fbc4f4a58177854c

For QA (and anyone curious), note that we are still cutting off the rendered Markdown once it hits a certain depth, so the sample message in the ticket renders as empty (see attached screenshot). We could always look at improving that if we needed to, but the message wasn't intended to be rendered as Markdown in the first place since it came from someone's email that was posted as plain text. It also renders wrong in the web app in a different way, so I'd say the best "fix" for that specific string would be to fix it so that the email integration escapes things that might mess up the Markdown.

I originally thought the issue was caused by commonmark.js being out of date, but that didn't end up being the case. Regardless, I've updated it to the latest master which should fix some cases where the app could hang due to certain bad Markdown strings being posted. The changes for that are here: https://github.com/mattermost/commonmark.js/compare/f6ab98dede6ce4b4e7adea140ac77249bfb2d6ce...mattermost:master. They look bigger than they are since commonmark decided to change some code styling which inflated the diff.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32254

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iOS Simulator (iPhone 11, iOS 14.3)

#### Screenshots
![Screen Shot 2021-01-29 at 6 02 47 PM](https://user-images.githubusercontent.com/3277310/106336109-345dae00-625c-11eb-8d48-b207fb10ca77.png)