### PR TITLE
Fix user added to channel event not correctly getting the channel id

### DIFF
--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -24,7 +24,8 @@ export async function handleUserAddedToChannelEvent(serverUrl: string, msg: any)
         return;
     }
     const currentUser = await queryCurrentUser(database.database);
-    const {team_id: teamId, channel_id: channelId, user_id: userId} = msg.data;
+    const {team_id: teamId, user_id: userId} = msg.data;
+    const {channel_id: channelId} = msg.broadcast;
     const models: Model[] = [];
 
     try {


### PR DESCRIPTION
#### Summary
We were trying to get the channel id from the data, but it was being sent through the broadcast information.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
