### PR TITLE
MM-32802 don't display nickname for current user in autocomplete

### DIFF
--- a/app/components/autocomplete/at_mention_item/at_mention_item.tsx
+++ b/app/components/autocomplete/at_mention_item/at_mention_item.tsx
@@ -66,23 +66,9 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-const AtMentionItem = (props: AtMentionItemProps) => {
+const AtMentionItem = ({firstName = '', isBot, isCurrentUser, isGuest, isShared, lastName = '', nickname = '',
+    onPress, showFullName, testID, theme, userId, username}: AtMentionItemProps) => {
     const insets = useSafeAreaInsets();
-    const {
-        firstName,
-        isBot,
-        isCurrentUser,
-        isGuest,
-        isShared,
-        lastName,
-        nickname,
-        onPress,
-        showFullName,
-        testID,
-        theme,
-        userId,
-        username,
-    } = props;
 
     const completeMention = () => {
         onPress(username);
@@ -96,7 +82,7 @@ const AtMentionItem = (props: AtMentionItemProps) => {
             name += `${firstName} ${lastName} `;
         }
 
-        if (hasNickname) {
+        if (hasNickname && !isCurrentUser) {
             name += name.length > 0 ? `(${nickname})` : nickname;
         }
 
@@ -152,7 +138,7 @@ const AtMentionItem = (props: AtMentionItemProps) => {
                         {isCurrentUser &&
                         <FormattedText
                             id='suggestion.mention.you'
-                            defaultMessage='(you)'
+                            defaultMessage=' (you)'
                         />}
                         {` @${username}`}
                     </Text>
@@ -172,12 +158,6 @@ const AtMentionItem = (props: AtMentionItemProps) => {
             </View>
         </TouchableWithFeedback>
     );
-};
-
-AtMentionItem.defaultProps = {
-    firstName: '',
-    lastName: '',
-    nickname: '',
 };
 
 export default AtMentionItem;

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -656,7 +656,7 @@
   "suggestion.mention.morechannels": "Other Channels",
   "suggestion.mention.nonmembers": "Not in Channel",
   "suggestion.mention.special": "Special Mentions",
-  "suggestion.mention.you": "(you)",
+  "suggestion.mention.you": " (you)",
   "suggestion.search.direct": "Direct Messages",
   "suggestion.search.private": "Private Channels",
   "suggestion.search.public": "Public Channels",


### PR DESCRIPTION
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32802

#### Release Note
```release-note
Removed the nickname from the user autocomplete when the item is the current user
```