### PR TITLE
Make FloatingTextInputLabels no longer than one line

### DIFF
--- a/app/components/floating_text_input_label/index.tsx
+++ b/app/components/floating_text_input_label/index.tsx
@@ -43,6 +43,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         fontFamily: 'OpenSans',
         fontSize: 16,
         zIndex: 10,
+        maxWidth: 315,
     },
     smallLabel: {
         fontSize: 10,
@@ -242,6 +243,7 @@ const FloatingTextInput = forwardRef<FloatingTextInputRef, FloatingTextInputProp
                     onPress={onAnimatedTextPress}
                     style={[styles.label, labelTextStyle, textAnimatedTextStyle]}
                     suppressHighlighting={true}
+                    numberOfLines={1}
                 >
                     {label}
                 </Animated.Text>


### PR DESCRIPTION
#### Summary
Long labels were not showing correctly. This was mainly seeing in the login screen. We have made it so they show only one line.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45173

#### Screenshots
![Screenshot from 2022-06-20 12-13-43](https://user-images.githubusercontent.com/1933730/174589209-ef4adcc2-29b6-43cd-8b10-a57cf378ad7f.png)
![Screenshot from 2022-06-20 12-14-30](https://user-images.githubusercontent.com/1933730/174589212-569daec2-3cce-4cc7-adeb-18176d3b6fdb.png)

```release-note
Fix long labels on login page.
```
