### PR TITLE
Fix logout by preventing the app from showing ErrorTeamsList screen

### DIFF
--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -36,6 +36,7 @@ export default class ChannelBase extends PureComponent {
         componentId: PropTypes.string.isRequired,
         currentChannelId: PropTypes.string,
         currentTeamId: PropTypes.string,
+        currentUserId: PropTypes.string,
         disableTermsModal: PropTypes.bool,
         isSupportedServer: PropTypes.bool,
         isSystemAdmin: PropTypes.bool,
@@ -132,7 +133,7 @@ export default class ChannelBase extends PureComponent {
             });
         }
 
-        if (prevProps.currentTeamId && !this.props.currentTeamId) {
+        if (this.props.currentUserId && prevProps.currentTeamId && !this.props.currentTeamId) {
             this.props.actions.selectDefaultTeam();
         }
 

--- a/app/screens/channel/index.js
+++ b/app/screens/channel/index.js
@@ -22,6 +22,7 @@ import Channel from './channel';
 
 function mapStateToProps(state) {
     const currentTeam = getCurrentTeam(state);
+    const currentUserId = getCurrentUserId(state);
     const roles = getCurrentUserId(state) ? getCurrentUserRoles(state) : '';
     const isSystemAdmin = checkIsSystemAdmin(roles);
     const serverVersion = Client4.getServerVersion() || getServerVersion(state);
@@ -42,6 +43,7 @@ function mapStateToProps(state) {
     return {
         currentChannelId,
         currentTeamId,
+        currentUserId,
         isSupportedServer,
         isSystemAdmin,
         showTermsOfService: shouldShowTermsOfService(state),


### PR DESCRIPTION
#### Summary
After https://github.com/mattermost/mattermost-mobile/pull/5295 logging out from the app caused the app to wrongly show the ErrorTeamsList as it attempted to load the default team after the user was logged out. This PR prevents that code from executing.
