### PR TITLE
[MM-37686] Invert colours for teams button to "fix" starkness on light backgrounds

### DIFF
--- a/app/components/sidebars/main/channels_list/switch_teams_button/__snapshots__/switch_teams_button.test.js.snap
+++ b/app/components/sidebars/main/channels_list/switch_teams_button/__snapshots__/switch_teams_button.test.js.snap
@@ -12,7 +12,7 @@ exports[`SwitchTeamsButton should match snapshot 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "rgba(255,255,255,0.24)",
           "borderRadius": 2,
           "flexDirection": "row",
           "height": 36,
@@ -28,7 +28,7 @@ exports[`SwitchTeamsButton should match snapshot 1`] = `
         size={24}
         style={
           Object {
-            "color": "#1153ab",
+            "color": "#ffffff",
             "left": -2,
             "top": 1,
           }

--- a/app/components/sidebars/main/channels_list/switch_teams_button/switch_teams_button.js
+++ b/app/components/sidebars/main/channels_list/switch_teams_button/switch_teams_button.js
@@ -131,13 +131,13 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontWeight: 'bold',
         },
         switcherArrow: {
-            color: theme.sidebarHeaderBg,
+            color: theme.sidebarHeaderTextColor,
             top: 1,
             left: -2,
         },
         switcherContainer: {
             alignItems: 'center',
-            backgroundColor: theme.sidebarHeaderTextColor,
+            backgroundColor: changeOpacity(theme.sidebarHeaderTextColor, 0.24),
             borderRadius: 2,
             flexDirection: 'row',
             justifyContent: 'center',

--- a/app/components/team_icon/__snapshots__/team_icon.test.js.snap
+++ b/app/components/team_icon/__snapshots__/team_icon.test.js.snap
@@ -27,6 +27,7 @@ exports[`TeamIcon should match snapshot 1`] = `
     style={
       Array [
         Object {
+          "backgroundColor": "white",
           "borderRadius": 2,
           "bottom": 0,
           "left": 0,

--- a/app/components/team_icon/__snapshots__/team_icon.test.js.snap
+++ b/app/components/team_icon/__snapshots__/team_icon.test.js.snap
@@ -6,7 +6,7 @@ exports[`TeamIcon should match snapshot 1`] = `
     Array [
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
+        "backgroundColor": "#145dbf",
         "borderRadius": 2,
         "height": 30,
         "justifyContent": "center",

--- a/app/components/team_icon/team_icon.js
+++ b/app/components/team_icon/team_icon.js
@@ -103,10 +103,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderRadius: 2,
             alignItems: 'center',
             justifyContent: 'center',
-            backgroundColor: theme.sidebarText,
+            backgroundColor: theme.sidebarBg,
         },
         text: {
-            color: theme.sidebarBg,
+            color: theme.sidebarText,
             fontFamily: 'OpenSans',
             fontWeight: '600',
             fontSize: 15,

--- a/app/components/team_icon/team_icon.js
+++ b/app/components/team_icon/team_icon.js
@@ -118,6 +118,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             bottom: 0,
             left: 0,
             right: 0,
+            backgroundColor: 'white',
         },
     };
 });


### PR DESCRIPTION
#### Summary
This PR "fixes" the starkness of the button when using a light sidebar background colour by inverting the colours.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37686

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
iPhone Simulator (iPhone 12, iOS 14.5)

#### Screenshots
<img width="520" alt="Screen Shot 2021-08-27 at 1 03 40 PM" src="https://user-images.githubusercontent.com/3245614/131166949-c88f357a-45b5-4fe4-8fbb-2a97e9400af2.png">
<img width="564" alt="Screen Shot 2021-08-27 at 1 03 58 PM" src="https://user-images.githubusercontent.com/3245614/131166967-5e1d4480-18bd-4b81-920d-8c76a5c5ae6b.png">

#### Release Note
```release-note
NONE
```
