### PR TITLE
[MM-37602] fix channel unread filtering for CRT

### DIFF
--- a/app/mm-redux/utils/channel_utils.ts
+++ b/app/mm-redux/utils/channel_utils.ts
@@ -43,10 +43,10 @@ export function buildDisplayableChannelListWithUnreadSection(usersState: UsersSt
     const locale = getUserLocale(currentUserId, profiles);
     const missingDirectChannels = createMissingDirectChannels(currentUserId, myChannels, myPreferences);
     const channels = buildChannels(usersState, myChannels, missingDirectChannels, teammateNameDisplay, locale);
-    const unreadChannels = [...buildChannelsWithMentions(channels, myMembers, locale), ...buildUnreadChannels(channels, myMembers, locale)];
+    const unreadChannels = [...buildChannelsWithMentions(channels, myMembers, locale), ...buildUnreadChannels(channels, myMembers, locale, collapsedThreadsEnabled)];
 
     // collapsedThreadsEnabled is set to "false" as we are filtering not just based on root posts
-    const notUnreadChannels = channels.filter((channel: Channel) => !isUnreadChannel(myMembers, channel, false));
+    const notUnreadChannels = channels.filter((channel: Channel) => !isUnreadChannel(myMembers, channel, collapsedThreadsEnabled));
 
     const favoriteChannels = buildFavoriteChannels(notUnreadChannels, myPreferences, locale);
     const notFavoriteChannels = buildNotFavoriteChannels(notUnreadChannels, myPreferences);
@@ -550,10 +550,10 @@ function channelHasMentions(members: RelationOneToOne<Channel, ChannelMembership
     return false;
 }
 
-function channelHasUnreadMessages(members: RelationOneToOne<Channel, ChannelMembership>, channel: Channel): boolean {
+function channelHasUnreadMessages(collapsedThreadsEnabled: boolean, members: RelationOneToOne<Channel, ChannelMembership>, channel: Channel): boolean {
     const member = members[channel.id];
     if (member) {
-        const msgCount = channel.total_msg_count - member.msg_count;
+        const msgCount = getMsgCountInChannel(collapsedThreadsEnabled, channel, member);
         const onlyMentions = member.notify_props && member.notify_props.mark_unread === General.MENTION;
         return (Boolean(msgCount) && !onlyMentions && member.mention_count === 0);
     }
@@ -715,8 +715,8 @@ function buildChannelsWithMentions(channels: Array<Channel>, members: RelationOn
         sort(sortChannelsByDisplayName.bind(null, locale));
 }
 
-function buildUnreadChannels(channels: Array<Channel>, members: RelationOneToOne<Channel, ChannelMembership>, locale: string) {
-    return channels.filter(channelHasUnreadMessages.bind(null, members)).
+function buildUnreadChannels(channels: Array<Channel>, members: RelationOneToOne<Channel, ChannelMembership>, locale: string, collapsedThreadsEnabled: boolean) {
+    return channels.filter(channelHasUnreadMessages.bind(null, collapsedThreadsEnabled, members)).
         sort(sortChannelsByDisplayName.bind(null, locale));
 }
 

--- a/app/mm-redux/utils/channel_utils.ts
+++ b/app/mm-redux/utils/channel_utils.ts
@@ -45,7 +45,6 @@ export function buildDisplayableChannelListWithUnreadSection(usersState: UsersSt
     const channels = buildChannels(usersState, myChannels, missingDirectChannels, teammateNameDisplay, locale);
     const unreadChannels = [...buildChannelsWithMentions(channels, myMembers, locale), ...buildUnreadChannels(channels, myMembers, locale, collapsedThreadsEnabled)];
 
-    // collapsedThreadsEnabled is set to "false" as we are filtering not just based on root posts
     const notUnreadChannels = channels.filter((channel: Channel) => !isUnreadChannel(myMembers, channel, collapsedThreadsEnabled));
 
     const favoriteChannels = buildFavoriteChannels(notUnreadChannels, myPreferences, locale);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Fixes filtering of unread channels with CRT

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-37602

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
- ios 12 simulator, ios 14.4 

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
