### PR TITLE
Remove ts-expect-error regarding legacy refs

### DIFF
--- a/app/components/emoji_picker/sections/index.tsx
+++ b/app/components/emoji_picker/sections/index.tsx
@@ -75,7 +75,7 @@ CategoryNames.forEach((name: string) => {
 
 const EmojiSections = ({customEmojis, customEmojisEnabled, onEmojiPress, recentEmojis, skinTone, width}: Props) => {
     const serverUrl = useServerUrl();
-    const list = useRef<SectionList<EmojiSection>>();
+    const list = useRef<SectionList<EmojiSection>>(null);
     const [sectionIndex, setSectionIndex] = useState(0);
     const [customEmojiPage, setCustomEmojiPage] = useState(0);
     const [fetchingCustomEmojis, setFetchingCustomEmojis] = useState(false);
@@ -221,8 +221,6 @@ const EmojiSections = ({customEmojis, customEmojisEnabled, onEmojiPress, recentE
                 onEndReached={onLoadMoreCustomEmojis}
                 onEndReachedThreshold={2}
                 onScroll={onScroll}
-
-                // @ts-expect-error ref
                 ref={list}
                 renderItem={renderItem}
                 renderSectionHeader={renderSectionHeader}

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -115,7 +115,7 @@ function AppsFormComponent({
     submit,
     performLookupCall,
 }: Props) {
-    const scrollView = useRef<ScrollView>();
+    const scrollView = useRef<ScrollView>(null);
     const [submitting, setSubmitting] = useState(false);
     const intl = useIntl();
     const serverUrl = useServerUrl();
@@ -388,8 +388,6 @@ function AppsFormComponent({
             style={style.container}
         >
             <ScrollView
-
-                // @ts-expect-error legacy ref
                 ref={scrollView}
                 style={style.scrollView}
             >

--- a/app/screens/create_or_edit_channel/channel_info_form.tsx
+++ b/app/screens/create_or_edit_channel/channel_info_form.tsx
@@ -118,7 +118,7 @@ export default function ChannelInfoForm({
     const purposeInput = useRef<TextInput>(null);
     const headerInput = useRef<TextInput>(null);
 
-    const scrollViewRef = useRef<KeyboardAwareScrollView>();
+    const scrollViewRef = useRef<KeyboardAwareScrollView>(null);
 
     const updateScrollTimeout = useRef<NodeJS.Timeout>();
 
@@ -230,8 +230,6 @@ export default function ChannelInfoForm({
         >
             <KeyboardAwareScrollView
                 testID={'create_or_edit_channel.scrollview'}
-
-                // @ts-expect-error legacy ref
                 ref={scrollViewRef}
                 keyboardShouldPersistTaps={'always'}
                 onKeyboardDidShow={onKeyboardDidShow}

--- a/app/screens/edit_profile/edit_profile.tsx
+++ b/app/screens/edit_profile/edit_profile.tsx
@@ -48,7 +48,7 @@ const EditProfile = ({
     const intl = useIntl();
     const serverUrl = useServerUrl();
     const theme = useTheme();
-    const keyboardAwareRef = useRef<KeyboardAwareScrollView>();
+    const keyboardAwareRef = useRef<KeyboardAwareScrollView>(null);
     const changedProfilePicture = useRef<NewProfileImage | undefined>(undefined);
     const scrollViewRef = useRef<KeyboardAwareScrollView>();
     const hasUpdateUserInfo = useRef<boolean>(false);
@@ -236,8 +236,6 @@ const EditProfile = ({
                     keyboardOpeningTime={0}
                     keyboardDismissMode='on-drag'
                     keyboardShouldPersistTaps='handled'
-
-                    // @ts-expect-error legacy ref
                     ref={keyboardAwareRef}
                     scrollToOverflowEnabled={true}
                     testID='edit_profile.scroll_view'

--- a/app/screens/edit_server/form.tsx
+++ b/app/screens/edit_server/form.tsx
@@ -24,7 +24,7 @@ type Props = {
     displayNameError?: string;
     handleUpdate: () => void;
     handleDisplayNameTextChanged: (text: string) => void;
-    keyboardAwareRef: MutableRefObject<KeyboardAwareScrollView | undefined>;
+    keyboardAwareRef: MutableRefObject<KeyboardAwareScrollView | null>;
     serverUrl: string;
     theme: Theme;
 };

--- a/app/screens/edit_server/index.tsx
+++ b/app/screens/edit_server/index.tsx
@@ -42,7 +42,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 
 const EditServer = ({closeButtonId, componentId, server, theme}: ServerProps) => {
     const {formatMessage} = useIntl();
-    const keyboardAwareRef = useRef<KeyboardAwareScrollView>();
+    const keyboardAwareRef = useRef<KeyboardAwareScrollView>(null);
     const [saving, setSaving] = useState(false);
     const [displayName, setDisplayName] = useState<string>(server.displayName);
     const [buttonDisabled, setButtonDisabled] = useState(true);
@@ -110,8 +110,6 @@ const EditServer = ({closeButtonId, componentId, server, theme}: ServerProps) =>
                     extraScrollHeight={20}
                     keyboardDismissMode='on-drag'
                     keyboardShouldPersistTaps='handled'
-
-                    // @ts-expect-error legacy ref
                     ref={keyboardAwareRef}
                     scrollToOverflowEnabled={true}
                     style={styles.flex}

--- a/app/screens/forgot_password/index.tsx
+++ b/app/screens/forgot_password/index.tsx
@@ -95,7 +95,7 @@ const ForgotPassword = ({serverUrl, theme}: Props) => {
     const [error, setError] = useState<string>('');
     const [isPasswordLinkSent, setIsPasswordLinkSent] = useState<boolean>(false);
     const {formatMessage} = useIntl();
-    const keyboardAwareRef = useRef<KeyboardAwareScrollView>();
+    const keyboardAwareRef = useRef<KeyboardAwareScrollView>(null);
     const styles = getStyleSheet(theme);
 
     const changeEmail = useCallback((emailAddress: string) => {
@@ -192,8 +192,6 @@ const ForgotPassword = ({serverUrl, theme}: Props) => {
                 extraScrollHeight={0}
                 keyboardDismissMode='on-drag'
                 keyboardShouldPersistTaps='handled'
-
-                // @ts-expect-error legacy ref
                 ref={keyboardAwareRef}
                 scrollToOverflowEnabled={true}
                 style={styles.flex}

--- a/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
@@ -152,7 +152,7 @@ const ServerItem = ({
     const [switching, setSwitching] = useState(false);
     const [badge, setBadge] = useState<BadgeValues>({isUnread: false, mentions: 0});
     const styles = getStyleSheet(theme);
-    const swipeable = useRef<Swipeable>();
+    const swipeable = useRef<Swipeable>(null);
     const subscription = useRef<Subscription|undefined>();
     const viewRef = useRef<View>(null);
     const [showTutorial, setShowTutorial] = useState(false);
@@ -372,8 +372,6 @@ const ServerItem = ({
                 renderRightActions={renderActions}
                 friction={2}
                 onSwipeableWillOpen={onSwipeableWillOpen}
-
-                // @ts-expect-error legacy ref
                 ref={swipeable}
                 rightThreshold={40}
             >

--- a/app/screens/interactive_dialog/index.tsx
+++ b/app/screens/interactive_dialog/index.tsx
@@ -102,7 +102,7 @@ function InteractiveDialog({
     const serverUrl = useServerUrl();
     const intl = useIntl();
 
-    const scrollView = useRef<ScrollView>();
+    const scrollView = useRef<ScrollView>(null);
 
     const onChange = useCallback((name: string, value: string | number | boolean) => {
         dispatchValues({name, value});
@@ -223,8 +223,6 @@ function InteractiveDialog({
             style={style.container}
         >
             <ScrollView
-
-                // @ts-expect-error legacy ref
                 ref={scrollView}
                 style={style.scrollView}
             >

--- a/app/screens/login/form.tsx
+++ b/app/screens/login/form.tsx
@@ -25,7 +25,7 @@ import type {LaunchProps} from '@typings/launch';
 
 interface LoginProps extends LaunchProps {
     config: Partial<ClientConfig>;
-    keyboardAwareRef: MutableRefObject<KeyboardAwareScrollView | undefined>;
+    keyboardAwareRef: MutableRefObject<KeyboardAwareScrollView | null>;
     license: Partial<ClientLicense>;
     numberSSOs: number;
     serverDisplayName: string;

--- a/app/screens/login/index.tsx
+++ b/app/screens/login/index.tsx
@@ -77,7 +77,7 @@ const LoginOptions = ({
     serverDisplayName, serverUrl, ssoOptions, theme,
 }: LoginOptionsProps) => {
     const styles = getStyles(theme);
-    const keyboardAwareRef = useRef<KeyboardAwareScrollView>();
+    const keyboardAwareRef = useRef<KeyboardAwareScrollView>(null);
     const dimensions = useWindowDimensions();
     const isTablet = useIsTablet();
     const translateX = useSharedValue(dimensions.width);
@@ -199,8 +199,6 @@ const LoginOptions = ({
                     extraScrollHeight={0}
                     keyboardDismissMode='on-drag'
                     keyboardShouldPersistTaps='handled'
-
-                    // @ts-expect-error legacy ref
                     ref={keyboardAwareRef}
                     scrollToOverflowEnabled={true}
                     style={styles.flex}

--- a/app/screens/mfa/index.tsx
+++ b/app/screens/mfa/index.tsx
@@ -97,7 +97,7 @@ const MFA = ({config, goToHome, license, loginId, password, serverDisplayName, s
     const dimensions = useWindowDimensions();
     const translateX = useSharedValue(dimensions.width);
     const isTablet = useIsTablet();
-    const keyboardAwareRef = useRef<KeyboardAwareScrollView>();
+    const keyboardAwareRef = useRef<KeyboardAwareScrollView>(null);
     const intl = useIntl();
     const [token, setToken] = useState<string>('');
     const [error, setError] = useState<string>('');
@@ -197,8 +197,6 @@ const MFA = ({config, goToHome, license, loginId, password, serverDisplayName, s
                     extraScrollHeight={0}
                     keyboardDismissMode='on-drag'
                     keyboardShouldPersistTaps='handled'
-
-                    // @ts-expect-error legacy ref
                     ref={keyboardAwareRef}
                     scrollToOverflowEnabled={true}
                     style={styles.flex}

--- a/app/screens/server/form.tsx
+++ b/app/screens/server/form.tsx
@@ -25,7 +25,7 @@ type Props = {
     handleConnect: () => void;
     handleDisplayNameTextChanged: (text: string) => void;
     handleUrlTextChanged: (text: string) => void;
-    keyboardAwareRef: MutableRefObject<KeyboardAwareScrollView | undefined>;
+    keyboardAwareRef: MutableRefObject<KeyboardAwareScrollView | null>;
     theme: Theme;
     url?: string;
     urlError?: string;

--- a/app/screens/server/index.tsx
+++ b/app/screens/server/index.tsx
@@ -63,7 +63,7 @@ const Server = ({
     const managedConfig = useManagedConfig<ManagedConfig>();
     const dimensions = useWindowDimensions();
     const translateX = useSharedValue(0);
-    const keyboardAwareRef = useRef<KeyboardAwareScrollView>();
+    const keyboardAwareRef = useRef<KeyboardAwareScrollView>(null);
     const [connecting, setConnecting] = useState(false);
     const [displayName, setDisplayName] = useState<string>('');
     const [buttonDisabled, setButtonDisabled] = useState(true);
@@ -330,8 +330,6 @@ const Server = ({
                     extraScrollHeight={20}
                     keyboardDismissMode='on-drag'
                     keyboardShouldPersistTaps='handled'
-
-                    // @ts-expect-error legacy ref
                     ref={keyboardAwareRef}
                     scrollToOverflowEnabled={true}
                     style={styles.flex}


### PR DESCRIPTION
#### Summary
On several places we added ts-expect-error regarding legacy refs. This may be problematic, since potentially may hide other errors in the future.

The fix was actually to pass null to the useRef function.

#### Ticket Link
None

```release-note
NONE
```
