### PR TITLE
Custom status warning issue fix

### DIFF
--- a/app/screens/channel_info/index.js
+++ b/app/screens/channel_info/index.js
@@ -46,7 +46,7 @@ function makeMapStateToProps() {
                 currentChannelGuestCount = 1;
             }
             customStatusEnabled = isCustomStatusEnabled(state);
-            customStatus = customStatusEnabled && getCustomStatus(state, teammateId);
+            customStatus = customStatusEnabled ? getCustomStatus(state, teammateId) : undefined;
             customStatusExpired = customStatusEnabled ? isCustomStatusExpired(state, customStatus) : true;
             customStatusExpirySupported = customStatusEnabled ? isCustomStatusExpirySupported(state) : false;
         }


### PR DESCRIPTION
#### Summary

Fixed the custom status invalid prop warning issue in the ChannelInfo screen

#### Ticket Link

Conversation link - https://community.mattermost.com/core/pl/33szr5jid3r3mre1hgo4r55snc

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information

This PR was tested on: 
- iPhone 12 Simulator - iOS 14.4
- Android Emulator - Pixel_3a_API_30_x86 - Android 10

#### Release Note

```release-note
Fixed the custom status invalid prop warning issue in the ChannelInfo screen
```
