### PR TITLE
MM-31874 Properly use theme mention highlight link color

### DIFF
--- a/app/components/at_mention/__snapshots__/at_mention.test.js.snap
+++ b/app/components/at_mention/__snapshots__/at_mention.test.js.snap
@@ -34,7 +34,7 @@ exports[`AtMention should match snapshot, with highlight 1`] = `
         },
         Object {
           "backgroundColor": "#ffe577",
-          "color": "#145dbf",
+          "color": "#166de0",
         },
       ]
     }

--- a/app/components/at_mention/at_mention.js
+++ b/app/components/at_mention/at_mention.js
@@ -206,7 +206,7 @@ export default class AtMention extends React.PureComponent {
         }
 
         if (highlighted) {
-            mentionTextStyle.push({backgroundColor, color: theme.mentionColor});
+            mentionTextStyle.push({backgroundColor, color: theme.mentionHighlightLink});
         }
 
         return (


### PR DESCRIPTION
#### Summary
In a previous PR #5268 then mention color used was the wrong one, this PR applies the `mentionHighlightLink` color to mentions that are highlighted.

Note: No dev review needed, it only replaces the color used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31874

#### Release Note
```release-note
NONE
```
