### PR TITLE
Remove team unreads and rely on channel member instead

### DIFF
--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -67,7 +67,6 @@ export const switchToChannelByName = async (serverUrl: string, channelName: stri
         let myChannel: MyChannelModel | ChannelMembership | undefined;
         let team: TeamModel | Team | undefined;
         let myTeam: MyTeamModel | TeamMembership | undefined;
-        let unreads: TeamUnread | undefined;
         let name = teamName;
         const roles: string [] = [];
         const system = await queryCommonSystemValues(database);
@@ -99,7 +98,6 @@ export const switchToChannelByName = async (serverUrl: string, channelName: stri
             }
             myTeam = added.member!;
             roles.push(...myTeam.roles.split(' '));
-            unreads = added.unreads!;
             joinedNewTeam = true;
         }
 
@@ -163,7 +161,7 @@ export const switchToChannelByName = async (serverUrl: string, channelName: stri
         const modelPromises: Array<Promise<Model[]>> = [];
         const {operator} = DatabaseManager.serverDatabases[serverUrl];
         if (!(team instanceof Model)) {
-            const prepT = prepareMyTeams(operator, [team], [(myTeam as TeamMembership)], [unreads!]);
+            const prepT = prepareMyTeams(operator, [team], [(myTeam as TeamMembership)]);
             if (prepT) {
                 modelPromises.push(...prepT);
             }
@@ -171,8 +169,6 @@ export const switchToChannelByName = async (serverUrl: string, channelName: stri
             const mt: MyTeam[] = [{
                 id: myTeam.team_id,
                 roles: myTeam.roles,
-                is_unread: unreads!.msg_count > 0,
-                mentions_count: unreads!.mention_count,
             }];
             modelPromises.push(
                 operator.handleMyTeam({myTeams: mt, prepareRecordsOnly: true}),

--- a/app/actions/remote/entry.ts
+++ b/app/actions/remote/entry.ts
@@ -130,7 +130,7 @@ export const loginEntry = async ({serverUrl, user, deviceToken}: AfterLoginArgs)
         let initialChannel: Channel|undefined;
         let myTeams: Team[]|undefined;
 
-        // Fetch in parallel server config & license / user preferences / teams / team membership / team unreads
+        // Fetch in parallel server config & license / user preferences / teams / team membership
         const promises: [Promise<ConfigAndLicenseRequest>, Promise<MyPreferencesRequest>, Promise<MyTeamsRequest>] = [
             fetchConfigAndLicense(serverUrl, true),
             fetchMyPreferences(serverUrl, true),
@@ -269,7 +269,7 @@ const fetchAppEntryData = async (serverUrl: string, initialTeamId: string): Prom
     const includeDeletedChannels = true;
     const fetchOnly = true;
 
-    // Fetch in parallel teams / team membership / team unreads / channels for current team / user preferences / user
+    // Fetch in parallel teams / team membership / channels for current team / user preferences / user
     const promises: [Promise<MyTeamsRequest>, Promise<MyChannelsRequest | undefined>, Promise<MyPreferencesRequest>, Promise<MyUserRequest>] = [
         fetchMyTeams(serverUrl, fetchOnly),
         initialTeamId ? fetchMyChannelsForTeam(serverUrl, initialTeamId, includeDeletedChannels, lastDisconnected, fetchOnly) : Promise.resolve(undefined),

--- a/app/actions/remote/retry.ts
+++ b/app/actions/remote/retry.ts
@@ -43,7 +43,7 @@ export const retryInitialTeamAndChannel = async (serverUrl: string) => {
             return {error: true};
         }
 
-        // Fetch in parallel server config & license / user preferences / teams / team membership / team unreads
+        // Fetch in parallel server config & license / user preferences / teams / team membership
         const promises: [Promise<ConfigAndLicenseRequest>, Promise<MyPreferencesRequest>, Promise<MyTeamsRequest>] = [
             fetchConfigAndLicense(serverUrl, true),
             fetchMyPreferences(serverUrl, true),
@@ -103,7 +103,7 @@ export const retryInitialTeamAndChannel = async (serverUrl: string) => {
             modelPromises.push(prefModel);
         }
 
-        const teamModels = prepareMyTeams(operator, teamData.teams!, teamData.memberships!, teamData.unreads!);
+        const teamModels = prepareMyTeams(operator, teamData.teams!, teamData.memberships!);
         if (teamModels) {
             modelPromises.push(...teamModels);
         }

--- a/app/actions/remote/user.ts
+++ b/app/actions/remote/user.ts
@@ -163,7 +163,6 @@ export const loadMe = async (serverUrl: string, {deviceToken, user}: LoadMeArgs)
 
         // Goes into myTeam table
         const teamMembersRequest = client.getMyTeamMembers();
-        const teamUnreadRequest = client.getMyTeamUnreads();
 
         const preferencesRequest = client.getMyPreferences();
         const configRequest = client.getClientConfigOld();
@@ -172,14 +171,12 @@ export const loadMe = async (serverUrl: string, {deviceToken, user}: LoadMeArgs)
         const [
             teams,
             teamMemberships,
-            teamUnreads,
             preferences,
             config,
             license,
         ] = await Promise.all([
             teamsRequest,
             teamMembersRequest,
-            teamUnreadRequest,
             preferencesRequest,
             configRequest,
             licenseRequest,
@@ -189,9 +186,8 @@ export const loadMe = async (serverUrl: string, {deviceToken, user}: LoadMeArgs)
         const teamRecords = operator.handleTeam({prepareRecordsOnly: true, teams});
         const teamMembershipRecords = operator.handleTeamMemberships({prepareRecordsOnly: true, teamMemberships});
 
-        const myTeams = teamUnreads.map((unread) => {
-            const matchingTeam = teamMemberships.find((team) => team.team_id === unread.team_id);
-            return {id: unread.team_id, roles: matchingTeam?.roles ?? '', is_unread: unread.msg_count > 0, mentions_count: unread.mention_count};
+        const myTeams = teamMemberships.map((tm) => {
+            return {id: tm.team_id, roles: tm.roles ?? ''};
         });
 
         const myTeamRecords = operator.handleMyTeam({

--- a/app/client/rest/teams.ts
+++ b/app/client/rest/teams.ts
@@ -16,8 +16,6 @@ export interface ClientTeamsMix {
     getMyTeams: () => Promise<Team[]>;
     getTeamsForUser: (userId: string) => Promise<Team[]>;
     getMyTeamMembers: () => Promise<TeamMembership[]>;
-    getMyTeamUnreads: () => Promise<TeamUnread[]>;
-    getTeamUnreads: (teamId: string) => Promise<TeamUnread>;
     getTeamMembers: (teamId: string, page?: number, perPage?: number) => Promise<TeamMembership[]>;
     getTeamMember: (teamId: string, userId: string) => Promise<TeamMembership>;
     addToTeam: (teamId: string, userId: string) => Promise<TeamMembership>;
@@ -107,20 +105,6 @@ const ClientTeams = (superclass: any) => class extends superclass {
             {method: 'get'},
         );
     };
-
-    getMyTeamUnreads = async () => {
-        return this.doFetch(
-            `${this.getUserRoute('me')}/teams/unread`,
-            {method: 'get'},
-        );
-    };
-
-    getTeamUnreads = async (teamId: string) => {
-        return this.doFetch(
-            `${this.getUserRoute('me')}/${this.getTeamRoute(teamId)}/unread`,
-            {method: 'get'},
-        );
-    }
 
     getTeamMembers = async (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
         return this.doFetch(

--- a/app/database/models/server/my_team.ts
+++ b/app/database/models/server/my_team.ts
@@ -18,12 +18,6 @@ export default class MyTeamModel extends Model {
     /** table (name) : MyTeam */
     static table = MY_TEAM;
 
-    /** is_unread : Boolean flag for unread messages on team level */
-    @field('is_unread') isUnread!: boolean;
-
-    /** mentions_count : Count of posts in which the user has been mentioned */
-    @field('mentions_count') mentionsCount!: number;
-
     /** roles : The different permissions that this user has in the team, concatenated together with comma to form a single string. */
     @field('roles') roles!: string;
 

--- a/app/database/operator/server_data_operator/handlers/team.test.ts
+++ b/app/database/operator/server_data_operator/handlers/team.test.ts
@@ -110,8 +110,6 @@ describe('*** Operator: Team Handlers tests ***', () => {
             {
                 id: 'teamA',
                 roles: 'roleA, roleB, roleC',
-                is_unread: true,
-                mentions_count: 3,
             },
         ];
 

--- a/app/database/operator/server_data_operator/transformers/team.test.ts
+++ b/app/database/operator/server_data_operator/transformers/team.test.ts
@@ -64,8 +64,6 @@ describe('*** TEAM Prepare Records Test ***', () => {
                 raw: {
                     id: 'teamA',
                     roles: 'roleA, roleB, roleC',
-                    is_unread: true,
-                    mentions_count: 3,
                 },
             },
         });

--- a/app/database/operator/server_data_operator/transformers/team.ts
+++ b/app/database/operator/server_data_operator/transformers/team.ts
@@ -190,8 +190,6 @@ export const transformMyTeamRecord = ({action, database, value}: TransformerArgs
     const fieldsMapper = (myTeam: MyTeamModel) => {
         myTeam._raw.id = isCreateAction ? (raw.id || myTeam.id) : record.id;
         myTeam.roles = raw.roles;
-        myTeam.isUnread = raw.is_unread;
-        myTeam.mentionsCount = raw.mentions_count;
     };
 
     return prepareBaseRecord({

--- a/app/database/schema/server/table_schemas/my_team.ts
+++ b/app/database/schema/server/table_schemas/my_team.ts
@@ -10,8 +10,6 @@ const {MY_TEAM} = MM_TABLES.SERVER;
 export default tableSchema({
     name: MY_TEAM,
     columns: [
-        {name: 'is_unread', type: 'boolean'},
-        {name: 'mentions_count', type: 'number'},
         {name: 'roles', type: 'string'},
     ],
 });

--- a/app/database/schema/server/test.ts
+++ b/app/database/schema/server/test.ts
@@ -322,13 +322,9 @@ describe('*** Test schema for SERVER database ***', () => {
                 [MY_TEAM]: {
                     name: MY_TEAM,
                     columns: {
-                        is_unread: {name: 'is_unread', type: 'boolean'},
-                        mentions_count: {name: 'mentions_count', type: 'number'},
                         roles: {name: 'roles', type: 'string'},
                     },
                     columnArray: [
-                        {name: 'is_unread', type: 'boolean'},
-                        {name: 'mentions_count', type: 'number'},
                         {name: 'roles', type: 'string'},
                     ],
                 },

--- a/app/queries/servers/entry.ts
+++ b/app/queries/servers/entry.ts
@@ -43,7 +43,7 @@ export const prepareModels = async ({operator, initialTeamId, removeTeams, remov
     }
 
     if (teamData?.teams?.length) {
-        const teamModels = prepareMyTeams(operator, teamData.teams, teamData.memberships || [], teamData.unreads || []);
+        const teamModels = prepareMyTeams(operator, teamData.teams, teamData.memberships || []);
         if (teamModels) {
             modelPromises.push(...teamModels);
         }

--- a/app/queries/servers/team.ts
+++ b/app/queries/servers/team.ts
@@ -46,14 +46,13 @@ export const addChannelToTeamHistory = async (operator: ServerDataOperator, team
     return operator.handleTeamChannelHistory({teamChannelHistories: [tch], prepareRecordsOnly});
 };
 
-export const prepareMyTeams = (operator: ServerDataOperator, teams: Team[], memberships: TeamMembership[], unreads: TeamUnread[]) => {
+export const prepareMyTeams = (operator: ServerDataOperator, teams: Team[], memberships: TeamMembership[]) => {
     try {
         const teamRecords = operator.handleTeam({prepareRecordsOnly: true, teams});
         const teamMemberships = memberships.filter((m) => teams.find((t) => t.id === m.team_id));
         const teamMembershipRecords = operator.handleTeamMemberships({prepareRecordsOnly: true, teamMemberships});
-        const myTeams: MyTeam[] = unreads.map((unread) => {
-            const matchingTeam = teamMemberships.find((team) => team.team_id === unread.team_id);
-            return {id: unread.team_id, roles: matchingTeam?.roles ?? '', is_unread: unread.msg_count > 0, mentions_count: unread.mention_count};
+        const myTeams: MyTeam[] = teamMemberships.map((tm) => {
+            return {id: tm.team_id, roles: tm.roles ?? ''};
         });
         const myTeamRecords = operator.handleMyTeam({
             prepareRecordsOnly: true,

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -102,4 +102,12 @@ RCT_EXPORT_METHOD(deleteEntititesFile: (RCTResponseSenderBlock) callback) {
   }
 }
 
+RCT_EXPORT_METHOD(addListener:(NSString *)eventName) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
+RCT_EXPORT_METHOD(removeListeners:(double)count) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
 @end

--- a/types/api/teams.d.ts
+++ b/types/api/teams.d.ts
@@ -49,9 +49,3 @@ type TeamsState = {
     groupsAssociatedToTeam: any;
     totalCount: number;
 };
-
-type TeamUnread = {
-    team_id: string;
-    mention_count: number;
-    msg_count: number;
-};

--- a/types/database/models/servers/my_team.d.ts
+++ b/types/database/models/servers/my_team.d.ts
@@ -11,12 +11,6 @@ export default class MyTeamModel extends Model {
     /** table (name) : MyTeam */
     static table: string;
 
-    /** is_unread : Boolean flag for unread messages on team level */
-    isUnread: boolean;
-
-    /** mentions_count : Count of posts in which the user has been mentioned */
-    mentionsCount: number;
-
     /** roles : The different permissions that this user has in the team, concatenated together with comma to form a single string. */
     roles: string;
 

--- a/types/database/raw_values.d.ts
+++ b/types/database/raw_values.d.ts
@@ -42,8 +42,6 @@ type GroupTeamRelation = {
 type MyTeam = {
     id: string;
     roles: string;
-    is_unread: boolean;
-    mentions_count: number;
 };
 
 type PostsInChannel = {


### PR DESCRIPTION
#### Summary
Removes the myTeam data that holds team unreads as well as removes request to fetch team unreads from the server. We will rely on the info in MyChannel as the source of truth for unreads

#### Release Note
```release-note
NONE
```
