### PR TITLE
[MM-25709] Keyboard / Input height in iOS for post edits

### DIFF
--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -250,7 +250,7 @@ export default class EditPost extends PureComponent {
             }
         }
 
-        const height = Platform.OS === 'android' ? (deviceHeight / 2) - 40 : (deviceHeight / 2);
+        const height = Platform.OS === 'android' ? (deviceHeight / 2) - 40 : (deviceHeight / 2) - 30;
         const autocompleteStyles = [
             style.autocompleteContainer,
             {flex: autocompleteVisible ? 1 : 0},


### PR DESCRIPTION
#### Summary

Adds padding for iOS (`30`) alongside with existing `40` for android.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-25709

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 

- Android Pixel 4 v29 (Simulator)
- iPhone 12 v14.4 (Simulator)

#### Screenshots

https://user-images.githubusercontent.com/456511/116016608-7d1cdb80-a680-11eb-8539-59a81fc6efe7.mov

#### Release Note

```release-note
Fixes iOS keyboard overlap on long edit posts
```
