### PR TITLE
Added YouTube query to Android Manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -82,5 +82,9 @@
             </intent-filter>
         </activity>
     </application>
-
+    <queries>
+      <intent>
+        <action android:name="com.google.android.youtube.api.service.START" />
+      </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
#### Summary
Android 11 onwards (API 30+) Android hides all other apps and services which are not part of the core system apps/services by default, this PR adds a query to the Android Manifest to allow Mattermost to open the YouTube app.

#### Release Note
```release-note
Fixed opening the YouTube app from within Mattermost
```