### PR TITLE
[MM-39149] Setting a Custom Status is Failing Silently

### DIFF
--- a/app/components/sidebars/settings/__snapshots__/settings_sidebar.test.js.snap
+++ b/app/components/sidebars/settings/__snapshots__/settings_sidebar.test.js.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SettingsSidebar Custom Status should close sidebar when update custom status succeeds 1`] = `
+<DrawerLayoutAdapter
+  drawerPosition="right"
+  drawerWidth={710}
+  forwardRef={
+    Object {
+      "current": null,
+    }
+  }
+  onDrawerClose={[Function]}
+  onDrawerOpen={[Function]}
+  renderNavigationView={[Function]}
+  useNativeAnimations={true}
+/>
+`;
+
+exports[`SettingsSidebar Custom Status should keep sidebar open when update custom status fails 1`] = `
+<DrawerLayoutAdapter
+  drawerPosition="right"
+  drawerWidth={710}
+  forwardRef={
+    Object {
+      "current": null,
+    }
+  }
+  onDrawerClose={[Function]}
+  onDrawerOpen={[Function]}
+  renderNavigationView={[Function]}
+  useNativeAnimations={true}
+/>
+`;
+
 exports[`SettingsSidebar should match snapshot 1`] = `
 <DrawerLayoutAdapter
   drawerPosition="right"

--- a/app/components/sidebars/settings/settings_sidebar.test.js
+++ b/app/components/sidebars/settings/settings_sidebar.test.js
@@ -5,6 +5,7 @@ import React from 'react';
 
 import Preferences from '@mm-redux/constants/preferences';
 import {CustomStatusDuration} from '@mm-redux/types/users';
+import EventEmitter from '@mm-redux/utils/event_emitter';
 import {shallowWithIntl} from '@test/intl-test-helper';
 
 import SettingsSidebar from './settings_sidebar.ios';
@@ -66,5 +67,45 @@ describe('SettingsSidebar', () => {
         );
 
         expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    describe('Custom Status', () => {
+        const tests = [
+            {case: 'should keep sidebar open when update custom status fails', error: 'update custom status fail'},
+            {case: 'should close sidebar when update custom status succeeds', error: undefined},
+        ];
+
+        tests.forEach((test) => {
+            it(test.case, () => {
+                const wrapper = shallowWithIntl(
+                    <SettingsSidebar
+                        {...baseProps}
+                        isCustomStatusEnabled={true}
+                        customStatus={{
+                            ...customStatus,
+                            duration: CustomStatusDuration.DATE_AND_TIME,
+                            expires_at: '2200-04-13T18:09:12.451Z',
+                        }}
+                    />,
+                );
+
+                const instance = wrapper.instance();
+                instance.componentDidMount();
+
+                const spy = jest.spyOn(instance, 'closeSettingsSidebar');
+
+                EventEmitter.emit('set_custom_status', test.error);
+
+                if (test.error) {
+                    expect(spy).not.toBeCalled();
+                    expect(wrapper.state('showRetryMessage')).toBe(true);
+                } else {
+                    expect(spy).toBeCalled();
+                    expect(wrapper.state('showRetryMessage')).toBe(false);
+                }
+
+                expect(wrapper.getElement()).toMatchSnapshot();
+            });
+        });
     });
 });

--- a/app/components/sidebars/settings/settings_sidebar_base.js
+++ b/app/components/sidebars/settings/settings_sidebar_base.js
@@ -57,7 +57,7 @@ export default class SettingsSidebarBase extends PureComponent {
     componentDidMount() {
         this.mounted = true;
         EventEmitter.on(NavigationTypes.CLOSE_SETTINGS_SIDEBAR, this.closeSettingsSidebar);
-        EventEmitter.on(CustomStatus.SET_CUSTOM_STATUS_FAILURE, this.handleSetCustomStatusFailure);
+        EventEmitter.on(CustomStatus.SET_CUSTOM_STATUS, this.handleSetCustomStatus);
     }
 
     componentDidUpdate(prevProps) {
@@ -67,13 +67,20 @@ export default class SettingsSidebarBase extends PureComponent {
     componentWillUnmount() {
         this.mounted = false;
         EventEmitter.off(NavigationTypes.CLOSE_SETTINGS_SIDEBAR, this.closeSettingsSidebar);
-        EventEmitter.off(CustomStatus.SET_CUSTOM_STATUS_FAILURE, this.handleSetCustomStatusFailure);
+        EventEmitter.off(CustomStatus.SET_CUSTOM_STATUS, this.handleSetCustomStatus);
     }
 
-    handleSetCustomStatusFailure = () => {
-        this.setState({
-            showRetryMessage: true,
-        });
+    handleSetCustomStatus = (error) => {
+        if (error) {
+            this.setState({showRetryMessage: true});
+        } else {
+            this.setState({
+                showStatus: true,
+                showRetryMessage: false,
+            });
+
+            this.closeSettingsSidebar();
+        }
     };
 
     handleCustomStatusChange = (prevCustomStatus, customStatus) => {
@@ -167,7 +174,6 @@ export default class SettingsSidebarBase extends PureComponent {
     };
 
     goToCustomStatusScreen = (intl) => {
-        this.closeSettingsSidebar();
         showModal('CustomStatus', intl.formatMessage({id: 'mobile.routes.custom_status', defaultMessage: 'Set a Status'}));
     };
 

--- a/app/constants/custom_status.ts
+++ b/app/constants/custom_status.ts
@@ -45,4 +45,4 @@ export const durationValues = {
     },
 };
 export const CUSTOM_STATUS_TEXT_CHARACTER_LIMIT = 100;
-export const SET_CUSTOM_STATUS_FAILURE = 'set_custom_status_failure';
+export const SET_CUSTOM_STATUS = 'set_custom_status';

--- a/app/screens/custom_status/custom_status_modal.tsx
+++ b/app/screens/custom_status/custom_status_modal.tsx
@@ -159,9 +159,7 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
                     status.expires_at = this.calculateExpiryTime(duration);
                 }
                 const {error} = await this.props.actions.setCustomStatus(status);
-                if (error) {
-                    EventEmitter.emit(CustomStatus.SET_CUSTOM_STATUS_FAILURE);
-                }
+                EventEmitter.emit(CustomStatus.SET_CUSTOM_STATUS, error);
             }
         } else if (customStatus?.emoji) {
             this.props.actions.unsetCustomStatus();


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Fixes issue where setting a custom status fails silently as the sidebar always closes after the request is completed (where it is successful or not). This PR keeps the sidebar open if setting a custom status fails so the error is visible to the user, and closes the sidebar when the request is successful.
 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes [MM-39149](https://mattermost.atlassian.net/browse/MM-39149)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

- iPhone 13, iOS 15.2

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

https://user-images.githubusercontent.com/23694620/154714636-6430f2fb-b40e-45fc-a4ed-6b1f08b74931.mp4



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
