### PR TITLE
[v1] Upgrade Commonmark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "mattermost-mobile",
       "version": "1.51.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
@@ -28,7 +27,7 @@
         "array.prototype.flat": "1.2.5",
         "base-64": "1.0.0",
         "buffer": "6.0.3",
-        "commonmark": "github:mattermost/commonmark.js#d1003be97d15414af6c21894125623c45e3f5096",
+        "commonmark": "github:mattermost/commonmark.js#90a62d97ed2dbd2d4711a5adda327128f5827983",
         "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#4e52e1725c0ef5b1e2ecfe9883220ec36c2eb67d",
         "deep-equal": "2.0.5",
         "deepmerge": "4.2.2",
@@ -7212,7 +7211,8 @@
     },
     "node_modules/commonmark": {
       "version": "0.30.0",
-      "resolved": "git+ssh://git@github.com/mattermost/commonmark.js.git#d1003be97d15414af6c21894125623c45e3f5096",
+      "resolved": "git+ssh://git@github.com/mattermost/commonmark.js.git#90a62d97ed2dbd2d4711a5adda327128f5827983",
+      "integrity": "sha512-uOpLyASVi9LYtsMcpBrxizpzfsxS459oLGbs7oroeCmEEzhabxZZQcqVKPNfhCOF4Rh8gA/05m9UCOzjBAx9Ww==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "entities": "~3.0.1",
@@ -29214,8 +29214,9 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "commonmark": {
-      "version": "git+ssh://git@github.com/mattermost/commonmark.js.git#d1003be97d15414af6c21894125623c45e3f5096",
-      "from": "commonmark@github:mattermost/commonmark.js#d1003be97d15414af6c21894125623c45e3f5096",
+      "version": "git+ssh://git@github.com/mattermost/commonmark.js.git#90a62d97ed2dbd2d4711a5adda327128f5827983",
+      "integrity": "sha512-uOpLyASVi9LYtsMcpBrxizpzfsxS459oLGbs7oroeCmEEzhabxZZQcqVKPNfhCOF4Rh8gA/05m9UCOzjBAx9Ww==",
+      "from": "commonmark@github:mattermost/commonmark.js#90a62d97ed2dbd2d4711a5adda327128f5827983",
       "requires": {
         "entities": "~3.0.1",
         "mdurl": "~1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "array.prototype.flat": "1.2.5",
         "base-64": "1.0.0",
         "buffer": "6.0.3",
-        "commonmark": "github:mattermost/commonmark.js#90a62d97ed2dbd2d4711a5adda327128f5827983",
+        "commonmark": "github:mattermost/commonmark.js#d1003be97d15414af6c21894125623c45e3f5096",
         "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#4e52e1725c0ef5b1e2ecfe9883220ec36c2eb67d",
         "deep-equal": "2.0.5",
         "deepmerge": "4.2.2",
@@ -7212,7 +7212,7 @@
     },
     "node_modules/commonmark": {
       "version": "0.30.0",
-      "resolved": "git+ssh://git@github.com/mattermost/commonmark.js.git#90a62d97ed2dbd2d4711a5adda327128f5827983",
+      "resolved": "git+ssh://git@github.com/mattermost/commonmark.js.git#d1003be97d15414af6c21894125623c45e3f5096",
       "license": "BSD-2-Clause",
       "dependencies": {
         "entities": "~3.0.1",
@@ -29214,8 +29214,8 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "commonmark": {
-      "version": "git+ssh://git@github.com/mattermost/commonmark.js.git#90a62d97ed2dbd2d4711a5adda327128f5827983",
-      "from": "commonmark@github:mattermost/commonmark.js#90a62d97ed2dbd2d4711a5adda327128f5827983",
+      "version": "git+ssh://git@github.com/mattermost/commonmark.js.git#d1003be97d15414af6c21894125623c45e3f5096",
+      "from": "commonmark@github:mattermost/commonmark.js#d1003be97d15414af6c21894125623c45e3f5096",
       "requires": {
         "entities": "~3.0.1",
         "mdurl": "~1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "array.prototype.flat": "1.2.5",
         "base-64": "1.0.0",
         "buffer": "6.0.3",
-        "commonmark": "github:mattermost/commonmark.js#90a62d97ed2dbd2d4711a5adda327128f5827983",
+        "commonmark": "github:mattermost/commonmark.js#d1003be97d15414af6c21894125623c45e3f5096",
         "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#4e52e1725c0ef5b1e2ecfe9883220ec36c2eb67d",
         "deep-equal": "2.0.5",
         "deepmerge": "4.2.2",
@@ -7211,8 +7211,8 @@
     },
     "node_modules/commonmark": {
       "version": "0.30.0",
-      "resolved": "git+ssh://git@github.com/mattermost/commonmark.js.git#90a62d97ed2dbd2d4711a5adda327128f5827983",
-      "integrity": "sha512-uOpLyASVi9LYtsMcpBrxizpzfsxS459oLGbs7oroeCmEEzhabxZZQcqVKPNfhCOF4Rh8gA/05m9UCOzjBAx9Ww==",
+      "resolved": "git+ssh://git@github.com/mattermost/commonmark.js.git#d1003be97d15414af6c21894125623c45e3f5096",
+      "integrity": "sha512-80VOWbVPw7LzPokYFKLVDsB9xdbfb3o4vBE0fPPronTJX84vDI37iqeud20Th6r4DZtghRkR9AJjBhYmC2jlsg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "entities": "~3.0.1",
@@ -29214,9 +29214,9 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "commonmark": {
-      "version": "git+ssh://git@github.com/mattermost/commonmark.js.git#90a62d97ed2dbd2d4711a5adda327128f5827983",
-      "integrity": "sha512-uOpLyASVi9LYtsMcpBrxizpzfsxS459oLGbs7oroeCmEEzhabxZZQcqVKPNfhCOF4Rh8gA/05m9UCOzjBAx9Ww==",
-      "from": "commonmark@github:mattermost/commonmark.js#90a62d97ed2dbd2d4711a5adda327128f5827983",
+      "version": "git+ssh://git@github.com/mattermost/commonmark.js.git#d1003be97d15414af6c21894125623c45e3f5096",
+      "integrity": "sha512-80VOWbVPw7LzPokYFKLVDsB9xdbfb3o4vBE0fPPronTJX84vDI37iqeud20Th6r4DZtghRkR9AJjBhYmC2jlsg==",
+      "from": "commonmark@github:mattermost/commonmark.js#d1003be97d15414af6c21894125623c45e3f5096",
       "requires": {
         "entities": "~3.0.1",
         "mdurl": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "array.prototype.flat": "1.2.5",
     "base-64": "1.0.0",
     "buffer": "6.0.3",
-    "commonmark": "github:mattermost/commonmark.js#90a62d97ed2dbd2d4711a5adda327128f5827983",
+    "commonmark": "github:mattermost/commonmark.js#d1003be97d15414af6c21894125623c45e3f5096",
     "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#4e52e1725c0ef5b1e2ecfe9883220ec36c2eb67d",
     "deep-equal": "2.0.5",
     "deepmerge": "4.2.2",


### PR DESCRIPTION
#### Summary
Fixes an issue where some messages could have been cut off if the markdown used had two or more links with an `=` sign

The actual fix is here https://github.com/mattermost/commonmark.js/pull/15

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43139

```release-note
Fixes an issue where some messages could have been cut off if the markdown used had two or more links with an `=` sign
```
