### PR TITLE
MM-41909: Allow 1 char channel name

### DIFF
--- a/app/components/edit_channel_info/index.js
+++ b/app/components/edit_channel_info/index.js
@@ -21,6 +21,7 @@ import FormattedText from '@components/formatted_text';
 import Loading from '@components/loading';
 import StatusBar from '@components/status_bar';
 import TextInputWithLocalizedPlaceholder from '@components/text_input_with_localized_placeholder';
+import {ViewTypes} from '@constants';
 import DEVICE from '@constants/device';
 import {General} from '@mm-redux/constants';
 import {t} from '@utils/i18n';
@@ -130,7 +131,7 @@ export default class EditChannelInfo extends PureComponent {
             return;
         }
 
-        const displayNameExists = displayName && displayName.length >= 1;
+        const displayNameExists = displayName && displayName.length >= ViewTypes.MIN_CHANNELNAME_LENGTH;
         this.props.enableRightButton(displayNameExists);
     };
 

--- a/app/components/edit_channel_info/index.js
+++ b/app/components/edit_channel_info/index.js
@@ -130,7 +130,7 @@ export default class EditChannelInfo extends PureComponent {
             return;
         }
 
-        const displayNameExists = displayName && displayName.length >= 2;
+        const displayNameExists = displayName && displayName.length >= 1;
         this.props.enableRightButton(displayNameExists);
     };
 

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -129,7 +129,7 @@ export default {
     FEATURE_TOGGLE_PREFIX: 'feature_enabled_',
     EMBED_PREVIEW: 'embed_preview',
     LINK_PREVIEW_DISPLAY: 'link_previews',
-    MIN_CHANNELNAME_LENGTH: 2,
+    MIN_CHANNELNAME_LENGTH: 1,
     MAX_CHANNELNAME_LENGTH: 64,
     ANDROID_TOP_LANDSCAPE: 46,
     ANDROID_TOP_PORTRAIT: 56,

--- a/app/screens/edit_channel/edit_channel.js
+++ b/app/screens/edit_channel/edit_channel.js
@@ -226,6 +226,11 @@ export default class EditChannel extends PureComponent {
                 messages.name_maxLength,
                 {maxLength: ViewTypes.MAX_CHANNELNAME_LENGTH},
             )};
+        } else if (channelURL.length < ViewTypes.MIN_CHANNELNAME_LENGTH) {
+            return {error: formatMessage(
+                messages.name_minLength,
+                {maxLength: ViewTypes.MIN_CHANNELNAME_LENGTH},
+            )};
         }
 
         const cleanedName = cleanUpUrlable(channelURL);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This is part of a series of pull requests aim to reduce the limit of channel display name as well as channel URL (referred to as name) to one character assuming there are no technical reasons for the 2 char limit.

Note: It seems to me that the create channel screen does not give user the ability to change the channelURL but they are allowed to do so in the editing screen. For this PR, my change is mainly on the editChannel screen. I noticed that the minLength limit is not enforced so I had added that validation as well.



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/19788
JIRA: https://mattermost.atlassian.net/browse/MM-41909
Related PR: https://github.com/mattermost/mattermost-server/pull/19845

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
