### PR TITLE
[Gekidou] bugs squash

### DIFF
--- a/app/components/jumbo_emoji/index.tsx
+++ b/app/components/jumbo_emoji/index.tsx
@@ -43,6 +43,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             fontSize: 50,
             lineHeight: 60,
         },
+        newLine: {
+            lineHeight: 60,
+        },
     };
 });
 
@@ -74,7 +77,7 @@ const JumboEmoji = ({baseTextStyle, isEdited, value}: JumboEmojiProps) => {
     };
 
     const renderNewLine = () => {
-        return <Text style={baseTextStyle}>{'\n'}</Text>;
+        return <Text style={[baseTextStyle, style.newLine]}>{'\n'}</Text>;
     };
 
     const renderEditedIndicator = ({context}: {context: string[]}) => {

--- a/app/components/post_list/more_messages/more_messages.tsx
+++ b/app/components/post_list/more_messages/more_messages.tsx
@@ -11,6 +11,7 @@ import FormattedText from '@components/formatted_text';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {Events} from '@constants';
 import {useServerUrl} from '@context/server';
+import {useIsTablet} from '@hooks/device';
 import {makeStyleSheetFromTheme, hexToHue} from '@utils/theme';
 import {typography} from '@utils/typography';
 
@@ -30,7 +31,7 @@ type Props = {
 }
 
 const HIDDEN_TOP = -60;
-const SHOWN_TOP = Platform.select({ios: 40, default: 0});
+const SHOWN_TOP = Platform.select({ios: 50, default: 5});
 const MIN_INPUT = 0;
 const MAX_INPUT = 1;
 
@@ -101,6 +102,7 @@ const MoreMessages = ({
     theme,
 }: Props) => {
     const serverUrl = useServerUrl();
+    const isTablet = useIsTablet();
     const pressed = useRef(false);
     const resetting = useRef(false);
     const initialScroll = useRef(false);
@@ -108,6 +110,7 @@ const MoreMessages = ({
     const [remaining, setRemaining] = useState(0);
     const underlayColor = useMemo(() => `hsl(${hexToHue(theme.buttonBg)}, 50%, 38%)`, [theme]);
     const top = useSharedValue(0);
+    const shownTop = isTablet ? 5 : SHOWN_TOP;
     const BARS_FACTOR = Math.abs((1) / (HIDDEN_TOP - SHOWN_TOP));
     const styles = getStyleSheet(theme);
     const animatedStyle = useAnimatedStyle(() => ({
@@ -123,13 +126,13 @@ const MoreMessages = ({
                 [
                     HIDDEN_TOP,
                     HIDDEN_TOP,
-                    SHOWN_TOP,
-                    SHOWN_TOP,
+                    shownTop,
+                    shownTop,
                 ],
                 Animated.Extrapolate.CLAMP,
             ), {damping: 15}),
         }],
-    }), []);
+    }), [isTablet, shownTop]);
 
     const resetCount = async () => {
         if (resetting.current) {

--- a/app/components/post_list/post/body/files/files.tsx
+++ b/app/components/post_list/post/body/files/files.tsx
@@ -100,7 +100,7 @@ const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, l
     const renderItems = (items: FileInfo[], moreImagesCount = 0, includeGutter = false) => {
         const singleImage = isSingleImage();
         let nonVisibleImagesCount: number;
-        let container: StyleProp<ViewStyle> = styles.container;
+        let container: StyleProp<ViewStyle> = items.length > 1 ? styles.container : undefined;
         const containerWithGutter = [container, styles.gutter];
 
         return items.map((file, idx) => {

--- a/app/screens/bottom_sheet/index.tsx
+++ b/app/screens/bottom_sheet/index.tsx
@@ -150,6 +150,9 @@ const BottomSheet = ({closeButtonId, componentId, initialSnapIndex = 0, renderCo
                 onCloseStart={() => {
                     backdropOpacity.value = 0;
                 }}
+                onOpenEnd={() => {
+                    backdropOpacity.value = 1;
+                }}
                 enabledBottomInitialAnimation={false}
                 renderHeader={Indicator}
                 enabledContentTapInteraction={false}


### PR DESCRIPTION
#### Summary
* [Fix JumboEmoji cutoff on Android](https://github.com/mattermost/mattermost-mobile/commit/4540670e73b75dfb11cb51d5f2cc7c219e857794) by setting the lineHeight for the new line separator
* [MM-43604 Fix More messages bar position](https://github.com/mattermost/mattermost-mobile/commit/900d7b163392d37b3589212dece644c5a323b630) by setting different values for iOS, Tablet and Android
* [MM-43532 Fix tap next to a single image to open trigger onPress](https://github.com/mattermost/mattermost-mobile/commit/00e56d9c5b0338d9833d792a396c296c84d87c1f) By removing the flex container for single attachments
* [MM-43606 Show backdrop when canceling the bottom sheet close](https://github.com/mattermost/mattermost-mobile/commit/34f8d12d83d786a34ca7ef67002565c0a0456dc3) by reverting the opacity when the bottom sheet opens

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43532
https://mattermost.atlassian.net/browse/MM-43606
https://mattermost.atlassian.net/browse/MM-43604
https://mattermost.atlassian.net/browse/MM-43605

```release-note
NONE
```
