### PR TITLE
Gekidou - Replies count query fix

### DIFF
--- a/app/components/post_list/post/header/index.ts
+++ b/app/components/post_list/post/header/index.ts
@@ -8,7 +8,7 @@ import {map, switchMap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {getPreferenceAsBool, getTeammateNameDisplaySetting} from '@helpers/api/preference';
-import {queryPostsInThread} from '@queries/servers/post';
+import {queryPostRepliesCount} from '@queries/servers/post';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeConfig, observeLicense} from '@queries/servers/system';
 import {isMinimumServerVersion} from '@utils/helpers';
@@ -37,7 +37,7 @@ const withHeaderProps = withObservables(
         const teammateNameDisplay = combineLatest([preferences, config, license]).pipe(
             map(([prefs, cfg, lcs]) => getTeammateNameDisplaySetting(prefs, cfg, lcs)),
         );
-        const commentCount = queryPostsInThread(database, post.rootId || post.id).observeCount();
+        const commentCount = queryPostRepliesCount(database, post.rootId || post.id).observeCount();
         const rootPostAuthor = differentThreadSequence ? post.root.observe().pipe(switchMap((root) => {
             if (root.length) {
                 return root[0].author.observe();

--- a/app/components/post_list/thread_overview/index.ts
+++ b/app/components/post_list/thread_overview/index.ts
@@ -7,7 +7,7 @@ import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
-import {observePost, queryPostsInThread} from '@queries/servers/post';
+import {observePost, queryPostRepliesCount} from '@queries/servers/post';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 
 import ThreadOverview from './thread_overview';
@@ -24,7 +24,7 @@ const enhanced = withObservables(
                 pipe(
                     switchMap((pref) => of$(Boolean(pref[0]?.value === 'true'))),
                 ),
-            repliesCount: queryPostsInThread(database, rootId).observeCount(),
+            repliesCount: queryPostRepliesCount(database, rootId).observeCount(false),
         };
     });
 

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -75,6 +75,14 @@ export const queryPostsInThread = (database: Database, rootId: string, sorted = 
     return database.get<PostsInThreadModel>(POSTS_IN_THREAD).query(...clauses);
 };
 
+export const queryPostRepliesCount = (database: Database, rootId: string, excludeDeleted = true) => {
+    const clauses: Q.Clause[] = [Q.where('root_id', rootId)];
+    if (excludeDeleted) {
+        clauses.push(Q.where('delete_at', Q.eq(0)));
+    }
+    return database.get(POST).query(...clauses);
+};
+
 export const getRecentPostsInThread = async (database: Database, rootId: string) => {
     const chunks = await queryPostsInThread(database, rootId, true, true).fetch();
     if (chunks.length) {


### PR DESCRIPTION
#### Summary
The current query to get replies count is querying `postsInThread` table to get the timestamps and returning a different count. This will query the table with the given root Id.

#### Device Information
This PR was tested on: Android 11

#### Release Note
```release-note
NONE
```
