### PR TITLE
Add refresh websocket event to refetch bindings

### DIFF
--- a/app/actions/websocket/apps.ts
+++ b/app/actions/websocket/apps.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fetchAppBindings} from '@mm-redux/actions/apps';
+import {getCurrentChannelId} from '@mm-redux/selectors/entities/common';
+import {getCurrentUserId} from '@mm-redux/selectors/entities/users';
+import {ActionResult, DispatchFunc, GetStateFunc} from '@mm-redux/types/actions';
+import {appsEnabled} from '@utils/apps';
+
+export function handleRefreshAppsBindings() {
+    return (dispatch: DispatchFunc, getState: GetStateFunc): ActionResult => {
+        const state = getState();
+        if (appsEnabled(state)) {
+            dispatch(fetchAppBindings(getCurrentUserId(state), getCurrentChannelId(state)));
+        }
+        return {data: true};
+    };
+}

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -46,8 +46,7 @@ import {handleLeaveTeamEvent, handleUpdateTeamEvent, handleTeamAddedEvent} from 
 import {handleStatusChangedEvent, handleUserAddedEvent, handleUserRemovedEvent, handleUserRoleUpdated, handleUserUpdatedEvent} from './users';
 import {getChannelSinceValue} from '@utils/channels';
 import {getPostIdsInChannel} from '@mm-redux/selectors/entities/posts';
-import {fetchAppBindings} from '@mm-redux/actions/apps';
-import {appsEnabled} from '@utils/apps';
+import {handleRefreshAppsBindings} from './apps';
 
 export function init(additionalOptions: any = {}) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -301,7 +300,7 @@ function handleClose(connectFailCount: number) {
 }
 
 function handleEvent(msg: WebSocketMessage) {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+    return (dispatch: DispatchFunc) => {
         switch (msg.event) {
         case WebsocketEvents.POSTED:
         case WebsocketEvents.EPHEMERAL_MESSAGE:
@@ -379,12 +378,8 @@ function handleEvent(msg: WebSocketMessage) {
             return dispatch(handleOpenDialogEvent(msg));
         case WebsocketEvents.RECEIVED_GROUP:
             return dispatch(handleGroupUpdatedEvent(msg));
-        case 'custom_com.mattermost.apps_refresh_bindings': {
-            const state = getState();
-            if (appsEnabled(state)) {
-                dispatch(fetchAppBindings(getCurrentUserId(state), getCurrentChannelId(state)));
-            }
-            break;
+        case WebsocketEvents.APPS_FRAMEWORK_REFRESH_BINDINGS: {
+            return dispatch(handleRefreshAppsBindings());
         }
         }
 

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -46,6 +46,7 @@ import {handleLeaveTeamEvent, handleUpdateTeamEvent, handleTeamAddedEvent} from 
 import {handleStatusChangedEvent, handleUserAddedEvent, handleUserRemovedEvent, handleUserRoleUpdated, handleUserUpdatedEvent} from './users';
 import {getChannelSinceValue} from '@utils/channels';
 import {getPostIdsInChannel} from '@mm-redux/selectors/entities/posts';
+import {fetchAppBindings} from '@mm-redux/actions/apps';
 
 export function init(additionalOptions: any = {}) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -299,7 +300,7 @@ function handleClose(connectFailCount: number) {
 }
 
 function handleEvent(msg: WebSocketMessage) {
-    return (dispatch: DispatchFunc) => {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         switch (msg.event) {
         case WebsocketEvents.POSTED:
         case WebsocketEvents.EPHEMERAL_MESSAGE:
@@ -377,6 +378,11 @@ function handleEvent(msg: WebSocketMessage) {
             return dispatch(handleOpenDialogEvent(msg));
         case WebsocketEvents.RECEIVED_GROUP:
             return dispatch(handleGroupUpdatedEvent(msg));
+        case 'custom_com.mattermost.apps_refresh_bindings': {
+            const state = getState();
+            dispatch(fetchAppBindings(getCurrentUserId(state), getCurrentChannelId(state)));
+            break;
+        }
         }
 
         return {data: true};

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -47,6 +47,7 @@ import {handleStatusChangedEvent, handleUserAddedEvent, handleUserRemovedEvent, 
 import {getChannelSinceValue} from '@utils/channels';
 import {getPostIdsInChannel} from '@mm-redux/selectors/entities/posts';
 import {fetchAppBindings} from '@mm-redux/actions/apps';
+import {appsEnabled} from '@utils/apps';
 
 export function init(additionalOptions: any = {}) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -380,7 +381,9 @@ function handleEvent(msg: WebSocketMessage) {
             return dispatch(handleGroupUpdatedEvent(msg));
         case 'custom_com.mattermost.apps_refresh_bindings': {
             const state = getState();
-            dispatch(fetchAppBindings(getCurrentUserId(state), getCurrentChannelId(state)));
+            if (appsEnabled(state)) {
+                dispatch(fetchAppBindings(getCurrentUserId(state), getCurrentChannelId(state)));
+            }
             break;
         }
         }

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -43,5 +43,6 @@ const WebsocketEvents = {
     INCREASE_POST_VISIBILITY_BY_ONE: 'increase_post_visibility_by_one',
     MEMBERROLE_UPDATED: 'memberrole_updated',
     RECEIVED_GROUP: 'received_group',
+    APPS_FRAMEWORK_REFRESH_BINDINGS: 'custom_com.mattermost.apps_refresh_bindings',
 };
 export default WebsocketEvents;


### PR DESCRIPTION
#### Summary
Add refresh bindings websocket event.

This naïve approach is the first iteration on handling changes in the bindings on server side. When the event is sent, we fetch one more time the bindings. Eventually we will look into better ways to handle this, maybe sending information through the websocket event.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33129

#### Related PR
Proxy: https://github.com/mattermost/mattermost-plugin-apps/pull/83
Webapp: https://github.com/mattermost/mattermost-webapp/pull/7599