### PR TITLE
MM-34640 Handle missing error on error response

### DIFF
--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -193,23 +193,34 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
 
     updateErrors = (elements: DialogElement[], fieldErrors?: {[x: string]: string}, formError?: string): boolean => {
         let hasErrors = false;
-
-        if (fieldErrors &&
-            Object.keys(fieldErrors).length >= 0 &&
-            checkIfErrorsMatchElements(fieldErrors as any, elements)
-        ) {
-            hasErrors = true;
-            this.setState({fieldErrors});
-        }
-
+        const state = {} as State;
         if (formError) {
             hasErrors = true;
-            this.setState({formError});
-            if (this.scrollView?.current) {
-                this.scrollView.current.scrollTo({x: 0, y: 0});
+            state.formError = formError;
+        }
+
+        if (fieldErrors && Object.keys(fieldErrors).length >= 0) {
+            hasErrors = true;
+            if (checkIfErrorsMatchElements(fieldErrors as any, elements)) {
+                state.fieldErrors = fieldErrors;
+            } else if (!state.formError) {
+                const field = Object.keys(fieldErrors)[0];
+                state.formError = this.context.intl.formatMessage({
+                    id: 'apps.error.responses.unknown_field_error',
+                    defaultMessage: 'Received an error for an unkown field. Field name: `{field}`. Error: `{error}`.',
+                }, {
+                    field,
+                    error: fieldErrors[field],
+                });
             }
         }
 
+        if (hasErrors) {
+            this.setState(state);
+            if (state.formError && this.scrollView?.current) {
+                this.scrollView.current.scrollTo({x: 0, y: 0});
+            }
+        }
         return hasErrors;
     }
 

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -45,6 +45,7 @@
   "apps.error.responses.navigate.no_url": "Response type is `navigate`, but no url was included in response.",
   "apps.error.responses.unexpected_error": "Received an unexpected error.",
   "apps.error.responses.unexpected_type": "App response type was not expected. Response type: {type}.",
+  "apps.error.responses.unknown_field_error": "Received an error for an unkown field. Field name: `{field}`. Error: `{error}`.",
   "apps.error.responses.unknown_type": "App response type not supported. Response type: {type}.",
   "apps.error.unknown": "Unknown error occurred.",
   "apps.suggestion.dynamic.error": "Dynamic select error",


### PR DESCRIPTION
#### Summary
When adding a field submission response had a error that did not map to any field, it considered as if no errors occurred and closed. Now we are showing a general error specifying the field and the error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34640

#### Related Pull Requests
Webapp: https://github.com/mattermost/mattermost-webapp/pull/8269

#### Release Note
```release-note
NONE
```