### PR TITLE
MM-39337 set allowFontScaling to TextInput components

### DIFF
--- a/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
+++ b/app/components/edit_channel_info/__snapshots__/edit_channel_info.test.js.snap
@@ -74,6 +74,7 @@ exports[`EditChannelInfo should match snapshot 1`] = `
             }
           >
             <TextInputWithLocalizedPlaceholder
+              allowFontScaling={true}
               autoCapitalize="none"
               autoCorrect={false}
               disableFullscreenUI={true}
@@ -140,6 +141,7 @@ exports[`EditChannelInfo should match snapshot 1`] = `
             }
           >
             <TextInputWithLocalizedPlaceholder
+              allowFontScaling={true}
               autoCapitalize="none"
               autoCorrect={false}
               blurOnSubmit={false}
@@ -229,6 +231,7 @@ exports[`EditChannelInfo should match snapshot 1`] = `
           }
         >
           <TextInputWithLocalizedPlaceholder
+            allowFontScaling={true}
             autoCapitalize="none"
             autoCorrect={false}
             blurOnSubmit={false}

--- a/app/components/edit_channel_info/index.js
+++ b/app/components/edit_channel_info/index.js
@@ -334,6 +334,7 @@ export default class EditChannelInfo extends PureComponent {
                                     </View>
                                     <View style={style.inputContainer}>
                                         <TextInputWithLocalizedPlaceholder
+                                            allowFontScaling={true}
                                             testID='edit_channel_info.name.input'
                                             ref={this.nameInput}
                                             value={displayName}
@@ -364,6 +365,7 @@ export default class EditChannelInfo extends PureComponent {
                                     </View>
                                     <View style={style.inputContainer}>
                                         <TextInputWithLocalizedPlaceholder
+                                            allowFontScaling={true}
                                             testID='edit_channel_info.purpose.input'
                                             ref={this.purposeInput}
                                             value={purpose}
@@ -407,6 +409,7 @@ export default class EditChannelInfo extends PureComponent {
                             </View>
                             <View style={style.inputContainer}>
                                 <TextInputWithLocalizedPlaceholder
+                                    allowFontScaling={true}
                                     testID='edit_channel_info.header.input'
                                     ref={this.headerInput}
                                     value={header}

--- a/app/components/post_draft/__snapshots__/post_draft.test.js.snap
+++ b/app/components/post_draft/__snapshots__/post_draft.test.js.snap
@@ -286,6 +286,7 @@ exports[`PostDraft Should render the DraftInput 1`] = `
       <View>
         <PasteInput
           accessible={true}
+          allowFontScaling={true}
           autoCapitalize="sentences"
           autoCompleteType="off"
           blurOnSubmit={false}

--- a/app/components/post_draft/post_input/__snapshots__/post_input.test.js.snap
+++ b/app/components/post_draft/post_input/__snapshots__/post_input.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`PostInput should match, full snapshot 1`] = `
 <ForwardRef
+  allowFontScaling={true}
   autoCompleteType="off"
   blurOnSubmit={false}
   disableCopyPaste={false}

--- a/app/components/post_draft/post_input/post_input.js
+++ b/app/components/post_draft/post_input/post_input.js
@@ -298,6 +298,7 @@ export default class PostInput extends PureComponent {
 
         return (
             <PasteableTextInput
+                allowFontScaling={true}
                 testID={testID}
                 ref={this.input}
                 disableCopyPaste={this.state.disableCopyAndPaste}

--- a/app/components/search_bar/__snapshots__/search_bar.test.js.snap
+++ b/app/components/search_bar/__snapshots__/search_bar.test.js.snap
@@ -33,6 +33,7 @@ exports[`SearchBar should match snapshot 1`] = `
     }
   >
     <ForwardRef(Themed.SearchBar)
+      allowFontScaling={true}
       autoCapitalize="auto-capitalize"
       autoCorrect={false}
       autoFocus={true}

