### PR TITLE
[Gekidou MM-39729] Websocket Events - hello, license, config

### DIFF
--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -24,7 +24,7 @@ import {handleNewPostEvent, handlePostDeleted, handlePostEdited, handlePostUnrea
 import {handlePreferenceChangedEvent, handlePreferencesChangedEvent, handlePreferencesDeletedEvent} from './preferences';
 import {handleAddCustomEmoji, handleReactionRemovedFromPostEvent, handleReactionAddedToPostEvent} from './reactions';
 import {handleUserRoleUpdatedEvent, handleTeamMemberRoleUpdatedEvent, handleRoleUpdatedEvent} from './roles';
-import {handleLicenseChangedEvent} from './system';
+import {handleLicenseChangedEvent, handleConfigChangedEvent} from './system';
 import {handleLeaveTeamEvent, handleUserAddedToTeamEvent, handleUpdateTeamEvent} from './teams';
 import {handleUserUpdatedEvent, handleUserTypingEvent} from './users';
 
@@ -277,9 +277,9 @@ export async function handleEvent(serverUrl: string, msg: WebSocketMessage) {
             break;
 
         case WebsocketEvents.CONFIG_CHANGED:
+            handleConfigChangedEvent(serverUrl, msg);
             break;
 
-        // return dispatch(handleConfigChangedEvent(msg));
         case WebsocketEvents.OPEN_DIALOG:
             break;
 

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -24,6 +24,7 @@ import {handleNewPostEvent, handlePostDeleted, handlePostEdited, handlePostUnrea
 import {handlePreferenceChangedEvent, handlePreferencesChangedEvent, handlePreferencesDeletedEvent} from './preferences';
 import {handleAddCustomEmoji, handleReactionRemovedFromPostEvent, handleReactionAddedToPostEvent} from './reactions';
 import {handleUserRoleUpdatedEvent, handleTeamMemberRoleUpdatedEvent, handleRoleUpdatedEvent} from './roles';
+import {handleLicenseChangedEvent} from './system';
 import {handleLeaveTeamEvent, handleUserAddedToTeamEvent, handleUpdateTeamEvent} from './teams';
 import {handleUserUpdatedEvent, handleUserTypingEvent} from './users';
 
@@ -272,9 +273,9 @@ export async function handleEvent(serverUrl: string, msg: WebSocketMessage) {
             break;
 
         case WebsocketEvents.LICENSE_CHANGED:
+            handleLicenseChangedEvent(serverUrl, msg);
             break;
 
-        // return dispatch(handleLicenseChangedEvent(msg));
         case WebsocketEvents.CONFIG_CHANGED:
             break;
 

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -255,11 +255,7 @@ export async function handleEvent(serverUrl: string, msg: WebSocketMessage) {
         case WebsocketEvents.TYPING:
             handleUserTypingEvent(serverUrl, msg);
             break;
-        case WebsocketEvents.HELLO:
-            break;
 
-        // handleHelloEvent(msg);
-        // break;
         case WebsocketEvents.REACTION_ADDED:
             handleReactionAddedToPostEvent(serverUrl, msg);
             break;

--- a/app/actions/websocket/system.ts
+++ b/app/actions/websocket/system.ts
@@ -21,3 +21,21 @@ export async function handleLicenseChangedEvent(serverUrl: string, msg: WebSocke
         // do nothing
     }
 }
+
+export async function handleConfigChangedEvent(serverUrl: string, msg: WebSocketMessage): Promise<void> {
+    const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
+    if (!operator) {
+        return;
+    }
+
+    try {
+        const config = msg.data.config;
+        const systems: IdValue[] = [{
+            id: SYSTEM_IDENTIFIERS.CONFIG,
+            value: JSON.stringify(config),
+        }];
+        await operator.handleSystem({systems, prepareRecordsOnly: false});
+    } catch {
+        // do nothing
+    }
+}

--- a/app/actions/websocket/system.ts
+++ b/app/actions/websocket/system.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {SYSTEM_IDENTIFIERS} from '@app/constants/database';
+import DatabaseManager from '@database/manager';
+
+export async function handleLicenseChangedEvent(serverUrl: string, msg: WebSocketMessage): Promise<void> {
+    const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
+    if (!operator) {
+        return;
+    }
+
+    const license = msg.data.license;
+    const systems: IdValue[] = [{
+        id: SYSTEM_IDENTIFIERS.LICENSE,
+        value: JSON.stringify(license),
+    }];
+
+    try {
+        await operator.handleSystem({systems, prepareRecordsOnly: false});
+    } catch {
+        // do nothing
+    }
+}

--- a/app/actions/websocket/system.ts
+++ b/app/actions/websocket/system.ts
@@ -10,13 +10,12 @@ export async function handleLicenseChangedEvent(serverUrl: string, msg: WebSocke
         return;
     }
 
-    const license = msg.data.license;
-    const systems: IdValue[] = [{
-        id: SYSTEM_IDENTIFIERS.LICENSE,
-        value: JSON.stringify(license),
-    }];
-
     try {
+        const license = msg.data.license;
+        const systems: IdValue[] = [{
+            id: SYSTEM_IDENTIFIERS.LICENSE,
+            value: JSON.stringify(license),
+        }];
         await operator.handleSystem({systems, prepareRecordsOnly: false});
     } catch {
         // do nothing


### PR DESCRIPTION
#### Summary
This PR handles the following teams websocket events:

- [x] hello(?)
- [x] License changed
- [x] Config changed

#### Hello
Websocket handler is removed, however the costant is not.  `WebsocketEvents.HELLO` is being used here. 
https://github.com/mattermost/mattermost-mobile/blob/gekidou/app/client/websocket/index.ts#L226

#### License
These values were stored when initially loaded in the WDB, but not included in the websocket license data. On a websocket event, the client information is sanitized with `GetSanitizedClientLiense()` whichi removes the following.
```
"SkuName":"Mattermost Enterprise Edition E10 - 12 Month End User Subscription",
"StartsAt":"1614574800000",
"Name":"Joram Wilander",
"SkuShortName":"E10",
"ExpiresAt":"1646110800000",
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39729

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
