### PR TITLE
[Gekidou] Disallow connecting to the same server from the multi-server selection

### DIFF
--- a/app/utils/server/index.ts
+++ b/app/utils/server/index.ts
@@ -170,6 +170,16 @@ export function alertServerError(intl: IntlShape, error: ClientErrorProps) {
     );
 }
 
+export function alertServerAlreadyConnected(intl: IntlShape) {
+    Alert.alert(
+        '',
+        intl.formatMessage({
+            id: 'mobile.server_identifier.exists',
+            defaultMessage: 'You are already connected to this server.',
+        }),
+    );
+}
+
 function unsupportedServerAdminAlert(intl: IntlShape) {
     const title = intl.formatMessage({id: 'mobile.server_upgrade.title', defaultMessage: 'Server upgrade required'});
 


### PR DESCRIPTION
#### Summary
On a mutli-server environment, we do not allow the user to connect to the same server (matching serverId's). There was a way to bypass this from within the server list bottom sheet, this PR fixes it.

```release-note
NONE
```
