### PR TITLE
Do not recreate onViewableItemsChange when the deeplink changes

### DIFF
--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -146,7 +146,7 @@ const PostList = ({
         if (onViewableItemsChangedListener.current && !deepLinkURL) {
             onViewableItemsChangedListener.current(viewableItems);
         }
-    }, [deepLinkURL]);
+    }, []);
 
     const renderItem = useCallback(({item, index}) => {
         if (isStartOfNewMessages(item)) {


### PR DESCRIPTION
#### Ticket Link
Reported in [community server](https://community.mattermost.com/core/pl/95b4s1ftkpnwdeegnba4j7ubow)

Ticket: https://mattermost.atlassian.net/browse/MM-36686

#### Release Note
```release-note
Fixes a crash when bringing the app from the background after tapping on a DeepLink
```