### PR TITLE
[Gekidou] perf improvement & fix upgrade path

### DIFF
--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -15,7 +15,7 @@ import {getTeammateNameDisplaySetting} from '@helpers/api/preference';
 import NetworkManager from '@managers/network_manager';
 import {prepareMyChannelsForTeam, getChannelById, getChannelByName, getMyChannel, getChannelInfo, queryMyChannelSettingsByIds} from '@queries/servers/channel';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
-import {getCommonSystemValues, getCurrentTeamId, getCurrentUserId, setCurrentChannelId} from '@queries/servers/system';
+import {getCommonSystemValues, getConfig, getCurrentTeamId, getCurrentUserId, getLicense, setCurrentChannelId} from '@queries/servers/system';
 import {prepareMyTeams, getNthLastChannelFromTeam, getMyTeamById, getTeamById, getTeamByName, queryMyTeams} from '@queries/servers/team';
 import {getCurrentUser} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
@@ -30,7 +30,7 @@ import {setDirectChannelVisible} from './preference';
 import {fetchRolesIfNeeded} from './role';
 import {forceLogoutIfNecessary} from './session';
 import {addUserToTeam, fetchTeamByName, removeUserFromTeam} from './team';
-import {fetchProfilesPerChannels, fetchUsersByIds, updateUsersNoLongerVisible} from './user';
+import {fetchProfilesInGroupChannels, fetchProfilesPerChannels, fetchUsersByIds, updateUsersNoLongerVisible} from './user';
 
 import type {Client} from '@client/rest';
 import type ChannelModel from '@typings/database/models/servers/channel';
@@ -426,61 +426,95 @@ export async function fetchMyChannel(serverUrl: string, teamId: string, channelI
     }
 }
 
