### PR TITLE
MM-35673 Detox/E2E: Add e2e for messaging

### DIFF
--- a/detox/e2e/support/ui/component/alert.js
+++ b/detox/e2e/support/ui/component/alert.js
@@ -12,6 +12,7 @@ class Alert {
     joinPrivateChannelTitle = isAndroid() ? element(by.text('Join private channel')) : element(by.label('Join private channel')).atIndex(0);
     leavePrivateChannelTitle = isAndroid() ? element(by.text('Leave Private Channel')) : element(by.label('Leave Private Channel')).atIndex(0);
     leavePublicChannelTitle = isAndroid() ? element(by.text('Leave Public Channel')) : element(by.label('Leave Public Channel')).atIndex(0);
+    messageLengthTitle = isAndroid() ? element(by.text('Message Length')) : element(by.label('Message Length')).atIndex(0);
     removeMembersTitle = isAndroid() ? element(by.text('Remove Members')) : element(by.label('Remove Members')).atIndex(0);
 
     // alert buttons

--- a/detox/e2e/support/ui/component/post_options.js
+++ b/detox/e2e/support/ui/component/post_options.js
@@ -26,6 +26,7 @@ class PostOptions {
     reactionPickerAction = element(by.id(this.testID.reactionPickerAction));
     replyAction = element(by.id(this.testID.replyAction));
     permalinkAction = element(by.id(this.testID.permalinkAction));
+    copyAction = element(by.id(this.testID.copyAction));
     deleteAction = element(by.id(this.testID.deleteAction));
     editAction = element(by.id(this.testID.editAction));
     saveAction = element(by.id(this.testID.saveAction));

--- a/detox/e2e/test/messaging/message_deletion.e2e.js
+++ b/detox/e2e/test/messaging/message_deletion.e2e.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {ChannelScreen} from '@support/ui/screen';
+import {
+    Channel,
+    Post,
+    Setup,
+} from '@support/server_api';
+
+describe('Message Deletion', () => {
+    const {
+        channelScreen,
+        deletePost,
+        postMessage,
+    } = ChannelScreen;
+    let testChannel;
+
+    beforeAll(async () => {
+        const {team, user} = await Setup.apiInit();
+
+        const {channel} = await Channel.apiGetChannelByName(team.id, 'town-square');
+        testChannel = channel;
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    it('MM-T115 should be able to delete message and cancel', async () => {
+        // # Post a message
+        const message = Date.now().toString();
+        await postMessage(message);
+
+        // # Delete post and cancel
+        const {post} = await Post.apiGetLastPostInChannel(testChannel.id);
+        await deletePost(post.id, message, {confirm: false});
+
+        // * Verify post is not deleted
+        await expect(channelScreen).toBeVisible();
+        await expect(element(by.text(message))).toBeVisible();
+    });
+
+    it('MM-T116 should remove message from channel when deleted', async () => {
+        // # Post a message
+        const message = Date.now().toString();
+        await postMessage(message);
+
+        // # Delete post
+        const {post} = await Post.apiGetLastPostInChannel(testChannel.id);
+        await deletePost(post.id, message);
+
+        // * Verify post is deleted
+        await expect(channelScreen).toBeVisible();
+        await expect(element(by.text(message))).not.toBeVisible();
+    });
+});

--- a/detox/e2e/test/messaging/message_draft.e2e.js
+++ b/detox/e2e/test/messaging/message_draft.e2e.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {Alert} from '@support/ui/component';
+import {ChannelScreen} from '@support/ui/screen';
+import {Setup} from '@support/server_api';
+
+describe('Message Draft', () => {
+    const {
+        postInput,
+        sendButton,
+        sendButtonDisabled,
+    } = ChannelScreen;
+
+    beforeAll(async () => {
+        const {user} = await Setup.apiInit();
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    it('MM-T107 should show warning message when message exceeds character limit', async () => {
+        // # Type message that exceeds character limit (16384)
+        let message = '1234567890'.repeat(1638) + '1234';
+        await postInput.replaceText(message);
+
+        // * Verify warning message is displayed and send button is disabled
+        await expect(Alert.messageLengthTitle).toBeVisible();
+        await expect(element(by.text('Your current message is too long. Current character count: 16384/16383'))).toBeVisible();
+        await Alert.okButton.tap();
+        await expect(sendButtonDisabled).toBeVisible();
+
+        // # Type message that wit max character limit (16383)
+        message = '1234567890'.repeat(1638) + '123';
+        await postInput.replaceText(message);
+
+        // * Verify warning message is not displayed and send button is enabled
+        await expect(Alert.messageLengthTitle).not.toBeVisible();
+        await expect(element(by.text('Your current message is too long. Current character count: 16383/16383'))).not.toBeVisible();
+        await expect(sendButton).toBeVisible();
+
+        // # Clear input
+        await postInput.clearText();
+    });
+
+    it('MM-T128 should save message draft when app is closed the re-opened', async () => {
+        // # Type a message draft
+        const message = Date.now().toString();
+        await postInput.typeText(message);
+
+        // * Verify message draft
+        await expect(postInput).toHaveText(message);
+
+        // # Send app to home and re-open
+        await device.sendToHome();
+        await device.launchApp({newInstance: false});
+
+        // * Verify message draft still exists
+        await expect(postInput).toHaveText(message);
+
+        // # Clear input
+        await postInput.clearText();
+    });
+});

--- a/detox/e2e/test/messaging/message_edit.e2e.js
+++ b/detox/e2e/test/messaging/message_edit.e2e.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {
+    ChannelScreen,
+    EditPostScreen,
+} from '@support/ui/screen';
+import {
+    Channel,
+    Post,
+    Setup,
+} from '@support/server_api';
+
+describe('Message Edit', () => {
+    const testMessage = Date.now().toString();
+    const additionalText = ' additional text';
+    const {
+        getPostListPostItem,
+        openPostOptionsFor,
+        postMessage,
+    } = ChannelScreen;
+    const {
+        messageInput,
+        saveButton,
+    } = EditPostScreen;
+    let testChannel;
+
+    beforeAll(async () => {
+        const {team, user} = await Setup.apiInit();
+        const {channel} = await Channel.apiGetChannelByName(team.id, 'town-square');
+        testChannel = channel;
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterAll(async () => {
+        await ChannelScreen.logout();
+    });
+
+    it('MM-T100 should be able to edit a message and cancel', async () => {
+        // # Post a message
+        await postMessage(testMessage);
+
+        // # Open edit post screen
+        const {post} = await Post.apiGetLastPostInChannel(testChannel.id);
+        await openPostOptionsFor(post.id, testMessage);
+        await EditPostScreen.open();
+
+        // # Edit post and cancel
+        await messageInput.tap();
+        await messageInput.typeText(additionalText);
+        await EditPostScreen.close();
+
+        // * Verify post is not edited
+        await ChannelScreen.toBeVisible();
+        const {postListPostItem} = await getPostListPostItem(post.id, testMessage);
+        await expect(postListPostItem).toBeVisible();
+    });
+
+    it('MM-T101 should be able to edit a message and save', async () => {
+        // # Open edit post screen
+        const {post} = await Post.apiGetLastPostInChannel(testChannel.id);
+        await openPostOptionsFor(post.id, testMessage);
+        await EditPostScreen.open();
+
+        // # Edit post and save
+        await messageInput.tap();
+        await messageInput.typeText(additionalText);
+        await saveButton.tap();
+
+        // * Verify post is edited
+        await ChannelScreen.toBeVisible();
+        const {postListPostItem} = await getPostListPostItem(post.id, `${testMessage}${additionalText} (edited)`);
+        await expect(postListPostItem).toBeVisible();
+    });
+});


### PR DESCRIPTION
#### Summary
- Added tests for MM-T100, MM-T101, MM-T107, MM-T108, MM-T115, MM-T116, MM-T128, MM-T151 in
    - `detox/e2e/test/messaging/message_deletion.e2e.js`
    - `detox/e2e/test/messaging/message_draft.e2e.js`
    - `detox/e2e/test/messaging/message_edit.e2e.js`
    - `detox/e2e/test/messaging/message_posting.e2e.js`

#### Ticket Link
JIRA tickets:
- https://mattermost.atlassian.net/browse/MM-35673

Zephyr cases:
- [MM-T100](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T100)
- [MM-T101](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T101)
- [MM-T107](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T107)
- [MM-T108](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T108)
- [MM-T115](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T115)
- [MM-T116](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T116)
- [MM-T128](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T128)
- [MM-T151](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T151)

#### Screenshots
![Screen Shot 2021-05-24 at 8 33 24 AM](https://user-images.githubusercontent.com/487991/119385901-adee3180-bc7b-11eb-8a7c-29e77ec9a87f.png)
![Screen Shot 2021-05-24 at 8 40 01 AM](https://user-images.githubusercontent.com/487991/119385913-afb7f500-bc7b-11eb-8fd5-6eb8262463f9.png)
![Screen Shot 2021-05-24 at 8 33 16 AM](https://user-images.githubusercontent.com/487991/119385920-b21a4f00-bc7b-11eb-9420-9502c6529e08.png)
![Screen Shot 2021-05-24 at 9 56 27 AM](https://user-images.githubusercontent.com/487991/119385927-b47ca900-bc7b-11eb-89c7-eeed6429a9bb.png)


#### Release Note
```release-note
NONE
```
