### PR TITLE
MM-29317 Select default team when current team is archived

### DIFF
--- a/app/components/post/post.js
+++ b/app/components/post/post.js
@@ -52,7 +52,7 @@ export default class Post extends PureComponent {
         hasComments: PropTypes.bool,
         isSearchResult: PropTypes.bool,
         commentedOnPost: PropTypes.object,
-        managedConfig: PropTypes.object.isRequired,
+        managedConfig: PropTypes.object,
         onHashtagPress: PropTypes.func,
         onPermalinkPress: PropTypes.func,
         shouldRenderReplyButton: PropTypes.bool,

--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -132,6 +132,10 @@ export default class ChannelBase extends PureComponent {
             });
         }
 
+        if (prevProps.currentTeamId && !this.props.currentTeamId) {
+            this.props.actions.selectDefaultTeam();
+        }
+
         if (this.props.currentTeamId &&
             (!this.props.currentChannelId || this.props.currentTeamId !== prevProps.currentTeamId)) {
             this.loadChannels(this.props.currentTeamId);

--- a/app/screens/channel/channel_base.test.js
+++ b/app/screens/channel/channel_base.test.js
@@ -106,4 +106,14 @@ describe('ChannelBase', () => {
         EventEmitter.emit(General.REMOVED_FROM_CHANNEL);
         expect(alert).toHaveBeenCalled();
     });
+
+    test('should call selectDefault team when the current team is archived', () => {
+        const wrapper = shallow(
+            <ChannelBase {...baseProps}/>,
+            {context: {intl: {formatMessage: jest.fn()}}},
+        );
+
+        wrapper.setProps({currentTeamId: '', currentChannelId: ''});
+        expect(baseProps.actions.selectDefaultTeam).toHaveBeenCalledTimes(1);
+    });
 });

--- a/app/screens/channel/index.js
+++ b/app/screens/channel/index.js
@@ -36,14 +36,17 @@ function mapStateToProps(state) {
         );
     }
 
+    const currentTeamId = currentTeam?.delete_at === 0 ? currentTeam?.id : '';
+    const currentChannelId = currentTeam?.delete_at === 0 ? getCurrentChannelId(state) : '';
+
     return {
-        currentTeamId: currentTeam?.id,
-        currentChannelId: getCurrentChannelId(state),
+        currentChannelId,
+        currentTeamId,
         isSupportedServer,
         isSystemAdmin,
+        showTermsOfService: shouldShowTermsOfService(state),
         teamName: currentTeam?.display_name,
         theme: getTheme(state),
-        showTermsOfService: shouldShowTermsOfService(state),
     };
 }
 


### PR DESCRIPTION
#### Summary
Switch teams when opening the app on a team that was archived.

does happened in iOS and Android.

Note: Archiving the team while the mobile app or webapp are opened, the client remains in the team. Another thing to note is that the server is not checking if the team has been archived so posting in a channel that belongs to the team is also possible while the client can still access the team. Not sure if the above reproduces while using **mmctl** instead of the binary cli.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29317
