### PR TITLE
Accept text shared with image on Android

### DIFF
--- a/android/app/src/main/java/com/mattermost/share/ShareModule.java
+++ b/android/app/src/main/java/com/mattermost/share/ShareModule.java
@@ -167,6 +167,11 @@ public class ShareModule extends ReactContextBaseJavaModule {
                     map.putString("type", type);
                     map.putBoolean("isString", false);
                     items.pushMap(map);
+
+                    map = Arguments.createMap();
+                    map.putString("value", extra);
+                    map.putBoolean("isString", true);
+                    items.pushMap(map);
                 }
             } else if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
                 ArrayList<Uri> uris = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Some android apps set both `EXTRA_STREAM` and `EXTRA_TEXT` in order to send text along with an image when you use their share functionality. Currently Mattermost Mobile only gets the image when this happens.

An example app that does this is [Knotwords](https://play.google.com/store/apps/details?id=com.noodlecake.knotwords) (to test complete a daily puzzle and try to share your result with Mattermost)

This PR enables Mattermost to also send the text alongside the image.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
- Oneplus 6 (Android 11)
- Samsung Galaxy 10+ (Android 12)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixed sharing of text alongside an image on Android
```
