### PR TITLE
Rename match lane to certs, fixes iOS build process

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -312,7 +312,7 @@ platform :ios do
   end
 
   desc 'Get iOS match profiles'
-  lane :match do
+  lane :certs do
     if !ENV['MATCH_PASSWORD'].nil? && !ENV['MATCH_PASSWORD'].empty?
       api_key = get_apple_api_key()
       match(


### PR DESCRIPTION

#### Release Note
```release-note
NONE
```