--- a/app/components/search_bar/index.js
+++ b/app/components/search_bar/index.js
@@ -323,6 +323,7 @@ export default class Search extends PureComponent {
                     ]}
                 >
                     <SearchBar
+                        allowFontScaling={true}
                         testID={searchInputTestID}
                         autoCapitalize={this.props.autoCapitalize}
                         autoCorrect={false}

--- a/app/components/widgets/settings/text_setting.js
+++ b/app/components/widgets/settings/text_setting.js
@@ -185,6 +185,7 @@ export default class TextSetting extends PureComponent {
                 <View style={[style.inputContainer, noediting]}>
                     <View>
                         <TextInput
+                            allowFontScaling={true}
                             value={value}
                             placeholder={placeholder}
                             placeholderTextColor={changeOpacity(theme.centerChannelColor, 0.5)}

--- a/app/screens/code/code.js
+++ b/app/screens/code/code.js
@@ -67,6 +67,7 @@ export default class Code extends React.PureComponent {
         if (Platform.OS === 'ios') {
             textComponent = (
                 <TextInput
+                    allowFontScaling={true}
                     editable={false}
                     multiline={true}
                     value={this.props.content}

--- a/app/screens/custom_status/custom_status_modal.tsx
+++ b/app/screens/custom_status/custom_status_modal.tsx
@@ -404,6 +404,7 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
         const customStatusInput = (
             <View style={style.inputContainer}>
                 <TextInput
+                    allowFontScaling={true}
                     testID='custom_status.input'
                     autoCapitalize='none'
                     autoCorrect={false}

--- a/app/screens/edit_post/__snapshots__/edit_post.test.js.snap
+++ b/app/screens/edit_post/__snapshots__/edit_post.test.js.snap
@@ -37,6 +37,7 @@ exports[`EditPost should match snapshot 1`] = `
         }
       >
         <TextInputWithLocalizedPlaceholder
+          allowFontScaling={true}
           blurOnSubmit={false}
           disableFullscreenUI={true}
           keyboardAppearance="light"

--- a/app/screens/edit_post/edit_post.js
+++ b/app/screens/edit_post/edit_post.js
@@ -272,6 +272,7 @@ export default class EditPost extends PureComponent {
                         {displayError}
                         <View style={[inputContainerStyle, {height}]}>
                             <TextInputWithLocalizedPlaceholder
+                                allowFontScaling={true}
                                 testID='edit_post.message.input'
                                 ref={this.messageRef}
                                 value={message}

--- a/app/screens/forgot_password/__snapshots__/forgot_password.test.js.snap
+++ b/app/screens/forgot_password/__snapshots__/forgot_password.test.js.snap
@@ -148,6 +148,7 @@ exports[`ForgotPassword should match snapshot 1`] = `
           }
         />
         <TextInput
+          allowFontScaling={true}
           autoCapitalize="none"
           autoCorrect={false}
           blurOnSubmit={false}
@@ -269,6 +270,7 @@ exports[`ForgotPassword snapshot for error on failure of email regex 1`] = `
           }
         />
         <TextInput
+          allowFontScaling={true}
           autoCapitalize="none"
           autoCorrect={false}
           blurOnSubmit={false}

--- a/app/screens/forgot_password/forgot_password.js
+++ b/app/screens/forgot_password/forgot_password.js
@@ -121,6 +121,7 @@ export default class ForgotPassword extends PureComponent {
                         defaultMessage='To reset your password, enter the email address you used to sign up'
                     />
                     <TextInput
+                        allowFontScaling={true}
                         ref={this.emailIdRef}
                         style={GlobalStyles.inputBox}
                         onChangeText={this.changeEmail}

--- a/app/screens/login/login.js
+++ b/app/screens/login/login.js
@@ -395,6 +395,7 @@ export default class Login extends PureComponent {
                             error={this.state.error}
                         />
                         <TextInput
+                            allowFontScaling={true}
                             testID='login.username.input'
                             autoCapitalize='none'
                             autoCorrect={false}
@@ -411,6 +412,7 @@ export default class Login extends PureComponent {
                             underlineColorAndroid='transparent'
                         />
                         <TextInput
+                            allowFontScaling={true}
                             testID='login.password.input'
                             autoCapitalize='none'
                             autoCorrect={false}

--- a/app/screens/mfa/mfa.js
+++ b/app/screens/mfa/mfa.js
@@ -162,6 +162,7 @@ export default class Mfa extends PureComponent {
                                 error={this.state.error}
                             />
                             <TextInputWithLocalizedPlaceholder
+                                allowFontScaling={true}
                                 ref={this.inputRef}
                                 value={this.state.token}
                                 onChangeText={this.handleInput}

--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -490,6 +490,7 @@ export default class SelectServer extends PureComponent {
                                 />
                             </View>
                             <TextInput
+                                allowFontScaling={true}
                                 testID='select_server.server_url.input'
                                 ref={this.inputRef}
                                 value={url}

--- a/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.tsx
+++ b/app/screens/settings/notification_settings_auto_responder/notification_settings_auto_responder.tsx
@@ -153,6 +153,7 @@ const NotificationSettingsAutoResponder = ({currentUser, currentUserStatus, intl
                     >
                         <View style={style.inputContainer}>
                             <TextInputWithLocalizedPlaceholder
+                                allowFontScaling={true}
                                 ref={autoresponderRef}
                                 value={autoResponderMessage}
                                 blurOnSubmit={true}

--- a/app/screens/settings/notification_settings_mentions/notification_settings_mentions.android.js
+++ b/app/screens/settings/notification_settings_mentions/notification_settings_mentions.android.js
@@ -69,6 +69,7 @@ class NotificationSettingsMentionsAndroid extends NotificationSettingsMentionsBa
                                 />
                             </View>
                             <TextInputWithLocalizedPlaceholder
+                                allowFontScaling={true}
                                 autoFocus={true}
                                 value={this.state.androidKeywords}
                                 blurOnSubmit={true}

--- a/app/screens/settings/notification_settings_mentions_keywords/__snapshots__/notification_settings_mentions_keywords.test.js.snap
+++ b/app/screens/settings/notification_settings_mentions_keywords/__snapshots__/notification_settings_mentions_keywords.test.js.snap
@@ -197,6 +197,7 @@ NotificationSettingsMentionsKeywords {
             }
           >
             <TextInputWithLocalizedPlaceholder
+              allowFontScaling={true}
               autoCapitalize="none"
               autoCorrect={false}
               blurOnSubmit={true}

--- a/app/screens/settings/notification_settings_mentions_keywords/notification_settings_mentions_keywords.js
+++ b/app/screens/settings/notification_settings_mentions_keywords/notification_settings_mentions_keywords.js
@@ -75,6 +75,7 @@ export default class NotificationSettingsMentionsKeywords extends PureComponent 
                 >
                     <View style={style.inputContainer}>
                         <TextInputWithLocalizedPlaceholder
+                            allowFontScaling={true}
                             ref={this.keywordsRef}
                             value={keywords}
                             blurOnSubmit={true}

--- a/share_extension/components/body.tsx
+++ b/share_extension/components/body.tsx
@@ -58,6 +58,7 @@ const Body = forwardRef<BodyRef, BodyProps>(({canPost, files, initialValue, plac
                 style={styles.flex}
             >
                 <TextInput
+                    allowFontScaling={true}
                     ref={inputRef}
                     autoCapitalize='sentences'
                     autoCompleteType='off'


### PR DESCRIPTION
#### Summary
Based on RN documentation `allowFontScaling` on TextInput should be set as true by default, but it does not seem to be the case anymore, this PR makes sure is enabled for every text input in the app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39337

#### Release Note
```release-note
Fixed Text input font scaling to follow the OS setting
```

Expected behavior: Font scaling only applies when the font size is changed in the OS setting before starting to write in the text input

Note: @amyblais to determine if this should be included in a dot release or not after speaking with customer support.