### PR TITLE
[v1] Prevent crash when latex is used

### DIFF
--- a/app/components/markdown/markdown.js
+++ b/app/components/markdown/markdown.js
@@ -108,6 +108,7 @@ export default class Markdown extends PureComponent {
                 channelLink: this.renderChannelLink,
                 emoji: this.renderEmoji,
                 hashtag: this.renderHashtag,
+                latexinline: this.renderParagraph,
 
                 paragraph: this.renderParagraph,
                 heading: this.renderHeading,
@@ -146,7 +147,7 @@ export default class Markdown extends PureComponent {
         if (node.type === 'image') {
             extraProps.reactChildren = node.react.children;
             extraProps.linkDestination = node.linkDestination;
-            extraProps.size = node.size;
+            extraProps.size = (typeof node.size === 'object') ? node.size : undefined;
         }
 
         return extraProps;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "1.49.1",
+      "version": "1.50.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -25837,8 +25837,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@mattermost/react-native-paste-input/-/react-native-paste-input-0.3.6.tgz",
       "integrity": "sha512-/XwUkWfkXDPv1/N+3sILKRoqa4sElqN/fADQzkC2KHYxVKN72297vMm8s+X1n2l+y7phNQ8ZmhjjL0ghuz/1og==",
-      "requires": {
-      }
+      "requires": {}
     },
     "@msgpack/msgpack": {
       "version": "2.7.1",
@@ -25890,8 +25889,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-4.1.2.tgz",
       "integrity": "sha512-jkdhMByMKD2CZ/5MPeBieYn8vkCfC4MOTouPpBpps3I8N6HUYJk+1JnDdktVYl2WINnqXpQptDA2YptVyifYAg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "@react-native-community/cli": {
       "version": "6.4.0",
@@ -26641,8 +26639,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/clipboard/-/clipboard-1.5.1.tgz",
       "integrity": "sha512-AHAmrkLEH5UtPaDiRqoULERHh3oNv7Dgs0bTC0hO5Z2GdNokAMPT5w8ci8aMcRemcwbtdHjxChgtjbeA38GBdA==",
-      "requires": {
-      }
+      "requires": {}
     },
     "@react-native-community/datetimepicker": {
       "version": "5.1.0",
@@ -26747,8 +26744,7 @@
           "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz",
           "integrity": "sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==",
           "dev": true,
-          "requires": {
-          }
+          "requires": {}
         },
         "eslint-plugin-react-native": {
           "version": "3.11.0",
@@ -26778,15 +26774,13 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.11.tgz",
       "integrity": "sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==",
-      "requires": {
-      }
+      "requires": {}
     },
     "@react-native-community/netinfo": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-7.1.9.tgz",
       "integrity": "sha512-xxbxFherpOjQeJm3rIx6gmZNEEBqVDIcmBII5QVSN8zf3xAwmaT/RxT74ISYDkeSlZwv4eegpkD4QA1ky52CNg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "@react-native-cookies/cookies": {
       "version": "6.0.11",
@@ -26827,8 +26821,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.0.tgz",
       "integrity": "sha512-C0roIxajvleskEpeYYJ1+2XTg8UqZO6o/SyzqTRuEUVsVD8CbFzKSOfj9kpfzA7jbYNzZPbzUJcm9kIigY9kHg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "@react-navigation/native": {
       "version": "6.0.7",
@@ -27765,8 +27758,7 @@
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
       "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
       "dev": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.4.1",
@@ -27782,8 +27774,7 @@
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
       "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
       "dev": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -27868,16 +27859,14 @@
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true,
       "peer": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -28265,8 +28254,7 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -30563,8 +30551,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
       "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
       "dev": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "eslint-plugin-import": {
       "version": "2.25.4",
@@ -30691,8 +30678,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "eslint-plugin-react-native-globals": {
       "version": "0.1.2",
@@ -34298,8 +34284,7 @@
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
       "dev": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -35120,8 +35105,7 @@
           "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
           "dev": true,
           "peer": true,
-          "requires": {
-          }
+          "requires": {}
         }
       }
     },
@@ -35130,8 +35114,7 @@
       "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
       "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
       "dev": true,
