### PR TITLE
[MM-35910]use user skin preferences for emoji

### DIFF
--- a/app/mm-redux/constants/preferences.ts
+++ b/app/mm-redux/constants/preferences.ts
@@ -22,6 +22,8 @@ const Preferences: Dictionary<any> = {
     INTERVAL_FIFTEEN_MINUTES: 15 * 60,
     INTERVAL_HOUR: 60 * 60,
     INTERVAL_IMMEDIATE: 30,
+    CATEGORY_EMOJI: 'emoji',
+    EMOJI_SKINTONE: 'emoji_skintone',
 
     CATEGORY_CUSTOM_STATUS: 'custom_status',
     NAME_CUSTOM_STATUS_TUTORIAL_STATE: 'custom_status_tutorial_state',


### PR DESCRIPTION
#### Summary

Base skin selection on user preference selected from the desktop

#### Ticket Link

[MM-35910](https://mattermost.atlassian.net/browse/MM-35910)

#### Device Information
This PR was tested on: ios simulator
android was not tested as gradle refused to install it, I believe this is related to my machine setup and not the PR itself

#### Screenshots

<img width="378" alt="Screen Shot 2021-07-01 at 00 32 28" src="https://user-images.githubusercontent.com/1515906/124039738-d21ff980-da03-11eb-9da4-a1367fb10e8b.png">

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
