### PR TITLE
Gekidou - Fix table associations

### DIFF
--- a/app/database/models/server/posts_in_channel.ts
+++ b/app/database/models/server/posts_in_channel.ts
@@ -24,7 +24,7 @@ export default class PostsInChannelModel extends Model implements PostsInChannel
     static associations: Associations = {
 
         /** A CHANNEL can have multiple POSTS_IN_CHANNEL. (relationship is 1:N)*/
-        [CHANNEL]: {type: 'belongs_to', key: 'id'},
+        [CHANNEL]: {type: 'belongs_to', key: 'channel_id'},
     };
 
     /** channel_id: Associated channel identifier */

--- a/app/database/models/server/posts_in_thread.ts
+++ b/app/database/models/server/posts_in_thread.ts
@@ -24,7 +24,7 @@ export default class PostsInThreadModel extends Model implements PostsInThreadMo
     static associations: Associations = {
 
         /** A POST can have a POSTS_IN_THREAD.(relationship is 1:1)*/
-        [POST]: {type: 'belongs_to', key: 'id'},
+        [POST]: {type: 'belongs_to', key: 'root_id'},
     };
 
     /** root_id: Associated root post identifier */


### PR DESCRIPTION
#### Summary
While reviewing the database diagrams, we notice that the associations between the PostsInChannel table and the PostInThread table were wrong.  This PR fixes the association.


#### Release Note
```release-note
NONE
```
