### PR TITLE
Use App CallRequest structure

### DIFF
--- a/app/actions/apps.ts
+++ b/app/actions/apps.ts
@@ -3,7 +3,7 @@
 
 import {Client4} from '@mm-redux/client';
 import {ActionFunc} from '@mm-redux/types/actions';
-import {AppCallResponse, AppCall, AppForm} from '@mm-redux/types/apps';
+import {AppCallResponse, AppForm, AppCallRequest} from '@mm-redux/types/apps';
 import {AppCallTypes, AppCallResponseTypes} from '@mm-redux/constants/apps';
 import {sendEphemeralPost} from './views/post';
 import {handleGotoLocation} from '@mm-redux/actions/integrations';
@@ -13,7 +13,7 @@ import CompassIcon from '@components/compass_icon';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import EphemeralStore from '@store/ephemeral_store';
 
-export function doAppCall<Res=unknown>(call: AppCall, intl: any): ActionFunc {
+export function doAppCall<Res=unknown>(call: AppCallRequest, intl: any): ActionFunc {
     return async (dispatch, getState) => {
         const ephemeral = (text: string) => dispatch(sendEphemeralPost(text, call?.context.channel_id, call?.context.root_id));
         try {
@@ -74,7 +74,7 @@ export function doAppCall<Res=unknown>(call: AppCall, intl: any): ActionFunc {
     };
 }
 
-const showAppForm = async (form: AppForm, call: AppCall, theme: Theme) => {
+const showAppForm = async (form: AppForm, call: AppCallRequest, theme: Theme) => {
     const closeButton = await CompassIcon.getImageSource('close', 24, theme.sidebarHeaderTextColor);
 
     let submitButtons = [{

--- a/app/actions/views/command.js
+++ b/app/actions/views/command.js
@@ -9,6 +9,7 @@ import {AppCallTypes} from '@mm-redux/constants/apps';
 import {AppCommandParser} from '@components/autocomplete/slash_suggestion/app_command_parser/app_command_parser';
 
 import {doAppCall} from '@actions/apps';
+import {appsEnabled} from '@utils/apps';
 
 export function executeCommand(message, channelId, rootId) {
     return async (dispatch, getState) => {
@@ -33,19 +34,22 @@ export function executeCommand(message, channelId, rootId) {
         const cmd = msg.substring(0, cmdLength).toLowerCase();
         msg = cmd + msg.substring(cmdLength, msg.length);
 
-        const parser = new AppCommandParser(null, args.root_id, args.channel_id);
-        if (parser.isAppCommand(msg)) {
-            const call = await parser.composeCallFromCommand(message);
-            if (!call) {
-                return {error: {message: 'Error submitting command'}};
-            }
+        const appsAreEnabled = appsEnabled(getState());
+        if (appsAreEnabled) {
+            const parser = new AppCommandParser(null, args.root_id, args.channel_id);
+            if (parser.isAppCommand(msg)) {
+                const call = await parser.composeCallFromCommand(message);
+                if (!call) {
+                    return {error: {message: 'Error submitting command'}};
+                }
 
-            call.type = AppCallTypes.SUBMIT;
-            const res = await dispatch(doAppCall(call));
-            if (res?.data?.error) {
-                return {error: {message: res.data.error}};
+                call.type = AppCallTypes.SUBMIT;
+                const res = await dispatch(doAppCall(call));
+                if (res?.data?.error) {
+                    return {error: {message: res.data.error}};
+                }
+                return res;
             }
-            return res;
         }
 
         const {data, error} = await dispatch(executeCommandService(msg, args));

--- a/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.test.ts
+++ b/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.test.ts
@@ -873,8 +873,13 @@ describe('AppCommandParser', () => {
         });
 
         test('full form', async () => {
-            const cmd = '/jira issue create --summary "Here it is" --epic epic1 --project';
-            const values = {};
+            const cmd = '/jira issue create --summary "Here it is" --epic epic1 --verbose true --project';
+            const values = {
+                summary: 'Here it is',
+                epic: 'epic1',
+                verbose: 'true',
+                project: '',
+            };
 
             const call = await parser.composeCallFromCommand(cmd);
             expect(call).toEqual({

--- a/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.test.ts
+++ b/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.test.ts
@@ -851,7 +851,7 @@ describe('AppCommandParser', () => {
         const base = {
             context: {
                 app_id: 'jira',
-                channel_id:'current_channel_id',
+                channel_id: 'current_channel_id',
                 location: '/command',
                 root_id: 'root_id',
                 team_id: 'team_id',
@@ -861,7 +861,7 @@ describe('AppCommandParser', () => {
         };
 
         test('empty form', async () => {
-            const cmd = '/jira issue create'
+            const cmd = '/jira issue create';
             const values = {};
 
             const call = await parser.composeCallFromCommand(cmd);
@@ -873,7 +873,7 @@ describe('AppCommandParser', () => {
         });
 
         test('full form', async () => {
-            const cmd = '/jira issue create --summary "Here it is" --epic epic1 --project'
+            const cmd = '/jira issue create --summary "Here it is" --epic epic1 --project';
             const values = {};
 
             const call = await parser.composeCallFromCommand(cmd);

--- a/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
+++ b/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
@@ -883,16 +883,17 @@ export class AppCommandParser {
             return [];
         }
 
-        const payload = this.composeCallFromParsed(parsed);
-        if (!payload) {
+        const call = this.composeCallFromParsed(parsed);
+        if (!call) {
             return [];
         }
-        payload.type = AppCallTypes.LOOKUP;
-        payload.selected_field = f.name;
-        payload.query = parsed.incomplete;
+        call.type = AppCallTypes.LOOKUP;
+        call.selected_field = f.name;
+        call.query = parsed.incomplete;
+        call.values = parsed.values;
 
         type ResponseType = {items: AppSelectOption[]};
-        const res: {data?: AppCallResponse<ResponseType>} = await this.store.dispatch(doAppCall<ResponseType>(payload, null));
+        const res: {data?: AppCallResponse<ResponseType>} = await this.store.dispatch(doAppCall<ResponseType>(call, null));
         const callResponse = res.data;
 
         if (callResponse?.type === AppCallResponseTypes.ERROR) {

--- a/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
+++ b/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
@@ -6,7 +6,7 @@
 import keyMirror from '@mm-redux/utils/key_mirror';
 
 import {
-    AppCall,
+    AppCallRequest,
     AppBinding,
     AppField,
     AppSelectOption,
@@ -15,7 +15,6 @@ import {
     AppForm,
     AutocompleteSuggestion,
     AutocompleteStaticSelect,
-    AppLookupCallValues,
     Channel,
     DispatchFunc,
     GlobalState,
@@ -484,7 +483,7 @@ export class AppCommandParser {
     }
 
     // composeCallFromCommand creates the form submission call
-    public composeCallFromCommand = async (command: string): Promise<AppCall | null> => {
+    public composeCallFromCommand = async (command: string): Promise<AppCallRequest | null> => {
         let parsed = new ParsedCommand(command, this);
 
         const commandBindings = this.getCommandBindings();
@@ -582,7 +581,7 @@ export class AppCommandParser {
     }
 
     // composeCallFromParsed creates the form submission call
-    composeCallFromParsed = (parsed: ParsedCommand): AppCall | null => {
+    composeCallFromParsed = (parsed: ParsedCommand): AppCallRequest | null => {
         if (!parsed.binding) {
             return null;
         }
@@ -683,7 +682,7 @@ export class AppCommandParser {
             return undefined;
         }
 
-        const payload: AppCall = {
+        const payload: AppCallRequest = {
             ...binding.call,
             type: AppCallTypes.FORM,
             context: {
@@ -884,18 +883,13 @@ export class AppCommandParser {
             return [];
         }
 
-        const values: AppLookupCallValues = {
-            name: f.name,
-            user_input: parsed.incomplete,
-            values: parsed.values,
-        };
-
         const payload = this.composeCallFromParsed(parsed);
         if (!payload) {
             return [];
         }
         payload.type = AppCallTypes.LOOKUP;
-        payload.values = values;
+        payload.selected_field = f.name;
+        payload.query = parsed.incomplete;
 
         type ResponseType = {items: AppSelectOption[]};
         const res: {data?: AppCallResponse<ResponseType>} = await this.store.dispatch(doAppCall<ResponseType>(payload, null));

--- a/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser_dependencies.ts
+++ b/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser_dependencies.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 export type {
-    AppCall,
+    AppCallRequest,
     AppBinding,
     AppField,
     AppSelectOption,
@@ -14,7 +14,6 @@ export type {
     AutocompleteStaticSelect,
     AutocompleteUserSelect,
     AutocompleteChannelSelect,
-    AppLookupCallValues,
 } from '@mm-redux/types/apps';
 
 import type {

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion.tsx
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion.tsx
@@ -112,6 +112,7 @@ export default class SlashSuggestion extends PureComponent<Props, State> {
             } else if (nextSuggestions === prevProps.suggestions) {
                 const args = {
                     channel_id: prevProps.channelId,
+                    team_id: prevProps.currentTeamId,
                     ...(prevProps.rootId && {root_id: prevProps.rootId, parent_id: prevProps.rootId}),
                 };
                 this.props.actions.getCommandAutocompleteSuggestions(nextValue, nextTeamId, args);

--- a/app/components/embedded_bindings/button_binding/button_binding.tsx
+++ b/app/components/embedded_bindings/button_binding/button_binding.tsx
@@ -11,13 +11,13 @@ import {getStatusColors} from '@utils/message_attachment_colors';
 import ButtonBindingText from './button_binding_text';
 import {Theme} from '@mm-redux/types/preferences';
 import {ActionResult} from '@mm-redux/types/actions';
-import {AppBinding, AppCall} from '@mm-redux/types/apps';
+import {AppBinding, AppCallRequest} from '@mm-redux/types/apps';
 import {Post} from '@mm-redux/types/posts';
-import {AppExpandLevels, AppBindingLocations} from '@mm-redux/constants/apps';
+import {AppExpandLevels, AppBindingLocations, AppCallTypes} from '@mm-redux/constants/apps';
 
 type Props = {
     actions: {
-        doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>;
+        doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>;
     };
     post: Post;
     binding: AppBinding;
@@ -30,13 +30,14 @@ export default class ButtonBinding extends PureComponent<Props> {
     };
     handleActionPress = preventDoubleTap(() => {
         const {binding, post, userId} = this.props;
-        const call: AppCall = {
+        const call: AppCallRequest = {
+            ...binding.call,
+            type: AppCallTypes.SUBMIT,
             path: binding.call?.path || '',
             expand: {
                 post: AppExpandLevels.EXPAND_ALL,
             },
             context: {
-                ...binding.call?.context,
                 acting_user_id: userId,
                 app_id: binding.app_id,
                 channel_id: post.channel_id,

--- a/app/components/embedded_bindings/button_binding/index.ts
+++ b/app/components/embedded_bindings/button_binding/index.ts
@@ -9,7 +9,7 @@ import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {GlobalState} from '@mm-redux/types/store';
 import {ActionFunc, ActionResult, GenericAction} from '@mm-redux/types/actions';
 import {getCurrentUserId} from '@mm-redux/selectors/entities/users';
-import {AppCall} from '@mm-redux/types/apps';
+import {AppCallRequest} from '@mm-redux/types/apps';
 import {doAppCall} from '@actions/apps';
 import {getPost} from '@mm-redux/selectors/entities/posts';
 
@@ -28,7 +28,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
 }
 
 type Actions = {
-    doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {

--- a/app/components/embedded_bindings/menu_binding/index.ts
+++ b/app/components/embedded_bindings/menu_binding/index.ts
@@ -8,7 +8,7 @@ import {GlobalState} from '@mm-redux/types/store';
 import {doAppCall} from '@actions/apps';
 import {getCurrentUserId} from '@mm-redux/selectors/entities/users';
 import {ActionFunc, ActionResult, GenericAction} from '@mm-redux/types/actions';
-import {AppCall} from '@mm-redux/types/apps';
+import {AppCallRequest} from '@mm-redux/types/apps';
 import {getPost} from '@mm-redux/selectors/entities/posts';
 
 import MenuBinding from './menu_binding';
@@ -25,7 +25,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
 }
 
 type Actions = {
-    doAppCall: (call: AppCall) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {

--- a/app/components/embedded_bindings/menu_binding/menu_binding.tsx
+++ b/app/components/embedded_bindings/menu_binding/menu_binding.tsx
@@ -7,13 +7,13 @@ import AutocompleteSelector from 'app/components/autocomplete_selector';
 import {intlShape} from 'react-intl';
 import {PostActionOption} from '@mm-redux/types/integration_actions';
 import {Post} from '@mm-redux/types/posts';
-import {AppBinding, AppCall} from '@mm-redux/types/apps';
+import {AppBinding, AppCallRequest} from '@mm-redux/types/apps';
 import {ActionResult} from '@mm-redux/types/actions';
-import {AppExpandLevels, AppBindingLocations} from '@mm-redux/constants/apps';
+import {AppExpandLevels, AppBindingLocations, AppCallTypes} from '@mm-redux/constants/apps';
 
 type Props = {
     actions: {
-        doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>;
+        doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>;
     };
     binding?: AppBinding;
     post: Post;
@@ -52,13 +52,14 @@ export default class MenuBinding extends PureComponent<Props, State> {
             userId,
         } = this.props;
 
-        const call: AppCall = {
+        const call: AppCallRequest = {
+            ...binding.call,
+            type: AppCallTypes.SUBMIT,
             path: binding.call?.path || '',
             expand: {
                 post: AppExpandLevels.EXPAND_ALL,
             },
             context: {
-                ...binding.call?.context,
                 acting_user_id: userId,
                 app_id: binding.app_id,
                 channel_id: post.channel_id,

--- a/app/mm-redux/client/client4.ts
+++ b/app/mm-redux/client/client4.ts
@@ -18,7 +18,7 @@ import {CustomEmoji} from '@mm-redux/types/emojis';
 import {Config} from '@mm-redux/types/config';
 import {Bot, BotPatch} from '@mm-redux/types/bots';
 import {SyncablePatch} from '@mm-redux/types/groups';
-import {AppCall} from '@mm-redux/types/apps';
+import {AppCallRequest} from '@mm-redux/types/apps';
 
 import fetch from './fetch_etag';
 import {General} from '../constants';
@@ -3050,7 +3050,7 @@ export default class Client4 {
         return `${this.url}/plugins/com.mattermost.apps`;
     }
 
-    executeAppCall = async (call: AppCall) => {
+    executeAppCall = async (call: AppCallRequest) => {
         call.context.user_agent = 'mobile';
         return this.doFetch(
             `${this.getAppsProxyRoute()}/api/v1/call`,

--- a/app/mm-redux/types/apps.ts
+++ b/app/mm-redux/types/apps.ts
@@ -11,7 +11,7 @@ export type AppManifest = {
 
 export type AppModalState = {
     form: AppForm;
-    call: AppCall;
+    call: AppCallRequest;
 }
 
 export type AppsState = {
@@ -59,11 +59,17 @@ export type AppCallType = string;
 
 export type AppCall = {
     path: string;
-    type?: AppCallType;
-    values?: AppCallValues;
-    context: AppContext;
-    raw_command?: string;
     expand?: AppExpand;
+    state?: any;
+};
+
+export type AppCallRequest = AppCall & {
+    type: AppCallType;
+    context: AppContext;
+    values?: AppCallValues;
+    raw_command?: string;
+    selected_field?: string;
+    query?: string;
 };
 
 export type AppCallResponseType = string;
@@ -188,12 +194,6 @@ export type AutocompleteDynamicSelect = AutocompleteElement;
 export type AutocompleteUserSelect = AutocompleteElement;
 
 export type AutocompleteChannelSelect = AutocompleteElement;
-
-export type AppLookupCallValues = {
-    user_input: string;
-    values: AppFormValues;
-    name: string;
-}
 
 export type FormResponseData = {
     errors?: {

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -17,13 +17,13 @@ import {dismissModal} from 'app/actions/navigation';
 
 import DialogIntroductionText from './dialog_introduction_text';
 import {Theme} from '@mm-redux/types/preferences';
-import {AppCall, AppCallResponse, AppField, AppForm, AppFormValue, AppFormValues, AppSelectOption, FormResponseData} from '@mm-redux/types/apps';
+import {AppCallResponse, AppField, AppForm, AppFormValues, AppSelectOption, FormResponseData, AppCallRequest} from '@mm-redux/types/apps';
 import {DialogElement} from '@mm-redux/types/integrations';
 import {AppCallResponseTypes} from '@mm-redux/constants/apps';
 import AppsFormField from './apps_form_field';
 
 export type Props = {
-    call: AppCall;
+    call: AppCallRequest;
     form: AppForm;
     actions: {
         submit: (submission: {
@@ -32,7 +32,7 @@ export type Props = {
             };
         }) => Promise<{data: AppCallResponse<FormResponseData>}>;
         performLookupCall: (field: AppField, values: AppFormValues, userInput: string) => Promise<AppSelectOption[]>;
-        refreshOnSelect: (field: AppField, values: AppFormValues, value: AppFormValue) => Promise<{data: AppCallResponse<any>}>;
+        refreshOnSelect: (field: AppField, values: AppFormValues) => Promise<{data: AppCallResponse<any>}>;
     };
     theme: Theme;
     componentId: string;
@@ -205,7 +205,7 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
         const values = {...this.state.values, [name]: value};
 
         if (field.refresh) {
-            this.props.actions.refreshOnSelect(field, values, value).then(({data}) => {
+            this.props.actions.refreshOnSelect(field, values).then(({data}) => {
                 if (data.type !== AppCallResponseTypes.ERROR) {
                     return;
                 }

--- a/app/screens/apps_form/apps_form_container.tsx
+++ b/app/screens/apps_form/apps_form_container.tsx
@@ -4,15 +4,15 @@
 import React, {PureComponent} from 'react';
 
 import {Theme} from '@mm-redux/types/preferences';
-import {AppCall, AppCallResponse, AppField, AppForm, AppFormValue, AppFormValues, AppLookupCallValues, AppSelectOption, FormResponseData} from '@mm-redux/types/apps';
+import {AppCallResponse, AppField, AppForm, AppFormValues, AppSelectOption, FormResponseData, AppCallRequest} from '@mm-redux/types/apps';
 import {AppCallResponseTypes, AppCallTypes} from '@mm-redux/constants/apps';
 import AppsFormComponent from './apps_form_component';
 
 export type Props = {
     form?: AppForm;
-    call?: AppCall;
+    call?: AppCallRequest;
     actions: {
-        doAppCall: (call: AppCall) => Promise<{data: AppCallResponse<FormResponseData>}>;
+        doAppCall: (call: AppCallRequest) => Promise<{data: AppCallResponse<FormResponseData>}>;
     };
     theme: Theme;
     componentId: string;
@@ -62,7 +62,7 @@ export default class AppsFormContainer extends PureComponent<Props, State> {
         return res;
     }
 
-    refreshOnSelect = async (field: AppField, values: AppFormValues, value: AppFormValue): Promise<{data: AppCallResponse<any>}> => {
+    refreshOnSelect = async (field: AppField, values: AppFormValues): Promise<{data: AppCallResponse<any>}> => {
         const {form} = this.state;
         if (!form) {
             return makeError('refreshOnSelect state.form is not defined');
@@ -85,11 +85,8 @@ export default class AppsFormContainer extends PureComponent<Props, State> {
         const res = await this.props.actions.doAppCall({
             ...call,
             type: AppCallTypes.FORM,
-            values: {
-                name: field.name,
-                values,
-                value,
-            },
+            values,
+            selected_field: field.name,
         });
 
         if (res?.data?.form) {
@@ -99,21 +96,18 @@ export default class AppsFormContainer extends PureComponent<Props, State> {
         return res;
     };
 
-    performLookupCall = async (field: AppField, formValues: AppFormValues, userInput: string): Promise<AppSelectOption[]> => {
+    performLookupCall = async (field: AppField, values: AppFormValues, userInput: string): Promise<AppSelectOption[]> => {
         const call = this.getCall();
         if (!call) {
             return [];
         }
 
-        const values: AppLookupCallValues = {
-            name: field.name,
-            user_input: userInput,
-            values: formValues,
-        };
         const res = await this.props.actions.doAppCall({
             ...call,
             type: AppCallTypes.LOOKUP,
             values,
+            selected_field: field.name,
+            query: userInput,
         });
 
         if (res.data.type === AppCallResponseTypes.ERROR) {
@@ -128,7 +122,7 @@ export default class AppsFormContainer extends PureComponent<Props, State> {
         return [];
     }
 
-    getCall = (): AppCall | null => {
+    getCall = (): AppCallRequest | null => {
         const {form} = this.state;
 
         const {call} = this.props;
@@ -144,7 +138,6 @@ export default class AppsFormContainer extends PureComponent<Props, State> {
             },
             values: {
                 ...call.values,
-                ...form?.call?.values,
             },
         };
     }

--- a/app/screens/apps_form/index.ts
+++ b/app/screens/apps_form/index.ts
@@ -7,14 +7,14 @@ import {connect} from 'react-redux';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {doAppCall} from '@actions/apps';
 
-import {AppCall, AppCallResponse} from '@mm-redux/types/apps';
+import {AppCallResponse, AppCallRequest} from '@mm-redux/types/apps';
 import {GlobalState} from '@mm-redux/types/store';
 import {ActionFunc, GenericAction} from '@mm-redux/types/actions';
 
 import AppsFormContainer from './apps_form_container';
 
 type Actions = {
-    doAppCall: (call: AppCall) => Promise<{data: AppCallResponse}>;
+    doAppCall: (call: AppCallRequest) => Promise<{data: AppCallResponse}>;
 };
 
 function mapStateToProps(state: GlobalState) {

--- a/app/screens/channel_info/bindings/bindings.tsx
+++ b/app/screens/channel_info/bindings/bindings.tsx
@@ -8,7 +8,7 @@ import {intlShape, injectIntl} from 'react-intl';
 import Separator from '@screens/channel_info/separator';
 
 import ChannelInfoRow from '../channel_info_row';
-import {AppBinding, AppCall} from '@mm-redux/types/apps';
+import {AppBinding, AppCallRequest} from '@mm-redux/types/apps';
 import {Theme} from '@mm-redux/types/preferences';
 import {Channel} from '@mm-redux/types/channels';
 import {AppCallTypes, AppExpandLevels, AppBindingLocations} from '@mm-redux/constants/apps';
@@ -23,7 +23,7 @@ type Props = {
     currentUser: UserProfile;
     appsEnabled: boolean;
     actions: {
-        doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>
+        doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>
     }
 }
 
@@ -61,7 +61,7 @@ type OptionProps = {
     currentUser: UserProfile;
     intl: typeof intlShape;
     actions: {
-        doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>
+        doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>
     },
 }
 
@@ -70,10 +70,8 @@ const Option = injectIntl((props: OptionProps) => {
         const channelId = props.currentChannel.id;
 
         const res = await props.actions.doAppCall({
+            ...props.binding.call,
             type: AppCallTypes.SUBMIT,
-            values: {
-                ...props.binding.call?.values,
-            },
             expand: {
                 channel: AppExpandLevels.EXPAND_ALL,
                 ...props.binding.call?.expand,

--- a/app/screens/channel_info/bindings/index.ts
+++ b/app/screens/channel_info/bindings/index.ts
@@ -9,7 +9,7 @@ import {AppBindingLocations} from '@mm-redux/constants/apps';
 import {getCurrentChannel} from '@mm-redux/selectors/entities/channels';
 import {GlobalState} from '@mm-redux/types/store';
 import {ActionResult, GenericAction, ActionFunc} from '@mm-redux/types/actions';
-import {AppCall} from '@mm-redux/types/apps';
+import {AppCallRequest} from '@mm-redux/types/apps';
 import {getCurrentUser} from '@mm-redux/selectors/entities/users';
 
 import {appsEnabled} from '@utils/apps';
@@ -32,7 +32,7 @@ function mapStateToProps(state: GlobalState) {
 }
 
 type Actions = {
-    doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {

--- a/app/screens/post_options/bindings/bindings.tsx
+++ b/app/screens/post_options/bindings/bindings.tsx
@@ -8,7 +8,7 @@ import {intlShape, injectIntl} from 'react-intl';
 import {isSystemMessage} from '@mm-redux/utils/post_utils';
 
 import PostOption from '../post_option';
-import {AppBinding, AppCall} from '@mm-redux/types/apps';
+import {AppBinding, AppCallRequest} from '@mm-redux/types/apps';
 import {Theme} from '@mm-redux/types/preferences';
 import {Post} from '@mm-redux/types/posts';
 import {UserProfile} from '@mm-redux/types/users';
@@ -23,7 +23,7 @@ type Props = {
     closeWithAnimation: () => void,
     appsEnabled: boolean,
     actions: {
-        doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>,
+        doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>,
     }
 }
 
@@ -67,7 +67,7 @@ type OptionProps = {
     closeWithAnimation: () => void,
     intl: typeof intlShape,
     actions: {
-        doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>,
+        doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>,
     },
 }
 
@@ -76,11 +76,9 @@ const Option = injectIntl((props: OptionProps) => {
         const {closeWithAnimation, post} = props;
 
         const res = await props.actions.doAppCall({
+            ...binding.call,
             type: AppCallTypes.SUBMIT,
             path: props.binding.call?.path || '',
-            values: {
-                ...props.binding.call?.values,
-            },
             expand: {
                 post: AppExpandLevels.EXPAND_ALL,
                 ...props.binding.call?.expand,

--- a/app/screens/post_options/bindings/index.ts
+++ b/app/screens/post_options/bindings/index.ts
@@ -7,7 +7,7 @@ import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 
 import {GlobalState} from '@mm-redux/types/store';
-import {AppCall} from '@mm-redux/types/apps';
+import {AppCallRequest} from '@mm-redux/types/apps';
 import {ActionResult, GenericAction, ActionFunc} from '@mm-redux/types/actions';
 import {getAppsBindings} from '@mm-redux/selectors/entities/apps';
 import {AppBindingLocations} from '@mm-redux/constants/apps';
@@ -32,7 +32,7 @@ function mapStateToProps(state: GlobalState) {
 }
 
 type Actions = {
-    doAppCall: (call: AppCall, intl: any) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest, intl: any) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {


### PR DESCRIPTION
#### Summary

The `Call` struct has been split into two structs.

- The `Call` struct is now a smaller struct provided by the App.
- The `CallRequest` contains the `Call`, and the other values sent to the server, such as `Type` and `Context`.

Other changes:

- `State` field added to `Call`
- `SelectedField` and `Query` added to remove the nested values in `Values`. Now `Values` is just the form values.

```go
type Call struct {
	Path   string      `json:"path,omitempty"`
	Expand *Expand     `json:"expand,omitempty"`
	State  interface{} `json:"state,omitempty"`
}

type CallRequest struct {
	Call
	Type          CallType               `json:"type"`
	Values        map[string]interface{} `json:"values,omitempty"`
	Context       *Context               `json:"context,omitempty"`
	RawCommand    string                 `json:"raw_command,omitempty"`
	SelectedField string                 `json:"selected_field,omitempty"`
	Query         string                 `json:"query,omitempty"`
}
```

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-33578

#### Related Pull Requests

https://github.com/mattermost/mattermost-mobile/pull/5107