### PR TITLE
[Gekidou] Unique servers

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/DatabaseHelper.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/DatabaseHelper.kt
@@ -174,7 +174,8 @@ class DatabaseHelper {
 
                         if (lastId == key) {
                             earliest = post.get("create_at") as Double
-                        } else if (firstId == key) {
+                        }
+                        if (firstId == key) {
                             latest = post.get("create_at") as Double
                         }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -10,8 +10,8 @@
     <string name="copyAndPasteProtection_description">Disable the ability to copy from or paste into any text inputs in the app.</string>
     <string name="serverUrl_title">Mattermost Server URL</string>
     <string name="serverUrl_description">Set a default Server URL for your Mattermost instance.</string>
-    <string name="serverUrl_title">Mattermost Server Name</string>
-    <string name="serverUrl_description">Set a default Server Name for your Mattermost instance.</string>
+    <string name="serverName_title">Mattermost Server Name</string>
+    <string name="serverName_description">Set a default Server Name for your Mattermost instance.</string>
     <string name="allowOtherServers_title">Allow Other Servers</string>
     <string name="allowOtherServers_description">Allow the user to change the above server URL.</string>
     <string name="username_title">Default Username</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,7 +9,9 @@
     <string name="copyAndPasteProtection_title">Copy&amp;Paste Protection</string>
     <string name="copyAndPasteProtection_description">Disable the ability to copy from or paste into any text inputs in the app.</string>
     <string name="serverUrl_title">Mattermost Server URL</string>
-    <string name="serverUrl_description">Set a default Mattermost server URL.</string>
+    <string name="serverUrl_description">Set a default Server URL for your Mattermost instance.</string>
+    <string name="serverUrl_title">Mattermost Server Name</string>
+    <string name="serverUrl_description">Set a default Server Name for your Mattermost instance.</string>
     <string name="allowOtherServers_title">Allow Other Servers</string>
     <string name="allowOtherServers_description">Allow the user to change the above server URL.</string>
     <string name="username_title">Default Username</string>

--- a/android/app/src/main/res/xml/app_restrictions.xml
+++ b/android/app/src/main/res/xml/app_restrictions.xml
@@ -38,6 +38,12 @@
             android:restrictionType="string"
             android:defaultValue="" />
     <restriction
+            android:key="serverName"
+            android:title="@string/serverName_title"
+            android:description="@string/serverName_description"
+            android:restrictionType="string"
+            android:defaultValue="" />
+    <restriction
             android:key="allowOtherServers"
             android:title="@string/allowOtherServers_title"
             android:description="@string/allowOtherServers_description"

--- a/app/queries/app/servers.ts
+++ b/app/queries/app/servers.ts
@@ -37,6 +37,11 @@ export const queryServerByIdentifier = async (appDatabase: Database, identifier:
     }
 };
 
+export const queryServerByDisplayName = async (appDatabase: Database, displayName: string) => {
+    const servers = (await appDatabase.get<ServerModel>(SERVERS).query(Q.where('display_name', displayName)).fetch());
+    return servers?.[0];
+};
+
 export const queryServerName = async (appDatabase: Database, serverUrl: string) => {
     try {
         const servers = (await appDatabase.get<ServerModel>(SERVERS).query(Q.where('url', serverUrl)).fetch());
@@ -45,4 +50,3 @@ export const queryServerName = async (appDatabase: Database, serverUrl: string) 
         return serverUrl;
     }
 };
-

