### PR TITLE
[Gekidou] fix flip of post list

### DIFF
--- a/app/screens/channel/channel_post_list/channel_post_list.tsx
+++ b/app/screens/channel/channel_post_list/channel_post_list.tsx
@@ -11,7 +11,6 @@ import {Screens} from '@constants';
 import {useServerUrl} from '@context/server';
 import {debounce} from '@helpers/api/general';
 import {useIsTablet} from '@hooks/device';
-import {sortPostsByNewest} from '@utils/post';
 
 import Intro from './intro';
 
@@ -44,7 +43,7 @@ const ChannelPostList = ({
     const onEndReached = useCallback(debounce(async () => {
         if (!fetchingPosts.current && canLoadPosts.current && posts.length) {
             fetchingPosts.current = true;
-            const lastPost = sortPostsByNewest(posts)[0];
+            const lastPost = posts[posts.length - 1];
             const result = await fetchPostsBefore(serverUrl, channelId, lastPost.id);
             canLoadPosts.current = ((result as ProcessedPosts).posts?.length ?? 1) > 0;
             fetchingPosts.current = false;

--- a/app/utils/post/index.ts
+++ b/app/utils/post/index.ts
@@ -62,16 +62,6 @@ export function shouldIgnorePost(post: Post): boolean {
     return Post.IGNORE_POST_TYPES.includes(post.type);
 }
 
-export const sortPostsByNewest = (posts: PostModel[]) => {
-    return posts.sort((a, b) => {
-        if (a.createAt > b.createAt) {
-            return 1;
-        }
-
-        return -1;
-    });
-};
-
 export const processPostsFetched = (data: PostResponse) => {
     const order = data.order;
     const posts = Object.values(data.posts) as Post[];


### PR DESCRIPTION
#### Summary
When the onEndReached of the list was being hit, we ended up re-sorting the posts in order to fetch more posts based on the last post id present in the post list.

What was happening before, when there are more posts to be fetched, the list behaved "OK" because the observer kicked in and we got the posts again correctly sorted from the database. The problem is actually when there are no more posts to fetch as no new posts were added to the db and the posts array was re-sorted, that caused the list to render incorrectly.

The fix consists on not re-sorting the posts array for two reason:
1. posts are already sorted by createAt, we just need to get the last one instead
2. By avoiding a sort we gain on performance.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43991

```release-note
NONE
```