-export async function fetchMissingSidebarInfo(serverUrl: string, directChannels: Channel[], locale?: string, teammateDisplayNameSetting?: string, currentUserId?: string, fetchOnly = false) {
-    const channelIds = directChannels.sort((a, b) => b.last_post_at - a.last_post_at).map((dc) => dc.id);
-    const result = await fetchProfilesPerChannels(serverUrl, channelIds, currentUserId, false);
-    if (result.error) {
-        return {error: result.error};
+export async function fetchMissingDirectChannelsInfo(serverUrl: string, directChannels: Channel[], locale?: string, teammateDisplayNameSetting?: string, currentUserId?: string, fetchOnly = false) {
+    const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
+    if (!operator) {
+        return {error: `${serverUrl} database not found`};
     }
 
+    const {database} = operator;
     const displayNameByChannel: Record<string, string> = {};
     const users: UserProfile[] = [];
+    const updatedChannels = new Set<Channel>();
 
-    if (result.data) {
-        result.data.forEach((data) => {
-            if (data.users?.length) {
-                users.push(...data.users);
-                if (data.users.length > 1) {
-                    displayNameByChannel[data.channelId] = displayGroupMessageName(data.users, locale, teammateDisplayNameSetting, currentUserId);
-                } else {
-                    displayNameByChannel[data.channelId] = displayUsername(data.users[0], locale, teammateDisplayNameSetting, false);
+    const dms: Channel[] = [];
+    const gms: Channel[] = [];
+    for (const c of directChannels) {
+        if (c.type === General.DM_CHANNEL) {
+            dms.push(c);
+            continue;
+        }
+        gms.push(c);
+    }
+
+    try {
+        const currentUser = await getCurrentUser(database);
+        const results = await Promise.all([
+            fetchProfilesPerChannels(serverUrl, dms.map((c) => c.id), currentUserId, false),
+            fetchProfilesInGroupChannels(serverUrl, gms.map((c) => c.id), false),
+        ]);
+
+        for (const result of results) {
+            if (result.data) {
+                result.data.forEach((data) => {
+                    if (data.users?.length) {
+                        users.push(...data.users);
+                        if (data.users.length > 1) {
+                            displayNameByChannel[data.channelId] = displayGroupMessageName(data.users, locale, teammateDisplayNameSetting, currentUserId);
+                        } else {
+                            displayNameByChannel[data.channelId] = displayUsername(data.users[0], locale, teammateDisplayNameSetting, false);
+                        }
+                    }
+                });
+
+                directChannels.forEach((c) => {
+                    const displayName = displayNameByChannel[c.id];
+                    if (displayName) {
+                        c.display_name = displayName;
+                        c.fake = true;
+                        updatedChannels.add(c);
+                    }
+                });
+
+                if (currentUserId) {
+                    const ownDirectChannel = dms.find((dm) => dm.name === getDirectChannelName(currentUserId, currentUserId));
+                    if (ownDirectChannel) {
+                        ownDirectChannel.display_name = displayUsername(currentUser, locale, teammateDisplayNameSetting, false);
+                    }
                 }
             }
-        });
-    }
-
-    directChannels.forEach((c) => {
-        const displayName = displayNameByChannel[c.id];
-        if (displayName) {
-            c.display_name = displayName;
-            c.fake = true;
         }
-    });
 
-    if (currentUserId) {
-        const ownDirectChannel = directChannels.find((dm) => dm.name === getDirectChannelName(currentUserId, currentUserId));
-        const database = DatabaseManager.serverDatabases[serverUrl]?.database;
-        if (ownDirectChannel && database) {
-            const currentUser = await getCurrentUser(database);
-            ownDirectChannel.display_name = displayUsername(currentUser, locale, teammateDisplayNameSetting, false);
-        }
-    }
-
-    if (!fetchOnly) {
-        const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
-        if (operator) {
+        const updatedChannelsArray = Array.from(updatedChannels);
+        if (!fetchOnly) {
             const modelPromises: Array<Promise<Model[]>> = [];
             if (users.length) {
-                modelPromises.push(operator.handleUsers({users, prepareRecordsOnly: true}));
-                modelPromises.push(operator.handleChannel({channels: directChannels, prepareRecordsOnly: true}));
+                modelPromises.push(operator.handleChannel({channels: updatedChannelsArray, prepareRecordsOnly: true}));
             }
 
             const models = await Promise.all(modelPromises);
             await operator.batchRecords(models.flat());
         }
+
+        return {directChannels: updatedChannelsArray, users};
+    } catch (error) {
+        return {error};
+    }
+}
+
+export async function fetchDirectChannelsInfo(serverUrl: string, directChannels: ChannelModel[]) {
+    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+    if (!database) {
+        return {error: `${serverUrl} database not found`};
     }
 
-    return {directChannels, users};
+    const preferences = await queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS).fetch();
+    const config = await getConfig(database);
+    const license = await getLicense(database);
+    const teammateDisplayNameSetting = getTeammateNameDisplaySetting(preferences, config, license);
+    const currentUser = await getCurrentUser(database);
+    const channels = directChannels.map((d) => d.toApi());
+    return fetchMissingDirectChannelsInfo(serverUrl, channels, currentUser?.locale, teammateDisplayNameSetting, currentUser?.id);
 }
 
 export async function joinChannel(serverUrl: string, userId: string, teamId: string, channelId?: string, channelName?: string, fetchOnly = false) {
@@ -773,7 +807,7 @@ export async function createDirectChannel(serverUrl: string, userId: string, dis
             const preferences = await queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.NAME_NAME_FORMAT).fetch();
             const system = await getCommonSystemValues(database);
             const teammateDisplayNameSetting = getTeammateNameDisplaySetting(preferences || [], system.config, system.license);
-            const {directChannels, users} = await fetchMissingSidebarInfo(serverUrl, [created], currentUser.locale, teammateDisplayNameSetting, currentUser.id, true);
+            const {directChannels, users} = await fetchMissingDirectChannelsInfo(serverUrl, [created], currentUser.locale, teammateDisplayNameSetting, currentUser.id, true);
             created.display_name = directChannels?.[0].display_name || created.display_name;
             if (users?.length) {
                 profiles.push(...users);
@@ -917,7 +951,7 @@ export async function createGroupChannel(serverUrl: string, userIds: string[]) {
         const preferences = await queryPreferencesByCategoryAndName(operator.database, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.NAME_NAME_FORMAT).fetch();
         const system = await getCommonSystemValues(operator.database);
         const teammateDisplayNameSetting = getTeammateNameDisplaySetting(preferences || [], system.config, system.license);
-        const {directChannels, users} = await fetchMissingSidebarInfo(serverUrl, [created], currentUser.locale, teammateDisplayNameSetting, currentUser.id, true);
+        const {directChannels, users} = await fetchMissingDirectChannelsInfo(serverUrl, [created], currentUser.locale, teammateDisplayNameSetting, currentUser.id, true);
 
         const member = {
             channel_id: created.id,

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -454,33 +454,32 @@ export async function fetchMissingDirectChannelsInfo(serverUrl: string, directCh
             fetchProfilesInGroupChannels(serverUrl, gms.map((c) => c.id), false),
         ]);
 
-        for (const result of results) {
-            if (result.data) {
-                result.data.forEach((data) => {
-                    if (data.users?.length) {
-                        users.push(...data.users);
-                        if (data.users.length > 1) {
-                            displayNameByChannel[data.channelId] = displayGroupMessageName(data.users, locale, teammateDisplayNameSetting, currentUserId);
-                        } else {
-                            displayNameByChannel[data.channelId] = displayUsername(data.users[0], locale, teammateDisplayNameSetting, false);
-                        }
+        const profileRequests = results.flat();
+        for (const result of profileRequests) {
+            result.data?.forEach((data) => {
+                if (data.users?.length) {
+                    users.push(...data.users);
+                    if (data.users.length > 1) {
+                        displayNameByChannel[data.channelId] = displayGroupMessageName(data.users, locale, teammateDisplayNameSetting, currentUserId);
+                    } else {
+                        displayNameByChannel[data.channelId] = displayUsername(data.users[0], locale, teammateDisplayNameSetting, false);
                     }
-                });
+                }
+            });
 
-                directChannels.forEach((c) => {
-                    const displayName = displayNameByChannel[c.id];
-                    if (displayName) {
-                        c.display_name = displayName;
-                        c.fake = true;
-                        updatedChannels.add(c);
-                    }
-                });
+            directChannels.forEach((c) => {
+                const displayName = displayNameByChannel[c.id];
+                if (displayName) {
+                    c.display_name = displayName;
+                    c.fake = true;
+                    updatedChannels.add(c);
+                }
+            });
 
-                if (currentUserId) {
-                    const ownDirectChannel = dms.find((dm) => dm.name === getDirectChannelName(currentUserId, currentUserId));
-                    if (ownDirectChannel) {
-                        ownDirectChannel.display_name = displayUsername(currentUser, locale, teammateDisplayNameSetting, false);
-                    }
+            if (currentUserId) {
+                const ownDirectChannel = dms.find((dm) => dm.name === getDirectChannelName(currentUserId, currentUserId));
+                if (ownDirectChannel) {
+                    ownDirectChannel.display_name = displayUsername(currentUser, locale, teammateDisplayNameSetting, false);
                 }
             }
         }

--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -45,6 +45,20 @@ export type AppEntryError = {
     error: Error | ClientError | string;
 }
 
+export type EntryResponse = {
+    models: Model[];
+    initialTeamId: string;
+    initialChannelId: string;
+    prefData: MyPreferencesRequest;
+    teamData: MyTeamsRequest;
+    chData?: MyChannelsRequest;
+    meData?: MyUserRequest;
+} | {
+    error: unknown;
+}
+
+const FETCH_MISSING_DM_TIMEOUT = 1000;
+
 export const teamsToRemove = async (serverUrl: string, removeTeamIds?: string[]) => {
     const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
     if (!operator) {
@@ -66,17 +80,6 @@ export const teamsToRemove = async (serverUrl: string, removeTeamIds?: string[])
     return undefined;
 };
 
-export type EntryResponse = {
-    models: Model[];
-    initialTeamId: string;
-    initialChannelId: string;
-    prefData: MyPreferencesRequest;
-    teamData: MyTeamsRequest;
-    chData?: MyChannelsRequest;
-    meData?: MyUserRequest;
-} | {
-    error: unknown;
-}
 export const entry = async (serverUrl: string, teamId?: string, channelId?: string, since = 0): Promise<EntryResponse> => {
     const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
     if (!operator) {
@@ -292,7 +295,7 @@ export async function deferredAppEntryActions(
             const teammateDisplayNameSetting = getTeammateNameDisplaySetting(preferences || [], config, license);
             fetchMissingDirectChannelsInfo(serverUrl, Array.from(channelsToFetchProfiles), currentUserLocale, teammateDisplayNameSetting, currentUserId);
         }
-    }, 1000);
+    }, FETCH_MISSING_DM_TIMEOUT);
 }
 
 export const registerDeviceToken = async (serverUrl: string) => {

--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -73,6 +73,7 @@ export type EntryResponse = {
     prefData: MyPreferencesRequest;
     teamData: MyTeamsRequest;
     chData?: MyChannelsRequest;
+    meData?: MyUserRequest;
 } | {
     error: unknown;
 }
@@ -121,7 +122,7 @@ export const entry = async (serverUrl: string, teamId?: string, channelId?: stri
 
     const models = await Promise.all(modelPromises);
 
-    return {models: models.flat(), initialChannelId, initialTeamId, prefData, teamData, chData};
+    return {models: models.flat(), initialChannelId, initialTeamId, prefData, teamData, chData, meData};
 };
 
 export const fetchAppEntryData = async (serverUrl: string, since: number, initialTeamId = ''): Promise<AppEntryData | AppEntryError> => {

--- a/app/actions/remote/notifications.ts
+++ b/app/actions/remote/notifications.ts
@@ -4,18 +4,14 @@
 import {Platform} from 'react-native';
 
 import {updatePostSinceCache} from '@actions/local/notification';
-import {fetchMissingSidebarInfo, fetchMyChannel, switchToChannelById} from '@actions/remote/channel';
+import {fetchDirectChannelsInfo, fetchMyChannel, switchToChannelById} from '@actions/remote/channel';
 import {forceLogoutIfNecessary} from '@actions/remote/session';
 import {fetchMyTeam} from '@actions/remote/team';
-import {Preferences} from '@constants';
 import DatabaseManager from '@database/manager';
-import {getTeammateNameDisplaySetting} from '@helpers/api/preference';
 import {getMyChannel, getChannelById} from '@queries/servers/channel';
-import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {getCommonSystemValues, getWebSocketLastDisconnected} from '@queries/servers/system';
 import {getMyTeamById} from '@queries/servers/team';
 import {getIsCRTEnabled} from '@queries/servers/thread';
-import {getCurrentUser} from '@queries/servers/user';
 import {emitNotificationError} from '@utils/notification';
 
 const fetchNotificationData = async (serverUrl: string, notification: NotificationWithData, skipEvents = false) => {
@@ -69,12 +65,9 @@ const fetchNotificationData = async (serverUrl: string, notification: Notificati
             }
 
             if (isDirectChannel) {
-                const preferences = await queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.NAME_NAME_FORMAT).fetch();
-                const currentUser = await getCurrentUser(database);
-                const teammateDisplayNameSetting = getTeammateNameDisplaySetting(preferences || [], system.config, system.license);
                 const channel = await getChannelById(database, channelId);
                 if (channel) {
-                    fetchMissingSidebarInfo(serverUrl, [channel.toApi()], currentUser?.locale, teammateDisplayNameSetting, currentUser?.id);
+                    fetchDirectChannelsInfo(serverUrl, [channel]);
                 }
             }
         }

--- a/app/actions/remote/retry.ts
+++ b/app/actions/remote/retry.ts
@@ -15,7 +15,7 @@ import {getCurrentUser} from '@queries/servers/user';
 import TeamModel from '@typings/database/models/servers/team';
 import {isDMorGM, selectDefaultChannelForTeam} from '@utils/channel';
 
-import {fetchMissingSidebarInfo, fetchMyChannelsForTeam, MyChannelsRequest} from './channel';
+import {fetchMissingDirectChannelsInfo, fetchMyChannelsForTeam, MyChannelsRequest} from './channel';
 import {fetchPostsForChannel} from './post';
 import {fetchMyPreferences, MyPreferencesRequest} from './preference';
 import {fetchRolesIfNeeded} from './role';
@@ -122,7 +122,7 @@ export async function retryInitialTeamAndChannel(serverUrl: string) {
         const channelsToFetchProfiles = new Set<Channel>(directChannels);
         if (channelsToFetchProfiles.size) {
             const teammateDisplayNameSetting = getTeammateNameDisplaySetting(prefData.preferences || [], clData.config, clData.license);
-            fetchMissingSidebarInfo(serverUrl, Array.from(channelsToFetchProfiles), user.locale, teammateDisplayNameSetting, user.id);
+            fetchMissingDirectChannelsInfo(serverUrl, Array.from(channelsToFetchProfiles), user.locale, teammateDisplayNameSetting, user.id);
         }
 
         fetchPostsForChannel(serverUrl, initialChannel.id);
@@ -201,7 +201,7 @@ export async function retryInitialChannel(serverUrl: string, teamId: string) {
         const channelsToFetchProfiles = new Set<Channel>(directChannels);
         if (channelsToFetchProfiles.size) {
             const teammateDisplayNameSetting = getTeammateNameDisplaySetting(preferences || [], config, license);
-            fetchMissingSidebarInfo(serverUrl, Array.from(channelsToFetchProfiles), user.locale, teammateDisplayNameSetting, user.id);
+            fetchMissingDirectChannelsInfo(serverUrl, Array.from(channelsToFetchProfiles), user.locale, teammateDisplayNameSetting, user.id);
         }
 
         fetchPostsForChannel(serverUrl, initialChannel.id);

--- a/app/actions/remote/user.ts
+++ b/app/actions/remote/user.ts
@@ -110,6 +110,79 @@ export async function fetchProfilesInChannel(serverUrl: string, channelId: strin
     }
 }
 
+export async function fetchProfilesInGroupChannels(serverUrl: string, groupChannelIds: string[], fetchOnly = false): Promise<ProfilesPerChannelRequest> {
+    const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
+    if (!operator) {
+        return {error: `${serverUrl} database not found`};
+    }
+
+    const {database} = operator;
+
+    let client: Client;
+    try {
+        client = NetworkManager.getClient(serverUrl);
+    } catch (error) {
+        return {error};
+    }
+
+    try {
+        // let's filter those channels that we already have the users
+        const membersCount = await getMembersCountByChannelsId(database, groupChannelIds);
+        const channelsToFetch = groupChannelIds.filter((c) => membersCount[c] <= 1);
+        if (!channelsToFetch.length) {
+            return {data: []};
+        }
+
+        // Batch fetching profiles per channel by chunks of 50
+        const gms = chunk(channelsToFetch, 50);
+        const data: ProfilesInChannelRequest[] = [];
+
+        const requests = gms.map((cIds) => client.getProfilesInGroupChannels(cIds));
+        const response = await Promise.all(requests);
+        for (const r of response) {
+            for (const id in r) {
+                if (r[id]) {
+                    data.push({
+                        channelId: id,
+                        users: r[id],
+                    });
+                }
+            }
+        }
+
+        if (!fetchOnly) {
+            const modelPromises: Array<Promise<Model[]>> = [];
+            const users = new Set<UserProfile>();
+            const memberships: Array<{channel_id: string; user_id: string}> = [];
+            for (const item of data) {
+                if (item.users?.length) {
+                    for (const u of item.users) {
+                        users.add(u);
+                        memberships.push({channel_id: item.channelId, user_id: u.id});
+                    }
+                }
+            }
+            if (memberships.length) {
+                modelPromises.push(operator.handleChannelMembership({
+                    channelMemberships: memberships,
+                    prepareRecordsOnly: true,
+                }));
+            }
+            if (users.size) {
+                const prepare = prepareUsers(operator, Array.from(users));
+                modelPromises.push(prepare);
+            }
+
+            const models = await Promise.all(modelPromises);
+            await operator.batchRecords(models.flat());
+        }
+
+        return {data};
+    } catch (error) {
+        return {error};
+    }
+}
+
 export async function fetchProfilesPerChannels(serverUrl: string, channelIds: string[], excludeUserId?: string, fetchOnly = false): Promise<ProfilesPerChannelRequest> {
     try {
         const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
@@ -121,10 +194,13 @@ export async function fetchProfilesPerChannels(serverUrl: string, channelIds: st
 
         // let's filter those channels that we already have the users
         const membersCount = await getMembersCountByChannelsId(database, channelIds);
-        const channelsToFetch = channelIds.filter((c) => membersCount[c] <= 1 || membersCount[c] > 2);
+        const channelsToFetch = channelIds.filter((c) => membersCount[c] <= 1);
+        if (!channelsToFetch.length) {
+            return {data: []};
+        }
 
-        // Batch fetching profiles per channel by chunks of 50
-        const channels = chunk(channelsToFetch, 50);
+        // Batch fetching profiles per channel by chunks of 300
+        const channels = chunk(channelsToFetch, 300);
         const data: ProfilesInChannelRequest[] = [];
 
         for await (const cIds of channels) {
@@ -139,10 +215,12 @@ export async function fetchProfilesPerChannels(serverUrl: string, channelIds: st
             const memberships: Array<{channel_id: string; user_id: string}> = [];
             for (const item of data) {
                 if (item.users?.length) {
-                    item.users.forEach((u) => {
-                        users.add(u);
-                        memberships.push({channel_id: item.channelId, user_id: u.id});
-                    });
+                    for (const u of item.users) {
+                        if (u.id !== excludeUserId) {
+                            users.add(u);
+                            memberships.push({channel_id: item.channelId, user_id: u.id});
+                        }
+                    }
                 }
             }
             if (memberships.length) {
@@ -152,7 +230,7 @@ export async function fetchProfilesPerChannels(serverUrl: string, channelIds: st
                 }));
             }
             if (users.size) {
-                const prepare = prepareUsers(operator, Array.from(users).filter((u) => u.id !== excludeUserId));
+                const prepare = prepareUsers(operator, Array.from(users));
                 modelPromises.push(prepare);
             }
 

--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -10,7 +10,7 @@ import {
     storeMyChannelsForTeam, updateChannelInfoFromChannel, updateMyChannelFromWebsocket,
 } from '@actions/local/channel';
 import {switchToGlobalThreads} from '@actions/local/thread';
-import {fetchMissingSidebarInfo, fetchMyChannel, fetchChannelStats, fetchChannelById, switchToChannelById} from '@actions/remote/channel';
+import {fetchMissingDirectChannelsInfo, fetchMyChannel, fetchChannelStats, fetchChannelById, switchToChannelById} from '@actions/remote/channel';
 import {fetchPostsForChannel} from '@actions/remote/post';
 import {fetchRolesIfNeeded} from '@actions/remote/role';
 import {fetchUsersByIds, updateUsersNoLongerVisible} from '@actions/remote/user';
@@ -205,7 +205,7 @@ export async function handleDirectAddedEvent(serverUrl: string, msg: WebSocketMe
 
         const teammateDisplayNameSetting = await getTeammateNameDisplay(database);
 
-        const {directChannels, users} = await fetchMissingSidebarInfo(serverUrl, channels, user.locale, teammateDisplayNameSetting, user.id, true);
+        const {directChannels, users} = await fetchMissingDirectChannelsInfo(serverUrl, channels, user.locale, teammateDisplayNameSetting, user.id, true);
         if (!directChannels?.[0]) {
             return;
         }

--- a/app/components/formatted_date/index.tsx
+++ b/app/components/formatted_date/index.tsx
@@ -3,6 +3,7 @@
 
 import moment from 'moment-timezone';
 import React from 'react';
+import {useIntl} from 'react-intl';
 import {Text, TextProps} from 'react-native';
 
 type FormattedDateProps = TextProps & {
@@ -12,6 +13,8 @@ type FormattedDateProps = TextProps & {
 }
 
 const FormattedDate = ({format = 'MMM DD, YYYY', timezone, value, ...props}: FormattedDateProps) => {
+    const {locale} = useIntl();
+    moment.locale(locale);
     let formattedDate = moment(value).format(format);
     if (timezone) {
         let zone: string;

--- a/app/hooks/team_switch.ts
+++ b/app/hooks/team_switch.ts
@@ -18,7 +18,7 @@ export const useTeamSwitch = () => {
                 setLoading(true);
             } else {
                 // eslint-disable-next-line max-nested-callbacks
-                time = setTimeout(() => setLoading(false), 200);
+                time = setTimeout(() => setLoading(false), 0);
             }
         });
         return () => {

--- a/app/screens/home/channel_list/additional_tablet_view/additional_tablet_view.tsx
+++ b/app/screens/home/channel_list/additional_tablet_view/additional_tablet_view.tsx
@@ -29,6 +29,7 @@ const globalScreen: SelectedView = {id: Screens.GLOBAL_THREADS, Component: Globa
 
 const AdditionalTabletView = ({onTeam, currentChannelId, isCRTEnabled}: Props) => {
     const [selected, setSelected] = useState<SelectedView>(isCRTEnabled && !currentChannelId ? globalScreen : channelScreen);
+    const [initiaLoad, setInitialLoad] = useState(true);
 
     useEffect(() => {
         const listener = DeviceEventEmitter.addListener(Navigation.NAVIGATION_HOME, (id: string) => {
@@ -44,7 +45,15 @@ const AdditionalTabletView = ({onTeam, currentChannelId, isCRTEnabled}: Props) =
         return () => listener.remove();
     }, []);
 
-    if (!selected || !onTeam) {
+    useEffect(() => {
+        const t = setTimeout(() => {
+            setInitialLoad(false);
+        }, 0);
+
+        return () => clearTimeout(t);
+    }, []);
+
+    if (!selected || !onTeam || initiaLoad) {
         return null;
     }
 

--- a/app/screens/home/channel_list/categories_list/categories/categories.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/categories.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useMemo, useRef} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {FlatList, StyleSheet, View} from 'react-native';
 
@@ -46,6 +46,7 @@ const Categories = ({categories, onlyUnreads, unreadsOnTop}: Props) => {
     const isTablet = useIsTablet();
     const switchingTeam = useTeamSwitch();
     const teamId = categories[0]?.teamId;
+    const [initiaLoad, setInitialLoad] = useState(true);
 
     const onChannelSwitch = useCallback(async (channelId: string) => {
         switchToChannelById(serverUrl, channelId);
@@ -87,13 +88,21 @@ const Categories = ({categories, onlyUnreads, unreadsOnTop}: Props) => {
         return orderedCategories;
     }, [categories, onlyUnreads, unreadsOnTop]);
 
+    useEffect(() => {
+        const t = setTimeout(() => {
+            setInitialLoad(false);
+        }, 0);
+
+        return () => clearTimeout(t);
+    }, []);
+
     if (!categories.length) {
         return <LoadCategoriesError/>;
     }
 
     return (
         <>
-            {!switchingTeam && (
+            {!switchingTeam && !initiaLoad && (
                 <FlatList
                     data={categoriesToShow}
                     ref={listRef}
@@ -108,7 +117,7 @@ const Categories = ({categories, onlyUnreads, unreadsOnTop}: Props) => {
                     strictMode={true}
                 />
             )}
-            {switchingTeam && (
+            {(switchingTeam || initiaLoad) && (
                 <View style={styles.loadingView}>
                     <Loading
                         size='large'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mattermost-mobile",
       "version": "2.0.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",

--- a/types/database/models/servers/channel.d.ts
+++ b/types/database/models/servers/channel.d.ts
@@ -81,5 +81,5 @@ export default class ChannelModel extends Model {
     /** categoryChannel: category of this channel */
     categoryChannel: Relation<CategoryChannelModel>;
 
-    toApi = () => Channel;
+    toApi(): Channel;
 }


### PR DESCRIPTION
#### Summary
- Improved loading of DM/GM by:
1. Load on demand only DM's and GM's that are visible in the channel list per category
2. Load missing direct messages info after a small delay after entry
    * Batch DM's by 300 requests in parallel
    * Introduce the use of the [Group Channel User Profiles API](https://api.mattermost.com/#operation/GetUsersByIds) which allows us to fetch up to 50 group message channel at a time which reduces the  amount of requests and time
- Improve team switching by updating the loading state on the next tick instead of waiting 200ms
- Improve perceived performance on app entry by adding the same loading indicator as the team switching
- Fixed the path from upgrading from v1 to v2
- Fixed a random locale issue that could format the date in the wrong language

```release-note
NONE
```
