### PR TITLE
MM-42320: Calls - Fix for: iOS loses calls audio after leaving 1st call and entering next

### DIFF
--- a/app/products/calls/connection.ts
+++ b/app/products/calls/connection.ts
@@ -56,7 +56,12 @@ export async function newClient(channelID: string, closeCb: () => void, setScree
         if (peer) {
             peer.destroy();
         }
-        InCallManager.stop();
+
+        // Allow time for the peer to be destroyed, which avoids the following error that can cause problems with accessing the audio system:
+        // AVAudioSession_iOS.mm:1243  Deactivating an audio session that has running I/O. All I/O should be stopped or paused prior to deactivating the audio session.
+        setTimeout(() => {
+            InCallManager.stop();
+        }, 1000);
 
         if (closeCb) {
             closeCb();

--- a/app/products/calls/simple-peer.ts
+++ b/app/products/calls/simple-peer.ts
@@ -421,7 +421,12 @@ export default class Peer extends stream.Duplex {
         this.isNegotiating = true;
     }
 
-    _destroy(err: Error | null, cb: (error: Error | null) => void) {
+    destroy(err?: Error, cb?: (error: Error | null) => void): this {
+        this._destroy(err, cb);
+        return this;
+    }
+
+    _destroy(err?: Error | null, cb?: (error: Error | null) => void) {
         if (this.destroyed || this.destroying) {
             return;
         }
@@ -491,7 +496,7 @@ export default class Peer extends stream.Duplex {
                 this.emit('error', err);
             }
             this.emit('close');
-            cb(null);
+            cb?.(null);
         }, 0);
     }
 


### PR DESCRIPTION
#### Summary
- The problem was a combination of the InCallManager being stopped too quickly (before the stream was closed), and the peer connection not being closed correctly.
- Here's the weird thing: `_destroy` is being called regardless, whether or not we have a `destroy` method. So I'm not totally sure what's going on -- if `_destroy` was always being called (and it was), why is the peer connection only being shut down when we have the `destroy` function declared?
  - The `destroy` function overrides a method from the `Duplex` class... So it might be that it (and `_destroy`) is called earlier, when the peer connection is not null. When `destroy` is not there, the peerconnection is not explicitly closed.
- This should also fix MM-42612 "iOS sometimes won't let go of input (causing orange status bar)"

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-42320
- https://mattermost.atlassian.net/browse/MM-42612

#### Checklist
- [ ] ~~Added or updated unit tests (required for all new features)~~
- [ ] ~~Has UI changes~~
- [ ] ~~Includes text changes and localization file updates~~
- [ ] ~~Have tested against the 5 core themes to ensure consistency between them.~~

#### Device Information
This PR was tested on:
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Release Note
```release-note
Calls: fixed bug on iOS where users could not get microphone/audio after the first call
```
