### PR TITLE
Automated cherry pick of #5163

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -632,7 +632,7 @@ function setLoadMorePostsVisible(visible) {
     };
 }
 
-function loadGroupData() {
+function loadGroupData(isReconnect = false) {
     return async (dispatch, getState) => {
         const state = getState();
         const actions = [];
@@ -665,9 +665,10 @@ function loadGroupData() {
                             });
                         }
                     } else {
+                        const getGroupsSince = isReconnect ? (state.websocket?.lastDisconnectAt || 0) : undefined;
                         const [getAllGroupsAssociatedToChannelsInTeam, getGroups] = await Promise.all([ //eslint-disable-line no-await-in-loop
                             Client4.getAllGroupsAssociatedToChannelsInTeam(team.id, true),
-                            Client4.getGroups(true, 0, 0),
+                            Client4.getGroups(false, 0, 0, getGroupsSince),
                         ]);
 
                         if (getAllGroupsAssociatedToChannelsInTeam.groups) {
@@ -713,7 +714,7 @@ function loadGroupData() {
     };
 }
 
-export function loadChannelsForTeam(teamId, skipDispatch = false) {
+export function loadChannelsForTeam(teamId, skipDispatch = false, isReconnect = false) {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -784,7 +785,7 @@ export function loadChannelsForTeam(teamId, skipDispatch = false) {
                 dispatch(loadUnreadChannelPosts(data.channels, data.channelMembers));
             }
 
-            dispatch(loadGroupData());
+            dispatch(loadGroupData(isReconnect));
         }
 
         return {data};

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -155,7 +155,7 @@ export function doReconnect(now: number) {
                 const currentTeamMembership = me.teamMembers.find((tm: TeamMembership) => tm.team_id === currentTeamId && tm.delete_at === 0);
 
                 if (currentTeamMembership) {
-                    const {data: myData}: any = await dispatch(loadChannelsForTeam(currentTeamId, true));
+                    const {data: myData}: any = await dispatch(loadChannelsForTeam(currentTeamId, true, true));
 
                     if (myData?.channels && myData?.channelMembers) {
                         actions.push({

--- a/app/client/rest/groups.ts
+++ b/app/client/rest/groups.ts
@@ -15,9 +15,9 @@ export interface ClientGroupsMix {
 }
 
 const ClientGroups = (superclass: any) => class extends superclass {
-    getGroups = async (filterAllowReference = false, page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getGroups = async (filterAllowReference = false, page = 0, perPage = PER_PAGE_DEFAULT, since = 0) => {
         return this.doFetch(
-            `${this.getBaseRoute()}/groups${buildQueryString({filter_allow_reference: filterAllowReference, page, per_page: perPage})}`,
+            `${this.getBaseRoute()}/groups${buildQueryString({filter_allow_reference: filterAllowReference, page, per_page: perPage, since})}`,
             {method: 'get'},
         );
     };


### PR DESCRIPTION
Cherry pick of #5163 on release-1.43.

/cc  @anurag6713

```release-note
On web socket reconnect, Instead of getting all the groups, fetch only the updated groups
```