### PR TITLE
fix android crash: change replaceAll with replace as is not available on some JSC

### DIFF
--- a/app/components/sidebars/main/channels_list/list/list.js
+++ b/app/components/sidebars/main/channels_list/list/list.js
@@ -431,7 +431,7 @@ export default class List extends PureComponent {
             case CategoryTypes.DIRECT_MESSAGES:
                 return CategoryTypes.DIRECT_MESSAGES.toLowerCase();
             default:
-                return name.replaceAll(' ', '_').toLowerCase();
+                return name.replace(/ /g, '_').toLowerCase();
             }
         };
 


### PR DESCRIPTION
#### Summary
Fixes a crash on android as the JS prototype for `replaceAll` has not been added to the version of JSC that ships with Android, this is now replaced with a regular expression with the `replace` function instead.

#### Release Note
```release-note
NONE
```
