### PR TITLE
Android clear notification preferences on version change

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -5,6 +5,8 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
 import android.util.Log;
@@ -33,6 +35,7 @@ import org.json.JSONObject;
 
 public class CustomPushNotification extends PushNotification {
     private static final String PUSH_NOTIFICATIONS = "PUSH_NOTIFICATIONS";
+    private static final String VERSION_PREFERENCE = "VERSION_PREFERENCE";
     private static final String PUSH_TYPE_MESSAGE = "message";
     private static final String PUSH_TYPE_CLEAR = "clear";
     private static final String PUSH_TYPE_SESSION = "session";
@@ -41,6 +44,29 @@ public class CustomPushNotification extends PushNotification {
     public CustomPushNotification(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
         CustomPushNotificationHelper.createNotificationChannels(context);
+
+        try {
+            PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+            String version = String.valueOf(pInfo.versionCode);
+            String storedVersion = null;
+            SharedPreferences pSharedPref = context.getSharedPreferences(VERSION_PREFERENCE, Context.MODE_PRIVATE);
+            if (pSharedPref != null) {
+                storedVersion = pSharedPref.getString("Version", "");
+            }
+
+            if (!version.equals(storedVersion)) {
+                if (pSharedPref != null) {
+                    SharedPreferences.Editor editor = pSharedPref.edit();
+                    editor.putString("Version", version);
+                    editor.apply();
+                }
+
+                Map<String, List<Integer>> inputMap = new HashMap<>();
+                saveNotificationsMap(context, inputMap);
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
     }
 
     public static void cancelNotification(Context context, String channelId, Integer notificationId) {
@@ -154,7 +180,7 @@ public class CustomPushNotification extends PushNotification {
                                 // Add the summary notification id as well
                                 list.add(0, notificationId + 1);
                             }
-
+                            
                             notificationsInChannel.put(channelId, list);
                             saveNotificationsMap(mContext, notificationsInChannel);
                         }

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -180,7 +180,7 @@ public class CustomPushNotification extends PushNotification {
                                 // Add the summary notification id as well
                                 list.add(0, notificationId + 1);
                             }
-                            
+
                             notificationsInChannel.put(channelId, list);
                             saveNotificationsMap(mContext, notificationsInChannel);
                         }


### PR DESCRIPTION
#### Summary
With this PR we are going to clean up the share preferences that hold notification tracking when a new version is installed. We do this to ensure that notifications are in sync with the drawer as when you install a new version notifications from the drawer get removed.

#### Release Note
```release-note
NONE
```
