### PR TITLE
fix: connect WebSocket when the network component mounts

### DIFF
--- a/app/components/network_indicator/network.tsx
+++ b/app/components/network_indicator/network.tsx
@@ -111,10 +111,7 @@ const NetworkIndicator = ({
     };
 
     const handleConnectionChange = ({hasInternet}: ConnectionChangedEvent) => {
-        if (firstRun.current) {
-            firstRun.current = false;
-            handleWebSocket(true);
-        } else {
+        if (!firstRun.current) {
             if (!hasInternet) {
                 setConnected(false);
             }
@@ -151,6 +148,11 @@ const NetworkIndicator = ({
     };
 
     useEffect(() => {
+        handleWebSocket(true);
+        firstRun.current = false;
+    }, []);
+
+    useEffect(() => {
         const networkListener = networkConnectionListener(handleConnectionChange);
         return () => networkListener.removeEventListener();
     }, []);
@@ -168,7 +170,6 @@ const NetworkIndicator = ({
     useEffect(() => {
         const handleAppStateChange = stateChange(async (appState: AppStateStatus) => {
             const active = appState === 'active';
-
             handleWebSocket(active);
 
             if (active) {


### PR DESCRIPTION
#### Summary
Connect the WebSocket when the network indicator component mounts. The first time the network component mounts the networkConnectionListener triggers and that was causing the websocket to connect the first time, but when mounting a second time the network listener did not change thus after a second mount WS was not connected.

This was very easy to reproduce by logging out and then log back in or switching servers.

#### Ticket Link
Reported in community server at https://community.mattermost.com/core/pl/isu7f7zbcbfm9y9ibm8dt5rknr

#### Release Note
```release-note
NONE
```
