### PR TITLE
[MM-26160] Updates to check if text is string before attaching as string

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -46,6 +46,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
         super(reactContext);
         mApplication = application;
     }
+
     private File tempFolder;
 
     @Override
@@ -125,8 +126,6 @@ public class ShareModule extends ReactContextBaseJavaModule {
         promise.resolve(map);
     }
 
-
-
     public WritableArray processIntent() {
         WritableMap map = Arguments.createMap();
         WritableArray items = Arguments.createArray();
@@ -157,8 +156,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
             } else if (Intent.ACTION_SEND.equals(action)) {
                 Uri uri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
                 if (uri != null) {
-                    text = "file://" + RealPathUtil.getRealPathFromURI(currentActivity, uri);
-                    map.putString("value", text);
+                    map.putString("value", "file://" + RealPathUtil.getRealPathFromURI(currentActivity, uri));
 
                     if (type.equals("image/*")) {
                         type = "image/jpeg";
@@ -227,7 +225,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
             MultipartBody.Builder builder = new MultipartBody.Builder()
                     .setType(MultipartBody.FORM);
 
-            for(int i = 0 ; i < files.size() ; i++) {
+            for (int i = 0; i < files.size(); i++) {
                 ReadableMap file = files.getMap(i);
                 String filePath = file.getString("fullPath").replaceFirst("file://", "");
                 File fileInfo = new File(filePath);
@@ -251,7 +249,7 @@ public class ShareModule extends ReactContextBaseJavaModule {
                     JSONObject responseJson = new JSONObject(responseData);
                     JSONArray fileInfoArray = responseJson.getJSONArray("file_infos");
                     JSONArray file_ids = new JSONArray();
-                    for(int i = 0 ; i < fileInfoArray.length() ; i++) {
+                    for (int i = 0; i < fileInfoArray.length(); i++) {
                         JSONObject fileInfo = fileInfoArray.getJSONObject(i);
                         file_ids.put(fileInfo.getString("id"));
                     }

--- a/share_extension/types/index.d.ts
+++ b/share_extension/types/index.d.ts
@@ -17,6 +17,7 @@ interface ShareFileInfo {
 interface ShareItem {
     type: string;
     value: string;
+    isString: boolean;
 }
 
 interface ShareState {

--- a/share_extension/utils/index.tsx
+++ b/share_extension/utils/index.tsx
@@ -64,11 +64,10 @@ export async function getSharedItems(items: Array<ShareItem>, intl: typeof intlS
 
     for (let i = 0; i < items.length; i++) {
         const item = items[i];
-        switch (item.type) {
-        case 'text/plain':
+
+        if (item.isString) {
             text.push(item.value);
-            break;
-        default: {
+        } else {
             let fileSize = {size: 0};
             const fullPath = item.value;
             try {
@@ -96,8 +95,6 @@ export async function getSharedItems(items: Array<ShareItem>, intl: typeof intlS
                 size: getFormattedFileSize(fileSize as FileInfo),
                 type: item.type,
             });
-            break;
-        }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This now explicitly checks that a "shared" text is actually a string before being treated as such.

The selected text being shared is available in `intent.getStringExtra(Intent.EXTRA_TEXT);` where we check for it - if it is blank and `text/plain` intent is still sent, we can safely assume it a `.txt` file.

Boolean `isString` is available on the JS side to check.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-26160

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on:

- Pixel 4 Simulator Android v29

#### Screenshots


https://user-images.githubusercontent.com/456511/116178057-431f0880-a758-11eb-9e9d-f35c6248ae7d.mov



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

Fixed text files being shared to Mattermost when part of a group of a files.

```
