### PR TITLE
MM-34681 Validate OpenGraph Image before attempting to load

### DIFF
--- a/app/components/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
+++ b/app/components/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
@@ -298,3 +298,77 @@ exports[`PostAttachmentOpenGraph should match state and snapshot, on renderImage
   </TouchableWithFeedbackIOS>
 </View>
 `;
+
+exports[`PostAttachmentOpenGraph should match state and snapshot, on renderImage 3`] = `
+<View
+  style={
+    Object {
+      "borderColor": "rgba(61,60,64,0.2)",
+      "borderRadius": 3,
+      "borderWidth": 1,
+      "flex": 1,
+      "marginTop": 10,
+      "padding": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(61,60,64,0.5)",
+          "fontSize": 12,
+          "marginBottom": 10,
+        }
+      }
+    >
+      Mattermost
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <TouchableWithFeedbackIOS
+      onPress={[Function]}
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+      type="opacity"
+    >
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={3}
+        style={
+          Array [
+            Object {
+              "color": "#2389d7",
+              "fontSize": 14,
+              "marginBottom": 10,
+            },
+            Object {
+              "marginRight": 0,
+            },
+          ]
+        }
+      >
+        Title
+      </Text>
+    </TouchableWithFeedbackIOS>
+  </View>
+</View>
+`;

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -15,7 +15,7 @@ import {generateId} from '@utils/file';
 import {openGalleryAtIndex, calculateDimensions} from '@utils/images';
 import {getNearestPoint} from '@utils/opengraph';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
-import {tryOpenURL} from '@utils/url';
+import {tryOpenURL, isValidUrl} from '@utils/url';
 
 const MAX_IMAGE_HEIGHT = 150;
 const VIEWPORT_IMAGE_OFFSET = 93;
@@ -93,7 +93,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
         }
 
         return {
-            hasImage: true,
+            hasImage: Boolean(isValidUrl(imageUrl) && ((ogImage.width && ogImage.height) || metaImages?.length)),
             ...dimensions,
             openGraphImageUrl: imageUrl,
         };

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -93,7 +93,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
         }
 
         return {
-            hasImage: Boolean(isValidUrl(imageUrl) && ((ogImage.width && ogImage.height) || metaImages?.length)),
+            hasImage: Boolean(isValidUrl(imageUrl) && (ogImage.width && ogImage.height)),
             ...dimensions,
             openGraphImageUrl: imageUrl,
         };

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.test.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.test.js
@@ -104,6 +104,22 @@ describe('PostAttachmentOpenGraph', () => {
         expect(wrapper.find(TouchableWithFeedback).exists()).toEqual(true);
     });
 
+    test('should match state and snapshot, on renderImage', () => {
+        const images = [{height: 440, width: 1200, url: '%REACT_APP_WEBSITE_BANNER%'}];
+        const openGraphDataWithImage = {...openGraphData, images};
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph
+                {...baseProps}
+                openGraphData={openGraphDataWithImage}
+            />,
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+        expect(wrapper.state('hasImage')).toEqual(false);
+        expect(wrapper.find(FastImage).exists()).toEqual(false);
+        expect(wrapper.find(TouchableWithFeedback).exists()).toEqual(true);
+    });
+
     test('should match state and snapshot, on renderDescription', () => {
         const wrapper = shallow(
             <PostAttachmentOpenGraph


### PR DESCRIPTION
#### Summary
Some link previews may include opengraph with an invalid image url or a valid url without an actual image.

With this PR we try and ensure that we only render the image component of the openGraph if an actual image with dimensions is found

Test link: https://atarinft.io/

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34681

#### Screenshots
Before
![image](https://user-images.githubusercontent.com/6757047/113949324-fab99e00-97dc-11eb-8f4e-cfe56dcd99eb.png)

After
![image](https://user-images.githubusercontent.com/6757047/113949386-250b5b80-97dd-11eb-9b15-f5acb3b1c39b.png)
