### PR TITLE
MM-36881 Bring back refresh control for channels and threads

### DIFF
--- a/app/actions/views/channel.js
+++ b/app/actions/views/channel.js
@@ -503,16 +503,7 @@ export function closeGMChannel(channel) {
 
 export function refreshChannelWithRetry(channelId) {
     return async (dispatch) => {
-        dispatch(setChannelRefreshing(true));
-        const posts = await dispatch(fetchPostActionWithRetry(getPosts(channelId)));
-        const actions = [setChannelRefreshing(false)];
-
-        if (posts) {
-            actions.push(setChannelRetryFailed(false));
-        }
-
-        dispatch(batchActions(actions, 'BATCH_REEFRESH_CHANNEL'));
-        return posts;
+        return dispatch(fetchPostActionWithRetry(getPosts(channelId)));
     };
 }
 

--- a/app/components/post_list/index.ts
+++ b/app/components/post_list/index.ts
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 
 import {handleSelectChannelByName, refreshChannelWithRetry} from '@actions/views/channel';
 import {closePermalink, showPermalink} from '@actions/views/permalink';
+import {getPostThread} from '@actions/views/post';
 import {setDeepLinkURL} from '@actions/views/root';
 import {getConfig, getCurrentUrl} from '@mm-redux/selectors/entities/general';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
@@ -48,6 +49,7 @@ function mapStateToProps() {
 
 const mapDispatchToProps = {
     closePermalink,
+    getPostThread,
     handleSelectChannelByName,
     refreshChannelWithRetry,
     setDeepLinkURL,

--- a/app/screens/channel/channel_post_list/channel_post_list.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.js
@@ -23,7 +23,6 @@ export default class ChannelPostList extends PureComponent {
             getPostThread: PropTypes.func.isRequired,
             increasePostVisibility: PropTypes.func.isRequired,
             selectPost: PropTypes.func.isRequired,
-            refreshChannelWithRetry: PropTypes.func.isRequired,
             setChannelRefreshing: PropTypes.func,
         }).isRequired,
         channelId: PropTypes.string.isRequired,

--- a/app/screens/channel/channel_post_list/channel_post_list.test.js
+++ b/app/screens/channel/channel_post_list/channel_post_list.test.js
@@ -15,7 +15,6 @@ describe('ChannelPostList', () => {
             getPostThread: jest.fn(),
             increasePostVisibility: jest.fn(),
             selectPost: jest.fn(),
-            refreshChannelWithRetry: jest.fn(),
         },
         channelId: 'channel-id',
         loadMorePostsVisible: false,

--- a/app/screens/channel/channel_post_list/index.js
+++ b/app/screens/channel/channel_post_list/index.js
@@ -4,11 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {
-    loadPostsIfNecessaryWithRetry,
-    increasePostVisibility,
-    refreshChannelWithRetry,
-} from '@actions/views/channel';
+import {loadPostsIfNecessaryWithRetry, increasePostVisibility} from '@actions/views/channel';
 import {getPostThread} from '@actions/views/post';
 import {Types} from '@constants';
 import {selectPost} from '@mm-redux/actions/posts';
@@ -45,7 +41,6 @@ function mapDispatchToProps(dispatch) {
             getPostThread,
             increasePostVisibility,
             selectPost,
-            refreshChannelWithRetry,
         }, dispatch),
     };
 }

--- a/app/screens/thread/__snapshots__/thread.ios.test.js.snap
+++ b/app/screens/thread/__snapshots__/thread.ios.test.js.snap
@@ -44,6 +44,7 @@ exports[`thread should match snapshot, has root post 1`] = `
               style={Object {}}
             />
           }
+          rootId="root_id"
           scrollViewNativeID="threadPostList"
           testID="thread.post_list"
         />
@@ -134,6 +135,7 @@ exports[`thread should match snapshot, render footer 1`] = `
       style={Object {}}
     />
   }
+  rootId="root_id"
   scrollViewNativeID="threadPostList"
   testID="thread.post_list"
 />
