### PR TITLE
MM-34585 Fix at_mention and channel_mention autocomplete on iOS

### DIFF
--- a/app/components/autocomplete/channel_mention/channel_mention.js
+++ b/app/components/autocomplete/channel_mention/channel_mention.js
@@ -17,7 +17,6 @@ import {t} from 'app/utils/i18n';
 export default class ChannelMention extends PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
-            searchChannels: PropTypes.func.isRequired,
             autocompleteChannelsForSearch: PropTypes.func.isRequired,
         }).isRequired,
         currentTeamId: PropTypes.string.isRequired,
@@ -229,7 +228,7 @@ export default class ChannelMention extends PureComponent {
                 keyExtractor={this.keyExtractor}
                 initialNumToRender={10}
                 nestedScrollEnabled={nestedScrollEnabled}
-                removeClippedSubviews={true}
+                removeClippedSubviews={Platform.OS === 'android'}
                 renderItem={this.renderItem}
                 renderSectionHeader={this.renderSectionHeader}
                 style={[style.listView, {maxHeight: maxListHeight}]}

--- a/app/components/autocomplete/channel_mention/index.js
+++ b/app/components/autocomplete/channel_mention/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {searchChannels, autocompleteChannelsForSearch} from '@mm-redux/actions/channels';
+import {autocompleteChannelsForSearch} from '@mm-redux/actions/channels';
 import {getMyChannelMemberships} from '@mm-redux/selectors/entities/channels';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from '@mm-redux/selectors/entities/teams';
@@ -56,7 +56,6 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            searchChannels,
             autocompleteChannelsForSearch,
         }, dispatch),
     };


### PR DESCRIPTION
#### Summary
After the introduction of #5199 the autocomplete for user and channel mentions that uses a SectionList were not working properly when displaying multiple sections, not allowing the user to tap on a result or scroll the list.

By setting the `removeSubclipViews` to false on iOS the issue is resolved, Android still applies the prop and works as expected.