### PR TITLE
MM-43904 - Fix: Calls: "Access to route for non-existent plugin" error log

### DIFF
--- a/app/client/rest/base.ts
+++ b/app/client/rest/base.ts
@@ -7,6 +7,7 @@
 import {RNFetchBlobFetchRepsonse} from 'rn-fetch-blob';
 import urlParse from 'url-parse';
 
+import Calls from '@constants/calls';
 import {Options} from '@mm-redux/types/client4';
 
 import * as ClientConstants from './constants';
@@ -286,12 +287,16 @@ export default class ClientBase {
         return `${this.getUserThreadsRoute(userId, teamId)}/${threadId}`;
     }
 
+    getPluginsRoute() {
+        return `${this.getBaseRoute()}/plugins`;
+    }
+
     getAppsProxyRoute() {
         return `${this.url}/plugins/com.mattermost.apps`;
     }
 
     getCallsRoute() {
-        return `${this.url}/plugins/com.mattermost.calls`;
+        return `${this.url}/plugins/${Calls.PluginId}`;
     }
 
     // Client Helpers

--- a/app/client/rest/index.ts
+++ b/app/client/rest/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import ClientPlugins, {ClientPluginsMix} from '@client/rest/plugins';
 import ClientCalls, {ClientCallsMix} from '@mmproducts/calls/client/rest';
 import mix from '@utils/mix';
 
@@ -36,7 +37,8 @@ interface Client extends ClientBase,
     ClientTeamsMix,
     ClientTosMix,
     ClientUsersMix,
