### PR TITLE
FriendlyDate component - Round dates to nearest 10th before taking floor

### DIFF
--- a/app/components/friendly_date/index.tsx
+++ b/app/components/friendly_date/index.tsx
@@ -37,7 +37,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
 
     // Message: Minutes Ago
     if (difference < DateTypes.SECONDS.HOUR) {
-        const minutes = Math.floor(difference / DateTypes.SECONDS.MINUTE);
+        const minutes = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.MINUTE) / 10);
         return intl.formatMessage({
             id: 'friendly_date.minsAgo',
             defaultMessage: '{count} {count, plural, one {min} other {mins}} ago',
@@ -48,7 +48,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
 
     // Message: Hours Ago
     if (difference < DateTypes.SECONDS.DAY) {
-        const hours = Math.floor(difference / DateTypes.SECONDS.HOUR);
+        const hours = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.HOUR) / 10);
         return intl.formatMessage({
             id: 'friendly_date.hoursAgo',
             defaultMessage: '{count} {count, plural, one {hour} other {hours}} ago',
@@ -67,7 +67,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
         }
         const completedAMonth = today.getMonth() !== date.getMonth() && today.getDate() >= date.getDate();
         if (!completedAMonth) {
-            const days = Math.floor(difference / DateTypes.SECONDS.DAY) || 1;
+            const days = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.DAY) / 10) || 1;
             return intl.formatMessage({
                 id: 'friendly_date.daysAgo',
                 defaultMessage: '{count} {count, plural, one {day} other {days}} ago',
@@ -83,7 +83,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
             today.getMonth() >= date.getMonth() &&
             today.getDate() >= date.getDate();
         if (!completedAnYear) {
-            const months = Math.floor(difference / DateTypes.SECONDS.DAYS_30) || 1;
+            const months = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.DAYS_30) / 10) || 1;
             return intl.formatMessage({
                 id: 'friendly_date.monthsAgo',
                 defaultMessage: '{count} {count, plural, one {month} other {months}} ago',
@@ -94,7 +94,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
     }
 
     // Message: Years Ago
-    const years = Math.floor(difference / DateTypes.SECONDS.DAYS_365) || 1;
+    const years = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.DAYS_365) / 10) || 1;
     return intl.formatMessage({
         id: 'friendly_date.yearsAgo',
         defaultMessage: '{count} {count, plural, one {year} other {years}} ago',

--- a/app/components/friendly_date/index.tsx
+++ b/app/components/friendly_date/index.tsx
@@ -37,7 +37,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
 
     // Message: Minutes Ago
     if (difference < DateTypes.SECONDS.HOUR) {
-        const minutes = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.MINUTE) / 10);
+        const minutes = Math.floor(Math.round((10 * difference) / DateTypes.SECONDS.MINUTE) / 10);
         return intl.formatMessage({
             id: 'friendly_date.minsAgo',
             defaultMessage: '{count} {count, plural, one {min} other {mins}} ago',
@@ -48,7 +48,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
 
     // Message: Hours Ago
     if (difference < DateTypes.SECONDS.DAY) {
-        const hours = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.HOUR) / 10);
+        const hours = Math.floor(Math.round((10 * difference) / DateTypes.SECONDS.HOUR) / 10);
         return intl.formatMessage({
             id: 'friendly_date.hoursAgo',
             defaultMessage: '{count} {count, plural, one {hour} other {hours}} ago',
@@ -67,7 +67,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
         }
         const completedAMonth = today.getMonth() !== date.getMonth() && today.getDate() >= date.getDate();
         if (!completedAMonth) {
-            const days = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.DAY) / 10) || 1;
+            const days = Math.floor(Math.round((10 * difference) / DateTypes.SECONDS.DAY) / 10) || 1;
             return intl.formatMessage({
                 id: 'friendly_date.daysAgo',
                 defaultMessage: '{count} {count, plural, one {day} other {days}} ago',
@@ -83,7 +83,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
             today.getMonth() >= date.getMonth() &&
             today.getDate() >= date.getDate();
         if (!completedAnYear) {
-            const months = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.DAYS_30) / 10) || 1;
+            const months = Math.floor(Math.round((10 * difference) / DateTypes.SECONDS.DAYS_30) / 10) || 1;
             return intl.formatMessage({
                 id: 'friendly_date.monthsAgo',
                 defaultMessage: '{count} {count, plural, one {month} other {months}} ago',
@@ -94,7 +94,7 @@ export function getFriendlyDate(intl: typeof intlShape, inputDate: number | Date
     }
 
     // Message: Years Ago
-    const years = Math.floor(Math.round(10 * difference / DateTypes.SECONDS.DAYS_365) / 10) || 1;
+    const years = Math.floor(Math.round((10 * difference) / DateTypes.SECONDS.DAYS_365) / 10) || 1;
     return intl.formatMessage({
         id: 'friendly_date.yearsAgo',
         defaultMessage: '{count} {count, plural, one {year} other {years}} ago',


### PR DESCRIPTION
#### Summary

There is a flaky test for the `FriendlyDate` component, where a date's value is being truncated while being slightly lower than the intended value, resulting in the number being a whole number lower than the intended value. It's unclear exactly what is causing the flaky test, but it may have something to do with daylight savings time.

This PR makes it so we first round to the nearest tenth before taking the `Math.floor` of the number. This makes it so `9.958333333333334` is rounded to `10.0` before taking the floor.

See https://app.circleci.com/pipelines/github/mattermost/mattermost-mobile/13663/workflows/77d1d1f1-0bbb-4cde-91ec-15ff8f624328/jobs/21150 and https://community-daily.mattermost.com/core/pl/6w31xfko9f84dgqgy4e9gw5s6c

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-42707
