### PR TITLE
PostList do not scroll to bottom after the first onEndReached

### DIFF
--- a/app/components/post_list/index.tsx
+++ b/app/components/post_list/index.tsx
@@ -113,7 +113,7 @@ const PostList = ({
 
     useEffect(() => {
         listRef.current?.scrollToOffset({offset: 0, animated: false});
-    }, [channelId, listRef.current]);
+    }, [channelId]);
 
     useEffect(() => {
         const scrollToBottom = (screen: string) => {
@@ -352,7 +352,6 @@ const PostList = ({
                     keyboardShouldPersistTaps='handled'
                     keyExtractor={keyExtractor}
                     initialNumToRender={INITIAL_BATCH_TO_RENDER + 5}
-                    listKey={`postList-${channelId}`}
                     ListFooterComponent={footer}
                     maintainVisibleContentPosition={SCROLL_POSITION_CONFIG}
                     maxToRenderPerBatch={10}


### PR DESCRIPTION
#### Summary
For some unknown reason we had the useEffect to listen to a dep change for a ref.current which caused the list to scroll to the bottom as the ref current object changed.

The reality is that refs should not be part of effect dependencies, so that was wrong in the first place, and secondly this also fixes the fact that the list was being scrolled to the bottom causing a UX problem.


```release-note
NONE
```