### PR TITLE
Fix android extension crash

### DIFF
--- a/share_extension/screens/channel_list.tsx
+++ b/share_extension/screens/channel_list.tsx
@@ -173,7 +173,7 @@ const ChannelList = ({intl}: ChannnelListProps) => {
                 style={styles.flex}
                 sections={sections}
                 ItemSeparatorComponent={renderItemSeparator}
-                removeClippedSubviews={true}
+                removeClippedSubviews={false}
                 renderItem={renderItem}
                 renderSectionHeader={renderSectionHeader}
                 keyExtractor={keyExtractor}

--- a/share_extension/screens/team_list.tsx
+++ b/share_extension/screens/team_list.tsx
@@ -77,7 +77,7 @@ const TeamList = () => {
             testID='share_extension.team_list.screen'
             data={teams}
             ItemSeparatorComponent={renderItemSeparator}
-            removeClippedSubviews={true}
+            removeClippedSubviews={false}
             renderItem={renderItem}
             keyExtractor={keyExtractor}
             keyboardShouldPersistTaps='always'


### PR DESCRIPTION
#### Summary
Fixing Android crash on the share extension when clearing a previous channel search

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38855

Fixes: #5693

#### Release Note
```release-note
Fixed a crash when clearing a previous channel search done in the Android Share Extension
```
