### PR TITLE
Do not resize images to upload

### DIFF
--- a/app/components/attachment_button/index.js
+++ b/app/components/attachment_button/index.js
@@ -179,7 +179,7 @@ export default class AttachmentButton extends PureComponent {
 
     attachFileFromLibrary = async () => {
         const options = {
-            quality: 0.8,
+            quality: 1,
             mediaType: 'mixed',
             includeBase64: false,
         };

--- a/app/components/post_draft/quick_actions/image_quick_action/index.tsx
+++ b/app/components/post_draft/quick_actions/image_quick_action/index.tsx
@@ -32,7 +32,7 @@ const ImageQuickAction = ({disabled, fileCount = 0, intl, maxFileCount, onUpload
         const selectionLimit = maxFileCount - fileCount;
         const options: ImageLibraryOptions = {
             selectionLimit,
-            quality: 0.8,
+            quality: 1,
             mediaType: 'mixed',
             includeBase64: false,
         };


### PR DESCRIPTION
#### Summary
The image picker library re-writes images to resize them and this does not support `gif` files, so they only resize the image using the first frame and not the entire gif animation. By setting the quality to be 100% the resize image processing does not take place and gifs work as expected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38309

Fixes: #5653

#### Release Note
```release-note
Fixed upload of animated gif files on Android
```