### PR TITLE
Fix crash when latex is used

### DIFF
--- a/app/components/markdown/index.tsx
+++ b/app/components/markdown/index.tsx
@@ -134,6 +134,7 @@ class Markdown extends PureComponent<MarkdownProps> {
             channelLink: this.renderChannelLink,
             emoji: this.renderEmoji,
             hashtag: this.renderHashtag,
+            latexinline: this.renderParagraph,
 
             paragraph: this.renderParagraph,
             heading: this.renderHeading,


### PR DESCRIPTION
#### Summary
Currently we don't support latex on mobile but there is some work in progress for that and the commonmark library now expects a renderer for it, until we add support we'll be using the paragraph renderer instead to avoid the crash.

```release-note
NONE
```
