### PR TITLE
Comment out create team options until we have a create team screen

### DIFF
--- a/app/components/team_sidebar/add_team/add_team_slide_up.tsx
+++ b/app/components/team_sidebar/add_team/add_team_slide_up.tsx
@@ -13,11 +13,10 @@ import type TeamModel from '@typings/database/models/servers/team';
 
 type Props = {
     otherTeams: TeamModel[];
-    canCreateTeams: boolean;
     showTitle?: boolean;
 }
 
-export default function AddTeamSlideUp({otherTeams, canCreateTeams, showTitle = true}: Props) {
+export default function AddTeamSlideUp({otherTeams, showTitle = true}: Props) {
     const intl = useIntl();
 
     const onPressCreate = useCallback(() => {
@@ -34,7 +33,7 @@ export default function AddTeamSlideUp({otherTeams, canCreateTeams, showTitle = 
             buttonIcon='plus'
             buttonText={intl.formatMessage({id: 'mobile.add_team.create_team', defaultMessage: 'Create a new team'})}
             onPress={onPressCreate}
-            showButton={canCreateTeams}
+            showButton={false}
             showTitle={showTitle}
             testID='team_sidebar.add_team_slide_up'
             title={intl.formatMessage({id: 'mobile.add_team.join_team', defaultMessage: 'Join Another Team'})}

--- a/app/components/team_sidebar/add_team/index.tsx
+++ b/app/components/team_sidebar/add_team/index.tsx
@@ -18,14 +18,14 @@ import AddTeamSlideUp from './add_team_slide_up';
 import type TeamModel from '@typings/database/models/servers/team';
 
 type Props = {
-    canCreateTeams: boolean;
     otherTeams: TeamModel[];
 }
 
 const ITEM_HEIGHT = 72;
-const CREATE_HEIGHT = 97;
 const HEADER_HEIGHT = 66;
 const CONTAINER_HEIGHT = 392;
+
+//const CREATE_HEIGHT = 97;
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
@@ -49,7 +49,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-export default function AddTeam({canCreateTeams, otherTeams}: Props) {
+export default function AddTeam({otherTeams}: Props) {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
     const dimensions = useWindowDimensions();
@@ -62,7 +62,6 @@ export default function AddTeam({canCreateTeams, otherTeams}: Props) {
             return (
                 <AddTeamSlideUp
                     otherTeams={otherTeams}
-                    canCreateTeams={canCreateTeams}
                     showTitle={!isTablet && Boolean(otherTeams.length)}
                 />
             );
@@ -70,7 +69,7 @@ export default function AddTeam({canCreateTeams, otherTeams}: Props) {
 
         let height = CONTAINER_HEIGHT;
         if (otherTeams.length) {
-            height = Math.min(maxHeight, HEADER_HEIGHT + (otherTeams.length * ITEM_HEIGHT) + (canCreateTeams ? CREATE_HEIGHT : 0));
+            height = Math.min(maxHeight, HEADER_HEIGHT + (otherTeams.length * ITEM_HEIGHT));
         }
 
         bottomSheet({
@@ -80,7 +79,7 @@ export default function AddTeam({canCreateTeams, otherTeams}: Props) {
             theme,
             title: intl.formatMessage({id: 'mobile.add_team.join_team', defaultMessage: 'Join Another Team'}),
         });
-    }), [canCreateTeams, otherTeams, isTablet, theme]);
+    }), [otherTeams, isTablet, theme]);
 
     return (
         <View style={styles.container}>

--- a/app/components/team_sidebar/index.ts
+++ b/app/components/team_sidebar/index.ts
@@ -3,25 +3,21 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {Permissions} from '@constants';
-import {queryRolesByNames} from '@queries/servers/role';
 import {queryMyTeams, queryOtherTeams} from '@queries/servers/team';
-import {observeCurrentUser} from '@queries/servers/user';
-import {hasPermission} from '@utils/role';
 
 import TeamSidebar from './team_sidebar';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const canCreateTeams = observeCurrentUser(database).pipe(
-        switchMap((u) => (u ? of$(u.roles.split(' ')) : of$([]))),
-        switchMap((values) => queryRolesByNames(database, values).observe()),
-        switchMap((r) => of$(hasPermission(r, Permissions.CREATE_TEAM, false))),
-    );
+    // TODO https://mattermost.atlassian.net/browse/MM-43622
+    // const canCreateTeams = observeCurrentUser(database).pipe(
+    //     switchMap((u) => (u ? of$(u.roles.split(' ')) : of$([]))),
+    //     switchMap((values) => queryRolesByNames(database, values).observe()),
+    //     switchMap((r) => of$(hasPermission(r, Permissions.CREATE_TEAM, false))),
+    // );
 
     const otherTeams = queryMyTeams(database).observe().pipe(
         switchMap((mm) => {
@@ -32,7 +28,6 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     );
 
     return {
-        canCreateTeams,
         otherTeams,
     };
 });

--- a/app/components/team_sidebar/team_sidebar.tsx
+++ b/app/components/team_sidebar/team_sidebar.tsx
@@ -14,7 +14,6 @@ import TeamList from './team_list';
 import type TeamModel from '@typings/database/models/servers/team';
 
 type Props = {
-    canCreateTeams: boolean;
     iconPad?: boolean;
     otherTeams: TeamModel[];
     teamsCount: number;
@@ -39,8 +38,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-export default function TeamSidebar({canCreateTeams, iconPad, otherTeams, teamsCount}: Props) {
-    const showAddTeam = canCreateTeams || otherTeams.length > 0;
+export default function TeamSidebar({iconPad, otherTeams, teamsCount}: Props) {
+    const showAddTeam = otherTeams.length > 0;
     const initialWidth = teamsCount > 1 ? TEAM_SIDEBAR_WIDTH : 0;
     const width = useSharedValue(initialWidth);
     const marginTop = useSharedValue(iconPad ? 44 : 0);
@@ -71,7 +70,6 @@ export default function TeamSidebar({canCreateTeams, iconPad, otherTeams, teamsC
                 <TeamList testID='team_sidebar.team_list'/>
                 {showAddTeam && (
                     <AddTeam
-                        canCreateTeams={canCreateTeams}
                         otherTeams={otherTeams}
                     />
                 )}

--- a/app/screens/select_team/index.ts
+++ b/app/screens/select_team/index.ts
@@ -3,30 +3,24 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
-import {Permissions} from '@constants';
-import {queryRolesByNames} from '@queries/servers/role';
 import {queryMyTeams} from '@queries/servers/team';
-import {observeCurrentUser} from '@queries/servers/user';
-import {hasPermission} from '@utils/role';
 
 import SelectTeam from './select_team';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const canCreateTeams = observeCurrentUser(database).pipe(
-        switchMap((u) => (u ? of$(u.roles.split(' ')) : of$([]))),
-        switchMap((values) => queryRolesByNames(database, values).observeWithColumns(['permissions'])),
-        switchMap((r) => of$(hasPermission(r, Permissions.CREATE_TEAM, false))),
-    );
+    // TODO https://mattermost.atlassian.net/browse/MM-43622
+    // const canCreateTeams = observeCurrentUser(database).pipe(
+    //     switchMap((u) => (u ? of$(u.roles.split(' ')) : of$([]))),
+    //     switchMap((values) => queryRolesByNames(database, values).observeWithColumns(['permissions'])),
+    //     switchMap((r) => of$(hasPermission(r, Permissions.CREATE_TEAM, false))),
+    // );
 
     const nTeams = queryMyTeams(database).observeCount();
 
     return {
-        canCreateTeams,
         nTeams,
     };
 });

--- a/app/screens/select_team/no_teams.tsx
+++ b/app/screens/select_team/no_teams.tsx
@@ -1,13 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback} from 'react';
+import React from 'react';
 import {useIntl} from 'react-intl';
 import {StyleSheet, Text, View} from 'react-native';
 
-import CompassIcon from '@components/compass_icon';
 import Empty from '@components/illustrations/no_team';
-import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {useTheme} from '@context/theme';
 import {buttonBackgroundStyle, buttonTextStyle} from '@utils/buttonStyles';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
@@ -59,21 +57,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 
 }));
 
-type Props = {
-    canCreateTeams: boolean;
-}
-
-const NoTeams = ({
-    canCreateTeams,
-}: Props) => {
+const NoTeams = () => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
     const intl = useIntl();
-
-    const onButtonPress = useCallback(async () => {
-        // TODO https://mattermost.atlassian.net/browse/MM-43622
-        //goToScreen(Screens.CREATE_TEAM, 'Create team');
-    }, []);
 
     return (
         <View style={styles.container}>
@@ -86,7 +73,7 @@ const NoTeams = ({
             <Text style={styles.description}>
                 {intl.formatMessage({id: 'select_team.no_team.description', defaultMessage: 'To join a team, ask a team admin for an invite, or create your own team. You may also want to check your email inbox for an invitation.'})}
             </Text>
-            {canCreateTeams &&
+            {/* {canCreateTeams && // TODO https://mattermost.atlassian.net/browse/MM-43622
                 <TouchableWithFeedback
                     style={styles.buttonStyle}
                     type={'opacity'}
@@ -98,7 +85,7 @@ const NoTeams = ({
                     />
                     <Text style={styles.buttonText}>{intl.formatMessage({id: 'mobile.add_team.create_team', defaultMessage: 'Create a new team'})}</Text>
                 </TouchableWithFeedback>
-            }
+            } */}
         </View>
     );
 };

--- a/app/screens/select_team/select_team.tsx
+++ b/app/screens/select_team/select_team.tsx
@@ -25,7 +25,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 }));
 
 type Props = {
-    canCreateTeams: boolean;
     nTeams: number;
 }
 
@@ -33,7 +32,6 @@ const safeAreaEdges = ['left' as const, 'right' as const];
 const safeAreaStyle = {flex: 1};
 
 const SelectTeam = ({
-    canCreateTeams,
     nTeams,
 }: Props) => {
     const theme = useTheme();
@@ -83,11 +81,10 @@ const SelectTeam = ({
         body = (
             <TeamList
                 teams={otherTeams}
-                canCreateTeam={canCreateTeams}
             />
         );
     } else {
-        body = (<NoTeams canCreateTeams={canCreateTeams}/>);
+        body = (<NoTeams/>);
     }
 
     return (

--- a/app/screens/select_team/team_list.tsx
+++ b/app/screens/select_team/team_list.tsx
@@ -13,8 +13,6 @@ import {resetToHome} from '@screens/navigation';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 
-import AddTeamItem from './add_team_item';
-
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     container: {
         flex: 1,
@@ -40,11 +38,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 }));
 
 type Props = {
-    canCreateTeam: boolean;
     teams: Team[];
 };
 function TeamList({
-    canCreateTeam,
     teams,
 }: Props) {
     const theme = useTheme();
@@ -68,12 +64,12 @@ function TeamList({
                 <Text style={styles.title}>{intl.formatMessage({id: 'select_team.title', defaultMessage: 'Select a team'})}</Text>
                 <Text style={styles.description}>{intl.formatMessage({id: 'select_team.description', defaultMessage: 'You are not yet a member of any teams. Select one below to get started.'})}</Text>
             </View>
-            {canCreateTeam && (
+            {/* {canCreateTeam && ( // TODO https://mattermost.atlassian.net/browse/MM-43622
                 <>
                     <AddTeamItem/>
                     <View style={styles.separator}/>
                 </>
-            )}
+            )} */}
             <TeamFlatList
                 teams={teams}
                 textColor={theme.sidebarText}


### PR DESCRIPTION
#### Summary
The create team screen is scheduled for post-ga, so we have to get rid of all the options where we create the team.

I decided to comment it out, so we can reuse the work already done.

#### Ticket Link
None

```release-note
NONE
```
