### PR TITLE
[MM-33892] Replace em dash with double dash for commands

### DIFF
--- a/app/actions/views/command.ts
+++ b/app/actions/views/command.ts
@@ -30,7 +30,7 @@ export function executeCommand(message: string, channelId: string, rootId: strin
         };
 
         let msg = message;
-        msg = filterEmDashFromCommand(msg);
+        msg = filterEmDashForCommand(msg);
 
         let cmdLength = msg.indexOf(' ');
         if (cmdLength < 0) {
@@ -92,6 +92,6 @@ export function executeCommand(message: string, channelId: string, rootId: strin
     };
 }
 
-const filterEmDashFromCommand = (command: string): string => {
-    return command.replace(/\u2014/g, "--");
+const filterEmDashForCommand = (command: string): string => {
+    return command.replace(/\u2014/g, '--');
 }

--- a/app/actions/views/command.ts
+++ b/app/actions/views/command.ts
@@ -94,4 +94,4 @@ export function executeCommand(message: string, channelId: string, rootId: strin
 
 const filterEmDashForCommand = (command: string): string => {
     return command.replace(/\u2014/g, '--');
-}
+};

--- a/app/actions/views/command.ts
+++ b/app/actions/views/command.ts
@@ -30,6 +30,7 @@ export function executeCommand(message: string, channelId: string, rootId: strin
         };
 
         let msg = message;
+        msg = filterEmDashFromCommand(msg);
 
         let cmdLength = msg.indexOf(' ');
         if (cmdLength < 0) {
@@ -43,7 +44,7 @@ export function executeCommand(message: string, channelId: string, rootId: strin
         if (appsAreEnabled) {
             const parser = new AppCommandParser({dispatch, getState}, intl, args.channel_id, args.root_id);
             if (parser.isAppCommand(msg)) {
-                const {call, errorMessage} = await parser.composeCallFromCommand(message);
+                const {call, errorMessage} = await parser.composeCallFromCommand(msg);
                 const createErrorMessage = (errMessage: string) => {
                     return {error: {message: errMessage}};
                 };
@@ -89,4 +90,8 @@ export function executeCommand(message: string, channelId: string, rootId: strin
 
         return {data, error};
     };
+}
+
+const filterEmDashFromCommand = (command: string): string => {
+    return command.replace(/\u2014/g, "--");
 }


### PR DESCRIPTION
#### Summary

There is an issue where an iPhone with Smart Punctuation enabled will convert `--` with an em dash `—`. Many commands rely on double dashes being preserved in the submitted text. This PR makes it so if a command is being submitted, the em dashes are replaced with double dashes.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-33892