### PR TITLE
[MM-31389] Show confirm modal for `@here` mentions

### DIFF
--- a/app/components/post_draft/draft_input/draft_input.js
+++ b/app/components/post_draft/draft_input/draft_input.js
@@ -329,12 +329,13 @@ export default class DraftInput extends PureComponent {
         const notificationsToChannel = enableConfirmNotificationsToChannel && useChannelMentions;
         const notificationsToGroups = enableConfirmNotificationsToChannel && useGroupMentions;
         const toAllOrChannel = DraftUtils.textContainsAtAllAtChannel(value);
-        const groupMentions = (!toAllOrChannel && notificationsToGroups) ? DraftUtils.groupsMentionedInText(groupsWithAllowReference, value) : [];
+        const toHere = DraftUtils.textContainsAtHere(value);
+        const groupMentions = (!toAllOrChannel && !toHere && notificationsToGroups) ? DraftUtils.groupsMentionedInText(groupsWithAllowReference, value) : [];
 
         if (value.indexOf('/') === 0) {
             this.sendCommand(value);
-        } else if (notificationsToChannel && membersCount > NOTIFY_ALL_MEMBERS && toAllOrChannel) {
-            this.showSendToAllOrChannelAlert(membersCount, value);
+        } else if (notificationsToChannel && membersCount > NOTIFY_ALL_MEMBERS && (toAllOrChannel || toHere)) {
+            this.showSendToAllOrChannelOrHereAlert(membersCount, value, toHere && !toAllOrChannel);
         } else if (groupMentions.length > 0) {
             const {groupMentionsSet, memberNotifyCount, channelTimezoneCount} = DraftUtils.mapGroupMentions(channelMemberCountsByGroup, groupMentions);
             if (memberNotifyCount > 0) {
@@ -364,11 +365,11 @@ export default class DraftInput extends PureComponent {
         }
     }
 
-    showSendToAllOrChannelAlert = (membersCount, msg) => {
+    showSendToAllOrChannelOrHereAlert = (membersCount, msg, atHere) => {
         const {formatMessage} = this.context.intl;
         const {channelTimezoneCount} = this.state;
         const {isTimezoneEnabled} = this.props;
-        const notifyAllMessage = DraftUtils.buildChannelWideMentionMessage(formatMessage, membersCount, isTimezoneEnabled, channelTimezoneCount);
+        const notifyAllMessage = DraftUtils.buildChannelWideMentionMessage(formatMessage, membersCount, isTimezoneEnabled, channelTimezoneCount, atHere);
         const cancel = () => {
             this.setInputValue(msg);
             this.setState({sendingMessage: false});

--- a/app/components/post_draft/draft_input/draft_input.test.js
+++ b/app/components/post_draft/draft_input/draft_input.test.js
@@ -110,6 +110,31 @@ describe('DraftInput', () => {
         expect(Alert.alert).toHaveBeenCalledWith('Confirm sending notifications to entire channel', expect.anything(), expect.anything());
     });
 
+    test('should send an alert when sending a message with a @here mention', () => {
+        const wrapper = shallowWithIntl(
+            <DraftInput
+                {...baseProps}
+                ref={ref}
+            />,
+        );
+        const message = '@here';
+        const instance = wrapper.instance();
+        expect(instance.input).toEqual({current: null});
+        instance.input = {
+            current: {
+                getValue: () => message,
+                setValue: jest.fn(),
+                changeDraft: jest.fn(),
+                resetTextInput: jest.fn(),
+            },
+        };
+
+        instance.handleSendMessage();
+        jest.runOnlyPendingTimers();
+        expect(Alert.alert).toBeCalled();
+        expect(Alert.alert).toHaveBeenCalledWith('Confirm sending notifications to entire channel', expect.anything(), expect.anything());
+    });
+
     test('should send an alert when sending a message with a group mention with group with count more than NOTIFY_ALL', () => {
         const wrapper = shallowWithIntl(
             <DraftInput

--- a/app/utils/draft.js
+++ b/app/utils/draft.js
@@ -109,14 +109,18 @@ export function alertSlashCommandFailed(formatMessage, error) {
     );
 }
 
-export function buildChannelWideMentionMessage(formatMessage, membersCount, isTimezoneEnabled, channelTimezoneCount) {
+export function buildChannelWideMentionMessage(formatMessage, membersCount, isTimezoneEnabled, channelTimezoneCount, atHere) {
     let notifyAllMessage = '';
     if (isTimezoneEnabled && channelTimezoneCount) {
+        const msgID = atHere ? t('mobile.post_textbox.entire_channel_here.message.with_timezones') : t('mobile.post_textbox.entire_channel.message.with_timezones');
+        const atHereMsg = 'By using @here you are about to send notifications up to {totalMembers, number} {totalMembers, plural, one {person} other {people}} in {timezones, number} {timezones, plural, one {timezone} other {timezones}}. Are you sure you want to do this?';
+        const atAllOrChannelMsg = 'By using @all or @channel you are about to send notifications to {totalMembers, number} {totalMembers, plural, one {person} other {people}} in {timezones, number} {timezones, plural, one {timezone} other {timezones}}. Are you sure you want to do this?';
+
         notifyAllMessage = (
             formatMessage(
                 {
-                    id: 'mobile.post_textbox.entire_channel.message.with_timezones',
-                    defaultMessage: 'By using @all or @channel you are about to send notifications to {totalMembers, number} {totalMembers, plural, one {person} other {people}} in {timezones, number} {timezones, plural, one {timezone} other {timezones}}. Are you sure you want to do this?',
+                    id: msgID,
+                    defaultMessage: atHere ? atHereMsg : atAllOrChannelMsg,
                 },
                 {
                     totalMembers: membersCount - 1,
@@ -125,11 +129,15 @@ export function buildChannelWideMentionMessage(formatMessage, membersCount, isTi
             )
         );
     } else {
+        const msgID = atHere ? t('mobile.post_textbox.entire_channel_here.message') : t('mobile.post_textbox.entire_channel.message');
+        const atHereMsg = 'By using @here you are about to send notifications to up to {totalMembers, number} {totalMembers, plural, one {person} other {people}}. Are you sure you want to do this?';
+        const atAllOrChannelMsg = 'By using @all or @channel you are about to send notifications to {totalMembers, number} {totalMembers, plural, one {person} other {people}}. Are you sure you want to do this?';
+
         notifyAllMessage = (
             formatMessage(
                 {
-                    id: 'mobile.post_textbox.entire_channel.message',
-                    defaultMessage: 'By using @all or @channel you are about to send notifications to {totalMembers, number} {totalMembers, plural, one {person} other {people}}. Are you sure you want to do this?',
+                    id: msgID,
+                    defaultMessage: atHere ? atHereMsg : atAllOrChannelMsg,
                 },
                 {
                     totalMembers: membersCount - 1,
@@ -255,6 +263,11 @@ export const mapGroupMentions = (channelMemberCountsByGroup, groupMentions) => {
 export const textContainsAtAllAtChannel = (text) => {
     const textWithoutCode = text.replace(CODE_REGEX, '');
     return (/(?:\B|\b_+)@(channel|all)(?!(\.|-|_)*[^\W_])/i).test(textWithoutCode);
+};
+
+export const textContainsAtHere = (text) => {
+    const textWithoutCode = text.replace(CODE_REGEX, '');
+    return (/(?:\B|\b_+)@(here)(?!(\.|-|_)*[^\W_])/i).test(textWithoutCode);
 };
 
 export const badDeepLink = (intl) => {

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -479,6 +479,8 @@
   "mobile.post_pre_header.flagged": "Saved",
   "mobile.post_pre_header.pinned": "Pinned",
   "mobile.post_pre_header.pinned_flagged": "Pinned and Saved",
+  "mobile.post_textbox.entire_channel_here.message": "By using @here you are about to send notifications to up to {totalMembers, number} {totalMembers, plural, one {person} other {people}}. Are you sure you want to do this?",
+  "mobile.post_textbox.entire_channel_here.message.with_timezones": "By using @here you are about to send notifications up to {totalMembers, number} {totalMembers, plural, one {person} other {people}} in {timezones, number} {timezones, plural, one {timezone} other {timezones}}. Are you sure you want to do this?",
   "mobile.post_textbox.entire_channel.cancel": "Cancel",
   "mobile.post_textbox.entire_channel.confirm": "Confirm",
   "mobile.post_textbox.entire_channel.message": "By using @all or @channel you are about to send notifications to {totalMembers, number} {totalMembers, plural, one {person} other {people}}. Are you sure you want to do this?",


### PR DESCRIPTION
#### Summary

PR makes `@here` mentions trigger a confirmation modal, similarly to `@all` and `@channel` when `EnableConfirmNotificationsToChannel` is set.

#### Ticket

https://mattermost.atlassian.net/browse/MM-31389

#### Release Note

```release-note
Included @here mentions in the `EnableConfirmNotificationsToChannel` config setting.
```

#### Related PRs

https://github.com/mattermost/mattermost-webapp/pull/8852