### PR TITLE
Show login options when using multiple SSO login methods

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -259,7 +259,7 @@ export default class SelectServer extends PureComponent {
             screen = 'SSO';
             title = formatMessage({id: 'mobile.routes.sso', defaultMessage: 'Single Sign-On'});
             props = {ssoType: enabledSSOs[0]};
-        } else if (hasLoginForm && numberSSOs > 0) {
+        } else if ((hasLoginForm && numberSSOs > 0) || numberSSOs > 1) {
             screen = 'LoginOptions';
             title = formatMessage({id: 'mobile.routes.loginOptions', defaultMessage: 'Login Chooser'});
         } else {


### PR DESCRIPTION
#### Summary
When multiple SSO's are available and email/password is not were were not showing the LoginOptions screen. This PR should fix it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43607

Fixes: #6183

#### Release Note
```release-note
Fixed Login when multiple SSO methods are enabled while email/password is disabled.
```