--- a/app/queries/app/servers.ts
+++ b/app/queries/app/servers.ts
@@ -38,8 +38,9 @@ export const queryServerByIdentifier = async (appDatabase: Database, identifier:
 };
 
 export const queryServerByDisplayName = async (appDatabase: Database, displayName: string) => {
-    const servers = (await appDatabase.get<ServerModel>(SERVERS).query(Q.where('display_name', displayName)).fetch());
-    return servers?.[0];
+    const servers = await queryAllServers(appDatabase);
+    const server = servers.find((s) => s.displayName.toLowerCase() === displayName.toLowerCase());
+    return server;
 };
 
 export const queryServerName = async (appDatabase: Database, serverUrl: string) => {

--- a/app/screens/server/form.tsx
+++ b/app/screens/server/form.tsx
@@ -191,12 +191,14 @@ const ServerForm = ({
                     value={displayName}
                 />
             </View>
+            {!displayNameError &&
             <FormattedText
                 defaultMessage={'Choose a display name for your server'}
                 id={'mobile.components.select_server_view.displayHelp'}
                 style={styles.chooseText}
                 testID={'mobile.components.select_server_view.displayHelp'}
             />
+            }
             <Button
                 containerStyle={[styles.connectButton, styleButtonBackground]}
                 disabled={buttonDisabled}

--- a/app/screens/server/index.tsx
+++ b/app/screens/server/index.tsx
@@ -57,6 +57,7 @@ const Server = ({componentId, extra, launchType, launchError, theme}: ServerProp
     const {formatMessage} = intl;
 
     useEffect(() => {
+        const serverName = managedConfig?.serverName || LocalConfig.DefaultServerName;
         let serverUrl = managedConfig?.serverUrl || LocalConfig.DefaultServerUrl;
         let autoconnect = managedConfig?.allowOtherServers === 'false' || LocalConfig.AutoSelectServerUrl;
 
@@ -79,11 +80,15 @@ const Server = ({componentId, extra, launchType, launchError, theme}: ServerProp
         if (serverUrl) {
             // If a server Url is set by the managed or local configuration, use it.
             setUrl(serverUrl);
+        }
 
-            if (autoconnect) {
-                // If no other servers are allowed or the local config for AutoSelectServerUrl is set, attempt to connect
-                handleConnect(managedConfig?.serverUrl || LocalConfig.DefaultServerUrl);
-            }
+        if (serverName) {
+            setDisplayName(serverName);
+        }
+
+        if (serverUrl && serverName && autoconnect) {
+            // If no other servers are allowed or the local config for AutoSelectServerUrl is set, attempt to connect
+            handleConnect(managedConfig?.serverUrl || LocalConfig.DefaultServerUrl);
         }
     }, []);
 
@@ -154,7 +159,7 @@ const Server = ({componentId, extra, launchType, launchError, theme}: ServerProp
     };
 
     const handleConnect = preventDoubleTap(async (manualUrl?: string) => {
-        if (buttonDisabled) {
+        if (buttonDisabled && !manualUrl) {
             return;
         }
 
@@ -174,7 +179,7 @@ const Server = ({componentId, extra, launchType, launchError, theme}: ServerProp
         }
 
         const server = await queryServerByDisplayName(DatabaseManager.appDatabase!.database, displayName);
-        if (server) {
+        if (server && server.lastActiveAt > 0) {
             setButtonDisabled(true);
             setDisplayNameError(formatMessage({
                 id: 'mobile.server_name.exists',
@@ -247,7 +252,7 @@ const Server = ({componentId, extra, launchType, launchError, theme}: ServerProp
         }
 
         const server = await queryServerByIdentifier(DatabaseManager.appDatabase!.database, data.config!.DiagnosticId);
-        if (server) {
+        if (server && server.lastActiveAt > 0) {
             setButtonDisabled(true);
             setUrlError(formatMessage({
                 id: 'mobile.server_identifier.exists',

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -1,5 +1,6 @@
 {
     "DefaultServerUrl": "",
+    "DefaultServerName": "",
     "TestServerUrl": "http://localhost:8065",
     "DefaultTheme": "default",
     "ShowErrorsList": false,


### PR DESCRIPTION
#### Summary
Following https://github.com/mattermost/mattermost-mobile/pull/5663 now we check if the server is already being used by checking the server identifier, this way we prevent adding the same server twice, even if the user enters a different url for the same server.

In a similar way we also check if the display name to inform the user in case they already have another server registered with the same name.

Also added a default setting in the `config.json` that allows to set a default server name as well as we are including an EMM managed configuration to set a default server name.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39735

Not related to this ticket: I've added a small fix for Android push notifications.

#### Release Note
```release-note
NONE
```
