### PR TITLE
MM-32591: Reliable Websockets: Client side changes

### DIFF
--- a/app/init/fetch.js
+++ b/app/init/fetch.js
@@ -46,7 +46,7 @@ const handleRedirectProtocol = (url, response) => {
 
 Client4.doFetchWithResponse = async (url, options) => {
     // eslint-disable-next-line no-console
-    console.log('Request endpoint', url);
+    // console.log('Request endpoint', url);
     const customHeaders = LocalConfig.CustomRequestHeaders;
     let waitsForConnectivity = false;
     let timeoutIntervalForResource = 30;

--- a/app/init/fetch.js
+++ b/app/init/fetch.js
@@ -46,7 +46,7 @@ const handleRedirectProtocol = (url, response) => {
 
 Client4.doFetchWithResponse = async (url, options) => {
     // eslint-disable-next-line no-console
-    // console.log('Request endpoint', url);
+    console.log('Request endpoint', url);
     const customHeaders = LocalConfig.CustomRequestHeaders;
     let waitsForConnectivity = false;
     let timeoutIntervalForResource = 30;

--- a/app/mm-redux/types/config.ts
+++ b/app/mm-redux/types/config.ts
@@ -75,6 +75,7 @@ export type Config = {
     EnablePreviewFeatures: string;
     EnablePreviewModeBanner: string;
     EnablePublicLink: string;
+    EnableReliableWebSockets: string;
     EnableSaml: string;
     EnableSignInWithEmail: string;
     EnableSignInWithUsername: string;


### PR DESCRIPTION
#### Summary
We send connection_id and sequence_number as part of the query params.

On receiving an event, we check if it's a hello packet, and if so,
we inspect the connection_id sent with it. If it's different to what
we have already, then we make the API calls and set sequence to 0.

And if the sequence number is different to what we expect, then
we just disconnect the connection, and expect the server to send
from where we left off.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32591
https://github.com/mattermost/mattermost-webapp/pull/7921

#### Release Note
```release-note
NONE
```
