### PR TITLE
MM-27251 Fetch team channels including archived since last known timestamp

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -717,6 +717,7 @@ export function loadChannelsForTeam(teamId, skipDispatch = false) {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
+        const lastConnectAt = state.websocket?.lastConnectAt || 0;
         const data = {
             sync: true,
             teamId,
@@ -724,13 +725,12 @@ export function loadChannelsForTeam(teamId, skipDispatch = false) {
         };
 
         const actions = [];
-
         if (currentUserId) {
             for (let i = 0; i <= MAX_RETRIES; i++) {
                 try {
-                    console.log('Fetching channels attempt', teamId, (i + 1)); //eslint-disable-line no-console
+                    console.log('Fetching channels attempt', (i + 1), teamId, 'include deleted since', lastConnectAt); //eslint-disable-line no-console
                     const [channels, channelMembers] = await Promise.all([ //eslint-disable-line no-await-in-loop
-                        Client4.getMyChannels(teamId, true),
+                        Client4.getMyChannels(teamId, true, lastConnectAt),
                         Client4.getMyChannelMembers(teamId),
                     ]);
 

--- a/app/actions/websocket/websocket.test.js
+++ b/app/actions/websocket/websocket.test.js
@@ -30,7 +30,7 @@ const mockConfigRequest = (config = {}) => {
 
 const mockChanelsRequest = (teamId, channels = []) => {
     nock(Client4.getUserRoute('me')).
-        get(`/teams/${teamId}/channels?include_deleted=true`).
+        get(`/teams/${teamId}/channels?include_deleted=true&last_delete_at=0`).
         reply(200, channels);
 };
 

--- a/app/client/rest/channels.ts
+++ b/app/client/rest/channels.ts
@@ -24,7 +24,7 @@ export interface ClientChannelsMix {
     getChannelByNameAndTeamName: (teamName: string, channelName: string, includeDeleted?: boolean) => Promise<Channel>;
     getChannels: (teamId: string, page?: number, perPage?: number) => Promise<Channel[]>;
     getArchivedChannels: (teamId: string, page?: number, perPage?: number) => Promise<Channel[]>;
-    getMyChannels: (teamId: string, includeDeleted?: boolean) => Promise<Channel[]>;
+    getMyChannels: (teamId: string, includeDeleted?: boolean, lastDeleteAt?: number) => Promise<Channel[]>;
     getMyChannelMember: (channelId: string) => Promise<ChannelMembership>;
     getMyChannelMembers: (teamId: string) => Promise<ChannelMembership[]>;
     getChannelMembers: (channelId: string, page?: number, perPage?: number) => Promise<ChannelMembership[]>;
@@ -186,9 +186,12 @@ const ClientChannels = (superclass: any) => class extends superclass {
         );
     };
 
-    getMyChannels = async (teamId: string, includeDeleted = false) => {
+    getMyChannels = async (teamId: string, includeDeleted = false, lastDeleteAt = 0) => {
         return this.doFetch(
-            `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({include_deleted: includeDeleted})}`,
+            `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({
+                include_deleted: includeDeleted,
+                last_delete_at: lastDeleteAt,
+            })}`,
             {method: 'get'},
         );
     };

--- a/app/mm-redux/actions/channels.ts
+++ b/app/mm-redux/actions/channels.ts
@@ -12,8 +12,7 @@ import {
     isManuallyUnread,
 } from '@mm-redux/selectors/entities/channels';
 import {getCurrentTeamId} from '@mm-redux/selectors/entities/teams';
-import {getConfig, getServerVersion} from '@mm-redux/selectors/entities/general';
-import {isMinimumServerVersion} from '@mm-redux/utils/helpers';
+import {getConfig} from '@mm-redux/selectors/entities/general';
 
 import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from '@mm-redux/types/actions';
 
@@ -546,9 +545,9 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
         let channels;
         let channelMembers;
         const state = getState();
-        const shouldFetchArchived = isMinimumServerVersion(getServerVersion(state), 5, 21);
+        const lastConnectAt = state.websocket?.lastConnectAt || 0;
         try {
-            const channelRequest = Client4.getMyChannels(teamId, shouldFetchArchived);
+            const channelRequest = Client4.getMyChannels(teamId, true, lastConnectAt);
             const memberRequest = Client4.getMyChannelMembers(teamId);
             channels = await channelRequest;
             channelMembers = await memberRequest;
@@ -577,7 +576,6 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
             {
                 type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS,
                 data: channelMembers,
-                sync: !shouldFetchArchived,
                 channels,
                 remove: getChannelsIdForTeam(state, teamId),
                 currentUserId,


### PR DESCRIPTION
#### Summary
Since server 5.28 we added the ability to retrieve archived channels since a moment in time to reduce the amount of channels that were return for a given request, now that the supported ESR is 5.31 we can safely introduce this feature.

We use the last known timestamp we had the WS connected when fetching the user channels.
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27251