### PR TITLE
[Gekidou] various fixes

### DIFF
--- a/app/actions/remote/role.ts
+++ b/app/actions/remote/role.ts
@@ -61,11 +61,9 @@ export const fetchRoles = async (serverUrl: string, teamMembership?: TeamMembers
 
     if (teamMembership?.length) {
         const teamRoles: string[] = [];
-        const teamMembers: string[] = [];
 
         teamMembership?.forEach((tm) => {
             teamRoles.push(...tm.roles.split(' '));
-            teamMembers.push(tm.team_id);
         });
 
         teamRoles.forEach(rolesToFetch.add, rolesToFetch);

--- a/app/actions/remote/role.ts
+++ b/app/actions/remote/role.ts
@@ -78,6 +78,7 @@ export const fetchRoles = async (serverUrl: string, teamMembership?: TeamMembers
         }
     }
 
+    rolesToFetch.delete('');
     if (rolesToFetch.size > 0) {
         return fetchRolesIfNeeded(serverUrl, Array.from(rolesToFetch), fetchOnly);
     }

--- a/app/actions/websocket/preferences.ts
+++ b/app/actions/websocket/preferences.ts
@@ -17,7 +17,6 @@ export async function handlePreferenceChangedEvent(serverUrl: string, msg: WebSo
             operator.handlePreferences({
                 prepareRecordsOnly: false,
                 preferences: [preference],
-                sync: true,
             });
         }
     } catch (error) {
@@ -38,7 +37,6 @@ export async function handlePreferencesChangedEvent(serverUrl: string, msg: WebS
             operator.handlePreferences({
                 prepareRecordsOnly: false,
                 preferences,
-                sync: true,
             });
         }
     } catch (error) {

--- a/app/database/models/server/channel.ts
+++ b/app/database/models/server/channel.ts
@@ -7,6 +7,7 @@ import Model, {Associations} from '@nozbe/watermelondb/Model';
 
 import {MM_TABLES} from '@constants/database';
 
+import type CategoryChannelModel from '@typings/database/models/servers/category_channel';
 import type ChannelInfoModel from '@typings/database/models/servers/channel_info';
 import type ChannelMembershipModel from '@typings/database/models/servers/channel_membership';
 import type DraftModel from '@typings/database/models/servers/draft';
@@ -126,6 +127,9 @@ export default class ChannelModel extends Model {
 
     /** settings: User specific settings/preferences for this channel */
     @immutableRelation(MY_CHANNEL_SETTINGS, 'id') settings!: Relation<MyChannelSettingsModel>;
+
+    /** categoryChannel : Query returning the membership data for the current user if it belongs to this channel */
+    @immutableRelation(CATEGORY_CHANNEL, 'channel_id') categoryChannel!: Relation<CategoryChannelModel>;
 
     toApi = (): Channel => {
         return {

--- a/app/database/models/server/team.ts
+++ b/app/database/models/server/team.ts
@@ -7,6 +7,7 @@ import Model, {Associations} from '@nozbe/watermelondb/Model';
 
 import {MM_TABLES} from '@constants/database';
 
+import type CategoryModel from '@typings/database/models/servers/category';
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type MyTeamModel from '@typings/database/models/servers/my_team';
 import type SlashCommandModel from '@typings/database/models/servers/slash_command';
@@ -15,6 +16,7 @@ import type TeamMembershipModel from '@typings/database/models/servers/team_memb
 import type TeamSearchHistoryModel from '@typings/database/models/servers/team_search_history';
 
 const {
+    CATEGORY,
     CHANNEL,
     TEAM,
     MY_TEAM,
@@ -33,6 +35,9 @@ export default class TeamModel extends Model {
 
     /** associations : Describes every relationship to this table. */
     static associations: Associations = {
+
+        /** A TEAM has a 1:N relationship with CATEGORY. A TEAM can possess multiple categories */
+        [CATEGORY]: {type: 'has_many', foreignKey: 'team_id'},
 
         /** A TEAM has a 1:N relationship with CHANNEL. A TEAM can possess multiple channels */
         [CHANNEL]: {type: 'has_many', foreignKey: 'team_id'},
@@ -76,6 +81,9 @@ export default class TeamModel extends Model {
 
     /** allowed_domains : List of domains that can join this team */
     @field('allowed_domains') allowedDomains!: string;
+
+    /** categories : All the categories associated with this team */
+    @children(CATEGORY) categories!: CategoryModel[];
 
     /** channels : All the channels associated with this team */
     @children(CHANNEL) channels!: ChannelModel[];

--- a/app/database/operator/server_data_operator/handlers/channel.test.ts
+++ b/app/database/operator/server_data_operator/handlers/channel.test.ts
@@ -5,11 +5,13 @@ import DatabaseManager from '@database/manager';
 import {
     isRecordChannelEqualToRaw,
     isRecordChannelInfoEqualToRaw,
+    isRecordChannelMembershipEqualToRaw,
     isRecordMyChannelEqualToRaw,
     isRecordMyChannelSettingsEqualToRaw,
 } from '@database/operator/server_data_operator/comparators';
 import {
     transformChannelInfoRecord,
+    transformChannelMembershipRecord,
     transformChannelRecord,
     transformMyChannelRecord,
     transformMyChannelSettingsRecord,
@@ -196,6 +198,67 @@ describe('*** Operator: Channel Handlers tests ***', () => {
             prepareRecordsOnly: false,
             findMatchingRecordBy: isRecordMyChannelEqualToRaw,
             transformer: transformMyChannelRecord,
+        });
+    });
+
+    it('=> HandleChannelMembership: should write to the CHANNEL_MEMBERSHIP table', async () => {
+        expect.assertions(2);
+        const channelMemberships: ChannelMembership[] = [
+            {
+                id: '17bfnb1uwb8epewp4q3x3rx9go-9ciscaqbrpd6d8s68k76xb9bte',
+                channel_id: '17bfnb1uwb8epewp4q3x3rx9go',
+                user_id: '9ciscaqbrpd6d8s68k76xb9bte',
+                roles: 'wqyby5r5pinxxdqhoaomtacdhc',
+                last_viewed_at: 1613667352029,
+                msg_count: 3864,
+                mention_count: 0,
+                notify_props: {
+                    desktop: 'default',
+                    email: 'default',
+                    ignore_channel_mentions: 'default',
+                    mark_unread: 'mention',
+                    push: 'default',
+                },
+                last_update_at: 1613667352029,
+                scheme_user: true,
+                scheme_admin: false,
+            },
+            {
+                id: '1yw6gxfr4bn1jbyp9nr7d53yew-9ciscaqbrpd6d8s68k76xb9bte',
+                channel_id: '1yw6gxfr4bn1jbyp9nr7d53yew',
+                user_id: '9ciscaqbrpd6d8s68k76xb9bte',
+                roles: 'channel_user',
+                last_viewed_at: 1615300540549,
+                msg_count: 16,
+                mention_count: 0,
+                notify_props: {
+                    desktop: 'default',
+                    email: 'default',
+                    ignore_channel_mentions: 'default',
+                    mark_unread: 'all',
+                    push: 'default',
+                },
+                last_update_at: 1615300540549,
+                scheme_user: true,
+                scheme_admin: false,
+            },
+        ];
+
+        const spyOnHandleRecords = jest.spyOn(operator, 'handleRecords');
+
+        await operator.handleChannelMembership({
+            channelMemberships,
+            prepareRecordsOnly: false,
+        });
+
+        expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
+        expect(spyOnHandleRecords).toHaveBeenCalledWith({
+            fieldName: 'user_id',
+            createOrUpdateRawValues: channelMemberships,
+            tableName: 'ChannelMembership',
+            prepareRecordsOnly: false,
+            findMatchingRecordBy: isRecordChannelMembershipEqualToRaw,
+            transformer: transformChannelMembershipRecord,
         });
     });
 });

--- a/app/database/operator/server_data_operator/handlers/reaction.test.ts
+++ b/app/database/operator/server_data_operator/handlers/reaction.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import DatabaseManager from '@database/manager';
+import ServerDataOperator from '@database/operator/server_data_operator';
+
+describe('*** Operator: User Handlers tests ***', () => {
+    let operator: ServerDataOperator;
+
+    beforeAll(async () => {
+        await DatabaseManager.init(['baseHandler.test.com']);
+        operator = DatabaseManager.serverDatabases['baseHandler.test.com'].operator;
+    });
+
+    it('=> HandleReactions: should write to Reactions table', async () => {
+        expect.assertions(2);
+
+        const spyOnPrepareRecords = jest.spyOn(operator, 'prepareRecords');
+        const spyOnBatchOperation = jest.spyOn(operator, 'batchRecords');
+
+        await operator.handleReactions({
+            postsReactions: [{
+                post_id: '4r9jmr7eqt8dxq3f9woypzurry',
+                reactions: [
+                    {
+                        create_at: 1608263728086,
+                        emoji_name: 'p4p1',
+                        post_id: '4r9jmr7eqt8dxq3f9woypzurry',
+                        user_id: 'ooumoqgq3bfiijzwbn8badznwc',
+                    },
+                ],
+            }],
+            prepareRecordsOnly: false,
+        });
+
+        // Called twice:  Once for Reaction record
+        expect(spyOnPrepareRecords).toHaveBeenCalledTimes(1);
+
+        // Only one batch operation for both tables
+        expect(spyOnBatchOperation).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/database/operator/server_data_operator/handlers/reaction.ts
+++ b/app/database/operator/server_data_operator/handlers/reaction.ts
@@ -20,7 +20,7 @@ const ReactionHandler = (superclass: any) => class extends superclass {
     /**
      * handleReactions: Handler responsible for the Create/Update operations occurring on the Reaction table from the 'Server' schema
      * @param {HandleReactionsArgs} handleReactions
-     * @param {ReactionsPerPost[]} handleReactions.reactions
+     * @param {ReactionsPerPost[]} handleReactions.postsReactions
      * @param {boolean} handleReactions.prepareRecordsOnly
      * @param {boolean} handleReactions.skipSync
      * @throws DataOperatorException

--- a/app/database/operator/server_data_operator/handlers/reaction.ts
+++ b/app/database/operator/server_data_operator/handlers/reaction.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {MM_TABLES} from '@constants/database';
+import DataOperatorException from '@database/exceptions/data_operator_exception';
+import {transformReactionRecord} from '@database/operator/server_data_operator/transformers/user';
+import {sanitizeReactions} from '@database/operator/utils/reaction';
+
+import type {HandleReactionsArgs} from '@typings/database/database';
+import type CustomEmojiModel from '@typings/database/models/servers/custom_emoji';
+import type ReactionModel from '@typings/database/models/servers/reaction';
+
+const {REACTION} = MM_TABLES.SERVER;
+
+export interface ReactionHandlerMix {
+    handleReactions: ({postsReactions, prepareRecordsOnly}: HandleReactionsArgs) => Promise<Array<ReactionModel | CustomEmojiModel>>;
+}
+
+const ReactionHandler = (superclass: any) => class extends superclass {
+    /**
+     * handleReactions: Handler responsible for the Create/Update operations occurring on the Reaction table from the 'Server' schema
+     * @param {HandleReactionsArgs} handleReactions
+     * @param {ReactionsPerPost[]} handleReactions.reactions
+     * @param {boolean} handleReactions.prepareRecordsOnly
+     * @param {boolean} handleReactions.skipSync
+     * @throws DataOperatorException
+     * @returns {Promise<Array<(ReactionModel | CustomEmojiModel)>>}
+     */
+    handleReactions = async ({postsReactions, prepareRecordsOnly, skipSync}: HandleReactionsArgs): Promise<ReactionModel[]> => {
+        const batchRecords: ReactionModel[] = [];
+
+        if (!postsReactions.length) {
+            throw new DataOperatorException(
+                'An empty "reactions" array has been passed to the handleReactions method',
+            );
+        }
+
+        for await (const postReactions of postsReactions) {
+            const {post_id, reactions} = postReactions;
+            const {
+                createReactions,
+                deleteReactions,
+            } = await sanitizeReactions({
+                database: this.database,
+                post_id,
+                rawReactions: reactions,
+                skipSync,
+            });
+
+            if (createReactions?.length) {
+                // Prepares record for model Reactions
+                const reactionsRecords = (await this.prepareRecords({
+                    createRaws: createReactions,
+                    transformer: transformReactionRecord,
+                    tableName: REACTION,
+                })) as ReactionModel[];
+                batchRecords.push(...reactionsRecords);
+            }
+
+            if (deleteReactions?.length && !skipSync) {
+                deleteReactions.forEach((outCast) => outCast.prepareDestroyPermanently());
+                batchRecords.push(...deleteReactions);
+            }
+        }
+
+        if (prepareRecordsOnly) {
+            return batchRecords;
+        }
+
+        if (batchRecords?.length) {
+            await this.batchRecords(batchRecords);
+        }
+
+        return batchRecords;
+    };
+};
+
+export default ReactionHandler;

--- a/app/database/operator/server_data_operator/handlers/user.test.ts
+++ b/app/database/operator/server_data_operator/handlers/user.test.ts
@@ -4,12 +4,10 @@
 import DatabaseManager from '@database/manager';
 import ServerDataOperator from '@database/operator/server_data_operator';
 import {
-    isRecordChannelMembershipEqualToRaw,
     isRecordPreferenceEqualToRaw,
     isRecordUserEqualToRaw,
 } from '@database/operator/server_data_operator/comparators';
 import {
-    transformChannelMembershipRecord,
     transformPreferenceRecord,
     transformUserRecord,
 } from '@database/operator/server_data_operator/transformers/user';
@@ -155,67 +153,6 @@ describe('*** Operator: User Handlers tests ***', () => {
             prepareRecordsOnly: true,
             findMatchingRecordBy: isRecordPreferenceEqualToRaw,
             transformer: transformPreferenceRecord,
-        });
-    });
-
-    it('=> HandleChannelMembership: should write to the CHANNEL_MEMBERSHIP table', async () => {
-        expect.assertions(2);
-        const channelMemberships: ChannelMembership[] = [
-            {
-                id: '17bfnb1uwb8epewp4q3x3rx9go-9ciscaqbrpd6d8s68k76xb9bte',
-                channel_id: '17bfnb1uwb8epewp4q3x3rx9go',
-                user_id: '9ciscaqbrpd6d8s68k76xb9bte',
-                roles: 'wqyby5r5pinxxdqhoaomtacdhc',
-                last_viewed_at: 1613667352029,
-                msg_count: 3864,
-                mention_count: 0,
-                notify_props: {
-                    desktop: 'default',
-                    email: 'default',
-                    ignore_channel_mentions: 'default',
-                    mark_unread: 'mention',
-                    push: 'default',
-                },
-                last_update_at: 1613667352029,
-                scheme_user: true,
-                scheme_admin: false,
-            },
-            {
-                id: '1yw6gxfr4bn1jbyp9nr7d53yew-9ciscaqbrpd6d8s68k76xb9bte',
-                channel_id: '1yw6gxfr4bn1jbyp9nr7d53yew',
-                user_id: '9ciscaqbrpd6d8s68k76xb9bte',
-                roles: 'channel_user',
-                last_viewed_at: 1615300540549,
-                msg_count: 16,
-                mention_count: 0,
-                notify_props: {
-                    desktop: 'default',
-                    email: 'default',
-                    ignore_channel_mentions: 'default',
-                    mark_unread: 'all',
-                    push: 'default',
-                },
-                last_update_at: 1615300540549,
-                scheme_user: true,
-                scheme_admin: false,
-            },
-        ];
-
-        const spyOnHandleRecords = jest.spyOn(operator, 'handleRecords');
-
-        await operator.handleChannelMembership({
-            channelMemberships,
-            prepareRecordsOnly: false,
-        });
-
-        expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
-        expect(spyOnHandleRecords).toHaveBeenCalledWith({
-            fieldName: 'user_id',
-            createOrUpdateRawValues: channelMemberships,
-            tableName: 'ChannelMembership',
-            prepareRecordsOnly: false,
-            findMatchingRecordBy: isRecordChannelMembershipEqualToRaw,
-            transformer: transformChannelMembershipRecord,
         });
     });
 });

--- a/app/database/operator/server_data_operator/handlers/user.ts
+++ b/app/database/operator/server_data_operator/handlers/user.ts
@@ -4,78 +4,30 @@
 import {MM_TABLES} from '@constants/database';
 import DataOperatorException from '@database/exceptions/data_operator_exception';
 import {
-    isRecordChannelMembershipEqualToRaw,
     isRecordPreferenceEqualToRaw,
     isRecordUserEqualToRaw,
 } from '@database/operator/server_data_operator/comparators';
 import {
-    transformChannelMembershipRecord,
     transformPreferenceRecord,
-    transformReactionRecord,
     transformUserRecord,
 } from '@database/operator/server_data_operator/transformers/user';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
-import {sanitizeReactions} from '@database/operator/utils/reaction';
 
 import type {
-    HandleChannelMembershipArgs,
     HandlePreferencesArgs,
-    HandleReactionsArgs,
     HandleUsersArgs,
 } from '@typings/database/database';
-import type ChannelMembershipModel from '@typings/database/models/servers/channel_membership';
-import type CustomEmojiModel from '@typings/database/models/servers/custom_emoji';
 import type PreferenceModel from '@typings/database/models/servers/preference';
-import type ReactionModel from '@typings/database/models/servers/reaction';
 import type UserModel from '@typings/database/models/servers/user';
 
-const {
-    CHANNEL_MEMBERSHIP,
-    PREFERENCE,
-    REACTION,
-    USER,
-} = MM_TABLES.SERVER;
+const {PREFERENCE, USER} = MM_TABLES.SERVER;
 
 export interface UserHandlerMix {
-    handleChannelMembership: ({channelMemberships, prepareRecordsOnly}: HandleChannelMembershipArgs) => Promise<ChannelMembershipModel[]>;
     handlePreferences: ({preferences, prepareRecordsOnly}: HandlePreferencesArgs) => Promise<PreferenceModel[]>;
-    handleReactions: ({postsReactions, prepareRecordsOnly}: HandleReactionsArgs) => Promise<Array<ReactionModel | CustomEmojiModel>>;
     handleUsers: ({users, prepareRecordsOnly}: HandleUsersArgs) => Promise<UserModel[]>;
 }
 
 const UserHandler = (superclass: any) => class extends superclass {
-    /**
-     * handleChannelMembership: Handler responsible for the Create/Update operations occurring on the CHANNEL_MEMBERSHIP table from the 'Server' schema
-     * @param {HandleChannelMembershipArgs} channelMembershipsArgs
-     * @param {ChannelMembership[]} channelMembershipsArgs.channelMemberships
-     * @param {boolean} channelMembershipsArgs.prepareRecordsOnly
-     * @throws DataOperatorException
-     * @returns {Promise<ChannelMembershipModel[]>}
-     */
-    handleChannelMembership = ({channelMemberships, prepareRecordsOnly = true}: HandleChannelMembershipArgs): Promise<ChannelMembershipModel[]> => {
-        if (!channelMemberships.length) {
-            throw new DataOperatorException(
-                'An empty "channelMemberships" array has been passed to the handleChannelMembership method',
-            );
-        }
-
-        const memberships: ChannelMember[] = channelMemberships.map((m) => ({
-            id: `${m.channel_id}-${m.user_id}`,
-            ...m,
-        }));
-
-        const createOrUpdateRawValues = getUniqueRawsBy({raws: memberships, key: 'id'});
-
-        return this.handleRecords({
-            fieldName: 'user_id',
-            findMatchingRecordBy: isRecordChannelMembershipEqualToRaw,
-            transformer: transformChannelMembershipRecord,
-            prepareRecordsOnly,
-            createOrUpdateRawValues,
-            tableName: CHANNEL_MEMBERSHIP,
-        });
-    };
-
     /**
      * handlePreferences: Handler responsible for the Create/Update operations occurring on the PREFERENCE table from the 'Server' schema
      * @param {HandlePreferencesArgs} preferencesArgs
@@ -122,64 +74,6 @@ const UserHandler = (superclass: any) => class extends superclass {
         }
 
         return records;
-    };
-
-    /**
-     * handleReactions: Handler responsible for the Create/Update operations occurring on the Reaction table from the 'Server' schema
-     * @param {HandleReactionsArgs} handleReactions
-     * @param {ReactionsPerPost[]} handleReactions.reactions
-     * @param {boolean} handleReactions.prepareRecordsOnly
-     * @param {boolean} handleReactions.skipSync
-     * @throws DataOperatorException
-     * @returns {Promise<Array<(ReactionModel | CustomEmojiModel)>>}
-     */
-    handleReactions = async ({postsReactions, prepareRecordsOnly, skipSync}: HandleReactionsArgs): Promise<ReactionModel[]> => {
-        const batchRecords: ReactionModel[] = [];
-
-        if (!postsReactions.length) {
-            throw new DataOperatorException(
-                'An empty "reactions" array has been passed to the handleReactions method',
-            );
-        }
-
-        for await (const postReactions of postsReactions) {
-            const {post_id, reactions} = postReactions;
-            const rawValues = getUniqueRawsBy({raws: reactions, key: 'emoji_name'}) as Reaction[];
-            const {
-                createReactions,
-                deleteReactions,
-            } = await sanitizeReactions({
-                database: this.database,
-                post_id,
-                rawReactions: rawValues,
-                skipSync,
-            });
-
-            if (createReactions?.length) {
-                // Prepares record for model Reactions
-                const reactionsRecords = (await this.prepareRecords({
-                    createRaws: createReactions,
-                    transformer: transformReactionRecord,
-                    tableName: REACTION,
-                })) as ReactionModel[];
-                batchRecords.push(...reactionsRecords);
-            }
-
-            if (deleteReactions?.length && !skipSync) {
-                deleteReactions.forEach((outCast) => outCast.prepareDestroyPermanently());
-                batchRecords.push(...deleteReactions);
-            }
-        }
-
-        if (prepareRecordsOnly) {
-            return batchRecords;
-        }
-
-        if (batchRecords?.length) {
-            await this.batchRecords(batchRecords);
-        }
-
-        return batchRecords;
     };
 
     /**

--- a/app/database/operator/server_data_operator/index.ts
+++ b/app/database/operator/server_data_operator/index.ts
@@ -7,6 +7,7 @@ import ChannelHandler, {ChannelHandlerMix} from '@database/operator/server_data_
 import PostHandler, {PostHandlerMix} from '@database/operator/server_data_operator/handlers/post';
 import PostsInChannelHandler, {PostsInChannelHandlerMix} from '@database/operator/server_data_operator/handlers/posts_in_channel';
 import PostsInThreadHandler, {PostsInThreadHandlerMix} from '@database/operator/server_data_operator/handlers/posts_in_thread';
+import ReactionHander, {ReactionHandlerMix} from '@database/operator/server_data_operator/handlers/reaction';
 import TeamHandler, {TeamHandlerMix} from '@database/operator/server_data_operator/handlers/team';
 import UserHandler, {UserHandlerMix} from '@database/operator/server_data_operator/handlers/user';
 import mix from '@utils/mix';
@@ -14,7 +15,7 @@ import mix from '@utils/mix';
 import type {Database} from '@nozbe/watermelondb';
 
 interface ServerDataOperator extends ServerDataOperatorBase, PostHandlerMix, PostsInChannelHandlerMix,
-    PostsInThreadHandlerMix, UserHandlerMix, ChannelHandlerMix, CategoryHandlerMix, TeamHandlerMix {}
+    PostsInThreadHandlerMix, ReactionHandlerMix, UserHandlerMix, ChannelHandlerMix, CategoryHandlerMix, TeamHandlerMix {}
 
 class ServerDataOperator extends mix(ServerDataOperatorBase).with(
     CategoryHandler,
@@ -22,6 +23,7 @@ class ServerDataOperator extends mix(ServerDataOperatorBase).with(
     PostHandler,
     PostsInChannelHandler,
     PostsInThreadHandler,
+    ReactionHander,
     TeamHandler,
     UserHandler,
 ) {

--- a/app/database/operator/server_data_operator/transformers/channel.test.ts
+++ b/app/database/operator/server_data_operator/transformers/channel.test.ts
@@ -6,6 +6,7 @@ import {
     transformChannelRecord,
     transformMyChannelRecord,
     transformMyChannelSettingsRecord,
+    transformChannelMembershipRecord,
 } from '@database/operator/server_data_operator/transformers/channel';
 import {createTestConnection} from '@database/operator/utils/create_test_connection';
 import {OperationType} from '@typings/database/enums';
@@ -138,5 +139,41 @@ describe('*** CHANNEL Prepare Records Test ***', () => {
 
         expect(preparedRecords).toBeTruthy();
         expect(preparedRecords!.collection.modelClass.name).toBe('MyChannelModel');
+    });
+
+    it('=> transformChannelMembershipRecord: should return an array of type ChannelMembership', async () => {
+        expect.assertions(3);
+
+        const database = await createTestConnection({databaseName: 'user_prepare_records', setActive: true});
+        expect(database).toBeTruthy();
+
+        const preparedRecords = await transformChannelMembershipRecord({
+            action: OperationType.CREATE,
+            database: database!,
+            value: {
+                record: undefined,
+                raw: {
+                    channel_id: '17bfnb1uwb8epewp4q3x3rx9go',
+                    user_id: '9ciscaqbrpd6d8s68k76xb9bte',
+                    roles: 'wqyby5r5pinxxdqhoaomtacdhc',
+                    last_viewed_at: 1613667352029,
+                    msg_count: 3864,
+                    mention_count: 0,
+                    notify_props: {
+                        desktop: 'default',
+                        email: 'default',
+                        ignore_channel_mentions: 'default',
+                        mark_unread: 'mention',
+                        push: 'default',
+                    },
+                    last_update_at: 1613667352029,
+                    scheme_user: true,
+                    scheme_admin: false,
+                },
+            },
+        });
+
+        expect(preparedRecords).toBeTruthy();
+        expect(preparedRecords!.collection.modelClass.name).toBe('ChannelMembershipModel');
     });
 });

--- a/app/database/operator/server_data_operator/transformers/user.test.ts
+++ b/app/database/operator/server_data_operator/transformers/user.test.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {
-    transformChannelMembershipRecord,
     transformPreferenceRecord,
     transformReactionRecord,
     transformUserRecord,
@@ -11,42 +10,6 @@ import {createTestConnection} from '@database/operator/utils/create_test_connect
 import {OperationType} from '@typings/database/enums';
 
 describe('*** USER Prepare Records Test ***', () => {
-    it('=> transformChannelMembershipRecord: should return an array of type ChannelMembership', async () => {
-        expect.assertions(3);
-
-        const database = await createTestConnection({databaseName: 'user_prepare_records', setActive: true});
-        expect(database).toBeTruthy();
-
-        const preparedRecords = await transformChannelMembershipRecord({
-            action: OperationType.CREATE,
-            database: database!,
-            value: {
-                record: undefined,
-                raw: {
-                    channel_id: '17bfnb1uwb8epewp4q3x3rx9go',
-                    user_id: '9ciscaqbrpd6d8s68k76xb9bte',
-                    roles: 'wqyby5r5pinxxdqhoaomtacdhc',
-                    last_viewed_at: 1613667352029,
-                    msg_count: 3864,
-                    mention_count: 0,
-                    notify_props: {
-                        desktop: 'default',
-                        email: 'default',
-                        ignore_channel_mentions: 'default',
-                        mark_unread: 'mention',
-                        push: 'default',
-                    },
-                    last_update_at: 1613667352029,
-                    scheme_user: true,
-                    scheme_admin: false,
-                },
-            },
-        });
-
-        expect(preparedRecords).toBeTruthy();
-        expect(preparedRecords!.collection.modelClass.name).toBe('ChannelMembershipModel');
-    });
-
     it('=> transformPreferenceRecord: should return an array of type Preference', async () => {
         expect.assertions(3);
 

--- a/app/database/operator/server_data_operator/transformers/user.ts
+++ b/app/database/operator/server_data_operator/transformers/user.ts
@@ -6,13 +6,11 @@ import {prepareBaseRecord} from '@database/operator/server_data_operator/transfo
 import {OperationType} from '@typings/database/enums';
 
 import type {TransformerArgs} from '@typings/database/database';
-import type ChannelMembershipModel from '@typings/database/models/servers/channel_membership';
 import type PreferenceModel from '@typings/database/models/servers/preference';
 import type ReactionModel from '@typings/database/models/servers/reaction';
 import type UserModel from '@typings/database/models/servers/user';
 
 const {
-    CHANNEL_MEMBERSHIP,
     PREFERENCE,
     REACTION,
     USER,
@@ -124,30 +122,3 @@ export const transformPreferenceRecord = ({action, database, value}: Transformer
     }) as Promise<PreferenceModel>;
 };
 
-/**
- * transformChannelMembershipRecord: Prepares a record of the SERVER database 'ChannelMembership' table for update or create actions.
- * @param {TransformerArgs} operator
- * @param {Database} operator.database
- * @param {RecordPair} operator.value
- * @returns {Promise<ChannelMembershipModel>}
- */
-export const transformChannelMembershipRecord = ({action, database, value}: TransformerArgs): Promise<ChannelMembershipModel> => {
-    const raw = value.raw as ChannelMembership;
-    const record = value.record as ChannelMembershipModel;
-    const isCreateAction = action === OperationType.CREATE;
-
-    // If isCreateAction is true, we will use the id (API response) from the RAW, else we shall use the existing record id from the database
-    const fieldsMapper = (channelMember: ChannelMembershipModel) => {
-        channelMember._raw.id = isCreateAction ? (raw?.id ?? channelMember.id) : record.id;
-        channelMember.channelId = raw.channel_id;
-        channelMember.userId = raw.user_id;
-    };
-
-    return prepareBaseRecord({
-        action,
-        database,
-        tableName: CHANNEL_MEMBERSHIP,
-        value,
-        fieldsMapper,
-    }) as Promise<ChannelMembershipModel>;
-};

--- a/app/database/operator/utils/reaction.ts
+++ b/app/database/operator/utils/reaction.ts
@@ -20,19 +20,17 @@ const {REACTION} = MM_TABLES.SERVER;
  * @returns {Promise<{createReactions: RawReaction[],  deleteReactions: Reaction[]}>}
  */
 export const sanitizeReactions = async ({database, post_id, rawReactions, skipSync}: SanitizeReactionsArgs) => {
-    const reactions = (await database.collections.
-        get(REACTION).
+    const reactions = (await database.
+        get<ReactionModel>(REACTION).
         query(Q.where('post_id', post_id)).
-        fetch()) as ReactionModel[];
+        fetch());
 
     // similarObjects: Contains objects that are in both the RawReaction array and in the Reaction table
     const similarObjects: ReactionModel[] = [];
 
     const createReactions: RecordPair[] = [];
 
-    for (let i = 0; i < rawReactions.length; i++) {
-        const raw = rawReactions[i];
-
+    for (const raw of rawReactions) {
         // If the reaction is not present let's add it to the db
         const exists = reactions.find((r) => (
             r.userId === raw.user_id &&
@@ -49,7 +47,7 @@ export const sanitizeReactions = async ({database, post_id, rawReactions, skipSy
         return {createReactions, deleteReactions: []};
     }
 
-    // finding out elements to delete using array subtract
+    // finding out elements to delete
     const deleteReactions = reactions.
         filter((reaction) => !similarObjects.includes(reaction));
 

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -96,7 +96,7 @@ export const prepareMyChannelsForTeam = async (operator: ServerDataOperator, tea
 export const prepareDeleteChannel = async (channel: ChannelModel): Promise<Model[]> => {
     const preparedModels: Model[] = [channel.prepareDestroyPermanently()];
 
-    const relations: Array<Relation<Model>> = [channel.membership, channel.info, channel.settings];
+    const relations: Array<Relation<Model>> = [channel.membership, channel.info, channel.settings, channel.categoryChannel];
     for await (const relation of relations) {
         try {
             const model = await relation?.fetch?.();

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -99,7 +99,7 @@ export const prepareDeleteChannel = async (channel: ChannelModel): Promise<Model
     const relations: Array<Relation<Model>> = [channel.membership, channel.info, channel.settings];
     for await (const relation of relations) {
         try {
-            const model = await relation.fetch();
+            const model = await relation?.fetch?.();
             if (model) {
                 preparedModels.push(model.prepareDestroyPermanently());
             }
@@ -114,14 +114,16 @@ export const prepareDeleteChannel = async (channel: ChannelModel): Promise<Model
         channel.postsInChannel,
     ];
     for await (const children of associatedChildren) {
-        const models = await children.fetch() as Model[];
-        models.forEach((model) => preparedModels.push(model.prepareDestroyPermanently()));
+        const models = await children?.fetch?.() as Model[] | undefined;
+        models?.forEach((model) => preparedModels.push(model.prepareDestroyPermanently()));
     }
 
-    const posts = await channel.posts.fetch() as PostModel[];
-    for await (const post of posts) {
-        const preparedPost = await prepareDeletePost(post);
-        preparedModels.push(...preparedPost);
+    const posts = await channel.posts?.fetch?.() as PostModel[] | undefined;
+    if (posts?.length) {
+        for await (const post of posts) {
+            const preparedPost = await prepareDeletePost(post);
+            preparedModels.push(...preparedPost);
+        }
     }
 
     return preparedModels;

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -16,7 +16,7 @@ export const prepareDeletePost = async (post: PostModel): Promise<Model[]> => {
     const relations: Array<Relation<Model> | Query<Model>> = [post.drafts, post.postsInThread];
     for await (const relation of relations) {
         try {
-            const model = await relation.fetch();
+            const model = await relation?.fetch();
             if (model) {
                 if (Array.isArray(model)) {
                     model.forEach((m) => preparedModels.push(m.prepareDestroyPermanently()));
@@ -31,8 +31,8 @@ export const prepareDeletePost = async (post: PostModel): Promise<Model[]> => {
 
     const associatedChildren: Array<Query<any>> = [post.files, post.reactions];
     for await (const children of associatedChildren) {
-        const models = await children.fetch() as Model[];
-        models.forEach((model) => preparedModels.push(model.prepareDestroyPermanently()));
+        const models = await children.fetch?.() as Model[] | undefined;
+        models?.forEach((model) => preparedModels.push(model.prepareDestroyPermanently()));
     }
 
     return preparedModels;

--- a/app/queries/servers/team.ts
+++ b/app/queries/servers/team.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Database, Model, Q, Query} from '@nozbe/watermelondb';
+import {Database, Model, Q, Query, Relation} from '@nozbe/watermelondb';
 
 import {Database as DatabaseConstants, Preferences} from '@constants';
 import {getPreferenceValue} from '@helpers/api/preference';
@@ -211,22 +211,16 @@ export const prepareDeleteTeam = async (team: TeamModel): Promise<Model[]> => {
     try {
         const preparedModels: Model[] = [team.prepareDestroyPermanently()];
 
-        try {
-            const model = await team.myTeam.fetch();
-            if (model) {
-                preparedModels.push(model.prepareDestroyPermanently());
+        const relations: Array<Relation<Model>> = [team.myTeam, team.teamChannelHistory];
+        for await (const relation of relations) {
+            try {
+                const model = await relation?.fetch?.();
+                if (model) {
+                    preparedModels.push(model.prepareDestroyPermanently());
+                }
+            } catch {
+                // Record not found, do nothing
             }
-        } catch {
-            // Record not found, do nothing
-        }
-
-        try {
-            const model = await team.teamChannelHistory.fetch();
-            if (model) {
-                preparedModels.push(model.prepareDestroyPermanently());
-            }
-        } catch {
-            // Record not found, do nothing
         }
 
         const associatedChildren: Array<Query<any>> = [
@@ -236,20 +230,22 @@ export const prepareDeleteTeam = async (team: TeamModel): Promise<Model[]> => {
         ];
         for await (const children of associatedChildren) {
             try {
-                const models = await children.fetch() as Model[];
-                models.forEach((model) => preparedModels.push(model.prepareDestroyPermanently()));
+                const models = await children.fetch?.() as Model[] | undefined;
+                models?.forEach((model) => preparedModels.push(model.prepareDestroyPermanently()));
             } catch {
                 // Record not found, do nothing
             }
         }
 
-        const channels = await team.channels.fetch() as ChannelModel[];
-        for await (const channel of channels) {
-            try {
-                const preparedChannel = await prepareDeleteChannel(channel);
-                preparedModels.push(...preparedChannel);
-            } catch {
-                // Record not found, do nothing
+        const channels = await team.channels.fetch?.() as ChannelModel[] | undefined;
+        if (channels?.length) {
+            for await (const channel of channels) {
+                try {
+                    const preparedChannel = await prepareDeleteChannel(channel);
+                    preparedModels.push(...preparedChannel);
+                } catch {
+                    // Record not found, do nothing
+                }
             }
         }
 

--- a/types/database/models/servers/channel.d.ts
+++ b/types/database/models/servers/channel.d.ts
@@ -71,5 +71,8 @@ export default class ChannelModel extends Model {
     /** settings: User specific settings/preferences for this channel */
     settings: Relation<MyChannelSettingsModel>;
 
+    /** categoryChannel: category of this channel */
+    categoryChannel: Relation<CategoryChanelModel>;
+
     toApi = () => Channel;
 }

--- a/types/database/models/servers/team.d.ts
+++ b/types/database/models/servers/team.d.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Query, Relation} from '@nozbe/watermelondb';
-import Model, {Associations} from '@nozbe/watermelondb/Model';
+import type {Query, Relation} from '@nozbe/watermelondb';
+import type Model, {Associations} from '@nozbe/watermelondb/Model';
 
 /**
  * A Team houses and enables communication to happen across channels and users.
@@ -40,6 +40,9 @@ export default class TeamModel extends Model {
 
     /** allowed_domains : List of domains that can join this team */
     allowedDomains: string;
+
+    /** categories : All the categories associated with this team */
+    categories: Query<CategoryModel>;
 
     /** channels : All the channels associated with this team */
     channels: Query<ChannelModel>;


### PR DESCRIPTION
#### Summary
Fixes in this PR:
1. at times for very old server data we were attempted to fetch an empty role which returns `null` by the server, now we are filtering empty roles (string) before fetching
2. The reactions handler was deleting all other reactions that matched the same emoji name on a post, basically each post could have one reaction per emoji as we were using the `getUniqueRawsBy` helper that receives only one key and in this case was the `emojiName`, as we get the list of all reactions from the post, is safe to compare them all and not only a filtered one.
3. prepareDeleteTeams, prepareDeleteChannels & prepareDeletePosts iterate over their relations and children to delete them as well, some of those may not have records and an error is thrown, here we made it safe so it does not throw
4. Finally some handlers like `handleReactions` and `handleChannelMemberships` were in the users operator which made no sense, so I moved them to the correct one.

#### Checklist
- [x] Added or updated unit tests (required for all new features)

```release-note
NONE
```
