### PR TITLE
[Gekidou] Fix create DM when searching profile

### DIFF
--- a/app/screens/create_direct_message/create_direct_message.tsx
+++ b/app/screens/create_direct_message/create_direct_message.tsx
@@ -149,7 +149,7 @@ export default function CreateDirectMessage({
     }, [selectedIds]);
 
     const createDirectChannel = useCallback(async (id: string): Promise<boolean> => {
-        const user = profiles.find((u) => u.id === id);
+        const user = selectedIds[id];
 
         const displayName = displayUsername(user, intl.locale, teammateNameDisplay);
 
@@ -170,7 +170,7 @@ export default function CreateDirectMessage({
         }
 
         return !result.error;
-    }, [profiles, intl.locale, teammateNameDisplay, serverUrl]);
+    }, [selectedIds, intl.locale, teammateNameDisplay, serverUrl]);
 
     const createGroupChannel = useCallback(async (ids: string[]): Promise<boolean> => {
         const result = await makeGroupChannel(serverUrl, ids);


### PR DESCRIPTION
#### Summary
When searching for a user the display name of the channel was set incorrectly as we were looking into the loaded profiles instead of the selected profiles.

```release-note
NONE
```
