### PR TITLE
Properly handle deleted system posts

### DIFF
--- a/app/utils/post_list/index.ts
+++ b/app/utils/post_list/index.ts
@@ -67,6 +67,11 @@ function combineUserActivityPosts(orderedPosts: Array<PostModel | string>) {
 
                 continue;
             }
+        } else if (post.deleteAt) {
+            out.push(post);
+
+            lastPostIsUserActivity = false;
+            combinedCount = 0;
         } else {
             const postIsUserActivity = Post.USER_ACTIVITY_POST_TYPES.includes(post.type);
             if (postIsUserActivity && lastPostIsUserActivity && combinedCount < MAX_COMBINED_SYSTEM_POSTS) {


### PR DESCRIPTION
#### Summary
If we delete system posts, we were getting a weird behavior. On iOS I saw crashes (because the props were being set to null) and on Android just the messages still be there.

This PR solves the issue (even though did not dive deep into why the differences between the tests I did on iOS and the tests I did on Android).

#### Ticket Link
None

```release-note
NONE
```
