### PR TITLE
[Gekidou] Fix bottom sheet initial animation

### DIFF
--- a/app/components/post_list/combined_user_activity/combined_user_activity.tsx
+++ b/app/components/post_list/combined_user_activity/combined_user_activity.tsx
@@ -114,7 +114,7 @@ const CombinedUserActivity = ({
         if (isTablet) {
             showModal(Screens.POST_OPTIONS, title, passProps, bottomSheetModalOptions(theme, 'close-post-options'));
         } else {
-            showModalOverCurrentContext(Screens.POST_OPTIONS, passProps);
+            showModalOverCurrentContext(Screens.POST_OPTIONS, passProps, bottomSheetModalOptions(theme));
         }
     }, [post, canDelete, isTablet, intl]);
 

--- a/app/components/post_list/post/body/reactions/reactions.tsx
+++ b/app/components/post_list/post/body/reactions/reactions.tsx
@@ -147,7 +147,7 @@ const Reactions = ({currentUserId, canAddReaction, canRemoveReaction, disabled, 
             if (isTablet) {
                 showModal(screen, title, passProps, bottomSheetModalOptions(theme, 'close-post-reactions'));
             } else {
-                showModalOverCurrentContext(screen, passProps);
+                showModalOverCurrentContext(screen, passProps, bottomSheetModalOptions(theme));
             }
         }
     }, [intl, isTablet, postId, theme]);

--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -172,7 +172,7 @@ const Post = ({
         if (isTablet) {
             showModal(Screens.POST_OPTIONS, title, passProps, bottomSheetModalOptions(theme, 'close-post-options'));
         } else {
-            showModalOverCurrentContext(Screens.POST_OPTIONS, passProps);
+            showModalOverCurrentContext(Screens.POST_OPTIONS, passProps, bottomSheetModalOptions(theme));
         }
     };
 

--- a/app/components/post_list/thread_overview/thread_overview.tsx
+++ b/app/components/post_list/thread_overview/thread_overview.tsx
@@ -80,7 +80,7 @@ const ThreadOverview = ({isSaved, repliesCount, rootPost, style, testID}: Props)
             if (isTablet) {
                 showModal(Screens.POST_OPTIONS, title, passProps, bottomSheetModalOptions(theme, 'close-post-options'));
             } else {
-                showModalOverCurrentContext(Screens.POST_OPTIONS, passProps);
+                showModalOverCurrentContext(Screens.POST_OPTIONS, passProps, bottomSheetModalOptions(theme));
             }
         }
     }), [rootPost]);

