### PR TITLE
[Gekidou MM-45251] CRT Thread auto follow on navigating to the thread screen 

### DIFF
--- a/app/actions/remote/thread.ts
+++ b/app/actions/remote/thread.ts
@@ -49,7 +49,7 @@ export const fetchAndSwitchToThread = async (serverUrl: string, rootId: string, 
         const post = await getPostById(database, rootId);
         if (post) {
             const thread = await getThreadById(database, rootId);
-            if (thread) {
+            if (thread?.isFollowing) {
                 const channel = await getChannelById(database, post.channelId);
                 if (channel) {
                     markThreadAsRead(serverUrl, channel.teamId, thread.id);


### PR DESCRIPTION
#### Summary
We are marking the thread as read for every user switching to the thread screen. This PR will make sure to mark as read for only the users following the thread.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45251

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
NONE
```