### PR TITLE
Make iOS notifications compatible with background fetch (v1)

### DIFF
--- a/app/actions/views/root.js
+++ b/app/actions/views/root.js
@@ -76,7 +76,7 @@ export function loadConfigAndLicense() {
     };
 }
 
-export function loadFromPushNotification(notification, isInitialNotification) {
+export function loadFromPushNotification(notification, isInitialNotification, skipChannelSwitch = false) {
     return async (dispatch, getState) => {
         const state = getState();
         const {payload} = notification;
@@ -108,12 +108,14 @@ export function loadFromPushNotification(notification, isInitialNotification) {
             await Promise.all(loading);
         }
 
-        dispatch(handleSelectTeamAndChannel(teamId, channelId));
-        dispatch(selectPost(''));
+        if (!skipChannelSwitch) {
+            dispatch(handleSelectTeamAndChannel(teamId, channelId));
+            dispatch(selectPost(''));
 
-        const {root_id: rootId} = notification.payload || {};
-        if (isCollapsedThreadsEnabled(state) && rootId) {
-            dispatch(selectPost(rootId));
+            const {root_id: rootId} = notification.payload || {};
+            if (isCollapsedThreadsEnabled(state) && rootId) {
+                dispatch(selectPost(rootId));
+            }
         }
         return {data: true};
     };

--- a/app/types/push_notification.d.ts
+++ b/app/types/push_notification.d.ts
@@ -6,7 +6,12 @@ interface NotificationUserInfo {
     test?: boolean;
 }
 
+interface NotificationWithAck extends Notification {
+    ack_id: string;
+}
+
 interface NotificationData {
+    ack_id: string;
     body?: string;
     channel_id: string;
     channel_name?: string;


### PR DESCRIPTION
#### Summary
With the introduction of this PR https://github.com/mattermost/mattermost-push-proxy/pull/87 Push notifications on iOS will now wake the app if it was not running so we need to make the init process to NOT treat the `initial notification` as the app being opened by tapping on it. So essentially after you received the notification, if the app icon is pressed it should open the application but not switch to the channel of the incoming notification.

This in needed in preparation for the alpha release as the push proxy will need to be updated by then.

```release-note
NONE
```
