### PR TITLE
Add feature flag

### DIFF
--- a/app/utils/apps.ts
+++ b/app/utils/apps.ts
@@ -1,12 +1,17 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {AppBindingLocations} from '@mm-redux/constants/apps';
+import {getConfig} from '@mm-redux/selectors/entities/general';
 import {AppBinding} from '@mm-redux/types/apps';
+import {Config} from '@mm-redux/types/config';
 import {GlobalState} from '@mm-redux/types/store';
 
 export function appsEnabled(state: GlobalState) { // eslint-disable-line @typescript-eslint/no-unused-vars
-    // TODO: Add feature branch and/or proxy state check
-    return true;
+    const enabled = getConfig(state)?.['FeatureFlagAppsEnabled' as keyof Partial<Config>];
+    if (enabled === 'true') {
+        return true;
+    }
+    return false;
 }
 
 export function copyAndFillBindings(binding?: AppBinding): AppBinding | undefined {

--- a/app/utils/apps.ts
+++ b/app/utils/apps.ts
@@ -8,10 +8,7 @@ import {GlobalState} from '@mm-redux/types/store';
 
 export function appsEnabled(state: GlobalState) { // eslint-disable-line @typescript-eslint/no-unused-vars
     const enabled = getConfig(state)?.['FeatureFlagAppsEnabled' as keyof Partial<Config>];
-    if (enabled === 'true') {
-        return true;
-    }
-    return false;
+    return enabled === 'true';
 }
 
 export function copyAndFillBindings(binding?: AppBinding): AppBinding | undefined {


### PR DESCRIPTION
#### Summary
Use the right feature flag when checking if apps are enabled or not.

DISCLAIMER: Since the server PR is not yet merged, this will render apps unusable on the client until that PR gets merged. After that, only server initialized with the feature flag set to true will show apps related code in the client.

#### Ticket Link
None

#### Related Pull Requests
Server: https://github.com/mattermost/mattermost-server/pull/16851
Webapp: https://github.com/mattermost/mattermost-webapp/pull/7643
