### PR TITLE
[Gekidou] Exclude detox from typescript check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,6 @@
             "@share/*": ["share_extension/*"],
             "@store": ["app/store/index"],
             "@store/*": ["app/store/*"],
-            "@support/*": ["detox/e2e/support/*"],
             "@telemetry/*": ["/app/telemetry/*"],
             "@typings/*": ["types/*"],
             "@test/*": ["test/*"],
@@ -65,12 +64,13 @@
             ]
         }
     },
-    "include": ["app/**/*", "share_extensionn/**/*", "test/**/*", "detox/**/*", "types/**/*"],
+    "include": ["app/**/*", "share_extensionn/**/*", "test/**/*", "types/**/*"],
     "exclude": [
         "node_modules",
         "build",
         "babel.config.js",
         "metro.config.js",
         "jest.config.js",
+        "detox/**/*",
     ],
 }


### PR DESCRIPTION
#### Summary
Exclude typescript check in detox folder from the main app, detox has its own typescript configuration and we prevent ts check from failing if the node modules from the detox folder have not been installed.

Merging right away but this is an FYI for @josephbaylon 

```release-note
NONE
```
