### PR TITLE
[Gekidou] [Bug] Unreads header is capitilized

### DIFF
--- a/app/screens/home/channel_list/categories_list/categories/unreads/unreads.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/unreads/unreads.tsx
@@ -16,6 +16,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     heading: {
         color: changeOpacity(theme.sidebarText, 0.64),
         ...typography('Heading', 75),
+        textTransform: 'uppercase',
         paddingLeft: 18,
         paddingVertical: 8,
         marginTop: 12,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Unreads section header is capitilized.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-44693

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots

<img width="515" alt="Screen Shot 2022-06-03 at 11 49 00 am" src="https://user-images.githubusercontent.com/456511/171771211-8ef9e422-086f-4d3a-8b26-7dc3875f84a6.png">


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
