### PR TITLE
Exclude Beta builds from v1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,14 +286,6 @@ jobs:
           name: Post results to Mattermost
           command: go run ../security-automation-config/dependency-check/post_results.go
 
-  build-android-beta:
-    executor: android
-    steps:
-      - build-android
-      - persist
-      - save:
-          filename: "*.apk"
-
   build-android-release:
     executor: android
     steps:
@@ -332,14 +324,6 @@ jobs:
       - persist
       - save:
           filename: "*.apk"
-
-  build-ios-beta:
-    executor: ios
-    steps:
-      - build-ios
-      - persist
-      - save:
-          filename: "*.ipa"
 
   build-ios-release:
     executor: ios
@@ -416,25 +400,7 @@ jobs:
           target: android
           file: "*.apk"
 
-  deploy-android-beta:
-    executor:
-      name: android
-      resource_class: medium
-    steps:
-      - deploy-to-store:
-          task: "Deploy to Google Play"
-          target: android
-          file: "*.apk"
-
   deploy-ios-release:
-    executor: ios
-    steps:
-      - deploy-to-store:
-          task: "Deploy to TestFlight"
-          target: ios
-          file: "*.ipa"
-
-  deploy-ios-beta:
     executor: ios
     steps:
       - deploy-to-store:
@@ -485,27 +451,6 @@ workflows:
                 - /^build-android-\d+$/
                 - /^build-android-release-\d+$/
 
-      - build-android-beta:
-          context: mattermost-mobile-android-beta
-          requires:
-            - test
-          filters:
-            branches:
-              only:
-                - /^build-\d+$/
-                - /^build-android-\d+$/
-                - /^build-android-beta-\d+$/
-      - deploy-android-beta:
-          context: mattermost-mobile-android-beta
-          requires:
-            - build-android-beta
-          filters:
-            branches:
-              only:
-                - /^build-\d+$/
-                - /^build-android-\d+$/
-                - /^build-android-beta-\d+$/
-
       - build-ios-release:
           context: mattermost-mobile-ios-release
           requires:
@@ -526,27 +471,6 @@ workflows:
                 - /^build-\d+$/
                 - /^build-ios-\d+$/
                 - /^build-ios-release-\d+$/
-
-      - build-ios-beta:
-          context: mattermost-mobile-ios-beta
-          requires:
-            - test
-          filters:
-            branches:
-              only:
-                - /^build-\d+$/
-                - /^build-ios-\d+$/
-                - /^build-ios-beta-\d+$/
-      - deploy-ios-beta:
-          context: mattermost-mobile-ios-beta
-          requires:
-            - build-ios-beta
-          filters:
-            branches:
-              only:
-                - /^build-\d+$/
-                - /^build-ios-\d+$/
-                - /^build-ios-beta-\d+$/
 
       - build-android-pr:
           context: mattermost-mobile-android-pr
@@ -590,7 +514,6 @@ workflows:
               only:
                 - /^build-\d+$/
                 - /^build-ios-\d+$/
-                - /^build-ios-beta-\d+$/
                 - /^build-ios-sim-\d+$/
                 
       - github-release:


### PR DESCRIPTION
#### Summary
As we approach the first public release of the v2 beta app, we are going to stop delivering the beta app for v1

```release-note
NONE
```
