### PR TITLE
Update postintall script for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "fix": "npm run lint -- --fix",
     "lint": "eslint --ignore-path .gitignore --ignore-pattern node_modules --quiet .",
     "pod-install": "cd ios && bundle exec pod install",
-    "postinstall": "patch-package && ./scripts/postinstall.sh",
+    "postinstall": "patch-package && sh ./scripts/postinstall.sh",
     "tsc": "NODE_OPTIONS=--max_old_space_size=12000 tsc --noEmit",
     "test": "jest --forceExit --runInBand",
     "test:watch": "npm test -- --watch",


### PR DESCRIPTION
I was getting a error when I run `npm install` when trying to launch the app on a fork of this repo.
```
'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mattermost-mobile@1.39.0 postinstall: `patch-package && ./scripts/postinstall.sh`
```
Adding the sh command fixes the issue.
Note: I have not tested the change on a non-Windows.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
