### PR TITLE
[Gekidou - MM-44939] Search Screen - Add File Options Bottom Sheet

### DIFF
--- a/app/screens/home/search/results/file_card.tsx
+++ b/app/screens/home/search/results/file_card.tsx
@@ -8,9 +8,12 @@ import CompassIcon from '@components/compass_icon';
 import FormattedDate from '@components/formatted_date';
 import FileIcon from '@components/post_list/post/body/files/file_icon';
 import {useTheme} from '@context/theme';
+import {bottomSheet} from '@screens/navigation';
 import {getFormattedFileSize} from '@utils/file';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
+
+import FileOptions from './file_options';
 
 type Props = {
     fileInfo: FileInfo;
@@ -90,8 +93,21 @@ export default function FileCard({channelName, fileInfo}: Props) {
 
     // TODO: hook this up
     const handleThreeDotPress = () => {
-        /* eslint-disable no-console */
-        console.log('pressed 3 dot');
+        const renderContent = () => {
+            return (
+                <FileOptions
+                    fileInfo={fileInfo}
+                />
+
+            );
+        };
+        bottomSheet({
+            closeButtonId: 'close-search-file-options',
+            renderContent,
+            snapPoints: [400, 10],
+            theme,
+            title: '',
+        });
     };
 
     // TODO: Get the channel name and display

--- a/app/screens/home/search/results/file_options.tsx
+++ b/app/screens/home/search/results/file_options.tsx
@@ -1,0 +1,224 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback, useState} from 'react';
+import {View, Text} from 'react-native';
+import {FlatList} from 'react-native-gesture-handler';
+
+import {fetchPostById} from '@actions/remote/post';
+import {fetchAndSwitchToThread} from '@actions/remote/thread';
+import FormattedDate from '@components/formatted_date';
+import FormattedText from '@components/formatted_text';
+import MenuItem from '@components/menu_item';
+import FileIcon from '@components/post_list/post/body/files/file_icon';
+import {useServerUrl} from '@context/server';
+import {useTheme} from '@context/theme';
+import {useIsTablet} from '@hooks/device';
+import {t} from '@i18n';
+import CopyPublicLink from '@screens/gallery/footer/copy_public_link';
+import DownloadWithAction from '@screens/gallery/footer/download_with_action';
+import {getFormattedFileSize} from '@utils/file';
+import {OptionsActions, OptionActionType} from '@utils/search';
+import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
+
+const format = 'MMM DD YYYY HH:MM A';
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        container: {
+            marginTop: -20,
+            marginLeft: -20,
+        },
+        headerContainer: {
+            float: 'left',
+            marginLeft: 20,
+            marginTop: 20,
+            marginBottom: 8,
+        },
+        iconContainer: {
+            marginLeft: -10,
+            marginBottom: 8,
+            alignSelf: 'flex-start',
+        },
+        nameText: {
+            color: theme.centerChannelColor,
+            ...typography('Heading', 400, 'SemiBold'),
+        },
+        infoContainer: {
+            marginVertical: 8,
+            alignItems: 'center',
+            flexDirection: 'row',
+        },
+        infoText: {
+            flexDirection: 'row',
+            color: changeOpacity(theme.centerChannelColor, 0.64),
+            ...typography('Body', 200, 'Regular'),
+        },
+        date: {
+            color: changeOpacity(theme.centerChannelColor, 0.64),
+            ...typography('Body', 200, 'Regular'),
+        },
+        menuText: {
+            color: theme.centerChannelColor,
+            ...typography('Body', 200, 'Regular'),
+        },
+    };
+});
+
+type FileOption = {
+    id: string;
+    iconName: string;
+    type: OptionActionType;
+    defaultMessage: string;
+}
+
+const data: FileOption[] = [
+    {
+        id: t('screen.search.results.file_options.download'),
+        iconName: 'download-outline',
+        type: OptionsActions.DOWNLOAD,
+        defaultMessage: 'Download',
+    }, {
+        id: t('screen.search.results.file_options.open_in_channel'),
+        iconName: 'globe',
+        type: OptionsActions.GOTO_CHANNEL,
+        defaultMessage: 'Open in channel',
+    }, {
+        id: t('screen.search.results.file.copy_link'),
+        iconName: 'link-variant',
+        type: OptionsActions.COPY_LINK,
+        defaultMessage: 'Copy Link',
+    },
+];
+
+type Props = {
+    fileInfo: FileInfo;
+}
+const FileOptions = ({fileInfo}: Props) => {
+    const theme = useTheme();
+    const style = getStyleSheet(theme);
+    const isTablet = useIsTablet();
+    const serverUrl = useServerUrl();
+    const [action, setAction] = useState<GalleryAction>('none');
+
+    const galleryItem = {...fileInfo, type: 'image'} as GalleryItemType;
+
+    const handleDownload = useCallback(async () => {
+        setAction('downloading');
+    }, []);
+
+    const handleCopyLink = useCallback(async () => {
+        setAction('copying');
+    }, []);
+
+    const handleGotoChannel = useCallback(async () => {
+        const fetchedPost = await fetchPostById(serverUrl, fileInfo.post_id, true);
+        const post = fetchedPost.post;
+        const rootId = post?.root_id || post?.id;
+        if (rootId) {
+            fetchAndSwitchToThread(serverUrl, rootId);
+        } else {
+            // what to do?
+        }
+    }, [fileInfo]);
+
+    const handlePress = (item: FileOption) => {
+        switch (item.type) {
+            case OptionsActions.DOWNLOAD:
+                handleDownload();
+                break;
+            case OptionsActions.GOTO_CHANNEL:
+                handleGotoChannel();
+                break;
+            case OptionsActions.COPY_LINK:
+                handleCopyLink();
+                break;
+
+            default:
+        }
+
+        // TODO: determine when and if to dismiss the modal
+        // dismissBottomSheet();
+    };
+
+    const renderLabelComponent = useCallback((item: FileOption) => {
+        return (
+            <FormattedText
+                style={style.menuText}
+                id={item.id}
+                defaultMessage={item.defaultMessage}
+            />
+        );
+    }, [style]);
+
+    const renderHeader = () => {
+        const size = getFormattedFileSize(fileInfo.size);
+        return (
+            <View style={style.headerContainer}>
+                <View style={style.iconContainer}>
+                    <FileIcon
+                        file={fileInfo}
+                        iconSize={72}
+                    />
+                </View>
+                <Text
+                    style={style.nameText}
+                    numberOfLines={2}
+                    ellipsizeMode={'tail'}
+                >
+                    {fileInfo.name}
+                </Text>
+                <View style={style.infoContainer}>
+                    <Text style={style.infoText}>{`${size} • `}</Text>
+                    <FormattedDate
+                        style={style.date}
+                        format={format}
+                        value={fileInfo.create_at as number}
+                    />
+                </View>
+            </View>
+        );
+    };
+
+    const renderItem = useCallback(({item}: {item: FileOption}) => {
+        return (
+            <MenuItem
+                labelComponent={renderLabelComponent(item)}
+                iconName={item.iconName}
+                iconContainerStyle={style.selected}
+                onPress={() => handlePress(item)}
+                testID={item.id}
+                theme={theme}
+                separator={false}
+            />
+        );
+    }, [renderLabelComponent, theme]);
+
+    return (
+        <View style={style.container}>
+            {renderHeader()}
+            <FlatList
+                data={data}
+                renderItem={renderItem}
+                contentContainerStyle={style.contentContainer}
+            />
+            {['downloading'].includes(action) &&
+                <DownloadWithAction
+                    action={action}
+                    item={galleryItem}
+                    setAction={setAction}
+                />
+            }
+            {action === 'copying' &&
+                <CopyPublicLink
+                    item={galleryItem}
+                    setAction={setAction}
+                />
+            }
+        </View>
+
+    );
+};
+
+export default FileOptions;

--- a/app/utils/search/index.ts
+++ b/app/utils/search/index.ts
@@ -6,5 +6,11 @@ export const TabTypes = keyMirror({
     MESSAGES: null,
     FILES: null,
 });
-
 export type TabType = keyof typeof TabTypes;
+
+export const OptionsActions = keyMirror({
+    DOWNLOAD: null,
+    GOTO_CHANNEL: null,
+    COPY_LINK: null,
+});
+export type OptionActionType = keyof typeof OptionsActions


### PR DESCRIPTION
#### Summary
This PR adds the File Options bottom sheet.

TODO 
- [ ] Add File Type to info (ex. `PDF`)  Leaving out. Same as in the file Card.

Long filenames are limited to two lines.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/7575921/174899157-476d13ca-fb63-49ac-9de4-fd05f01b009f.png">


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<img width="517" alt="image" src="https://user-images.githubusercontent.com/7575921/173706390-4707bb4d-b2cf-4532-88c0-e44347c2c091.png">

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
