### PR TITLE
MM-39054 patch Android react-native-file-viewer

### DIFF
--- a/patches/react-native-file-viewer+2.1.4.patch
+++ b/patches/react-native-file-viewer+2.1.4.patch
@@ -1,0 +1,103 @@
+diff --git a/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java b/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
+index 11fd79f..92156a1 100644
+--- a/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
++++ b/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
+@@ -6,6 +6,8 @@ import android.content.Intent;
+ import android.content.pm.PackageManager;
+ import android.net.Uri;
+ import androidx.core.content.FileProvider;
++
++import android.text.TextUtils;
+ import android.webkit.MimeTypeMap;
+ 
+ import com.facebook.react.bridge.ActivityEventListener;
+@@ -41,6 +43,21 @@ public class RNFileViewerModule extends ReactContextBaseJavaModule {
+     reactContext.addActivityEventListener(mActivityEventListener);
+   }
+ 
++  private static String getExtension(String uri) {
++    if (uri == null) {
++      return null;
++    }
++
++    int dot = uri.lastIndexOf(".");
++    if (dot >= 0) {
++      // exclude the dot
++      return uri.substring(dot + 1);
++    } else {
++      // No extension.
++      return "";
++    }
++  }
++
+   @ReactMethod
+   public void open(String path, Integer currentId, ReadableMap options) {
+     Uri contentUri = null;
+@@ -51,6 +68,7 @@ public class RNFileViewerModule extends ReactContextBaseJavaModule {
+       contentUri = Uri.parse(path);
+     } else {
+       File newFile = new File(path);
++
+       try {
+         final String packageName = getCurrentActivity().getPackageName();
+         final String authority = new StringBuilder(packageName).append(".provider").toString();
+@@ -68,6 +86,9 @@ public class RNFileViewerModule extends ReactContextBaseJavaModule {
+     }
+ 
+     String extension = MimeTypeMap.getFileExtensionFromUrl(path).toLowerCase();
++    if (TextUtils.isEmpty(extension)) {
++      extension = getExtension(path);
++    }
+     String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+ 
+     Intent shareIntent = new Intent();
+@@ -84,9 +105,9 @@ public class RNFileViewerModule extends ReactContextBaseJavaModule {
+       intentActivity = shareIntent;
+     }
+ 
+-    PackageManager pm = getCurrentActivity().getPackageManager();
+-
+-    if (shareIntent.resolveActivity(pm) != null) {
++//    PackageManager pm = getCurrentActivity().getPackageManager();
++//
++//    if (shareIntent.resolveActivity(pm) != null) {
+       try {
+         getCurrentActivity().startActivityForResult(intentActivity, currentId + RN_FILE_VIEWER_REQUEST);
+         sendEvent(OPEN_EVENT, currentId, null);
+@@ -94,21 +115,21 @@ public class RNFileViewerModule extends ReactContextBaseJavaModule {
+       catch(Exception e) {
+         sendEvent(OPEN_EVENT, currentId, e.getMessage());
+       }
+-      } else {
+-        try {
+-          if (showStoreSuggestions) {
+-            if(mimeType == null) {
+-              throw new Exception("It wasn't possible to detect the type of the file");
+-            }
+-            Intent storeIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("market://search?q=" + mimeType + "&c=apps"));
+-            getCurrentActivity().startActivity(storeIntent);
+-          }
+-          throw new Exception("No app associated with this mime type");
+-        }
+-        catch(Exception e) {
+-          sendEvent(OPEN_EVENT, currentId, e.getMessage());
+-        }
+-      }
++//    } else {
++//        try {
++//          if (showStoreSuggestions) {
++//            if(mimeType == null) {
++//              throw new Exception("It wasn't possible to detect the type of the file");
++//            }
++//            Intent storeIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("market://search?q=" + mimeType + "&c=apps"));
++//            getCurrentActivity().startActivity(storeIntent);
++//          }
++//          throw new Exception("No app associated with this mime type");
++//        }
++//        catch(Exception e) {
++//          sendEvent(OPEN_EVENT, currentId, e.getMessage());
++//        }
++//      }
+   }
+ 
+   @Override


### PR DESCRIPTION
#### Summary
this PR patches `react-native-file-viewer` for Android as it was failing to extract the extension for file paths that include spaces in the filename using `android.webkit.MimeTypeMap` which is an android library, if by using that method the library fails to extract the extension we then use a method that gets the extension by splitting the filename in the last dot.

The patch also excludes the store suggestions as we never make use of it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39054


#### Release Note

```release-note
NONE
```
