### PR TITLE
[MM-32579] Retry failed FastImage requests

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -444,7 +444,7 @@ export default class Markdown extends PureComponent {
     };
 
     render() {
-        let ast = this.parser.parse(this.props.value);
+        let ast = this.parser.parse(this.props.value.toString());
 
         ast = combineTextNodes(ast);
         ast = addListItemIndices(ast);

--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -73,6 +73,7 @@ export default class Markdown extends PureComponent {
         disableChannelLink: false,
         disableAtChannelMentionHighlight: false,
         disableGallery: false,
+        value: '',
     };
 
     constructor(props) {

--- a/app/components/markdown/markdown.test.js
+++ b/app/components/markdown/markdown.test.js
@@ -44,4 +44,15 @@ describe('Markdown', () => {
             <Markdown {...props}/>,
         );
     });
+
+    test('should not crash when given a non-string value', () => {
+        const props = {
+            ...baseProps,
+            value: 10,
+        };
+
+        shallow(
+            <Markdown {...props}/>,
+        );
+    });
 });


### PR DESCRIPTION
#### Summary
FastImage does not provide a way to retry failed requests. This won't be an issue in v2 since swizzling the request will apply any retry interceptors added to the APIClient, but for v1 the easiest thing to do was to add a `key` prop and update it to force a re-render and hence a new request.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32579

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
* iPhone SE, iOS 14