### PR TITLE
Prevent the initialIndex from being less than 0

### DIFF
--- a/app/components/post_list/index.ts
+++ b/app/components/post_list/index.ts
@@ -37,7 +37,7 @@ function mapStateToProps() {
         return {
             deepLinkURL: state.views.root.deepLinkURL,
             postIds: ids,
-            initialIndex,
+            initialIndex: Math.max(initialIndex, 0),
             serverURL: getCurrentUrl(state),
             siteURL: getConfig(state)?.SiteURL,
             theme: getTheme(state),


### PR DESCRIPTION
#### Summary
A race condition can cause the app to display the more messages above banner while there isn't yet a new line message indicator in the post list, that in turn has the initialIndex to be -1. If a user tries to scroll to the -1 index, FlatList will throw and error which is not really being caught.

This PR prevents the initialIndex to be less than 0 at all times.

#### Ticket Link
Fixes: #5500

#### Release Note
```release-note
NONE
```
