### PR TITLE
Remove unneeded actions on team switch

### DIFF
--- a/app/actions/remote/team.ts
+++ b/app/actions/remote/team.ts
@@ -11,7 +11,7 @@ import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {prepareCategories, prepareCategoryChannels} from '@queries/servers/categories';
 import {prepareMyChannelsForTeam, getDefaultChannelForTeam} from '@queries/servers/channel';
-import {prepareCommonSystemValues, getCurrentTeamId, getWebSocketLastDisconnected} from '@queries/servers/system';
+import {prepareCommonSystemValues, getCurrentTeamId} from '@queries/servers/system';
 import {addTeamToTeamHistory, prepareDeleteTeam, prepareMyTeams, getNthLastChannelFromTeam, queryTeamsById, syncTeamTable} from '@queries/servers/team';
 import EphemeralStore from '@store/ephemeral_store';
 import {isTablet} from '@utils/helpers';
@@ -279,7 +279,6 @@ export async function handleTeamChange(serverUrl: string, teamId: string) {
                 await switchToChannelById(serverUrl, channelId, teamId);
             }
             DeviceEventEmitter.emit(Events.TEAM_SWITCH, false);
-            completeTeamChange(serverUrl, teamId, channelId);
             return;
         }
     }
@@ -298,25 +297,4 @@ export async function handleTeamChange(serverUrl: string, teamId: string) {
         await operator.batchRecords(models);
     }
     DeviceEventEmitter.emit(Events.TEAM_SWITCH, false);
-
-    completeTeamChange(serverUrl, teamId, channelId);
 }
-
-const completeTeamChange = async (serverUrl: string, teamId: string, channelId: string) => {
-    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
-    if (!database) {
-        return;
-    }
-
-    // If WebSocket is not disconnected we fetch everything since this moment
-    const lastDisconnectedAt = (await getWebSocketLastDisconnected(database)) || Date.now();
-    const {channels, memberships, error} = await fetchMyChannelsForTeam(serverUrl, teamId, true, lastDisconnectedAt, false, true);
-
-    if (error) {
-        DeviceEventEmitter.emit(Events.TEAM_LOAD_ERROR, serverUrl, error);
-    }
-
-    if (channels?.length && memberships?.length) {
-        fetchPostsForUnreadChannels(serverUrl, channels, memberships, channelId);
-    }
-};


### PR DESCRIPTION
#### Summary
On team switch we are fetching all the channels and unreads. This should have been done already on init, and synced through websockets, so there is no need to fetch them again.

Thanks @jwilander for the help on this.

#### Ticket Link
None

```release-note
NONE
```
