### PR TITLE
Enable Hermes on Android v1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,8 +77,8 @@ import com.android.build.OutputFile
 project.ext.react = [
     entryFile: "index.js",
     bundleConfig: "metro.config.js",
-    bundleCommand: "ram-bundle",
-    enableHermes: false,
+    bundleCommand: "bundle",
+    enableHermes: true,
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
#### Summary
This PR enables the Hermes JS engine on Android for the mobile app v1. We should test the entire app and make sure there are no touch lags (this was the case the first time we attempted to enable Hermes 2 years ago) TTI (Time to Interaction) should be at least 2x faster.

note: if this PR crashes on Android is probably cause #5801 needs to be merged first and this branch rebased with master. Although it seems Hermes does include the prototype for `replaceAll`

#### Release Note
```release-note
Android performance improvements
```
