### PR TITLE
[Gekidou] [Bug] DM Icon will be 'archive-outline' if user is archived

### DIFF
--- a/app/components/channel_icon/dm_avatar/dm_avatar.tsx
+++ b/app/components/channel_icon/dm_avatar/dm_avatar.tsx
@@ -8,6 +8,8 @@ import ProfilePicture from '@components/profile_picture';
 import {useTheme} from '@context/theme';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 
+import ChannelIcon from '..';
+
 import type UserModel from '@typings/database/models/servers/user';
 
 type Props = {
@@ -29,6 +31,18 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 const DmAvatar = ({author, isInfo}: Props) => {
     const theme = useTheme();
     const style = getStyleSheet(theme);
+
+    if (author?.deleteAt && author.deleteAt > 0) {
+        return (
+            <ChannelIcon
+                name={author.username}
+                isArchived={true}
+                shared={false}
+                type=''
+            />
+        );
+    }
+
     return (
         <View style={style.container}>
             <ProfilePicture

--- a/app/components/channel_icon/dm_avatar/dm_avatar.tsx
+++ b/app/components/channel_icon/dm_avatar/dm_avatar.tsx
@@ -39,6 +39,7 @@ const DmAvatar = ({author, isInfo}: Props) => {
                 isArchived={true}
                 shared={false}
                 type=''
+                size={24}
             />
         );
     }

--- a/app/components/channel_icon/dm_avatar/dm_avatar.tsx
+++ b/app/components/channel_icon/dm_avatar/dm_avatar.tsx
@@ -27,6 +27,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
     icon: {
         color: changeOpacity(theme.sidebarText, 0.4),
+        left: 1,
+    },
+    iconInfo: {
+        color: changeOpacity(theme.centerChannelColor, 0.72),
     },
 }));
 
@@ -34,11 +38,12 @@ const DmAvatar = ({author, isInfo}: Props) => {
     const theme = useTheme();
     const style = getStyleSheet(theme);
 
-    if (author?.deleteAt && author.deleteAt > 0) {
+    if (author?.deleteAt) {
         return (
             <CompassIcon
                 name='archive-outline'
-                style={[style.icon, {fontSize: 24, left: 1}]}
+                style={[style.icon, isInfo && style.iconInfo]}
+                size={24}
             />
         );
     }

--- a/app/components/channel_icon/dm_avatar/dm_avatar.tsx
+++ b/app/components/channel_icon/dm_avatar/dm_avatar.tsx
@@ -4,11 +4,10 @@
 import React from 'react';
 import {View} from 'react-native';
 
+import CompassIcon from '@components/compass_icon';
 import ProfilePicture from '@components/profile_picture';
 import {useTheme} from '@context/theme';
-import {makeStyleSheetFromTheme} from '@utils/theme';
-
-import ChannelIcon from '..';
+import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
 import type UserModel from '@typings/database/models/servers/user';
 
@@ -26,6 +25,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     statusInfo: {
         backgroundColor: theme.centerChannelBg,
     },
+    icon: {
+        color: changeOpacity(theme.sidebarText, 0.4),
+    },
 }));
 
 const DmAvatar = ({author, isInfo}: Props) => {
@@ -34,12 +36,9 @@ const DmAvatar = ({author, isInfo}: Props) => {
 
     if (author?.deleteAt && author.deleteAt > 0) {
         return (
-            <ChannelIcon
-                name={author.username}
-                isArchived={true}
-                shared={false}
-                type=''
-                size={24}
+            <CompassIcon
+                name='archive-outline'
+                style={[style.icon, {fontSize: 24, left: 1}]}
             />
         );
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Show's the archived icon for a user that has been archived in the DM's list.

Tech note: This does call the it's own parent component again, but in the logic it exits out earlier with the `isArchived={true}` option without calling itself.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-45142


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
