### PR TITLE
Fix testID

### DIFF
--- a/app/components/profile_picture/profile_picture.js
+++ b/app/components/profile_picture/profile_picture.js
@@ -182,7 +182,7 @@ export default class ProfilePicture extends PureComponent {
         return (
             <View
                 style={[style.container, containerStyle]}
-                testID={`${testID}.${user.id}`}
+                testID={`${testID}.${user?.id}`}
             >
                 {image}
                 {(showStatus || edit) && (user && !user.is_bot) &&


### PR DESCRIPTION
#### Summary
Ensure that `id` is only accessed if `user` is defined.

#### Device Information
This PR was tested on:
* iPhone 12 simulator, iOS 14.4