### PR TITLE
Fix crash with keyboard-aware-scroll-view and rn 65

### DIFF
--- a/patches/react-native-keyboard-aware-scroll-view+0.9.4.patch
+++ b/patches/react-native-keyboard-aware-scroll-view+0.9.4.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareHOC.js b/node_modules/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareHOC.js
+index 3d94b82..88b037c 100644
+--- a/node_modules/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareHOC.js
++++ b/node_modules/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareHOC.js
+@@ -273,12 +273,12 @@ function KeyboardAwareHOC(
+ 
+     scrollToPosition = (x: number, y: number, animated: boolean = true) => {
+       const responder = this.getScrollResponder()
+-      responder && responder.scrollResponderScrollTo({ x, y, animated })
++      responder && responder.scrollTo({ x, y, animated })
+     }
+ 
+     scrollToEnd = (animated?: boolean = true) => {
+       const responder = this.getScrollResponder()
+-      responder && responder.scrollResponderScrollToEnd({ animated })
++      responder && responder.scrollToEnd({ animated })
+     }
+ 
+     scrollForExtraHeightOnAndroid = (extraHeight: number) => {


### PR DESCRIPTION
#### Summary
After upgrading to RN65 this library was crashing the app.

Fix taken from: https://github.com/APSL/react-native-keyboard-aware-scroll-view/pull/501

#### Release Note

```release-note
NONE
```
