### PR TITLE
Gekidou - Removed redundant getConfig call

### DIFF
--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -34,7 +34,6 @@ export const getThreadById = async (database: Database, threadId: string) => {
 };
 
 export const observeIsCRTEnabled = (database: Database) => {
-    getConfig(database);
     const config = observeConfig(database);
     const preferences = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS).observe();
     return combineLatest([config, preferences]).pipe(


### PR DESCRIPTION
#### Summary
While going through the code I notice that we are calling getConfig but not using it; hence, this PR removes it.


#### Release Note
```release-note
NONE
```