### PR TITLE
CRT fixes for MM-44210 & MM-44156

### DIFF
--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -272,13 +272,13 @@ export async function resetMessageCount(serverUrl: string, channelId: string) {
     }
 }
 
-export async function storeMyChannelsForTeam(serverUrl: string, teamId: string, channels: Channel[], memberships: ChannelMembership[], prepareRecordsOnly = false) {
+export async function storeMyChannelsForTeam(serverUrl: string, teamId: string, channels: Channel[], memberships: ChannelMembership[], prepareRecordsOnly = false, isCRTEnabled?: boolean) {
     const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
     if (!operator) {
         return {error: `${serverUrl} database not found`};
     }
     const modelPromises: Array<Promise<Model[]>> = [
-        ...await prepareMyChannelsForTeam(operator, teamId, channels, memberships),
+        ...await prepareMyChannelsForTeam(operator, teamId, channels, memberships, isCRTEnabled),
     ];
 
     const models = await Promise.all(modelPromises);

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -342,7 +342,7 @@ export async function fetchChannelStats(serverUrl: string, channelId: string, fe
     }
 }
 
-export async function fetchMyChannelsForTeam(serverUrl: string, teamId: string, includeDeleted = true, since = 0, fetchOnly = false, excludeDirect = false): Promise<MyChannelsRequest> {
+export async function fetchMyChannelsForTeam(serverUrl: string, teamId: string, includeDeleted = true, since = 0, fetchOnly = false, excludeDirect = false, isCRTEnabled?: boolean): Promise<MyChannelsRequest> {
     const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
     if (!operator) {
         return {error: `${serverUrl} database not found`};
@@ -378,7 +378,7 @@ export async function fetchMyChannelsForTeam(serverUrl: string, teamId: string, 
         }, []);
 
         if (!fetchOnly) {
-            const {models: chModels} = await storeMyChannelsForTeam(serverUrl, teamId, channels, memberships, true);
+            const {models: chModels} = await storeMyChannelsForTeam(serverUrl, teamId, channels, memberships, true, isCRTEnabled);
             const {models: catModels} = await storeCategories(serverUrl, categories, true, true); // Re-sync
             const models = (chModels || []).concat(catModels || []);
             if (models.length) {

--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -26,7 +26,7 @@ import {prepareModels} from '@queries/servers/entry';
 import {getConfig, getPushVerificationStatus, getWebSocketLastDisconnected} from '@queries/servers/system';
 import {deleteMyTeams, getAvailableTeamIds, getNthLastChannelFromTeam, queryMyTeams, queryMyTeamsByIds, queryTeamsById} from '@queries/servers/team';
 import {isDMorGM} from '@utils/channel';
-import {isCRTEnabled} from '@utils/thread';
+import {processIsCRTEnabled} from '@utils/thread';
 
 import type ClientError from '@client/rest/error';
 
@@ -38,6 +38,7 @@ export type AppEntryData = {
     meData: MyUserRequest;
     removeTeamIds?: string[];
     removeChannelIds?: string[];
+    isCRTEnabled: boolean;
 }
 
 export type AppEntryError = {
@@ -90,7 +91,7 @@ export const entry = async (serverUrl: string, teamId?: string, channelId?: stri
         return {error: fetchedData.error};
     }
 
-    const {initialTeamId, teamData, chData, prefData, meData, removeTeamIds, removeChannelIds} = fetchedData;
+    const {initialTeamId, teamData, chData, prefData, meData, removeTeamIds, removeChannelIds, isCRTEnabled} = fetchedData;
     const error = teamData.error || chData?.error || prefData.error || meData.error;
     if (error) {
         return {error};
@@ -113,7 +114,7 @@ export const entry = async (serverUrl: string, teamId?: string, channelId?: stri
         removeChannels = await queryChannelsById(database, removeChannelIds).fetch();
     }
 
-    const modelPromises = await prepareModels({operator, initialTeamId, removeTeams, removeChannels, teamData, chData, prefData, meData});
+    const modelPromises = await prepareModels({operator, initialTeamId, removeTeams, removeChannels, teamData, chData, prefData, meData, isCRTEnabled});
     if (rolesData.roles?.length) {
         modelPromises.push(operator.handleRole({roles: rolesData.roles, prepareRecordsOnly: true}));
     }
@@ -134,12 +135,12 @@ export const fetchAppEntryData = async (serverUrl: string, since: number, initia
 
     const confReq = await fetchConfigAndLicense(serverUrl);
     const prefData = await fetchMyPreferences(serverUrl, fetchOnly);
-    const isCRT = (prefData.preferences && isCRTEnabled(prefData.preferences, confReq.config));
+    const isCRTEnabled = Boolean(prefData.preferences && processIsCRTEnabled(prefData.preferences, confReq.config));
 
     // Fetch in parallel teams / team membership / channels for current team / user preferences / user
     const promises: [Promise<MyTeamsRequest>, Promise<MyChannelsRequest | undefined>, Promise<MyUserRequest>] = [
         fetchMyTeams(serverUrl, fetchOnly),
-        initialTeamId ? fetchMyChannelsForTeam(serverUrl, initialTeamId, includeDeletedChannels, since, fetchOnly, false, isCRT) : Promise.resolve(undefined),
+        initialTeamId ? fetchMyChannelsForTeam(serverUrl, initialTeamId, includeDeletedChannels, since, fetchOnly, false, isCRTEnabled) : Promise.resolve(undefined),
         fetchMe(serverUrl, fetchOnly),
     ];
 
@@ -156,7 +157,7 @@ export const fetchAppEntryData = async (serverUrl: string, since: number, initia
         const myTeams = teamData.teams!.filter((t) => teamMembers.has(t.id));
         const defaultTeam = selectDefaultTeam(myTeams, meData.user?.locale || DEFAULT_LOCALE, teamOrderPreference, config?.ExperimentalPrimaryTeam);
         if (defaultTeam?.id) {
-            chData = await fetchMyChannelsForTeam(serverUrl, defaultTeam.id, includeDeletedChannels, since, fetchOnly, false, isCRT);
+            chData = await fetchMyChannelsForTeam(serverUrl, defaultTeam.id, includeDeletedChannels, since, fetchOnly, false, isCRTEnabled);
         }
     }
 
@@ -172,6 +173,7 @@ export const fetchAppEntryData = async (serverUrl: string, since: number, initia
         prefData,
         meData,
         removeTeamIds,
+        isCRTEnabled,
     };
 
     if (teamData.teams?.length === 0 && !teamData.error) {
@@ -195,7 +197,7 @@ export const fetchAppEntryData = async (serverUrl: string, since: number, initia
         }
 
         const availableTeamIds = await getAvailableTeamIds(database, initialTeamId, teamData.teams, prefData.preferences, meData.user?.locale);
-        const alternateTeamData = await fetchAlternateTeamData(serverUrl, availableTeamIds, removeTeamIds, includeDeletedChannels, since, fetchOnly);
+        const alternateTeamData = await fetchAlternateTeamData(serverUrl, availableTeamIds, removeTeamIds, includeDeletedChannels, since, fetchOnly, isCRTEnabled);
 
         data = {
             ...data,
@@ -225,13 +227,13 @@ export const fetchAppEntryData = async (serverUrl: string, since: number, initia
 
 export const fetchAlternateTeamData = async (
     serverUrl: string, availableTeamIds: string[], removeTeamIds: string[],
-    includeDeleted = true, since = 0, fetchOnly = false) => {
+    includeDeleted = true, since = 0, fetchOnly = false, isCRTEnabled?: boolean) => {
     let initialTeamId = '';
     let chData;
 
     for (const teamId of availableTeamIds) {
         // eslint-disable-next-line no-await-in-loop
-        chData = await fetchMyChannelsForTeam(serverUrl, teamId, includeDeleted, since, fetchOnly);
+        chData = await fetchMyChannelsForTeam(serverUrl, teamId, includeDeleted, since, fetchOnly, false, isCRTEnabled);
         const chError = chData.error as ClientError | undefined;
         if (chError?.status_code === 403) {
             removeTeamIds.push(teamId);
@@ -270,7 +272,7 @@ export async function deferredAppEntryActions(
         await fetchTeamsChannelsAndUnreadPosts(serverUrl, since, teamData.teams, teamData.memberships, initialTeamId);
     }
 
-    if (preferences && isCRTEnabled(preferences, config)) {
+    if (preferences && processIsCRTEnabled(preferences, config)) {
         if (initialTeamId) {
             await fetchNewThreads(serverUrl, initialTeamId, false);
         }

--- a/app/database/operator/server_data_operator/transformers/channel.ts
+++ b/app/database/operator/server_data_operator/transformers/channel.ts
@@ -4,7 +4,6 @@
 import {MM_TABLES} from '@constants/database';
 import {prepareBaseRecord} from '@database/operator/server_data_operator/transformers/index';
 import {extractChannelDisplayName} from '@helpers/database';
-import {getIsCRTEnabled} from '@queries/servers/thread';
 import {OperationType} from '@typings/database/enums';
 
 import type {TransformerArgs} from '@typings/database/database';
@@ -126,18 +125,16 @@ export const transformMyChannelRecord = async ({action, database, value}: Transf
     const record = value.record as MyChannelModel;
     const isCreateAction = action === OperationType.CREATE;
 
-    const isCRTEnabled = await getIsCRTEnabled(database);
-
     const fieldsMapper = (myChannel: MyChannelModel) => {
         myChannel._raw.id = isCreateAction ? (raw.channel_id || myChannel.id) : record.id;
         myChannel.roles = raw.roles;
 
-        // ignoring msg_count_root because msg_count is already calculated in "handleMyChannel" based on CRT is enabled or not
+        // ignoring msg_count_root because msg_count, mention_count, last_post_at is already calculated in "handleMyChannel" based on CRT is enabled or not
         myChannel.messageCount = raw.msg_count;
+        myChannel.mentionsCount = raw.mention_count;
+        myChannel.lastPostAt = raw.last_post_at || 0;
 
         myChannel.isUnread = Boolean(raw.is_unread);
-        myChannel.mentionsCount = isCRTEnabled ? raw.mention_count_root! : raw.mention_count;
-        myChannel.lastPostAt = (isCRTEnabled ? (raw.last_root_post_at || raw.last_post_at) : raw.last_post_at) || 0;
         myChannel.lastViewedAt = raw.last_viewed_at;
         myChannel.viewedAt = record?.viewedAt || 0;
     };

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -59,7 +59,7 @@ type MembershipReduce = {
     membershipsMap: Record<string, MembershipWithId>;
 }
 
-export const prepareMyChannelsForTeam = async (operator: ServerDataOperator, teamId: string, channels: Channel[], channelMembers: ChannelMembership[]) => {
+export const prepareMyChannelsForTeam = async (operator: ServerDataOperator, teamId: string, channels: Channel[], channelMembers: ChannelMembership[], isCRTEnabled?: boolean) => {
     const {database} = operator;
     const allChannelsForTeam = (await queryAllChannelsForTeam(database, teamId).fetch()).
         reduce((map: Record<string, ChannelModel>, channel) => {
@@ -115,7 +115,7 @@ export const prepareMyChannelsForTeam = async (operator: ServerDataOperator, tea
         const channelRecords = operator.handleChannel({channels, prepareRecordsOnly: true});
         const channelInfoRecords = operator.handleChannelInfo({channelInfos, prepareRecordsOnly: true});
         const membershipRecords = operator.handleChannelMembership({channelMemberships: channelMembers, prepareRecordsOnly: true});
-        const myChannelRecords = operator.handleMyChannel({channels, myChannels: memberships, prepareRecordsOnly: true});
+        const myChannelRecords = operator.handleMyChannel({channels, myChannels: memberships, prepareRecordsOnly: true, isCRTEnabled});
         const myChannelSettingsRecords = operator.handleMyChannelSettings({settings: memberships, prepareRecordsOnly: true});
 
         return [channelRecords, channelInfoRecords, membershipRecords, myChannelRecords, myChannelSettingsRecords];

--- a/app/queries/servers/entry.ts
+++ b/app/queries/servers/entry.ts
@@ -26,9 +26,10 @@ type PrepareModelsArgs = {
     chData?: MyChannelsRequest;
     prefData?: MyPreferencesRequest;
     meData?: MyUserRequest;
+    isCRTEnabled?: boolean;
 }
 
-export async function prepareModels({operator, initialTeamId, removeTeams, removeChannels, teamData, chData, prefData, meData}: PrepareModelsArgs): Promise<Array<Promise<Model[]>>> {
+export async function prepareModels({operator, initialTeamId, removeTeams, removeChannels, teamData, chData, prefData, meData, isCRTEnabled}: PrepareModelsArgs): Promise<Array<Promise<Model[]>>> {
     const modelPromises: Array<Promise<Model[]>> = [];
 
     if (removeTeams?.length) {
@@ -53,7 +54,7 @@ export async function prepareModels({operator, initialTeamId, removeTeams, remov
     }
 
     if (initialTeamId && chData?.channels?.length && chData.memberships?.length) {
-        modelPromises.push(...await prepareMyChannelsForTeam(operator, initialTeamId, chData.channels, chData.memberships));
+        modelPromises.push(...await prepareMyChannelsForTeam(operator, initialTeamId, chData.channels, chData.memberships, isCRTEnabled));
     }
 
     if (prefData?.preferences?.length) {

--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -7,7 +7,7 @@ import {map, switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
-import {isCRTEnabled} from '@utils/thread';
+import {processIsCRTEnabled} from '@utils/thread';
 
 import {queryPreferencesByCategoryAndName} from './preference';
 import {getConfig, observeConfig} from './system';
@@ -22,7 +22,7 @@ const {SERVER: {CHANNEL, POST, THREAD, THREADS_IN_TEAM, THREAD_PARTICIPANT, USER
 export const getIsCRTEnabled = async (database: Database): Promise<boolean> => {
     const config = await getConfig(database);
     const preferences = await queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS).fetch();
-    return isCRTEnabled(preferences, config);
+    return processIsCRTEnabled(preferences, config);
 };
 
 export const getThreadById = async (database: Database, threadId: string) => {
@@ -39,7 +39,7 @@ export const observeIsCRTEnabled = (database: Database) => {
     const preferences = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS).observeWithColumns(['value']);
     return combineLatest([config, preferences]).pipe(
         map(
-            ([cfg, prefs]) => isCRTEnabled(prefs, cfg),
+            ([cfg, prefs]) => processIsCRTEnabled(prefs, cfg),
         ),
     );
 };

--- a/app/utils/thread/index.ts
+++ b/app/utils/thread/index.ts
@@ -6,7 +6,7 @@ import {getPreferenceValue} from '@helpers/api/preference';
 
 import type PreferenceModel from '@typings/database/models/servers/preference';
 
-export function isCRTEnabled(preferences: PreferenceModel[]|PreferenceType[], config?: ClientConfig): boolean {
+export function processIsCRTEnabled(preferences: PreferenceModel[]|PreferenceType[], config?: ClientConfig): boolean {
     let preferenceDefault = Preferences.COLLAPSED_REPLY_THREADS_OFF;
     const configValue = config?.CollapsedThreads;
     if (configValue === Config.DEFAULT_ON) {

--- a/types/database/database.d.ts
+++ b/types/database/database.d.ts
@@ -199,6 +199,7 @@ export type HandleSystemArgs = PrepareOnly & {
 export type HandleMyChannelArgs = PrepareOnly & {
   channels?: Channel[];
   myChannels?: ChannelMembership[];
+  isCRTEnabled?: boolean;
 };
 
 export type HandleChannelInfoArgs = PrepareOnly &{


### PR DESCRIPTION
#### Summary
During the app entry we are fetching the user preferences and `myChannel` data at the same time. `isCRTEnabled` is always returned as `false` as the data is not available in the DB.

We are processing and passing the value of `isCRTEnabled` manually so that correct data gets saved in the DB depending on the CRT setting.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44156
https://mattermost.atlassian.net/browse/MM-44210

```release-note
NONE
```
