### PR TITLE
[Gekidou] unreads category section

### DIFF
--- a/app/components/channel_list/categories/categories.tsx
+++ b/app/components/channel_list/categories/categories.tsx
@@ -27,15 +27,26 @@ const styles = StyleSheet.create({
     },
 });
 
-const extractKey = (item: CategoryModel) => item.id;
+const extractKey = (item: CategoryModel) => (Array.isArray(item) ? 'UNREADS' : item.id);
 
 const Categories = ({categories, currentChannelId, currentUserId, currentTeamId, unreadChannels}: Props) => {
     const intl = useIntl();
     const listRef = useRef<FlatList>(null);
 
     const unreadChannelIds = useMemo(() => new Set(unreadChannels.map((myC) => myC.id)), [unreadChannels]);
+    const categoriesToDisplay: Array<CategoryModel|string[]> = useMemo(() => {
+        if (unreadChannelIds.size) {
+            return [Array.from(unreadChannelIds), ...categories];
+        }
 
-    const renderCategory = useCallback((data: {item: CategoryModel}) => {
+        return categories;
+    }, [categories, unreadChannelIds]);
+
+    const renderCategory = useCallback((data: {item: CategoryModel | string[]}) => {
+        if (Array.isArray(data.item)) {
+            return <UnreadCategories unreadChannels={unreadChannels}/>;
+        }
+
         return (
             <>
                 <CategoryHeader category={data.item}/>
@@ -48,7 +59,7 @@ const Categories = ({categories, currentChannelId, currentUserId, currentTeamId,
                 />
             </>
         );
-    }, [categories, currentChannelId, intl.locale]);
+    }, [categories, currentChannelId, intl.locale, unreadChannels]);
 
     useEffect(() => {
         listRef.current?.scrollToOffset({animated: false, offset: 0});
@@ -62,23 +73,20 @@ const Categories = ({categories, currentChannelId, currentUserId, currentTeamId,
     }
 
     return (
-        <>
-            {unreadChannels.length > 0 && <UnreadCategories unreadChannels={unreadChannels}/>}
-            <FlatList
-                data={categories}
-                ref={listRef}
-                renderItem={renderCategory}
-                style={styles.mainList}
-                showsHorizontalScrollIndicator={false}
-                showsVerticalScrollIndicator={false}
-                keyExtractor={extractKey}
-                removeClippedSubviews={true}
-                initialNumToRender={5}
-                windowSize={15}
-                updateCellsBatchingPeriod={10}
-                maxToRenderPerBatch={5}
-            />
-        </>
+        <FlatList
+            data={categoriesToDisplay}
+            ref={listRef}
+            renderItem={renderCategory}
+            style={styles.mainList}
+            showsHorizontalScrollIndicator={false}
+            showsVerticalScrollIndicator={false}
+            keyExtractor={extractKey}
+            removeClippedSubviews={true}
+            initialNumToRender={5}
+            windowSize={15}
+            updateCellsBatchingPeriod={10}
+            maxToRenderPerBatch={5}
+        />
     );
 };
 

--- a/app/components/channel_list/categories/index.ts
+++ b/app/components/channel_list/categories/index.ts
@@ -29,7 +29,7 @@ const enhanced = withObservables(
         const categories = queryCategoriesByTeamIds(database, [currentTeamId]).observeWithColumns(['sort_order']);
 
         const unreadsOnTop = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS).
-            observe().
+            observeWithColumns(['value']).
             pipe(
                 switchMap((prefs: PreferenceModel[]) => of$(getPreferenceAsBool(prefs, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS, false))),
             );

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -377,9 +377,12 @@ export const queryMyChannelUnreads = (database: Database, currentTeamId: string)
     return database.get<MyChannelModel>(MY_CHANNEL).query(
         Q.on(
             CHANNEL,
-            Q.or(
-                Q.where('team_id', Q.eq(currentTeamId)),
-                Q.where('team_id', Q.eq('')),
+            Q.and(
+                Q.or(
+                    Q.where('team_id', Q.eq(currentTeamId)),
+                    Q.where('team_id', Q.eq('')),
+                ),
+                Q.where('delete_at', Q.eq(0)),
             ),
         ),
         Q.where('is_unread', Q.eq(true)),


### PR DESCRIPTION
#### Summary
This PR fixes the unreads category section by:
* Observe the value column of the preferences in case the unreads section preferences toggle its value
* Exclude archived channels from the unreads category section
* To be able to scroll through all categories including the unreads one, we now include the render on the section in the `renderItems` of the Categories FlatList, without it if there are enough unreads scrolling to other categories is impossible.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43326

#### Release Note
```release-note
NONE
```
