### PR TITLE
MM-37609 Specify screenId for files uploads handler

### DIFF
--- a/app/components/pasteable_text_input/__snapshots__/index.test.js.snap
+++ b/app/components/pasteable_text_input/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ exports[`PasteableTextInput should render pasteable text input 1`] = `
   allowFontScaling={true}
   onPaste={[Function]}
   rejectResponderTermination={true}
+  screenId="Channel"
   underlineColorAndroid="transparent"
 >
   My Text

--- a/app/components/pasteable_text_input/index.js
+++ b/app/components/pasteable_text_input/index.js
@@ -15,6 +15,7 @@ export class PasteableTextInput extends React.PureComponent {
     static propTypes = {
         ...TextInput.PropTypes,
         forwardRef: PropTypes.any,
+        screenId: PropTypes.string.isRequired,
     }
 
     componentDidMount() {
@@ -49,7 +50,7 @@ export class PasteableTextInput extends React.PureComponent {
             data = event;
         }
 
-        EventEmitter.emit(PASTE_FILES, error, data);
+        EventEmitter.emit(PASTE_FILES, error, data, this.props.screenId);
     }
 
     render() {

--- a/app/components/pasteable_text_input/index.test.js
+++ b/app/components/pasteable_text_input/index.test.js
@@ -18,7 +18,10 @@ describe('PasteableTextInput', () => {
         const onPaste = jest.fn();
         const text = 'My Text';
         const component = shallow(
-            <PasteableTextInput onPaste={onPaste}>{text}</PasteableTextInput>,
+            <PasteableTextInput
+                onPaste={onPaste}
+                screenId='Channel'
+            >{text}</PasteableTextInput>,
         );
         expect(component).toMatchSnapshot();
     });
@@ -27,17 +30,17 @@ describe('PasteableTextInput', () => {
         const event = {someData: 'data'};
         const text = 'My Text';
         shallow(
-            <PasteableTextInput>{text}</PasteableTextInput>,
+            <PasteableTextInput screenId='Channel'>{text}</PasteableTextInput>,
         );
         nativeEventEmitter.emit('onPaste', event);
-        expect(emit).toHaveBeenCalledWith(PASTE_FILES, null, event);
+        expect(emit).toHaveBeenCalledWith(PASTE_FILES, null, event, 'Channel');
     });
 
     test('should remove onPaste listener when unmount', () => {
         const mockRemove = jest.fn();
         const text = 'My Text';
         const component = shallow(
-            <PasteableTextInput>{text}</PasteableTextInput>,
+            <PasteableTextInput screenId='Channel'>{text}</PasteableTextInput>,
         );
 
         component.instance().subscription.remove = mockRemove;
@@ -46,9 +49,9 @@ describe('PasteableTextInput', () => {
     });
 
     test('should emit PASTE_FILES event only for last subscription', () => {
-        const component1 = shallow(<PasteableTextInput/>);
+        const component1 = shallow(<PasteableTextInput screenId='Channel'/>);
         const instance1 = component1.instance();
-        const component2 = shallow(<PasteableTextInput/>);
+        const component2 = shallow(<PasteableTextInput screenId='Thread'/>);
         const instance2 = component2.instance();
 
         instance1.onPaste();

--- a/app/components/post_draft/__snapshots__/post_draft.test.js.snap
+++ b/app/components/post_draft/__snapshots__/post_draft.test.js.snap
@@ -293,6 +293,7 @@ exports[`PostDraft Should render the DraftInput 1`] = `
           placeholder="Write to "
           placeholderTextColor="rgba(61,60,64,0.5)"
           rejectResponderTermination={true}
