### PR TITLE
[Gekidou] Do not show tutorial if screen is closed

### DIFF
--- a/app/components/user_list_row/index.tsx
+++ b/app/components/user_list_row/index.tsx
@@ -139,8 +139,10 @@ export default function UserListRow({
                 endX: x + w + 20,
                 endY: y + h,
             };
-            setShowTutorial(true);
-            setItemBounds(bounds);
+            if (viewRef.current) {
+                setShowTutorial(true);
+                setItemBounds(bounds);
+            }
         });
     };
 

--- a/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
@@ -202,8 +202,11 @@ const ServerItem = ({
                 endX: x + w + 20,
                 endY: y + h,
             };
-            setShowTutorial(true);
-            setItemBounds(bounds);
+
+            if (viewRef.current) {
+                setShowTutorial(true);
+                setItemBounds(bounds);
+            }
         });
     };
 


### PR DESCRIPTION
#### Summary
Tutorials for server and user lists were being displayed even after the screen was closed quickly.

Applies to server tutorial and create/open DM

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45134

```release-note
NONE
```
