### PR TITLE
Fixed custom status issues

### DIFF
--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -151,6 +151,9 @@ export function doReconnect(now: number) {
                 }
 
                 actions.push({
+                    type: UserTypes.RECEIVED_ME,
+                    data: me.user,
+                }, {
                     type: PreferenceTypes.RECEIVED_ALL_PREFERENCES,
                     data: me.preferences,
                 }, {

--- a/app/components/custom_status/custom_status_emoji.tsx
+++ b/app/components/custom_status/custom_status_emoji.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useMemo} from 'react';
 import {Text, TextStyle} from 'react-native';
 import {useSelector} from 'react-redux';
 
@@ -17,7 +17,7 @@ interface ComponentProps {
 }
 
 const CustomStatusEmoji = ({emojiSize, userID, style, testID}: ComponentProps) => {
-    const getCustomStatus = makeGetCustomStatus();
+    const getCustomStatus = useMemo(makeGetCustomStatus, []);
     const customStatus = useSelector((state: GlobalState) => {
         return getCustomStatus(state, userID);
     });

--- a/app/components/post_list/post/header/header.tsx
+++ b/app/components/post_list/post/header/header.tsx
@@ -92,6 +92,7 @@ const Header = ({
                         <CustomStatusEmoji
                             userID={post.user_id}
                             style={style.customStatusEmoji}
+                            testID='post_header'
                         />
                     )}
                     {!isSystemPost &&

--- a/detox/e2e/test/custom_statuses/custom_status.e2e.js
+++ b/detox/e2e/test/custom_statuses/custom_status.e2e.js
@@ -213,14 +213,14 @@ describe('Custom status', () => {
 
         // # Post a message and check if custom status emoji is present in the post header
         await ChannelScreen.postMessage(message);
-        await expect(element(by.id(`custom_status_emoji.${customStatus.emojiName}`).withAncestor(by.id('post_header')))).toBeVisible();
+        await expect(element(by.id(`post_header.custom_status_emoji.${customStatus.emojiName}`))).toBeVisible();
 
         // # Open the reply thread for the last post
         const {post} = await Post.apiGetLastPostInChannel(testChannel.id);
         await ChannelScreen.openReplyThreadFor(post.id, message);
 
         // * Check if the custom status emoji is present in the post header and close thread
-        await expect(element(by.id(`custom_status_emoji.${customStatus.emojiName}`).withAncestor(by.id('post_header')))).toBeVisible();
+        await expect(element(by.id(`post_header.custom_status_emoji.${customStatus.emojiName}`))).toBeVisible();
         await ThreadScreen.back();
 
         // # Open user profile screen


### PR DESCRIPTION
#### Summary

- Fixed MM-36571 - RN: Custom status does not reflect changes from webapp when backgrounded
- Fixed MM-36601 - RN Custom status is not shown in right sidebar after setting custom status from webapp
- Fixed selector memoization for multiple instances of CustomStatusEmoji component
- Fixed MM-T3893 failing e2e test

#### Ticket Links

- https://mattermost.atlassian.net/browse/MM-36571
- https://mattermost.atlassian.net/browse/MM-36601

#### Device Information
This PR was tested on: 

- iPhone 12 Simulator - iOS 14.4
- Android Emulator - Pixel_3a_API_30_x86 - Android 10

#### Release Note

```release-note
Fixed MM-36571 and MM-36601 issues
Fixed selector memoization for multiple instances of CustomStatusEmoji component
Fixed MM-T3893 failing e2e test
```