### PR TITLE
[MM-41753] Calls: keep audio on when app is on background

### DIFF
--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -100,6 +100,7 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>


### PR DESCRIPTION
#### Summary

Adding audio background capability to iOS build to allow calls to stay on when app goes into background.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-41753

#### Release Note

```release-note
NONE
```

