### PR TITLE
[MM-29217] Remove Posts.ParentId

### DIFF
--- a/app/actions/views/command.ts
+++ b/app/actions/views/command.ts
@@ -26,7 +26,6 @@ export function executeCommand(message: string, channelId: string, rootId: strin
             channel_id: channelId,
             team_id: teamId,
             root_id: rootId,
-            parent_id: rootId,
         };
 
         let msg = message;

--- a/app/actions/views/post.js
+++ b/app/actions/views/post.js
@@ -40,7 +40,6 @@ export function sendEphemeralPost(message, channelId = '', parentId = '', userId
             create_at: timestamp,
             update_at: timestamp,
             root_id: parentId,
-            parent_id: parentId,
             props: {},
         };
 
@@ -62,7 +61,6 @@ export function sendAddToChannelEphemeralPost(user, addedUsername, message, chan
             create_at: timestamp,
             update_at: timestamp,
             root_id: postRootId,
-            parent_id: postRootId,
             props: {
                 username: user.username,
                 addedUsername,

--- a/app/actions/websocket/posts.test.js
+++ b/app/actions/websocket/posts.test.js
@@ -43,7 +43,7 @@ describe('Websocket Post Events', () => {
     it('Websocket Handle New Post if post does not exist', async () => {
         PostSelectors.getPost = jest.fn();
         const channelId = TestHelper.basicChannel.id;
-        const message = JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2});
+        const message = JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2});
 
         nock(Client4.getBaseRoute()).
             post('/users/ids').
@@ -76,7 +76,7 @@ describe('Websocket Post Events', () => {
         const emit = jest.spyOn(EventEmitter, 'emit');
         const currentChannelId = TestHelper.generateId();
         const otherChannelId = TestHelper.generateId();
-        const messageFor = (channelId) => ({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2});
+        const messageFor = (channelId) => ({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2});
 
         await store.dispatch(ChannelActions.selectChannel(currentChannelId));
         await TestHelper.wait(100);
@@ -126,7 +126,7 @@ describe('Websocket Post Events', () => {
                 channel_display_name: TestHelper.basicChannel.display_name,
                 channel_name: TestHelper.basicChannel.name,
                 channel_type: 'O',
-                post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${userId}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`,
+                post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${userId}", "channel_id": "${channelId}", "root_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`,
                 sender_name: TestHelper.basicUser.username,
                 team_id: TestHelper.basicTeam.id,
             },
@@ -147,7 +147,7 @@ describe('Websocket Post Events', () => {
 
     it('Websocket Handle Post Edited', async () => {
         const post = {id: '71k8gz5ompbpfkrzaxzodffj8w'};
-        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_EDITED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1585236976007,"edit_at": 1585236976007,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${TestHelper.basicChannel.id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test (edited)","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 2}));
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_EDITED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1585236976007,"edit_at": 1585236976007,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${TestHelper.basicChannel.id}","root_id": "","original_id": "","message": "Unit Test (edited)","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 2}));
 
         await TestHelper.wait(300);
 
@@ -163,7 +163,7 @@ describe('Websocket Post Events', () => {
 
         post.id = '71k8gz5ompbpfkrzaxzodffj8w';
         store.dispatch(PostActions.receivedPost(post));
-        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_DELETED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${post.channel_id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 7}));
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_DELETED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${post.channel_id}","root_id": "","original_id": "","message": "Unit Test","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 7}));
 
         const entities = store.getState().entities;
         const {posts} = entities.posts;

--- a/app/components/autocomplete/slash_suggestion/slash_suggestion.tsx
+++ b/app/components/autocomplete/slash_suggestion/slash_suggestion.tsx
@@ -118,7 +118,7 @@ export default class SlashSuggestion extends PureComponent<Props, State> {
                 const args = {
                     channel_id: prevProps.channelId,
                     team_id: prevProps.currentTeamId,
-                    ...(prevProps.rootId && {root_id: prevProps.rootId, parent_id: prevProps.rootId}),
+                    ...(prevProps.rootId && {root_id: prevProps.rootId}),
                 };
                 this.props.actions.getCommandAutocompleteSuggestions(nextValue, nextTeamId, args);
             } else {

--- a/app/components/post_draft/draft_input/draft_input.js
+++ b/app/components/post_draft/draft_input/draft_input.js
@@ -161,7 +161,6 @@ export default class DraftInput extends PureComponent {
             user_id: currentUserId,
             channel_id: channelId,
             root_id: rootId,
-            parent_id: rootId,
             message: value,
         };
 

--- a/app/mm-redux/types/integrations.ts
+++ b/app/mm-redux/types/integrations.ts
@@ -131,5 +131,4 @@ export type CommandArgs = {
     channel_id: string;
     team_id: string;
     root_id?: string;
-    parent_id?: string;
 }

--- a/app/mm-redux/types/posts.ts
+++ b/app/mm-redux/types/posts.ts
@@ -59,7 +59,6 @@ export type Post = {
     user_id: string;
     channel_id: string;
     root_id: string;
-    parent_id: string;
     original_id: string;
     message: string;
     type: PostType;

--- a/detox/e2e/plugins/post_message_as.js
+++ b/detox/e2e/plugins/post_message_as.js
@@ -33,7 +33,6 @@ module.exports = async ({sender, message, channelId, rootId, createAt = 0, baseU
                 message,
                 type: '',
                 create_at: createAt,
-                parent_id: rootId,
                 root_id: rootId,
             },
         });

--- a/detox/e2e/support/server_api/post.js
+++ b/detox/e2e/support/server_api/post.js
@@ -31,7 +31,6 @@ export const apiCreatePost = async ({channelId, message, rootId, props = {}, cre
         const payload = {
             channel_id: channelId,
             message,
-            parent_id: rootId,
             root_id: rootId,
             props,
             create_at: createAt,

--- a/detox/webhook_server.js
+++ b/detox/webhook_server.js
@@ -103,7 +103,6 @@ async function postOAuthMessage(req, res) {
                 message,
                 type: '',
                 create_at: createAt,
-                parent_id: rootId,
                 root_id: rootId,
             },
         });


### PR DESCRIPTION
#### Summary

Removing the deprecated `Posts.ParentId`.

Not entirely sure if this can be merged prior to 6.0 release. It should be okay given we've been using rootId for a long time but we can always wait to be on the safe side. The `release-6.0` branch doesn't seem to exist yet so pointing to master for now.

#### Ticket

https://mattermost.atlassian.net/browse/MM-29217

#### Release Notes

```release-note
Removed deprecated Posts.ParentId in favor of the semantically equivalent Posts.RootId
```

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/17923
https://github.com/mattermost/enterprise/pull/1019
https://github.com/mattermost/mattermost-webapp/pull/8401
https://github.com/mattermost/mattermost-api-reference/pull/648
