### PR TITLE
Android Send Notification event to JS only once when the app is in the foreground

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -119,8 +119,9 @@ public class CustomPushNotification extends PushNotification {
         switch (type) {
             case PUSH_TYPE_MESSAGE:
             case PUSH_TYPE_SESSION:
-                boolean createSummary = type.equals(PUSH_TYPE_MESSAGE);
                 if (!mAppLifecycleFacade.isAppVisible()) {
+                    boolean createSummary = type.equals(PUSH_TYPE_MESSAGE);
+
                     if (type.equals(PUSH_TYPE_MESSAGE)) {
                         if (channelId != null) {
                             Map<String, List<Integer>> notificationsInChannel = loadNotificationsMap(mContext);
@@ -145,8 +146,6 @@ public class CustomPushNotification extends PushNotification {
                     }
 
                     buildNotification(notificationId, createSummary);
-                } else {
-                    notifyReceivedToJS();
                 }
                 break;
             case PUSH_TYPE_CLEAR:


### PR DESCRIPTION
#### Summary
When a notification was received on Android and the app was in the foreground we were sending the event to JS twice, this PR removes the duplication of the event being emitted.

#### Release Note

```release-note
NONE
```
