### PR TITLE
Add SVG support

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -17,7 +17,7 @@ import Emoji from '@components/emoji';
 import FormattedText from '@components/formatted_text';
 import Hashtag from '@components/markdown/hashtag';
 import {blendColors, concatStyles, makeStyleSheetFromTheme} from '@utils/theme';
-import {getScheme} from '@utils/url';
+import {getScheme, isSVGLink} from '@utils/url';
 
 import MarkdownBlockQuote from './markdown_block_quote';
 import MarkdownCodeBlock from './markdown_code_block';
@@ -187,6 +187,21 @@ export default class Markdown extends PureComponent {
 
     renderImage = ({linkDestination, reactChildren, context, src}) => {
         if (!this.props.imagesMetadata) {
+            if (isSVGLink(src)) {
+                return (
+                    <MarkdownImage
+                        disable={this.props.disableGallery}
+                        errorTextStyle={[this.computeTextStyle(this.props.baseTextStyle, context), this.props.textStyles.error]}
+                        linkDestination={linkDestination}
+                        imagesMetadata={this.props.imagesMetadata}
+                        isReplyPost={this.props.isReplyPost}
+                        postId={this.props.postId}
+                        source={src}
+                    >
+                        {reactChildren}
+                    </MarkdownImage>
+                );
+            }
             return null;
         }
 

--- a/app/components/markdown/markdown_table_image/markdown_table_image.tsx
+++ b/app/components/markdown/markdown_table_image/markdown_table_image.tsx
@@ -14,6 +14,7 @@ import {generateId} from '@utils/file';
 
 import type {PostImage} from '@mm-redux/types/posts';
 import {FileInfo} from '@mm-redux/types/files';
+import {fileNameFromLink} from '@utils/url';
 
 type MarkdownTableImageProps = {
     disable: boolean;
@@ -53,7 +54,7 @@ const MarkTableImage = ({disable, imagesMetadata, postId, serverURL, source}: Ma
     const getFileInfo = () => {
         const {height, width} = metadata;
         const link = decodeURIComponent(getImageSource());
-        let filename = parseUrl(link.substr(link.lastIndexOf('/'))).pathname.replace('/', '');
+        let filename = parseUrl(fileNameFromLink(link)).pathname.replace('/', '');
         let extension = filename.split('.').pop();
 
         if (extension === filename) {

--- a/app/components/message_attachments/attachment_image/index.tsx
+++ b/app/components/message_attachments/attachment_image/index.tsx
@@ -9,6 +9,7 @@ import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {generateId} from '@utils/file';
 import {isGifTooLarge, openGalleryAtIndex, calculateDimensions} from '@utils/images';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {fileNameFromLink} from '@utils/url';
 
 import {Theme} from '@mm-redux/types/preferences';
 import {PostImage} from '@mm-redux/types/posts';
@@ -88,7 +89,7 @@ export default class AttachmentImage extends PureComponent<Props, State> {
             } as FileInfo;
         }
 
-        let filename = imageUrl.substring(imageUrl.lastIndexOf('/') + 1, imageUrl.indexOf('?') === -1 ? imageUrl.length : imageUrl.indexOf('?'));
+        let filename = fileNameFromLink(imageUrl);
         const extension = filename.split('.').pop();
 
         if (extension === filename) {
@@ -135,6 +136,16 @@ export default class AttachmentImage extends PureComponent<Props, State> {
 
         if (imageMetadata) {
             this.setImageDimensionsFromMeta(imageURL, imageMetadata);
+            return;
+        }
+
+        const {extension} = this.getFileInfo();
+        if (extension === 'svg') {
+            if (this.mounted) {
+                this.setState({
+                    imageUri: imageURL,
+                });
+            }
         }
     };
 

--- a/app/components/message_attachments/message_attachment.tsx
+++ b/app/components/message_attachments/message_attachment.tsx
@@ -20,6 +20,7 @@ import AttachmentText from './attachment_text';
 import AttachmentThumbnail from './attachment_thumbnail';
 import AttachmentTitle from './attachment_title';
 import AttachmentFooter from './attachment_footer';
+import {isSVGLink} from '@utils/url';
 
 type Props = {
     attachment: MessageAttachmentType,
@@ -49,7 +50,7 @@ export default function MessageAttachment(props: Props) {
 
     const style = getStyleSheet(theme);
     const STATUS_COLORS = getStatusColors(theme);
-    const hasImage = Boolean(metadata?.images?.[attachment.image_url]);
+    const hasImage = Boolean(metadata?.images?.[attachment.image_url]) || isSVGLink(attachment.image_url);
 
     let borderStyle;
     if (attachment.color) {

--- a/app/components/post_attachment_opengraph/post_attachment_opengraph.js
+++ b/app/components/post_attachment_opengraph/post_attachment_opengraph.js
@@ -15,7 +15,7 @@ import {generateId} from '@utils/file';
 import {openGalleryAtIndex, calculateDimensions} from '@utils/images';
 import {getNearestPoint} from '@utils/opengraph';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
-import {tryOpenURL, isValidUrl} from '@utils/url';
+import {tryOpenURL, isValidUrl, fileNameFromLink} from '@utils/url';
 
 const MAX_IMAGE_HEIGHT = 150;
 const VIEWPORT_IMAGE_OFFSET = 93;
@@ -101,7 +101,7 @@ export default class PostAttachmentOpenGraph extends PureComponent {
 
     getFilename = (uri) => {
         const link = decodeURIComponent(uri);
-        let filename = parseUrl(link.substr(link.lastIndexOf('/'))).pathname.replace('/', '');
+        let filename = parseUrl(fileNameFromLink(link)).pathname.replace('/', '');
         const extension = filename.split('.').pop();
 
         if (extension === filename) {

--- a/app/components/post_body_additional_content/post_body_additional_content.js
+++ b/app/components/post_body_additional_content/post_body_additional_content.js
@@ -21,7 +21,7 @@ import TouchableWithFeedback from '@components/touchable_with_feedback';
 import EventEmitter from '@mm-redux/utils/event_emitter';
 import {generateId} from '@utils/file';
 import {calculateDimensions, getViewPortWidth, openGalleryAtIndex} from '@utils/images';
-import {getYouTubeVideoId, isImageLink, isYoutubeLink, tryOpenURL} from '@utils/url';
+import {fileNameFromLink, getYouTubeVideoId, isImageLink, isYoutubeLink, tryOpenURL} from '@utils/url';
 import EmbeddedBindings from '@components/embedded_bindings';
 
 const MAX_YOUTUBE_IMAGE_HEIGHT = 202;
@@ -123,7 +123,7 @@ export default class PostBodyAdditionalContent extends ImageViewPort {
         }
 
         const url = decodeURIComponent(link);
-        let filename = parseUrl(url.substr(url.lastIndexOf('/'))).pathname.replace('/', '');
+        let filename = parseUrl(fileNameFromLink(url)).pathname.replace('/', '');
         let extension = filename.split('.').pop();
 
         if (extension === filename) {

--- a/app/components/retriable_fast_image/index.tsx
+++ b/app/components/retriable_fast_image/index.tsx
@@ -1,8 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {ErrorBoundary} from '@sentry/react-native';
+import {isSVGLink} from '@utils/url';
 import React, {PureComponent} from 'react';
 import FastImage, {FastImageProps} from 'react-native-fast-image';
+import {SvgCssUri} from 'react-native-svg';
 
 export const FAST_IMAGE_MAX_RETRIES = 3;
 
@@ -30,12 +33,28 @@ export default class RetriableFastImage extends PureComponent<RetriableFastImage
     }
 
     render() {
-        return (
+        let image = (
             <FastImage
                 {...this.props}
                 key={`${this.props.id}-${this.state.retry}`}
                 onError={this.onError}
             />
+        );
+        const {source} = this.props;
+        if (typeof (source) === 'object' && source.uri && isSVGLink(source.uri)) {
+            image = (
+                <SvgCssUri
+                    uri={source.uri}
+                    width={'100%'}
+                    height={'200'}
+                    style={{maxWidth: '100%', maxHeight: '100%'}}
+                />
+            );
+        }
+        return (
+            <ErrorBoundary>
+                {image}
+            </ErrorBoundary>
         );
     }
 }

--- a/app/screens/gallery/gallery_image.tsx
+++ b/app/screens/gallery/gallery_image.tsx
@@ -9,6 +9,8 @@ import {DeviceTypes} from '@constants';
 import {calculateDimensions} from '@utils/images';
 
 import {GalleryItemProps} from 'types/screens/gallery';
+import {SvgCssUri} from 'react-native-svg';
+import {ErrorBoundary} from '@sentry/react';
 
 // @ts-expect-error: Ignore the typescript error for createAnimatedComponent
 const AnimatedImage = Animated.createAnimatedComponent(FastImage);
@@ -19,6 +21,18 @@ const GalleryImage = ({file, deviceHeight, deviceWidth, style}: GalleryItemProps
     const calculatedDimensions = calculateDimensions(height, width, deviceWidth, deviceHeight - statusBar);
     const uri = localPath || imageUri;
 
+    if (file.extension === 'svg') {
+        return (
+            <ErrorBoundary>
+                <SvgCssUri
+                    uri={uri || null}
+                    width={'100%'}
+                    height={'200'}
+                    style={[{maxWidth: '100%', maxHeight: '100%'}]}
+                />
+            </ErrorBoundary>
+        );
+    }
     return (
         <AnimatedImage
             source={{uri}}

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -191,3 +191,17 @@ export function tryOpenURL(url, onError = emptyErrorHandlingFunction, onSuccess 
         then(onSuccess).
         catch(onError);
 }
+
+export function isSVGLink(imageUrl) {
+    const filename = fileNameFromLink(imageUrl);
+    const extension = filename.split('.').pop();
+    if (extension === 'svg') {
+        return true;
+    }
+    return false;
+}
+
+export function fileNameFromLink(url) {
+    const queryStripped = url.substring(0, url.indexOf('?') === -1 ? url.length : url.indexOf('?'));
+    return queryStripped.substring(queryStripped.lastIndexOf('/') + 1, queryStripped.length);
+}


### PR DESCRIPTION
#### Summary
This adds SVG support specially in three different locations:
- Markdown images
- Interactive Messages images
- Gallery view of these images

Known issues:
- The SVG rendering is really strict. SVGs that are correctly shown on webapp may not show or show differently.
- SVGs without a viewbox property will not get resized. Instead, you will only get the slice of the svg
- Missing or malformed SVGs will create errors in the console
- Only files with ".svg" extension are treated as svg

This is a first naïve approach in several places. Feel free to add any comment so we can iterate on this.

#### Ticket Link
None
