### PR TITLE
MM-36269 fix post reaction handle press

### DIFF
--- a/app/components/post_list/post/body/reactions/reaction.tsx
+++ b/app/components/post_list/post/body/reactions/reaction.tsx
@@ -48,7 +48,7 @@ const Reaction = ({count, emojiName, highlight, onPress, onLongPress, theme}: Re
 
     const handlePress = useCallback(() => {
         onPress(emojiName, highlight);
-    }, []);
+    }, [highlight]);
 
     return (
         <TouchableWithFeedback


### PR DESCRIPTION
#### Summary
Once you tapped on an existing reaction a second time it wouldn't work because of `useCallback` did not had the `highlight` dependency

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36269

#### Release Note
```release-note
NONE
```
