### PR TITLE
Quick fix on failed unit test with custom expiry status

### DIFF
--- a/app/components/custom_status/custom_status_expiry.test.tsx
+++ b/app/components/custom_status/custom_status_expiry.test.tsx
@@ -5,11 +5,15 @@ import React from 'react';
 import moment from 'moment-timezone';
 
 import Preferences from '@mm-redux/constants/preferences';
-import * as PreferenceSelectors from '@mm-redux/selectors/entities/preferences';
 import {renderWithReduxIntl} from 'test/testing_library';
 import CustomStatusExpiry from './custom_status_expiry';
 
 jest.mock('@mm-redux/selectors/entities/preferences');
+
+jest.mock('@mm-redux/selectors/entities/preferences', () => ({
+    getBool: jest.fn().mockReturnValue(false),
+    isCollapsedThreadsEnabled: jest.fn(),
+}));
 
 describe('components/custom_status/custom_status_expiry', () => {
     const date = moment().endOf('day');
@@ -19,7 +23,6 @@ describe('components/custom_status/custom_status_expiry', () => {
         time: date.toDate(),
     };
 
-    (PreferenceSelectors.getBool as jest.Mock).mockReturnValue(false);
     it('should match snapshot', () => {
         const wrapper = renderWithReduxIntl(
             <CustomStatusExpiry


### PR DESCRIPTION
#### Summary
Quick fix on failed unit test with custom expiry status

https://github.com/mattermost/mattermost-mobile/pull/5434#issuecomment-885200233

#### Release Note
```release-note
NONE
```
