### PR TITLE
MM-36880 Load other teams you can join when deleting cache

### DIFF
--- a/app/init/global_event_handler.js
+++ b/app/init/global_event_handler.js
@@ -18,6 +18,7 @@ import {resetMomentLocale} from '@i18n';
 import {setupPermanentSidebar} from '@init/device';
 import PushNotifications from '@init/push_notifications';
 import {setAppState, setServerVersion} from '@mm-redux/actions/general';
+import {getTeams} from '@mm-redux/actions/teams';
 import {autoUpdateTimezone} from '@mm-redux/actions/timezone';
 import {close as closeWebSocket} from '@actions/websocket';
 import {Client4} from '@client/rest';
@@ -213,6 +214,7 @@ class GlobalEventHandler {
 
         await dispatch(loadConfigAndLicense());
         await dispatch(loadMe(user));
+        dispatch(getTeams());
 
         const window = Dimensions.get('window');
         this.onOrientationChange({window});


### PR DESCRIPTION
#### Summary
Display the option for other teams you can join after deleting cache & data.

#### Ticket Link
Fixes: #5512
JIRA: https://mattermost.atlassian.net/browse/MM-36880

#### Release Note
```release-note
Fixed a bug where the option to join another team was not present after deleting cache & data
```