### PR TITLE
MM-43904 - Fix: Calls batch actions

### DIFF
--- a/app/products/calls/store/actions/calls.test.js
+++ b/app/products/calls/store/actions/calls.test.js
@@ -141,14 +141,14 @@ describe('Actions.Calls', () => {
     });
 
     it('loadCalls', async () => {
-        await store.dispatch(await store.dispatch(CallsActions.loadCalls()));
+        await store.dispatch(CallsActions.loadCalls());
         expect(Client4.getCalls).toBeCalledWith();
         assert.equal(store.getState().entities.calls.calls['channel-1'].channelId, 'channel-1');
         assert.equal(store.getState().entities.calls.enabled['channel-1'], true);
     });
 
     it('loadConfig', async () => {
-        await store.dispatch(await store.dispatch(CallsActions.loadConfig()));
+        await store.dispatch(CallsActions.loadConfig());
         expect(Client4.getCallsConfig).toBeCalledWith();
         assert.equal(store.getState().entities.calls.config.DefaultEnabled, true);
         assert.equal(store.getState().entities.calls.config.AllowEnableCalls, true);


### PR DESCRIPTION
#### Summary
- Error discovered in testing, I made batching the actions overly complicated, which broke the simple `dispatch(loadConfig())` here: https://github.com/mattermost/mattermost-mobile/blob/912287fbe054d5edf49e725eb14d294d248e7423/app/products/calls/hooks.ts#L60  
- Fixing it by simplifying the batching.
- Apologies for the churn, everyone. Thank you @josephbaylon for finding it. Will involve Joseph earlier.
- @amyblais I'll need to cherry-pick again, and I'll add the label for 1.52. Thanks!

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-43904
- Fixes #6210 

#### Release Note
```release-note
NONE
```
