### PR TITLE
Fix warnings on channel info row Formatted Text

### DIFF
--- a/app/screens/channel_info/bindings/bindings.tsx
+++ b/app/screens/channel_info/bindings/bindings.tsx
@@ -169,7 +169,6 @@ class Option extends React.PureComponent<OptionProps, OptionState> {
                     action={this.onPress}
                     defaultMessage={binding.label}
                     theme={theme}
-                    textId={binding.app_id + binding.location}
                     image={binding.icon ? {uri: binding.icon} : null}
                 />
             </>

--- a/app/screens/channel_info/channel_info_row.js
+++ b/app/screens/channel_info/channel_info_row.js
@@ -79,17 +79,24 @@ function channelInfoRow(props) {
         );
     }
 
+    const labelStyle = [style.label, {color: textColor || theme.centerChannelColor}];
+    let label = <Text style={labelStyle}>{defaultMessage}</Text>;
+    if (textId) {
+        label = (
+            <FormattedText
+                style={labelStyle}
+                id={textId}
+                defaultMessage={defaultMessage}
+            />
+        );
+    }
     const RowComponent = (
         <View
             testID={testID}
             style={style.container}
         >
             {iconElement}
-            <FormattedText
-                style={[style.label, {color: textColor || theme.centerChannelColor}]}
-                id={textId}
-                defaultMessage={defaultMessage}
-            />
+            {label}
             <Text style={style.detail}>{detail}</Text>
             {actionElement}
         </View>
@@ -120,7 +127,7 @@ channelInfoRow.propTypes = {
     imageTintColor: PropTypes.string,
     isLandscape: PropTypes.bool,
     rightArrow: PropTypes.bool,
-    textId: PropTypes.string.isRequired,
+    textId: PropTypes.string,
     togglable: PropTypes.bool,
     textColor: PropTypes.string,
     theme: PropTypes.object.isRequired,


### PR DESCRIPTION
#### Summary
Channel Info row is expecting a textID and default message in order to create a `<FormattedText>` component for the element label. This created lots of warnings for bindings, since they are not system defined, and therefore have not a translation in the i18n bundle. This also could create some issues if coincidentally, the formed text id that was being formed became the same as some translation id we have in the system.

In order to solve this, we have removed the requirement of the text id, and only create the `<FormattedText>` field when it is given.

Another solution would have been to move the localization out of this component, and let the elements be directly the component to render (or the translated text), but that solution would imply a bigger changelog.

#### Ticket Link
None

#### Release Note
```release-note
None
```
