### PR TITLE
[Gekidou] Update database to hold if a user is a team or channel admin

### DIFF
--- a/app/database/models/server/channel_membership.ts
+++ b/app/database/models/server/channel_membership.ts
@@ -37,6 +37,9 @@ export default class ChannelMembershipModel extends Model implements ChannelMemb
     /* user_id: The foreign key to the related User record*/
     @field('user_id') userId!: string;
 
+    /* scheme_admin: Determines if the user is an admin of the channel*/
+    @field('scheme_admin') schemeAdmin!: boolean;
+
     /** memberChannel : The related channel this member belongs to */
     @immutableRelation(CHANNEL, 'channel_id') memberChannel!: Relation<ChannelModel>;
 

--- a/app/database/models/server/team_membership.ts
+++ b/app/database/models/server/team_membership.ts
@@ -37,6 +37,9 @@ export default class TeamMembershipModel extends Model implements TeamMembership
     /* user_id: The foreign key to the related User record*/
     @field('user_id') userId!: string;
 
+    /* scheme_admin: Determines if the user is an admin of the team*/
+    @field('scheme_admin') schemeAdmin!: boolean;
+
     /** memberUser: The related user in the team */
     @immutableRelation(USER, 'user_id') memberUser!: Relation<UserModel>;
 

--- a/app/database/operator/server_data_operator/handlers/team.test.ts
+++ b/app/database/operator/server_data_operator/handlers/team.test.ts
@@ -85,10 +85,15 @@ describe('*** Operator: Team Handlers tests ***', () => {
             prepareRecordsOnly: false,
         });
 
