### PR TITLE
MM-44423 : Gekidou - event screenDidDisappear called twice

### DIFF
--- a/app/screens/snack_bar/index.tsx
+++ b/app/screens/snack_bar/index.tsx
@@ -206,7 +206,8 @@ const SnackBar = ({barType, componentId, onAction, sourceScreen}: SnackBarProps)
     // This effect checks if we are navigating away and if so, it dismisses the snack bar
     useEffect(() => {
         const onHideSnackBar = (event?: ComponentEvent) => {
-            if (componentId !== event?.componentId) {
+            const evtComponentId = event?.componentId;
+            if ((componentId !== evtComponentId) && (sourceScreen !== evtComponentId)) {
                 animateHiding(true);
             }
         };


### PR DESCRIPTION
#### Summary
This PR ensures that the `sourceScreen` and the  `event.componentId`  are different and by doing so, the snackbar shows up like it should.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44423

#### Release Note
```release-note
NONE
```