+          screenId="NavigationScreen1"
           style={
             Object {
               "color": "#3d3c40",

--- a/app/components/post_draft/draft_input/draft_input.js
+++ b/app/components/post_draft/draft_input/draft_input.js
@@ -484,6 +484,7 @@ export default class DraftInput extends PureComponent {
                         <View style={style.actionsContainer}>
                             <QuickActions
                                 testID={quickActionsTestID}
+                                screenId={screenId}
                                 ref={this.quickActions}
                                 fileCount={files.length}
                                 inputEventType={valueEvent}

--- a/app/components/post_draft/post_input/__snapshots__/post_input.test.js.snap
+++ b/app/components/post_draft/post_input/__snapshots__/post_input.test.js.snap
@@ -13,6 +13,7 @@ exports[`PostInput should match, full snapshot 1`] = `
   onSelectionChange={[Function]}
   placeholder="Write to Test Channel"
   placeholderTextColor="rgba(61,60,64,0.5)"
+  screenId="Channel"
   style={
     Object {
       "color": "#3d3c40",

--- a/app/components/post_draft/post_input/post_input.js
+++ b/app/components/post_draft/post_input/post_input.js
@@ -39,6 +39,7 @@ export default class PostInput extends PureComponent {
         isLandscape: PropTypes.bool,
         maxMessageLength: PropTypes.number,
         rootId: PropTypes.string,
+        screenId: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
         updateInitialValue: PropTypes.func.isRequired,
         userTyping: PropTypes.func.isRequired,
@@ -273,7 +274,7 @@ export default class PostInput extends PureComponent {
 
     render() {
         const {formatMessage} = this.context.intl;
-        const {testID, channelDisplayName, isLandscape, theme} = this.props;
+        const {testID, channelDisplayName, screenId, isLandscape, theme} = this.props;
         const style = getStyleSheet(theme);
         const placeholder = this.getPlaceHolder();
         let maxHeight = DEVICE.POST_INPUT_MAX_HEIGHT;
@@ -300,6 +301,7 @@ export default class PostInput extends PureComponent {
                 textContentType='none'
                 autoCompleteType='off'
                 keyboardAppearance={getKeyboardAppearanceFromTheme(theme)}
+                screenId={screenId}
             />
         );
     }

--- a/app/components/post_draft/post_input/post_input.test.js
+++ b/app/components/post_draft/post_input/post_input.test.js
@@ -25,6 +25,7 @@ describe('PostInput', () => {
         onSend: jest.fn(),
         readonly: false,
         rootId: '',
+        screenId: 'Channel',
         theme: Preferences.THEMES.default,
         updateInitialValue: jest.fn(),
         userTyping: jest.fn(),

--- a/app/components/post_draft/quick_actions/quick_actions.js
+++ b/app/components/post_draft/quick_actions/quick_actions.js
@@ -16,6 +16,7 @@ import InputAction from './input_quick_action';
 export default class QuickActions extends PureComponent {
     static propTypes = {
         testID: PropTypes.string,
+        screenId: PropTypes.string.isRequired,
         canUploadFiles: PropTypes.bool,
         fileCount: PropTypes.number,
         inputEventType: PropTypes.string.isRequired,
@@ -59,8 +60,8 @@ export default class QuickActions extends PureComponent {
         this.props.onTextChange(newValue);
     }
 
-    handleUploadFiles(files) {
-        EventEmitter.emit(UPLOAD_FILES, files);
+    handleUploadFiles = (files) => {
+        EventEmitter.emit(UPLOAD_FILES, files, this.props.screenId);
     }
 
     render() {

--- a/app/components/post_draft/quick_actions/quick_actions.test.js
+++ b/app/components/post_draft/quick_actions/quick_actions.test.js
@@ -16,6 +16,7 @@ describe('QuickActions', () => {
         fileCount: 1,
         inputEventType: 'input-event-type',
         maxFileSize: 10,
+        screenId: 'Channel',
         theme: Preferences.THEMES.default,
     };
 

--- a/app/components/post_draft/uploads/uploads.js
+++ b/app/components/post_draft/uploads/uploads.js
@@ -19,7 +19,6 @@ import FormattedText from '@components/formatted_text';
 import {MAX_FILE_COUNT, MAX_FILE_COUNT_WARNING, UPLOAD_FILES, PASTE_FILES} from '@constants/post_draft';
 import EventEmitter from '@mm-redux/utils/event_emitter';
 import {getFormattedFileSize} from '@mm-redux/utils/file_utils';
-import EphemeralStore from '@store/ephemeral_store';
 import {openGalleryAtIndex} from '@utils/gallery';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 
@@ -159,8 +158,8 @@ export default class Uploads extends PureComponent {
         }
     };
 
-    handlePasteFiles = (error, files) => {
-        if (this.props.screenId !== EphemeralStore.getNavigationTopComponentId()) {
+    handlePasteFiles = (error, files, screenId) => {
+        if (screenId !== this.props.screenId) {
             return;
         }
 
@@ -188,7 +187,7 @@ export default class Uploads extends PureComponent {
             return;
         }
 
-        this.handleUploadFiles(files);
+        this.handleUploadFiles(files, screenId);
     };
 
     handleUploadDisabled = () => {
@@ -206,8 +205,8 @@ export default class Uploads extends PureComponent {
         }
     };
 
-    handleUploadFiles = async (files) => {
-        if (this.props.screenId !== EphemeralStore.getNavigationTopComponentId()) {
+    handleUploadFiles = async (files, screenId) => {
+        if (screenId !== this.props.screenId) {
             return;
         }
 

--- a/app/components/post_draft/uploads/uploads.test.js
+++ b/app/components/post_draft/uploads/uploads.test.js
@@ -5,7 +5,6 @@ import {shallow} from 'enzyme';
 import React from 'react';
 
 import Preferences from '@mm-redux/constants/preferences';
-import EphemeralStore from '@store/ephemeral_store';
 
 import Uploads from './uploads';
 
@@ -18,12 +17,12 @@ describe('Uploads', () => {
         handleRemoveLastFile: jest.fn(),
         initUploadFiles: jest.fn(),
         maxFileSize: 100,
+        screenId: 'Channel',
         theme: Preferences.THEMES.default,
     };
 
     test('handleUploadFiles should return early if screen is not the top screen', async () => {
         const topScreenId = 'top-screen';
-        EphemeralStore.getNavigationTopComponentId = jest.fn(() => (topScreenId));
 
         const props = {
             ...baseProps,
@@ -42,7 +41,6 @@ describe('Uploads', () => {
 
     test('handlePasteFiles should display an error if uploads are disabled', () => {
         const topScreenId = 'top-screen';
-        EphemeralStore.getNavigationTopComponentId = jest.fn(() => (topScreenId));
 
         const props = {
             ...baseProps,
@@ -56,7 +54,7 @@ describe('Uploads', () => {
         instance.showPasteFilesErrorDialog = jest.fn();
         instance.handleUploadDisabled = jest.fn();
 
-        instance.handlePasteFiles(undefined, []);
+        instance.handlePasteFiles(undefined, [], topScreenId);
         expect(instance.showPasteFilesErrorDialog).not.toHaveBeenCalled();
         expect(instance.handleUploadDisabled).toHaveBeenCalled();
     });


### PR DESCRIPTION
#### Summary
When uploading files by browsing files and images or when capturing a photo/video send the screenId that matches the action so that the file is attached to the right post. This also applies to pasting files.

Changes applies to both Android and iOS

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37609

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Release Note
```release-note
Fixed attaching files to the correct post
```