+        const memberships = teamMemberships.map((m) => ({
+            ...m,
+            id: `${m.team_id}-${m.user_id}`,
+        }));
+
         expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
         expect(spyOnHandleRecords).toHaveBeenCalledWith({
             fieldName: 'user_id',
-            createOrUpdateRawValues: teamMemberships,
+            createOrUpdateRawValues: memberships,
             tableName: 'TeamMembership',
             prepareRecordsOnly: false,
             buildKeyRecordBy: buildTeamMembershipKey,

--- a/app/database/operator/server_data_operator/handlers/team.ts
+++ b/app/database/operator/server_data_operator/handlers/team.ts
@@ -59,7 +59,12 @@ const TeamHandler = (superclass: any) => class extends superclass {
             return [];
         }
 
-        const createOrUpdateRawValues = getUniqueRawsBy({raws: teamMemberships, key: 'team_id'});
+        const memberships: TeamMembership[] = teamMemberships.map((m) => ({
+            ...m,
+            id: `${m.team_id}-${m.user_id}`,
+        }));
+
+        const createOrUpdateRawValues = getUniqueRawsBy({raws: memberships, key: 'id'});
 
         return this.handleRecords({
             fieldName: 'user_id',

--- a/app/database/operator/server_data_operator/transformers/channel.ts
+++ b/app/database/operator/server_data_operator/transformers/channel.ts
@@ -165,6 +165,7 @@ export const transformChannelMembershipRecord = ({action, database, value}: Tran
         channelMember._raw.id = isCreateAction ? (raw?.id ?? channelMember.id) : record.id;
         channelMember.channelId = raw.channel_id;
         channelMember.userId = raw.user_id;
+        channelMember.schemeAdmin = raw.scheme_admin ?? false;
     };
 
     return prepareBaseRecord({

--- a/app/database/operator/server_data_operator/transformers/team.ts
+++ b/app/database/operator/server_data_operator/transformers/team.ts
@@ -37,6 +37,7 @@ export const transformTeamMembershipRecord = ({action, database, value}: Transfo
         teamMembership._raw.id = isCreateAction ? (raw?.id ?? teamMembership.id) : record.id;
         teamMembership.teamId = raw.team_id;
         teamMembership.userId = raw.user_id;
+        teamMembership.schemeAdmin = raw.scheme_admin;
     };
 
     return prepareBaseRecord({

--- a/app/database/schema/server/table_schemas/channel_membership.ts
+++ b/app/database/schema/server/table_schemas/channel_membership.ts
@@ -12,5 +12,6 @@ export default tableSchema({
     columns: [
         {name: 'channel_id', type: 'string', isIndexed: true},
         {name: 'user_id', type: 'string', isIndexed: true},
+        {name: 'scheme_admin', type: 'boolean'},
     ],
 });

--- a/app/database/schema/server/table_schemas/team_membership.ts
+++ b/app/database/schema/server/table_schemas/team_membership.ts
@@ -12,5 +12,6 @@ export default tableSchema({
     columns: [
         {name: 'team_id', type: 'string', isIndexed: true},
         {name: 'user_id', type: 'string', isIndexed: true},
+        {name: 'scheme_admin', type: 'boolean'},
     ],
 });

--- a/app/database/schema/server/test.ts
+++ b/app/database/schema/server/test.ts
@@ -137,10 +137,12 @@ describe('*** Test schema for SERVER database ***', () => {
                     columns: {
                         channel_id: {name: 'channel_id', type: 'string', isIndexed: true},
                         user_id: {name: 'user_id', type: 'string', isIndexed: true},
+                        scheme_admin: {name: 'scheme_admin', type: 'boolean'},
                     },
                     columnArray: [
                         {name: 'channel_id', type: 'string', isIndexed: true},
                         {name: 'user_id', type: 'string', isIndexed: true},
+                        {name: 'scheme_admin', type: 'boolean'},
                     ],
                 },
                 [CUSTOM_EMOJI]: {
@@ -486,10 +488,12 @@ describe('*** Test schema for SERVER database ***', () => {
                     columns: {
                         team_id: {name: 'team_id', type: 'string', isIndexed: true},
                         user_id: {name: 'user_id', type: 'string', isIndexed: true},
+                        scheme_admin: {name: 'scheme_admin', type: 'boolean'},
                     },
                     columnArray: [
                         {name: 'team_id', type: 'string', isIndexed: true},
                         {name: 'user_id', type: 'string', isIndexed: true},
+                        {name: 'scheme_admin', type: 'boolean'},
                     ],
                 },
                 [TEAM_SEARCH_HISTORY]: {

--- a/docs/database/server/server.md
+++ b/docs/database/server/server.md
@@ -55,6 +55,7 @@ ChannelMembership
 id PK string # composition ID Channel.id-User.id
 channel_id string INDEX FK >- Channel.id
 user_id string INDEX FK >- User.id
+scheme_admin bool
 
 CustomEmoji
 -
@@ -241,6 +242,7 @@ TeamMembership
 id PK string # auto-generated
 team_id string INDEX FK >- Team.id
 user_id string INDEX FK >- User.id
+scheme_admin bool
 
 
 TeamSearchHistory

--- a/types/api/channels.d.ts
+++ b/types/api/channels.d.ts
@@ -51,6 +51,7 @@ type ChannelMember = {
     id?: string;
     channel_id: string;
     user_id: string;
+    scheme_admin?: boolean;
 }
 type ChannelMembership = {
     id?: string;

--- a/types/database/database.d.ts
+++ b/types/database/database.d.ts
@@ -239,7 +239,7 @@ export type HandleTeamArgs = PrepareOnly & {
 };
 
 export type HandleChannelMembershipArgs = PrepareOnly & {
-  channelMemberships?: Array<Pick<ChannelMembership, 'user_id' | 'channel_id'>>;
+  channelMemberships?: Array<Pick<ChannelMembership, 'user_id' | 'channel_id' | 'scheme_admin'>>;
 };
 
 export type HandleTeamMembershipArgs = PrepareOnly & {

--- a/types/database/models/servers/channel_membership.d.ts
+++ b/types/database/models/servers/channel_membership.d.ts
@@ -24,6 +24,9 @@ export default class ChannelMembershipModel extends Model {
     /* user_id: The foreign key to the related User record*/
     userId: string;
 
+    /* scheme_admin: Determines if the user is an admin of the channel*/
+    schemeAdmin: boolean;
+
     /** memberChannel : The related channel this member belongs to */
     memberChannel: Relation<ChannelModel>;
 

--- a/types/database/models/servers/team_membership.d.ts
+++ b/types/database/models/servers/team_membership.d.ts
@@ -24,6 +24,9 @@ export default class TeamMembershipModel extends Model {
     /* user_id: The foreign key to the related User record*/
     userId: string;
 
+    /* scheme_admin: Determines if the user is an admin of the channel*/
+    schemeAdmin: boolean;
+
     /** memberUser: The related user in the team */
     memberUser: Relation<UserModel>;
 


### PR DESCRIPTION
#### Summary
The User Profile screen needs to display a badge when the user is a TeamAdmin or a Channel Admin. This means that we need to store the `scheme_admin` prop of the team & channel memberships

```release-note
NONE
```
