### PR TITLE
Mobile-only collapse state

### DIFF
--- a/app/components/sidebars/main/channels_list/list/list.js
+++ b/app/components/sidebars/main/channels_list/list/list.js
@@ -113,10 +113,9 @@ export default class List extends PureComponent {
             this.props.orderedChannelIds !== orderedChannelIds) {
                 this.setSections(this.buildSections(this.props));
             }
-        } else if (
+        } else if ( // Rebuild sections only if categories or unreads have changed
             !isEqual(this.props.categories, categories) ||
-            this.props.unreadChannelIds !== unreadChannelIds) {
-            // Rebuild sections only if categories or unreads have changed
+            !isEqual(this.props.unreadChannelIds, unreadChannelIds)) {
             this.setCategorySections(this.buildCategorySections());
         }
 

--- a/app/mm-redux/types/channel_categories.ts
+++ b/app/mm-redux/types/channel_categories.ts
@@ -25,7 +25,7 @@ export type ChannelCategory = {
     sorting: CategorySorting;
     channel_ids: Array<$ID<Channel>>;
     muted: boolean;
-    collapsed: boolean;
+    collapsed?: boolean;
 };
 
 export type OrderedChannelCategories = {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Updates code to ignore `collapsed` state on the server.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38963

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 

- [SIM] iPhone 12 / iOS14.5
- [SIM] Pixel 4a / API29

#### Screenshots

https://user-images.githubusercontent.com/456511/136132689-12d1177c-670f-4e37-94c3-18e14b17b9d6.mov

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Category collapse state is local / mobile-only.
```
