### PR TITLE
[Gekidou] Post removal

### DIFF
--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -135,7 +135,7 @@ const Post = ({
             }
 
             const isValidSystemMessage = isAutoResponder || !isSystemPost;
-            if (post.deleteAt !== 0 && isValidSystemMessage && !isPendingOrFailed) {
+            if (post.deleteAt === 0 && isValidSystemMessage && !isPendingOrFailed) {
                 if ([Screens.CHANNEL, Screens.PERMALINK].includes(location)) {
                     DeviceEventEmitter.emit('goToThread', post);
                 }


### PR DESCRIPTION
#### Summary
This PR fixes a couple of things:
1. The handler onPress for the Post component was not calling `removePost` when the post was deleted.
2. The more important fix is the operator for `handlePosts` here are are only storing the posts that were fetch that have not been deleted and we are removing from the database any post that was deleted on the server that we still have in the database.


```release-note
NONE
```
