### PR TITLE
[MM-42533] Fix hidden custom theme

### DIFF
--- a/app/screens/settings/theme/__snapshots__/theme.test.js.snap
+++ b/app/screens/settings/theme/__snapshots__/theme.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Theme should match snapshot 1`] = `
-<View
+<ScrollView
   style={
     Object {
       "flex": 1,
@@ -390,5 +390,5 @@ exports[`Theme should match snapshot 1`] = `
       />
     </View>
   </View>
-</View>
+</ScrollView>
 `;

--- a/app/screens/settings/theme/theme.js
+++ b/app/screens/settings/theme/theme.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {intlShape} from 'react-intl';
 import {Text, View} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
 import FormattedText from '@components/formatted_text';
@@ -112,7 +113,7 @@ export default class Theme extends React.PureComponent {
         const {customTheme} = this.state;
         const style = getStyleSheet(theme);
         return (
-            <View style={style.container}>
+            <ScrollView style={style.container}>
                 <StatusBar/>
                 <View style={style.wrapper}>
                     <View style={style.tilesContainer}>
@@ -132,7 +133,7 @@ export default class Theme extends React.PureComponent {
                         </SafeAreaView>
                     }
                 </View>
-            </View>
+            </ScrollView>
         );
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Can't confirm by scrolling if `custom theme` is checked (in Advanced Settings > Display > Theme Screen) using an Android Emulator

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-42533

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
Samsung Galaxy M31 - Android 11
Android Emulator M1 Preview
iPhone 13 Simulator - iOS 15.2

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

![MM_ANDROID_CUSTOM_THEME](https://user-images.githubusercontent.com/33412680/158438733-7fe0fe05-a08d-4cc7-8757-6c04b1e12550.gif)
![MM_iOS_CUSTOM_THEME](https://user-images.githubusercontent.com/33412680/158438755-ca844239-c352-4fd7-887d-7eae5071d23c.gif)
