### PR TITLE
Remove apparently unneeded fix to improve the experience by not changing the keyboards

### DIFF
--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -17,7 +17,6 @@ import {Events, Screens} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
-import useDidUpdate from '@hooks/did_update';
 import {t} from '@i18n';
 import NavigationStore from '@store/navigation_store';
 import {extractFileInfo} from '@utils/file';
@@ -295,22 +294,6 @@ export default function PostInput({
             listener.remove();
         };
     }, [handleHardwareEnterPress]);
-
-    useDidUpdate(() => {
-        if (!value) {
-            if (Platform.OS === 'android') {
-                // Fixes the issue where Android predictive text would prepend suggestions to the post draft when messages
-                // are typed successively without blurring the input
-                setKeyboardType('email-address');
-            }
-        }
-    }, [value]);
-
-    useDidUpdate(() => {
-        if (Platform.OS === 'android' && keyboardType === 'email-address') {
-            setKeyboardType('default');
-        }
-    }, [keyboardType]);
 
     return (
         <PasteableTextInput


### PR DESCRIPTION
#### Summary
Due to issues in the React Native library, changing between default and email keyboards does not work. We were doing this switch to clear the suggestions after the clear, but we are no longer seeing that issue. Therefore, we are removing the fix to make sure the experience is better, by not changing the keyboard.

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/issues/6408

#### Release Note
```release-note
Fix keyboard changing to email after clearing the input box.
```
