### PR TITLE
Dismiss post options before executing action

### DIFF
--- a/app/screens/post_options/options/copy_text_option.tsx
+++ b/app/screens/post_options/options/copy_text_option.tsx
@@ -13,9 +13,9 @@ type Props = {
     postMessage: string;
 }
 const CopyTextOption = ({postMessage}: Props) => {
-    const handleCopyText = useCallback(() => {
+    const handleCopyText = useCallback(async () => {
+        await dismissBottomSheet(Screens.POST_OPTIONS);
         Clipboard.setString(postMessage);
-        dismissBottomSheet(Screens.POST_OPTIONS);
     }, [postMessage]);
 
     return (

--- a/app/screens/post_options/options/delete_post_option.tsx
+++ b/app/screens/post_options/options/delete_post_option.tsx
@@ -35,9 +35,9 @@ const DeletePostOption = ({combinedPost, post}: Props) => {
             }, {
                 text: formatMessage({id: 'post_info.del', defaultMessage: 'Delete'}),
                 style: 'destructive',
-                onPress: () => {
+                onPress: async () => {
+                    await dismissBottomSheet(Screens.POST_OPTIONS);
                     deletePost(serverUrl, combinedPost || post);
-                    dismissBottomSheet(Screens.POST_OPTIONS);
                 },
             }],
         );

--- a/app/screens/post_options/options/mark_unread_option.tsx
+++ b/app/screens/post_options/options/mark_unread_option.tsx
@@ -17,9 +17,9 @@ type Props = {
 const MarkAsUnreadOption = ({postId}: Props) => {
     const serverUrl = useServerUrl();
 
-    const onPress = useCallback(() => {
+    const onPress = useCallback(async () => {
+        await dismissBottomSheet(Screens.POST_OPTIONS);
         markPostAsUnread(serverUrl, postId);
-        dismissBottomSheet(Screens.POST_OPTIONS);
     }, [serverUrl, postId]);
 
     return (

--- a/app/screens/post_options/options/pin_channel_option.tsx
+++ b/app/screens/post_options/options/pin_channel_option.tsx
@@ -18,9 +18,9 @@ type PinChannelProps = {
 const PinChannelOption = ({isPostPinned, postId}: PinChannelProps) => {
     const serverUrl = useServerUrl();
 
-    const onPress = useCallback(() => {
+    const onPress = useCallback(async () => {
+        await dismissBottomSheet(Screens.POST_OPTIONS);
         togglePinPost(serverUrl, postId);
-        dismissBottomSheet(Screens.POST_OPTIONS);
     }, [postId, serverUrl]);
 
     let defaultMessage;

--- a/app/screens/thread_options/options/mark_as_unread_option.tsx
+++ b/app/screens/thread_options/options/mark_as_unread_option.tsx
@@ -22,9 +22,9 @@ const MarkAsUnreadOption = ({teamId, thread, post}: Props) => {
     const serverUrl = useServerUrl();
 
     const onHandlePress = useCallback(async () => {
+        await dismissBottomSheet(Screens.THREAD_OPTIONS);
         const timestamp = thread.unreadReplies ? Date.now() : post.createAt;
         updateThreadRead(serverUrl, teamId, thread.id, timestamp);
-        dismissBottomSheet(Screens.THREAD_OPTIONS);
     }, [serverUrl, thread]);
 
     const id = thread.unreadReplies ? t('global_threads.options.mark_as_read') : t('mobile.post_info.mark_unread');


### PR DESCRIPTION
#### Summary
For some options, dismissing the post/thread options after executing certain actions that update the DB, the post options would not dismiss, this PR ensures that the post options dismisses before executing the action.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43971

```release-note
NONE
```
