### PR TITLE
Fix message not being added to the database when it fails

### DIFF
--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -51,7 +51,7 @@ export const createPost = async (serverUrl: string, post: Partial<Post>, files: 
         return {error};
     }
 
-    const currentUserId = queryCurrentUserId(operator.database);
+    const currentUserId = await queryCurrentUserId(operator.database);
     const timestamp = Date.now();
     const pendingPostId = post.pending_post_id || `${currentUserId}:${timestamp}`;
 
@@ -66,6 +66,7 @@ export const createPost = async (serverUrl: string, post: Partial<Post>, files: 
         pending_post_id: pendingPostId,
         create_at: timestamp,
         update_at: timestamp,
+        delete_at: 0,
     } as Post;
 
     if (files.length) {


### PR DESCRIPTION
#### Summary
When a message failed (or took some time to be created in the server) was not being added to the database.

This was due to `delete_at` not defined, and used to do a filter on the database layer. I decided to define `delete_at` instead of checking in the database for 0 or undefined.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
