### PR TITLE
MM-37232 Fix crash on markdown emoji with hardbreak parser

### DIFF
--- a/app/components/markdown/markdown_emoji/__snapshots__/markdown_emoji.test.js.snap
+++ b/app/components/markdown/markdown_emoji/__snapshots__/markdown_emoji.test.js.snap
@@ -31,3 +31,164 @@ exports[`MarkdownEmoji should match snapshot 1`] = `
   </Unknown>
 </Unknown>
 `;
+
+exports[`MarkdownEmoji should render with hardbreaks 1`] = `
+<Unknown
+  context={Array []}
+  first={true}
+  last={true}
+  literal={null}
+  nodeKey="22"
+>
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    emojiName="fire"
+    literal=":fire:"
+    nodeKey="4"
+  >
+    <Unknown
+      context={
+        Array [
+          "paragraph",
+          "emoji",
+        ]
+      }
+      literal=":fire:"
+      nodeKey="3"
+    />
+  </Unknown>
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    literal=" "
+    nodeKey="5"
+  />
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    emojiName="fire"
+    literal=":fire:"
+    nodeKey="8"
+  >
+    <Unknown
+      context={
+        Array [
+          "paragraph",
+          "emoji",
+        ]
+      }
+      literal=":fire:"
+      nodeKey="7"
+    />
+  </Unknown>
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    literal=""
+    nodeKey="9"
+  />
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    literal={null}
+    nodeKey="10"
+  />
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    emojiName="fire"
+    literal=":fire:"
+    nodeKey="13"
+  >
+    <Unknown
+      context={
+        Array [
+          "paragraph",
+          "emoji",
+        ]
+      }
+      literal=":fire:"
+      nodeKey="12"
+    />
+  </Unknown>
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    literal=" "
+    nodeKey="14"
+  />
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    emojiName="fire"
+    literal=":fire:"
+    nodeKey="17"
+  >
+    <Unknown
+      context={
+        Array [
+          "paragraph",
+          "emoji",
+        ]
+      }
+      literal=":fire:"
+      nodeKey="16"
+    />
+  </Unknown>
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    literal=" "
+    nodeKey="18"
+  />
+  <Unknown
+    context={
+      Array [
+        "paragraph",
+      ]
+    }
+    emojiName="fire"
+    literal=":fire:"
+    nodeKey="21"
+  >
+    <Unknown
+      context={
+        Array [
+          "paragraph",
+          "emoji",
+        ]
+      }
+      literal=":fire:"
+      nodeKey="20"
+    />
+  </Unknown>
+</Unknown>
+`;

--- a/app/components/markdown/markdown_emoji/markdown_emoji.js
+++ b/app/components/markdown/markdown_emoji/markdown_emoji.js
@@ -39,6 +39,7 @@ export default class MarkdownEmoji extends PureComponent {
                 paragraph: this.renderParagraph,
                 document: this.renderParagraph,
                 text: this.renderText,
+                hardbreak: this.renderNewLine,
             },
         });
     };
@@ -73,9 +74,13 @@ export default class MarkdownEmoji extends PureComponent {
 
     renderText = ({context, literal}) => {
         const style = this.computeTextStyle(this.props.baseTextStyle, context);
-
         return <Text style={style}>{literal}</Text>;
     };
+
+    renderNewLine = ({context}) => {
+        const style = this.computeTextStyle(this.props.baseTextStyle, context);
+        return <Text style={style}>{'\n'}</Text>;
+    }
 
     renderEditedIndicator = ({context}) => {
         let spacer = '';
@@ -101,7 +106,7 @@ export default class MarkdownEmoji extends PureComponent {
     };
 
     render() {
-        const ast = this.parser.parse(this.props.value);
+        const ast = this.parser.parse(this.props.value.replace(/\n*$/, ''));
 
         if (this.props.isEdited) {
             const editIndicatorNode = new Node('edited_indicator');

--- a/app/components/markdown/markdown_emoji/markdown_emoji.test.js
+++ b/app/components/markdown/markdown_emoji/markdown_emoji.test.js
@@ -24,4 +24,17 @@ describe('MarkdownEmoji', () => {
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    test('should render with hardbreaks', () => {
+        const wrapper = shallow(
+            <MarkdownEmoji
+                {...baseProps}
+                value={`:fire: :fire:       
+               :fire: :fire: :fire:
+               `}
+            />,
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Summary
The markdown emoji component did not had a function to handle a hard break so a post like the one described here #5545 caused a crash.

#### Ticket Link
Fixes: #5545
JIRA: https://mattermost.atlassian.net/browse/MM-37232

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Release Note
```release-note
Fixed a crash when a message with only emoji's includes a hard break
```