### PR TITLE
Add binding validation on binding fetch

### DIFF
--- a/app/mm-redux/reducers/entities/__snapshots__/apps.test.js.snap
+++ b/app/mm-redux/reducers/entities/__snapshots__/apps.test.js.snap
@@ -1,0 +1,340 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bindings Invalid channel header get filtered 1`] = `
+Object {
+  "bindings": Array [
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locA",
+        },
+      ],
+      "call": Object {},
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "2",
+      "bindings": Array [
+        Object {
+          "app_id": "2",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locA",
+        },
+      ],
+      "call": Object {},
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "icon": "icon",
+          "label": "b",
+          "location": "/channel_header/locB",
+        },
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "c",
+          "location": "/channel_header/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/channel_header",
+    },
+    Object {
+      "app_id": "2",
+      "bindings": Array [
+        Object {
+          "app_id": "2",
+          "bindings": undefined,
+          "call": Object {},
+          "icon": "icon",
+          "label": "c",
+          "location": "/channel_header/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/channel_header",
+    },
+    Object {
+      "app_id": "3",
+      "bindings": Array [
+        Object {
+          "app_id": "3",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "c",
+          "location": "/channel_header/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/channel_header",
+    },
+    Object {
+      "app_id": "3",
+      "bindings": Array [
+        Object {
+          "app_id": "3",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "c",
+          "location": "/command/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/command",
+    },
+  ],
+}
+`;
+
+exports[`bindings Invalid commands get filtered 1`] = `
+Object {
+  "bindings": Array [
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locA",
+        },
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locB",
+        },
+      ],
+      "call": Object {},
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "icon": "icon",
+          "label": "b",
+          "location": "/channel_header/locB",
+        },
+      ],
+      "call": Object {},
+      "location": "/channel_header",
+    },
+    Object {
+      "app_id": "3",
+      "bindings": Array [
+        Object {
+          "app_id": "3",
+          "bindings": Array [
+            Object {
+              "app_id": "3",
+              "bindings": undefined,
+              "call": Object {},
+              "label": "c2",
+              "location": "/command/locC/subC2",
+            },
+          ],
+          "call": Object {},
+          "label": "c",
+          "location": "/command/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/command",
+    },
+    Object {
+      "app_id": "1",
+      "bindings": Array [],
+      "location": "/command",
+    },
+    Object {
+      "app_id": "2",
+      "bindings": Array [
+        Object {
+          "app_id": "2",
+          "bindings": Array [
+            Object {
+              "app_id": "2",
+              "bindings": undefined,
+              "call": Object {},
+              "label": "c1",
+              "location": "/command/locC/subC1",
+            },
+            Object {
+              "app_id": "2",
+              "bindings": undefined,
+              "call": Object {},
+              "label": "c2",
+              "location": "/command/locC/subC2",
+            },
+          ],
+          "call": Object {},
+          "label": "c",
+          "location": "/command/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/command",
+    },
+  ],
+}
+`;
+
+exports[`bindings Invalid post menu get filtered 1`] = `
+Object {
+  "bindings": Array [
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locB",
+        },
+      ],
+      "call": Object {},
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "2",
+      "bindings": Array [
+        Object {
+          "app_id": "2",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locA",
+        },
+        Object {
+          "app_id": "2",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "b",
+          "location": "/post_menu/locB",
+        },
+      ],
+      "call": Object {},
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "3",
+      "bindings": Array [],
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "icon": "icon",
+          "label": "b",
+          "location": "/channel_header/locB",
+        },
+      ],
+      "call": Object {},
+      "location": "/channel_header",
+    },
+    Object {
+      "app_id": "3",
+      "bindings": Array [
+        Object {
+          "app_id": "3",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "c",
+          "location": "/command/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/command",
+    },
+  ],
+}
+`;
+
+exports[`bindings No element get filtered 1`] = `
+Object {
+  "bindings": Array [
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locA",
+        },
+      ],
+      "call": Object {},
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "2",
+      "bindings": Array [
+        Object {
+          "app_id": "2",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "a",
+          "location": "/post_menu/locA",
+        },
+      ],
+      "call": Object {},
+      "location": "/post_menu",
+    },
+    Object {
+      "app_id": "1",
+      "bindings": Array [
+        Object {
+          "app_id": "1",
+          "bindings": undefined,
+          "call": Object {},
+          "icon": "icon",
+          "label": "b",
+          "location": "/channel_header/locB",
+        },
+      ],
+      "call": Object {},
+      "location": "/channel_header",
+    },
+    Object {
+      "app_id": "3",
+      "bindings": Array [
+        Object {
+          "app_id": "3",
+          "bindings": undefined,
+          "call": Object {},
+          "label": "c",
+          "location": "/command/locC",
+        },
+      ],
+      "call": Object {},
+      "location": "/command",
+    },
+  ],
+}
+`;

--- a/app/mm-redux/reducers/entities/apps.test.js
+++ b/app/mm-redux/reducers/entities/apps.test.js
@@ -1,0 +1,360 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {AppsTypes} from '@mm-redux/action_types';
+import * as Reducers from './apps';
+
+describe('bindings', () => {
+    const initialState = [];
+
+    test('No element get filtered', () => {
+        const data = {
+            bindings: [
+                {
+                    app_id: '1',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            label: 'a',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '2',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            label: 'a',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '1',
+                    location: '/channel_header',
+                    bindings: [
+                        {
+                            location: 'locB',
+                            label: 'b',
+                            icon: 'icon',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '3',
+                    location: '/command',
+                    bindings: [
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            call: {},
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const state = Reducers.bindings(
+            initialState,
+            {
+                type: AppsTypes.RECEIVED_APP_BINDINGS,
+                data,
+            },
+        );
+
+        expect(state).toMatchSnapshot();
+    });
+
+    test('Invalid channel header get filtered', () => {
+        const data = {
+            bindings: [
+                {
+                    app_id: '1',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            label: 'a',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '2',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            label: 'a',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '1',
+                    location: '/channel_header',
+                    bindings: [
+                        {
+                            location: 'locB',
+                            label: 'b',
+                            icon: 'icon',
+                            call: {},
+                        },
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '2',
+                    location: '/channel_header',
+                    bindings: [
+                        {
+                            location: 'locB',
+                            icon: 'icon',
+                            call: {},
+                        },
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            icon: 'icon',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '3',
+                    location: '/channel_header',
+                    bindings: [
+                        {
+                            location: 'locB',
+                            call: {},
+                        },
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '3',
+                    location: '/command',
+                    bindings: [
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            call: {},
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const state = Reducers.bindings(
+            initialState,
+            {
+                type: AppsTypes.RECEIVED_APP_BINDINGS,
+                data,
+            },
+        );
+
+        expect(state).toMatchSnapshot();
+    });
+
+    test('Invalid post menu get filtered', () => {
+        const data = {
+            bindings: [
+                {
+                    app_id: '1',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            call: {},
+                        },
+                        {
+                            location: 'locB',
+                            label: 'a',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '2',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            label: 'a',
+                            call: {},
+                        },
+                        {
+                            location: 'locB',
+                            label: 'b',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '3',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '1',
+                    location: '/channel_header',
+                    bindings: [
+                        {
+                            location: 'locB',
+                            label: 'b',
+                            icon: 'icon',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '3',
+                    location: '/command',
+                    bindings: [
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            call: {},
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const state = Reducers.bindings(
+            initialState,
+            {
+                type: AppsTypes.RECEIVED_APP_BINDINGS,
+                data,
+            },
+        );
+
+        expect(state).toMatchSnapshot();
+    });
+
+    test('Invalid commands get filtered', () => {
+        const data = {
+            bindings: [
+                {
+                    app_id: '1',
+                    location: '/post_menu',
+                    bindings: [
+                        {
+                            location: 'locA',
+                            label: 'a',
+                            call: {},
+                        },
+                        {
+                            location: 'locB',
+                            label: 'a',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '1',
+                    location: '/channel_header',
+                    bindings: [
+                        {
+                            location: 'locB',
+                            label: 'b',
+                            icon: 'icon',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '3',
+                    location: '/command',
+                    bindings: [
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            bindings: [
+                                {
+                                    location: 'subC1',
+                                    call: {},
+                                },
+                                {
+                                    location: 'subC2',
+                                    label: 'c2',
+                                    call: {},
+                                },
+                            ],
+                        },
+                        {
+                            location: 'locD',
+                            label: 'd',
+                            bindings: [
+                                {
+                                    location: 'subC1',
+                                    call: {},
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    app_id: '1',
+                    location: '/command',
+                    bindings: [
+                        {
+                            location: 'locC',
+                            call: {},
+                        },
+                    ],
+                },
+                {
+                    app_id: '2',
+                    location: '/command',
+                    bindings: [
+                        {
+                            location: 'locC',
+                            label: 'c',
+                            call: {},
+                            bindings: [
+                                {
+                                    location: 'subC1',
+                                    label: 'c1',
+                                    call: {},
+                                },
+                                {
+                                    location: 'subC2',
+                                    label: 'c2',
+                                    call: {},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const state = Reducers.bindings(
+            initialState,
+            {
+                type: AppsTypes.RECEIVED_APP_BINDINGS,
+                data,
+            },
+        );
+
+        expect(state).toMatchSnapshot();
+    });
+});

--- a/app/mm-redux/reducers/entities/apps.ts
+++ b/app/mm-redux/reducers/entities/apps.ts
@@ -5,10 +5,12 @@ import {combineReducers} from 'redux';
 import {AppsTypes} from '@mm-redux/action_types';
 import {AppBinding, AppsState} from '@mm-redux/types/apps';
 import {GenericAction} from '@mm-redux/types/actions';
+import {validateBindings} from '@utils/apps';
 
-function bindings(state: AppBinding[] = [], action: GenericAction): AppBinding[] {
+export function bindings(state: AppBinding[] = [], action: GenericAction): AppBinding[] {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_BINDINGS: {
+        validateBindings(action.data);
         return action.data || [];
     }
     default:

--- a/app/screens/channel_info/bindings/bindings.tsx
+++ b/app/screens/channel_info/bindings/bindings.tsx
@@ -10,7 +10,7 @@ import ChannelInfoRow from '../channel_info_row';
 import {AppBinding, AppCall} from '@mm-redux/types/apps';
 import {Theme} from '@mm-redux/types/preferences';
 import {Channel} from '@mm-redux/types/channels';
-import {AppCallTypes, AppExpandLevels, AppBindingLocations} from '@mm-redux/constants/apps';
+import {AppCallTypes, AppExpandLevels} from '@mm-redux/constants/apps';
 import {UserProfile} from '@mm-redux/types/users';
 import {dismissModal} from '@actions/navigation';
 
@@ -80,7 +80,7 @@ const Option = injectIntl((props: OptionProps) => {
             context: {
                 app_id: props.binding.app_id,
                 channel_id: channelId,
-                location: AppBindingLocations.CHANNEL_HEADER_ICON,
+                location: props.binding.location,
                 user_id: props.currentUser.id,
             },
             path: props.binding.call?.path || '',

--- a/app/screens/post_options/bindings/bindings.tsx
+++ b/app/screens/post_options/bindings/bindings.tsx
@@ -88,6 +88,7 @@ const Option = injectIntl((props: OptionProps) => {
                 channel_id: post.channel_id,
                 post_id: post.id,
                 user_id: props.currentUser.id,
+                location: props.binding.location,
             },
         }, props.intl);
         closeWithAnimation();

--- a/app/utils/apps.test.ts
+++ b/app/utils/apps.test.ts
@@ -2,10 +2,10 @@
 // See LICENSE.txt for license information.
 
 import {AppBinding, AppCall} from '@mm-redux/types/apps';
-import {fillBindingsInformation} from './apps';
+import {fillAndTrimBindingsInformation} from './apps';
 
 describe('Apps Utils', () => {
-    describe('fillBindingsInformation', () => {
+    describe('fillAndTrimBindingsInformation', () => {
         test('Apps IDs, and Calls propagate down, and locations get formed', () => {
             const inBinding: AppBinding = {
                 app_id: 'id',
@@ -71,7 +71,7 @@ describe('Apps Utils', () => {
                 ],
             } as AppBinding;
 
-            fillBindingsInformation(inBinding);
+            fillAndTrimBindingsInformation(inBinding);
             expect(inBinding).toEqual(outBinding);
         });
 
@@ -144,7 +144,7 @@ describe('Apps Utils', () => {
                 ],
             } as AppBinding;
 
-            fillBindingsInformation(inBinding);
+            fillAndTrimBindingsInformation(inBinding);
             expect(inBinding).toEqual(outBinding);
         });
 
@@ -215,7 +215,7 @@ describe('Apps Utils', () => {
                 ],
             } as AppBinding;
 
-            fillBindingsInformation(inBinding);
+            fillAndTrimBindingsInformation(inBinding);
             expect(inBinding).toEqual(outBinding);
         });
 
@@ -292,7 +292,7 @@ describe('Apps Utils', () => {
                 ],
             } as AppBinding;
 
-            fillBindingsInformation(inBinding);
+            fillAndTrimBindingsInformation(inBinding);
             expect(inBinding).toEqual(outBinding);
         });
 
@@ -347,7 +347,7 @@ describe('Apps Utils', () => {
                 ],
             } as AppBinding;
 
-            fillBindingsInformation(inBinding);
+            fillAndTrimBindingsInformation(inBinding);
             expect(inBinding).toEqual(outBinding);
         });
 
@@ -402,7 +402,7 @@ describe('Apps Utils', () => {
                 ],
             } as AppBinding;
 
-            fillBindingsInformation(inBinding);
+            fillAndTrimBindingsInformation(inBinding);
             expect(inBinding).toEqual(outBinding);
         });
 
@@ -436,7 +436,7 @@ describe('Apps Utils', () => {
                 bindings: [] as AppBinding[],
             } as AppBinding;
 
-            fillBindingsInformation(inBinding);
+            fillAndTrimBindingsInformation(inBinding);
             expect(inBinding).toEqual(outBinding);
         });
     });


### PR DESCRIPTION
#### Summary
Add binding validation on binding fetch. Any binding without a call or an app id in a leaf node (either by inheritance or having it itself) is considered not valid and filtered. Also, certain locations have certain requisites (for mobile, right now, just the label for each location).

Very similar changes as in https://github.com/mattermost/mattermost-redux/pull/1381

#### Ticket Link
None