### PR TITLE
[Gekidou] Update Markdown theme

### DIFF
--- a/app/components/emoji/index.tsx
+++ b/app/components/emoji/index.tsx
@@ -62,7 +62,7 @@ const Emoji = (props: Props) => {
         } else {
             unicode = emoji.image;
         }
-    } else {
+    } else if (!isUnicodeEmoji(name)) {
         const custom = customEmojis.find((ce) => ce.name === name);
         if (custom) {
             try {
@@ -71,7 +71,7 @@ const Emoji = (props: Props) => {
             } catch {
                 // do nothing
             }
-        } else if (name && !isUnicodeEmoji(name)) {
+        } else if (name) {
             fetchCustomEmojiInBatch(serverUrl, name);
         }
     }

--- a/app/components/emoji/index.tsx
+++ b/app/components/emoji/index.tsx
@@ -21,6 +21,7 @@ import NetworkManager from '@managers/network_manager';
 import {queryCustomEmojisByName} from '@queries/servers/custom_emoji';
 import {observeConfigBooleanValue} from '@queries/servers/system';
 import {EmojiIndicesByAlias, Emojis} from '@utils/emoji';
+import {isUnicodeEmoji} from '@utils/emoji/helpers';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 import type CustomEmojiModel from '@typings/database/models/servers/custom_emoji';
@@ -52,16 +53,17 @@ const Emoji = (props: Props) => {
     let assetImage = '';
     let unicode;
     let imageUrl = '';
+    const name = emojiName.trim();
 
-    if (EmojiIndicesByAlias.has(emojiName)) {
-        const emoji = Emojis[EmojiIndicesByAlias.get(emojiName)!];
+    if (EmojiIndicesByAlias.has(name)) {
+        const emoji = Emojis[EmojiIndicesByAlias.get(name)!];
         if (emoji.category === 'custom') {
             assetImage = emoji.fileName;
         } else {
             unicode = emoji.image;
         }
     } else {
-        const custom = customEmojis.find((ce) => ce.name === emojiName);
+        const custom = customEmojis.find((ce) => ce.name === name);
         if (custom) {
             try {
                 const client = NetworkManager.getClient(serverUrl);
@@ -69,8 +71,8 @@ const Emoji = (props: Props) => {
             } catch {
                 // do nothing
             }
-        } else {
-            fetchCustomEmojiInBatch(serverUrl, emojiName);
+        } else if (name && !isUnicodeEmoji(name)) {
+            fetchCustomEmojiInBatch(serverUrl, name);
         }
     }
 

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -3,7 +3,7 @@
 
 import {Parser, Node} from 'commonmark';
 import Renderer from 'commonmark-react-renderer';
-import React, {ReactElement, useRef} from 'react';
+import React, {ReactElement, useMemo, useRef} from 'react';
 import {Dimensions, GestureResponderEvent, Platform, StyleProp, Text, TextStyle, View} from 'react-native';
 
 import CompassIcon from '@components/compass_icon';
@@ -497,7 +497,7 @@ const Markdown = ({
     };
 
     const parser = useRef(new Parser({urlFilter, minimumHashtagLength})).current;
-    const renderer = useRef(createRenderer()).current;
+    const renderer = useMemo(() => createRenderer(), [theme]);
     let ast = parser.parse(value.toString());
 
     ast = combineTextNodes(ast);

--- a/app/components/markdown/markdown_latex_block/index.tsx
+++ b/app/components/markdown/markdown_latex_block/index.tsx
@@ -46,6 +46,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             flexDirection: 'row',
             flex: 1,
         },
+        mathStyle: {
+            color: theme.centerChannelColor,
+        },
         rightColumn: {
             flexDirection: 'column',
             flex: 1,
@@ -209,6 +212,7 @@ const LatexCodeBlock = ({content, theme}: Props) => {
                                     math={latexCode}
                                     renderError={onRenderErrorMessage}
                                     resizeMode={'cover'}
+                                    style={styles}
                                 />
                             </View>
                         ))}

--- a/app/components/markdown/markdown_latex_inline/index.tsx
+++ b/app/components/markdown/markdown_latex_inline/index.tsx
@@ -24,6 +24,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         mathStyle: {
             marginBottom: Platform.select({default: -10, ios: 2.5}),
+            color: theme.centerChannelColor,
         },
         viewStyle: {
             flexDirection: 'row',

--- a/app/utils/emoji/helpers.ts
+++ b/app/utils/emoji/helpers.ts
@@ -10,6 +10,8 @@ import {Emojis, EmojiIndicesByAlias, EmojiIndicesByUnicode} from '.';
 
 import type CustomEmojiModel from '@typings/database/models/servers/custom_emoji';
 
+const UNICODE_REGEX = /\p{Emoji}/u;
+
 const RE_NAMED_EMOJI = /(:([a-zA-Z0-9_+-]+):)/g;
 
 const RE_UNICODE_EMOJI = emojiRegex();
@@ -50,6 +52,10 @@ function isEmoticon(text: string) {
     }
 
     return false;
+}
+
+export function isUnicodeEmoji(text: string) {
+    return UNICODE_REGEX.test(text);
 }
 
 export function getEmoticonName(value: string) {


### PR DESCRIPTION
#### Summary
This PR addresses 3 things:
1. When using the app at the same time as the webapp and the theme is updating on the webapp, correct colors where not being updated because of the renderer reference used by the Markdown component
2. Latex now uses the correct color value for the math formulas
3. Emoji with unicode were attempting to find an emoji on the server without need

```release-note
NONE
```
