### PR TITLE
Fix time zone settings search bar (MM-23644)

### DIFF
--- a/app/screens/settings/timezone/select_timezone/__snapshots__/select_timezone.test.js.snap
+++ b/app/screens/settings/timezone/select_timezone/__snapshots__/select_timezone.test.js.snap
@@ -20,10 +20,8 @@ exports[`Settings SelectTimezone should match snapshot 1`] = `
   <View
     style={
       Object {
-        "backgroundColor": "#192a4d",
-        "height": 44,
-        "paddingLeft": 8,
-        "width": "100%",
+        "height": 38,
+        "marginVertical": 5,
       }
     }
   >
@@ -39,8 +37,8 @@ exports[`Settings SelectTimezone should match snapshot 1`] = `
       inputHeight={33}
       inputStyle={
         Object {
-          "backgroundColor": "rgba(255,255,255,0.2)",
-          "color": "#ffffff",
+          "backgroundColor": "rgba(63,67,80,0.2)",
+          "color": "#3f4350",
           "fontSize": 15,
         }
       }
@@ -51,17 +49,17 @@ exports[`Settings SelectTimezone should match snapshot 1`] = `
       onChangeText={[Function]}
       onSelectionChange={[Function]}
       placeholder="Search"
-      placeholderTextColor="rgba(255,255,255,0.5)"
+      placeholderTextColor="rgba(63,67,80,0.5)"
       returnKeyType="search"
       searchBarRightMargin={0}
       searchIconSize={24}
-      selectionColor="rgba(255,255,255,0.5)"
+      selectionColor="rgba(63,67,80,0.5)"
       showArrow={false}
       showCancel={true}
       testID="settings.select_timezone.search_bar"
-      tintColorDelete="rgba(255,255,255,0.5)"
-      tintColorSearch="rgba(255,255,255,0.5)"
-      titleCancelColor="#ffffff"
+      tintColorDelete="rgba(63,67,80,0.5)"
+      tintColorSearch="rgba(63,67,80,0.5)"
+      titleCancelColor="#3f4350"
       value=""
     />
   </View>

--- a/app/screens/settings/timezone/select_timezone/select_timezone.js
+++ b/app/screens/settings/timezone/select_timezone/select_timezone.js
@@ -158,7 +158,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             color: theme.centerChannelColor,
             fontSize: 15,
         },
-        
+
         searchBar: {
             height: 38,
             marginVertical: 5,

--- a/app/screens/settings/timezone/select_timezone/select_timezone.js
+++ b/app/screens/settings/timezone/select_timezone/select_timezone.js
@@ -100,12 +100,6 @@ export default class Timezone extends PureComponent {
         const {intl} = this.context;
         const style = getStyleSheet(theme);
 
-        const searchBarInput = {
-            backgroundColor: changeOpacity(theme.sidebarHeaderTextColor, 0.2),
-            color: theme.sidebarHeaderTextColor,
-            fontSize: 15,
-        };
-
         return (
             <SafeAreaView
                 testID='settings.select_timezone.screen'
@@ -113,7 +107,7 @@ export default class Timezone extends PureComponent {
                 style={style.container}
             >
                 <StatusBar/>
-                <View style={style.header}>
+                <View style={style.searchBar}>
                     <SearchBar
                         testID='settings.select_timezone.search_bar'
                         ref={this.setSearchBarRef}
@@ -121,12 +115,12 @@ export default class Timezone extends PureComponent {
                         cancelTitle={intl.formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'})}
                         backgroundColor='transparent'
                         inputHeight={Platform.OS === 'ios' ? 33 : 46}
-                        inputStyle={searchBarInput}
-                        placeholderTextColor={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
-                        selectionColor={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
-                        tintColorSearch={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
-                        tintColorDelete={changeOpacity(theme.sidebarHeaderTextColor, 0.5)}
-                        titleCancelColor={theme.sidebarHeaderTextColor}
+                        inputStyle={style.searchBarInput}
+                        placeholderTextColor={changeOpacity(theme.centerChannelColor, 0.5)}
+                        selectionColor={changeOpacity(theme.centerChannelColor, 0.5)}
+                        tintColorSearch={changeOpacity(theme.centerChannelColor, 0.5)}
+                        tintColorDelete={changeOpacity(theme.centerChannelColor, 0.5)}
+                        titleCancelColor={theme.centerChannelColor}
                         onChangeText={this.handleTextChanged}
                         autoCapitalize='none'
                         value={value}
@@ -158,20 +152,16 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flex: 1,
             backgroundColor: theme.centerChannelBg,
         },
-        header: {
-            backgroundColor: theme.sidebarHeaderBg,
+
+        searchBarInput: {
+            backgroundColor: changeOpacity(theme.centerChannelColor, 0.2),
+            color: theme.centerChannelColor,
+            fontSize: 15,
+        },
+        
+        searchBar: {
             height: 38,
-            width: '100%',
-            ...Platform.select({
-                android: {
-                    height: 46,
-                    justifyContent: 'center',
-                },
-                ios: {
-                    height: 44,
-                    paddingLeft: 8,
-                },
-            }),
+            marginVertical: 5,
         },
     };
 });


### PR DESCRIPTION
Also some small code improvements:
- renamed header to searchBar
- moved searchBarInput to getStyleSheet

Both of which are logical to me and are more consistent with e.g. screens/channel_members

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
-->
Fix the search bar to be consistent with the manage members search bar
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

Otherwise, link the JIRA ticket.
-->

  Fixes https://github.com/mattermost/mattermost-server/issues/16244#event-6194983442
  Fixes https://mattermost.atlassian.net/browse/MM-23644

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iPhone 11, iOS 15.3.1

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

![IMG_8452](https://user-images.githubusercontent.com/5548333/157069416-eb3b0b6e-b73f-4a24-b9ad-66f5249632da.PNG)

![IMG_8453](https://user-images.githubusercontent.com/5548333/157069432-85b8cedd-449a-4484-a7bd-eb55a815822c.PNG)

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Changed search bar in manual time zone selection view to be consistent with the rest of the app
```
