### PR TITLE
MM-37660 Fix keep mention for channel A when opening a push notification on channel B

### DIFF
--- a/app/components/network_indicator/network.tsx
+++ b/app/components/network_indicator/network.tsx
@@ -185,16 +185,20 @@ const NetworkIndicator = ({
 
         return () => {
             AppState.removeEventListener('change', handleAppStateChange);
+            if (clearNotificationTimeout.current && AppState.currentState !== 'active') {
+                clearTimeout(clearNotificationTimeout.current);
+            }
         };
     }, [netinfo.isInternetReachable, channelId]);
 
     useEffect(() => {
-        clearNotificationTimeout.current = setTimeout(clearNotifications, 150);
+        if (channelId) {
+            clearNotificationTimeout.current = setTimeout(clearNotifications, 1500);
+        }
 
         return () => {
-            if (clearNotificationTimeout.current) {
+            if (clearNotificationTimeout.current && channelId) {
                 clearTimeout(clearNotificationTimeout.current);
-                clearNotificationTimeout.current = undefined;
             }
         };
     }, [channelId]);

--- a/app/components/network_indicator/network.tsx
+++ b/app/components/network_indicator/network.tsx
@@ -174,10 +174,10 @@ const NetworkIndicator = ({
             handleWebSocket(active);
 
             if (active) {
-                // Clear the notifications for the current channel after one second
+                // Clear the notifications for the current channel after two seconds
                 // this is done so we can cancel it in case the app is brought to the
                 // foreground by tapping a notification from another channel
-                clearNotificationTimeout.current = setTimeout(clearNotifications, 1000);
+                clearNotificationTimeout.current = setTimeout(clearNotifications, 2000);
             }
         });
 
@@ -186,13 +186,17 @@ const NetworkIndicator = ({
         return () => {
             AppState.removeEventListener('change', handleAppStateChange);
         };
-    }, [netinfo.isInternetReachable]);
+    }, [netinfo.isInternetReachable, channelId]);
 
     useEffect(() => {
-        if (clearNotificationTimeout.current) {
-            clearTimeout(clearNotificationTimeout.current);
-            clearNotificationTimeout.current = undefined;
-        }
+        clearNotificationTimeout.current = setTimeout(clearNotifications, 150);
+
+        return () => {
+            if (clearNotificationTimeout.current) {
+                clearTimeout(clearNotificationTimeout.current);
+                clearNotificationTimeout.current = undefined;
+            }
+        };
     }, [channelId]);
 
     useEffect(() => {

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -100,18 +100,23 @@ class PushNotifications {
                 Notifications.ios.removeDeliveredNotifications(ids);
             }
 
-            if (Store.redux) {
-                const totalMentions = getBadgeCount(Store.redux.getState());
-                if (totalMentions > -1) {
-                    // replaces the badge count based on the redux store.
-                    badgeCount = totalMentions;
-                }
-            }
+            this.setBadgeCountByMentions(badgeCount);
+        }
+    }
 
-            if (Platform.OS === 'ios') {
-                badgeCount = badgeCount <= 0 ? 0 : badgeCount;
-                Notifications.ios.setBadgeCount(badgeCount);
+    setBadgeCountByMentions = (initialBadge = 0) => {
+        let badgeCount = initialBadge;
+        if (Store.redux) {
+            const totalMentions = getBadgeCount(Store.redux.getState());
+            if (totalMentions > -1) {
+                // replaces the badge count based on the redux store.
+                badgeCount = totalMentions;
             }
+        }
+
+        if (Platform.OS === 'ios') {
+            badgeCount = badgeCount <= 0 ? 0 : badgeCount;
+            Notifications.ios.setBadgeCount(badgeCount);
         }
     }
 
@@ -167,6 +172,7 @@ class PushNotifications {
 
                     if (foreground) {
                         EventEmitter.emit(ViewTypes.NOTIFICATION_IN_APP, notification);
+                        this.setBadgeCountByMentions();
                     } else if (userInteraction && !payload.userInfo?.local) {
                         dispatch(loadFromPushNotification(notification));
                         const componentId = EphemeralStore.getNavigationTopComponentId();

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -149,13 +149,13 @@ class PushNotifications {
             const interval = setInterval(() => {
                 if (Store.redux) {
                     clearInterval(interval);
-                    this.handleNotification(notification);
+                    this.handleNotification(notification, true);
                 }
             }, 500);
         }
     }
 
-    handleNotification = (notification: NotificationWithData) => {
+    handleNotification = (notification: NotificationWithData, isInitialNotification = false) => {
         const {payload, foreground, userInteraction} = notification;
 
         if (Store.redux && payload) {
@@ -174,7 +174,7 @@ class PushNotifications {
                         EventEmitter.emit(ViewTypes.NOTIFICATION_IN_APP, notification);
                         this.setBadgeCountByMentions();
                     } else if (userInteraction && !payload.userInfo?.local) {
-                        dispatch(loadFromPushNotification(notification));
+                        dispatch(loadFromPushNotification(notification, isInitialNotification));
                         const componentId = EphemeralStore.getNavigationTopComponentId();
                         if (componentId) {
                             EventEmitter.emit(NavigationTypes.CLOSE_MAIN_SIDEBAR);

--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -9,7 +9,6 @@ import {Alert, Animated, Keyboard, StyleSheet} from 'react-native';
 import {showModal, showModalOverCurrentContext} from '@actions/navigation';
 import CompassIcon from '@components/compass_icon';
 import {TYPING_VISIBLE} from '@constants/post_draft';
-import PushNotifications from '@init/push_notifications';
 import {General} from '@mm-redux/constants';
 import EventEmitter from '@mm-redux/utils/event_emitter';
 import EphemeralStore from '@store/ephemeral_store';
@@ -87,7 +86,6 @@ export default class ChannelBase extends PureComponent {
         }
 
         if (currentChannelId) {
-            this.clearChannelNotifications();
             requestAnimationFrame(() => {
                 actions.getChannelStats(currentChannelId);
             });
@@ -125,8 +123,6 @@ export default class ChannelBase extends PureComponent {
         }
 
         if (this.props.currentChannelId && this.props.currentChannelId !== prevProps.currentChannelId) {
-            this.clearChannelNotifications();
-
             requestAnimationFrame(() => {
                 this.props.actions.getChannelStats(this.props.currentChannelId);
             });
@@ -137,13 +133,6 @@ export default class ChannelBase extends PureComponent {
         EventEmitter.off('leave_team', this.handleLeaveTeam);
         EventEmitter.off(TYPING_VISIBLE, this.runTypingAnimations);
         EventEmitter.off(General.REMOVED_FROM_CHANNEL, this.handleRemovedFromChannel);
-    }
-
-    clearChannelNotifications = () => {
-        const clearNotificationsTimeout = setTimeout(() => {
-            clearTimeout(clearNotificationsTimeout);
-            PushNotifications.clearChannelNotifications(this.props.currentChannelId);
-        }, 1000);
     }
 
     registerTypingAnimation = (animation) => {


### PR DESCRIPTION
#### Summary
When the app was sitting in the background and a user tapped on a push notification (which brings the app to the foreground) there were three issues:
1. A race condition that did not cancel the previous setTimeout
2. Two sources from where we called the function to clear the channel notifications
3. The channel id from which we needed to cancel the notifications was not being updated properly thus it used the last one set (first current channel Id)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37660

#### Release Note
```release-note
Fixed a race condition when bringing the app to the foreground by tapping in a notification that belongs to a channel other than the current channel that cause the current channel to missed any mentions if it had any.
```

Additional note: We need to bring this fix to the Gekidou branch.