### PR TITLE
[MM-37840, MM-37841] do not mark channel as read when clearing push notifications

### DIFF
--- a/app/components/network_indicator/network.tsx
+++ b/app/components/network_indicator/network.tsx
@@ -193,7 +193,9 @@ const NetworkIndicator = ({
 
     useEffect(() => {
         if (channelId) {
-            clearNotificationTimeout.current = setTimeout(clearNotifications, 1500);
+            clearNotificationTimeout.current = setTimeout(() => {
+                PushNotifications.clearChannelNotifications(channelId);
+            }, 1500);
         }
 
         return () => {

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -68,6 +68,7 @@ export default class EditPost extends PureComponent {
 
         this.rightButton.color = props.theme.sidebarHeaderTextColor;
         this.rightButton.text = context.intl.formatMessage({id: 'edit_post.save', defaultMessage: 'Save'});
+        this.rightButtonEnabled = true;
 
         setButtons(props.componentId, {
             leftButtons: [{...this.leftButton, icon: props.closeButton}],
@@ -99,14 +100,18 @@ export default class EditPost extends PureComponent {
 
     emitCanEditPost = (enabled) => {
         const {componentId} = this.props;
-        setButtons(componentId, {
-            leftButtons: [{...this.leftButton, icon: this.props.closeButton}],
-            rightButtons: [{...this.rightButton, enabled}],
-        });
+        if (this.rightButtonEnabled !== enabled) {
+            this.rightButtonEnabled = enabled;
+            setButtons(componentId, {
+                leftButtons: [{...this.leftButton, icon: this.props.closeButton}],
+                rightButtons: [{...this.rightButton, enabled}],
+            });
+        }
     };
 
     emitEditing = (loading) => {
         const {componentId} = this.props;
+        this.rightButtonEnabled = !loading;
         setButtons(componentId, {
             leftButtons: [{...this.leftButton, icon: this.props.closeButton}],
             rightButtons: [{...this.rightButton, enabled: !loading}],


### PR DESCRIPTION
#### Summary
When the channel is switch we clear push notifications in the drawer (if any) that belong to the channel being viewed, this was calling to mark the channel as read. Made it so it only marks the channel as read only on reconnect.

This PR also fixes the buttons blinking seen on the edit post screen every time a key was being pressed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37840
https://mattermost.atlassian.net/browse/MM-37841

#### Release Note
```release-note
NONE
```
