### PR TITLE
Restores cancel button for various bottom-sheet calls

### DIFF
--- a/app/components/at_mention/at_mention.js
+++ b/app/components/at_mention/at_mention.js
@@ -113,7 +113,6 @@ export default class AtMention extends React.PureComponent {
 
             BottomSheet.showBottomSheetWithOptions({
                 options: [actionText, cancelText],
-                cancelButtonIndex: 1,
             }, (value) => {
                 if (value !== 1) {
                     this.handleCopyMention();

--- a/app/components/markdown/markdown_code_block/markdown_code_block.js
+++ b/app/components/markdown/markdown_code_block/markdown_code_block.js
@@ -78,7 +78,6 @@ export default class MarkdownCodeBlock extends React.PureComponent {
             const actionText = formatMessage({id: 'mobile.markdown.code.copy_code', defaultMessage: 'Copy Code'});
             BottomSheet.showBottomSheetWithOptions({
                 options: [actionText, cancelText],
-                cancelButtonIndex: 1,
             }, (value) => {
                 if (value !== 1) {
                     this.handleCopyCode();

--- a/app/components/markdown/markdown_image/markdown_image.js
+++ b/app/components/markdown/markdown_image/markdown_image.js
@@ -151,7 +151,6 @@ export default class MarkdownImage extends ImageViewPort {
             const actionText = formatMessage({id: 'mobile.markdown.link.copy_url', defaultMessage: 'Copy URL'});
             BottomSheet.showBottomSheetWithOptions({
                 options: [actionText, cancelText],
-                cancelButtonIndex: 1,
             }, (value) => {
                 if (value !== 1) {
                     this.handleLinkCopy();

--- a/app/components/markdown/markdown_link/markdown_link.js
+++ b/app/components/markdown/markdown_link/markdown_link.js
@@ -137,7 +137,6 @@ export default class MarkdownLink extends PureComponent {
             const actionText = formatMessage({id: 'mobile.markdown.link.copy_url', defaultMessage: 'Copy URL'});
             BottomSheet.showBottomSheetWithOptions({
                 options: [actionText, cancelText],
-                cancelButtonIndex: 1,
             }, (value) => {
                 if (value !== 1) {
                     this.handleLinkCopy();

--- a/app/components/sidebars/main/channels_list/list/list.js
+++ b/app/components/sidebars/main/channels_list/list/list.js
@@ -213,7 +213,7 @@ export default class List extends PureComponent {
         const moreChannelsText = formatMessage({id: 'more_channels.title', defaultMessage: 'Browse for a Channel'});
         const newChannelText = formatMessage({id: 'mobile.create_channel', defaultMessage: 'Create a new Channel'});
         const newDirectChannelText = formatMessage({id: 'mobile.more_dms.title', defaultMessage: 'Add a Conversation'});
-        const cancelText = formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'});
+
         const options = [];
         const actions = [];
 
@@ -229,20 +229,14 @@ export default class List extends PureComponent {
 
         actions.push(this.goToDirectMessages);
         options.push({text: newDirectChannelText, icon: 'account-plus-outline'});
-        options.push(cancelText);
-
-        const cancelButtonIndex = options.length - 1;
 
         BottomSheet.showBottomSheetWithOptions({
             anchor: this.combinedActionsRef?.current ? findNodeHandle(this.combinedActionsRef.current) : null,
             options,
             title: 'Add Channels',
             subtitle: `To the ${category.display_name} category`,
-            cancelButtonIndex,
         }, (value) => {
-            if (value !== cancelButtonIndex) {
-                actions[value]();
-            }
+            actions[value]();
         });
     };
 

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -101,7 +101,6 @@ export default class ChannelInfoHeader extends React.PureComponent {
 
             BottomSheet.showBottomSheetWithOptions({
                 options: [actionText, cancelText],
-                cancelButtonIndex: 1,
             }, (value) => {
                 if (value === 0) {
                     this.handleCopy(text);

--- a/app/screens/more_channels/more_channels.js
+++ b/app/screens/more_channels/more_channels.js
@@ -430,7 +430,6 @@ export default class MoreChannels extends PureComponent {
 
         BottomSheet.showBottomSheetWithOptions({
             options,
-            cancelButtonIndex: 3,
             title: titleText,
         }, (value) => {
             let typeOfChannels;

--- a/app/utils/bottom_sheet/bottom_sheet.ts
+++ b/app/utils/bottom_sheet/bottom_sheet.ts
@@ -11,7 +11,13 @@ export default {
             callback(index);
         }
 
-        const items = options.options.splice(0, options.cancelButtonIndex).map((o: string | {icon: string; text: string}, index: any) => ({
+        let items = options.options;
+
+        if (typeof options.cancelButtonIndex === 'number') {
+            items = items.splice(0, options.cancelButtonIndex);
+        }
+
+        items = items.map((o: string | {icon: string; text: string}, index: any) => ({
             action: () => itemAction(index),
             text: typeof o === 'string' ? o : o.text,
             icon: typeof o === 'string' ? null : o.icon,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Cleans up the cancel button logic; restoring it for:
- More Channels
- `@` mentions
- Channel Info Header
- Markdown Code Blocks
- Markdown Images
- Markdown Links 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39159

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
- [SIM] iPhone 12 / iOS14.5

#### Screenshots

<img width="491" alt="Screen Shot 2021-10-07 at 9 32 12 am" src="https://user-images.githubusercontent.com/456511/136292798-981f9d7f-239f-4262-8719-2abceb2a1797.png">

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Restores cancel button on bottom sheet
```