-      "requires": {
-      }
+      "requires": {}
     },
     "jsesc": {
       "version": "2.5.2",
@@ -38523,8 +38506,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.0.tgz",
       "integrity": "sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-intl": {
       "version": "2.8.0",
@@ -38732,8 +38714,7 @@
       "version": "8.4.8",
       "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-8.4.8.tgz",
       "integrity": "sha512-92676ZWHZHsPM/EW1ulgb2MuVfjYfMWRTWMbLcrCsipkcMaZ9Traz5mpsnCS7KZpsOksnvUinzDIjsct2XGc6Q==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-document-picker": {
       "version": "8.0.0",
@@ -38771,22 +38752,19 @@
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/react-native-exception-handler/-/react-native-exception-handler-2.10.10.tgz",
       "integrity": "sha512-otAXGoZDl1689OoUJWN/rXxVbdoZ3xcmyF1uq/CsizdLwwyZqVGd6d+p/vbYvnF996FfEyAEBnHrdFxulTn51w==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-fast-image": {
       "version": "8.5.11",
       "resolved": "https://registry.npmjs.org/react-native-fast-image/-/react-native-fast-image-8.5.11.tgz",
       "integrity": "sha512-cNW4bIJg3nvKaheG8vGMfqCt5LMWX9MS5+wMudgKIHbGO51spRr4sgnlhVgwHLcZ5aeNOVJ8CPRxDIWKRq/0QA==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-file-viewer": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/react-native-file-viewer/-/react-native-file-viewer-2.1.5.tgz",
       "integrity": "sha512-MGC6sx9jsqHdefhVQ6o0akdsPGpkXgiIbpygb2Sg4g4bh7v6K1cardLV1NwGB9A6u1yICOSDT/MOC//9Ez6EUg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-gesture-handler": {
       "version": "2.2.0",
@@ -38804,43 +38782,37 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/react-native-haptic-feedback/-/react-native-haptic-feedback-1.13.0.tgz",
       "integrity": "sha512-g8G5QURitDeC/zRlobDvUXLxKYfMlIM2HQNWJKbHPSu61qfs0djnK4s1NZuQzihkeAO0KJ4AS2XWvKBzUmlXtA==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-hw-keyboard-event": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/react-native-hw-keyboard-event/-/react-native-hw-keyboard-event-0.0.4.tgz",
       "integrity": "sha512-G8qp0nm17PHigLb/axgdF9xg51BKCG2p1AGeq//J/luLp5zNczIcQJh+nm02R1MeEUE3e53wqO4LMe0MV3raZg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-image-picker": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/react-native-image-picker/-/react-native-image-picker-4.7.3.tgz",
       "integrity": "sha512-eRKm4wlsmZHmsWFyv77kYc2F+ZyEVqe0m7mqhsMzWk6TQT4FBDtEDxmRDDFq+ivCu/1QD+EPhmYcAIpeGr7Ekg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-incall-manager": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-native-incall-manager/-/react-native-incall-manager-3.3.0.tgz",
       "integrity": "sha512-SvomgHUoKqVso/BGv02b4ndBqenlqYqW3pptZz5qHwteidKFNWI6ny+PPw5X55MdK0lyTbzBoiT3DwS06Qu0lg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-keyboard-aware-scrollview": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-native-keyboard-aware-scrollview/-/react-native-keyboard-aware-scrollview-2.1.0.tgz",
       "integrity": "sha512-XfWozWFPhdecfxN+wuqERX3mCGDrAim5siC6TWg3Qw7wK/zlwIwe1UIsHDNOQCzf9oIh0SkZXvoOFsMrnyIVmQ==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-keyboard-tracking-view": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/react-native-keyboard-tracking-view/-/react-native-keyboard-tracking-view-5.7.0.tgz",
       "integrity": "sha512-MDeEwAbn9LJDOfHq0QLCGaZirVLk2X/tHqkAqz3y6uxryTRdSl9PwleOVar5Jx2oAPEg4J9BXbUD1wwOOi+5Kg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-keychain": {
       "version": "8.0.0",
@@ -38851,29 +38823,25 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz",
       "integrity": "sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-local-auth": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-local-auth/-/react-native-local-auth-1.6.0.tgz",
       "integrity": "sha512-36cYGZGCG82pMiVJbQa5WMA93khP4v5JqLutFkMyB/eRpCULHmojNIBlbUPIY9SCeN4sg5VBRFTVGCtTg2r2kA==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-localize": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/react-native-localize/-/react-native-localize-2.1.9.tgz",
       "integrity": "sha512-n2Bi5P0cII8BrnG23Fs9PmpYcufD3JRbr1IBn3ArIA3Z3cGWg4eebv6am+CgdFC4kTPWUlVzX9fEgEMA+X8d6w==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-mmkv-storage": {
       "version": "0.6.11",
       "resolved": "https://registry.npmjs.org/react-native-mmkv-storage/-/react-native-mmkv-storage-0.6.11.tgz",
       "integrity": "sha512-PaxUxbTwr+PHfzoYt6E1Mds9/CjV5uOFVstuBW0laFUWlGrTHgiaLWR8VwJt0EPScSl5Lz4RM8IiqmXbIUSbbw==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-navigation": {
       "version": "7.25.1",
@@ -38898,8 +38866,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/react-native-notifications/-/react-native-notifications-4.1.3.tgz",
       "integrity": "sha512-A4SmRyfh2OlkptlJQvcQKkfnBKO1toUShmFplTkLXPNCqfpm/i4Fz+Uv+LzHSvbsU5U7EYf3JX9sfuyR06ZGPg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-passcode-status": {
       "version": "1.1.2",
@@ -38910,8 +38877,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.2.0.tgz",
       "integrity": "sha512-UPXxf2twjYL9vPI4HP2kT15AOTY489MhsNuyAgp+wJM2IRkkSVW6rO3k4WuSRL9ZmPhwkWb9bYjf8EEwRzZcXg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-ratings": {
       "version": "8.0.4",
@@ -38969,8 +38935,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.3.2.tgz",
       "integrity": "sha512-yOwiiPJ1rk+/nfK13eafbpW6sKW0jOnsRem2C1LPJjM3tfTof6hlvV5eWHATye3XOpu2cJ7N+HdkUvUDGwFD2Q==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-screens": {
       "version": "3.10.2",
@@ -38995,8 +38960,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz",
       "integrity": "sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-slider": {
       "version": "0.11.0",
@@ -39010,8 +38974,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-native-startup-time/-/react-native-startup-time-2.0.0.tgz",
       "integrity": "sha512-tYruEDvwoVEOf+FMTTqp3aHNfA5ARWXXV+ar4wJBIQBdIlPEYDQWaYljOAV2dITuTsKAyPY2Q/N58gkKvGWIrA==",
-      "requires": {
-      }
+      "requires": {}
     },
     "react-native-svg": {
       "version": "12.1.1",
@@ -39376,8 +39339,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.5.0.tgz",
       "integrity": "sha512-6orZWyCnIQXMGY4DUGM0oj0L7oYnwTACsfsru/J7r94RM3P9eS7SORGpr3LCeRCMoIMQcpfKZ7X4NdyFHBS8Eg==",
-      "requires": {
-      }
+      "requires": {}
     },
     "redux-mock-store": {
       "version": "1.5.4",
@@ -39392,8 +39354,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
       "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
-      "requires": {
-      }
+      "requires": {}
     },
     "redux-persist-node-storage": {
       "version": "2.0.0",
@@ -39422,8 +39383,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
       "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "requires": {
-      }
+      "requires": {}
     },
     "reflect.ownkeys": {
       "version": "0.2.0",
@@ -39766,8 +39726,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/rn-placeholder/-/rn-placeholder-3.0.3.tgz",
       "integrity": "sha512-EmVeLT8zDcTPilQZ2OHO/IiYUy2gApKGgbshDZBX0C4qxsn0cFATwgwOwyz8O7Vwg1Hul97Ci95hu7d6Js6XMQ==",
-      "requires": {
-      }
+      "requires": {}
     },
     "rst-selector-parser": {
       "version": "2.2.3",
@@ -40083,8 +40042,7 @@
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
           "dev": true,
-          "requires": {
-          }
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -41129,8 +41087,7 @@
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
           "dev": true,
           "peer": true,
-          "requires": {
-          }
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -41853,8 +41810,7 @@
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
           "dev": true,
           "peer": true,
-          "requires": {
-          }
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -42123,8 +42079,7 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "requires": {
-      }
+      "requires": {}
     },
     "xcode": {
       "version": "3.0.1",


### PR DESCRIPTION
#### Summary
With the updated commonmark library the parser takes into account latex which had no renderer assigned, and this caused the app to crash.

In this PR we are assigning the renderer to be just a regular paragraph as #5651 should include the rendering of the latex code.

This PR also includes a small change in determine if markdown images have a size set (this just avoids a prop type warning being displayed in dev mode)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42624

#### Release Note
```release-note
Fixed crash when attempting to render latex code present in a message
```