### PR TITLE
[Gekidou] multi server fixes

### DIFF
--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -286,7 +286,7 @@ export const fetchMissingSidebarInfo = async (serverUrl: string, directChannels:
                 if (data.users.length > 1) {
                     displayNameByChannel[data.channelId] = displayGroupMessageName(data.users, locale, teammateDisplayNameSetting, currentUserId);
                 } else {
-                    displayNameByChannel[data.channelId] = displayUsername(data.users[0], locale, teammateDisplayNameSetting);
+                    displayNameByChannel[data.channelId] = displayUsername(data.users[0], locale, teammateDisplayNameSetting, false);
                 }
             }
         });

--- a/app/actions/remote/entry/app.ts
+++ b/app/actions/remote/entry/app.ts
@@ -79,7 +79,7 @@ export const appEntry = async (serverUrl: string, since = 0) => {
 
     const {id: currentUserId, locale: currentUserLocale} = meData.user || (await getCurrentUser(database))!;
     const {config, license} = await getCommonSystemValues(database);
-    deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, initialTeamId);
+    await deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, initialTeamId);
 
     if (!since) {
         // Load data from other servers

--- a/app/actions/remote/entry/notification.ts
+++ b/app/actions/remote/entry/notification.ts
@@ -137,7 +137,7 @@ export const pushNotificationEntry = async (serverUrl: string, notification: Not
     const {id: currentUserId, locale: currentUserLocale} = meData.user || (await getCurrentUser(operator.database))!;
     const {config, license} = await getCommonSystemValues(operator.database);
 
-    deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, selectedTeamId, selectedChannelId);
+    await deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, selectedTeamId, selectedChannelId);
     syncOtherServers(serverUrl);
     const error = teamData.error || chData?.error || prefData.error || meData.error;
     return {error, userId: meData?.user?.id};

--- a/app/database/operator/server_data_operator/transformers/channel.ts
+++ b/app/database/operator/server_data_operator/transformers/channel.ts
@@ -43,7 +43,7 @@ export const transformChannelRecord = ({action, database, value}: TransformerArg
         // for DM & GM's  channels do not override the display name
         // until we get the new info if there is any
         let displayName;
-        if (raw.type === General.DM_CHANNEL && record?.displayName) {
+        if (raw.type === General.DM_CHANNEL && (record?.displayName || raw.display_name)) {
             displayName = raw.display_name || record?.displayName;
         } else if (raw.type === General.GM_CHANNEL) {
             const rawMembers = raw.display_name.split(',').length;

--- a/app/init/credentials.ts
+++ b/app/init/credentials.ts
@@ -33,7 +33,7 @@ export const getAllServerCredentials = async (): Promise<ServerCredential[]> => 
 
 export const getActiveServerUrl = async () => {
     let serverUrl = await DatabaseManager.getActiveServerUrl();
-    if (serverUrl) {
+    if (!serverUrl) {
         let serverUrls: string[];
         if (Platform.OS === 'ios') {
             serverUrls = await KeyChain.getAllInternetPasswordServers();

--- a/app/utils/user/index.ts
+++ b/app/utils/user/index.ts
@@ -40,7 +40,7 @@ export function displayGroupMessageName(users: Array<UserProfile | UserModel>, l
 
     users.forEach((u) => {
         if (u.id !== excludeUserId) {
-            names.push(displayUsername(u, locale, teammateDisplayNameSetting));
+            names.push(displayUsername(u, locale, teammateDisplayNameSetting, false));
         }
     });
 


### PR DESCRIPTION
#### Summary
1. when using multiple servers it was always setting as the initial url the first server that had credentials registered instead of the active server, this cause the requests to be executed for the wrong initial server first
2. Attempt to improve the update of the DM display name to avoid empty strings
3. Made it so that DMs and GMs do not display `Someone`
4. Start fetching the data for other servers after the initial server finishes fetching initial load.

```release-note
NONE
```
