### PR TITLE
MM-42358: Calls Mobile: Android/iOS switching app bugs

### DIFF
--- a/app/products/calls/store/reducers/calls.test.js
+++ b/app/products/calls/store/reducers/calls.test.js
@@ -219,7 +219,7 @@ describe('Reducers.calls.joined', () => {
             data: {calls: {'channel-1': {}, 'channel-2': {}}, enabled: {'channel-1': true}},
         };
         const state = callsReducer(initialState, testAction);
-        assert.equal(state.joined, '');
+        assert.equal(state.joined, 'test');
     });
 
     it('RECEIVED_MYSELF_JOINED_CALL', async () => {

--- a/app/products/calls/store/reducers/calls.ts
+++ b/app/products/calls/store/reducers/calls.ts
@@ -121,9 +121,6 @@ function joined(state = '', action: GenericAction) {
     case CallsTypes.RECEIVED_MYSELF_JOINED_CALL: {
         return action.data;
     }
-    case CallsTypes.RECEIVED_CALLS: {
-        return '';
-    }
     case CallsTypes.RECEIVED_MYSELF_LEFT_CALL: {
         return '';
     }


### PR DESCRIPTION
#### Summary
- Switching to a different app and back results in blank CallScreen and losing call status (even though the call is still connected working the same as before the app switch). Affected both Android and iOS.
- Fix: don't erase the joined state when receiving new calls data (which happens on every reconnect)
- Looking at the code, I can't think of a way this would affect the rest of the calls product, and I tested with both OSes. 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-42358

#### Checklist
- [ ] ~~Added or updated unit tests (required for all new features)~~
- [ ] ~~Has UI changes~~
- [ ] ~~Includes text changes and localization file updates~~
- [ ] ~~Have tested against the 5 core themes to ensure consistency between them.~~

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Screenshots
- n/a

#### Release Note

```release-note
Fixed a bug that resulted in dropping the Call state when switching to another app and returning.
```
