### PR TITLE
Fix interactive message submit button by adding a default when none i…

### DIFF
--- a/app/components/interactive_dialog_controller/interactive_dialog_controller.js
+++ b/app/components/interactive_dialog_controller/interactive_dialog_controller.js
@@ -75,6 +75,8 @@ export default class InteractiveDialogController extends PureComponent {
     }
 
     showInteractiveDialogScreen = (dialog) => {
+        const {formatMessage} = this.context.intl;
+
         const options = {
             topBar: {
                 leftButtons: [{
@@ -84,7 +86,7 @@ export default class InteractiveDialogController extends PureComponent {
                 rightButtons: [{
                     id: 'submit-dialog',
                     showAsAction: 'always',
-                    text: dialog.submit_label,
+                    text: dialog.submit_label || formatMessage({id: 'mobile.interactive_dialog.defaultSubmit', defaultMessage: 'Submit'}),
                 }],
             },
         };

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -332,6 +332,7 @@
   "mobile.gallery.title": "{index} of {total}",
   "mobile.general.error.title": "Error",
   "mobile.help.title": "Help",
+  "mobile.interactive_dialog.defaultSubmit": "Submit",
   "mobile.intro_messages.default_message": "This is the first channel teammates see when they sign up - use it for posting updates everyone needs to know.",
   "mobile.intro_messages.default_welcome": "Welcome to {name}!",
   "mobile.intro_messages.DM": "This is the start of your direct message history with {teammate}. Direct messages and files shared here are not shown to people outside this area.",


### PR DESCRIPTION
…s defined

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
