### PR TITLE
MM-39348 CRT crash

### DIFF
--- a/app/components/post_draft/post_draft.js
+++ b/app/components/post_draft/post_draft.js
@@ -55,7 +55,7 @@ export default class PostDraft extends PureComponent {
     updateNativeScrollView = (scrollViewNativeID) => {
         if (this.keyboardTracker?.current && this.props.scrollViewNativeID === scrollViewNativeID) {
             this.resetScrollView = requestAnimationFrame(() => {
-                this.keyboardTracker.current.resetScrollView(scrollViewNativeID);
+                this.keyboardTracker.current?.resetScrollView(scrollViewNativeID);
                 cancelAnimationFrame(this.resetScrollView);
                 this.resetScrollView = null;
             });


### PR DESCRIPTION
#### Summary
As navigating to global threads, we are replacing the channel component, requestAnimationFrame code is being executed after the post draft component is unmounted. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39348

#### Device Information
This PR was tested on: iPhone 12, iOS 15.0

#### Release Note
```release-note
NONE
```