### PR TITLE
[Gekidou MM-44209] Markdown heading style updates

### DIFF
--- a/app/utils/markdown/index.ts
+++ b/app/utils/markdown/index.ts
@@ -3,11 +3,9 @@
 
 import {Platform, StyleSheet} from 'react-native';
 
+import {getViewPortWidth} from '@utils/images';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
-
-import { typography } from '../typography';
-
-import {getViewPortWidth} from '../images';
+import {typography} from '@utils/typography';
 
 type LanguageObject = {
     [key: string]: {

--- a/app/utils/markdown/index.ts
+++ b/app/utils/markdown/index.ts
@@ -37,52 +37,58 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme: Theme) => {
             fontFamily: 'OpenSans',
         },
         heading1: {
-            fontFamily: 'OpenSans-Bold',
-            fontSize: 24,
-            lineHeight: 25,
+            fontFamily: 'Metropolis-Semibold',
+            fontSize: 28,
+            lineHeight: 34,
         },
         heading1Text: {
-            paddingVertical: 8,
+            paddingTop: 12,
+            paddingBottom: 8,
         },
         heading2: {
-            fontFamily: 'OpenSans-Bold',
-            fontSize: 22,
-            lineHeight: 25,
+            fontFamily: 'Metropolis-Semibold',
+            fontSize: 25,
+            lineHeight: 30,
         },
         heading2Text: {
-            paddingVertical: 6,
+            paddingTop: 12,
+            paddingBottom: 8,
         },
         heading3: {
-            fontFamily: 'OpenSans-Bold',
-            fontSize: 21,
-            lineHeight: 25,
+            fontFamily: 'Metropolis-Semibold',
+            fontSize: 22,
+            lineHeight: 28,
         },
         heading3Text: {
-            paddingVertical: 6,
+            paddingTop: 12,
+            paddingBottom: 8,
         },
         heading4: {
-            fontFamily: 'OpenSans-Bold',
+            fontFamily: 'Metropolis-Semibold',
             fontSize: 20,
-            lineHeight: 25,
+            lineHeight: 24,
         },
         heading4Text: {
-            paddingVertical: 5,
+            paddingTop: 12,
+            paddingBottom: 6,
         },
         heading5: {
-            fontFamily: 'OpenSans-Bold',
-            fontSize: 19,
-            lineHeight: 25,
+            fontFamily: 'Metropolis-Semibold',
+            fontSize: 18,
+            lineHeight: 24,
         },
         heading5Text: {
-            paddingVertical: 5,
+            paddingTop: 12,
+            paddingBottom: 6,
         },
         heading6: {
-            fontFamily: 'OpenSans-Bold',
+            fontFamily: 'Metropolis-Semibold',
             fontSize: 18,
-            lineHeight: 25,
+            lineHeight: 24,
         },
         heading6Text: {
-            paddingVertical: 4,
+            paddingTop: 12,
+            paddingBottom: 6,
         },
         code: {
             alignSelf: 'center',
@@ -114,7 +120,7 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme: Theme) => {
 export const getMarkdownBlockStyles = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         adjacentParagraph: {
-            marginTop: 6,
+            marginTop: 8,
         },
         horizontalRule: {
             backgroundColor: theme.centerChannelColor,

--- a/app/utils/markdown/index.ts
+++ b/app/utils/markdown/index.ts
@@ -5,6 +5,8 @@ import {Platform, StyleSheet} from 'react-native';
 
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
+import { typography } from '../typography';
+
 import {getViewPortWidth} from '../images';
 
 type LanguageObject = {
@@ -37,54 +39,42 @@ export const getMarkdownTextStyles = makeStyleSheetFromTheme((theme: Theme) => {
             fontFamily: 'OpenSans',
         },
         heading1: {
-            fontFamily: 'Metropolis-Semibold',
-            fontSize: 28,
-            lineHeight: 34,
+            ...typography('Heading', 700),
         },
         heading1Text: {
             paddingTop: 12,
-            paddingBottom: 8,
+            paddingBottom: 6,
         },
         heading2: {
-            fontFamily: 'Metropolis-Semibold',
-            fontSize: 25,
-            lineHeight: 30,
+            ...typography('Heading', 600),
         },
         heading2Text: {
             paddingTop: 12,
-            paddingBottom: 8,
+            paddingBottom: 6,
         },
         heading3: {
-            fontFamily: 'Metropolis-Semibold',
-            fontSize: 22,
-            lineHeight: 28,
+            ...typography('Heading', 500),
         },
         heading3Text: {
             paddingTop: 12,
-            paddingBottom: 8,
+            paddingBottom: 6,
         },
         heading4: {
-            fontFamily: 'Metropolis-Semibold',
-            fontSize: 20,
-            lineHeight: 24,
+            ...typography('Heading', 400),
         },
         heading4Text: {
             paddingTop: 12,
             paddingBottom: 6,
         },
         heading5: {
-            fontFamily: 'Metropolis-Semibold',
-            fontSize: 18,
-            lineHeight: 24,
+            ...typography('Heading', 300),
         },
         heading5Text: {
             paddingTop: 12,
             paddingBottom: 6,
         },
         heading6: {
-            fontFamily: 'Metropolis-Semibold',
-            fontSize: 18,
-            lineHeight: 24,
+            ...typography('Heading', 200),
         },
         heading6Text: {
             paddingTop: 12,


### PR DESCRIPTION
#### Summary
Udpates heading styles to use Metropolis and adjust some spacing for markdown rendering.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-44209

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS Simulator (iPhone 13), Android Simulator (Pixel 3)

#### Screenshots
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="564" alt="image" src="https://user-images.githubusercontent.com/2040554/169403727-e5a2c31a-d70e-4213-889a-e043a0aad403.png">
</td>
<td>
<img width="564" alt="image" src="https://user-images.githubusercontent.com/2040554/169403559-ce996f1c-82a9-4814-9d60-c15ee0fc8773.png">
</td>

```release-note
NONE
```