### PR TITLE
MM-32725 Reduce KeyStore qty access

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostCredentialsHelper.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostCredentialsHelper.java
@@ -16,12 +16,20 @@ import com.mattermost.react_native_interface.KeysReadableArray;
 
 public class MattermostCredentialsHelper {
     static final String CURRENT_SERVER_URL = "@currentServerUrl";
+    static KeychainModule keychainModule;
+    static AsyncStorageHelper asyncStorage;
 
     public static void getCredentialsForCurrentServer(ReactApplicationContext context, ResolvePromise promise) {
-        final KeychainModule keychainModule = new KeychainModule(context);
-        final AsyncStorageHelper asyncStorage = new AsyncStorageHelper(context);
         final ArrayList<String> keys = new ArrayList<String>(1);
         keys.add(CURRENT_SERVER_URL);
+
+        if (keychainModule == null) {
+            keychainModule = new KeychainModule(context);
+        }
+
+        if (asyncStorage == null) {
+            asyncStorage = new AsyncStorageHelper(context);
+        }
         KeysReadableArray asyncStorageKeys = new KeysReadableArray() {
             @Override
             public int size() {

--- a/patches/react-native-keychain+6.2.0.patch
+++ b/patches/react-native-keychain+6.2.0.patch
@@ -1,8 +1,24 @@
 diff --git a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java
-index d4ded69..7b1042a 100644
+index d4ded69..af35eaa 100644
 --- a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java
 +++ b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java
-@@ -139,13 +139,13 @@ public class KeychainModule extends ReactContextBaseJavaModule {
+@@ -1,6 +1,7 @@
+ package com.oblador.keychain;
+ 
+ import android.os.Build;
++import android.os.Bundle;
+ import android.os.Looper;
+ import android.text.TextUtils;
+ import android.util.Log;
+@@ -128,6 +129,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
+   //region Members
+   /** Name-to-instance lookup  map. */
+   private final Map<String, CipherStorage> cipherStorageMap = new HashMap<>();
++  private final Map<String, Bundle> cachedCredentialsMap = new HashMap<>();
+   /** Shared preferences storage. */
+   private final PrefsStorage prefsStorage;
+   //endregion
+@@ -139,13 +141,13 @@ public class KeychainModule extends ReactContextBaseJavaModule {
      super(reactContext);
      prefsStorage = new PrefsStorage(reactContext);
  
@@ -20,3 +36,24 @@ index d4ded69..7b1042a 100644
    }
  
    /** Allow initialization in chain. */
+@@ -277,6 +279,12 @@ public class KeychainModule extends ReactContextBaseJavaModule {
+                                     @Nullable final ReadableMap options,
+                                     @NonNull final Promise promise) {
+     try {
++      Bundle cached = cachedCredentialsMap.get(alias);
++      if (cached != null) {
++        promise.resolve(Arguments.fromBundle(cached));
++        return;
++      }
++
+       final ResultSet resultSet = prefsStorage.getEncryptedEntry(alias);
+ 
+       if (resultSet == null) {
+@@ -299,6 +307,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
+       credentials.putString(Maps.USERNAME, decryptionResult.username);
+       credentials.putString(Maps.PASSWORD, decryptionResult.password);
+       credentials.putString(Maps.STORAGE, current.getCipherStorageName());
++      cachedCredentialsMap.put(alias, Arguments.toBundle(credentials));
+ 
+       promise.resolve(credentials);
+     } catch (KeyStoreAccessException e) {


### PR DESCRIPTION
#### Summary
This PR attempts to reduce the amount of times we access the KeyStore to retrieve session information with help of an in-memory cache.

The cache is initialized with every Keychain instance, one for the app running and another one for the notifications.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32725