### PR TITLE
MM-35671 Detox/E2E: Add e2e for markdown table, separator, and block quote

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -369,7 +369,12 @@ export default class Markdown extends PureComponent {
     };
 
     renderThematicBreak = () => {
-        return <View style={this.props.blockStyles.horizontalRule}/>;
+        return (
+            <View
+                style={this.props.blockStyles.horizontalRule}
+                testID='markdown_thematic_break'
+            />
+        );
     };
 
     renderSoftBreak = () => {

--- a/app/components/markdown/markdown_block_quote.js
+++ b/app/components/markdown/markdown_block_quote.js
@@ -30,7 +30,10 @@ export default class MarkdownBlockQuote extends PureComponent {
         }
 
         return (
-            <View style={style.container}>
+            <View
+                style={style.container}
+                testID='markdown_block_quote'
+            >
                 <View style={style.icon}>
                     {icon}
                 </View>

--- a/app/components/markdown/markdown_table/__snapshots__/markdown_table.test.js.snap
+++ b/app/components/markdown/markdown_table/__snapshots__/markdown_table.test.js.snap
@@ -8,6 +8,7 @@ exports[`MarkdownTable should match snapshot 1`] = `
       "paddingRight": 10,
     }
   }
+  testID="markdown_table"
   type="opacity"
 >
   <ScrollView

--- a/app/components/markdown/markdown_table/markdown_table.js
+++ b/app/components/markdown/markdown_table/markdown_table.js
@@ -242,6 +242,7 @@ export default class MarkdownTable extends React.PureComponent {
                     type='opacity'
                     onPress={this.handlePress}
                     style={[style.expandButton, {left: expandButtonOffset}]}
+                    testID='markdown_table.expand.button'
                 >
                     <View style={[style.iconContainer, {width: this.getTableWidth()}]}>
                         <View style={style.iconButton}>
@@ -260,6 +261,7 @@ export default class MarkdownTable extends React.PureComponent {
                 style={style.tablePadding}
                 onPress={this.handlePress}
                 type='opacity'
+                testID='markdown_table'
             >
                 <ScrollView
                     onContentSizeChange={this.handleContentSizeChange}

--- a/app/screens/table/index.js
+++ b/app/screens/table/index.js
@@ -23,10 +23,11 @@ export default class Table extends React.PureComponent {
         let container;
         if (Platform.OS === 'android') {
             container = (
-                <ScrollView>
+                <ScrollView testID='table.screen'>
                     <ScrollView
                         contentContainerStyle={viewStyle}
                         horizontal={true}
+                        testID='table.scroll_view'
                     >
                         {content}
                     </ScrollView>
@@ -34,10 +35,14 @@ export default class Table extends React.PureComponent {
             );
         } else {
             container = (
-                <SafeAreaView style={style.container}>
+                <SafeAreaView
+                    style={style.container}
+                    testID='table.screen'
+                >
                     <ScrollView
                         style={style.fullHeight}
                         contentContainerStyle={viewStyle}
+                        testID='table.scroll_view'
                     >
                         {content}
                     </ScrollView>

--- a/detox/e2e/support/ui/component/post.js
+++ b/detox/e2e/support/ui/component/post.js
@@ -6,6 +6,7 @@ import ProfilePicture from './profile_picture';
 class Post {
     testID = {
         postProfilePicturePrefix: 'post_profile_picture.profile_picture.',
+        blockQuote: 'markdown_block_quote',
         emoji: 'markdown_emoji',
         image: 'markdown_image',
         message: 'markdown_text',
@@ -16,25 +17,36 @@ class Post {
         postPreHeaderText: 'post_pre_header.text',
         showLessButton: 'show_more.button.minus',
         showMoreButton: 'show_more.button.plus',
+        table: 'markdown_table',
+        tableExpandButton: 'markdown_table.expand.button',
+        thematicBreak: 'markdown_thematic_break',
     }
 
     getPost = (postItemSourceTestID, postId, postMessage, postProfileOptions = {}) => {
         const postItemMatcher = this.getPostItemMatcher(postItemSourceTestID, postId, postMessage);
+        const postItemBlockQuoteMatcher = by.id(this.testID.blockQuote).withAncestor(postItemMatcher);
         const postItemEmojiMatcher = by.id(this.testID.emoji).withAncestor(postItemMatcher);
         const postItemImageMatcher = by.id(this.testID.image).withAncestor(postItemMatcher);
         const postItemMessageMatcher = by.id(this.testID.message).withAncestor(postItemMatcher);
         const postItemPreHeaderTextMatch = by.id(this.testID.postPreHeaderText).withAncestor(postItemMatcher);
         const postItemShowLessButtonMatcher = by.id(this.testID.showLessButton).withAncestor(postItemMatcher);
         const postItemShowMoreButtonMatcher = by.id(this.testID.showMoreButton).withAncestor(postItemMatcher);
+        const postItemTableMatcher = by.id(this.testID.table).withAncestor(postItemMatcher);
+        const postItemTableExpandButtonMatcher = by.id(this.testID.tableExpandButton).withAncestor(postItemMatcher);
+        const postItemThematicBreakMatcher = by.id(this.testID.thematicBreak).withAncestor(postItemMatcher);
 
         return {
             postItem: element(postItemMatcher),
+            postItemBlockQuote: element(postItemBlockQuoteMatcher),
             postItemEmoji: element(postItemEmojiMatcher),
             postItemImage: element(postItemImageMatcher),
             postItemMessage: element(postItemMessageMatcher),
             postItemPreHeaderText: element(postItemPreHeaderTextMatch),
             postItemShowLessButton: element(postItemShowLessButtonMatcher),
             postItemShowMoreButton: element(postItemShowMoreButtonMatcher),
+            postItemTable: element(postItemTableMatcher),
+            postItemTableExpandButton: element(postItemTableExpandButtonMatcher),
+            postItemThematicBreak: element(postItemThematicBreakMatcher),
             ...this.getPostHeader(postItemMatcher),
             ...this.getPostProfilePicture(postItemMatcher, postProfileOptions),
         };

--- a/detox/e2e/support/ui/component/post_list.js
+++ b/detox/e2e/support/ui/component/post_list.js
@@ -23,6 +23,7 @@ class PostList {
     getPost = (postId, postMessage, postProfileOptions = {}) => {
         const {
             postItem,
+            postItemBlockQuote,
             postItemEmoji,
             postItemHeaderDateTime,
             postItemHeaderDisplayName,
@@ -35,10 +36,14 @@ class PostList {
             postItemProfilePictureUserStatus,
             postItemShowLessButton,
             postItemShowMoreButton,
+            postItemTable,
+            postItemTableExpandButton,
+            postItemThematicBreak,
         } = Post.getPost(this.testID.postListPostItem, postId, postMessage, postProfileOptions);
 
         return {
             postListPostItem: postItem,
+            postListPostItemBlockQuote: postItemBlockQuote,
             postListPostItemEmoji: postItemEmoji,
             postListPostItemHeaderDateTime: postItemHeaderDateTime,
             postListPostItemHeaderDisplayName: postItemHeaderDisplayName,
@@ -51,6 +56,9 @@ class PostList {
             postListPostItemProfilePictureUserStatus: postItemProfilePictureUserStatus,
             postListPostItemShowLessButton: postItemShowLessButton,
             postListPostItemShowMoreButton: postItemShowMoreButton,
+            postListPostItemTable: postItemTable,
+            postListPostItemTableExpandButton: postItemTableExpandButton,
+            postListPostItemThematicBreak: postItemThematicBreak,
         };
     }
 

--- a/detox/e2e/support/ui/screen/index.js
+++ b/detox/e2e/support/ui/screen/index.js
@@ -32,6 +32,7 @@ import SearchResultPostScreen from './search_result_post';
 import SearchScreen from './search';
 import SelectServerScreen from './select_server';
 import SelectTeamScreen from './select_team';
+import TableScreen from './table';
 import ThreadScreen from './thread';
 import UserProfileScreen from './user_profile';
 
@@ -67,6 +68,7 @@ export {
     SearchScreen,
     SelectServerScreen,
     SelectTeamScreen,
+    TableScreen,
     ThreadScreen,
     UserProfileScreen,
 };

--- a/detox/e2e/support/ui/screen/long_post.js
+++ b/detox/e2e/support/ui/screen/long_post.js
@@ -14,6 +14,7 @@ class LongPostScreen {
     getPost = (postId, postMessage, postProfileOptions = {}) => {
         const {
             postItem,
+            postItemBlockQuote,
             postItemEmoji,
             postItemHeaderDateTime,
             postItemHeaderDisplayName,
@@ -25,10 +26,14 @@ class LongPostScreen {
             postItemProfilePictureUserStatus,
             postItemShowLessButton,
             postItemShowMoreButton,
+            postItemTable,
+            postItemTableExpandButton,
+            postItemThematicBreak,
         } = Post.getPost(this.testID.longPostItem, postId, postMessage, postProfileOptions);
 
         return {
             longPostItem: postItem,
+            longPostItemBlockQuote: postItemBlockQuote,
             longPostItemEmoji: postItemEmoji,
             longPostItemHeaderDateTime: postItemHeaderDateTime,
             longPostItemHeaderDisplayName: postItemHeaderDisplayName,
@@ -40,6 +45,9 @@ class LongPostScreen {
             longPostItemProfilePictureUserStatus: postItemProfilePictureUserStatus,
             longPostItemShowLessButton: postItemShowLessButton,
             longPostItemShowMoreButton: postItemShowMoreButton,
+            longPostItemTable: postItemTable,
+            longPostItemTableExpandButton: postItemTableExpandButton,
+            longPostItemThematicBreak: postItemThematicBreak,
         };
     }
 

--- a/detox/e2e/support/ui/screen/search_result_post.js
+++ b/detox/e2e/support/ui/screen/search_result_post.js
@@ -11,6 +11,7 @@ class SearchResultPostScreen {
     getPost = (postId, postMessage, postProfileOptions = {}) => {
         const {
             postItem,
+            postItemBlockQuote,
             postItemEmoji,
             postItemHeaderDateTime,
             postItemHeaderDisplayName,
@@ -22,10 +23,14 @@ class SearchResultPostScreen {
             postItemProfilePictureUserStatus,
             postItemShowLessButton,
             postItemShowMoreButton,
+            postItemTable,
+            postItemTableExpandButton,
+            postItemThematicBreak,
         } = Post.getPost(this.testID.searchResultPostItem, postId, postMessage, postProfileOptions);
 
         return {
             searchResultPostItem: postItem,
+            searchResultPostItemBlockQuote: postItemBlockQuote,
             searchResultPostItemEmoji: postItemEmoji,
             searchResultPostItemHeaderDateTime: postItemHeaderDateTime,
             searchResultPostItemHeaderDisplayName: postItemHeaderDisplayName,
@@ -37,6 +42,9 @@ class SearchResultPostScreen {
             searchResultPostItemProfilePictureUserStatus: postItemProfilePictureUserStatus,
             searchResultPostItemShowLessButton: postItemShowLessButton,
             searchResultPostItemShowMoreButton: postItemShowMoreButton,
+            searchResultPostItemTable: postItemTable,
+            searchResultPostItemTableExpandButton: postItemTableExpandButton,
+            searchResultPostItemThematicBreak: postItemThematicBreak,
         };
     }
 

--- a/detox/e2e/support/ui/screen/table.js
+++ b/detox/e2e/support/ui/screen/table.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+class TableScreen {
+    testID = {
+        tableScreen: 'table.screen',
+        tableScrollView: 'table.scroll_view',
+        backButton: 'screen.back.button',
+    }
+
+    tableScreen = element(by.id(this.testID.tableScreen));
+    tableScrollView = element(by.id(this.testID.tableScrollView));
+    backButton = element(by.id(this.testID.backButton));
+
+    toBeVisible = async () => {
+        await expect(this.tableScreen).toBeVisible();
+
+        return this.tableScreen;
+    }
+
+    back = async () => {
+        await this.backButton.tap();
+        await expect(this.tableScreen).not.toBeVisible();
+    }
+}
+
+const tableScreen = new TableScreen();
+export default tableScreen;

--- a/detox/e2e/test/messaging/markdown_block_quote.e2e.js
+++ b/detox/e2e/test/messaging/markdown_block_quote.e2e.js
@@ -31,7 +31,7 @@ describe('Markdown Block Quote', () => {
     });
 
     it('MM-T195 should display markdown block quote', async () => {
-        // # Post a markdown separator
+        // # Post a markdown block quote
         const markdownBlockQuote = 'this is a quote that i am making long so it wraps on mobile this is a quote that i am making long so it wraps on mobile this is a quote that i am making long so it wraps on mobile this is a quote that i am making long so it wraps on mobile';
         await Post.apiCreatePost({
             channelId: townSquareChannel.id,

--- a/detox/e2e/test/messaging/markdown_block_quote.e2e.js
+++ b/detox/e2e/test/messaging/markdown_block_quote.e2e.js
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {ChannelScreen} from '@support/ui/screen';
+import {
+    Channel,
+    Post,
+    Setup,
+} from '@support/server_api';
+
+describe('Markdown Block Quote', () => {
+    let townSquareChannel;
+
+    beforeAll(async () => {
+        const {team, user} = await Setup.apiInit();
+
+        ({channel: townSquareChannel} = await Channel.apiGetChannelByName(team.id, 'town-square'));
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    it('MM-T195 should display markdown block quote', async () => {
+        // # Post a markdown separator
+        const markdownBlockQuote = 'this is a quote that i am making long so it wraps on mobile this is a quote that i am making long so it wraps on mobile this is a quote that i am making long so it wraps on mobile this is a quote that i am making long so it wraps on mobile';
+        await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: `>${markdownBlockQuote}`,
+        });
+
+        // * Verify markdown block quote is displayed
+        const {post} = await Post.apiGetLastPostInChannel(townSquareChannel.id);
+        const {postListPostItemBlockQuote} = await ChannelScreen.getPostListPostItem(post.id);
+        await expect(postListPostItemBlockQuote).toBeVisible();
+        await expect(element(by.text(markdownBlockQuote))).toBeVisible();
+    });
+});

--- a/detox/e2e/test/messaging/markdown_separator.e2e.js
+++ b/detox/e2e/test/messaging/markdown_separator.e2e.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {ChannelScreen} from '@support/ui/screen';
+import {
+    Channel,
+    Post,
+    Setup,
+} from '@support/server_api';
+
+describe('Markdown Separator', () => {
+    let townSquareChannel;
+
+    beforeAll(async () => {
+        const {team, user} = await Setup.apiInit();
+
+        ({channel: townSquareChannel} = await Channel.apiGetChannelByName(team.id, 'town-square'));
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    it('MM-T191 should display markdown separator', async () => {
+        // # Post a markdown separator
+        const markdownSeparator = '---';
+        await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: markdownSeparator,
+        });
+
+        // * Verify markdown separator is displayed
+        const {post} = await Post.apiGetLastPostInChannel(townSquareChannel.id);
+        const {postListPostItemThematicBreak} = await ChannelScreen.getPostListPostItem(post.id);
+        await expect(postListPostItemThematicBreak).toBeVisible();
+    });
+});

--- a/detox/e2e/test/messaging/markdown_table.e2e.js
+++ b/detox/e2e/test/messaging/markdown_table.e2e.js
@@ -1,0 +1,231 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {
+    ChannelScreen,
+    TableScreen,
+} from '@support/ui/screen';
+import {
+    Channel,
+    Post,
+    Setup,
+} from '@support/server_api';
+import {isIos} from '@support/utils';
+
+describe('Markdown Table', () => {
+    const {channelPostList} = ChannelScreen;
+    const {tableScrollView} = TableScreen;
+    let townSquareChannel;
+
+    beforeAll(async () => {
+        const {team, user} = await Setup.apiInit();
+
+        ({channel: townSquareChannel} = await Channel.apiGetChannelByName(team.id, 'town-square'));
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    it('MM-T190 should display markdown table', async () => {
+        // # Post a markdown table
+        const markdownTable =
+            '| A | B | C |\n' +
+            '|:---|:---|:---|\n' +
+            '| 1 | Name | Toast |\n' +
+            '| 2 | Name | Server |\n';
+        await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: markdownTable,
+        });
+
+        // * Verify markdown table is displayed
+        const {post} = await Post.apiGetLastPostInChannel(townSquareChannel.id);
+        const {postListPostItemTable} = await ChannelScreen.getPostListPostItem(post.id);
+        await expect(postListPostItemTable).toBeVisible();
+    });
+
+    it('MM-T1441 should wrap long text and is visible on screen', async () => {
+        // # Post a markdown table
+        const markdownTable =
+            '| Left header that wraps | Center header that wraps | Right header that wraps |\n' +
+            '| :-- | :-: | --: |\n' +
+            '| Left text that wraps row | Center text that wraps row | Right text that wraps row |\n';
+        await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: markdownTable,
+        });
+
+        // * Verify long text wraps properly and is visible
+        const {post} = await Post.apiGetLastPostInChannel(townSquareChannel.id);
+        const {
+            postListPostItemTable,
+            postListPostItemTableExpandButton,
+        } = await ChannelScreen.getPostListPostItem(post.id);
+        await expect(postListPostItemTable).toBeVisible();
+        await expect(element(by.text('Left header that wraps'))).toBeVisible();
+        await expect(element(by.text('Center header that wraps'))).toBeVisible();
+        await expect(element(by.text('Right header that wraps'))).toBeVisible();
+        await expect(element(by.text('Left text that wraps row'))).toBeVisible();
+        await expect(element(by.text('Center text that wraps row'))).toBeVisible();
+        await expect(element(by.text('Right text that wraps row'))).toBeVisible();
+
+        // # Expand to full view
+        if (isIos()) {
+            await channelPostList.scrollTo('bottom');
+        }
+        await postListPostItemTableExpandButton.tap();
+        await TableScreen.toBeVisible();
+        await expect(element(by.text('Left header that wraps'))).toBeVisible();
+        await expect(element(by.text('Center header that wraps'))).toBeVisible();
+        await expect(element(by.text('Right header that wraps'))).toBeVisible();
+        await expect(element(by.text('Left text that wraps row'))).toBeVisible();
+        await expect(element(by.text('Center text that wraps row'))).toBeVisible();
+        await expect(element(by.text('Right text that wraps row'))).toBeVisible();
+
+        // # Go back to channel
+        await TableScreen.back();
+    });
+
+    it('MM-T1443 should allow horizontal scroll in full view', async () => {
+        // # Post a markdown table
+        const markdownTable =
+            '| Header | Header | Header | Header | Header | Header | Header | Header HS last |\n' +
+            '| :-- | :-: | --: | --: | :-- | :-: | --: | --: |\n' +
+            '| Left | Center | Right | Right | Left | Center | Right | Right |\n'.repeat(7) +
+            '| Left | Center | Right | Right | Left | Center | Right | Right HS last |\n';
+        await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: markdownTable,
+        });
+
+        // * Verify long text wraps properly and is visible
+        const {post} = await Post.apiGetLastPostInChannel(townSquareChannel.id);
+        const {
+            postListPostItemTable,
+            postListPostItemTableExpandButton,
+        } = await ChannelScreen.getPostListPostItem(post.id);
+        await expect(postListPostItemTable).toBeVisible();
+        await expect(element(by.text('Header HS last'))).not.toBeVisible();
+        await expect(element(by.text('Right HS last'))).not.toBeVisible();
+
+        // # Expand to full view
+        if (isIos()) {
+            await channelPostList.scrollTo('bottom');
+        }
+        await postListPostItemTableExpandButton.tap();
+        await TableScreen.toBeVisible();
+        await expect(element(by.text('Header HS last'))).not.toBeVisible();
+        await expect(element(by.text('Right HS last'))).not.toBeVisible();
+
+        // * Verify scrollable to the right
+        await tableScrollView.scrollTo('right');
+        await expect(element(by.text('Header HS last'))).toBeVisible();
+        await expect(element(by.text('Right HS last'))).toBeVisible();
+
+        // # Go back to channel
+        await TableScreen.back();
+    });
+
+    it('MM-T1444 should allow vertical scroll in full view', async () => {
+        // # Post a markdown table
+        const markdownTable =
+            '| Header | Header | Header VS last |\n' +
+            '| :-- | :-: | --: |\n' +
+            '| Left | Center | Right |\n'.repeat(30) +
+            '| Left | Center | Right VS last |\n';
+        await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: markdownTable,
+        });
+
+        // * Verify long text wraps properly and is visible
+        const {post} = await Post.apiGetLastPostInChannel(townSquareChannel.id);
+        const {
+            postListPostItemTable,
+            postListPostItemTableExpandButton,
+        } = await ChannelScreen.getPostListPostItem(post.id);
+        await expect(postListPostItemTable).toBeVisible();
+        await expect(element(by.text('Header VS last'))).toBeVisible();
+        await expect(element(by.text('Right VS last'))).not.toBeVisible();
+
+        // # Expand to full view
+        if (isIos()) {
+            await channelPostList.scrollTo('bottom');
+        }
+        await postListPostItemTableExpandButton.tap();
+        await TableScreen.toBeVisible();
+        await expect(element(by.text('Header VS last'))).toBeVisible();
+        await expect(element(by.text('Right VS last'))).not.toBeVisible();
+
+        // * Verify scrollable to the bottom
+        if (isIos()) {
+            await tableScrollView.scrollTo('bottom');
+        } else {
+            await waitFor(element(by.text('Right VS last'))).toBeVisible().whileElement(by.id(TableScreen.testID.tableScreen)).scroll(1000, 'down');
+        }
+        await expect(element(by.text('Header VS last'))).not.toBeVisible();
+        await expect(element(by.text('Right VS last'))).toBeVisible();
+
+        // # Go back to channel
+        await TableScreen.back();
+    });
+
+    it('MM-T1445 should allow both horizontal and vertical scrolls in full view', async () => {
+        // # Post a markdown table
+        const markdownTable =
+            '| Header | Header | Header | Header | Header | Header | Header | Header last |\n' +
+            '| :-- | :-: | --: | --: | :-- | :-: | --: | --: |\n' +
+            '| Left | Center | Right | Right | Left | Center | Right | Right |\n'.repeat(30) +
+            '| Left | Center | Right | Right | Left | Center | Right | Right last |\n';
+        await Post.apiCreatePost({
+            channelId: townSquareChannel.id,
+            message: markdownTable,
+        });
+
+        // * Verify long text wraps properly and is visible
+        const {post} = await Post.apiGetLastPostInChannel(townSquareChannel.id);
+        const {
+            postListPostItemTable,
+            postListPostItemTableExpandButton,
+        } = await ChannelScreen.getPostListPostItem(post.id);
+        await expect(postListPostItemTable).toBeVisible();
+        await expect(element(by.text('Header last'))).not.toBeVisible();
+        await expect(element(by.text('Right last'))).not.toBeVisible();
+
+        // # Expand to full view
+        if (isIos()) {
+            await channelPostList.scrollTo('bottom');
+        }
+        await postListPostItemTableExpandButton.tap();
+        await TableScreen.toBeVisible();
+        await expect(element(by.text('Header last'))).not.toBeVisible();
+        await expect(element(by.text('Right last'))).not.toBeVisible();
+
+        // * Verify scrollable to the right
+        await tableScrollView.scrollTo('right');
+        await expect(element(by.text('Header last'))).toBeVisible();
+        await expect(element(by.text('Right last'))).not.toBeVisible();
+
+        // * Verify scrollable to the bottom
+        if (isIos()) {
+            await tableScrollView.scrollTo('bottom');
+        } else {
+            await waitFor(element(by.text('Right last'))).toBeVisible().whileElement(by.id(TableScreen.testID.tableScreen)).scroll(1000, 'down');
+        }
+        await expect(element(by.text('Header last'))).not.toBeVisible();
+        await expect(element(by.text('Right last'))).toBeVisible();
+
+        // # Go back to channel
+        await TableScreen.back();
+    });
+});

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -685,7 +685,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: a9d587d6e54ad6434444325023dce4ea19b96095
+  FBReactNativeSpec: 5f648f4f07de2b0b37afa48029ed2b894d9ebfd0
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   jail-monkey: 0b62fb896246639f4203ea90358e08db91b7f5ea
   libwebp: e90b9c01d99205d03b6bb8f2c8c415e5a4ef66f0

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -685,7 +685,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 5f648f4f07de2b0b37afa48029ed2b894d9ebfd0
+  FBReactNativeSpec: a9d587d6e54ad6434444325023dce4ea19b96095
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   jail-monkey: 0b62fb896246639f4203ea90358e08db91b7f5ea
   libwebp: e90b9c01d99205d03b6bb8f2c8c415e5a4ef66f0


### PR DESCRIPTION
#### Summary
- Added tests for MM-T190, MM-T191, MM-T195, MM-T1441, MM-T1443, MM-T1444, MM-T1445 in
    - `detox/e2e/test/messaging/markdown_block_quote.e2e.js`
    - `detox/e2e/test/messaging/markdown_separator.e2e.js`
    - `detox/e2e/test/messaging/markdown_table.e2e.js`
- Added new screen
    - `detox/e2e/support/ui/screen/table.js`
- Added new testIDs and helper variables

#### Ticket Link
JIRA tickets:
- https://mattermost.atlassian.net/browse/MM-35671

Zephyr cases:
- [MM-T190](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T190)
- [MM-T191](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T191)
- [MM-T195](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T195)
- [MM-T1441](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T1441)
- [MM-T1443](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T1443)
- [MM-T1444](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T1444)
- [MM-T1445](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T1445)

#### Screenshots
![Screen Shot 2021-05-20 at 1 04 19 PM](https://user-images.githubusercontent.com/487991/119052083-e5599700-b978-11eb-82fd-fe4c9cf9d70e.png)
![Screen Shot 2021-05-20 at 1 26 34 PM](https://user-images.githubusercontent.com/487991/119052084-e5f22d80-b978-11eb-9bc0-b9621ede6c86.png)
![Screen Shot 2021-05-20 at 2 11 50 PM](https://user-images.githubusercontent.com/487991/119052086-e68ac400-b978-11eb-9c00-20bb16b84a2e.png)


#### Release Note
```release-note
NONE
```