--- a/app/screens/bottom_sheet/index.tsx
+++ b/app/screens/bottom_sheet/index.tsx
@@ -30,10 +30,13 @@ const BottomSheet = ({closeButtonId, componentId, initialSnapIndex = 0, renderCo
     const dimensions = useWindowDimensions();
     const isTablet = useIsTablet();
     const theme = useTheme();
+    const firstRun = useRef(isTablet);
     const lastSnap = snapPoints.length - 1;
 
     const close = useCallback(() => {
-        dismissModal({componentId});
+        if (firstRun.current) {
+            dismissModal({componentId});
+        }
     }, [componentId]);
 
     useEffect(() => {
@@ -65,6 +68,11 @@ const BottomSheet = ({closeButtonId, componentId, initialSnapIndex = 0, renderCo
         hapticFeedback();
         Keyboard.dismiss();
         sheetRef.current?.snapTo(initialSnapIndex);
+        const t = setTimeout(() => {
+            firstRun.current = true;
+        }, 100);
+
+        return () => clearTimeout(t);
     }, []);
 
     useEffect(() => {
@@ -89,7 +97,7 @@ const BottomSheet = ({closeButtonId, componentId, initialSnapIndex = 0, renderCo
                 }}
             >
                 <Animated.View
-                    style={{...StyleSheet.absoluteFillObject, backgroundColor: 'rgba(0, 0, 0, 0.5)'}}
+                    style={StyleSheet.absoluteFill}
                 />
             </TapGestureHandler>
         );
@@ -127,10 +135,10 @@ const BottomSheet = ({closeButtonId, componentId, initialSnapIndex = 0, renderCo
                 ref={sheetRef}
                 snapPoints={snapPoints}
                 borderRadius={10}
-                initialSnap={initialSnapIndex}
+                initialSnap={snapPoints.length - 1}
                 renderContent={renderContainerContent}
                 onCloseEnd={close}
-                enabledBottomInitialAnimation={true}
+                enabledBottomInitialAnimation={false}
                 renderHeader={Indicator}
                 enabledContentTapInteraction={false}
             />

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -76,27 +76,44 @@ export const loginAnimationOptions = () => {
     };
 };
 
-export const bottomSheetModalOptions = (theme: Theme, closeButtonId: string) => {
-    const closeButton = CompassIcon.getImageSourceSync('close', 24, theme.centerChannelColor);
+export const bottomSheetModalOptions = (theme: Theme, closeButtonId?: string) => {
+    if (closeButtonId) {
+        const closeButton = CompassIcon.getImageSourceSync('close', 24, theme.centerChannelColor);
+        return {
+            modalPresentationStyle: OptionsModalPresentationStyle.formSheet,
+            modal: {
+                swipeToDismiss: true,
+            },
+            topBar: {
+                leftButtons: [{
+                    id: closeButtonId,
+                    icon: closeButton,
+                    testID: closeButtonId,
+                }],
+                leftButtonColor: changeOpacity(theme.centerChannelColor, 0.56),
+                background: {
+                    color: theme.centerChannelBg,
+                },
+                title: {
+                    color: theme.centerChannelColor,
+                },
+            },
+        };
+    }
+
     return {
-        modalPresentationStyle: OptionsModalPresentationStyle.formSheet,
-        modal: {
-            swipeToDismiss: true,
+        layout: {
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
         },
-        topBar: {
-            leftButtons: [{
-                id: closeButtonId,
-                icon: closeButton,
-                testID: closeButtonId,
-            }],
-            leftButtonColor: changeOpacity(theme.centerChannelColor, 0.56),
-            background: {
-                color: theme.centerChannelBg,
+        animations: {
+            showModal: {
+                enabled: false,
             },
-            title: {
-                color: theme.centerChannelColor,
+            dismissModal: {
+                enabled: false,
             },
         },
+        modal: {swipeToDismiss: true},
     };
 };
 
@@ -654,7 +671,7 @@ export async function bottomSheet({title, renderContent, snapPoints, initialSnap
             initialSnapIndex,
             renderContent,
             snapPoints,
-        }, {modal: {swipeToDismiss: true}});
+        }, bottomSheetModalOptions(theme));
     }
 }
 

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -102,9 +102,6 @@ export const bottomSheetModalOptions = (theme: Theme, closeButtonId?: string) =>
     }
 
     return {
-        layout: {
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        },
         animations: {
             showModal: {
                 enabled: false,
@@ -114,6 +111,11 @@ export const bottomSheetModalOptions = (theme: Theme, closeButtonId?: string) =>
             },
         },
         modal: {swipeToDismiss: true},
+        statusBar: {
+            backgroundColor: null,
+            drawBehind: true,
+            translucent: true,
+        },
     };
 };
 


### PR DESCRIPTION
#### Summary
Instead of setting the BottomSheet initialSnap to the opened index, we set it to the one closed and set the value of `enabledBottomInitialAnimation` so that it does not animate automatically. Then on mount, we snap to the initial index so that the animation run smoothly.

We now are passing options to `showModalOverCurrentContext` when opening the bottom sheet, to remove the alpha animation on the modal.

in the bottom sheet component, I added a ref for `firstRun` so that when `close` triggers the first time it does not do anything until we animate the bottom sheet to open for the first time (as soon as the component mounts).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42698

#### Release Note
```release-note
NONE
```
