### PR TITLE
Automated cherry pick of #5812

### DIFF
--- a/patches/@react-native-community+netinfo+6.0.4.patch
+++ b/patches/@react-native-community+netinfo+6.0.4.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts b/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts
+index ed49fb7..23dc6ae 100644
+--- a/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts
++++ b/node_modules/@react-native-community/netinfo/src/internal/internetReachability.ts
+@@ -109,20 +109,20 @@ export default class InternetReachability {
+           const nextTimeoutInterval = this._isInternetReachable
+             ? this._configuration.reachabilityLongTimeout
+             : this._configuration.reachabilityShortTimeout;
+-          this._currentTimeoutHandle = setTimeout(
+-            this._checkInternetReachability,
+-            nextTimeoutInterval,
+-          );
++          // this._currentTimeoutHandle = setTimeout(
++          //   this._checkInternetReachability,
++          //   nextTimeoutInterval,
++          // );
+         },
+       )
+       .catch(
+         (error: Error | 'timedout' | 'canceled'): void => {
+           if (error !== 'canceled') {
+             this._setIsInternetReachable(false);
+-            this._currentTimeoutHandle = setTimeout(
+-              this._checkInternetReachability,
+-              this._configuration.reachabilityShortTimeout,
+-            );
++            // this._currentTimeoutHandle = setTimeout(
++            //   this._checkInternetReachability,
++            //   this._configuration.reachabilityShortTimeout,
++            // );
+           }
+         },
+       )


### PR DESCRIPTION
Cherry pick of #5812 on release-1.48.

/cc  @enahum

```release-note
NONE
```