### PR TITLE
MM-42787 - Gekidou User DB field remote_id

### DIFF
--- a/app/database/models/server/user.ts
+++ b/app/database/models/server/user.ts
@@ -57,7 +57,7 @@ export default class UserModel extends Model implements UserModelInterface {
         /** USER has a 1:N relationship with TEAM_MEMBERSHIP.  A user can join multiple teams */
         [TEAM_MEMBERSHIP]: {type: 'has_many', foreignKey: 'user_id'},
 
-        /** USER has a 1:N relationship with THREAD_PARTICIPANT. A user can participante in multiple threads */
+        /** USER has a 1:N relationship with THREAD_PARTICIPANT. A user can participate in multiple threads */
         [THREAD_PARTICIPANT]: {type: 'has_many', foreignKey: 'user_id'},
     };
 
@@ -107,7 +107,7 @@ export default class UserModel extends Model implements UserModelInterface {
     @field('username') username!: string;
 
     /** remote_id : The ID of the remote organization that this user belongs to */
-    @field('remote_id') remoteId!: string;
+    @field('remote_id') remoteId!: string | null;
 
     /** notify_props : Notification preferences/configurations */
     @json('notify_props', safeParseJSON) notifyProps!: UserNotifyProps | null;

--- a/app/database/models/server/user.ts
+++ b/app/database/models/server/user.ts
@@ -14,6 +14,7 @@ import type PostModel from '@typings/database/models/servers/post';
 import type PreferenceModel from '@typings/database/models/servers/preference';
 import type ReactionModel from '@typings/database/models/servers/reaction';
 import type TeamMembershipModel from '@typings/database/models/servers/team_membership';
+import type UserModelInterface from '@typings/database/models/servers/user';
 import type {UserMentionKey} from '@typings/global/markdown';
 
 const {
@@ -31,7 +32,7 @@ const {
  * The User model represents the 'USER' table and its relationship to other
  * shareholders in the app.
  */
-export default class UserModel extends Model {
+export default class UserModel extends Model implements UserModelInterface {
     /** table (name) : User */
     static table = USER;
 
@@ -104,6 +105,9 @@ export default class UserModel extends Model {
 
     /** username : The user's username */
     @field('username') username!: string;
+
+    /** remote_id : The ID of the remote organization that this user belongs to */
+    @field('remote_id') remoteId!: string;
 
     /** notify_props : Notification preferences/configurations */
     @json('notify_props', safeParseJSON) notifyProps!: UserNotifyProps | null;

--- a/app/database/operator/server_data_operator/handlers/reaction.ts
+++ b/app/database/operator/server_data_operator/handlers/reaction.ts
@@ -3,7 +3,7 @@
 
 import {MM_TABLES} from '@constants/database';
 import DataOperatorException from '@database/exceptions/data_operator_exception';
-import {transformReactionRecord} from '@database/operator/server_data_operator/transformers/user';
+import {transformReactionRecord} from '@database/operator/server_data_operator/transformers/reaction';
 import {sanitizeReactions} from '@database/operator/utils/reaction';
 
 import type {HandleReactionsArgs} from '@typings/database/database';

--- a/app/database/operator/server_data_operator/transformers/reaction.test.ts
+++ b/app/database/operator/server_data_operator/transformers/reaction.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {transformReactionRecord} from '@database/operator/server_data_operator/transformers/reaction';
+import {createTestConnection} from '@database/operator/utils/create_test_connection';
+import {OperationType} from '@typings/database/enums';
+
+describe('*** REACTION Prepare Records Test ***', () => {
+    it('=> transformReactionRecord: should return an array of type Reaction', async () => {
+        expect.assertions(3);
+
+        const database = await createTestConnection({databaseName: 'reaction_prepare_records', setActive: true});
+        expect(database).toBeTruthy();
+
+        const preparedRecords = await transformReactionRecord({
+            action: OperationType.CREATE,
+            database: database!,
+            value: {
+                record: undefined,
+                raw: {
+                    id: 'ps81iqbddesfby8jayz7owg4yypoo',
+                    user_id: 'q3mzxua9zjfczqakxdkowc6u6yy',
+                    post_id: 'ps81iqbddesfby8jayz7owg4yypoo',
+                    emoji_name: 'thumbsup',
+                    create_at: 1596032651748,
+                    update_at: 1608253011321,
+                    delete_at: 0,
+                },
+            },
+        });
+
+        expect(preparedRecords).toBeTruthy();
+        expect(preparedRecords!.collection.modelClass.name).toBe('ReactionModel');
+    });
+});

--- a/app/database/operator/server_data_operator/transformers/reaction.ts
+++ b/app/database/operator/server_data_operator/transformers/reaction.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {MM_TABLES} from '@constants/database';
+import {prepareBaseRecord} from '@database/operator/server_data_operator/transformers/index';
+import {OperationType} from '@typings/database/enums';
+
+import type {TransformerArgs} from '@typings/database/database';
+import type ReactionModel from '@typings/database/models/servers/reaction';
+
+const {REACTION} = MM_TABLES.SERVER;
+
+/**
+ * transformReactionRecord: Prepares a record of the SERVER database 'Reaction' table for update or create actions.
+ * @param {TransformerArgs} operator
+ * @param {Database} operator.database
+ * @param {RecordPair} operator.value
+ * @returns {Promise<ReactionModel>}
+ */
+export const transformReactionRecord = ({action, database, value}: TransformerArgs): Promise<ReactionModel> => {
+    const raw = value.raw as Reaction;
+    const record = value.record as ReactionModel;
+    const isCreateAction = action === OperationType.CREATE;
+
+    // id of reaction comes from server response
+    const fieldsMapper = (reaction: ReactionModel) => {
+        reaction._raw.id = isCreateAction ? (raw?.id ?? reaction.id) : record.id;
+        reaction.userId = raw.user_id;
+        reaction.postId = raw.post_id;
+        reaction.emojiName = raw.emoji_name;
+        reaction.createAt = raw.create_at;
+    };
+
+    return prepareBaseRecord({
+        action,
+        database,
+        tableName: REACTION,
+        value,
+        fieldsMapper,
+    }) as Promise<ReactionModel>;
+};

--- a/app/database/operator/server_data_operator/transformers/user.test.ts
+++ b/app/database/operator/server_data_operator/transformers/user.test.ts
@@ -1,11 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {
-    transformPreferenceRecord,
-    transformReactionRecord,
-    transformUserRecord,
-} from '@database/operator/server_data_operator/transformers/user';
+import {transformPreferenceRecord, transformUserRecord} from '@database/operator/server_data_operator/transformers/user';
 import {createTestConnection} from '@database/operator/utils/create_test_connection';
 import {OperationType} from '@typings/database/enums';
 
@@ -27,33 +23,6 @@ describe('*** USER Prepare Records Test ***', () => {
 
         expect(preparedRecords).toBeTruthy();
         expect(preparedRecords!.collection.modelClass.name).toBe('PreferenceModel');
-    });
-
-    it('=> transformReactionRecord: should return an array of type Reaction', async () => {
-        expect.assertions(3);
-
-        const database = await createTestConnection({databaseName: 'user_prepare_records', setActive: true});
-        expect(database).toBeTruthy();
-
-        const preparedRecords = await transformReactionRecord({
-            action: OperationType.CREATE,
-            database: database!,
-            value: {
-                record: undefined,
-                raw: {
-                    id: 'ps81iqbddesfby8jayz7owg4yypoo',
-                    user_id: 'q3mzxua9zjfczqakxdkowc6u6yy',
-                    post_id: 'ps81iqbddesfby8jayz7owg4yypoo',
-                    emoji_name: 'thumbsup',
-                    create_at: 1596032651748,
-                    update_at: 1608253011321,
-                    delete_at: 0,
-                },
-            },
-        });
-
-        expect(preparedRecords).toBeTruthy();
-        expect(preparedRecords!.collection.modelClass.name).toBe('ReactionModel');
     });
 
     it('=> transformUserRecord: should return an array of type User', async () => {

--- a/app/database/operator/server_data_operator/transformers/user.ts
+++ b/app/database/operator/server_data_operator/transformers/user.ts
@@ -7,44 +7,9 @@ import {OperationType} from '@typings/database/enums';
 
 import type {TransformerArgs} from '@typings/database/database';
 import type PreferenceModel from '@typings/database/models/servers/preference';
-import type ReactionModel from '@typings/database/models/servers/reaction';
 import type UserModel from '@typings/database/models/servers/user';
 
-const {
-    PREFERENCE,
-    REACTION,
-    USER,
-} = MM_TABLES.SERVER;
-
-/**
- * transformReactionRecord: Prepares a record of the SERVER database 'Reaction' table for update or create actions.
- * @param {TransformerArgs} operator
- * @param {Database} operator.database
- * @param {RecordPair} operator.value
- * @returns {Promise<ReactionModel>}
- */
-export const transformReactionRecord = ({action, database, value}: TransformerArgs): Promise<ReactionModel> => {
-    const raw = value.raw as Reaction;
-    const record = value.record as ReactionModel;
-    const isCreateAction = action === OperationType.CREATE;
-
-    // id of reaction comes from server response
-    const fieldsMapper = (reaction: ReactionModel) => {
-        reaction._raw.id = isCreateAction ? (raw?.id ?? reaction.id) : record.id;
-        reaction.userId = raw.user_id;
-        reaction.postId = raw.post_id;
-        reaction.emojiName = raw.emoji_name;
-        reaction.createAt = raw.create_at;
-    };
-
-    return prepareBaseRecord({
-        action,
-        database,
-        tableName: REACTION,
-        value,
-        fieldsMapper,
-    }) as Promise<ReactionModel>;
-};
+const {PREFERENCE, USER} = MM_TABLES.SERVER;
 
 /**
  * transformUserRecord: Prepares a record of the SERVER database 'User' table for update or create actions.

--- a/app/database/operator/server_data_operator/transformers/user.ts
+++ b/app/database/operator/server_data_operator/transformers/user.ts
@@ -43,6 +43,7 @@ export const transformUserRecord = ({action, database, value}: TransformerArgs):
         user.props = raw.props || null;
         user.timezone = raw.timezone || null;
         user.isBot = raw.is_bot;
+        user.remoteId = raw?.remote_id ?? '';
         if (raw.status) {
             user.status = raw.status;
         }

--- a/app/database/schema/server/table_schemas/user.ts
+++ b/app/database/schema/server/table_schemas/user.ts
@@ -28,5 +28,6 @@ export default tableSchema({
         {name: 'status', type: 'string'},
         {name: 'timezone', type: 'string'},
         {name: 'username', type: 'string'},
+        {name: 'remote_id', type: 'string'},
     ],
 });

--- a/app/database/schema/server/table_schemas/user.ts
+++ b/app/database/schema/server/table_schemas/user.ts
@@ -28,6 +28,6 @@ export default tableSchema({
         {name: 'status', type: 'string'},
         {name: 'timezone', type: 'string'},
         {name: 'username', type: 'string'},
-        {name: 'remote_id', type: 'string'},
+        {name: 'remote_id', type: 'string', isOptional: true},
     ],
 });

--- a/app/database/schema/server/test.ts
+++ b/app/database/schema/server/test.ts
@@ -520,7 +520,7 @@ describe('*** Test schema for SERVER database ***', () => {
                         status: {name: 'status', type: 'string'},
                         timezone: {name: 'timezone', type: 'string'},
                         username: {name: 'username', type: 'string'},
-                        remote_id: {name: 'remote_id', type: 'string'},
+                        remote_id: {name: 'remote_id', type: 'string', isOptional: true},
                     },
                     columnArray: [
                         {name: 'auth_service', type: 'string'},
@@ -541,7 +541,7 @@ describe('*** Test schema for SERVER database ***', () => {
                         {name: 'status', type: 'string'},
                         {name: 'timezone', type: 'string'},
                         {name: 'username', type: 'string'},
-                        {name: 'remote_id', type: 'string'},
+                        {name: 'remote_id', type: 'string', isOptional: true},
                     ],
                 },
             },

--- a/app/database/schema/server/test.ts
+++ b/app/database/schema/server/test.ts
@@ -520,6 +520,7 @@ describe('*** Test schema for SERVER database ***', () => {
                         status: {name: 'status', type: 'string'},
                         timezone: {name: 'timezone', type: 'string'},
                         username: {name: 'username', type: 'string'},
+                        remote_id: {name: 'remote_id', type: 'string'},
                     },
                     columnArray: [
                         {name: 'auth_service', type: 'string'},
@@ -540,6 +541,7 @@ describe('*** Test schema for SERVER database ***', () => {
                         {name: 'status', type: 'string'},
                         {name: 'timezone', type: 'string'},
                         {name: 'username', type: 'string'},
+                        {name: 'remote_id', type: 'string'},
                     ],
                 },
             },

--- a/app/utils/user/index.ts
+++ b/app/utils/user/index.ts
@@ -6,10 +6,10 @@ import {Alert} from 'react-native';
 
 import {General, Permissions, Preferences} from '@constants';
 import {CustomStatusDuration} from '@constants/custom_status';
-import {UserModel} from '@database/models/server';
 import {DEFAULT_LOCALE, getLocalizedMessage, t} from '@i18n';
 import {toTitleCase} from '@utils/helpers';
 
+import type UserModel from '@typings/database/models/servers/user';
 import type {IntlShape} from 'react-intl';
 
 export function displayUsername(user?: UserProfile | UserModel, locale?: string, teammateDisplayNameSetting?: string, useFallbackUsername = true) {
@@ -51,7 +51,7 @@ export function getFullName(user: UserProfile | UserModel): string {
     let firstName: string;
     let lastName: string;
 
-    if (user instanceof UserModel) {
+    if ('lastName' in user) {
         firstName = user.firstName;
         lastName = user.lastName;
     } else {
@@ -197,7 +197,7 @@ export function isBot(user: UserProfile | UserModel): boolean {
 }
 
 export function isShared(user: UserProfile | UserModel): boolean {
-    return 'remote_id' in user ? Boolean(user.remote_id) : Boolean((user as UserModel)?.remoteId);
+    return ('remoteId' in user) ? Boolean(user.remoteId) : Boolean(user.remote_id);
 }
 
 export function removeUserFromList(userId: string, originalList: UserProfile[]): UserProfile[] {

--- a/app/utils/user/index.ts
+++ b/app/utils/user/index.ts
@@ -197,7 +197,7 @@ export function isBot(user: UserProfile | UserModel): boolean {
 }
 
 export function isShared(user: UserProfile | UserModel): boolean {
-    return 'remote_id' in user ? Boolean(user.remote_id) : Boolean(user.props?.remote_id);
+    return 'remote_id' in user ? Boolean(user.remote_id) : Boolean((user as UserModel)?.remoteId);
 }
 
 export function removeUserFromList(userId: string, originalList: UserProfile[]): UserProfile[] {

--- a/types/database/models/servers/user.d.ts
+++ b/types/database/models/servers/user.d.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {field} from '@nozbe/watermelondb/decorators';
 import Model, {Associations} from '@nozbe/watermelondb/Model';
 
 import type ChannelModel from './channel';

--- a/types/database/models/servers/user.d.ts
+++ b/types/database/models/servers/user.d.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {field} from '@nozbe/watermelondb/decorators';
 import Model, {Associations} from '@nozbe/watermelondb/Model';
 
 import type ChannelModel from './channel';
@@ -67,6 +68,9 @@ export default class UserModel extends Model {
 
     /** username : The user's username */
     username: string;
+
+    /** remote_id : The ID of the remote organization that this user belongs to */
+    remoteId!: string;
 
     /** notify_props : Notification preferences/configurations */
     notifyProps: UserNotifyProps | null;

--- a/types/database/models/servers/user.d.ts
+++ b/types/database/models/servers/user.d.ts
@@ -69,7 +69,7 @@ export default class UserModel extends Model {
     username: string;
 
     /** remote_id : The ID of the remote organization that this user belongs to */
-    remoteId!: string;
+    remoteId: string;
 
     /** notify_props : Notification preferences/configurations */
     notifyProps: UserNotifyProps | null;

--- a/types/database/models/servers/user.d.ts
+++ b/types/database/models/servers/user.d.ts
@@ -69,7 +69,7 @@ export default class UserModel extends Model {
     username: string;
 
     /** remote_id : The ID of the remote organization that this user belongs to */
-    remoteId: string;
+    remoteId: string | null;
 
     /** notify_props : Notification preferences/configurations */
     notifyProps: UserNotifyProps | null;


### PR DESCRIPTION
#### Summary
When fetching users for shared channels, they will have a 'remote_id' property set in their user profile server response.  With this PR, we are creating a new field in the Users table schema and propagating this change throughout the database and codebase. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42787

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Release Note
```release-note
NONE
```
