### PR TITLE
[Gekidou] Show login screen when selecting a previous server

### DIFF
--- a/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
@@ -9,7 +9,9 @@ import Swipeable from 'react-native-gesture-handler/Swipeable';
 
 import {storeMultiServerTutorial} from '@actions/app/global';
 import {appEntry} from '@actions/remote/entry';
+import {doPing} from '@actions/remote/general';
 import {logout} from '@actions/remote/session';
+import {fetchConfigAndLicense} from '@actions/remote/systems';
 import CompassIcon from '@components/compass_icon';
 import Loading from '@components/loading';
 import ServerIcon from '@components/server_icon';
@@ -21,7 +23,7 @@ import DatabaseManager from '@database/manager';
 import {subscribeServerUnreadAndMentions} from '@database/subscription/unreads';
 import {useIsTablet} from '@hooks/device';
 import {dismissBottomSheet} from '@screens/navigation';
-import {addNewServer, alertServerLogout, alertServerRemove, editServer} from '@utils/server';
+import {alertServerError, alertServerLogout, alertServerRemove, editServer, loginToServer} from '@utils/server';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 import {removeProtocol, stripTrailingSlashes} from '@utils/url';
@@ -195,8 +197,22 @@ const ServerItem = ({highlight, isActive, server, tutorialWatched}: Props) => {
         return style;
     }, [server.lastActiveAt]);
 
-    const handleLogin = useCallback(() => {
-        addNewServer(theme, server.url, displayName);
+    const handleLogin = useCallback(async () => {
+        swipeable.current?.close();
+        setSwitching(true);
+        const result = await doPing(server.url);
+        if (result.error) {
+            alertServerError(intl, result.error as ClientErrorProps);
+            setSwitching(false);
+            return;
+        }
+        const data = await fetchConfigAndLicense(server.url, true);
+        if (data.error) {
+            alertServerError(intl, result.error as ClientErrorProps);
+            setSwitching(false);
+            return;
+        }
+        loginToServer(theme, server.url, displayName, data.config!, data.license!);
     }, [server, theme, intl]);
 
     const handleDismissTutorial = useCallback(() => {

--- a/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
@@ -208,7 +208,7 @@ const ServerItem = ({highlight, isActive, server, tutorialWatched}: Props) => {
         }
         const data = await fetchConfigAndLicense(server.url, true);
         if (data.error) {
-            alertServerError(intl, result.error as ClientErrorProps);
+            alertServerError(intl, data.error as ClientErrorProps);
             setSwitching(false);
             return;
         }

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -184,6 +184,8 @@ export function resetToHome(passProps: LaunchProps = {launchType: LaunchType.Nor
 
     if (passProps.launchType === LaunchType.AddServer) {
         dismissModal({componentId: Screens.SERVER});
+        dismissModal({componentId: Screens.LOGIN});
+        dismissModal({componentId: Screens.SSO});
         dismissModal({componentId: Screens.BOTTOM_SHEET});
         return;
     }

--- a/app/screens/sso/sso.test.tsx
+++ b/app/screens/sso/sso.test.tsx
@@ -23,6 +23,7 @@ jest.mock('@utils/url', () => {
 
 describe('SSO', () => {
     const baseProps = {
+        componentId: 'SSO',
         license: {
             IsLicensed: 'true',
         },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -270,6 +270,9 @@ jest.mock('react-native-navigation', () => {
                 bindComponent: jest.fn(() => {
                     return {remove: jest.fn()};
                 }),
+                registerNavigationButtonPressedListener: jest.fn(() => {
+                    return {buttonId: 'buttonId'};
+                }),
             }),
             setRoot: jest.fn(),
             pop: jest.fn(),


### PR DESCRIPTION
#### Summary
When selecting a server without an active session from the server list, take the user directly to the login screen and bypass the Add Server screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43640

```release-note
NONE
```
