### PR TITLE
Support link highlighting on capitalized link scheme

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -90,7 +90,7 @@ export default class Markdown extends PureComponent {
     urlFilter = (url) => {
         const scheme = getScheme(url);
 
-        return !scheme || this.props.autolinkedUrlSchemes.indexOf(scheme) !== -1;
+        return !scheme || this.props.autolinkedUrlSchemes.indexOf(scheme.toLowerCase()) !== -1;
     };
 
     createRenderer = () => {

--- a/app/components/markdown/markdown.test.js
+++ b/app/components/markdown/markdown.test.js
@@ -4,11 +4,13 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 
+import {General} from '../../mm-redux/constants';
+
 import Markdown from './markdown.js';
 
 describe('Markdown', () => {
     const baseProps = {
-        autolinkedUrlSchemes: ['mattermost'],
+        autolinkedUrlSchemes: General.DEFAULT_AUTOLINKED_URL_SCHEMES,
         baseTextStyle: {},
         mentionKeys: [{key: 'user.name'}, {key: '@channel'}, {key: '@all'}, {key: '@here'}],
         minimumHashtagLength: 3,
@@ -55,5 +57,32 @@ describe('Markdown', () => {
         shallow(
             <Markdown {...props}/>,
         );
+    });
+
+    test('should return true for an uncapitalized scheme', () => {
+        const url = 'https://www.mattermost.com/';
+        const wrapper = shallow(
+            <Markdown {...baseProps}/>,
+        );
+
+        expect(wrapper.instance().urlFilter(url)).toBe(true);
+    });
+
+    test('should return true for a capitalized scheme', () => {
+        const url = 'Https://www.mattermost.com/';
+        const wrapper = shallow(
+            <Markdown {...baseProps}/>,
+        );
+
+        expect(wrapper.instance().urlFilter(url)).toBe(true);
+    });
+
+    test('should return false for an unknown scheme', () => {
+        const url = 'unknown://www.mattermost.com/';
+        const wrapper = shallow(
+            <Markdown {...baseProps}/>,
+        );
+
+        expect(wrapper.instance().urlFilter(url)).toBe(false);
     });
 });


### PR DESCRIPTION
#### Summary
Support link highlighting on capitalized link scheme. A _scheme_ refer to the first part of a URL, such as `https://`. Currently, `https://` gets highlighted, but `Https://` (capital H) does not. 

As a fix, ignore capitalization to highlight both versions. (This is useful, since on mobile, most users have auto-capitalize sentence turned on, which capitalizes the first character of a sentence / message.)

Added some unit tests to verify the functionality.

#### Ticket Link
Jira ticket: [29280](https://mattermost.atlassian.net/browse/MM-29280)

Note: this Jira ticket mentioned Android, but I fixed this on iOS. However, the issue seems pretty universal to me.

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: iPhone 12, iOS 15.1.1

#### Screenshots
![IMG_0764](https://user-images.githubusercontent.com/33723088/158473296-293c7fee-20d4-41fc-b752-4ae0c4e43486.PNG)
![IMG_0765](https://user-images.githubusercontent.com/33723088/158473303-2ec5677b-9b13-4782-9c27-dffcc24e26d3.PNG)

#### Release Note
```release-note
Added support for link highlighting when a capitalized link scheme, such as Https:// instead of https://
```