### PR TITLE
Apply patch for minSdkVersion

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -333,7 +333,7 @@ PODS:
     - React-Core
   - react-native-document-picker (8.0.0):
     - React-Core
-  - react-native-emm (1.2.0):
+  - react-native-emm (1.2.1):
     - React-Core
   - react-native-hw-keyboard-event (0.0.4):
     - React
@@ -894,7 +894,7 @@ SPEC CHECKSUMS:
   react-native-cameraroll: 2957f2bce63ae896a848fbe0d5352c1bd4d20866
   react-native-cookies: 7e14e823f32bd7c868134c7e207c89a46fa28f98
   react-native-document-picker: 429972f7ece4463aa5bcdd789622b3a674a3c5d1
-  react-native-emm: 547137d1ca5f7b73d64608b57cc3540734b78974
+  react-native-emm: 3dec2bc8e93eff704f52db3bfbd6ec2adfd49b0f
   react-native-hw-keyboard-event: b517cefb8d5c659a38049c582de85ff43337dc53
   react-native-image-picker: 4e6008ad8c2321622affa2c85432a5ebd02d480c
   react-native-netinfo: e922cb2e3eaf9ccdf16b8d4744a89657377aa4a1

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
         "@mattermost/compass-icons": "0.1.22",
-        "@mattermost/react-native-emm": "1.2.0",
+        "@mattermost/react-native-emm": "1.2.1",
         "@mattermost/react-native-network-client": "github:mattermost/react-native-network-client",
         "@mattermost/react-native-paste-input": "0.4.0",
         "@nozbe/watermelondb": "0.24.0",
@@ -3532,9 +3532,9 @@
       }
     },
     "node_modules/@mattermost/react-native-emm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-emm/-/react-native-emm-1.2.0.tgz",
-      "integrity": "sha512-1WKaOL8ziR8Tcq9qzPXSzIncNnxoLFUzi4yK0MjiXdsw/IraCljSdSm5jrkDwNLefZyiLv2eDewPAGT/UGQtVQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-emm/-/react-native-emm-1.2.1.tgz",
+      "integrity": "sha512-K8hg0PcfpZfI1YVxNXJ4uBSnYp6W+eXTFxhZ3itacbH7d5twlt11uHZCSei7BiSRszraKeg4A2UaAgiXIymzpw==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -26881,9 +26881,9 @@
       }
     },
     "@mattermost/react-native-emm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-emm/-/react-native-emm-1.2.0.tgz",
-      "integrity": "sha512-1WKaOL8ziR8Tcq9qzPXSzIncNnxoLFUzi4yK0MjiXdsw/IraCljSdSm5jrkDwNLefZyiLv2eDewPAGT/UGQtVQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-emm/-/react-native-emm-1.2.1.tgz",
+      "integrity": "sha512-K8hg0PcfpZfI1YVxNXJ4uBSnYp6W+eXTFxhZ3itacbH7d5twlt11uHZCSei7BiSRszraKeg4A2UaAgiXIymzpw==",
       "requires": {}
     },
     "@mattermost/react-native-network-client": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@formatjs/intl-pluralrules": "4.3.3",
     "@formatjs/intl-relativetimeformat": "10.0.1",
     "@mattermost/compass-icons": "0.1.22",
-    "@mattermost/react-native-emm": "1.2.0",
+    "@mattermost/react-native-emm": "1.2.1",
     "@mattermost/react-native-network-client": "github:mattermost/react-native-network-client",
     "@mattermost/react-native-paste-input": "0.4.0",
     "@nozbe/watermelondb": "0.24.0",

--- a/patches/@rudderstack+rudder-sdk-react-native+1.2.1.patch
+++ b/patches/@rudderstack+rudder-sdk-react-native+1.2.1.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@rudderstack/rudder-sdk-react-native/android/build.gradle b/node_modules/@rudderstack/rudder-sdk-react-native/android/build.gradle
+index 1536175..e4dd282 100644
+--- a/node_modules/@rudderstack/rudder-sdk-react-native/android/build.gradle
++++ b/node_modules/@rudderstack/rudder-sdk-react-native/android/build.gradle
+@@ -15,7 +15,7 @@ android {
+     compileSdkVersion 29
+ 
+     defaultConfig {
+-        minSdkVersion 16
++        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 21
+         targetSdkVersion 29
+         versionCode 1
+         versionName "1.0"
+diff --git a/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h b/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h
+index f9020d1..d2cf7c9 100644
+--- a/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h
++++ b/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h
+@@ -1,6 +1,6 @@
+ 
+-#if __has_include("RCTBridgeModule.h")
+-#import "RCTBridgeModule.h"
++#if __has_include(<React/RCTBridgeModule.h>)
++#import <React/RCTBridgeModule.h>
+ #else
+ #import <React/RCTBridgeModule.h>
+ #endif

--- a/patches/@stream-io+flat-list-mvcp+0.10.1.patch
+++ b/patches/@stream-io+flat-list-mvcp+0.10.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@stream-io/flat-list-mvcp/android/build.gradle b/node_modules/@stream-io/flat-list-mvcp/android/build.gradle
+index 1cad8fd..b0b564f 100644
+--- a/node_modules/@stream-io/flat-list-mvcp/android/build.gradle
++++ b/node_modules/@stream-io/flat-list-mvcp/android/build.gradle
+@@ -29,7 +29,7 @@ android {
+   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+   buildToolsVersion getExtOrDefault('buildToolsVersion')
+   defaultConfig {
+-    minSdkVersion 16
++    minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 21
+     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+     versionCode 1
+     versionName "1.0"

--- a/patches/react-native-hw-keyboard-event+0.0.4.patch
+++ b/patches/react-native-hw-keyboard-event+0.0.4.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/react-native-hw-keyboard-event/android/build.gradle b/node_modules/react-native-hw-keyboard-event/android/build.gradle
+index a70aace..6443899 100644
+--- a/node_modules/react-native-hw-keyboard-event/android/build.gradle
++++ b/node_modules/react-native-hw-keyboard-event/android/build.gradle
+@@ -4,7 +4,7 @@ android {
+     compileSdkVersion 28
+ 
+     defaultConfig {
+-        minSdkVersion 16
++        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 21
+         targetSdkVersion 28
+         versionCode 1
+         versionName "1.0"
 diff --git a/node_modules/react-native-hw-keyboard-event/index.d.ts b/node_modules/react-native-hw-keyboard-event/index.d.ts
 index 91999f1..53c7a42 100644
 --- a/node_modules/react-native-hw-keyboard-event/index.d.ts


### PR DESCRIPTION
#### Summary
- Bump up version of `@mattermost/react-native-emm` to `1.2.1` (https://github.com/mattermost/react-native-emm/pull/7)
- Apply patches for `@rudderstack/rudder-sdk-react-native`, `@stream-io/flat-list-mvcp`, `react-native-hw-keyboard-event`
- This so `./gradle assembleAndroidTest` builds successfully on android.

#### Release Note
```release-note
NONE
```