### PR TITLE
Fix send message with physical keyboard on iPad 15

### DIFF
--- a/ios/Mattermost/AppDelegate.m
+++ b/ios/Mattermost/AppDelegate.m
@@ -146,15 +146,29 @@ NSString* const NOTIFICATION_UPDATE_BADGE_ACTION = @"update_badge";
 */
 RNHWKeyboardEvent *hwKeyEvent = nil;
 - (NSMutableArray<UIKeyCommand *> *)keyCommands {
-  NSMutableArray *keys = [NSMutableArray new];
   if (hwKeyEvent == nil) {
     hwKeyEvent = [[RNHWKeyboardEvent alloc] init];
   }
+  
+  NSMutableArray *commands = [NSMutableArray new];
+  
   if ([hwKeyEvent isListening]) {
-    [keys addObject: [UIKeyCommand keyCommandWithInput:@"\r" modifierFlags:0 action:@selector(sendEnter:)]];
-    [keys addObject: [UIKeyCommand keyCommandWithInput:@"\r" modifierFlags:UIKeyModifierShift action:@selector(sendShiftEnter:)]];
+    UIKeyCommand *enter = [UIKeyCommand keyCommandWithInput:@"\r" modifierFlags:0 action:@selector(sendEnter:)];
+    UIKeyCommand *shiftEnter = [UIKeyCommand keyCommandWithInput:@"\r" modifierFlags:UIKeyModifierShift action:@selector(sendShiftEnter:)];
+    if (@available(iOS 13.0, *)) {
+      [enter setTitle:@"Send message"];
+      [shiftEnter setTitle:@"Add new line"];
+    }
+    if (@available(iOS 15.0, *)) {
+      [enter setWantsPriorityOverSystemBehavior:YES];
+      [shiftEnter setWantsPriorityOverSystemBehavior:YES];
+    }
+    
+    [commands addObject: enter];
+    [commands addObject: shiftEnter];
   }
-  return keys;
+  
+  return commands;
 }
 
 - (void)sendEnter:(UIKeyCommand *)sender {


### PR DESCRIPTION
#### Summary
apps built with Xcode 13 and running on iPad 15, requires us to set a new property called WantsPriorityOverSystemBehavior.

#### Ticket Link
Fixes #5736 

#### Device Information
This PR was tested on: iPad Pro 11 with iOS 15 and 15.01

```release-note
NONE
```
