### PR TITLE
Detox/E2E: Server List e2e tests in Gekidou

### DIFF
--- a/app/screens/edit_server/form.tsx
+++ b/app/screens/edit_server/form.tsx
@@ -145,6 +145,8 @@ const EditServerForm = ({
         );
     }
 
+    const saveButtonTestId = buttonDisabled ? 'edit_server_form.save.button.disabled' : 'edit_server_form.save.button';
+
     return (
         <View style={styles.formContainer}>
             <View style={[styles.fullWidth, displayNameError?.length ? styles.error : undefined]}>
@@ -164,7 +166,7 @@ const EditServerForm = ({
                     ref={displayNameRef}
                     returnKeyType='done'
                     spellCheck={false}
-                    testID='select_server.server_display_name.input'
+                    testID='edit_server_form.server_display_name.input'
                     theme={theme}
                     value={displayName}
                 />
@@ -174,7 +176,7 @@ const EditServerForm = ({
                 defaultMessage={'Server: {url}'}
                 id={'edit_server.display_help'}
                 style={styles.chooseText}
-                testID={'edit_server.display_help'}
+                testID={'edit_server_form.display_help'}
                 values={{url: removeProtocol(stripTrailingSlashes(serverUrl))}}
             />
             }
@@ -182,7 +184,7 @@ const EditServerForm = ({
                 containerStyle={[styles.connectButton, styleButtonBackground]}
                 disabled={buttonDisabled}
                 onPress={onUpdate}
-                testID='select_server.connect.button'
+                testID={saveButtonTestId}
             >
                 {buttonIcon}
                 <FormattedText

--- a/app/screens/edit_server/header.tsx
+++ b/app/screens/edit_server/header.tsx
@@ -40,13 +40,13 @@ const EditServerHeader = ({theme}: Props) => {
                 defaultMessage='Edit server name'
                 id='edit_server.title'
                 style={styles.title}
-                testID='edit_server.title'
+                testID='edit_server_header.title'
             />
             <FormattedText
                 defaultMessage='Specify a display name for this server'
                 id='edit_server.description'
                 style={styles.description}
-                testID='edit_server.description'
+                testID='edit_server_header.description'
             />
         </View>
     );

--- a/app/screens/edit_server/index.tsx
+++ b/app/screens/edit_server/index.tsx
@@ -99,7 +99,7 @@ const EditServer = ({closeButtonId, componentId, server, theme}: ServerProps) =>
             <SafeAreaView
                 key={'server_content'}
                 style={styles.flex}
-                testID='select_server.screen'
+                testID='edit_server.screen'
             >
                 <KeyboardAwareScrollView
                     bounces={false}

--- a/app/screens/server/index.tsx
+++ b/app/screens/server/index.tsx
@@ -319,7 +319,6 @@ const Server = ({
             <AnimatedSafeArea
                 key={'server_content'}
                 style={[styles.flex, transform]}
-                testID='select_server.screen'
             >
                 <KeyboardAwareScrollView
                     bounces={false}

--- a/detox/e2e/support/server_api/user.ts
+++ b/detox/e2e/support/server_api/user.ts
@@ -227,7 +227,7 @@ export const generateRandomUser = ({prefix = 'user', randomIdLength = 6} = {}) =
     return {
         email: `${prefix}${randomId}@sample.mattermost.com`,
         username: `${prefix}${randomId}`,
-        password: 'passwd',
+        password: `P${randomId}!1234`,
         first_name: `F${randomId}`,
         last_name: `L${randomId}`,
         nickname: `N${randomId}`,

--- a/detox/e2e/support/ui/component/alert.ts
+++ b/detox/e2e/support/ui/component/alert.ts
@@ -10,10 +10,16 @@ class Alert {
 
         return isAndroid() ? element(by.text(title)) : element(by.label(title)).atIndex(0);
     };
+    removeServerTitle = (serverDisplayName: string) => {
+        const title = `Are you sure you want to remove ${serverDisplayName}?`;
+
+        return isAndroid() ? element(by.text(title)) : element(by.label(title)).atIndex(0);
+    };
 
     // alert buttons
     cancelButton = isAndroid() ? element(by.text('CANCEL')) : element(by.label('Cancel')).atIndex(1);
     logoutButton = isAndroid() ? element(by.text('LOG OUT')) : element(by.label('Log out')).atIndex(1);
+    removeButton = isAndroid() ? element(by.text('REMOVE')) : element(by.label('Remove')).atIndex(1);
 }
 
 const alert = new Alert();

--- a/detox/e2e/support/ui/screen/edit_server.ts
+++ b/detox/e2e/support/ui/screen/edit_server.ts
@@ -6,6 +6,7 @@ import {timeouts} from '@support/utils';
 class EditServerScreen {
     testID = {
         editServerScreen: 'edit_server.screen',
+        closeButton: 'close-server-edit',
         headerTitle: 'edit_server_header.title',
         headerDescription: 'edit_server_header.description',
         serverDisplayNameInput: 'edit_server_form.server_display_name.input',
@@ -16,6 +17,7 @@ class EditServerScreen {
     };
 
     editServerScreen = element(by.id(this.testID.editServerScreen));
+    closeButton = element(by.id(this.testID.closeButton));
     headerTitle = element(by.id(this.testID.headerTitle));
     headerDescription = element(by.id(this.testID.headerDescription));
     serverDisplayNameInput = element(by.id(this.testID.serverDisplayNameInput));

--- a/detox/e2e/support/ui/screen/edit_server.ts
+++ b/detox/e2e/support/ui/screen/edit_server.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {timeouts} from '@support/utils';
+
+class EditServerScreen {
+    testID = {
+        editServerScreen: 'edit_server.screen',
+        headerTitle: 'edit_server_header.title',
+        headerDescription: 'edit_server_header.description',
+        serverDisplayNameInput: 'edit_server_form.server_display_name.input',
+        serverDisplayNameInputError: 'edit_server_form.server_display_name.input.error',
+        displayHelp: 'edit_server_form.display_help',
+        saveButton: 'edit_server_form.save.button',
+        saveButtonDisabled: 'edit_server_form.save.button.disabled',
+    };
+
+    editServerScreen = element(by.id(this.testID.editServerScreen));
+    headerTitle = element(by.id(this.testID.headerTitle));
+    headerDescription = element(by.id(this.testID.headerDescription));
+    serverDisplayNameInput = element(by.id(this.testID.serverDisplayNameInput));
+    serverDisplayNameInputError = element(by.id(this.testID.serverDisplayNameInputError));
+    displayHelp = element(by.id(this.testID.displayHelp));
+    saveButton = element(by.id(this.testID.saveButton));
+    saveButtonDisabled = element(by.id(this.testID.saveButtonDisabled));
+
+    toBeVisible = async () => {
+        await waitFor(this.editServerScreen).toExist().withTimeout(timeouts.TEN_SEC);
+        await waitFor(this.serverDisplayNameInput).toBeVisible().withTimeout(timeouts.TEN_SEC);
+
+        return this.editServerScreen;
+    };
+}
+
+const editServerScreen = new EditServerScreen();
+export default editServerScreen;

--- a/detox/e2e/support/ui/screen/index.ts
+++ b/detox/e2e/support/ui/screen/index.ts
@@ -3,6 +3,7 @@
 
 import AccountScreen from './account';
 import ChannelListScreen from './channel_list';
+import EditServerScreen from './edit_server';
 import HomeScreen from './home';
 import LoginScreen from './login';
 import ServerScreen from './server';
@@ -11,6 +12,7 @@ import ServerListScreen from './server_list';
 export {
     AccountScreen,
     ChannelListScreen,
+    EditServerScreen,
     HomeScreen,
     LoginScreen,
     ServerScreen,

--- a/detox/e2e/support/ui/screen/server.ts
+++ b/detox/e2e/support/ui/screen/server.ts
@@ -6,6 +6,7 @@ import {timeouts} from '@support/utils';
 class ServerScreen {
     testID = {
         serverScreen: 'server.screen',
+        closeButton: 'close-server',
         headerTitleAddServer: 'server_header.title.add_server',
         headerTitleConnectToServer: 'server_header.title.connect_to_server',
         headerWelcome: 'server_header.welcome',
@@ -20,6 +21,7 @@ class ServerScreen {
     };
 
     serverScreen = element(by.id(this.testID.serverScreen));
+    closeButton = element(by.id(this.testID.closeButton));
     headerTitleAddServer = element(by.id(this.testID.headerTitleAddServer));
     headerTitleConnectToServer = element(by.id(this.testID.headerTitleConnectToServer));
     headerWelcome = element(by.id(this.testID.headerWelcome));

--- a/detox/e2e/test/server_login/server_list.e2e.ts
+++ b/detox/e2e/test/server_login/server_list.e2e.ts
@@ -1,0 +1,230 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {
+    User,
+    Setup,
+} from '@support/server_api';
+import {
+    serverOneUrl,
+    serverTwoUrl,
+    serverThreeUrl,
+    siteOneUrl,
+    siteTwoUrl,
+    siteThreeUrl,
+} from '@support/test_config';
+import {
+    Alert,
+} from '@support/ui/component';
+import {
+    ChannelListScreen,
+    EditServerScreen,
+    HomeScreen,
+    LoginScreen,
+    ServerScreen,
+    ServerListScreen,
+} from '@support/ui/screen';
+import {expect} from 'detox';
+
+describe('Server Login - Server List', () => {
+    const serverOneDisplayName = 'Server 1';
+    const serverTwoDisplayName = 'Server 2';
+    const serverThreeDisplayName = 'Server 3';
+    let serverOneUser;
+    let serverTwoUser;
+    let serverThreeUser;
+
+    beforeAll(async () => {
+        // # Log in to the first server
+        ({user: serverOneUser} = await Setup.apiInit(siteOneUrl));
+        await expect(ServerScreen.headerTitleConnectToServer).toBeVisible();
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await LoginScreen.login(serverOneUser);
+    });
+
+    afterAll(async () => {
+        // # Log out
+        await HomeScreen.logout();
+    });
+
+    it('MM-T4691_1 - should be able to add and log in to new servers', async () => {
+        // * Verify on channel list screen of the first server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
+
+        // # Open server list screen
+        await ServerListScreen.open();
+
+        // * Verify first server is active
+        await ServerListScreen.toBeVisible();
+        await expect(ServerListScreen.getServerItemActive(serverOneDisplayName)).toBeVisible();
+
+        // # Add a second server and log in to the second server
+        await User.apiAdminLogin(siteTwoUrl);
+        ({user: serverTwoUser} = await Setup.apiInit(siteTwoUrl));
+        await ServerListScreen.addServerButton.tap();
+        await expect(ServerScreen.headerTitleAddServer).toBeVisible();
+        await ServerScreen.connectToServer(serverTwoUrl, serverTwoDisplayName);
+        await LoginScreen.login(serverTwoUser);
+
+        // * Verify on channel list screen of the second server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverTwoDisplayName);
+
+        // # Open server list screen
+        await ServerListScreen.open();
+
+        // * Verify second server is active and first server is inactive
+        await ServerListScreen.toBeVisible();
+        await expect(ServerListScreen.getServerItemActive(serverTwoDisplayName)).toBeVisible();
+        await expect(ServerListScreen.getServerItemInactive(serverOneDisplayName)).toBeVisible();
+
+        // # Add a third server and log in to the third server
+        await User.apiAdminLogin(siteThreeUrl);
+        ({user: serverThreeUser} = await Setup.apiInit(siteThreeUrl));
+        await ServerListScreen.addServerButton.tap();
+        await expect(ServerScreen.headerTitleAddServer).toBeVisible();
+        await ServerScreen.connectToServer(serverThreeUrl, serverThreeDisplayName);
+        await LoginScreen.login(serverThreeUser);
+
+        // * Verify on channel list screen of the third server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverThreeDisplayName);
+
+        // # Open server list screen
+        await ServerListScreen.open();
+
+        // * Verify third server is active, and first and second servers are inactive
+        await ServerListScreen.toBeVisible();
+        await expect(ServerListScreen.getServerItemActive(serverThreeDisplayName)).toBeVisible();
+        await expect(ServerListScreen.getServerItemInactive(serverOneDisplayName)).toBeVisible();
+        await expect(ServerListScreen.getServerItemInactive(serverTwoDisplayName)).toBeVisible();
+
+        // # Go back to first server
+        await ServerListScreen.getServerItemInactive(serverOneDisplayName).tap();
+    });
+
+    it('MM-T4691_2 - should be able to switch to another existing server', async () => {
+        // * Verify on channel list screen of the first server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
+
+        // # Tap on third server
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemInactive(serverThreeDisplayName).tap();
+
+        // * Verify on channel list screen of the third server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverThreeDisplayName);
+
+        // # Go back to first server
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemInactive(serverOneDisplayName).tap();
+    });
+
+    it('MM-T4691_3 - should be able to edit server display name of active and inactive servers', async () => {
+        // * Verify on channel list screen of the first server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
+
+        // # Swipe left on first server and tap on edit option
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemActive(serverOneDisplayName).swipe('left');
+        await ServerListScreen.getServerItemEditOption(serverOneDisplayName).tap();
+
+        // * Verify on edit server screen
+        await EditServerScreen.toBeVisible();
+
+        // # Enter the same first server display name
+        await EditServerScreen.serverDisplayNameInput.replaceText(serverOneDisplayName);
+
+        // * Verify save button is disabled
+        await expect(EditServerScreen.saveButtonDisabled).toBeVisible();
+
+        // # Enter a new first server display name
+        const newServerOneDisplayName = `${serverOneDisplayName} new`;
+        await EditServerScreen.serverDisplayNameInput.replaceText(newServerOneDisplayName);
+
+        // * Verify save button is enabled
+        await expect(EditServerScreen.saveButton).toBeVisible();
+
+        // # Tap on save button
+        await EditServerScreen.saveButton.tap();
+
+        // * Verify the new first server display name
+        await expect(ServerListScreen.getServerItemActive(newServerOneDisplayName)).toBeVisible();
+
+        // # Revert back to original first server display name and go back to first server
+        await ServerListScreen.getServerItemActive(newServerOneDisplayName).swipe('left');
+        await ServerListScreen.getServerItemEditOption(newServerOneDisplayName).tap();
+        await EditServerScreen.serverDisplayNameInput.replaceText(serverOneDisplayName);
+        await EditServerScreen.saveButton.tap();
+        await ServerListScreen.getServerItemActive(serverOneDisplayName).tap();
+    });
+
+    it('MM-T4691_4 - should be able to remove a server from the list', async () => {
+        // * Verify on channel list screen of the first server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
+
+        // # Swipe left on first server and tap on remove option
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemActive(serverOneDisplayName).swipe('left');
+        await ServerListScreen.getServerItemRemoveOption(serverOneDisplayName).tap();
+
+        // * Verify remove server alert is displayed
+        await expect(Alert.removeServerTitle(serverOneDisplayName)).toBeVisible();
+
+        // # Tap on remove button and go back to server list screen
+        await Alert.removeButton.tap();
+        await ServerListScreen.open();
+
+        // * Verify first server is removed
+        await expect(ServerListScreen.getServerItemActive(serverOneDisplayName)).not.toExist();
+        await expect(ServerListScreen.getServerItemInactive(serverOneDisplayName)).not.toExist();
+
+        // # Add first server back to the list and log in to the first server
+        await User.apiAdminLogin(siteOneUrl);
+        ({user: serverOneUser} = await Setup.apiInit(siteOneUrl));
+        await ServerListScreen.addServerButton.tap();
+        await expect(ServerScreen.headerTitleAddServer).toBeVisible();
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await LoginScreen.login(serverOneUser);
+    });
+
+    it('MM-T4691_5 - should be able to log out a server from the list', async () => {
+        // * Verify on channel list screen of the first server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
+
+        // # Swipe left on first server and tap on logout option
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemActive(serverOneDisplayName).swipe('left');
+        await ServerListScreen.getServerItemLogoutOption(serverOneDisplayName).tap();
+
+        // * Verify logout server alert is displayed
+        await expect(Alert.logoutTitle(serverOneDisplayName)).toBeVisible();
+
+        // # Tap on logout button and go back to server list screen
+        await Alert.logoutButton.tap();
+        await ServerListScreen.open();
+
+        // * Verify first server is logged out
+        await ServerListScreen.getServerItemInactive(serverOneDisplayName).swipe('left');
+        await expect(ServerListScreen.getServerItemLoginOption(serverOneDisplayName)).toBeVisible();
+
+        // # Log back in to first server
+        await ServerListScreen.getServerItemLoginOption(serverOneDisplayName).tap();
+        await User.apiAdminLogin(siteOneUrl);
+        ({user: serverOneUser} = await Setup.apiInit(siteOneUrl));
+        await expect(ServerScreen.headerTitleAddServer).toBeVisible();
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await LoginScreen.login(serverOneUser);
+    });
+});

--- a/detox/e2e/test/server_login/server_list.e2e.ts
+++ b/detox/e2e/test/server_login/server_list.e2e.ts
@@ -36,9 +36,9 @@ describe('Server Login - Server List', () => {
     const serverOneDisplayName = 'Server 1';
     const serverTwoDisplayName = 'Server 2';
     const serverThreeDisplayName = 'Server 3';
-    let serverOneUser;
-    let serverTwoUser;
-    let serverThreeUser;
+    let serverOneUser: any;
+    let serverTwoUser: any;
+    let serverThreeUser: any;
 
     beforeAll(async () => {
         // # Log in to the first server
@@ -115,7 +115,7 @@ describe('Server Login - Server List', () => {
         await ChannelListScreen.toBeVisible();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
 
-        // # Tap on third server
+        // # Open server list screen and tap on third server
         await ServerListScreen.open();
         await ServerListScreen.getServerItemInactive(serverThreeDisplayName).tap();
 
@@ -123,7 +123,7 @@ describe('Server Login - Server List', () => {
         await ChannelListScreen.toBeVisible();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverThreeDisplayName);
 
-        // # Go back to first server
+        // # Open server list screen and go back to first server
         await ServerListScreen.open();
         await ServerListScreen.getServerItemInactive(serverOneDisplayName).tap();
     });
@@ -133,7 +133,7 @@ describe('Server Login - Server List', () => {
         await ChannelListScreen.toBeVisible();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
 
-        // # Swipe left on first server and tap on edit option
+        // # Open server list screen, swipe left on first server and tap on edit option
         await ServerListScreen.open();
         await ServerListScreen.getServerItemActive(serverOneDisplayName).swipe('left');
         await ServerListScreen.getServerItemEditOption(serverOneDisplayName).tap();
@@ -173,7 +173,7 @@ describe('Server Login - Server List', () => {
         await ChannelListScreen.toBeVisible();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
 
-        // # Swipe left on first server and tap on remove option
+        // # Open server list screen, swipe left on first server and tap on remove option
         await ServerListScreen.open();
         await ServerListScreen.getServerItemActive(serverOneDisplayName).swipe('left');
         await ServerListScreen.getServerItemRemoveOption(serverOneDisplayName).tap();
@@ -190,8 +190,6 @@ describe('Server Login - Server List', () => {
         await expect(ServerListScreen.getServerItemInactive(serverOneDisplayName)).not.toExist();
 
         // # Add first server back to the list and log in to the first server
-        await User.apiAdminLogin(siteOneUrl);
-        ({user: serverOneUser} = await Setup.apiInit(siteOneUrl));
         await ServerListScreen.addServerButton.tap();
         await expect(ServerScreen.headerTitleAddServer).toBeVisible();
         await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
@@ -203,7 +201,7 @@ describe('Server Login - Server List', () => {
         await ChannelListScreen.toBeVisible();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
 
-        // # Swipe left on first server and tap on logout option
+        // # Open server list screen, swipe left on first server and tap on logout option
         await ServerListScreen.open();
         await ServerListScreen.getServerItemActive(serverOneDisplayName).swipe('left');
         await ServerListScreen.getServerItemLogoutOption(serverOneDisplayName).tap();
@@ -221,10 +219,37 @@ describe('Server Login - Server List', () => {
 
         // # Log back in to first server
         await ServerListScreen.getServerItemLoginOption(serverOneDisplayName).tap();
-        await User.apiAdminLogin(siteOneUrl);
-        ({user: serverOneUser} = await Setup.apiInit(siteOneUrl));
         await expect(ServerScreen.headerTitleAddServer).toBeVisible();
         await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
         await LoginScreen.login(serverOneUser);
+    });
+
+    it('MM-T4691_6 - should not be able to add server for an already existing server', async () => {
+        // * Verify on channel list screen of the first server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
+
+        // # Open server list screen, attempt to add a server already logged in and with inactive session
+        await ServerListScreen.open();
+        await ServerListScreen.addServerButton.tap();
+        await expect(ServerScreen.headerTitleAddServer).toBeVisible();
+        await ServerScreen.serverUrlInput.replaceText(serverTwoUrl);
+        await ServerScreen.serverDisplayNameInput.replaceText(serverTwoDisplayName);
+        await ServerScreen.connectButton.tap();
+
+        // * Verify same name server error
+        const sameNameServerError = 'You are using this name for another server.';
+        await expect(ServerScreen.serverDisplayNameInputError).toHaveText(sameNameServerError);
+
+        // # Attempt to add a server already logged in and with active session, with the same server display name
+        await ServerScreen.serverUrlInput.replaceText(serverOneUrl);
+        await ServerScreen.serverDisplayNameInput.replaceText(serverOneDisplayName);
+        await ServerScreen.connectButton.tap();
+
+        // * Verify same name server error
+        await expect(ServerScreen.serverDisplayNameInputError).toHaveText(sameNameServerError);
+
+        // # Close server screen to go back to first server
+        await ServerScreen.closeButton.tap();
     });
 });

--- a/detox/e2e/test/smoke_test/server_login.e2e.ts
+++ b/detox/e2e/test/smoke_test/server_login.e2e.ts
@@ -73,5 +73,9 @@ describe('Server Login', () => {
         // * Verify on channel list screen of the second server
         await ChannelListScreen.toBeVisible();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverTwoDisplayName);
+
+        // # Go back to first server
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemInactive(serverOneDisplayName).tap();
     });
 });

--- a/detox/e2e/test/smoke_test/server_login.e2e.ts
+++ b/detox/e2e/test/smoke_test/server_login.e2e.ts
@@ -7,28 +7,35 @@
 // - Use element testID when selecting an element. Create one if none.
 // *******************************************************************
 
-import {Setup} from '@support/server_api';
+import {
+    Setup,
+    User,
+} from '@support/server_api';
 import {
     serverOneUrl,
     siteOneUrl,
+    serverTwoUrl,
+    siteTwoUrl,
 } from '@support/test_config';
 import {
     ChannelListScreen,
     HomeScreen,
     LoginScreen,
+    ServerListScreen,
     ServerScreen,
 } from '@support/ui/screen';
 import {expect} from 'detox';
 
 describe('Server Login', () => {
     const serverOneDisplayName = 'Server 1';
+    const serverTwoDisplayName = 'Server 2';
 
     afterAll(async () => {
         // # Log out
         await HomeScreen.logout(serverOneDisplayName);
     });
 
-    it('MM-T4675 - should be able to connect to a server, log in, and show channel list screen', async () => {
+    it('MM-T4675_1 - should be able to connect to a server, log in, and show channel list screen', async () => {
         // * Verify on server screen
         await ServerScreen.toBeVisible();
 
@@ -46,5 +53,25 @@ describe('Server Login', () => {
         await ChannelListScreen.toBeVisible();
         await expect(ChannelListScreen.headerTeamDisplayName).toHaveText(team.display_name);
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
+    });
+
+    it('MM-T4675_2 - should be able to add a new server and log in to the new server', async () => {
+        // # Open server list screen
+        await ServerListScreen.open();
+
+        // * Verify on server list screen
+        await ServerListScreen.toBeVisible();
+
+        // # Add a second server and log in to the second server
+        await User.apiAdminLogin(siteTwoUrl);
+        const {user} = await Setup.apiInit(siteTwoUrl);
+        await ServerListScreen.addServerButton.tap();
+        await expect(ServerScreen.headerTitleAddServer).toBeVisible();
+        await ServerScreen.connectToServer(serverTwoUrl, serverTwoDisplayName);
+        await LoginScreen.login(user);
+
+        // * Verify on channel list screen of the second server
+        await ChannelListScreen.toBeVisible();
+        await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverTwoDisplayName);
     });
 });


### PR DESCRIPTION
#### Summary
- Added e2e for server list
- Created associated zephyr test cases under `Mobile V2` folder

Mobile V2/Smoke Test: Added step for adding new server
[MM-T4675](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4675)

Mobile V2/Server Login: Added several steps for Server List e2e
[MM-T4691](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4691)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42406

#### Screenshots
![Screen Shot 2022-03-21 at 1 01 44 PM](https://user-images.githubusercontent.com/487991/159354528-0d8291e4-5f89-415f-bc3c-8a3a47a4da94.png)
![Screen Shot 2022-03-23 at 9 55 25 AM](https://user-images.githubusercontent.com/487991/159754359-a31dddaa-1eb7-48b0-86e8-708c614c35b3.png)

#### Release Note
```release-note
NONE
```
