### PR TITLE
Properly handle notification snooze on Android

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -1,10 +1,12 @@
 package com.mattermost.rnbeta;
 
 import android.app.Notification;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.service.notification.StatusBarNotification;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -49,10 +51,23 @@ public class CustomPushNotification extends PushNotification {
                 return;
             }
 
-            notifications.remove(notificationId);
-            saveNotificationsMap(context, notificationsInChannel);
-            final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            final NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
             notificationManager.cancel(notificationId);
+            notifications.remove(notificationId);
+            final StatusBarNotification[] statusNotifications = notificationManager.getActiveNotifications();
+            boolean hasMore = false;
+            for (final StatusBarNotification status : statusNotifications) {
+                if (status.getNotification().extras.getString("channel_id").equals(channelId)) {
+                    hasMore = true;
+                    break;
+                }
+            }
+
+            if (!hasMore) {
+                notificationsInChannel.remove(channelId);
+            }
+
+            saveNotificationsMap(context, notificationsInChannel);
         }
     }
 


### PR DESCRIPTION
#### Summary
Android has a feature where a user can snooze notifications, this notifications are snoozed on a per-channel basis, to handle it properly notifications needs to have a group summary which was not being created if notifications where manually dismissed at some point. This PR makes sure that when all notifications from a channel are cleared or dismissed the next notification will then create a group summary, ensuring that every notification being displayed has one and can be snoozed accordingly.

#### Ticket Link
N/A

#### Release Note
```release-note
Fixed ability to snooze push notifications on Android
```
