### PR TITLE
Patch node modules minSdkVersion affected by RN 0.64.1 upgrade

### DIFF
--- a/patches/jail-monkey+2.3.4.patch
+++ b/patches/jail-monkey+2.3.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/jail-monkey/android/build.gradle b/node_modules/jail-monkey/android/build.gradle
+index 29f27c0..cac1ee4 100644
+--- a/node_modules/jail-monkey/android/build.gradle
++++ b/node_modules/jail-monkey/android/build.gradle
+@@ -5,7 +5,7 @@ android {
+     buildToolsVersion "28.0.3"
+ 
+     defaultConfig {
+-        minSdkVersion 19
++        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 19
+         targetSdkVersion 28
+         versionCode 1
+         versionName "1.0"

--- a/patches/react-native-haptic-feedback+1.11.0.patch
+++ b/patches/react-native-haptic-feedback+1.11.0.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/react-native-haptic-feedback/android/build.gradle b/node_modules/react-native-haptic-feedback/android/build.gradle
+index c326a26..87f4814 100644
+--- a/node_modules/react-native-haptic-feedback/android/build.gradle
++++ b/node_modules/react-native-haptic-feedback/android/build.gradle
+@@ -20,7 +20,7 @@ android {
+     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+ 
+     defaultConfig {
+-        minSdkVersion 16
++        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
+         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+         versionCode 1
+         versionName "1.0"
 diff --git a/node_modules/react-native-haptic-feedback/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java b/node_modules/react-native-haptic-feedback/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
 index cc597e0..db3c3f9 100644
 --- a/node_modules/react-native-haptic-feedback/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java

--- a/patches/react-native-hw-keyboard-event+0.0.4.patch
+++ b/patches/react-native-hw-keyboard-event+0.0.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-hw-keyboard-event/android/build.gradle b/node_modules/react-native-hw-keyboard-event/android/build.gradle
+index a70aace..d2acc75 100644
+--- a/node_modules/react-native-hw-keyboard-event/android/build.gradle
++++ b/node_modules/react-native-hw-keyboard-event/android/build.gradle
+@@ -4,7 +4,7 @@ android {
+     compileSdkVersion 28
+ 
+     defaultConfig {
+-        minSdkVersion 16
++        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
+         targetSdkVersion 28
+         versionCode 1
+         versionName "1.0"

--- a/patches/react-native-local-auth+1.6.0.patch
+++ b/patches/react-native-local-auth+1.6.0.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/react-native-local-auth/android/build.gradle b/node_modules/react-native-local-auth/android/build.gradle
+index 0c9a9c2..a7551eb 100644
+--- a/node_modules/react-native-local-auth/android/build.gradle
++++ b/node_modules/react-native-local-auth/android/build.gradle
+@@ -15,7 +15,7 @@ android {
+     buildToolsVersion "23.0.1"
+ 
+     defaultConfig {
+-        minSdkVersion 16
++        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
+         targetSdkVersion 23
+         versionCode 1
+         versionName "1.0"
 diff --git a/node_modules/react-native-local-auth/LocalAuth.android.js b/node_modules/react-native-local-auth/LocalAuth.android.js
 index 49242b4..8deada5 100644
 --- a/node_modules/react-native-local-auth/LocalAuth.android.js

--- a/patches/react-native-webview+7.0.1.patch
+++ b/patches/react-native-webview+7.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-webview/android/build.gradle b/node_modules/react-native-webview/android/build.gradle
+index a30ab0a..2d02677 100644
+--- a/node_modules/react-native-webview/android/build.gradle
++++ b/node_modules/react-native-webview/android/build.gradle
+@@ -29,7 +29,7 @@ android {
+   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+   buildToolsVersion getExtOrDefault('buildToolsVersion')
+   defaultConfig {
+-    minSdkVersion 16
++    minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
+     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+     versionCode 1
+     versionName "1.0"


### PR DESCRIPTION
#### Summary
- Patched affected node modules minSdkVersion as suggested here: https://github.com/wix/Detox/issues/2712#issuecomment-840490767
- These were failing when running `./gradlew assembleAndroidTest` and are now passing
- I also smoke tested the app, especially the affected areas by the modules

#### Ticket Link
NA

#### Release Note
```release-note
NONE
```
