### PR TITLE
Fix upside down loading message text while scrolling the post list

### DIFF
--- a/app/components/load_more_posts/load_more_posts.js
+++ b/app/components/load_more_posts/load_more_posts.js
@@ -3,11 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
-import {
-    ActivityIndicator,
-    View,
-    ViewPropTypes,
-} from 'react-native';
+import {ActivityIndicator, Platform, View, ViewPropTypes} from 'react-native';
 
 import FormattedText from '@components/formatted_text';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
@@ -75,6 +71,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             height: 28,
             marginVertical: 10,
             overflow: 'hidden',
+            ...Platform.select({
+                android: {
+                    scaleY: -1,
+                },
+            }),
         },
         text: {
             fontSize: 14,


### PR DESCRIPTION
#### Summary
When fixing the performance issues on Android by flipping the post list instead of inverting, the component that shows a `loading messages` text was left behind. This PR fixes it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38174

#### Release Note
```release-note
NONE
```
