### PR TITLE
Content safety

### DIFF
--- a/app/components/post_list/post/body/content/embedded_bindings/index.tsx
+++ b/app/components/post_list/post/body/content/embedded_bindings/index.tsx
@@ -22,7 +22,7 @@ const EmbeddedBindings = ({embeds, postId, theme}: Props) => {
         content.push(
             <EmbeddedBinding
                 embed={embed}
-                key={'att_' + i.toString()}
+                key={'binding_' + i.toString()}
                 postId={postId}
                 theme={theme}
             />,

--- a/app/components/post_list/post/body/content/index.tsx
+++ b/app/components/post_list/post/body/content/index.tsx
@@ -65,22 +65,28 @@ const Content = ({isReplyPost, post, theme}: ContentProps) => {
             />
         );
     case contentType.message_attachment:
-        return (
-            <MessageAttachments
-                attachments={post.props.attachments}
-                metadata={post.metadata}
-                postId={post.id}
-                theme={theme}
-            />
-        );
+        if (post.props.attachments?.length) {
+            return (
+                <MessageAttachments
+                    attachments={post.props.attachments}
+                    metadata={post.metadata}
+                    postId={post.id}
+                    theme={theme}
+                />
+            );
+        }
+        break;
     case contentType.app_bindings:
-        return (
-            <EmbeddedBindings
-                embeds={post.props.app_bindings}
-                postId={post.id}
-                theme={theme}
-            />
-        );
+        if (post.props.app_bindings?.length) {
+            return (
+                <EmbeddedBindings
+                    embeds={post.props.app_bindings}
+                    postId={post.id}
+                    theme={theme}
+                />
+            );
+        }
+        break;
     }
 
     return null;

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -20,7 +20,7 @@ target 'Mattermost' do
   pod 'Permission-PhotoLibrary', :path => "#{permissions_path}/PhotoLibrary"
   pod 'Permission-PhotoLibraryAddOnly', :path => "#{permissions_path}/PhotoLibraryAddOnly"
 
-  pod 'XCDYouTubeKit', '2.8.3'
+  pod 'XCDYouTubeKit', :git => 'https://github.com/hinge-agency/XCDYouTubeKit.git', :branch => 'fix/issue-534-XCDYouTubeVideoErrorDomain-error-code-3'
   pod 'Swime', '3.0.6'
 
 # Enables Flipper.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -430,7 +430,7 @@ PODS:
     - Sentry/Core (= 7.0.0)
   - Sentry/Core (7.0.0)
   - Swime (3.0.6)
-  - XCDYouTubeKit (2.8.3)
+  - XCDYouTubeKit (2.15.2)
   - Yoga (1.14.0)
   - YoutubePlayer-in-WKWebView (0.3.5)
 
@@ -512,7 +512,7 @@ DEPENDENCIES:
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Swime (= 3.0.6)
-  - XCDYouTubeKit (= 2.8.3)
+  - XCDYouTubeKit (from `https://github.com/hinge-agency/XCDYouTubeKit.git`, branch `fix/issue-534-XCDYouTubeVideoErrorDomain-error-code-3`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -526,7 +526,6 @@ SPEC REPOS:
     - SDWebImageWebPCoder
     - Sentry
     - Swime
-    - XCDYouTubeKit
     - YoutubePlayer-in-WKWebView
 
 EXTERNAL SOURCES:
@@ -678,8 +677,16 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-svg"
   RNVectorIcons:
     :path: "../node_modules/react-native-vector-icons"
+  XCDYouTubeKit:
+    :branch: fix/issue-534-XCDYouTubeVideoErrorDomain-error-code-3
+    :git: https://github.com/hinge-agency/XCDYouTubeKit.git
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
+
+CHECKOUT OPTIONS:
+  XCDYouTubeKit:
+    :commit: 38170db3934e575ad4bfb782dedc544f304b482f
+    :git: https://github.com/hinge-agency/XCDYouTubeKit.git
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
@@ -765,10 +772,10 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: d0dac55073088d24b2ac1b191a71a8f8d0adac21
   Sentry: 89d26e036063b9cb9caa59b6951dd2f8277aa13b
   Swime: d7b2c277503b6cea317774aedc2dce05613f8b0b
-  XCDYouTubeKit: 46df93c4dc4d48763ad720d997704384635c4335
+  XCDYouTubeKit: b120aced3d8638ffb570c5450cddb5a1dac448c7
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
   YoutubePlayer-in-WKWebView: cfbf46da51d7370662a695a8f351e5fa1d3e1008
 
-PODFILE CHECKSUM: a4402d26aaec4ef7e58bd8304848d89c876d285a
+PODFILE CHECKSUM: c3bbb0fd2d81abb15a1f699210f18b2577ec458f
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
#### Summary
This PR adds some safety checks around post message attachments and app bindings to prevent the app from crashing when `null` is present in the post metadata for some reason.

Also includes a fix for YouTube video playback (for example this one https://www.youtube.com/watch?v=eWCXZIRm7iU&t=707). Fix taken from https://github.com/0xced/XCDYouTubeKit/issues/534

#### Release Note
```release-note
* Prevented crash when message attachments or app bindings are `null`
* Fixed iOS YouTube video playback
```
