### PR TITLE
Fix Share extension authentication and error alerts

### DIFF
--- a/ios/MattermostShare/ChannelsViewController.swift
+++ b/ios/MattermostShare/ChannelsViewController.swift
@@ -45,22 +45,16 @@ class ChannelsViewController: UIViewController {
  
   func configureSearchBar() {
     searchController.searchResultsUpdater = self
-    searchController.hidesNavigationBarDuringPresentation = false
+    searchController.hidesNavigationBarDuringPresentation = true
     searchController.dimsBackgroundDuringPresentation = false
     searchController.searchBar.searchBarStyle = .minimal
     searchController.searchBar.autocapitalizationType = .none
     searchController.searchBar.delegate = self
 
-    self.definesPresentationContext = true
+    self.definesPresentationContext = false
     
     if #available(iOS 11.0, *) {
       // For iOS 11 and later, place the search bar in the navigation bar.
-      
-      // Give space at the top so provide a better look and feel
-      let offset = UIOffset(horizontal: 0.0, vertical: 6.0)
-      searchController.searchBar.searchFieldBackgroundPositionAdjustment = offset
-      
-      
       navigationItem.searchController = searchController
     } else {
       // For iOS 10 and earlier, place the search controller's search bar in the table view's header.


### PR DESCRIPTION
#### Summary
Fixes a crash when trying to share content into Mattermost on iOS and the app is configured to use AppConfig with the `inAppPinCode` setting to authenticate the user with biometrics before allowing the sharing of content.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38299

Fixes: #5657

#### Release Note
```release-note
Fixes a crash when attempting to share content into Mattermost on iOS when Biometric authentication is required.
```

To test the app needs to be enrolled with an EMM Provider and have the `inAppPinCode` setting set as `"true"`