### PR TITLE
Handle double submit on modals

### DIFF
--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -157,7 +157,6 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
 
         this.submitting = true;
         const res = await this.props.actions.submit(submission);
-        this.submitting = false;
 
         if (res.error) {
             const errorResponse = res.error;
@@ -165,7 +164,9 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
             const hasErrors = this.updateErrors(elements, errorResponse.data?.errors, errorMessage);
             if (!hasErrors) {
                 this.handleHide();
+                return;
             }
+            this.submitting = false;
             return;
         }
 
@@ -176,6 +177,7 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
             this.handleHide();
             return;
         case AppCallResponseTypes.FORM:
+            this.submitting = false;
             return;
         default:
             this.updateErrors([], undefined, this.context.intl.formatMessage({
@@ -184,6 +186,7 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
             }, {
                 type: callResponse.type,
             }));
+            this.submitting = false;
         }
     }
 

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -114,6 +114,10 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
     }
 
     handleSubmit = async (button?: string) => {
+        if (this.state.submitting) {
+            return;
+        }
+
         const {fields} = this.props.form;
         const values = this.state.values;
         const fieldErrors: {[name: string]: React.ReactNode} = {};
@@ -149,7 +153,10 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
             submission.values[this.props.form.submit_buttons] = button;
         }
 
+        this.setState({submitting: true});
         const res = await this.props.actions.submit(submission);
+        this.setState({submitting: false});
+
         if (res.error) {
             const errorResponse = res.error;
             const errorMessage = errorResponse.error;

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -22,6 +22,7 @@ import {AppCallRequest, AppCallResponse, AppField, AppForm, AppFormValue, AppFor
 import {DialogElement} from '@mm-redux/types/integrations';
 import {AppCallResponseTypes} from '@mm-redux/constants/apps';
 import AppsFormField from './apps_form_field';
+import {preventDoubleTap} from '@utils/tap';
 
 export type Props = {
     call: AppCallRequest;
@@ -112,7 +113,9 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
         }
     }
 
-    handleSubmit = async (button?: string) => {
+    handleSubmit = (button?: string) => preventDoubleTap(this.doSubmit(button));
+
+    doSubmit = async (button?: string) => {
         if (this.submitting) {
             return;
         }

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -113,8 +113,6 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
         }
     }
 
-    handleSubmit = (button?: string) => preventDoubleTap(this.doSubmit(button));
-
     doSubmit = async (button?: string) => {
         if (this.submitting) {
             return;
@@ -189,6 +187,8 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
             this.submitting = false;
         }
     }
+
+    handleSubmit = preventDoubleTap(this.doSubmit);
 
     updateErrors = (elements: DialogElement[], fieldErrors?: {[x: string]: string}, formError?: string): boolean => {
         let hasErrors = false;

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -43,7 +43,6 @@ type State = {
     values: {[name: string]: string};
     formError: string | null;
     fieldErrors: {[name: string]: React.ReactNode};
-    submitting: boolean;
     form: AppForm;
 }
 
@@ -62,6 +61,7 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
     private scrollView: React.RefObject<ScrollView>;
     navigationEventListener?: EventSubscription;
 
+    private submitting = false;
     static contextTypes = {
         intl: intlShape.isRequired,
     };
@@ -76,7 +76,6 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
             values,
             formError: null,
             fieldErrors: {},
-            submitting: false,
             form,
         };
 
@@ -114,7 +113,7 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
     }
 
     handleSubmit = async (button?: string) => {
-        if (this.state.submitting) {
+        if (this.submitting) {
             return;
         }
 
@@ -153,9 +152,9 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
             submission.values[this.props.form.submit_buttons] = button;
         }
 
-        this.setState({submitting: true});
+        this.submitting = true;
         const res = await this.props.actions.submit(submission);
-        this.setState({submitting: false});
+        this.submitting = false;
 
         if (res.error) {
             const errorResponse = res.error;


### PR DESCRIPTION
#### Summary
Avoid double submitting modals for apps.
Same PR as https://github.com/mattermost/mattermost-mobile/pull/5235 but had to make a new one due to the feature/cloud-apps branch being deleted. All reviewers approved this earlier, so it should be fine to merge.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34112