### PR TITLE
Specifying minimum server version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mattermost Mobile
 
-- **Minimum Server versions:** Current ESR version (5.31)
+- **Minimum Server versions:** Current ESR version (5.31.3)
 - **Supported iOS versions:** 11+
 - **Supported Android versions:** 7.0+
 

--- a/fastlane/metadata/changelog
+++ b/fastlane/metadata/changelog
@@ -1,4 +1,4 @@
-This version is compatible with Mattermost servers v5.31+.
+This version is compatible with Mattermost servers v5.31.3+.
 
 Please see [changelog](https://docs.mattermost.com/administration/mobile-changelog.html) for full release notes. If you're interested in helping beta test upcoming versions before they are released, please see our [documentation](https://github.com/mattermost/mattermost-mobile#testing).
 


### PR DESCRIPTION
#### Summary
[Due to a bug in the server](https://github.com/mattermost/mattermost-mobile/pull/5339), the minimum server version is 5.31.3.

This value should include the dot release in future updates