### PR TITLE
MM-35680 Detox/E2E: Add e2e for untrusted certificate prompt

### DIFF
--- a/detox/e2e/support/ui/component/alert.js
+++ b/detox/e2e/support/ui/component/alert.js
@@ -15,6 +15,7 @@ class Alert {
     leavePublicChannelTitle = isAndroid() ? element(by.text('Leave Public Channel')) : element(by.label('Leave Public Channel')).atIndex(0);
     messageLengthTitle = isAndroid() ? element(by.text('Message Length')) : element(by.label('Message Length')).atIndex(0);
     removeMembersTitle = isAndroid() ? element(by.text('Remove Members')) : element(by.label('Remove Members')).atIndex(0);
+    untrustedCertificateTitle = isAndroid() ? element(by.text('Untrusted Certificate')) : element(by.label('Untrusted Certificate')).atIndex(0);
 
     // alert buttons
     cancelButton = isAndroid() ? element(by.text('CANCEL')) : element(by.label('Cancel')).atIndex(1);

--- a/detox/e2e/test/signin_authentication/select_server.e2e.js
+++ b/detox/e2e/test/signin_authentication/select_server.e2e.js
@@ -7,6 +7,7 @@
 // - Use element testID when selecting an element. Create one if none.
 // *******************************************************************
 
+import {Alert} from '@support/ui/component';
 import {
     LoginScreen,
     SelectServerScreen,
@@ -85,5 +86,31 @@ describe('Select Server', () => {
 
         // * Verify that it goes into Login screen
         await LoginScreen.toBeVisible();
+    });
+
+    it('MM-T2348 should show untrusted certificate prompt when connecting to a server with invalid SSL or invalid host', async () => {
+        await SelectServerScreen.toBeVisible();
+
+        // # Attempt to connect to invalid SSL
+        const invalidSsl = 'expired.badssl.com';
+        await serverUrlInput.clearText();
+        await serverUrlInput.typeText(invalidSsl);
+        await connectButton.tap();
+
+        // * Verify untrusted certificate alert is displayed with invalid SSL
+        await expect(Alert.untrustedCertificateTitle).toBeVisible();
+        await expect(element(by.text(`The certificate from ${invalidSsl} is not trusted.\n\nPlease contact your System Administrator to resolve the certificate issues and allow connections to this server.`))).toBeVisible();
+        await Alert.okButton.tap();
+
+        // # Attempt to connect to invalid host
+        const invalidHost = 'wrong.host.badssl.com';
+        await serverUrlInput.clearText();
+        await serverUrlInput.typeText(invalidHost);
+        await connectButton.tap();
+
+        // * Verify untrusted certificate alert is displayed with invalid host
+        await expect(Alert.untrustedCertificateTitle).toBeVisible();
+        await expect(element(by.text(`The certificate from ${invalidHost} is not trusted.\n\nPlease contact your System Administrator to resolve the certificate issues and allow connections to this server.`))).toBeVisible();
+        await Alert.okButton.tap();
     });
 });


### PR DESCRIPTION
#### Summary
- Added test for MM-T2348 in
    - `detox/e2e/test/signin_authentication/select_server.e2e.js`

#### Ticket Link
JIRA tickets:
- https://mattermost.atlassian.net/browse/MM-35680

Zephyr cases:
- [MM-T2348](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T2348)

#### Screenshots
![Screen Shot 2021-07-12 at 8 33 05 AM](https://user-images.githubusercontent.com/487991/125338528-292ba580-e305-11eb-9793-5785c6eb912c.png)

#### Release Note
```release-note
NONE
```
