### PR TITLE
[Gekidou] Fix update lastPostAt

### DIFF
--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -358,6 +358,8 @@ export async function updateLastPostAt(serverUrl: string, channelId: string, las
         } catch (error) {
             return {error};
         }
+
+        return {member};
     }
 
     return {member: undefined};

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -131,6 +131,10 @@ export async function createPost(serverUrl: string, post: Partial<Post>, files: 
             posts: [created],
             prepareRecordsOnly: true,
         });
+        const {member} = await updateLastPostAt(serverUrl, created.channel_id, created.create_at, true);
+        if (member) {
+            models.push(member);
+        }
         if (isCRTEnabled) {
             const {models: threadModels} = await createThreadFromNewPost(serverUrl, created, true);
             if (threadModels?.length) {


### PR DESCRIPTION
#### Summary
LastPostAt was not being updated as the prepare function was always returning `undefined` instead of the prepared model, apart from that we needed to update the last post at when posting a new message

#### Release Note
```release-note
NONE
```
