### PR TITLE
Hides favourites category if empty

### DIFF
--- a/app/components/sidebars/main/channels_list/list/list.js
+++ b/app/components/sidebars/main/channels_list/list/list.js
@@ -472,6 +472,9 @@ export default class List extends PureComponent {
         // Add the rest
         if (this.props.categories) {
             this.props.categories.reduce((prev, cat) => {
+                if (cat.type === 'favorites' && !cat.channel_ids.length) {
+                    return prev;
+                }
                 prev.push({
                     name: cat.display_name,
                     action: cat.type === 'direct_messages' ? this.goToDirectMessages : () => this.showCreateChannelOptions(cat),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38939

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 
- [SIM] iPhone 12 / iOS14.5
- [SIM] Pixel 4a / API28

#### Screenshots

<img width="472" alt="Screen Shot 2021-10-06 at 1 52 23 pm" src="https://user-images.githubusercontent.com/456511/136133459-93138a70-69df-4c21-b7bf-88d47653fcda.png">
<img width="472" alt="Screen Shot 2021-10-06 at 1 52 12 pm" src="https://user-images.githubusercontent.com/456511/136133474-6788fb22-823f-4651-93b1-e43a62cd48e2.png">

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Hides favourite category if empty
```