@@ -153,6 +155,7 @@ exports[`thread should match snapshot, render footer 2`] = `
     ]
   }
   renderFooter={null}
+  rootId="root_id"
   scrollViewNativeID="threadPostList"
   testID="thread.post_list"
 />

--- a/app/screens/thread/thread.android.js
+++ b/app/screens/thread/thread.android.js
@@ -42,6 +42,7 @@ export default class ThreadAndroid extends ThreadBase {
                             currentUserId={myMember && myMember.user_id}
                             lastViewedAt={this.state.lastViewedAt}
                             location={THREAD}
+                            rootId={rootId}
                         />
                     </Animated.View>
                     <PostDraft

--- a/app/screens/thread/thread.ios.js
+++ b/app/screens/thread/thread.ios.js
@@ -55,6 +55,7 @@ export default class ThreadIOS extends ThreadBase {
                             currentUserId={myMember && myMember.user_id}
                             lastViewedAt={this.state.lastViewedAt}
                             location={THREAD}
+                            rootId={rootId}
                             scrollViewNativeID={SCROLLVIEW_NATIVE_ID}
                         />
                     </Animated.View>

--- a/patches/react-native+0.64.2.patch
+++ b/patches/react-native+0.64.2.patch
@@ -1,3 +1,24 @@
+diff --git a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
+index a069a24..a21fa38 100644
+--- a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
++++ b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
+@@ -1222,9 +1222,15 @@ class ScrollView extends React.Component<Props, State> {
+         // Note: we should split props.style on the inner and outer props
+         // however, the ScrollView still needs the baseStyle to be scrollable
+         const {outer, inner} = splitLayoutProps(flattenStyle(props.style));
++        let inverted;
++        if (inner.scaleY) {
++          inverted = {scaleY: -1};
++          delete inner['scaleY']
++        }
++
+         return React.cloneElement(
+           refreshControl,
+-          {style: [baseStyle, outer]},
++          {style: [baseStyle, outer, inverted]},
+           <ScrollViewClass
+             {...props}
+             style={[baseStyle, inner]}
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js b/node_modules/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
 index dffccc4..dc426c2 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -40,10 +61,10 @@ index 2249d54..cc303b3 100644
    horizontallyInverted: {
      transform: [{scaleX: -1}],
 diff --git a/node_modules/react-native/react.gradle b/node_modules/react-native/react.gradle
-index 5995ad5..dbae7e3 100644
+index dd34c98..4d74938 100644
 --- a/node_modules/react-native/react.gradle
 +++ b/node_modules/react-native/react.gradle
-@@ -157,7 +157,7 @@ afterEvaluate {
+@@ -151,7 +151,7 @@ afterEvaluate {
  
              // Set up dev mode
              def devEnabled = !(config."devDisabledIn${targetName}"
@@ -52,7 +73,7 @@ index 5995ad5..dbae7e3 100644
  
              def extraArgs = config.extraPackagerArgs ?: [];
  
-@@ -177,7 +177,7 @@ afterEvaluate {
+@@ -171,7 +171,7 @@ afterEvaluate {
                      def hermesFlags;
                      def hbcTempFile = file("${jsBundleFile}.hbc")
                      exec {
@@ -61,7 +82,7 @@ index 5995ad5..dbae7e3 100644
                              // Can't use ?: since that will also substitute valid empty lists
                              hermesFlags = config.hermesFlagsRelease
                              if (hermesFlags == null) hermesFlags = ["-O", "-output-source-map"]
-@@ -221,7 +221,7 @@ afterEvaluate {
+@@ -215,7 +215,7 @@ afterEvaluate {
                  ? config."bundleIn${targetName}"
                  : config."bundleIn${variant.buildType.name.capitalize()}" != null
                      ? config."bundleIn${variant.buildType.name.capitalize()}"
@@ -70,7 +91,7 @@ index 5995ad5..dbae7e3 100644
          }
  
          // Expose a minimal interface on the application variant and the task itself:
-@@ -318,7 +318,7 @@ afterEvaluate {
+@@ -312,7 +312,7 @@ afterEvaluate {
          // This should really be done by packaging all Hermes releated libs into
          // two separate HermesDebug and HermesRelease AARs, but until then we'll
          // kludge it by deleting the .so files out of the /transforms/ directory.


### PR DESCRIPTION
#### Summary
Brings back the pull to refresh functionality on channels and threads, and actually fetch the latest posts in the channel or the posts that belong to the thread depending on the screen the user is in.

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-36881

#### Release Note
```release-note
Added back pull to refresh
```

#### Test Note
on Android we should test, check and double check that there is no performance degradation while scrolling the post list.