### PR TITLE
Minor performance improvements in post list

### DIFF
--- a/app/components/post_list/date_separator/index.tsx
+++ b/app/components/post_list/date_separator/index.tsx
@@ -86,4 +86,4 @@ const DateSeparator = (props: DateSeparatorProps) => {
     );
 };
 
-export default DateSeparator;
+export default React.memo(DateSeparator);

--- a/app/components/post_list/post/index.ts
+++ b/app/components/post_list/post/index.ts
@@ -5,7 +5,7 @@ import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 import React from 'react';
 import {of as of$, combineLatest} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {Permissions, Preferences} from '@constants';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
@@ -106,6 +106,7 @@ const withPost = withObservables(
         const isSaved = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_SAVED_POST, post.id).
             observeWithColumns(['value']).pipe(
                 switchMap((pref) => of$(Boolean(pref.length))),
+                distinctUntilChanged(),
             );
 
         if (post.props?.add_channel_member && isPostEphemeral(post)) {
@@ -118,7 +119,9 @@ const withPost = withObservables(
                     return observeShouldHighlightReplyBar(currentUser, post, postsInThreads[0]);
                 }
                 return of$(false);
-            }));
+            }),
+            distinctUntilChanged(),
+        );
 
         let differentThreadSequence = true;
         if (post.rootId) {
@@ -128,14 +131,17 @@ const withPost = withObservables(
 
         if (post.message.length && !(/^\s{4}/).test(post.message)) {
             isJumboEmoji = queryAllCustomEmojis(post.database).observe().pipe(
-                // eslint-disable-next-line max-nested-callbacks
-                switchMap((customEmojis: CustomEmojiModel[]) => of$(hasJumboEmojiOnly(post.message, customEmojis.map((c) => c.name))),
+                switchMap(
+                    // eslint-disable-next-line max-nested-callbacks
+                    (customEmojis: CustomEmojiModel[]) => of$(hasJumboEmojiOnly(post.message, customEmojis.map((c) => c.name))),
                 ),
+                distinctUntilChanged(),
             );
         }
         const hasReplies = observeHasReplies(post);
         const isConsecutivePost = author.pipe(
             switchMap((user) => of$(Boolean(post && previousPost && !user?.isBot && areConsecutivePosts(post, previousPost)))),
+            distinctUntilChanged(),
         );
 
         return {

--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -41,6 +41,7 @@ export const observeIsCRTEnabled = (database: Database) => {
         map(
             ([cfg, prefs]) => processIsCRTEnabled(prefs, cfg),
         ),
+        distinctUntilChanged(),
     );
 };
 

--- a/app/screens/channel/channel_post_list/index.ts
+++ b/app/screens/channel/channel_post_list/index.ts
@@ -7,7 +7,7 @@ import withObservables from '@nozbe/with-observables';
 import React from 'react';
 import {AppStateStatus} from 'react-native';
 import {combineLatest, of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {getPreferenceAsBool} from '@helpers/api/preference';
@@ -28,6 +28,7 @@ const enhanced = withObservables(['channelId', 'forceQueryAfterAppState'], ({dat
         isCRTEnabled: isCRTEnabledObserver,
         lastViewedAt: observeMyChannel(database, channelId).pipe(
             switchMap((myChannel) => of$(myChannel?.viewedAt)),
+            distinctUntilChanged(),
         ),
         posts: combineLatest([isCRTEnabledObserver, postsInChannelObserver]).pipe(
             switchMap(([isCRTEnabled, postsInChannel]) => {
@@ -42,6 +43,7 @@ const enhanced = withObservables(['channelId', 'forceQueryAfterAppState'], ({dat
         shouldShowJoinLeaveMessages: queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE).
             observeWithColumns(['value']).pipe(
                 switchMap((preferences) => of$(getPreferenceAsBool(preferences, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true))),
+                distinctUntilChanged(),
             ),
     };
 });


### PR DESCRIPTION
#### Summary
While investigating https://mattermost.atlassian.net/browse/MM-45181 , I saw some blocking when receiving a message through the websocket in the current channel.

I have done a few tweaks that seem to alleviate the problem, mainly by "memoizing the observables" (using `distinctUntilChanged`), so there are no uneeded re-renders or recalculation of observables.

One of the problems I saw in Flipper is that the observables of all the loaded posts were triggering, which with the changes, they re-render less often. I also saw that the date separator was not memoized. This was left as is in another PR since in general, there won't be many date separators in the channel, but I decided to add here to take account for not so active channels.

#### Ticket Link
May fix https://mattermost.atlassian.net/browse/MM-45181

#### Release Note
```release-note
Performance improvements on Post List
```
