### PR TITLE
MM-33891 Add em dash support for commands

### DIFF
--- a/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
+++ b/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
@@ -263,6 +263,15 @@ export class ParsedCommand {
                     this.i++;
                     break;
                 }
+                case '—': {
+                    // Em dash, introduced when two '-' are set in iOS. Will be considered as such.
+                    this.state = ParseState.Flag;
+                    this.i++;
+                    this.incomplete = '';
+                    this.incompleteStart = this.i;
+                    flagEqualsUsed = false;
+                    break;
+                }
                 default: {
                     // Positional parameter.
                     this.position++;
@@ -1093,9 +1102,13 @@ export class AppCommandParser {
         }
 
         // There have been 0 to 2 dashes in the command prior to this call, adjust.
+        const prevCharIndex = parsed.incompleteStart - 1;
         let prefix = '--';
-        for (let i = parsed.incompleteStart - 1; i > 0 && i >= parsed.incompleteStart - 2 && parsed.command[i] === '-'; i--) {
+        for (let i = prevCharIndex; i > 0 && i >= parsed.incompleteStart - 2 && parsed.command[i] === '-'; i--) {
             prefix = prefix.substring(1);
+        }
+        if (prevCharIndex > 0 && parsed.command[prevCharIndex] === '—') {
+            prefix = '';
         }
 
         const applicable = parsed.form.fields.filter((field) => field.label && field.label.toLowerCase().startsWith(parsed.incomplete.toLowerCase()) && !parsed.values[field.name]);


### PR DESCRIPTION
#### Summary
If an em dash is added to a command by introducing to dashes on iOS, it is considered as two dashes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33891

#### Release Note
```release-note
NONE
```
