### PR TITLE
MM-32851: honour defaults in interactive dialogs

### DIFF
--- a/app/screens/interactive_dialog/dialog_element.js
+++ b/app/screens/interactive_dialog/dialog_element.js
@@ -36,6 +36,13 @@ export default class DialogElement extends PureComponent {
         this.state = {
             selected: null,
         };
+
+        if (props.type === 'select' && props.value) {
+            const selected = props.options.find((option) => option.value === props.value);
+            if (selected) {
+                this.state.selected = selected;
+            }
+        }
     }
 
     onChange = (name, value) => {

--- a/app/screens/interactive_dialog/dialog_element.test.js
+++ b/app/screens/interactive_dialog/dialog_element.test.js
@@ -7,6 +7,7 @@ import {shallow} from 'enzyme';
 import Preferences from '@mm-redux/constants/preferences';
 import RadioSetting from 'app/components/widgets/settings/radio_setting';
 import BoolSetting from 'app/components/widgets/settings/bool_setting';
+import AutocompleteSelector from 'app/components/autocomplete_selector';
 import DialogElement from './dialog_element.js';
 
 describe('DialogElement', () => {
@@ -94,6 +95,42 @@ describe('DialogElement', () => {
                 />,
             );
             expect(wrapper.find(BoolSetting).find({value: false}).exists()).toBe(true);
+        });
+    });
+
+    describe('select', () => {
+        const baseProps = {
+            ...baseDialogProps,
+            theme,
+            display_name: 'Select',
+            name: 'select',
+            optional: false,
+            type: 'select',
+            options: [
+                {name: 'name1', value: 'value1'},
+                {name: 'name2', value: 'value2'},
+                {name: 'name3', value: 'value3'},
+            ],
+        };
+
+        test('handles unknown value', () => {
+            const wrapper = shallow(
+                <DialogElement
+                    {...baseProps}
+                    value={'unknown'}
+                />,
+            );
+            expect(wrapper.find(AutocompleteSelector).find({selected: null}).exists()).toBe(true);
+        });
+
+        test('handles known value', () => {
+            const wrapper = shallow(
+                <DialogElement
+                    {...baseProps}
+                    value={'value2'}
+                />,
+            );
+            expect(wrapper.find(AutocompleteSelector).find({selected: {name: 'name2', value: 'value2'}}).exists()).toBe(true);
         });
     });
 });


### PR DESCRIPTION
#### Summary
The `select` support for interactive dialogs was missing support for handling the default value provided by the server.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-32851

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iOS Simulator