### PR TITLE
[Gekidou MM-44791] Styling changes to thread items in global threads view

### DIFF
--- a/app/screens/global_threads/threads_list/thread/thread.tsx
+++ b/app/screens/global_threads/threads_list/thread/thread.tsx
@@ -38,8 +38,9 @@ type Props = {
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         container: {
-            paddingTop: 16,
+            paddingTop: 12,
             paddingRight: 16,
+            paddingBottom: 6,
             flex: 1,
             flexDirection: 'row',
             borderBottomColor: changeOpacity(theme.centerChannelColor, 0.08),
@@ -47,7 +48,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         badgeContainer: {
             marginTop: 3,
-            width: 32,
+            width: 26,
         },
         postContainer: {
             flex: 1,
@@ -56,7 +57,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             alignItems: 'center',
             flex: 1,
             flexDirection: 'row',
-            marginBottom: 9,
+            marginBottom: 6,
         },
         headerInfoContainer: {
             alignItems: 'center',
@@ -71,10 +72,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         threadStarter: {
             color: theme.centerChannelColor,
-            fontSize: 15,
-            fontWeight: '600',
-            lineHeight: 22,
-            paddingRight: 8,
+            ...typography('Body', 200, 'SemiBold'),
+            paddingRight: 6,
         },
         channelNameContainer: {
             backgroundColor: changeOpacity(theme.centerChannelColor, 0.08),
@@ -86,12 +85,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             ...typography('Body', 25, 'SemiBold'),
             letterSpacing: 0.1,
             textTransform: 'uppercase',
-            marginHorizontal: 12,
+            marginHorizontal: 6,
             marginVertical: 2,
         },
         date: {
             color: changeOpacity(theme.centerChannelColor, 0.64),
-            ...typography('Body', 25, 'Light'),
+            ...typography('Body', 50, 'Regular'),
         },
         message: {
             color: theme.centerChannelColor,


### PR DESCRIPTION
#### Summary
Small UI tweaks to the Thread Item for the Global Threads View to align better with designed components:

- The channel name label that shows on thread list items has extra horizontal padding that shouldn’t be there.
- The font used for the author should be open sans body 200
- The time stamp appears too light and should be using body 50 
- Update margin under header
- Update margin under footer
- Reduce badge space on the left

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-44791

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS and Android Simulator

#### Screenshots
<table>
<tr>
<td>iOS</td>
<td>Android</td>
</tr>
<tr>
<td>
<img width="564" alt="Screen Shot 2022-06-03 at 11 18 17 AM" src="https://user-images.githubusercontent.com/2040554/171884606-4427cc7b-5054-44c5-8872-e7fe29b820ae.png">
</td>
<td><img width="472" alt="Screen Shot 2022-06-03 at 11 19 31 AM" src="https://user-images.githubusercontent.com/2040554/171884512-8ccabbd2-d1ee-4126-a075-77e1c38db3bb.png"></td>


</tr>
</table>

#### Release Note
```release-note
UI changes to thread list items in the global threads view
```