-    ClientCallsMix
+    ClientCallsMix,
+    ClientPluginsMix
 {}
 
 class Client extends mix(ClientBase).with(
@@ -55,6 +57,7 @@ class Client extends mix(ClientBase).with(
     ClientTos,
     ClientUsers,
     ClientCalls,
+    ClientPlugins,
 ) {}
 
 const Client4 = new Client();

--- a/app/client/rest/plugins.ts
+++ b/app/client/rest/plugins.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {ClientPluginManifest} from '@mm-redux/types/plugins';
+
+export interface ClientPluginsMix {
+    getPluginsManifests: () => Promise<ClientPluginManifest[]>;
+}
+
+const ClientPlugins = (superclass: any) => class extends superclass {
+    getPluginsManifests = async () => {
+        return this.doFetch(
+            `${this.getPluginsRoute()}/webapp`,
+            {method: 'get'},
+        );
+    };
+};
+
+export default ClientPlugins;

--- a/app/constants/calls.ts
+++ b/app/constants/calls.ts
@@ -10,4 +10,6 @@ const RequiredServer = {
     PATCH_VERSION: 0,
 };
 
-export default {RequiredServer, RefreshConfigMillis};
+const PluginId = 'com.mattermost.calls';
+
+export default {RequiredServer, RefreshConfigMillis, PluginId};

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -1,5 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import Calls from '@constants/calls';
+
 const WebsocketEvents = {
     POSTED: 'posted',
     POST_EDITED: 'post_edited',
@@ -53,18 +56,18 @@ const WebsocketEvents = {
     SIDEBAR_CATEGORY_UPDATED: 'sidebar_category_updated',
     SIDEBAR_CATEGORY_DELETED: 'sidebar_category_deleted',
     SIDEBAR_CATEGORY_ORDER_UPDATED: 'sidebar_category_order_updated',
-    CALLS_CHANNEL_ENABLED: 'custom_com.mattermost.calls_channel_enable_voice',
-    CALLS_CHANNEL_DISABLED: 'custom_com.mattermost.calls_channel_disable_voice',
-    CALLS_USER_CONNECTED: 'custom_com.mattermost.calls_user_connected',
-    CALLS_USER_DISCONNECTED: 'custom_com.mattermost.calls_user_disconnected',
-    CALLS_USER_MUTED: 'custom_com.mattermost.calls_user_muted',
-    CALLS_USER_UNMUTED: 'custom_com.mattermost.calls_user_unmuted',
-    CALLS_USER_VOICE_ON: 'custom_com.mattermost.calls_user_voice_on',
-    CALLS_USER_VOICE_OFF: 'custom_com.mattermost.calls_user_voice_off',
-    CALLS_CALL_START: 'custom_com.mattermost.calls_call_start',
-    CALLS_SCREEN_ON: 'custom_com.mattermost.calls_user_screen_on',
-    CALLS_SCREEN_OFF: 'custom_com.mattermost.calls_user_screen_off',
-    CALLS_USER_RAISE_HAND: 'custom_com.mattermost.calls_user_raise_hand',
-    CALLS_USER_UNRAISE_HAND: 'custom_com.mattermost.calls_user_unraise_hand',
+    CALLS_CHANNEL_ENABLED: `custom_${Calls.PluginId}_channel_enable_voice`,
+    CALLS_CHANNEL_DISABLED: `custom_${Calls.PluginId}_channel_disable_voice`,
+    CALLS_USER_CONNECTED: `custom_${Calls.PluginId}_user_connected`,
+    CALLS_USER_DISCONNECTED: `custom_${Calls.PluginId}_user_disconnected`,
+    CALLS_USER_MUTED: `custom_${Calls.PluginId}_user_muted`,
+    CALLS_USER_UNMUTED: `custom_${Calls.PluginId}_user_unmuted`,
+    CALLS_USER_VOICE_ON: `custom_${Calls.PluginId}_user_voice_on`,
+    CALLS_USER_VOICE_OFF: `custom_${Calls.PluginId}_user_voice_off`,
+    CALLS_CALL_START: `custom_${Calls.PluginId}_call_start`,
+    CALLS_SCREEN_ON: `custom_${Calls.PluginId}_user_screen_on`,
+    CALLS_SCREEN_OFF: `custom_${Calls.PluginId}_user_screen_off`,
+    CALLS_USER_RAISE_HAND: `custom_${Calls.PluginId}_user_raise_hand`,
+    CALLS_USER_UNRAISE_HAND: `custom_${Calls.PluginId}_user_unraise_hand`,
 };
 export default WebsocketEvents;

--- a/app/products/calls/store/action_types/calls.ts
+++ b/app/products/calls/store/action_types/calls.ts
@@ -24,4 +24,5 @@ export default keyMirror({
     SET_SCREENSHARE_URL: null,
     SET_SPEAKERPHONE: null,
     RECEIVED_CONFIG: null,
+    RECEIVED_PLUGIN_ENABLED: null,
 });

--- a/app/products/calls/store/actions/calls.test.js
+++ b/app/products/calls/store/actions/calls.test.js
@@ -39,6 +39,12 @@ jest.mock('@client/rest', () => ({
             DefaultEnabled: true,
             last_retrieved_at: 1234,
         })),
+        getPluginsManifests: jest.fn(() => (
+            [
+                {id: 'playbooks'},
+                {id: 'com.mattermost.calls'},
+            ]
+        )),
         enableChannelCalls: jest.fn(() => null),
         disableChannelCalls: jest.fn(() => null),
     },
@@ -150,6 +156,7 @@ describe('Actions.Calls', () => {
 
     it('batchLoadConfig', async () => {
         await store.dispatch(CallsActions.batchLoadCalls());
+        expect(Client4.getPluginsManifests).toBeCalledWith();
         expect(Client4.getCallsConfig).toBeCalledWith();
         expect(Client4.getCalls).toBeCalledWith();
 

--- a/app/products/calls/store/reducers/calls.ts
+++ b/app/products/calls/store/reducers/calls.ts
@@ -216,6 +216,16 @@ function speakerphoneOn(state = false, action: GenericAction) {
     }
 }
 
+function pluginEnabled(state = false, action: GenericAction) {
+    switch (action.type) {
+    case CallsTypes.RECEIVED_PLUGIN_ENABLED: {
+        return action.data;
+    }
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     calls,
     enabled,
@@ -223,4 +233,5 @@ export default combineReducers({
     screenShareURL,
     speakerphoneOn,
     config,
+    pluginEnabled,
 });

--- a/app/products/calls/store/selectors/calls.ts
+++ b/app/products/calls/store/selectors/calls.ts
@@ -61,3 +61,7 @@ export function isSupportedServer(state: GlobalState) {
 
     return false;
 }
+
+export function isCallsPluginEnabled(state: GlobalState) {
+    return state.entities.calls.pluginEnabled;
+}

--- a/app/products/calls/store/types/calls.ts
+++ b/app/products/calls/store/types/calls.ts
@@ -11,6 +11,7 @@ export type CallsState = {
     screenShareURL: string;
     speakerphoneOn: boolean;
     config: ServerConfig;
+    pluginEnabled: boolean;
 }
 
 export type Call = {

--- a/app/products/calls/websocket.ts
+++ b/app/products/calls/websocket.ts
@@ -2,13 +2,14 @@
 // See LICENSE.txt for license information.
 import {EventEmitter} from 'events';
 
+import Calls from '@constants/calls';
 import {encode} from '@msgpack/msgpack/dist';
 
 export default class WebSocketClient extends EventEmitter {
     private ws: WebSocket | null;
     private seqNo = 0;
     private connID = '';
-    private eventPrefix = 'custom_com.mattermost.calls';
+    private eventPrefix = `custom_${Calls.PluginId}`;
 
     constructor(connURL: string) {
         super();

--- a/app/screens/channel/channel.android.js
+++ b/app/screens/channel/channel.android.js
@@ -64,7 +64,7 @@ export default class ChannelAndroid extends ChannelBase {
     }
 
     render() {
-        const {theme, viewingGlobalThreads, isSupportedServerCalls} = this.props;
+        const {theme, viewingGlobalThreads, isCallsEnabled} = this.props;
         let component;
 
         if (viewingGlobalThreads) {
@@ -106,11 +106,12 @@ export default class ChannelAndroid extends ChannelBase {
                 {component}
                 <NetworkIndicator/>
                 <AnnouncementBanner/>
-                {isSupportedServerCalls &&
+                {isCallsEnabled &&
                     <FloatingCallContainer>
                         <JoinCall/>
                         <CurrentCall/>
-                    </FloatingCallContainer>}
+                    </FloatingCallContainer>
+                }
             </>
         );
 

--- a/app/screens/channel/channel.ios.js
+++ b/app/screens/channel/channel.ios.js
@@ -57,7 +57,7 @@ export default class ChannelIOS extends ChannelBase {
     };
 
     render() {
-        const {currentChannelId, theme, viewingGlobalThreads, isSupportedServerCalls} = this.props;
+        const {currentChannelId, theme, viewingGlobalThreads, isCallsEnabled} = this.props;
 
         let component;
         let renderDraftArea = false;
@@ -85,11 +85,12 @@ export default class ChannelIOS extends ChannelBase {
             <>
                 <AnnouncementBanner/>
                 <NetworkIndicator/>
-                {isSupportedServerCalls &&
+                {isCallsEnabled &&
                     <FloatingCallContainer>
                         <JoinCall/>
                         <CurrentCall/>
-                    </FloatingCallContainer>}
+                    </FloatingCallContainer>
+                }
             </>
         );
         const header = (

--- a/app/screens/channel/channel_base.js
+++ b/app/screens/channel/channel_base.js
@@ -40,6 +40,7 @@ export default class ChannelBase extends PureComponent {
         viewingGlobalThreads: PropTypes.bool,
         collapsedThreadsEnabled: PropTypes.bool.isRequired,
         isSupportedServerCalls: PropTypes.bool.isRequired,
+        isCallsEnabled: PropTypes.bool.isRequired,
         selectedPost: PropTypes.shape({
             id: PropTypes.string.isRequired,
             channel_id: PropTypes.string.isRequired,

--- a/app/screens/channel/index.js
+++ b/app/screens/channel/index.js
@@ -18,7 +18,10 @@ import {getCurrentUserId, getCurrentUserRoles, shouldShowTermsOfService} from '@
 import {isMinimumServerVersion} from '@mm-redux/utils/helpers';
 import {isSystemAdmin as checkIsSystemAdmin} from '@mm-redux/utils/user_utils';
 import {batchLoadCalls} from '@mmproducts/calls/store/actions/calls';
-import {isSupportedServer as isSupportedServerForCalls} from '@mmproducts/calls/store/selectors/calls';
+import {
+    isCallsPluginEnabled,
+    isSupportedServer as isSupportedServerForCalls,
+} from '@mmproducts/calls/store/selectors/calls';
 import {getViewingGlobalThreads} from '@selectors/threads';
 
 import Channel from './channel';
@@ -44,6 +47,7 @@ function mapStateToProps(state) {
     const currentChannelId = currentTeam?.delete_at === 0 ? getCurrentChannelId(state) : '';
     const collapsedThreadsEnabled = isCollapsedThreadsEnabled(state);
     const isSupportedServerCalls = isSupportedServerForCalls(state);
+    const isCallsEnabled = isCallsPluginEnabled(state);
 
     return {
         currentChannelId,
@@ -58,6 +62,7 @@ function mapStateToProps(state) {
         theme: getTheme(state),
         viewingGlobalThreads: collapsedThreadsEnabled && getViewingGlobalThreads(state),
         isSupportedServerCalls,
+        isCallsEnabled,
     };
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -733,7 +733,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 244195e30d63d7f564c55da4410b9a24e8fbceaa
   FBReactNativeSpec: c94002c1d93da3658f4d5119c6994d19961e3d52
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   jail-monkey: 07b83767601a373db876e939b8dbf3f5eb15f073
@@ -746,7 +746,7 @@ SPEC CHECKSUMS:
   Permission-Notifications: bb420c3d28328df24de1b476b41ed8249ccf2537
   Permission-PhotoLibrary: 7bec836dcdd04a0bfb200c314f1aae06d4476357
   Permission-PhotoLibraryAddOnly: 06fb0cdb1d35683b235ad8c464ef0ecc88859ea3
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: cd47794163052d2b8318c891a7a14fcfaccc75ab
   RCTTypeSafety: 393bb40b3e357b224cde53d3fec26813c52428b1
   RCTYouTube: a8bb45705622a6fc9decf64be04128d3658ed411

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -733,7 +733,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 244195e30d63d7f564c55da4410b9a24e8fbceaa
   FBReactNativeSpec: c94002c1d93da3658f4d5119c6994d19961e3d52
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   jail-monkey: 07b83767601a373db876e939b8dbf3f5eb15f073
@@ -746,7 +746,7 @@ SPEC CHECKSUMS:
   Permission-Notifications: bb420c3d28328df24de1b476b41ed8249ccf2537
   Permission-PhotoLibrary: 7bec836dcdd04a0bfb200c314f1aae06d4476357
   Permission-PhotoLibraryAddOnly: 06fb0cdb1d35683b235ad8c464ef0ecc88859ea3
-  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
+  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
   RCTRequired: cd47794163052d2b8318c891a7a14fcfaccc75ab
   RCTTypeSafety: 393bb40b3e357b224cde53d3fec26813c52428b1
   RCTYouTube: a8bb45705622a6fc9decf64be04128d3658ed411


### PR DESCRIPTION
#### Summary
- Customers are reporting many debug loglines with: ` Access to route for non-existent plugin       caller="app/plugin_requests.go:37" missing_plugin_id=com.mattermost.calls url=/plugins/com.mattermost.calls/config error="plugin not found: com.mattermost.calls"`
- This is because we were using an http request to `calls/config` and `calls/channels` as a check for whether the plugin is enabled. But this outputs the debug line above. 
- We needed a solution that would check if the plugin was enabled but wouldn't output the debug line. 
- Settled on pulling the publicly accessible plugin webapp manifests and checking if calls is registered there. If it is it's enabled.
- Bonus: We can use that to short-circuit some of the channel components (the calls banners), which will speed up the app.
- Also refactoring the plugin id while I'm at it.
- @enahum Since some customers are unhappy about this, would it make sense to put this into a dot-release for 1.51?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-43904

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] ~~Has UI changes~~
- [ ] ~~Includes text changes and localization file updates~~
- [ ] ~~Have tested against the 5 core themes to ensure consistency between them.~~

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Release Note
```release-note
Calls: Fixed "Access to route for non-existent plugin" in the server's log
```

