### PR TITLE
MM-37674 Fix android push notification crash

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotificationHelper.java
@@ -80,7 +80,10 @@ public class CustomPushNotificationHelper {
                     .setName(senderName);
 
             try {
-                sender.setIcon(IconCompat.createWithBitmap(Objects.requireNonNull(userAvatar(context, senderId))));
+                Bitmap avatar = userAvatar(context, senderId);
+                if (avatar != null) {
+                    sender.setIcon(IconCompat.createWithBitmap(avatar));
+                }
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -242,7 +245,10 @@ public class CustomPushNotificationHelper {
                     .setName("Me");
 
             try {
-                sender.setIcon(IconCompat.createWithBitmap(Objects.requireNonNull(userAvatar(context, "me"))));
+                Bitmap avatar = userAvatar(context, "me");
+                if (avatar != null) {
+                    sender.setIcon(IconCompat.createWithBitmap(avatar));
+                }
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -393,7 +399,10 @@ public class CustomPushNotificationHelper {
         if (channelName.equals(senderName)) {
             try {
                 String senderId = bundle.getString("sender_id");
-                notification.setLargeIcon(userAvatar(context, senderId));
+                Bitmap avatar = userAvatar(context, senderId);
+                if (avatar != null) {
+                    notification.setLargeIcon(avatar);
+                }
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
#### Summary
At times the senderId or current user avatar will fail to fetch and the Android push notification crashes, this PR checks for the existence instead of assuming the avatar is there to prevent the crash.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37674

#### Release Note
```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
Fixed a silent crash that could happen for some users when receiving a push notification on Android
```
