### PR TITLE
MM-37577 Do not set post id when posting a message

### DIFF
--- a/app/mm-redux/actions/posts.test.js
+++ b/app/mm-redux/actions/posts.test.js
@@ -38,12 +38,14 @@ describe('Actions.Posts', () => {
     it('createPost', async () => {
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.fakePost(channelId);
+        const createPost = jest.spyOn(Client4, 'createPost');
 
         nock(Client4.getBaseRoute()).
             post('/posts').
             reply(201, {...post, id: TestHelper.generateId()});
 
         await Actions.createPost(post)(store.dispatch, store.getState);
+        expect(createPost).toHaveBeenCalledWith(expect.objectContaining({id: ''}));
 
         const state = store.getState();
         const createRequest = state.requests.posts.createPost;

--- a/app/mm-redux/actions/posts.ts
+++ b/app/mm-redux/actions/posts.ts
@@ -182,6 +182,7 @@ export function createPost(post: Post, files: any[] = []) {
 
         let newPost = {
             ...post,
+            id: '',
             pending_post_id: pendingPostId,
             create_at: timestamp,
             update_at: timestamp,


### PR DESCRIPTION
#### Summary
When a message failed to post an id was being assign to the post object saved in the store that matched the `pending_post_id` so that the storage layer can do its thing.

Not sure since when, but now the server is complaining that you cannot "update an existing Post", the mobile app will now send and empty string as the post id every time we attempt to post. I wonder if the server change was done on purpose or if there is something unexpected that happened there. In any case if the change on the server was on purpose, it then should be marked as a breaking change as old app version will not be able to retry successfully to post a message with a newer server. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37577

```release-note
NONE
```
