### PR TITLE
Add getMostRecentServerUrl function

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 
-[*.{js,jsx,json,html}]
+[*.{js,jsx,json,html,ts,tsx}]
 indent_style = space
 indent_size = 4
 

--- a/app/database/manager/__mocks__/index.ts
+++ b/app/database/manager/__mocks__/index.ts
@@ -150,7 +150,7 @@ class DatabaseManager {
       }
 
       if (setAsActiveDatabase) {
-          await this.setMostRecentServerConnection(serverUrl);
+          await this.setActiveServerDatabase(serverUrl);
       }
 
       return connection;
@@ -195,12 +195,12 @@ class DatabaseManager {
   };
 
   /**
-   * setMostRecentServerConnection: Set the new active server database.  The serverUrl is used to ensure that we do not duplicate entries in the default database.
+   * setActiveServerDatabase: Set the new active server database.  The serverUrl is used to ensure that we do not duplicate entries in the default database.
    * This method should be called when switching to another server.
    * @param {string} serverUrl
    * @returns {Promise<void>}
    */
-  setMostRecentServerConnection = async (serverUrl: string) => {
+  setActiveServerDatabase = async (serverUrl: string) => {
       const defaultDatabase = await this.getDefaultDatabase();
 
       if (defaultDatabase) {
@@ -244,10 +244,10 @@ class DatabaseManager {
   };
 
   /**
-   * getMostRecentServerUrl: Use this getter method to retrieve the active server URL.
+   * getActiveServerUrl: Use this getter method to retrieve the active server URL.
    * @returns {string}
    */
-   getMostRecentServerUrl = async (): Promise<string|undefined> => {
+   getActiveServerUrl = async (): Promise<string|undefined> => {
        const defaultDatabase = await this.getDefaultDatabase();
 
        if (defaultDatabase) {
@@ -262,20 +262,20 @@ class DatabaseManager {
        return undefined;
    };
 
-  /**
-   * getMostRecentServerConnection: The DatabaseManager should be the only one setting the active database.  Hence, we have made the activeDatabase property private.
+   /**
+   * getActiveServerDatabase: The DatabaseManager should be the only one setting the active database. Hence, we have made the activeDatabase property private.
    * Use this getter method to retrieve the active database if it has been set in your code.
    * @returns {Promise<MostRecentConnection | undefined>}
    */
-  getMostRecentServerDatabase = async (): Promise<DatabaseInstance> => {
-      const serverUrl = await this.getMostRecentServerUrl();
+   getActiveServerDatabase = async (): Promise<DatabaseInstance> => {
+       const serverUrl = await this.getActiveServerUrl();
 
-      if (serverUrl) {
-          const serverDatabase = await this.getDatabaseConnection({serverUrl, setAsActiveDatabase: false});
-          return serverDatabase;
-      }
-      return undefined;
-  };
+       if (serverUrl) {
+           const serverDatabase = await this.getDatabaseConnection({serverUrl, setAsActiveDatabase: false});
+           return serverDatabase;
+       }
+       return undefined;
+   };
 
   /**
    * getDefaultDatabase : Returns the default database.

--- a/app/database/manager/__mocks__/index.ts
+++ b/app/database/manager/__mocks__/index.ts
@@ -265,7 +265,7 @@ class DatabaseManager {
    /**
    * getActiveServerDatabase: The DatabaseManager should be the only one setting the active database. Hence, we have made the activeDatabase property private.
    * Use this getter method to retrieve the active database if it has been set in your code.
-   * @returns {Promise<MostRecentConnection | undefined>}
+   * @returns {Promise<DatabaseInstance | undefined>}
    */
    getActiveServerDatabase = async (): Promise<DatabaseInstance> => {
        const serverUrl = await this.getActiveServerUrl();

--- a/app/database/manager/index.ts
+++ b/app/database/manager/index.ts
@@ -234,23 +234,35 @@ class DatabaseManager {
   };
 
   /**
+   * getMostRecentServerUrl: Use this getter method to retrieve the active server URL.
+   * @returns {string}
+   */
+   getMostRecentServerUrl = async (): Promise<string|undefined> => {
+    const defaultDatabase = await this.getDefaultDatabase();
+
+    if (defaultDatabase) {
+        const serverRecords = await defaultDatabase.collections.get(GLOBAL).query(Q.where('name', RECENTLY_VIEWED_SERVERS)).fetch() as IGlobal[];
+
+        if (serverRecords.length) {
+            const recentServers = serverRecords[0].value as string[];
+            return recentServers[0];
+        }
+        return undefined;
+    }
+    return undefined;
+};
+
+  /**
    * getMostRecentServerConnection: The DatabaseManager should be the only one setting the active database.  Hence, we have made the activeDatabase property private.
    * Use this getter method to retrieve the active database if it has been set in your code.
    * @returns {DatabaseInstance}
    */
-  getMostRecentServerConnection = async (): Promise<DatabaseInstance> => {
-      const defaultDatabase = await this.getDefaultDatabase();
+  getMostRecentServerDatabase = async (): Promise<DatabaseInstance> => {
+      const serverUrl = await this.getMostRecentServerUrl();
 
-      if (defaultDatabase) {
-          const serverRecords = await defaultDatabase.collections.get(GLOBAL).query(Q.where('name', RECENTLY_VIEWED_SERVERS)).fetch() as IGlobal[];
-
-          if (serverRecords.length) {
-              const activeServer = serverRecords[0].value as string[];
-              const activeServerUrl = activeServer[0];
-              const activeServerDatabase = await this.getDatabaseConnection({serverUrl: activeServerUrl, setAsActiveDatabase: false});
-              return activeServerDatabase;
-          }
-          return undefined;
+      if (serverUrl) {
+          const serverDatabase = await this.getDatabaseConnection({serverUrl: serverUrl, setAsActiveDatabase: false});
+          return serverDatabase;
       }
       return undefined;
   };

--- a/app/database/manager/index.ts
+++ b/app/database/manager/index.ts
@@ -145,7 +145,7 @@ class DatabaseManager {
       }
 
       if (setAsActiveDatabase) {
-          await this.setMostRecentServerConnection(serverUrl);
+          await this.setActiveServerDatabase(serverUrl);
       }
 
       return connection;
@@ -195,12 +195,12 @@ class DatabaseManager {
   };
 
   /**
-   * setMostRecentServerConnection: Set the new active server database.  The serverUrl is used to ensure that we do not duplicate entries in the default database.
+   * setActiveServerDatabase: Set the new active server database.  The serverUrl is used to ensure that we do not duplicate entries in the default database.
    * This method should be called when switching to another server.
    * @param {string} serverUrl
    * @returns {Promise<void>}
    */
-  setMostRecentServerConnection = async (serverUrl: string) => {
+  setActiveServerDatabase = async (serverUrl: string) => {
       const defaultDatabase = await this.getDefaultDatabase();
       if (defaultDatabase) {
           // retrieve recentlyViewedServers from Global entity
@@ -233,34 +233,34 @@ class DatabaseManager {
   };
 
   /**
-   * getMostRecentServerUrl: Use this getter method to retrieve the active server URL.
+   * getActiveServerUrl: Use this getter method to retrieve the active server URL.
    * @returns {string}
    */
-   getMostRecentServerUrl = async (): Promise<string|undefined> => {
-    const defaultDatabase = await this.getDefaultDatabase();
+   getActiveServerUrl = async (): Promise<string|undefined> => {
+       const defaultDatabase = await this.getDefaultDatabase();
 
-    if (defaultDatabase) {
-        const serverRecords = await defaultDatabase.collections.get(GLOBAL).query(Q.where('name', RECENTLY_VIEWED_SERVERS)).fetch() as IGlobal[];
+       if (defaultDatabase) {
+           const serverRecords = await defaultDatabase.collections.get(GLOBAL).query(Q.where('name', RECENTLY_VIEWED_SERVERS)).fetch() as IGlobal[];
 
-        if (serverRecords.length) {
-            const recentServers = serverRecords[0].value as string[];
-            return recentServers[0];
-        }
-        return undefined;
-    }
-    return undefined;
-};
+           if (serverRecords.length) {
+               const recentServers = serverRecords[0].value as string[];
+               return recentServers[0];
+           }
+           return undefined;
+       }
+       return undefined;
+   };
 
   /**
-   * getMostRecentServerConnection: The DatabaseManager should be the only one setting the active database.  Hence, we have made the activeDatabase property private.
+   * getActiveServerDatabase: The DatabaseManager should be the only one setting the active database.  Hence, we have made the activeDatabase property private.
    * Use this getter method to retrieve the active database if it has been set in your code.
    * @returns {Promise<MostRecentConnection | undefined>}
    */
-  getMostRecentServerDatabase = async (): Promise<DatabaseInstance> => {
-      const serverUrl = await this.getMostRecentServerUrl();
+  getActiveServerDatabase = async (): Promise<DatabaseInstance> => {
+      const serverUrl = await this.getActiveServerUrl();
 
       if (serverUrl) {
-          const serverDatabase = await this.getDatabaseConnection({serverUrl: serverUrl, setAsActiveDatabase: false});
+          const serverDatabase = await this.getDatabaseConnection({serverUrl, setAsActiveDatabase: false});
           return serverDatabase;
       }
       return undefined;

--- a/app/database/manager/test_manual.ts
+++ b/app/database/manager/test_manual.ts
@@ -38,12 +38,12 @@ export default async () => {
 
     // Test: It should return the current active server database
     const testGetActiveServerConnection = () => {
-        // const activeServer = DatabaseManager.getMostRecentServerConnection();
+        // const activeServer = DatabaseManager.getActiveServerDatabase();
     };
 
     // Test: It should set the current active server database to the provided server url.
     const testSetActiveServerConnection = async () => {
-        await databaseClient.setMostRecentServerConnection('https://comm4.mattermost.com');
+        await databaseClient.setActiveServerDatabase('https://comm4.mattermost.com');
     };
 
     // Test: It should return database instance(s) if there are valid server urls in the provided list.

--- a/app/database/operator/utils/create_test_connection.ts
+++ b/app/database/operator/utils/create_test_connection.ts
@@ -21,7 +21,7 @@ export const createTestConnection = async ({databaseName = 'db_name', setActive 
     });
 
     if (setActive) {
-        await databaseClient.setMostRecentServerConnection(serverUrl);
+        await databaseClient.setActiveServerDatabase(serverUrl);
     }
 
     return database;

--- a/app/database/operator/utils/test.ts
+++ b/app/database/operator/utils/test.ts
@@ -81,7 +81,7 @@ describe('DataOperator: Utils tests', () => {
                 serverUrl,
             },
         });
-        await databaseManagerClient.setMostRecentServerConnection(serverUrl);
+        await databaseManagerClient.setActiveServerDatabase(serverUrl);
 
         const operatorClient = new Operator(database!);
 

--- a/app/utils/database.ts
+++ b/app/utils/database.ts
@@ -47,11 +47,11 @@ export const getDefaultDatabase = async () => {
 export const getActiveServerDatabase = async () => {
     try {
         const databaseClient = new DatabaseManager();
-        const recentConnection = await databaseClient.getMostRecentServerConnection();
+        const activeServerDatabase = await databaseClient.getActiveServerDatabase();
 
         return {
-            error: recentConnection?.connection ? null : 'Unable to retrieve the current active server database.',
-            activeServerDatabase: recentConnection?.connection ?? null,
+            error: activeServerDatabase ? null : 'Unable to retrieve the current active server database.',
+            activeServerDatabase,
         };
     } catch (e) {
         return {


### PR DESCRIPTION
In the init process I need to know what the active server URL is. I extracted out querying of that value into `getMostRecentServerUrl` and then used that function in `getMostRecentServerDatabase` which used to be called `getMostRecentServerConnection`. There's more work to be done here (like tests and mocks) but wanted your thoughts. Regarding the term "connection" in the previous method, I'd rather use "database" as that's what is actually being returned. Regarding the term "most recent", I think we should use "active" instead, at least in the functions here. More broadly, maybe we can get rid of the `RECENTLY_VIEWED_SERVERS` and instead add some timestamp field (ie, lastViewed) to the Server model. We could then query for active server.