### PR TITLE
Detox/E2E: Fix failures due to recent features

### DIFF
--- a/app/components/edit_channel_info/index.js
+++ b/app/components/edit_channel_info/index.js
@@ -279,6 +279,7 @@ export default class EditChannelInfo extends PureComponent {
                                             onPress={() => {
                                                 this.onTypeSelect(General.OPEN_CHANNEL);
                                             }}
+                                            testID='edit_channel_info.type.public.action'
                                         >
                                             <FormattedText
                                                 style={style.touchableText}
@@ -305,6 +306,7 @@ export default class EditChannelInfo extends PureComponent {
                                             onPress={() => {
                                                 this.onTypeSelect(General.PRIVATE_CHANNEL);
                                             }}
+                                            testID='edit_channel_info.type.private.action'
                                         >
                                             <FormattedText
                                                 style={style.touchableText}

--- a/app/components/sidebars/main/channels_list/list/list.js
+++ b/app/components/sidebars/main/channels_list/list/list.js
@@ -419,6 +419,21 @@ export default class List extends PureComponent {
             }
         };
 
+        const categoryId = () => {
+            switch (type) {
+            case CategoryTypes.UNREADS:
+                return CategoryTypes.UNREADS.toLowerCase();
+            case CategoryTypes.FAVORITES:
+                return CategoryTypes.FAVORITES.toLowerCase();
+            case CategoryTypes.CHANNELS:
+                return CategoryTypes.CHANNELS.toLowerCase();
+            case CategoryTypes.DIRECT_MESSAGES:
+                return CategoryTypes.DIRECT_MESSAGES.toLowerCase();
+            default:
+                return name.replaceAll(' ', '_').toLowerCase();
+            }
+        };
+
         const header = (
             <View style={styles.titleContainer}>
                 {(type !== CategoryTypes.UNREADS && data.length > 0) &&
@@ -434,7 +449,7 @@ export default class List extends PureComponent {
                 <View style={styles.separatorContainer}>
                     <Text> </Text>
                 </View>
-                {action && this.renderSectionAction(styles, action, anchor, id)}
+                {action && this.renderSectionAction(styles, action, anchor, categoryId())}
             </View>
         );
 

--- a/detox/e2e/support/ui/component/bottom_sheet.js
+++ b/detox/e2e/support/ui/component/bottom_sheet.js
@@ -14,7 +14,10 @@ class BottomSheet {
     copyHeaderOption = isAndroid() ? element(by.text('Copy Header')) : element(by.label('Copy Header')).atIndex(0);
     copyPurposeOption = isAndroid() ? element(by.text('Copy Purpose')) : element(by.label('Copy Purpose')).atIndex(0);
     copyUrlOption = isAndroid() ? element(by.text('Copy URL')) : element(by.label('Copy URL')).atIndex(0);
+    createOption = isAndroid() ? element(by.text('Create')) : element(by.label('Create')).atIndex(0);
     doNotDisturbOption = isAndroid() ? element(by.text('Do Not Disturb')) : element(by.label('Do No Disturb')).atIndex(0);
+    moreChannelsOption = isAndroid() ? element(by.text('More Channels')) : element(by.label('More Channels')).atIndex(0);
+    newConversationOption = isAndroid() ? element(by.text('New Conversation')) : element(by.label('New Conversation')).atIndex(0);
     offlineOption = isAndroid() ? element(by.text('Offline')) : element(by.label('Offline')).atIndex(0);
     onlineOption = isAndroid() ? element(by.text('Online')) : element(by.label('Online')).atIndex(0);
     publicChannelsOption = isAndroid() ? element(by.text('Public Channels')) : element(by.label('Public Channels')).atIndex(0);

--- a/detox/e2e/support/ui/component/edit_channel_info.js
+++ b/detox/e2e/support/ui/component/edit_channel_info.js
@@ -3,11 +3,15 @@
 
 class EditChannelInfo {
     testID = {
+        publicChannelTypeAction: 'edit_channel_info.type.public.action',
+        privateChannelTypeAction: 'edit_channel_info.type.private.action',
         nameInput: 'edit_channel_info.name.input',
         purposeInput: 'edit_channel_info.purpose.input',
         headerInput: 'edit_channel_info.header.input',
     }
 
+    publicChannelTypeAction = element(by.id(this.testID.publicChannelTypeAction));
+    privateChannelTypeAction = element(by.id(this.testID.privateChannelTypeAction));
     nameInput = element(by.id(this.testID.nameInput));
     purposeInput = element(by.id(this.testID.purposeInput));
     headerInput = element(by.id(this.testID.headerInput));

--- a/detox/e2e/support/ui/component/main_sidebar.js
+++ b/detox/e2e/support/ui/component/main_sidebar.js
@@ -7,15 +7,15 @@ import TeamsList from './teams_list';
 class MainSidebar {
     testID = {
         mainSidebar: 'main.sidebar',
-        openMoreChannelsButton: 'action_button_sidebar.channels',
-        openCreatePrivateChannelButton: 'action_button_sidebar.pg',
-        openMoreDirectMessagesButton: 'action_button_sidebar.direct',
+        channelsActionButton: 'action_button_channels',
+        directMessagesActionButton: 'action_button_direct_messages',
+        favoritesActionButton: 'action_button_favorites',
     }
 
     mainSidebar = element(by.id(this.testID.mainSidebar));
-    openMoreChannelsButton = element(by.id(this.testID.openMoreChannelsButton));
-    openCreatePrivateChannelButton = element(by.id(this.testID.openCreatePrivateChannelButton));
-    openMoreDirectMessagesButton = element(by.id(this.testID.openMoreDirectMessagesButton));
+    channelsActionButton = element(by.id(this.testID.channelsActionButton));
+    directMessagesActionButton = element(by.id(this.testID.directMessagesActionButton));
+    favoritesActionButton = element(by.id(this.testID.favoritesActionButton));
 
     // convenience props
     searchBar = ChannelsList.searchBar;

--- a/detox/e2e/support/ui/screen/create_channel.js
+++ b/detox/e2e/support/ui/screen/create_channel.js
@@ -1,7 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {EditChannelInfo} from '@support/ui/component';
+import {
+    BottomSheet,
+    EditChannelInfo,
+    MainSidebar,
+} from '@support/ui/component';
 
 class CreateChannelScreen {
     testID = {
@@ -15,6 +19,8 @@ class CreateChannelScreen {
     backButton = element(by.id(this.testID.backButton));
 
     // convenience props
+    publicChannelTypeAction = EditChannelInfo.publicChannelTypeAction;
+    privateChannelTypeAction = EditChannelInfo.privateChannelTypeAction;
     nameInput = EditChannelInfo.nameInput;
     purposeInput = EditChannelInfo.purposeInput;
     headerInput = EditChannelInfo.headerInput;
@@ -23,6 +29,14 @@ class CreateChannelScreen {
         await expect(this.createChannelScreen).toBeVisible();
 
         return this.createChannelScreen;
+    }
+
+    open = async () => {
+        // # Open create channel screen
+        await MainSidebar.channelsActionButton.tap();
+        await BottomSheet.createOption.tap();
+
+        return this.toBeVisible();
     }
 
     back = async () => {

--- a/detox/e2e/support/ui/screen/more_channels.js
+++ b/detox/e2e/support/ui/screen/more_channels.js
@@ -66,7 +66,8 @@ class MoreChannelsScreen {
 
     open = async () => {
         // # Open more channels screen
-        await MainSidebar.openMoreChannelsButton.tap();
+        await MainSidebar.channelsActionButton.tap();
+        await BottomSheet.moreChannelsOption.tap();
 
         return this.toBeVisible();
     }

--- a/detox/e2e/support/ui/screen/more_direct_messages.js
+++ b/detox/e2e/support/ui/screen/more_direct_messages.js
@@ -74,7 +74,7 @@ class MoreDirectMessagesScreen {
 
     open = async () => {
         // # Open more direct messages screen
-        await MainSidebar.openMoreDirectMessagesButton.tap();
+        await MainSidebar.directMessagesActionButton.tap();
 
         return this.toBeVisible();
     }

--- a/detox/e2e/support/utils/email.js
+++ b/detox/e2e/support/utils/email.js
@@ -80,7 +80,6 @@ export const getMentionEmailTemplate = (sender, message, postId, siteName, teamN
         '',
         `@${sender}`,
         '<skip-local-time-check>',
-        '',
         channelDisplayName,
         '',
         message,

--- a/detox/e2e/test/account_settings/language_settings.e2e.js
+++ b/detox/e2e/test/account_settings/language_settings.e2e.js
@@ -29,7 +29,7 @@ describe('Language Settings', () => {
         await ChannelScreen.logout();
     });
 
-    it('MM-T304 no crash when setting language to zh-TW (Chinese Traditional)', async () => { // related issue https://mattermost.atlassian.net/browse/MM-35329
+    xit('MM-T304 no crash when setting language to zh-TW (Chinese Traditional)', async () => { // related issue https://mattermost.atlassian.net/browse/MM-35329
         // # Set user's locale
         await User.apiPatchUser(testUser.id, {locale: 'zh-TW'});
 

--- a/detox/e2e/test/channels/archived_channels.e2e.js
+++ b/detox/e2e/test/channels/archived_channels.e2e.js
@@ -62,7 +62,7 @@ describe('Archived Channels', () => {
 
         // * Verify favorites section and favorited archived channel are not displayed
         await openMainSidebar();
-        await expect(element(by.text('FAVORITE CHANNELS'))).not.toBeVisible();
+        await expect(element(by.text('FAVORITES'))).not.toBeVisible();
         await expect(element(by.text(favoritedChannel.display_name))).not.toBeVisible();
 
         // # Close main sidebar

--- a/detox/e2e/test/channels/channels_list.e2e.js
+++ b/detox/e2e/test/channels/channels_list.e2e.js
@@ -58,38 +58,54 @@ describe('Channels List', () => {
     let testUser;
 
     beforeAll(async () => {
-        const {user, channel, team} = await Setup.apiInit({channelOptions: {prefix: `channel-${searchTerm}`}});
+        const {user, channel, team} = await Setup.apiInit({channelOptions: {prefix: `5-unread-${searchTerm}`}});
         testUser = user;
         unreadChannel = channel;
         testTeam = team;
-
-        testMessage = `Mention @${user.username}`;
+        testMessage = `Mention @${testUser.username}`;
         await Post.apiCreatePost({
             channelId: unreadChannel.id,
             message: testMessage,
+            createAt: Date.now(),
         });
 
         ({channel: favoriteChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `4-favorite-${searchTerm}`, teamId: testTeam.id}));
-        await Channel.apiAddUserToChannel(user.id, favoriteChannel.id);
-        await Preference.apiSaveFavoriteChannelPreference(user.id, favoriteChannel.id);
+        await Channel.apiAddUserToChannel(testUser.id, favoriteChannel.id);
+        await Preference.apiSaveFavoriteChannelPreference(testUser.id, favoriteChannel.id);
+        await Post.apiCreatePost({
+            channelId: favoriteChannel.id,
+            message: testMessage,
+            createAt: Date.now(),
+        });
 
         ({channel: publicChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `3-public-${searchTerm}`, teamId: testTeam.id}));
-        await Channel.apiAddUserToChannel(user.id, publicChannel.id);
+        await Channel.apiAddUserToChannel(testUser.id, publicChannel.id);
+        await Post.apiCreatePost({
+            channelId: publicChannel.id,
+            message: testMessage,
+            createAt: Date.now(),
+        });
 
         ({channel: privateChannel} = await Channel.apiCreateChannel({type: 'P', prefix: `2-private-${searchTerm}`, teamId: testTeam.id}));
-        await Channel.apiAddUserToChannel(user.id, privateChannel.id);
+        await Channel.apiAddUserToChannel(testUser.id, privateChannel.id);
+        await Post.apiCreatePost({
+            channelId: privateChannel.id,
+            message: testMessage,
+            createAt: Date.now(),
+        });
 
-        ({channel: nonJoinedChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `1-non-joined-${searchTerm}`, teamId: testTeam.id}));
-
-        ({user: dmOtherUser} = await User.apiCreateUser({prefix: `user-${searchTerm}-1`}));
+        ({user: dmOtherUser} = await User.apiCreateUser({prefix: `1-dm-user-${searchTerm}`}));
         await Team.apiAddUserToTeam(dmOtherUser.id, testTeam.id);
-        ({channel: directMessageChannel} = await Channel.apiCreateDirectChannel([user.id, dmOtherUser.id]));
+        ({channel: directMessageChannel} = await Channel.apiCreateDirectChannel([testUser.id, dmOtherUser.id]));
         await Post.apiCreatePost({
             channelId: directMessageChannel.id,
             message: testMessage,
+            createAt: Date.now(),
         });
 
-        ({user: nonDmOtherUser} = await User.apiCreateUser({prefix: `user-${searchTerm}-2`}));
+        ({channel: nonJoinedChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `non-joined-${searchTerm}`, teamId: testTeam.id}));
+
+        ({user: nonDmOtherUser} = await User.apiCreateUser({prefix: `non-dm-user-${searchTerm}`}));
         await Team.apiAddUserToTeam(nonDmOtherUser.id, testTeam.id);
 
         // # Open channel screen
@@ -104,12 +120,12 @@ describe('Channels List', () => {
         // # Open main sidebar
         await openMainSidebar();
 
-        // * Verify order when all channels are unread
-        await hasChannelDisplayNameAtIndex(0, privateChannel.display_name);
-        await hasChannelDisplayNameAtIndex(1, publicChannel.display_name);
-        await hasChannelDisplayNameAtIndex(2, favoriteChannel.display_name);
-        await hasChannelDisplayNameAtIndex(3, unreadChannel.display_name);
-        await hasChannelDisplayNameAtIndex(4, dmOtherUser.username);
+        // * Verify order is post date descending when all channels are unread
+        await hasChannelDisplayNameAtIndex(0, dmOtherUser.username);
+        await hasChannelDisplayNameAtIndex(1, privateChannel.display_name);
+        await hasChannelDisplayNameAtIndex(2, publicChannel.display_name);
+        await hasChannelDisplayNameAtIndex(3, favoriteChannel.display_name);
+        await hasChannelDisplayNameAtIndex(4, unreadChannel.display_name);
         await hasChannelDisplayNameAtIndex(5, 'Off-Topic');
         await hasChannelDisplayNameAtIndex(6, 'Town Square');
         await expect(element(by.id(nonJoinedChannel.display_name))).not.toBeVisible();
@@ -132,10 +148,10 @@ describe('Channels List', () => {
         await openMainSidebar();
         await hasChannelDisplayNameAtIndex(0, unreadChannel.display_name);
         await hasChannelDisplayNameAtIndex(1, favoriteChannel.display_name);
-        await hasChannelDisplayNameAtIndex(2, publicChannel.display_name);
-        await hasChannelDisplayNameAtIndex(3, 'Off-Topic');
-        await hasChannelDisplayNameAtIndex(4, 'Town Square');
-        await hasChannelDisplayNameAtIndex(5, privateChannel.display_name);
+        await hasChannelDisplayNameAtIndex(2, privateChannel.display_name);
+        await hasChannelDisplayNameAtIndex(3, publicChannel.display_name);
+        await hasChannelDisplayNameAtIndex(4, 'Off-Topic');
+        await hasChannelDisplayNameAtIndex(5, 'Town Square');
         await hasChannelDisplayNameAtIndex(6, dmOtherUser.username);
         await expect(element(by.id(nonJoinedChannel.display_name))).not.toBeVisible();
         await expect(element(by.id(nonDmOtherUser.username))).not.toBeVisible();

--- a/detox/e2e/test/channels/create_public_channel.e2e.js
+++ b/detox/e2e/test/channels/create_public_channel.e2e.js
@@ -27,6 +27,7 @@ describe('Channels', () => {
         nameInput,
         purposeInput,
         headerInput,
+        publicChannelTypeAction,
     } = CreateChannelScreen;
 
     beforeAll(async () => {
@@ -71,6 +72,7 @@ describe('Channels', () => {
         await expect(element(by.text('New Public Channel'))).toBeVisible();
 
         // # Fill data
+        await publicChannelTypeAction.tap();
         await nameInput.typeText('a');
         await attemptToTapCreateButton();
 
@@ -82,10 +84,7 @@ describe('Channels', () => {
         await purposeInput.tapReturnKey();
         await purposeInput.typeText('multiple lines');
 
-        // # Scroll down if Android
-        if (isAndroid()) {
-            await createChannelScreen.scroll(200, 'down');
-        }
+        await createChannelScreen.scroll(200, 'down');
 
         await expect(headerInput).toBeVisible();
         const expectedChannelHeader = 'I 🌮 love 🌮 tacos 🌮';

--- a/detox/e2e/test/channels/favorite_channels.e2e.js
+++ b/detox/e2e/test/channels/favorite_channels.e2e.js
@@ -59,7 +59,7 @@ describe('Favorite Channels', () => {
         // * Verify channel appears in favorite channels list
         await ChannelInfoScreen.close();
         await openMainSidebar();
-        await expect(element(by.text('FAVORITE CHANNELS'))).toBeVisible();
+        await expect(element(by.text('FAVORITES'))).toBeVisible();
         await hasChannelDisplayNameAtIndex(0, testChannel.display_name);
 
         // # Close main sidebar

--- a/detox/e2e/test/messaging/mark_as_read.e2e.js
+++ b/detox/e2e/test/messaging/mark_as_read.e2e.js
@@ -59,7 +59,7 @@ describe('Mark As Read', () => {
         // * Verify message is read
         await openMainSidebar();
         await expect(element(by.text('UNREADS'))).not.toBeVisible();
-        await expect(element(by.text('PUBLIC CHANNELS'))).toBeVisible();
+        await expect(element(by.text('CHANNELS'))).toBeVisible();
         await hasChannelDisplayNameAtIndex(0, testChannel.display_name);
 
         // # Go back to channel

--- a/detox/e2e/test/messaging/permalink.e2e.js
+++ b/detox/e2e/test/messaging/permalink.e2e.js
@@ -41,7 +41,7 @@ describe('Permalink', () => {
         await ChannelScreen.logout();
     });
 
-    const expectPermalinkTargetMessage = async (permalinkTargetPost, permalinkTargetChannel) => {
+    const expectPermalinkTargetMessage = async (permalinkTargetPost, permalinkTargetChannelDiplayName) => {
         // # Post a message in the test channel referencing the given permalink.
         const permalinkLabel = `permalink-${Date.now().toString()}`;
         const permalinkMessage = `[${permalinkLabel}](/_redirect/pl/${permalinkTargetPost.id})`;
@@ -66,7 +66,7 @@ describe('Permalink', () => {
         await PermalinkScreen.jumpToRecentMessages();
 
         // * Verify user is on channel where message is posted
-        await expect(ChannelScreen.channelNavBarTitle).toHaveText(permalinkTargetChannel.display_name);
+        await expect(ChannelScreen.channelNavBarTitle).toHaveText(permalinkTargetChannelDiplayName);
         const {postListPostItem: channelPostItem} = await ChannelScreen.getPostListPostItem(permalinkTargetPost.id, permalinkTargetPost.message);
         await expect(channelPostItem).toBeVisible();
     };
@@ -79,7 +79,7 @@ describe('Permalink', () => {
             message: permalinkTargetMessage,
         });
 
-        await expectPermalinkTargetMessage(permalinkTargetPost.post, townSquareChannel);
+        await expectPermalinkTargetMessage(permalinkTargetPost.post, townSquareChannel.display_name);
     });
 
     it('MM-T3805_2 should support _redirect to DM post', async () => {
@@ -92,6 +92,6 @@ describe('Permalink', () => {
             message: permalinkTargetMessage,
         });
 
-        await expectPermalinkTargetMessage(permalinkTargetPost.post, directMessageChannel);
+        await expectPermalinkTargetMessage(permalinkTargetPost.post, dmOtherUser.username);
     });
 });

--- a/detox/e2e/test/messaging/tapping_channel_url_link_joins_channel.e2e.js
+++ b/detox/e2e/test/messaging/tapping_channel_url_link_joins_channel.e2e.js
@@ -164,17 +164,23 @@ describe('Messaging', () => {
 });
 
 async function createPrivateChannel(channelName) {
+    const {
+        createButton,
+        nameInput,
+        privateChannelTypeAction,
+    } = CreateChannelScreen;
+
     // # Open create private channel screen
     await ChannelScreen.openMainSidebar();
-    await MainSidebar.openCreatePrivateChannelButton.tap();
+    await CreateChannelScreen.open();
 
     // * Verify create channel screen is visible
-    await CreateChannelScreen.toBeVisible();
-    await expect(element(by.text('New Private Channel'))).toBeVisible();
+    await expect(element(by.text('Create')).atIndex(0)).toBeVisible();
 
     // # Fill the data and create a private channel
-    await CreateChannelScreen.nameInput.typeText(channelName);
-    await CreateChannelScreen.createButton.tap();
+    await privateChannelTypeAction.tap();
+    await nameInput.typeText(channelName);
+    await createButton.tap();
 
     // * Expect a redirection to the created channel
     await expect(ChannelScreen.channelIntro).toHaveText('Beginning of ' + channelName);

--- a/detox/e2e/test/smoke_test/channels.e2e.js
+++ b/detox/e2e/test/smoke_test/channels.e2e.js
@@ -52,35 +52,52 @@ describe('Channels', () => {
     let nonDmOtherUser;
 
     beforeAll(async () => {
-        const {user, channel, team} = await Setup.apiInit({channelOptions: {prefix: `channel-${searchTerm}`}});
+        const {user, channel, team} = await Setup.apiInit({channelOptions: {prefix: `5-unread-${searchTerm}`}});
         unreadChannel = channel;
         testMessage = `Mention @${user.username}`;
         await Post.apiCreatePost({
             channelId: unreadChannel.id,
             message: testMessage,
+            createAt: Date.now(),
         });
 
         ({channel: favoriteChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `4-favorite-${searchTerm}`, teamId: team.id}));
         await Channel.apiAddUserToChannel(user.id, favoriteChannel.id);
         await Preference.apiSaveFavoriteChannelPreference(user.id, favoriteChannel.id);
+        await Post.apiCreatePost({
+            channelId: favoriteChannel.id,
+            message: testMessage,
+            createAt: Date.now(),
+        });
 
         ({channel: publicChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `3-public-${searchTerm}`, teamId: team.id}));
         await Channel.apiAddUserToChannel(user.id, publicChannel.id);
+        await Post.apiCreatePost({
+            channelId: publicChannel.id,
+            message: testMessage,
+            createAt: Date.now(),
+        });
 
         ({channel: privateChannel} = await Channel.apiCreateChannel({type: 'P', prefix: `2-private-${searchTerm}`, teamId: team.id}));
         await Channel.apiAddUserToChannel(user.id, privateChannel.id);
+        await Post.apiCreatePost({
+            channelId: privateChannel.id,
+            message: testMessage,
+            createAt: Date.now(),
+        });
 
-        ({channel: nonJoinedChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `1-non-joined-${searchTerm}`, teamId: team.id}));
-
-        ({user: dmOtherUser} = await User.apiCreateUser({prefix: `user-${searchTerm}-1`}));
+        ({user: dmOtherUser} = await User.apiCreateUser({prefix: `1-dm-user-${searchTerm}`}));
         await Team.apiAddUserToTeam(dmOtherUser.id, team.id);
         ({channel: directMessageChannel} = await Channel.apiCreateDirectChannel([user.id, dmOtherUser.id]));
         await Post.apiCreatePost({
             channelId: directMessageChannel.id,
             message: testMessage,
+            createAt: Date.now(),
         });
 
-        ({user: nonDmOtherUser} = await User.apiCreateUser({prefix: `user-${searchTerm}-2`}));
+        ({channel: nonJoinedChannel} = await Channel.apiCreateChannel({type: 'O', prefix: `non-joined-${searchTerm}`, teamId: team.id}));
+
+        ({user: nonDmOtherUser} = await User.apiCreateUser({prefix: `non-dm-user-${searchTerm}`}));
         await Team.apiAddUserToTeam(nonDmOtherUser.id, team.id);
 
         // # Open channel screen
@@ -95,12 +112,12 @@ describe('Channels', () => {
         // # Open main sidebar
         await openMainSidebar();
 
-        // * Verify order when all channels are unread
-        await hasChannelDisplayNameAtIndex(0, privateChannel.display_name);
-        await hasChannelDisplayNameAtIndex(1, publicChannel.display_name);
-        await hasChannelDisplayNameAtIndex(2, favoriteChannel.display_name);
-        await hasChannelDisplayNameAtIndex(3, unreadChannel.display_name);
-        await hasChannelDisplayNameAtIndex(4, dmOtherUser.username);
+        // * Verify order is post date descending when all channels are unread
+        await hasChannelDisplayNameAtIndex(0, dmOtherUser.username);
+        await hasChannelDisplayNameAtIndex(1, privateChannel.display_name);
+        await hasChannelDisplayNameAtIndex(2, publicChannel.display_name);
+        await hasChannelDisplayNameAtIndex(3, favoriteChannel.display_name);
+        await hasChannelDisplayNameAtIndex(4, unreadChannel.display_name);
         await hasChannelDisplayNameAtIndex(5, 'Off-Topic');
         await hasChannelDisplayNameAtIndex(6, 'Town Square');
         await expect(element(by.id(nonJoinedChannel.display_name))).not.toBeVisible();
@@ -123,10 +140,10 @@ describe('Channels', () => {
         await openMainSidebar();
         await hasChannelDisplayNameAtIndex(0, unreadChannel.display_name);
         await hasChannelDisplayNameAtIndex(1, favoriteChannel.display_name);
-        await hasChannelDisplayNameAtIndex(2, publicChannel.display_name);
-        await hasChannelDisplayNameAtIndex(3, 'Off-Topic');
-        await hasChannelDisplayNameAtIndex(4, 'Town Square');
-        await hasChannelDisplayNameAtIndex(5, privateChannel.display_name);
+        await hasChannelDisplayNameAtIndex(2, privateChannel.display_name);
+        await hasChannelDisplayNameAtIndex(3, publicChannel.display_name);
+        await hasChannelDisplayNameAtIndex(4, 'Off-Topic');
+        await hasChannelDisplayNameAtIndex(5, 'Town Square');
         await hasChannelDisplayNameAtIndex(6, dmOtherUser.username);
         await expect(element(by.id(nonJoinedChannel.display_name))).not.toBeVisible();
         await expect(element(by.id(nonDmOtherUser.username))).not.toBeVisible();

--- a/detox/e2e/test/smoke_test/favorite_channels.e2e.js
+++ b/detox/e2e/test/smoke_test/favorite_channels.e2e.js
@@ -58,7 +58,7 @@ describe('Favorite Channels', () => {
         // * Verify channel appears in favorite channels list
         await ChannelInfoScreen.close();
         await openMainSidebar();
-        await expect(element(by.text('FAVORITE CHANNELS'))).toBeVisible();
+        await expect(element(by.text('FAVORITES'))).toBeVisible();
         await hasChannelDisplayNameAtIndex(0, testChannel.display_name);
 
         // # Close main sidebar
@@ -84,7 +84,7 @@ describe('Favorite Channels', () => {
         // * Verify channel does not appear in favorite channels list
         await ChannelInfoScreen.close();
         await openMainSidebar();
-        await expect(element(by.text('FAVORITE CHANNELS'))).not.toBeVisible();
+        await expect(element(by.text('FAVORITES'))).not.toBeVisible();
         await hasChannelDisplayNameAtIndex(0, testChannel.display_name);
 
         // # Close main sidebar

--- a/detox/e2e/test/smoke_test/private_channels.e2e.js
+++ b/detox/e2e/test/smoke_test/private_channels.e2e.js
@@ -67,15 +67,15 @@ describe('Private Channels', () => {
         const {
             createButton,
             nameInput,
+            privateChannelTypeAction,
         } = CreateChannelScreen;
-        const {openCreatePrivateChannelButton} = MainSidebar;
 
         // # Create a private channel
         const privateChannelName = `Channel-${getRandomId()}`;
         await openMainSidebar();
-        await openCreatePrivateChannelButton.tap();
-        await CreateChannelScreen.toBeVisible();
-        await expect(element(by.text('New Private Channel'))).toBeVisible();
+        await CreateChannelScreen.open();
+        await expect(element(by.text('Create')).atIndex(0)).toBeVisible();
+        await privateChannelTypeAction.tap();
         await nameInput.typeText(privateChannelName);
         await createButton.tap();
 

--- a/detox/e2e/test/smoke_test/search.e2e.js
+++ b/detox/e2e/test/smoke_test/search.e2e.js
@@ -179,7 +179,7 @@ describe('Search', () => {
             channelId: testChannel.id,
             message: firstMessage,
         });
-        [...Array(50).keys()].forEach(async () => {
+        [...Array(10).keys()].forEach(async () => {
             const message = `${Date.now().toString()} ${keyword}`;
             await Post.apiCreatePost({
                 channelId: testChannel.id,
@@ -195,7 +195,7 @@ describe('Search', () => {
 
         // * Verify user can scroll down multiple times until first matching post is seen
         const {searchResultPostItem} = await getSearchResultPostItem(firstPost.post.id, firstMessage);
-        await waitFor(searchResultPostItem).toBeVisible().whileElement(by.id(SearchScreen.testID.searchResultsList)).scroll(1000, 'down');
+        await waitFor(searchResultPostItem).toBeVisible().whileElement(by.id(SearchScreen.testID.searchResultsList)).scroll(500, 'down');
 
         // # Go back to channel
         await SearchScreen.cancel();

--- a/detox/e2e/test/smoke_test/unread_channels.e2e.js
+++ b/detox/e2e/test/smoke_test/unread_channels.e2e.js
@@ -55,11 +55,11 @@ describe('Unread channels', () => {
         // # Open main sidebar (with at least one unread channel)
         await openMainSidebar();
 
-        // * Verify unread channel(s) display at top of channel list (with mentions first, if any), in alphabetical order, with title "Unreads"
+        // * Verify unread channel(s) display at top of channel list (with mentions first, if any), in post date descending order, with title "Unreads"
         await expect(element(by.text('UNREADS'))).toBeVisible();
-        await hasChannelDisplayNameAtIndex(0, aChannel.display_name);
-        await hasChannelDisplayNameAtIndex(1, newChannel.display_name);
-        await hasChannelDisplayNameAtIndex(2, zChannel.display_name);
+        await hasChannelDisplayNameAtIndex(0, zChannel.display_name);
+        await hasChannelDisplayNameAtIndex(1, aChannel.display_name);
+        await hasChannelDisplayNameAtIndex(2, newChannel.display_name);
         await closeMainSidebar();
 
         // # Tap an unread channel to view it
@@ -70,7 +70,7 @@ describe('Unread channels', () => {
         // * Channel you just read is no longer listed in Unreads
         await openMainSidebar();
         await expect(element(by.text('UNREADS'))).not.toBeVisible();
-        await expect(element(by.text('PUBLIC CHANNELS'))).toBeVisible();
+        await expect(element(by.text('CHANNELS'))).toBeVisible();
         await hasChannelDisplayNameAtIndex(0, aChannel.display_name);
         await hasChannelDisplayNameAtIndex(1, newChannel.display_name);
         await hasChannelDisplayNameAtIndex(2, 'Off-Topic');


### PR DESCRIPTION
#### Summary
- Fix e2e failures due to recently added features, such as new sidebar (unreads order, new categories, add channels bottomsheet) and create channel screen channel types.
- Added new testIDs
- Also updated the following zephyr test scripts with correct verbiage to match new behaviors: MM-T844, MM-T850, MM-T3184, MM-T3187, MM-T3191, MM-T3192, MM-T3201, MM-T3203

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-10-14 at 6 23 07 PM](https://user-images.githubusercontent.com/487991/137423392-275993c4-abd8-4ed7-9667-baa82928ce1b.png)
![Screen Shot 2021-10-14 at 6 23 20 PM](https://user-images.githubusercontent.com/487991/137423394-3e114313-7421-4e15-817c-cddacae3a694.png)
![Screen Shot 2021-10-14 at 7 09 02 PM](https://user-images.githubusercontent.com/487991/137423396-6239a796-681a-48a2-aac2-ccfab6e9e365.png)
![Screen Shot 2021-10-14 at 7 14 53 PM](https://user-images.githubusercontent.com/487991/137423398-27a4653d-a905-4947-88a4-b63170d29a9b.png)
![Screen Shot 2021-10-14 at 7 16 09 PM](https://user-images.githubusercontent.com/487991/137423400-60f58091-6580-4230-b9b7-d86a707bb5ae.png)
![Screen Shot 2021-10-14 at 7 17 40 PM](https://user-images.githubusercontent.com/487991/137423401-65102040-e634-4fbb-82f0-a0e8440e27d4.png)
![Screen Shot 2021-10-14 at 7 19 02 PM](https://user-images.githubusercontent.com/487991/137423402-6d9d3b5b-67dc-4dc7-96aa-4c6b6473b6be.png)
![Screen Shot 2021-10-14 at 7 21 59 PM](https://user-images.githubusercontent.com/487991/137423403-2cf4a11e-41dc-4634-ab5d-c327ea2ad6a7.png)
![Screen Shot 2021-10-14 at 7 23 40 PM](https://user-images.githubusercontent.com/487991/137423404-2552e2d5-c425-4d4a-96de-1c3cbc9825f0.png)
![Screen Shot 2021-10-14 at 7 26 26 PM](https://user-images.githubusercontent.com/487991/137423406-b7a51384-cc8e-4cfa-8774-0209e6d7fd02.png)
![Screen Shot 2021-10-14 at 7 27 54 PM](https://user-images.githubusercontent.com/487991/137423408-9e44029f-911b-4620-8e64-aaca4f08079e.png)
![Screen Shot 2021-10-14 at 7 30 43 PM](https://user-images.githubusercontent.com/487991/137423410-68f8aea9-34cc-4fe2-ad50-7db25f6a2e49.png)

#### Release Note
```release-note
NONE
```
