### PR TITLE
Filters to prune only custom categories

### DIFF
--- a/app/actions/local/category.ts
+++ b/app/actions/local/category.ts
@@ -58,12 +58,14 @@ export const storeCategories = async (serverUrl: string, categories: CategoryWit
         const teamIds = pluckUnique('team_id')(categories) as string[];
         const localCategories = await queryCategoriesByTeamIds(database, teamIds);
 
-        localCategories.forEach((localCategory) => {
-            if (!remoteCategoryIds.includes(localCategory.id)) {
-                localCategory.prepareDestroyPermanently();
-                flattenedModels.push(localCategory);
-            }
-        });
+        localCategories.
+            filter((category) => category.type === 'custom').
+            forEach((localCategory) => {
+                if (!remoteCategoryIds.includes(localCategory.id)) {
+                    localCategory.prepareDestroyPermanently();
+                    flattenedModels.push(localCategory);
+                }
+            });
     }
 
     if (prepareRecordsOnly) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Only custom categories are pruned.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://mattermost.atlassian.net/browse/MM-42166

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
