### PR TITLE
Fixed custom status warning issue

### DIFF
--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -32,7 +32,7 @@ function makeMapStateToProps() {
 
         let teammateId;
         let isTeammateGuest = false;
-        let customStatusEnabled;
+        let customStatusEnabled = false;
         let customStatus;
         const isDirectMessage = currentChannel.type === General.DM_CHANNEL;
 


### PR DESCRIPTION
#### Summary

Fixed the warning about the `isCustomStatusEnabled` prop in the ChannelInfo screen

#### Ticket Link

https://community.mattermost.com/core/pl/5w7c6hji7trjxx8gryzhakjhba

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 
- iPhone 12 Simulator - iOS 14.4
- Android Emulator - Pixel_3a_API_30_x86 - Android 10

#### Release Note

```release-note
NONE
```
