### PR TITLE
[MM-38216] Add multiteam mentions and saved posts

### DIFF
--- a/app/client/rest/posts.ts
+++ b/app/client/rest/posts.ts
@@ -178,11 +178,11 @@ const ClientPosts = (superclass: any) => class extends superclass {
         );
     };
 
-    getFlaggedPosts = async (userId: string, channelId = '', teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
-        analytics.trackAPI('api_posts_get_flagged', {team_id: teamId});
+    getFlaggedPosts = async (userId: string, channelId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+        analytics.trackAPI('api_posts_get_flagged');
 
         return this.doFetch(
-            `${this.getUserRoute(userId)}/posts/flagged${buildQueryString({channel_id: channelId, team_id: teamId, page, per_page: perPage})}`,
+            `${this.getUserRoute(userId)}/posts/flagged${buildQueryString({channel_id: channelId, page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
@@ -250,8 +250,13 @@ const ClientPosts = (superclass: any) => class extends superclass {
     searchPostsWithParams = async (teamId: string, params: any) => {
         analytics.trackAPI('api_posts_search', {team_id: teamId});
 
+        let route = `${this.getPostsRoute()}/search`;
+        if (teamId) {
+            route = `${this.getTeamRoute(teamId)}/posts/search`;
+        }
+
         return this.doFetch(
-            `${this.getTeamRoute(teamId)}/posts/search`,
+            route,
             {method: 'post', body: JSON.stringify(params)},
         );
     };

--- a/app/client/rest/posts.ts
+++ b/app/client/rest/posts.ts
@@ -178,11 +178,11 @@ const ClientPosts = (superclass: any) => class extends superclass {
         );
     };
 
-    getFlaggedPosts = async (userId: string, channelId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
-        analytics.trackAPI('api_posts_get_flagged');
+    getFlaggedPosts = async (userId: string, channelId = '', teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+        analytics.trackAPI('api_posts_get_flagged', {team_id: teamId});
 
         return this.doFetch(
-            `${this.getUserRoute(userId)}/posts/flagged${buildQueryString({channel_id: channelId, page, per_page: perPage})}`,
+            `${this.getUserRoute(userId)}/posts/flagged${buildQueryString({channel_id: channelId, team_id: teamId, page, per_page: perPage})}`,
             {method: 'get'},
         );
     };

--- a/app/mm-redux/actions/search.ts
+++ b/app/mm-redux/actions/search.ts
@@ -114,13 +114,12 @@ export function getFlaggedPosts(): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const userId = getCurrentUserId(state);
-        const teamId = getCurrentTeamId(state);
 
         dispatch({type: SearchTypes.SEARCH_FLAGGED_POSTS_REQUEST});
 
         let posts;
         try {
-            posts = await Client4.getFlaggedPosts(userId, '', teamId);
+            posts = await Client4.getFlaggedPosts(userId);
 
             await Promise.all([getProfilesAndStatusesForPosts(posts.posts, dispatch, getState) as any, dispatch(getMissingChannelsFromPosts(posts.posts)) as any]);
         } catch (error) {
@@ -202,7 +201,6 @@ export function clearPinnedPosts(channelId: string): ActionFunc {
 export function getRecentMentions(): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
-        const teamId = getCurrentTeamId(state);
 
         let posts;
         try {
@@ -213,7 +211,7 @@ export function getRecentMentions(): ActionFunc {
             const terms = termKeys.map(({key}) => key).join(' ').trim() + ' ';
 
             analytics.trackAPI('api_posts_search_mention');
-            posts = await Client4.searchPosts(teamId, terms, true);
+            posts = await Client4.searchPosts('', terms, true);
 
             const profilesAndStatuses = getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
             const missingChannels = dispatch(getMissingChannelsFromPosts(posts.posts));

--- a/app/screens/search/channel_display_name/__snapshots__/channel_display_name.test.js.snap
+++ b/app/screens/search/channel_display_name/__snapshots__/channel_display_name.test.js.snap
@@ -51,24 +51,32 @@ exports[`SearchResultPost should match snapshot when team is provided 1`] = `
   >
     channel
   </Text>
-  <Text
-    numberOfLines={1}
-    style={
-      Object {
-        "borderLeftColor": "rgba(63,67,80,0.5)",
-        "borderLeftWidth": 1,
-        "borderStyle": "solid",
-        "color": "rgba(63,67,80,0.5)",
-        "flexShrink": 2,
-        "fontSize": 12,
-        "fontWeight": "400",
-        "marginLeft": 8,
-        "paddingBottom": 1,
-        "paddingLeft": 8,
+  <React.Fragment>
+    <View
+      style={
+        Object {
+          "borderLeftColor": "rgba(63,67,80,0.2)",
+          "borderLeftWidth": 1,
+          "borderStyle": "solid",
+          "height": 16,
+          "marginLeft": 8,
+          "marginRight": 8,
+        }
       }
-    }
-  >
-    team
-  </Text>
+    />
+    <Text
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(63,67,80,0.5)",
+          "flexShrink": 2,
+          "fontSize": 12,
+          "fontWeight": "400",
+        }
+      }
+    >
+      team
+    </Text>
+  </React.Fragment>
 </View>
 `;

--- a/app/screens/search/channel_display_name/__snapshots__/channel_display_name.test.js.snap
+++ b/app/screens/search/channel_display_name/__snapshots__/channel_display_name.test.js.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchResultPost should match snapshot when no team is provided 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "baseline",
+      "flexDirection": "row",
+      "marginTop": 5,
+      "paddingHorizontal": 16,
+    }
+  }
+>
+  <Text
+    numberOfLines={1}
+    style={
+      Object {
+        "color": "rgba(63,67,80,0.8)",
+        "flexShrink": 1,
+        "fontSize": 14,
+        "fontWeight": "600",
+      }
+    }
+  >
+    channel
+  </Text>
+</View>
+`;
+
+exports[`SearchResultPost should match snapshot when team is provided 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "baseline",
+      "flexDirection": "row",
+      "marginTop": 5,
+      "paddingHorizontal": 16,
+    }
+  }
+>
+  <Text
+    numberOfLines={1}
+    style={
+      Object {
+        "color": "rgba(63,67,80,0.8)",
+        "flexShrink": 1,
+        "fontSize": 14,
+        "fontWeight": "600",
+      }
+    }
+  >
+    channel
+  </Text>
+  <Text
+    numberOfLines={1}
+    style={
+      Object {
+        "borderLeftColor": "rgba(63,67,80,0.5)",
+        "borderLeftWidth": 1,
+        "borderStyle": "solid",
+        "color": "rgba(63,67,80,0.5)",
+        "flexShrink": 2,
+        "fontSize": 12,
+        "fontWeight": "400",
+        "marginLeft": 8,
+        "paddingBottom": 1,
+        "paddingLeft": 8,
+      }
+    }
+  >
+    team
+  </Text>
+</View>
+`;

--- a/app/screens/search/channel_display_name/__snapshots__/channel_display_name.test.js.snap
+++ b/app/screens/search/channel_display_name/__snapshots__/channel_display_name.test.js.snap
@@ -55,6 +55,7 @@ exports[`SearchResultPost should match snapshot when team is provided 1`] = `
     <View
       style={
         Object {
+          "alignSelf": "stretch",
           "borderLeftColor": "rgba(63,67,80,0.2)",
           "borderLeftWidth": 1,
           "borderStyle": "solid",

--- a/app/screens/search/channel_display_name/channel_display_name.js
+++ b/app/screens/search/channel_display_name/channel_display_name.js
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
-import {Text} from 'react-native';
+import {Text, View} from 'react-native';
 
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
@@ -11,14 +11,20 @@ export default class ChannelDisplayName extends PureComponent {
     static propTypes = {
         displayName: PropTypes.string,
         theme: PropTypes.object.isRequired,
+        channelTeamName: PropTypes.string,
     };
 
     render() {
-        const {displayName, theme} = this.props;
+        const {displayName, theme, channelTeamName} = this.props;
         const styles = getStyleFromTheme(theme);
 
         return (
-            <Text style={styles.channelName}>{displayName}</Text>
+            <View style={styles.container}>
+                <Text style={styles.channelName}>{displayName}</Text>
+                {Boolean(channelTeamName) &&
+                <Text style={styles.teamName}>{' | ' + channelTeamName}</Text>
+                }
+            </View>
         );
     }
 }
@@ -29,8 +35,18 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.8),
             fontSize: 14,
             fontWeight: '600',
+        },
+        teamName: {
+            color: changeOpacity(theme.centerChannelColor, 0.5),
+            fontSize: 12,
+            fontWeight: '400',
+            padding: 1,
+        },
+        container: {
+            flexDirection: 'row',
             marginTop: 5,
             paddingHorizontal: 16,
+            alignItems: 'baseline',
         },
     };
 });

--- a/app/screens/search/channel_display_name/channel_display_name.js
+++ b/app/screens/search/channel_display_name/channel_display_name.js
@@ -28,7 +28,7 @@ export default class ChannelDisplayName extends PureComponent {
                 <Text
                     style={styles.teamName}
                     numberOfLines={1}
-                >{' | ' + channelTeamName}</Text>
+                >{channelTeamName}</Text>
                 }
             </View>
         );
@@ -47,8 +47,13 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.5),
             fontSize: 12,
             fontWeight: '400',
-            padding: 1,
+            paddingBottom: 1,
+            paddingLeft: 8,
+            marginLeft: 8,
             flexShrink: 2,
+            borderStyle: 'solid',
+            borderLeftWidth: 1,
+            borderLeftColor: changeOpacity(theme.centerChannelColor, 0.5),
         },
         container: {
             flexDirection: 'row',

--- a/app/screens/search/channel_display_name/channel_display_name.js
+++ b/app/screens/search/channel_display_name/channel_display_name.js
@@ -20,9 +20,15 @@ export default class ChannelDisplayName extends PureComponent {
 
         return (
             <View style={styles.container}>
-                <Text style={styles.channelName}>{displayName}</Text>
+                <Text
+                    style={styles.channelName}
+                    numberOfLines={1}
+                >{displayName}</Text>
                 {Boolean(channelTeamName) &&
-                <Text style={styles.teamName}>{' | ' + channelTeamName}</Text>
+                <Text
+                    style={styles.teamName}
+                    numberOfLines={1}
+                >{' | ' + channelTeamName}</Text>
                 }
             </View>
         );
@@ -35,12 +41,14 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.8),
             fontSize: 14,
             fontWeight: '600',
+            flexShrink: 1,
         },
         teamName: {
             color: changeOpacity(theme.centerChannelColor, 0.5),
             fontSize: 12,
             fontWeight: '400',
             padding: 1,
+            flexShrink: 2,
         },
         container: {
             flexDirection: 'row',

--- a/app/screens/search/channel_display_name/channel_display_name.js
+++ b/app/screens/search/channel_display_name/channel_display_name.js
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
-import {Text, View} from 'react-native';
+import {Platform, Text, View} from 'react-native';
 
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
@@ -59,7 +59,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             height: 16,
             marginRight: 8,
             marginLeft: 8,
-            alignSelf: 'stretch',
+            alignSelf: Platform.select({ios: 'stretch'}),
         },
         container: {
             flexDirection: 'row',

--- a/app/screens/search/channel_display_name/channel_display_name.js
+++ b/app/screens/search/channel_display_name/channel_display_name.js
@@ -59,6 +59,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             height: 16,
             marginRight: 8,
             marginLeft: 8,
+            alignSelf: 'stretch',
         },
         container: {
             flexDirection: 'row',

--- a/app/screens/search/channel_display_name/channel_display_name.js
+++ b/app/screens/search/channel_display_name/channel_display_name.js
@@ -11,11 +11,11 @@ export default class ChannelDisplayName extends PureComponent {
     static propTypes = {
         displayName: PropTypes.string,
         theme: PropTypes.object.isRequired,
-        channelTeamName: PropTypes.string,
+        teamName: PropTypes.string,
     };
 
     render() {
-        const {displayName, theme, channelTeamName} = this.props;
+        const {displayName, theme, teamName} = this.props;
         const styles = getStyleFromTheme(theme);
 
         return (
@@ -24,13 +24,13 @@ export default class ChannelDisplayName extends PureComponent {
                     style={styles.channelName}
                     numberOfLines={1}
                 >{displayName}</Text>
-                {Boolean(channelTeamName) &&
+                {Boolean(teamName) &&
                 <>
                     <View style={styles.separator}/>
                     <Text
                         style={styles.teamName}
                         numberOfLines={1}
-                    >{channelTeamName}</Text>
+                    >{teamName}</Text>
                 </>
                 }
             </View>

--- a/app/screens/search/channel_display_name/channel_display_name.js
+++ b/app/screens/search/channel_display_name/channel_display_name.js
@@ -25,10 +25,13 @@ export default class ChannelDisplayName extends PureComponent {
                     numberOfLines={1}
                 >{displayName}</Text>
                 {Boolean(channelTeamName) &&
-                <Text
-                    style={styles.teamName}
-                    numberOfLines={1}
-                >{channelTeamName}</Text>
+                <>
+                    <View style={styles.separator}/>
+                    <Text
+                        style={styles.teamName}
+                        numberOfLines={1}
+                    >{channelTeamName}</Text>
+                </>
                 }
             </View>
         );
@@ -47,13 +50,15 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             color: changeOpacity(theme.centerChannelColor, 0.5),
             fontSize: 12,
             fontWeight: '400',
-            paddingBottom: 1,
-            paddingLeft: 8,
-            marginLeft: 8,
             flexShrink: 2,
+        },
+        separator: {
             borderStyle: 'solid',
+            borderLeftColor: changeOpacity(theme.centerChannelColor, 0.2),
             borderLeftWidth: 1,
-            borderLeftColor: changeOpacity(theme.centerChannelColor, 0.5),
+            height: 16,
+            marginRight: 8,
+            marginLeft: 8,
         },
         container: {
             flexDirection: 'row',

--- a/app/screens/search/channel_display_name/channel_display_name.test.js
+++ b/app/screens/search/channel_display_name/channel_display_name.test.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {shallow} from 'enzyme';
+import React from 'react';
+
+import {Preferences} from '@mm-redux/constants';
+
+import ChannelDisplayName from './channel_display_name';
+
+describe('SearchResultPost', () => {
+    const baseProps = {
+        displayName: 'channel',
+        channelTeamName: '',
+        theme: Preferences.THEMES.denim,
+    };
+
+    test('should match snapshot when no team is provided', async () => {
+        const wrapper = shallow(<ChannelDisplayName {...baseProps}/>);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('should match snapshot when team is provided', async () => {
+        const props = {
+            ...baseProps,
+            channelTeamName: 'team',
+        };
+        const wrapper = shallow(<ChannelDisplayName {...props}/>);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/app/screens/search/channel_display_name/channel_display_name.test.js
+++ b/app/screens/search/channel_display_name/channel_display_name.test.js
@@ -11,7 +11,7 @@ import ChannelDisplayName from './channel_display_name';
 describe('SearchResultPost', () => {
     const baseProps = {
         displayName: 'channel',
-        channelTeamName: '',
+        teamName: '',
         theme: Preferences.THEMES.denim,
     };
 
@@ -24,7 +24,7 @@ describe('SearchResultPost', () => {
     test('should match snapshot when team is provided', async () => {
         const props = {
             ...baseProps,
-            channelTeamName: 'team',
+            teamName: 'team',
         };
         const wrapper = shallow(<ChannelDisplayName {...props}/>);
 

--- a/app/screens/search/channel_display_name/index.js
+++ b/app/screens/search/channel_display_name/index.js
@@ -7,11 +7,12 @@ import {General} from '@mm-redux/constants';
 import {makeGetChannel} from '@mm-redux/selectors/entities/channels';
 import {getPost} from '@mm-redux/selectors/entities/posts';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
-import {getTeam} from '@mm-redux/selectors/entities/teams';
+import {getTeam, getTeamMemberships} from '@mm-redux/selectors/entities/teams';
 
 import ChannelDisplayName from './channel_display_name';
 
-function makeMapStateToProps() {
+// Exported for testing
+export function makeMapStateToProps() {
     const getChannel = makeGetChannel();
     return (state, ownProps) => {
         const post = getPost(state, ownProps.postId);
@@ -19,7 +20,8 @@ function makeMapStateToProps() {
         let channelTeamName = '';
         if (channel) {
             const isDMorGM = channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
-            if (!isDMorGM) {
+            const memberships = getTeamMemberships(state);
+            if (!isDMorGM && memberships && Object.values(memberships).length > 1) {
                 channelTeamName = getTeam(state, channel.team_id)?.display_name;
             }
         }

--- a/app/screens/search/channel_display_name/index.js
+++ b/app/screens/search/channel_display_name/index.js
@@ -3,9 +3,11 @@
 
 import {connect} from 'react-redux';
 
+import {General} from '@mm-redux/constants';
 import {makeGetChannel} from '@mm-redux/selectors/entities/channels';
 import {getPost} from '@mm-redux/selectors/entities/posts';
 import {getTheme} from '@mm-redux/selectors/entities/preferences';
+import {getTeam} from '@mm-redux/selectors/entities/teams';
 
 import ChannelDisplayName from './channel_display_name';
 
@@ -14,10 +16,16 @@ function makeMapStateToProps() {
     return (state, ownProps) => {
         const post = getPost(state, ownProps.postId);
         const channel = post ? getChannel(state, {id: post.channel_id}) : null;
+        let channelTeamName = '';
+        const isDMorGM = channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
+        if (!isDMorGM) {
+            channelTeamName = getTeam(state, channel.team_id)?.display_name;
+        }
 
         return {
             displayName: channel ? channel.display_name : '',
             theme: getTheme(state),
+            channelTeamName,
         };
     };
 }

--- a/app/screens/search/channel_display_name/index.js
+++ b/app/screens/search/channel_display_name/index.js
@@ -17,19 +17,19 @@ export function makeMapStateToProps() {
     return (state, ownProps) => {
         const post = getPost(state, ownProps.postId);
         const channel = post ? getChannel(state, {id: post.channel_id}) : null;
-        let channelTeamName = '';
+        let teamName = '';
         if (channel) {
             const isDMorGM = channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
             const memberships = getTeamMemberships(state);
             if (!isDMorGM && memberships && Object.values(memberships).length > 1) {
-                channelTeamName = getTeam(state, channel.team_id)?.display_name;
+                teamName = getTeam(state, channel.team_id)?.display_name;
             }
         }
 
         return {
             displayName: channel ? channel.display_name : '',
             theme: getTheme(state),
-            channelTeamName,
+            teamName,
         };
     };
 }

--- a/app/screens/search/channel_display_name/index.js
+++ b/app/screens/search/channel_display_name/index.js
@@ -17,9 +17,11 @@ function makeMapStateToProps() {
         const post = getPost(state, ownProps.postId);
         const channel = post ? getChannel(state, {id: post.channel_id}) : null;
         let channelTeamName = '';
-        const isDMorGM = channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
-        if (!isDMorGM) {
-            channelTeamName = getTeam(state, channel.team_id)?.display_name;
+        if (channel) {
+            const isDMorGM = channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
+            if (!isDMorGM) {
+                channelTeamName = getTeam(state, channel.team_id)?.display_name;
+            }
         }
 
         return {

--- a/app/screens/search/channel_display_name/index.test.js
+++ b/app/screens/search/channel_display_name/index.test.js
@@ -111,7 +111,7 @@ describe('components/SearchResultsItem/WithStore', () => {
 
     test('should not show team name if user only belongs to one team', () => {
         const newProps = mstp(defaultState, defaultProps);
-        expect(newProps.channelTeamName).toBe('');
+        expect(newProps.teamName).toBe('');
     });
 
     test('should show team name for open and private channels when user belongs to more than one team', () => {
@@ -129,7 +129,7 @@ describe('components/SearchResultsItem/WithStore', () => {
             },
         };
         let newProps = mstp(state, defaultProps);
-        expect(newProps.channelTeamName).toBe(team.display_name);
+        expect(newProps.teamName).toBe(team.display_name);
 
         state = {
             ...state,
@@ -149,7 +149,7 @@ describe('components/SearchResultsItem/WithStore', () => {
         };
 
         newProps = mstp(state, defaultProps);
-        expect(newProps.channelTeamName).toBe(team.display_name);
+        expect(newProps.teamName).toBe(team.display_name);
     });
 
     test('should not show team name for dm and group channels when user belongs to more than one team', () => {
@@ -178,7 +178,7 @@ describe('components/SearchResultsItem/WithStore', () => {
         };
 
         let newProps = mstp(state, defaultProps);
-        expect(newProps.channelTeamName).toBe('');
+        expect(newProps.teamName).toBe('');
 
         state = {
             ...state,
@@ -197,6 +197,6 @@ describe('components/SearchResultsItem/WithStore', () => {
             },
         };
         newProps = mstp(state, defaultProps);
-        expect(newProps.channelTeamName).toBe('');
+        expect(newProps.teamName).toBe('');
     });
 });

--- a/app/screens/search/channel_display_name/index.test.js
+++ b/app/screens/search/channel_display_name/index.test.js
@@ -1,0 +1,202 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {General} from '@mm-redux/constants';
+
+import {makeMapStateToProps} from './index';
+
+describe('components/SearchResultsItem/WithStore', () => {
+    const team = {
+        id: 'team_id',
+        display_name: 'team display name',
+        name: 'team_name',
+    };
+
+    const otherTeam = {
+        id: 'other_team_id',
+        display_name: 'other team display name',
+        name: 'other_team_name',
+    };
+
+    const currentUserID = 'other';
+    const user = {
+        id: 'user_id',
+        username: 'username',
+        is_bot: false,
+    };
+    const channel = {
+        id: 'channel_id_open',
+        type: General.OPEN_CHANNEL,
+        team_id: team.id,
+        name: 'open channel',
+        display_name: 'open channel',
+    };
+
+    const dmChannel = {
+        id: 'channel_id_dm',
+        type: General.DM_CHANNEL,
+        name: `${currentUserID}__${user.id}`,
+        display_name: `${currentUserID}__${user.id}`,
+    };
+
+    const post = {
+        channel_id: channel.id,
+        create_at: 1502715365009,
+        delete_at: 0,
+        edit_at: 1502715372443,
+        id: 'id',
+        is_pinned: false,
+        message: 'post message',
+        original_id: '',
+        pending_post_id: '',
+        props: {},
+        root_id: '',
+        type: '',
+        update_at: 1502715372443,
+        user_id: 'user_id',
+        reply_count: 0,
+    };
+
+    const defaultState = {
+        entities: {
+            general: {
+                config: {
+                    EnablePostUsernameOverride: 'true',
+                },
+                license: {},
+            },
+            users: {
+                profiles: {
+                    [user.id]: user,
+                },
+                currentUserId: currentUserID,
+                statuses: {},
+                profilesInChannel: {},
+            },
+            channels: {
+                channels: {
+                    [channel.id]: channel,
+                    [dmChannel.id]: dmChannel,
+                },
+            },
+            teams: {
+                myMembers: {
+                    [team.id]: {},
+                },
+                teams: {
+                    [team.id]: team,
+                    [otherTeam.id]: otherTeam,
+                },
+                currentTeamId: team.id,
+            },
+            posts: {
+                posts: {
+                    [post.id]: post,
+                },
+                postsInThread: {},
+            },
+            preferences: {
+                myPreferences: {
+                    hasOwnProperty: () => true,
+                },
+            },
+        },
+    };
+
+    const defaultProps = {
+        postId: post.id,
+    };
+
+    const mstp = makeMapStateToProps();
+
+    test('should not show team name if user only belongs to one team', () => {
+        const newProps = mstp(defaultState, defaultProps);
+        expect(newProps.channelTeamName).toBe('');
+    });
+
+    test('should show team name for open and private channels when user belongs to more than one team', () => {
+        let state = {
+            ...defaultState,
+            entities: {
+                ...defaultState.entities,
+                teams: {
+                    ...defaultState.entities.teams,
+                    myMembers: {
+                        ...defaultState.entities.teams.myMembers,
+                        [otherTeam.id]: {},
+                    },
+                },
+            },
+        };
+        let newProps = mstp(state, defaultProps);
+        expect(newProps.channelTeamName).toBe(team.display_name);
+
+        state = {
+            ...state,
+            entities: {
+                ...state.entities,
+                channels: {
+                    ...state.entities.channels,
+                    channels: {
+                        ...state.entities.channels.channels,
+                        [channel.id]: {
+                            ...channel,
+                            type: General.PRIVATE_CHANNEL,
+                        },
+                    },
+                },
+            },
+        };
+
+        newProps = mstp(state, defaultProps);
+        expect(newProps.channelTeamName).toBe(team.display_name);
+    });
+
+    test('should not show team name for dm and group channels when user belongs to more than one team', () => {
+        let state = {
+            ...defaultState,
+            entities: {
+                ...defaultState.entities,
+                teams: {
+                    ...defaultState.entities.teams,
+                    myMembers: {
+                        ...defaultState.entities.teams.myMembers,
+                        [otherTeam.id]: {},
+                    },
+                },
+                posts: {
+                    ...defaultState.entities.posts,
+                    posts: {
+                        ...defaultState.entities.posts.posts,
+                        [post.id]: {
+                            ...defaultState.entities.posts.posts[post.id],
+                            channel_id: dmChannel.id,
+                        },
+                    },
+                },
+            },
+        };
+
+        let newProps = mstp(state, defaultProps);
+        expect(newProps.channelTeamName).toBe('');
+
+        state = {
+            ...state,
+            entities: {
+                ...state.entities,
+                channels: {
+                    ...state.entities.channels,
+                    channels: {
+                        ...state.entities.channels.channels,
+                        [dmChannel.id]: {
+                            ...dmChannel,
+                            type: General.GM_CHANNEL,
+                        },
+                    },
+                },
+            },
+        };
+        newProps = mstp(state, defaultProps);
+        expect(newProps.channelTeamName).toBe('');
+    });
+});


### PR DESCRIPTION
#### Summary
Previously, channel mentions and saved posts only showed you the results for the current team. This PR makes it possible to show for several teams.

Saved posts should work fine with any server version for normal users. Sysadmins will be shown messages from channels/teams they are not members from, which may create some bugs. Those are addressed in this PR: https://github.com/mattermost/mattermost-server/pull/18380
Multiteam mentions require changes in the server, which are in this PR: https://github.com/mattermost/mattermost-server/pull/18371

This PR would open the path to allow multi-team search both on front and back-end. We just need to clarify how do we specify the team or all teams in the search query.

In contrast to Webapp, opening threads from a different team was possible before from permalink views, so there is no need to handle that case.

Known issues:
- The component used to render the posts is used in many places (search results, mention results, pinned posts results and saved posts, if I am not mistaken). Therefore, right now any of those will always show the name of the team. This is specially redundant in pinned posts. Depending on the design, it is simple to solve, but I am waiting for a design answer.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38216

(Also related) https://mattermost.atlassian.net/browse/MM-8459

#### Related Pull Requests
Server: https://github.com/mattermost/mattermost-server/pull/18371

#### Screenshots
![Screenshot from 2021-09-14 12-04-53](https://user-images.githubusercontent.com/1933730/133240133-5eba6ce0-df05-4c57-828d-d145d0f21180.png)
![Screenshot from 2021-09-14 12-08-24](https://user-images.githubusercontent.com/1933730/133240140-50ef7ccc-d8a8-4f4a-9c59-4c551e39985e.png)

#### Release Note
```release-note
Recent mentions and saved posts now show across all teams.
```
