### PR TITLE
Disable reachability test

### DIFF
--- a/patches/@react-native-community+netinfo+6.0.4.patch
+++ b/patches/@react-native-community+netinfo+6.0.4.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts b/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts
+index ed49fb7..23dc6ae 100644
+--- a/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts
++++ b/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts
+@@ -109,20 +109,20 @@ export default class InternetReachability {
+           const nextTimeoutInterval = this._isInternetReachable
+             ? this._configuration.reachabilityLongTimeout
+             : this._configuration.reachabilityShortTimeout;
+-          this._currentTimeoutHandle = setTimeout(
+-            this._checkInternetReachability,
+-            nextTimeoutInterval,
+-          );
++          // this._currentTimeoutHandle = setTimeout(
++          //   this._checkInternetReachability,
++          //   nextTimeoutInterval,
++          // );
+         },
+       )
+       .catch(
+         (error: Error | 'timedout' | 'canceled'): void => {
+           if (error !== 'canceled') {
+             this._setIsInternetReachable(false);
+-            this._currentTimeoutHandle = setTimeout(
+-              this._checkInternetReachability,
+-              this._configuration.reachabilityShortTimeout,
+-            );
++            // this._currentTimeoutHandle = setTimeout(
++            //   this._checkInternetReachability,
++            //   this._configuration.reachabilityShortTimeout,
++            // );
+           }
+         },
+       )


### PR DESCRIPTION
#### Summary
It has been reported that the netInfo library is causing high battery consumption https://github.com/react-native-netinfo/react-native-netinfo/issues/178 as it performs repeated reachability tests to determine if the device has internet connection. We don't really make use of this functionality as we have our own implementation to check if the server is reachable or not, thus disabling this functionality should at least attempt to reduce the battery consumption.

#### Release Note
```release-note
NONE
```
