### PR TITLE
Fix lingering draft when switching channels while never leaving the channel screen

### DIFF
--- a/app/components/post_draft/index.ts
+++ b/app/components/post_draft/index.ts
@@ -28,7 +28,7 @@ type OwnProps = {
 
 const observeFirst = (v: DraftModel[]) => v[0]?.observe() || of$(undefined);
 
-const enhanced = withObservables([], (ownProps: WithDatabaseArgs & OwnProps) => {
+const enhanced = withObservables(['channelId', 'rootId'], (ownProps: WithDatabaseArgs & OwnProps) => {
     const {database, rootId = ''} = ownProps;
     let channelId = of$(ownProps.channelId);
     if (!ownProps.channelId) {

--- a/app/components/post_draft/index.ts
+++ b/app/components/post_draft/index.ts
@@ -28,7 +28,7 @@ type OwnProps = {
 
 const observeFirst = (v: DraftModel[]) => v[0]?.observe() || of$(undefined);
 
-const enhanced = withObservables(['channelId', 'rootId'], (ownProps: WithDatabaseArgs & OwnProps) => {
+const enhanced = withObservables(['channelId', 'rootId', 'channelIsArchived'], (ownProps: WithDatabaseArgs & OwnProps) => {
     const {database, rootId = ''} = ownProps;
     let channelId = of$(ownProps.channelId);
     if (!ownProps.channelId) {

--- a/app/components/post_draft/post_draft.tsx
+++ b/app/components/post_draft/post_draft.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {RefObject, useState} from 'react';
+import React, {RefObject, useEffect, useState} from 'react';
 import {Platform, View} from 'react-native';
 import {KeyboardTrackingView, KeyboardTrackingViewRef} from 'react-native-keyboard-tracking-view';
 
@@ -50,6 +50,12 @@ function PostDraft({
     const [cursorPosition, setCursorPosition] = useState(message.length);
     const [postInputTop, setPostInputTop] = useState(0);
     const isTablet = useIsTablet();
+
+    // Update draft in case we switch channels or threads
+    useEffect(() => {
+        setValue(message);
+        setCursorPosition(message.length);
+    }, [channelId, rootId]);
 
     if (channelIsArchived || deactivatedChannel) {
         const archivedTestID = `${testID}.archived`;


### PR DESCRIPTION
#### Summary
In some circunstances (like jumping to a message from the permalink view) we change channels without unmounting and mounting again the post draft. The post draft is not updating the value when the draft changes on purpose, to avoid back and forth with the information between the database, the local state, and the native state.

This lead to the draft never updating when switching to a different channel, and some other potential nasty bugs along the way (navigating to a readOnly channel this way may show you the channel as a normal channel).

I updated the observer to take in mind changes in the props, and added an effect to update the value of the draft and cursor position whenever we switch channels or threads.

#### Ticket Link
None

#### Release Note
```release-note
Fix bug where the draft lingers when switching to a different channel.
```
