### PR TITLE
[Gekidou] Fix connecting to servers with subpath on Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4119,7 +4119,7 @@
     },
     "node_modules/@mattermost/react-native-network-client": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mattermost/react-native-network-client.git#71fd5252acce0b3d0595401951f6509104e23f85",
+      "resolved": "git+ssh://git@github.com/mattermost/react-native-network-client.git#dd7a5b76e5b75dd42f413e646777446710b420b9",
       "license": "MIT",
       "dependencies": {
         "validator": "13.7.0",
@@ -28792,7 +28792,7 @@
       "requires": {}
     },
     "@mattermost/react-native-network-client": {
-      "version": "git+ssh://git@github.com/mattermost/react-native-network-client.git#71fd5252acce0b3d0595401951f6509104e23f85",
+      "version": "git+ssh://git@github.com/mattermost/react-native-network-client.git#dd7a5b76e5b75dd42f413e646777446710b420b9",
       "from": "@mattermost/react-native-network-client@github:mattermost/react-native-network-client",
       "requires": {
         "validator": "13.7.0",


### PR DESCRIPTION
#### Summary
The actual fix can be found here https://github.com/mattermost/react-native-network-client/commit/dd7a5b76e5b75dd42f413e646777446710b420b9

```release-note
NONE
```
