### PR TITLE
Open forms in bindings on all locations

### DIFF
--- a/app/components/post_list/post/body/content/embedded_bindings/button_binding/button_binding.tsx
+++ b/app/components/post_list/post/body/content/embedded_bindings/button_binding/button_binding.tsx
@@ -58,11 +58,15 @@ const ButtonBinding = ({binding, doAppCall, intl, post, postEphemeralCallRespons
     const style = getStyleSheet(theme);
 
     const onPress = useCallback(preventDoubleTap(async () => {
-        if (!binding.call || pressed.current) {
+        if (pressed.current) {
             return;
         }
 
-        pressed.current = true;
+        const call = binding.form?.call || binding.call;
+
+        if (!call) {
+            return;
+        }
 
         const context = createCallContext(
             binding.app_id,
@@ -72,13 +76,20 @@ const ButtonBinding = ({binding, doAppCall, intl, post, postEphemeralCallRespons
             post.id,
         );
 
-        const call = createCallRequest(
-            binding.call,
+        const callRequest = createCallRequest(
+            call,
             context,
             {post: AppExpandLevels.EXPAND_ALL},
         );
 
-        const res = await doAppCall(call, AppCallTypes.SUBMIT, intl);
+        if (binding.form) {
+            showAppForm(binding.form, callRequest, theme);
+            return;
+        }
+
+        pressed.current = true;
+
+        const res = await doAppCall(callRequest, AppCallTypes.SUBMIT, intl);
         pressed.current = false;
 
         if (res.error) {

--- a/app/components/post_list/post/body/content/embedded_bindings/menu_binding/menu_binding.tsx
+++ b/app/components/post_list/post/body/content/embedded_bindings/menu_binding/menu_binding.tsx
@@ -42,7 +42,9 @@ const MenuBinding = ({binding, doAppCall, intl, post, postEphemeralCallResponseF
             return;
         }
 
-        if (!bind.call) {
+        const call = bind.form?.call || bind.call;
+
+        if (!call) {
             return;
         }
 
@@ -54,13 +56,18 @@ const MenuBinding = ({binding, doAppCall, intl, post, postEphemeralCallResponseF
             post.id,
         );
 
-        const call = createCallRequest(
-            bind.call,
+        const callRequest = createCallRequest(
+            call,
             context,
             {post: AppExpandLevels.EXPAND_ALL},
         );
 
-        const res = await doAppCall(call, AppCallTypes.SUBMIT, intl);
+        if (bind.form) {
+            showAppForm(bind.form, callRequest);
+            return;
+        }
+
+        const res = await doAppCall(callRequest, AppCallTypes.SUBMIT, intl);
         if (res.error) {
             const errorResponse = res.error;
             const errorMessage = errorResponse.error || intl.formatMessage({

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -167,6 +167,8 @@ export default class AppsFormComponent extends PureComponent<Props, State> {
         const callResponse = res.data!;
         switch (callResponse.type) {
         case AppCallResponseTypes.OK:
+            await this.handleHide();
+            return;
         case AppCallResponseTypes.NAVIGATE:
             await this.handleHide();
             this.props.actions.handleGotoLocation(callResponse.navigate_to_url!, this.context.intl);

--- a/app/screens/channel_info/bindings/bindings.tsx
+++ b/app/screens/channel_info/bindings/bindings.tsx
@@ -88,7 +88,9 @@ class Option extends React.PureComponent<OptionProps, OptionState> {
             return;
         }
 
-        if (!binding.call) {
+        const call = binding.form?.call || binding.call;
+
+        if (!call) {
             return;
         }
 
@@ -98,14 +100,20 @@ class Option extends React.PureComponent<OptionProps, OptionState> {
             currentChannel.id,
             currentChannel.team_id || currentTeamId,
         );
-        const call = createCallRequest(
-            binding.call,
+        const callRequest = createCallRequest(
+            call,
             context,
         );
 
+        if (binding.form) {
+            await dismissModal();
+            showAppForm(binding.form, callRequest, theme);
+            return;
+        }
+
         this.setState({submitting: true});
 
-        const res = await doAppCall(call, AppCallTypes.SUBMIT, intl);
+        const res = await doAppCall(callRequest, AppCallTypes.SUBMIT, intl);
 
         this.setState({submitting: false});
 

--- a/app/screens/post_options/bindings/bindings.tsx
+++ b/app/screens/post_options/bindings/bindings.tsx
@@ -86,9 +86,12 @@ class Option extends React.PureComponent<OptionProps> {
         const {post, teamID, binding, intl, theme} = this.props;
         const {doAppCall, postEphemeralCallResponseForPost} = this.props.actions;
 
-        if (!binding.call) {
+        const call = binding.form?.call || binding.call;
+
+        if (!call) {
             return;
         }
+
         const context = createCallContext(
             binding.app_id,
             binding.location,
@@ -97,15 +100,20 @@ class Option extends React.PureComponent<OptionProps> {
             post.id,
             post.root_id,
         );
-        const call = createCallRequest(
-            binding.call,
+        const callRequest = createCallRequest(
+            call,
             context,
             {
                 post: AppExpandLevels.ALL,
             },
         );
 
-        const callPromise = doAppCall(call, AppCallTypes.SUBMIT, intl);
+        if (binding.form) {
+            showAppForm(binding.form, callRequest, theme);
+            return;
+        }
+
+        const callPromise = doAppCall(callRequest, AppCallTypes.SUBMIT, intl);
         await this.close();
 
         const res = await callPromise;
@@ -134,7 +142,7 @@ class Option extends React.PureComponent<OptionProps> {
             this.props.actions.handleGotoLocation(callResp.navigate_to_url!, intl);
             break;
         case AppCallResponseTypes.FORM:
-            showAppForm(callResp.form, call, theme);
+            showAppForm(callResp.form, callRequest, theme);
             break;
         default: {
             const title = intl.formatMessage({


### PR DESCRIPTION
#### Summary
Previously, bindings in other locations than commands will always submit, ignoring fields like "form". Now, if a binding has a form, it will automatically open the app form without communicating with the app.

#### Related PRs
Webapp: https://github.com/mattermost/mattermost-webapp/pull/8784

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
