### PR TITLE
[Gekidou] Open & Render Tables in their own screen

### DIFF
--- a/app/components/markdown/markdown_table/index.tsx
+++ b/app/components/markdown/markdown_table/index.tsx
@@ -8,6 +8,7 @@ import LinearGradient from 'react-native-linear-gradient';
 
 import CompassIcon from '@components/compass_icon';
 import {CELL_MAX_WIDTH, CELL_MIN_WIDTH} from '@components/markdown/markdown_table_cell';
+import {Screens} from '@constants';
 import DeviceTypes from '@constants/device';
 import {goToScreen} from '@screens/navigation';
 import {preventDoubleTap} from '@utils/tap';
@@ -144,15 +145,15 @@ class MarkdownTable extends PureComponent<MarkdownTableProps, MarkdownTableState
 
     handlePress = preventDoubleTap(() => {
         const {intl} = this.props;
-        const screen = 'Table';
+        const screen = Screens.TABLE;
         const title = intl.formatMessage({
             id: 'mobile.routes.table',
             defaultMessage: 'Table',
         });
         const passProps = {
-            renderRows: this.renderRows,
-            tableWidth: this.getTableWidth(true),
             renderAsFlex: this.shouldRenderAsFlex(true),
+            renderRows: this.renderRows,
+            width: this.getTableWidth(true),
         };
 
         goToScreen(screen, title, passProps);

--- a/app/constants/screens.ts
+++ b/app/constants/screens.ts
@@ -49,6 +49,7 @@ export const SETTINGS_NOTIFICATION_MENTION = 'SettingsNotificationMention';
 export const SETTINGS_NOTIFICATION_PUSH = 'SettingsNotificationPush';
 export const SNACK_BAR = 'SnackBar';
 export const SSO = 'SSO';
+export const TABLE = 'Table';
 export const THREAD = 'Thread';
 export const THREAD_FOLLOW_BUTTON = 'ThreadFollowButton';
 export const THREAD_OPTIONS = 'ThreadOptions';
@@ -102,6 +103,7 @@ export default {
     SETTINGS_NOTIFICATION_PUSH,
     SNACK_BAR,
     SSO,
+    TABLE,
     THREAD,
     THREAD_FOLLOW_BUTTON,
     THREAD_OPTIONS,

--- a/app/screens/index.tsx
+++ b/app/screens/index.tsx
@@ -167,9 +167,6 @@ Navigation.setLazyComponentRegistrator((screenName) => {
         case Screens.SETTINGS:
             screen = withServerDatabase(require('@screens/settings').default);
             break;
-        case Screens.SETTINGS_DISPLAY:
-            screen = withServerDatabase(require('@screens/settings/display').default);
-            break;
         case Screens.SETTINGS_NOTIFICATION:
             screen = withServerDatabase(require('@screens/settings/notifications').default);
             break;
@@ -194,6 +191,9 @@ Navigation.setLazyComponentRegistrator((screenName) => {
         }
         case Screens.SSO:
             screen = withIntl(require('@screens/sso').default);
+            break;
+        case Screens.TABLE:
+            screen = withServerDatabase(require('@screens/table').default);
             break;
         case Screens.THREAD:
             screen = withServerDatabase(require('@screens/thread').default);

--- a/app/screens/table/index.tsx
+++ b/app/screens/table/index.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {Platform, ScrollView, StyleSheet} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
+type Props = {
+    renderAsFlex: boolean;
+    renderRows: (isFullView: boolean) => JSX.Element|null;
+    width: number;
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    fullHeight: {
+        height: '100%',
+    },
+    displayFlex: {
+        ...Platform.select({
+            android: {
+                flex: 1,
+            },
+            ios: {
+                flex: 0,
+            },
+        }),
+    },
+});
+
+const Table = ({renderAsFlex, renderRows, width}: Props) => {
+    const content = renderRows(true);
+    const viewStyle = renderAsFlex ? styles.displayFlex : {width};
+
+    if (Platform.OS === 'android') {
+        return (
+            <ScrollView testID='table.screen'>
+                <ScrollView
+                    contentContainerStyle={viewStyle}
+                    horizontal={true}
+                    testID='table.scroll_view'
+                >
+                    {content}
+                </ScrollView>
+            </ScrollView>
+        );
+    }
+
+    return (
+        <SafeAreaView
+            style={styles.container}
+            testID='table.screen'
+        >
+            <ScrollView
+                style={styles.fullHeight}
+                contentContainerStyle={viewStyle}
+                testID='table.scroll_view'
+            >
+                {content}
+            </ScrollView>
+        </SafeAreaView>
+    );
+};
+
+export default Table;


### PR DESCRIPTION
#### Summary
When a post contains a table, tapping on the table opens a screen showing the entire content of the table.

```release-note
NONE
```
