### PR TITLE
[Gekidou] set badge count on cancel notifications

### DIFF
--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -9,6 +9,7 @@ import {CHANNELS_CATEGORY, DMS_CATEGORY} from '@constants/categories';
 import DatabaseManager from '@database/manager';
 import {getTeammateNameDisplaySetting} from '@helpers/api/preference';
 import {extractChannelDisplayName} from '@helpers/database';
+import PushNotifications from '@init/push_notifications';
 import {prepareDeleteChannel, prepareMyChannelsForTeam, queryAllMyChannel, getMyChannel, getChannelById, queryUsersOnChannel} from '@queries/servers/channel';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {prepareCommonSystemValues, PrepareCommonSystemValuesArgs, getCommonSystemValues, getCurrentTeamId, setCurrentChannelId, getCurrentUserId} from '@queries/servers/system';
@@ -88,6 +89,8 @@ export async function switchToChannel(serverUrl: string, channelId: string, team
                 if (models.length && !prepareRecordsOnly) {
                     await operator.batchRecords(models);
                 }
+
+                PushNotifications.cancelChannelNotifications(channelId);
 
                 if (!EphemeralStore.theme) {
                     // When opening the app from a push notification the theme may not be set in the EphemeralStore

--- a/app/database/subscription/unreads.ts
+++ b/app/database/subscription/unreads.ts
@@ -7,9 +7,9 @@ import {combineLatestWith} from 'rxjs/operators';
 
 import {MM_TABLES} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {observeThreadMentionCount} from '@queries/servers/thread';
-
-import type MyChannelModel from '@typings/database/models/servers/my_channel';
+import {queryMyTeams} from '@queries/servers/team';
+import {getIsCRTEnabled, observeThreadMentionCount, queryThreads} from '@queries/servers/thread';
+import MyChannelModel from '@typings/database/models/servers/my_channel';
 
 const {SERVER: {CHANNEL, MY_CHANNEL}} = MM_TABLES;
 
@@ -71,4 +71,38 @@ export const subscribeUnreadAndMentionsByServer = (serverUrl: string, observer: 
     }
 
     return subscription;
+};
+
+export const getTotalMentionsForServer = async (serverUrl: string) => {
+    const server = DatabaseManager.serverDatabases[serverUrl];
+    let count = 0;
+    if (server?.database) {
+        const {database} = server;
+        const myChannels = await database.get<MyChannelModel>(MY_CHANNEL).
+            query(
+                Q.on(CHANNEL, Q.where('delete_at', Q.eq(0))),
+                Q.where('mentions_count', Q.gt(0)),
+            ).fetch();
+
+        for (const mc of myChannels) {
+            count += mc.mentionsCount;
+        }
+
+        const isCRTEnabled = await getIsCRTEnabled(database);
+        if (isCRTEnabled) {
+            let includeDmGm = true;
+            const myTeamIds = await queryMyTeams(database).fetchIds();
+            for await (const teamId of myTeamIds) {
+                const threads = await queryThreads(database, teamId, false, includeDmGm).extend(
+                    Q.where('unread_mentions', Q.gt(0)),
+                ).fetch();
+                includeDmGm = false;
+                for (const t of threads) {
+                    count += t.unreadMentions;
+                }
+            }
+        }
+    }
+
+    return count;
 };


### PR DESCRIPTION
#### Summary
* When switching channels we'll call `cancelChannelNotifications` to remove notifications that belong to the channel.
* When canceling notifications on iOS we will update the badge number to match the remaining mentions on all servers.
* Once the app receives a clear notification (which depends on  https://github.com/mattermost/mattermost-push-proxy/pull/102) we also run `cancelChannelNotifications`
* Adds a suffix to the deviceId platform being registered in the session. Once this PR is merged we need to make sure the previous referenced PR for the push proxy is merged and deployed in order to properly receive notifications.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43486

```release-note
NONE
```
