### PR TITLE
Create configuration folder for notice.txt generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ env.d.ts
 
 # Xcode
 #
-build/
+build/*
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -103,3 +103,6 @@ detox/detox_pixel_4_xl_api_30
 
 #editor-settings
 .vscode
+
+# Notice.txt generation
+!build/notice-file

--- a/build/notice-file/config.yaml
+++ b/build/notice-file/config.yaml
@@ -1,0 +1,14 @@
+---
+
+title: "Mattermost Mobile"
+copyright: "© 2016-present Mattermost, Inc.  All Rights Reserved.  See LICENSE.txt for license information."
+description: "This document includes a list of open source components used in Mattermost Mobile, including those that have been modified."
+reviewers: 
+  - "mattermost/release-managers"
+  - "enahum"
+search:
+  - "package.json"
+dependencies: []
+devDependencies: []
+
+...


### PR DESCRIPTION
#### Summary
We are working to automate Notice.txt file generation and some of the properties need to be managed by developers.

To support that feature, we created a configuration file in the repo under build folder. 

#### Ticket Link
https://mattermost.atlassian.net/browse/DOPS-448

#### Release Note
```release-note
NONE
```
