### PR TITLE
[MM-45155] Add support for Calls when MM installation is served under a subpath

### DIFF
--- a/app/products/calls/connection.ts
+++ b/app/products/calls/connection.ts
@@ -44,7 +44,7 @@ export async function newClient(channelID: string, iceServers: ICEServersConfigs
         console.log('Unable to get media device:', err); // eslint-disable-line no-console
     }
 
-    const ws = new WebSocketClient(Client4.getWebSocketUrl());
+    const ws = new WebSocketClient(Client4.getWebSocketUrl(), Client4.getToken());
 
     const disconnect = () => {
         if (!isClosed) {

--- a/app/products/calls/websocket.ts
+++ b/app/products/calls/websocket.ts
@@ -7,13 +7,14 @@ import {encode} from '@msgpack/msgpack/dist';
 
 export default class WebSocketClient extends EventEmitter {
     private ws: WebSocket | null;
-    private seqNo = 0;
+    private seqNo = 1;
     private connID = '';
     private eventPrefix = `custom_${Calls.PluginId}`;
 
-    constructor(connURL: string) {
+    constructor(connURL: string, authToken: string) {
         super();
-        this.ws = new WebSocket(connURL);
+
+        this.ws = new WebSocket(connURL, [], {headers: {authorization: `Bearer ${authToken}`}});
 
         this.ws.onerror = (err) => {
             this.emit('error', err);
@@ -73,6 +74,7 @@ export default class WebSocketClient extends EventEmitter {
             seq: this.seqNo++,
             data,
         };
+
         if (this.ws && this.ws.readyState === WebSocket.OPEN) {
             if (binary) {
                 this.ws.send(encode(msg));
@@ -87,7 +89,7 @@ export default class WebSocketClient extends EventEmitter {
             this.ws.close();
             this.ws = null;
         }
-        this.seqNo = 0;
+        this.seqNo = 1;
         this.connID = '';
         this.emit('close');
     }


### PR DESCRIPTION
#### Summary

Fixes https://github.com/mattermost/mattermost-plugin-calls/issues/112

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/114

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45155

#### Device Information

Tested on my Android test device and looks good.

@cpoile Could you give it a try on an iOS device as well just to confirm? I can provide a test server and credentials.

#### Release Note

```release-note
Add support for using Calls when the Mattermost installation is served under a subpath.
```