### PR TITLE
Add markdown to apps forms descriptions and errors

### DIFF
--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.tsx
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.tsx
@@ -4,15 +4,12 @@
 import React from 'react';
 import {Image, Text, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import FastImage from 'react-native-fast-image';
 
 import {Theme} from '@mm-redux/types/preferences';
 
-import Markdown from '@components/markdown';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
-import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
-
+import FastImage from 'react-native-fast-image';
 const slashIcon = require('@assets/images/autocomplete/slash_command.png');
 const bangIcon = require('@assets/images/autocomplete/slash_command_error.png');
 
@@ -27,7 +24,6 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => {
             borderRadius: 4,
             justifyContent: 'center',
             alignItems: 'center',
-            alignSelf: 'flex-start',
             marginTop: 8,
         },
         iconColor: {
@@ -134,12 +130,13 @@ const SlashSuggestionItem = (props: Props) => {
                 </View>
                 <View style={style.suggestionContainer}>
                     <Text style={style.suggestionName}>{`${suggestionText}`}</Text>
-                    <Markdown
-                        baseTextStyle={style.suggestionDescription}
-                        textStyles={getMarkdownTextStyles(theme)}
-                        blockStyles={getMarkdownBlockStyles(theme)}
-                        value={description}
-                    />
+                    <Text
+                        ellipsizeMode='tail'
+                        numberOfLines={1}
+                        style={style.suggestionDescription}
+                    >
+                        {description}
+                    </Text>
                 </View>
             </View>
         </TouchableWithFeedback>

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion_item.tsx
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion_item.tsx
@@ -4,12 +4,15 @@
 import React from 'react';
 import {Image, Text, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import FastImage from 'react-native-fast-image';
 
 import {Theme} from '@mm-redux/types/preferences';
 
+import Markdown from '@components/markdown';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
-import FastImage from 'react-native-fast-image';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
+
 const slashIcon = require('@assets/images/autocomplete/slash_command.png');
 const bangIcon = require('@assets/images/autocomplete/slash_command_error.png');
 
@@ -24,6 +27,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => {
             borderRadius: 4,
             justifyContent: 'center',
             alignItems: 'center',
+            alignSelf: 'flex-start',
             marginTop: 8,
         },
         iconColor: {
@@ -130,13 +134,12 @@ const SlashSuggestionItem = (props: Props) => {
                 </View>
                 <View style={style.suggestionContainer}>
                     <Text style={style.suggestionName}>{`${suggestionText}`}</Text>
-                    <Text
-                        ellipsizeMode='tail'
-                        numberOfLines={1}
-                        style={style.suggestionDescription}
-                    >
-                        {description}
-                    </Text>
+                    <Markdown
+                        baseTextStyle={style.suggestionDescription}
+                        textStyles={getMarkdownTextStyles(theme)}
+                        blockStyles={getMarkdownBlockStyles(theme)}
+                        value={description}
+                    />
                 </View>
             </View>
         </TouchableWithFeedback>

--- a/app/components/autocomplete_selector/autocomplete_selector.js
+++ b/app/components/autocomplete_selector/autocomplete_selector.js
@@ -10,13 +10,13 @@ import {displayUsername} from '@mm-redux/utils/user_utils';
 
 import CompassIcon from '@components/compass_icon';
 import FormattedText from '@components/formatted_text';
+import Markdown from '@components/markdown';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 import {preventDoubleTap} from '@utils/tap';
 import {makeStyleSheetFromTheme, changeOpacity} from '@utils/theme';
 import {ViewTypes} from '@constants';
 import {goToScreen} from '@actions/navigation';
-import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
-import Markdown from '@components/markdown/markdown';
 
 export default class AutocompleteSelector extends PureComponent {
     static propTypes = {
@@ -173,8 +173,6 @@ export default class AutocompleteSelector extends PureComponent {
             helpTextContent = (
                 <View style={style.helpTextContainer} >
                     <Markdown
-                        mentionKeys={[]}
-                        theme={theme}
                         baseTextStyle={style.helpText}
                         textStyles={textStyles}
                         blockStyles={blockStyles}
@@ -189,8 +187,6 @@ export default class AutocompleteSelector extends PureComponent {
             errorTextContent = (
                 <View style={style.errorTextContainer} >
                     <Markdown
-                        mentionKeys={[]}
-                        theme={theme}
                         baseTextStyle={style.errorText}
                         textStyles={textStyles}
                         blockStyles={blockStyles}

--- a/app/components/autocomplete_selector/autocomplete_selector.js
+++ b/app/components/autocomplete_selector/autocomplete_selector.js
@@ -15,6 +15,8 @@ import {preventDoubleTap} from '@utils/tap';
 import {makeStyleSheetFromTheme, changeOpacity} from '@utils/theme';
 import {ViewTypes} from '@constants';
 import {goToScreen} from '@actions/navigation';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
+import Markdown from '@components/markdown/markdown';
 
 export default class AutocompleteSelector extends PureComponent {
     static propTypes = {
@@ -122,6 +124,8 @@ export default class AutocompleteSelector extends PureComponent {
         } = this.props;
         const {selectedText} = this.state;
         const style = getStyleSheet(theme);
+        const textStyles = getMarkdownTextStyles(theme);
+        const blockStyles = getMarkdownBlockStyles(theme);
 
         let text = placeholder || intl.formatMessage({id: 'mobile.action_menu.select', defaultMessage: 'Select an option'});
         let selectedStyle = style.dropdownPlaceholder;
@@ -167,18 +171,32 @@ export default class AutocompleteSelector extends PureComponent {
         let helpTextContent;
         if (helpText) {
             helpTextContent = (
-                <Text style={style.helpText}>
-                    {helpText}
-                </Text>
+                <View style={style.helpTextContainer} >
+                    <Markdown
+                        mentionKeys={[]}
+                        theme={theme}
+                        baseTextStyle={style.helpText}
+                        textStyles={textStyles}
+                        blockStyles={blockStyles}
+                        value={helpText}
+                    />
+                </View>
             );
         }
 
         let errorTextContent;
         if (errorText) {
             errorTextContent = (
-                <Text style={style.errorText}>
-                    {errorText}
-                </Text>
+                <View style={style.errorTextContainer} >
+                    <Markdown
+                        mentionKeys={[]}
+                        theme={theme}
+                        baseTextStyle={style.errorText}
+                        textStyles={textStyles}
+                        blockStyles={blockStyles}
+                        value={errorText}
+                    />
+                </View>
             );
         }
 
@@ -265,17 +283,21 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 14,
             marginLeft: 5,
         },
+        helpTextContainer: {
+            marginHorizontal: 15,
+            marginTop: 10,
+        },
         helpText: {
             fontSize: 12,
             color: changeOpacity(theme.centerChannelColor, 0.5),
+        },
+        errorTextContainer: {
             marginHorizontal: 15,
             marginVertical: 10,
         },
         errorText: {
             fontSize: 12,
             color: theme.errorTextColor,
-            marginHorizontal: 15,
-            marginVertical: 10,
         },
         asterisk: {
             color: theme.errorTextColor,

--- a/app/components/autocomplete_selector/autocomplete_selector.js
+++ b/app/components/autocomplete_selector/autocomplete_selector.js
@@ -191,6 +191,8 @@ export default class AutocompleteSelector extends PureComponent {
                         textStyles={textStyles}
                         blockStyles={blockStyles}
                         value={errorText}
+                        disableAtChannelMentionHighlight={true}
+                        disableHashtags={true}
                     />
                 </View>
             );

--- a/app/components/widgets/settings/bool_setting.js
+++ b/app/components/widgets/settings/bool_setting.js
@@ -14,6 +14,8 @@ import {
     changeOpacity,
     makeStyleSheetFromTheme,
 } from '@utils/theme';
+import Markdown from '@components/markdown/markdown';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 
 export default class BoolSetting extends PureComponent {
     static propTypes = {
@@ -49,6 +51,8 @@ export default class BoolSetting extends PureComponent {
             theme,
         } = this.props;
         const style = getStyleSheet(theme);
+        const textStyles = getMarkdownTextStyles(theme);
+        const blockStyles = getMarkdownBlockStyles(theme);
 
         let optionalContent;
         let asterisk;
@@ -81,18 +85,32 @@ export default class BoolSetting extends PureComponent {
         let helpTextContent;
         if (helpText) {
             helpTextContent = (
-                <Text style={style.helpText}>
-                    {helpText}
-                </Text>
+                <View style={style.helpTextContainer} >
+                    <Markdown
+                        mentionKeys={[]}
+                        theme={theme}
+                        baseTextStyle={style.helpText}
+                        textStyles={textStyles}
+                        blockStyles={blockStyles}
+                        value={helpText}
+                    />
+                </View>
             );
         }
 
         let errorTextContent;
         if (errorText) {
             errorTextContent = (
-                <Text style={style.errorText}>
-                    {errorText}
-                </Text>
+                <View style={style.errorTextContainer} >
+                    <Markdown
+                        mentionKeys={[]}
+                        theme={theme}
+                        baseTextStyle={style.errorText}
+                        textStyles={textStyles}
+                        blockStyles={blockStyles}
+                        value={errorText}
+                    />
+                </View>
             );
         }
 
@@ -159,17 +177,21 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 14,
             marginLeft: 5,
         },
+        helpTextContainer: {
+            marginHorizontal: 15,
+            marginTop: 10,
+        },
         helpText: {
             fontSize: 12,
             color: changeOpacity(theme.centerChannelColor, 0.5),
+        },
+        errorTextContainer: {
             marginHorizontal: 15,
-            marginTop: 10,
+            marginVertical: 10,
         },
         errorText: {
             fontSize: 12,
             color: theme.errorTextColor,
-            marginHorizontal: 15,
-            marginVertical: 10,
         },
         asterisk: {
             color: theme.errorTextColor,

--- a/app/components/widgets/settings/bool_setting.js
+++ b/app/components/widgets/settings/bool_setting.js
@@ -10,12 +10,12 @@ import {
 } from 'react-native';
 
 import FormattedText from '@components/formatted_text';
+import Markdown from '@components/markdown';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 import {
     changeOpacity,
     makeStyleSheetFromTheme,
 } from '@utils/theme';
-import Markdown from '@components/markdown/markdown';
-import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 
 export default class BoolSetting extends PureComponent {
     static propTypes = {
@@ -87,8 +87,6 @@ export default class BoolSetting extends PureComponent {
             helpTextContent = (
                 <View style={style.helpTextContainer} >
                     <Markdown
-                        mentionKeys={[]}
-                        theme={theme}
                         baseTextStyle={style.helpText}
                         textStyles={textStyles}
                         blockStyles={blockStyles}
@@ -103,8 +101,6 @@ export default class BoolSetting extends PureComponent {
             errorTextContent = (
                 <View style={style.errorTextContainer} >
                     <Markdown
-                        mentionKeys={[]}
-                        theme={theme}
                         baseTextStyle={style.errorText}
                         textStyles={textStyles}
                         blockStyles={blockStyles}

--- a/app/components/widgets/settings/text_setting.js
+++ b/app/components/widgets/settings/text_setting.js
@@ -11,13 +11,13 @@ import {
 } from 'react-native';
 
 import FormattedText from '@components/formatted_text';
+import Markdown from '@components/markdown';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 import {
     changeOpacity,
     makeStyleSheetFromTheme,
     getKeyboardAppearanceFromTheme,
 } from '@utils/theme';
-import Markdown from '@components/markdown/markdown';
-import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 
 export default class TextSetting extends PureComponent {
     static validTypes = ['input', 'textarea', 'number', 'email', 'tel', 'url', 'password'];
@@ -136,8 +136,6 @@ export default class TextSetting extends PureComponent {
             helpTextContent = (
                 <View style={style.helpTextContainer} >
                     <Markdown
-                        mentionKeys={[]}
-                        theme={theme}
                         baseTextStyle={style.helpText}
                         textStyles={textStyles}
                         blockStyles={blockStyles}
@@ -152,8 +150,6 @@ export default class TextSetting extends PureComponent {
             errorTextContent = (
                 <View style={style.errorTextContainer} >
                     <Markdown
-                        mentionKeys={[]}
-                        theme={theme}
                         baseTextStyle={style.errorText}
                         textStyles={textStyles}
                         blockStyles={blockStyles}
@@ -168,8 +164,6 @@ export default class TextSetting extends PureComponent {
             disabledTextContent = (
                 <View style={style.helpTextContainer} >
                     <Markdown
-                        mentionKeys={[]}
-                        theme={theme}
                         baseTextStyle={style.helpText}
                         textStyles={textStyles}
                         blockStyles={blockStyles}

--- a/app/components/widgets/settings/text_setting.js
+++ b/app/components/widgets/settings/text_setting.js
@@ -16,6 +16,8 @@ import {
     makeStyleSheetFromTheme,
     getKeyboardAppearanceFromTheme,
 } from '@utils/theme';
+import Markdown from '@components/markdown/markdown';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 
 export default class TextSetting extends PureComponent {
     static validTypes = ['input', 'textarea', 'number', 'email', 'tel', 'url', 'password'];
@@ -82,6 +84,8 @@ export default class TextSetting extends PureComponent {
             testID,
         } = this.props;
         const style = getStyleSheet(theme);
+        const textStyles = getMarkdownTextStyles(theme);
+        const blockStyles = getMarkdownBlockStyles(theme);
 
         let labelContent = label;
         if (label && label.defaultMessage) {
@@ -130,27 +134,48 @@ export default class TextSetting extends PureComponent {
         let helpTextContent;
         if (helpText) {
             helpTextContent = (
-                <Text style={style.helpText}>
-                    {helpText}
-                </Text>
+                <View style={style.helpTextContainer} >
+                    <Markdown
+                        mentionKeys={[]}
+                        theme={theme}
+                        baseTextStyle={style.helpText}
+                        textStyles={textStyles}
+                        blockStyles={blockStyles}
+                        value={helpText}
+                    />
+                </View>
             );
         }
 
         let errorTextContent;
         if (errorText) {
             errorTextContent = (
-                <Text style={style.errorText}>
-                    {errorText}
-                </Text>
+                <View style={style.errorTextContainer} >
+                    <Markdown
+                        mentionKeys={[]}
+                        theme={theme}
+                        baseTextStyle={style.errorText}
+                        textStyles={textStyles}
+                        blockStyles={blockStyles}
+                        value={errorText}
+                    />
+                </View>
             );
         }
 
         let disabledTextContent;
         if (disabled && disabledText) {
             disabledTextContent = (
-                <Text style={style.helpText}>
-                    {disabledText}
-                </Text>
+                <View style={style.helpTextContainer} >
+                    <Markdown
+                        mentionKeys={[]}
+                        theme={theme}
+                        baseTextStyle={style.helpText}
+                        textStyles={textStyles}
+                        blockStyles={blockStyles}
+                        value={disabledText}
+                    />
+                </View>
             );
         }
 
@@ -238,17 +263,21 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 14,
             marginLeft: 5,
         },
+        helpTextContainer: {
+            marginHorizontal: 15,
+            marginTop: 10,
+        },
         helpText: {
             fontSize: 12,
             color: changeOpacity(theme.centerChannelColor, 0.5),
+        },
+        errorTextContainer: {
             marginHorizontal: 15,
-            marginTop: 10,
+            marginVertical: 10,
         },
         errorText: {
             fontSize: 12,
             color: theme.errorTextColor,
-            marginHorizontal: 15,
-            marginTop: 10,
         },
         asterisk: {
             color: theme.errorTextColor,

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -3,13 +3,12 @@
 
 import {intlShape} from 'react-intl';
 import React, {PureComponent} from 'react';
-import {ScrollView} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import {EventSubscription, Navigation} from 'react-native-navigation';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {checkDialogElementForError, checkIfErrorsMatchElements} from '@mm-redux/utils/integration_utils';
 
-import ErrorText from 'app/components/error_text';
 import StatusBar from 'app/components/status_bar';
 import FormattedText from '@components/formatted_text';
 
@@ -24,6 +23,9 @@ import {AppCallResponseTypes} from '@mm-redux/constants/apps';
 import AppsFormField from './apps_form_field';
 import {preventDoubleTap} from '@utils/tap';
 import {DoAppCallResult} from 'types/actions/apps';
+import {GlobalStyles} from 'app/styles';
+import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
+import Markdown from '@components/markdown/markdown';
 
 export type Props = {
     call: AppCallRequest;
@@ -343,11 +345,16 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
                 >
                     <StatusBar/>
                     {formError && (
-                        <ErrorText
-                            testID='interactive_dialog.error.text'
-                            textStyle={style.errorContainer}
-                            error={formError}
-                        />
+                        <View style={style.errorContainer} >
+                            <Markdown
+                                mentionKeys={[]}
+                                theme={theme}
+                                baseTextStyle={style.errorLabel}
+                                textStyles={getMarkdownTextStyles(theme)}
+                                blockStyles={getMarkdownBlockStyles(theme)}
+                                value={formError}
+                            />
+                        </View>
                     )}
                     {header &&
                         <DialogIntroductionText
@@ -398,6 +405,11 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => {
         scrollView: {
             marginBottom: 20,
             marginTop: 10,
+        },
+        errorLabel: {
+            fontSize: 12,
+            textAlign: 'left',
+            color: (theme.errorTextColor || '#DA4A4A'),
         },
     };
 });

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -7,25 +7,24 @@ import {ScrollView, View} from 'react-native';
 import {EventSubscription, Navigation} from 'react-native-navigation';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
-import {checkDialogElementForError, checkIfErrorsMatchElements} from '@mm-redux/utils/integration_utils';
-
-import StatusBar from 'app/components/status_bar';
-import FormattedText from '@components/formatted_text';
-
-import {changeOpacity, makeStyleSheetFromTheme} from 'app/utils/theme';
-import {dismissModal} from 'app/actions/navigation';
-
-import DialogIntroductionText from './dialog_introduction_text';
-import {Theme} from '@mm-redux/types/preferences';
+import {AppCallResponseTypes} from '@mm-redux/constants/apps';
 import {AppCallRequest, AppField, AppForm, AppFormValue, AppFormValues, AppLookupResponse, AppSelectOption, FormResponseData} from '@mm-redux/types/apps';
 import {DialogElement} from '@mm-redux/types/integrations';
-import {AppCallResponseTypes} from '@mm-redux/constants/apps';
-import AppsFormField from './apps_form_field';
-import {preventDoubleTap} from '@utils/tap';
-import {DoAppCallResult} from 'types/actions/apps';
-import {GlobalStyles} from 'app/styles';
+import {Theme} from '@mm-redux/types/preferences';
+import {checkDialogElementForError, checkIfErrorsMatchElements} from '@mm-redux/utils/integration_utils';
+
+import StatusBar from '@components/status_bar';
+import FormattedText from '@components/formatted_text';
+import Markdown from '@components/markdown';
+
+import {dismissModal} from '@actions/navigation';
 import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
-import Markdown from '@components/markdown/markdown';
+import {preventDoubleTap} from '@utils/tap';
+import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {DoAppCallResult} from 'types/actions/apps';
+
+import AppsFormField from './apps_form_field';
+import DialogIntroductionText from './dialog_introduction_text';
 
 export type Props = {
     call: AppCallRequest;
@@ -347,8 +346,6 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
                     {formError && (
                         <View style={style.errorContainer} >
                             <Markdown
-                                mentionKeys={[]}
-                                theme={theme}
                                 baseTextStyle={style.errorLabel}
                                 textStyles={getMarkdownTextStyles(theme)}
                                 blockStyles={getMarkdownBlockStyles(theme)}


### PR DESCRIPTION
#### Summary
Add markdown to apps forms field descriptions and errors.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35179

#### Related PRs
Webapp: https://github.com/mattermost/mattermost-webapp/pull/8219

#### Screenshots
![Screenshot from 2021-06-04 17-28-51](https://user-images.githubusercontent.com/1933730/120826811-1e8a2d80-c55b-11eb-81c9-f8704754eef3.png)
![Screenshot from 2021-06-04 17-29-02](https://user-images.githubusercontent.com/1933730/120826815-1f22c400-c55b-11eb-8c9b-b4d1d798d437.png)
![Screenshot from 2021-06-04 17-29-11](https://user-images.githubusercontent.com/1933730/120826818-1f22c400-c55b-11eb-9f87-b2152148ce86.png)
![Screenshot from 2021-06-04 17-29-22](https://user-images.githubusercontent.com/1933730/120826822-1fbb5a80-c55b-11eb-8eb4-66e286624435.png)
![Screenshot from 2021-06-07 16-01-07](https://user-images.githubusercontent.com/1933730/121030319-a8c7d100-c7a9-11eb-88f4-f75c8e027739.png)
![Screenshot from 2021-06-07 16-01-32](https://user-images.githubusercontent.com/1933730/121030321-a9606780-c7a9-11eb-991f-361cda96eb4c.png)

#### Release Note
```release-note
Add markdown support for app fields descriptions and errors.
```
