### PR TITLE
MM-38737 Image preview can only be viewed once in threads

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -105,7 +105,9 @@ Navigation.events().registerAppLaunchedListener(() => {
 });
 
 export function componentDidAppearListener({componentId}) {
-    EphemeralStore.addNavigationComponentId(componentId);
+    if (componentId.indexOf('!screen') !== 0) {
+        EphemeralStore.addNavigationComponentId(componentId);
+    }
 
     switch (componentId) {
     case 'MainSidebar':

--- a/app/mattermost.test.js
+++ b/app/mattermost.test.js
@@ -52,6 +52,12 @@ describe('componentDidAppearListener', () => {
         expect(EventEmitter.emit).toHaveBeenCalledTimes(1);
         expect(EventEmitter.emit).toHaveBeenCalledWith(NavigationTypes.BLUR_POST_DRAFT);
     });
+
+    it('should not add componentIds starting with "!screen" to the store as they are not screens', () => {
+        const componentId = '!screen';
+        componentDidAppearListener({componentId});
+        expect(EphemeralStore.addNavigationComponentId).not.toHaveBeenCalledWith(componentId);
+    });
 });
 
 describe('componentDidDisappearListener', () => {

--- a/app/screens/thread/thread_base.js
+++ b/app/screens/thread/thread_base.js
@@ -57,7 +57,8 @@ export default class ThreadBase extends PureComponent {
 
         if (props.collapsedThreadsEnabled) {
             // Without unique id, it breaks navigation from permalink view.
-            this.threadFollowId = Math.floor(Math.random() * 0x10000000000).toString(16);
+            // Adding prefix "!screen" to exclude it from being added to stack
+            this.threadFollowId = '!screen-' + Math.floor(Math.random() * 0x10000000000).toString(16);
 
             let titleText;
             if (channelType === General.DM_CHANNEL) {


### PR DESCRIPTION
#### Summary
- We pop the `Gallery` screen from the stack while closing the gallery view.
- With CRT, Inside the `Thread` screen, we have added `follow button` component which is being added in the stack. 
- Instead of popping the `Gallery` screen and returning to the `Thread` screen, It is popping out to the `follow button` component.
- We are not excluding the `follow button` component from being added to the ephemeral store 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38737

#### Device Information
This PR was tested on: iOS 15 Simulator, Android 11 Emulator 

#### Release Note
```release-note
NONE
```