### PR TITLE
Substitute all console.x by an appropiate log util function

### DIFF
--- a/app/actions/local/category.ts
+++ b/app/actions/local/category.ts
@@ -10,6 +10,7 @@ import {getCurrentUserId} from '@queries/servers/system';
 import {queryMyTeams} from '@queries/servers/team';
 import {isDMorGM} from '@utils/channel';
 import {pluckUnique} from '@utils/helpers';
+import {logError} from '@utils/log';
 
 import type ChannelModel from '@typings/database/models/servers/channel';
 
@@ -26,8 +27,7 @@ export const deleteCategory = async (serverUrl: string, categoryId: string) => {
 
         return {category};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('FAILED TO DELETE CATEGORY', categoryId);
+        logError('FAILED TO DELETE CATEGORY', categoryId);
         return {error};
     }
 };
@@ -77,8 +77,7 @@ export async function storeCategories(serverUrl: string, categories: CategoryWit
 
         return {models: flattenedModels};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('FAILED TO STORE CATEGORIES', error);
+        logError('FAILED TO STORE CATEGORIES', error);
         return {error};
     }
 }
@@ -98,8 +97,7 @@ export const toggleCollapseCategory = async (serverUrl: string, categoryId: stri
 
         return {category};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('FAILED TO COLLAPSE CATEGORY', categoryId, error);
+        logError('FAILED TO COLLAPSE CATEGORY', categoryId, error);
         return {error};
     }
 };

--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -21,6 +21,7 @@ import {getCurrentUser, queryUsersById} from '@queries/servers/user';
 import {dismissAllModalsAndPopToRoot, dismissAllModalsAndPopToScreen} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {isTablet} from '@utils/helpers';
+import {logError, logInfo} from '@utils/log';
 import {displayGroupMessageName, displayUsername, getUserIdFromChannelName} from '@utils/user';
 
 import type ChannelModel from '@typings/database/models/servers/channel';
@@ -91,14 +92,13 @@ export async function switchToChannel(serverUrl: string, channelId: string, team
                     dismissAllModalsAndPopToScreen(Screens.CHANNEL, '', undefined, {topBar: {visible: false}});
                 }
 
-                console.log('channel switch to', channel?.displayName, channelId, (Date.now() - dt), 'ms'); //eslint-disable-line
+                logInfo('channel switch to', channel?.displayName, channelId, (Date.now() - dt), 'ms');
             }
         }
 
         return {models};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed to switch to channelId', channelId, 'teamId', teamId, 'error', error);
+        logError('Failed to switch to channelId', channelId, 'teamId', teamId, 'error', error);
         return {error};
     }
 }
@@ -129,8 +129,7 @@ export async function removeCurrentUserFromChannel(serverUrl: string, channelId:
         }
         return {models};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('failed to removeCurrentUserFromChannel', error);
+        logError('failed to removeCurrentUserFromChannel', error);
         return {error};
     }
 }
@@ -148,8 +147,7 @@ export async function setChannelDeleteAt(serverUrl: string, channelId: string, d
         });
         await operator.batchRecords([model]);
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('FAILED TO BATCH CHANGES FOR CHANNEL DELETE AT', error);
+        logError('FAILED TO BATCH CHANGES FOR CHANNEL DELETE AT', error);
     }
 }
 
@@ -184,8 +182,7 @@ export async function markChannelAsViewed(serverUrl: string, channelId: string, 
 
         return {member};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed markChannelAsViewed', error);
+        logError('Failed markChannelAsViewed', error);
         return {error};
     }
 }
@@ -212,8 +209,7 @@ export async function markChannelAsUnread(serverUrl: string, channelId: string, 
 
         return {member};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed markChannelAsUnread', error);
+        logError('Failed markChannelAsUnread', error);
         return {error};
     }
 }
@@ -232,8 +228,7 @@ export async function resetMessageCount(serverUrl: string, channelId: string) {
 
         return member;
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed resetMessageCount', error);
+        logError('Failed resetMessageCount', error);
         return {error};
     }
 }
@@ -262,8 +257,7 @@ export async function storeMyChannelsForTeam(serverUrl: string, teamId: string, 
 
         return {models: flattenedModels};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed storeMyChannelsForTeam', error);
+        logError('Failed storeMyChannelsForTeam', error);
         return {error};
     }
 }
@@ -282,8 +276,7 @@ export async function updateMyChannelFromWebsocket(serverUrl: string, channelMem
         }
         return {model: member};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateMyChannelFromWebsocket', error);
+        logError('Failed updateMyChannelFromWebsocket', error);
         return {error};
     }
 }
@@ -302,8 +295,7 @@ export async function updateChannelInfoFromChannel(serverUrl: string, channel: C
         }
         return {model: newInfo};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateChannelInfoFromChannel', error);
+        logError('Failed updateChannelInfoFromChannel', error);
         return {error};
     }
 }
@@ -330,8 +322,7 @@ export async function updateLastPostAt(serverUrl: string, channelId: string, las
 
         return {member: undefined};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateLastPostAt', error);
+        logError('Failed updateLastPostAt', error);
         return {error};
     }
 }
@@ -385,8 +376,7 @@ export async function updateChannelsDisplayName(serverUrl: string, channels: Cha
 
         return {models};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateChannelsDisplayName', error);
+        logError('Failed updateChannelsDisplayName', error);
         return {error};
     }
 }
@@ -402,8 +392,7 @@ export async function showUnreadChannelsOnly(serverUrl: string, onlyUnreads: boo
             prepareRecordsOnly: false,
         });
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed showUnreadChannelsOnly', error);
+        logError('Failed showUnreadChannelsOnly', error);
         return {error};
     }
 }
@@ -432,9 +421,7 @@ export const updateDmGmDisplayName = async (serverUrl: string) => {
 
         return {channels};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateDmGmDisplayName', error);
+        logError('Failed updateDmGmDisplayName', error);
         return {error};
     }
 };
-

--- a/app/actions/local/draft.ts
+++ b/app/actions/local/draft.ts
@@ -3,6 +3,7 @@
 
 import DatabaseManager from '@database/manager';
 import {getDraft} from '@queries/servers/drafts';
+import {logError} from '@utils/log';
 
 export async function updateDraftFile(serverUrl: string, channelId: string, rootId: string, file: FileInfo, prepareRecordsOnly = false) {
     try {
@@ -30,8 +31,7 @@ export async function updateDraftFile(serverUrl: string, channelId: string, root
 
         return {draft};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateDraftFile', error);
+        logError('Failed updateDraftFile', error);
         return {error};
     }
 }
@@ -63,8 +63,7 @@ export async function removeDraftFile(serverUrl: string, channelId: string, root
 
         return {draft};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed removeDraftFile', error);
+        logError('Failed removeDraftFile', error);
         return {error};
     }
 }
@@ -105,8 +104,7 @@ export async function updateDraftMessage(serverUrl: string, channelId: string, r
 
         return {draft};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateDraftMessage', error);
+        logError('Failed updateDraftMessage', error);
         return {error};
     }
 }
@@ -136,8 +134,7 @@ export async function addFilesToDraft(serverUrl: string, channelId: string, root
 
         return {draft};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed addFilesToDraft', error);
+        logError('Failed addFilesToDraft', error);
         return {error};
     }
 }
@@ -154,8 +151,7 @@ export const removeDraft = async (serverUrl: string, channelId: string, rootId =
 
         return {draft};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed removeDraft', error);
+        logError('Failed removeDraft', error);
         return {error};
     }
 };

--- a/app/actions/local/file.ts
+++ b/app/actions/local/file.ts
@@ -3,14 +3,14 @@
 
 import DatabaseManager from '@database/manager';
 import {getFileById} from '@queries/servers/file';
+import {logError} from '@utils/log';
 
 export const updateLocalFile = async (serverUrl: string, file: FileInfo) => {
     try {
         const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         return operator.handleFiles({files: [file], prepareRecordsOnly: false});
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateLocalFile', error);
+        logError('Failed updateLocalFile', error);
         return {error};
     }
 };
@@ -29,8 +29,7 @@ export const updateLocalFilePath = async (serverUrl: string, fileId: string, loc
 
         return {error: undefined};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateLocalFilePath', error);
+        logError('Failed updateLocalFilePath', error);
         return {error};
     }
 };

--- a/app/actions/local/group.ts
+++ b/app/actions/local/group.ts
@@ -4,6 +4,7 @@
 import {fetchFilteredChannelGroups, fetchFilteredTeamGroups, fetchGroupsForAutocomplete} from '@actions/remote/groups';
 import DatabaseManager from '@database/manager';
 import {prepareGroups, queryGroupsByName, queryGroupsByNameInChannel, queryGroupsByNameInTeam} from '@queries/servers/group';
+import {logError} from '@utils/log';
 
 import type GroupModel from '@typings/database/models/servers/group';
 
@@ -21,8 +22,7 @@ export const searchGroupsByName = async (serverUrl: string, name: string): Promi
         }
         throw groups.error;
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('searchGroupsByName - ERROR', e);
+        logError('searchGroupsByName - ERROR', e);
         return queryGroupsByName(operator.database, name).fetch();
     }
 };
@@ -41,8 +41,7 @@ export const searchGroupsByNameInTeam = async (serverUrl: string, name: string, 
         }
         throw groups.error;
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('searchGroupsByNameInTeam - ERROR', e);
+        logError('searchGroupsByNameInTeam - ERROR', e);
         return queryGroupsByNameInTeam(operator.database, name, teamId).fetch();
     }
 };
@@ -61,8 +60,7 @@ export const searchGroupsByNameInChannel = async (serverUrl: string, name: strin
         }
         throw groups.error;
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('searchGroupsByNameInChannel - ERROR', e);
+        logError('searchGroupsByNameInChannel - ERROR', e);
         return queryGroupsByNameInChannel(operator.database, name, channelId).fetch();
     }
 };

--- a/app/actions/local/notification.ts
+++ b/app/actions/local/notification.ts
@@ -3,6 +3,7 @@
 
 import DatabaseManager from '@database/manager';
 import {getPostById, queryPostsInChannel, queryPostsInThread} from '@queries/servers/post';
+import {logError} from '@utils/log';
 
 export const updatePostSinceCache = async (serverUrl: string, notification: NotificationWithData) => {
     try {
@@ -23,8 +24,7 @@ export const updatePostSinceCache = async (serverUrl: string, notification: Noti
         }
         return {};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updatePostSinceCache', error);
+        logError('Failed updatePostSinceCache', error);
         return {error};
     }
 };

--- a/app/actions/local/post.ts
+++ b/app/actions/local/post.ts
@@ -6,6 +6,7 @@ import DatabaseManager from '@database/manager';
 import {getPostById, prepareDeletePost} from '@queries/servers/post';
 import {getCurrentUserId} from '@queries/servers/system';
 import {generateId} from '@utils/general';
+import {logError} from '@utils/log';
 import {getPostIdsForCombinedUserActivityPost} from '@utils/post_list';
 
 import type PostModel from '@typings/database/models/servers/post';
@@ -49,8 +50,7 @@ export const sendAddToChannelEphemeralPost = async (serverUrl: string, user: Use
 
         return {posts};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed sendAddToChannelEphemeralPost', error);
+        logError('Failed sendAddToChannelEphemeralPost', error);
         return {error};
     }
 };
@@ -97,8 +97,7 @@ export const sendEphemeralPost = async (serverUrl: string, message: string, chan
 
         return {post};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed sendEphemeralPost', error);
+        logError('Failed sendEphemeralPost', error);
         return {error};
     }
 };
@@ -132,8 +131,7 @@ export async function removePost(serverUrl: string, post: PostModel | Post) {
 
         return {post};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed removePost', error);
+        logError('Failed removePost', error);
         return {error};
     }
 }
@@ -158,8 +156,7 @@ export async function markPostAsDeleted(serverUrl: string, post: Post, prepareRe
         }
         return {model};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed markPostAsDeleted', error);
+        logError('Failed markPostAsDeleted', error);
         return {error};
     }
 }

--- a/app/actions/local/reactions.ts
+++ b/app/actions/local/reactions.ts
@@ -5,6 +5,7 @@ import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import {getRecentReactions} from '@queries/servers/system';
 import {getEmojiFirstAlias} from '@utils/emoji/helpers';
+import {logError} from '@utils/log';
 
 const MAXIMUM_RECENT_EMOJI = 27;
 
@@ -37,8 +38,7 @@ export const addRecentReaction = async (serverUrl: string, emojiNames: string[],
             prepareRecordsOnly,
         });
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed addRecentReaction', error);
+        logError('Failed addRecentReaction', error);
         return {error};
     }
 };

--- a/app/actions/local/team.ts
+++ b/app/actions/local/team.ts
@@ -3,6 +3,7 @@
 
 import DatabaseManager from '@database/manager';
 import {prepareDeleteTeam, getMyTeamById, removeTeamFromTeamHistory} from '@queries/servers/team';
+import {logError} from '@utils/log';
 
 export async function removeUserFromTeam(serverUrl: string, teamId: string) {
     try {
@@ -25,8 +26,7 @@ export async function removeUserFromTeam(serverUrl: string, teamId: string) {
 
         return {error: undefined};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed removeUserFromTeam', error);
+        logError('Failed removeUserFromTeam', error);
         return {error};
     }
 }

--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -16,6 +16,7 @@ import {dismissAllModalsAndPopToRoot, goToScreen} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import NavigationStore from '@store/navigation_store';
 import {isTablet} from '@utils/helpers';
+import {logError} from '@utils/log';
 import {changeOpacity} from '@utils/theme';
 
 import type Model from '@nozbe/watermelondb/Model';
@@ -51,8 +52,7 @@ export const switchToGlobalThreads = async (serverUrl: string, teamId?: string, 
 
         return {models};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed switchToGlobalThreads', error);
+        logError('Failed switchToGlobalThreads', error);
         return {error};
     }
 };
@@ -155,8 +155,7 @@ export const switchToThread = async (serverUrl: string, rootId: string, isFromNo
 
         return {};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed switchToThread', error);
+        logError('Failed switchToThread', error);
         return {error};
     }
 };
@@ -199,8 +198,7 @@ export async function createThreadFromNewPost(serverUrl: string, post: Post, pre
 
         return {models};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed createThreadFromNewPost', error);
+        logError('Failed createThreadFromNewPost', error);
         return {error};
     }
 }
@@ -254,8 +252,7 @@ export async function processReceivedThreads(serverUrl: string, threads: Thread[
         }
         return {models};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed processReceivedThreads', error);
+        logError('Failed processReceivedThreads', error);
         return {error};
     }
 }
@@ -274,8 +271,7 @@ export async function markTeamThreadsAsRead(serverUrl: string, teamId: string, p
         }
         return {models};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed markTeamThreadsAsRead', error);
+        logError('Failed markTeamThreadsAsRead', error);
         return {error};
     }
 }
@@ -301,8 +297,7 @@ export async function updateThread(serverUrl: string, threadId: string, updatedT
         }
         return {model};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed markTeamThreadsAsRead', error);
+        logError('Failed markTeamThreadsAsRead', error);
         return {error};
     }
 }

--- a/app/actions/local/user.ts
+++ b/app/actions/local/user.ts
@@ -6,6 +6,7 @@ import General from '@constants/general';
 import DatabaseManager from '@database/manager';
 import {getRecentCustomStatuses} from '@queries/servers/system';
 import {getCurrentUser, getUserById} from '@queries/servers/user';
+import {logError} from '@utils/log';
 
 import {addRecentReaction} from './reactions';
 
@@ -24,8 +25,7 @@ export async function setCurrentUserStatusOffline(serverUrl: string) {
         await operator.batchRecords([user]);
         return null;
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed setCurrentUserStatusOffline', error);
+        logError('Failed setCurrentUserStatusOffline', error);
         return {error};
     }
 }
@@ -58,8 +58,7 @@ export async function updateLocalCustomStatus(serverUrl: string, user: UserModel
 
         return {};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateLocalCustomStatus', error);
+        logError('Failed updateLocalCustomStatus', error);
         return {error};
     }
 }
@@ -90,8 +89,7 @@ export const updateRecentCustomStatuses = async (serverUrl: string, customStatus
             prepareRecordsOnly,
         });
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateRecentCustomStatuses', error);
+        logError('Failed updateRecentCustomStatuses', error);
         return {error};
     }
 };
@@ -125,8 +123,7 @@ export const updateLocalUser = async (
         }
         return {user};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed updateLocalUser', error);
+        logError('Failed updateLocalUser', error);
         return {error};
     }
 };
@@ -146,8 +143,7 @@ export const storeProfile = async (serverUrl: string, profile: UserProfile) => {
 
         return {user: records[0]};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed storeProfile', error);
+        logError('Failed storeProfile', error);
         return {error};
     }
 };

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -21,6 +21,7 @@ import {getCurrentUser} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
 import {generateChannelNameFromDisplayName, getDirectChannelName, isDMorGM} from '@utils/channel';
 import {isTablet} from '@utils/helpers';
+import {logError, logInfo} from '@utils/log';
 import {showMuteChannelSnackbar} from '@utils/snack_bar';
 import {PERMALINK_GENERIC_TEAM_NAME_REDIRECT} from '@utils/url';
 import {displayGroupMessageName, displayUsername} from '@utils/user';
@@ -581,8 +582,7 @@ export async function joinChannel(serverUrl: string, userId: string, teamId: str
                     try {
                         await operator.batchRecords(flattenedModels);
                     } catch {
-                        // eslint-disable-next-line no-console
-                        console.log('FAILED TO BATCH CHANNELS');
+                        logError('FAILED TO BATCH CHANNELS');
                     }
                 }
             }
@@ -720,7 +720,7 @@ export async function switchToChannelByName(serverUrl: string, channelName: stri
                     errorHandler(intl);
                     return {error: 'Refused to join Private channel'};
                 }
-                console.log('joining channel', displayName, channel.id); //eslint-disable-line
+                logInfo('joining channel', displayName, channel.id);
                 const result = await joinChannel(serverUrl, system.currentUserId, team.id, channel.id, undefined, true);
                 if (result.error || !result.channel) {
                     if (joinedNewTeam) {

--- a/app/actions/remote/entry/app.ts
+++ b/app/actions/remote/entry/app.ts
@@ -8,6 +8,7 @@ import {prepareCommonSystemValues, getCommonSystemValues, getCurrentTeamId, getW
 import {getCurrentUser} from '@queries/servers/user';
 import {deleteV1Data} from '@utils/file';
 import {isTablet} from '@utils/helpers';
+import {logInfo} from '@utils/log';
 
 import {deferredAppEntryActions, entry, registerDeviceToken, syncOtherServers, verifyPushProxy} from './common';
 
@@ -59,8 +60,7 @@ export async function appEntry(serverUrl: string, since = 0, isUpgrade = false) 
 
     const dt = Date.now();
     await operator.batchRecords(models);
-    // eslint-disable-next-line no-console
-    console.log('ENTRY MODELS BATCHING TOOK', `${Date.now() - dt}ms`);
+    logInfo('ENTRY MODELS BATCHING TOOK', `${Date.now() - dt}ms`);
 
     const {id: currentUserId, locale: currentUserLocale} = meData?.user || (await getCurrentUser(database))!;
     const {config, license} = await getCommonSystemValues(database);

--- a/app/actions/remote/entry/login.ts
+++ b/app/actions/remote/entry/login.ts
@@ -8,6 +8,7 @@ import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {prepareCommonSystemValues, setCurrentTeamAndChannelId} from '@queries/servers/system';
 import {isTablet} from '@utils/helpers';
+import {logWarning} from '@utils/log';
 import {scheduleExpiredNotification} from '@utils/notification';
 
 import {deferredAppEntryActions, entry, EntryResponse} from './common';
@@ -67,8 +68,7 @@ export async function loginEntry({serverUrl, user, deviceToken}: AfterLoginArgs)
                     try {
                         sessions = await getSessions(serverUrl, 'me');
                     } catch (e) {
-                        // eslint-disable-next-line no-console
-                        console.warn('Failed to get user sessions', e);
+                        logWarning('Failed to get user sessions', e);
                         return;
                     }
 

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -24,6 +24,7 @@ import {getCurrentUserId, getCurrentChannelId} from '@queries/servers/system';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
 import {queryAllUsers} from '@queries/servers/user';
 import {getValidEmojis, matchEmoticons} from '@utils/emoji/helpers';
+import {logError} from '@utils/log';
 import {processPostsFetched} from '@utils/post';
 import {getPostIdsForCombinedUserActivityPost} from '@utils/post_list';
 
@@ -307,8 +308,7 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
             const {authors: fetchedAuthors} = await fetchPostAuthors(serverUrl, data.posts, true);
             authors = fetchedAuthors || [];
         } catch (error) {
-            // eslint-disable-next-line no-console
-            console.log('FETCH AUTHORS ERROR', error);
+            logError('FETCH AUTHORS ERROR', error);
         }
 
         if (!fetchOnly) {
@@ -487,8 +487,7 @@ export async function fetchPostsBefore(serverUrl: string, channelId: string, pos
 
                 await operator.batchRecords(models);
             } catch (error) {
-                // eslint-disable-next-line no-console
-                console.log('FETCH AUTHORS ERROR', error);
+                logError('FETCH AUTHORS ERROR', error);
             }
         }
 
@@ -713,8 +712,7 @@ export async function fetchPostsAround(serverUrl: string, channelId: string, pos
                     models.push(...userModels);
                 }
             } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error('FETCH AUTHORS ERROR', error);
+                logError('FETCH AUTHORS ERROR', error);
             }
 
             posts = await operator.handlePosts({
@@ -736,8 +734,7 @@ export async function fetchPostsAround(serverUrl: string, channelId: string, pos
 
         return {posts: extractRecordsForTable<PostModel>(posts, MM_TABLES.SERVER.POST)};
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('FETCH POSTS AROUND ERROR', error);
+        logError('FETCH POSTS AROUND ERROR', error);
         forceLogoutIfNecessary(serverUrl, error as ClientErrorProps);
         return {error};
     }

--- a/app/actions/remote/search.ts
+++ b/app/actions/remote/search.ts
@@ -7,6 +7,7 @@ import NetworkManager from '@managers/network_manager';
 import {prepareMissingChannelsForAllTeams} from '@queries/servers/channel';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
 import {getCurrentUser} from '@queries/servers/user';
+import {logError} from '@utils/log';
 
 import {fetchPostAuthors, fetchMissingChannelsFromPosts} from './post';
 import {forceLogoutIfNecessary} from './session';
@@ -124,8 +125,7 @@ export const searchPosts = async (serverUrl: string, params: PostSearchParams): 
             posts: postsArray,
         };
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('Failed: searchPosts', error);
+        logError('Failed: searchPosts', error);
         forceLogoutIfNecessary(serverUrl, error as ClientErrorProps);
         return {error};
     }

--- a/app/actions/remote/session.ts
+++ b/app/actions/remote/session.ts
@@ -12,6 +12,7 @@ import WebsocketManager from '@managers/websocket_manager';
 import {getDeviceToken} from '@queries/app/global';
 import {getCurrentUserId, getCommonSystemValues} from '@queries/servers/system';
 import EphemeralStore from '@store/ephemeral_store';
+import {logWarning} from '@utils/log';
 import {getCSRFFromCookie} from '@utils/security';
 import {getDeviceTimezone, isTimezoneEnabled} from '@utils/timezone';
 
@@ -172,8 +173,7 @@ export const logout = async (serverUrl: string, skipServerLogout = false, remove
             await client.logout();
         } catch (error) {
             // We want to log the user even if logging out from the server failed
-            // eslint-disable-next-line no-console
-            console.warn('An error ocurred loging out from the server', serverUrl, error);
+            logWarning('An error ocurred loging out from the server', serverUrl, error);
         }
     }
 

--- a/app/actions/remote/systems.ts
+++ b/app/actions/remote/systems.ts
@@ -9,6 +9,7 @@ import DatabaseManager from '@database/manager';
 import {getServerCredentials} from '@init/credentials';
 import NetworkManager from '@managers/network_manager';
 import {getCommonSystemValues} from '@queries/servers/system';
+import {logError} from '@utils/log';
 
 import type ClientError from '@client/rest/error';
 
@@ -43,8 +44,7 @@ export const fetchDataRetentionPolicy = async (serverUrl: string) => {
 
         operator.handleSystem({systems, prepareRecordsOnly: false}).
             catch((error) => {
-                // eslint-disable-next-line no-console
-                console.log('An error ocurred while saving data retention policies', error);
+                logError('An error ocurred while saving data retention policies', error);
             });
     }
 
@@ -89,8 +89,7 @@ export const fetchConfigAndLicense = async (serverUrl: string, fetchOnly = false
                 if (systems.length) {
                     await operator.handleSystem({systems, prepareRecordsOnly: false}).
                         catch((error) => {
-                            // eslint-disable-next-line no-console
-                            console.log('An error ocurred while saving config & license', error);
+                            logError('An error ocurred while saving config & license', error);
                         });
                 }
             }

--- a/app/actions/remote/user.ts
+++ b/app/actions/remote/user.ts
@@ -16,6 +16,7 @@ import NetworkManager from '@managers/network_manager';
 import {getMembersCountByChannelsId, queryChannelsByTypes} from '@queries/servers/channel';
 import {getCurrentTeamId, getCurrentUserId} from '@queries/servers/system';
 import {getCurrentUser, getUserById, prepareUsers, queryAllUsers, queryUsersById, queryUsersByUsername} from '@queries/servers/user';
+import {logError} from '@utils/log';
 import {getUserTimezoneProps, removeUserFromList} from '@utils/user';
 
 import {forceLogoutIfNecessary} from './session';
@@ -874,8 +875,7 @@ export const getAllSupportedTimezones = async (serverUrl: string) => {
         const allTzs = await client.getTimezones();
         return allTzs;
     } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log('FAILED TO GET ALL TIMEZONES', error);
+        logError('FAILED TO GET ALL TIMEZONES', error);
         return [];
     }
 };

--- a/app/actions/websocket/category.ts
+++ b/app/actions/websocket/category.ts
@@ -5,6 +5,7 @@ import {deleteCategory, storeCategories} from '@actions/local/category';
 import {fetchCategories} from '@actions/remote/category';
 import DatabaseManager from '@database/manager';
 import {queryCategoriesById} from '@queries/servers/categories';
+import {logError} from '@utils/log';
 
 type WebsocketCategoriesMessage = {
     broadcast: {
@@ -23,8 +24,7 @@ const addOrUpdateCategories = async (serverUrl: string, categories: CategoryWith
     try {
         storeCategories(serverUrl, categories);
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Category WS: addOrUpdateCategories', e, categories);
+        logError('Category WS: addOrUpdateCategories', e, categories);
     }
 };
 
@@ -36,8 +36,7 @@ export async function handleCategoryCreatedEvent(serverUrl: string, msg: Websock
             addOrUpdateCategories(serverUrl, [category]);
         }
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Category WS: handleCategoryCreatedEvent', e, msg);
+        logError('Category WS: handleCategoryCreatedEvent', e, msg);
 
         if (msg.broadcast.team_id) {
             fetchCategories(serverUrl, msg.broadcast.team_id);
@@ -54,8 +53,7 @@ export async function handleCategoryUpdatedEvent(serverUrl: string, msg: Websock
             addOrUpdateCategories(serverUrl, categories);
         }
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Category WS: handleCategoryUpdatedEvent', e, msg);
+        logError('Category WS: handleCategoryUpdatedEvent', e, msg);
         if (msg.broadcast.team_id) {
             fetchCategories(serverUrl, msg.broadcast.team_id, true);
         }
@@ -74,8 +72,7 @@ export async function handleCategoryDeletedEvent(serverUrl: string, msg: Websock
             fetchCategories(serverUrl, msg.broadcast.team_id);
         }
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Category WS: handleCategoryDeletedEvent', e, msg);
+        logError('Category WS: handleCategoryDeletedEvent', e, msg);
     }
 }
 
@@ -102,8 +99,7 @@ export async function handleCategoryOrderUpdatedEvent(serverUrl: string, msg: We
             await operator.batchRecords(categories);
         }
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Category WS: handleCategoryOrderUpdatedEvent', e, msg);
+        logError('Category WS: handleCategoryOrderUpdatedEvent', e, msg);
 
         if (msg.broadcast.team_id) {
             fetchCategories(serverUrl, msg.data.team_id);

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -17,6 +17,7 @@ import {getCurrentUser} from '@queries/servers/user';
 import {dismissAllModals, popToRoot} from '@screens/navigation';
 import NavigationStore from '@store/navigation_store';
 import {isTablet} from '@utils/helpers';
+import {logInfo} from '@utils/log';
 
 import {handleCategoryCreatedEvent, handleCategoryDeletedEvent, handleCategoryOrderUpdatedEvent, handleCategoryUpdatedEvent} from './category';
 import {handleChannelConvertedEvent, handleChannelCreatedEvent,
@@ -142,8 +143,7 @@ async function doReconnect(serverUrl: string) {
 
     const dt = Date.now();
     await operator.batchRecords(models);
-    // eslint-disable-next-line no-console
-    console.log('WEBSOCKET RECONNECT MODELS BATCHING TOOK', `${Date.now() - dt}ms`);
+    logInfo('WEBSOCKET RECONNECT MODELS BATCHING TOOK', `${Date.now() - dt}ms`);
 
     const {id: currentUserId, locale: currentUserLocale} = (await getCurrentUser(database))!;
     const {config, license} = await getCommonSystemValues(database);

--- a/app/components/formatted_markdown_text/index.tsx
+++ b/app/components/formatted_markdown_text/index.tsx
@@ -10,6 +10,7 @@ import {GestureResponderEvent, StyleProp, Text, TextStyle} from 'react-native';
 import AtMention from '@components/markdown/at_mention';
 import MarkdownLink from '@components/markdown/markdown_link';
 import {useTheme} from '@context/theme';
+import {logWarning} from '@utils/log';
 import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 import {concatStyles, changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
@@ -106,7 +107,7 @@ const FormattedMarkdownText = ({baseTextStyle, channelId, defaultMessage, id, lo
     };
 
     const renderHTML = (props: never) => {
-        console.warn(`HTML used in FormattedMarkdownText component with id ${id}`); // eslint-disable-line no-console
+        logWarning(`HTML used in FormattedMarkdownText component with id ${id}`);
         return renderText(props);
     };
 

--- a/app/components/markdown/transform.test.ts
+++ b/app/components/markdown/transform.test.ts
@@ -14,10 +14,11 @@ import {
     mentionKeysToPatterns,
     pullOutImages,
 } from '@components/markdown/transform';
+import {logError} from '@utils/log';
 
 import type {UserMentionKey} from '@typings/global/markdown';
 
-/* eslint-disable max-lines, no-console, no-underscore-dangle */
+/* eslint-disable max-lines, no-underscore-dangle */
 
 describe('Components.Markdown.transform', () => {
     const parser = new Parser();
@@ -2827,28 +2828,28 @@ describe('Components.Markdown.transform', () => {
 // Confirms that all parent, child, and sibling linkages are correct and go both ways.
 function verifyAst(node: Node) {
     if (node.prev && node.prev.next !== node) {
-        console.error('node is not linked properly to prev'); //eslint-disable-line no-console
+        logError('node is not linked properly to prev');
         return false;
     }
 
     if (node.next && node.next.prev !== node) {
-        console.error('node is not linked properly to next'); //eslint-disable-line no-console
+        logError('node is not linked properly to next');
         return false;
     }
 
     if (!node.firstChild && node.lastChild) {
-        console.error('node has children, but is not linked to first child'); //eslint-disable-line no-console
+        logError('node has children, but is not linked to first child');
         return false;
     }
 
     if (node.firstChild && !node.lastChild) {
-        console.error('node has children, but is not linked to last child'); //eslint-disable-line no-console
+        logError('node has children, but is not linked to last child');
         return false;
     }
 
     for (let child = node.firstChild; child; child = child.next) {
         if (child.parent !== node) {
-            console.error('node is not linked properly to child'); //eslint-disable-line no-console
+            logError('node is not linked properly to child');
             return false;
         }
 
@@ -2857,25 +2858,25 @@ function verifyAst(node: Node) {
         }
 
         if (!child.next && child !== node.lastChild) {
-            console.error('node children are not linked correctly'); //eslint-disable-line no-console
+            logError('node children are not linked correctly');
             return false;
         }
     }
 
     if (node.firstChild && node.firstChild.prev) {
-        console.error('node\'s first child has previous sibling'); //eslint-disable-line no-console
+        logError('node\'s first child has previous sibling');
         return false;
     }
 
     if (node.lastChild && node.lastChild.next) {
-        console.error('node\'s last child has next sibling'); //eslint-disable-line no-console
+        logError('node\'s last child has next sibling');
         return false;
     }
 
     return true;
 }
 
-function astToString(node: Node, indent = '') { // eslint-disable-line no-unused-vars
+function astToString(node: Node, indent = '') {
     if (!node) {
         return '';
     }

--- a/app/components/post_list/post/body/content/embedded_bindings/menu_binding/index.tsx
+++ b/app/components/post_list/post/body/content/embedded_bindings/menu_binding/index.tsx
@@ -14,6 +14,7 @@ import {useServerUrl} from '@context/server';
 import {observeCurrentTeamId} from '@queries/servers/system';
 import {WithDatabaseArgs} from '@typings/database/database';
 import {createCallContext} from '@utils/apps';
+import {logDebug} from '@utils/log';
 
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type PostModel from '@typings/database/models/servers/post';
@@ -38,7 +39,7 @@ const MenuBinding = ({binding, currentTeamId, post, teamID}: Props) => {
 
         const bind = binding.bindings?.find((b) => b.location === picked);
         if (!bind) {
-            console.debug('Trying to select element not present in binding.'); //eslint-disable-line no-console
+            logDebug('Trying to select element not present in binding.');
             return;
         }
 

--- a/app/database/operator/app_data_operator/index.ts
+++ b/app/database/operator/app_data_operator/index.ts
@@ -6,6 +6,7 @@ import {buildAppInfoKey} from '@database/operator/app_data_operator/comparator';
 import {transformInfoRecord, transformGlobalRecord} from '@database/operator/app_data_operator/transformers';
 import BaseDataOperator from '@database/operator/base_data_operator';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {HandleInfoArgs, HandleGlobalArgs} from '@typings/database/database';
 
@@ -14,8 +15,7 @@ const {APP: {INFO, GLOBAL}} = MM_TABLES;
 export default class AppDataOperator extends BaseDataOperator {
     handleInfo = async ({info, prepareRecordsOnly = true}: HandleInfoArgs) => {
         if (!info?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "info" array has been passed to the handleInfo',
             );
             return [];
@@ -33,8 +33,7 @@ export default class AppDataOperator extends BaseDataOperator {
 
     handleGlobal = async ({globals, prepareRecordsOnly = true}: HandleGlobalArgs) => {
         if (!globals?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "globals" array has been passed to the handleGlobal',
             );
             return [];

--- a/app/database/operator/base_data_operator/index.ts
+++ b/app/database/operator/base_data_operator/index.ts
@@ -9,6 +9,7 @@ import {
     retrieveRecords,
 } from '@database/operator/utils/general';
 import {OperationType} from '@typings/database/enums';
+import {logWarning} from '@utils/log';
 
 import type {WriterInterface} from '@nozbe/watermelondb/Database';
 import type Model from '@nozbe/watermelondb/Model';
@@ -130,8 +131,7 @@ export default class BaseDataOperator {
      */
     prepareRecords = async ({tableName, createRaws, deleteRaws, updateRaws, transformer}: OperationArgs): Promise<Model[]> => {
         if (!this.database) {
-            // eslint-disable-next-line no-console
-            console.warn('Database not defined in prepareRecords');
+            logWarning('Database not defined in prepareRecords');
             return [];
         }
 
@@ -195,8 +195,7 @@ export default class BaseDataOperator {
                 });
             }
         } catch (e) {
-            // eslint-disable-next-line no-console
-            console.warn('batchRecords error ', e as Error);
+            logWarning('batchRecords error ', e as Error);
         }
     }
 
@@ -213,8 +212,7 @@ export default class BaseDataOperator {
      */
     async handleRecords({buildKeyRecordBy, fieldName, transformer, createOrUpdateRawValues, deleteRawValues = [], tableName, prepareRecordsOnly = true}: HandleRecordsArgs): Promise<Model[]> {
         if (!createOrUpdateRawValues.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 `An empty "rawValues" array has been passed to the handleRecords method for tableName ${tableName}`,
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/category.ts
+++ b/app/database/operator/server_data_operator/handlers/category.ts
@@ -9,6 +9,7 @@ import {
     transformCategoryRecord,
 } from '@database/operator/server_data_operator/transformers/category';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {
     HandleCategoryChannelArgs,
@@ -38,8 +39,7 @@ const CategoryHandler = (superclass: any) => class extends superclass {
      */
     handleCategories = async ({categories, prepareRecordsOnly = true}: HandleCategoryArgs): Promise<CategoryModel[]> => {
         if (!categories?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "categories" array has been passed to the handleCategories method',
             );
             return [];
@@ -92,8 +92,7 @@ const CategoryHandler = (superclass: any) => class extends superclass {
      */
     handleCategoryChannels = async ({categoryChannels, prepareRecordsOnly = true}: HandleCategoryChannelArgs): Promise<CategoryModel[]> => {
         if (!categoryChannels?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "categoryChannels" array has been passed to the handleCategories method',
             );
 

--- a/app/database/operator/server_data_operator/handlers/channel.ts
+++ b/app/database/operator/server_data_operator/handlers/channel.ts
@@ -17,6 +17,7 @@ import {
 } from '@database/operator/server_data_operator/transformers/channel';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
 import {getIsCRTEnabled} from '@queries/servers/thread';
+import {logWarning} from '@utils/log';
 
 import type {HandleChannelArgs, HandleChannelInfoArgs, HandleChannelMembershipArgs, HandleMyChannelArgs, HandleMyChannelSettingsArgs} from '@typings/database/database';
 import type ChannelModel from '@typings/database/models/servers/channel';
@@ -52,8 +53,7 @@ const ChannelHandler = (superclass: any) => class extends superclass {
      */
     handleChannel = async ({channels, prepareRecordsOnly = true}: HandleChannelArgs): Promise<ChannelModel[]> => {
         if (!channels?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "channels" array has been passed to the handleChannel method',
             );
             return [];
@@ -103,8 +103,7 @@ const ChannelHandler = (superclass: any) => class extends superclass {
      */
     handleMyChannelSettings = async ({settings, prepareRecordsOnly = true}: HandleMyChannelSettingsArgs): Promise<MyChannelSettingsModel[]> => {
         if (!settings?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "settings" array has been passed to the handleMyChannelSettings method',
             );
 
@@ -162,8 +161,7 @@ const ChannelHandler = (superclass: any) => class extends superclass {
      */
     handleChannelInfo = async ({channelInfos, prepareRecordsOnly = true}: HandleChannelInfoArgs): Promise<ChannelInfoModel[]> => {
         if (!channelInfos?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty "channelInfos" array has been passed to the handleMyChannelSettings method',
             );
 
@@ -223,8 +221,7 @@ const ChannelHandler = (superclass: any) => class extends superclass {
      */
     handleMyChannel = async ({channels, myChannels, isCRTEnabled, prepareRecordsOnly = true}: HandleMyChannelArgs): Promise<MyChannelModel[]> => {
         if (!myChannels?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "myChannels" array has been passed to the handleMyChannel method',
             );
 
@@ -232,8 +229,7 @@ const ChannelHandler = (superclass: any) => class extends superclass {
         }
 
         if (!channels?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "channels" array has been passed to the handleMyChannel method',
             );
 
@@ -313,8 +309,7 @@ const ChannelHandler = (superclass: any) => class extends superclass {
      */
     handleChannelMembership = async ({channelMemberships, prepareRecordsOnly = true}: HandleChannelMembershipArgs): Promise<ChannelMembershipModel[]> => {
         if (!channelMemberships?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty "channelMemberships" array has been passed to the handleChannelMembership method',
             );
 

--- a/app/database/operator/server_data_operator/handlers/group.ts
+++ b/app/database/operator/server_data_operator/handlers/group.ts
@@ -4,6 +4,7 @@
 import {MM_TABLES} from '@constants/database';
 import {transformGroupRecord} from '@database/operator/server_data_operator/transformers/group';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {HandleGroupArgs} from '@typings/database/database';
 import type GroupModel from '@typings/database/models/servers/group';
@@ -24,8 +25,7 @@ const GroupHandler = (superclass: any) => class extends superclass implements Gr
       */
     handleGroups = async ({groups, prepareRecordsOnly = true}: HandleGroupArgs): Promise<GroupModel[]> => {
         if (!groups?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "groups" array has been passed to the handleGroups method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/index.ts
+++ b/app/database/operator/server_data_operator/handlers/index.ts
@@ -9,6 +9,7 @@ import {
     transformSystemRecord,
 } from '@database/operator/server_data_operator/transformers/general';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {Model} from '@nozbe/watermelondb';
 import type {HandleCustomEmojiArgs, HandleRoleArgs, HandleSystemArgs, OperationArgs} from '@typings/database/database';
@@ -21,8 +22,7 @@ const {SERVER: {CUSTOM_EMOJI, ROLE, SYSTEM}} = MM_TABLES;
 export default class ServerDataOperatorBase extends BaseDataOperator {
     handleRole = async ({roles, prepareRecordsOnly = true}: HandleRoleArgs) => {
         if (!roles?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "roles" array has been passed to the handleRole',
             );
             return [];
@@ -39,8 +39,7 @@ export default class ServerDataOperatorBase extends BaseDataOperator {
 
     handleCustomEmojis = async ({emojis, prepareRecordsOnly = true}: HandleCustomEmojiArgs) => {
         if (!emojis?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "emojis" array has been passed to the handleCustomEmojis',
             );
             return [];
@@ -57,8 +56,7 @@ export default class ServerDataOperatorBase extends BaseDataOperator {
 
     handleSystem = async ({systems, prepareRecordsOnly = true}: HandleSystemArgs) => {
         if (!systems?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "systems" array has been passed to the handleSystem',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/post.ts
+++ b/app/database/operator/server_data_operator/handlers/post.ts
@@ -13,6 +13,7 @@ import {
 } from '@database/operator/server_data_operator/transformers/post';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
 import {createPostsChain} from '@database/operator/utils/post';
+import {logWarning} from '@utils/log';
 
 import type Database from '@nozbe/watermelondb/Database';
 import type Model from '@nozbe/watermelondb/Model';
@@ -49,8 +50,7 @@ const PostHandler = (superclass: any) => class extends superclass {
      */
     handleDraft = async ({drafts, prepareRecordsOnly = true}: HandleDraftArgs): Promise<DraftModel[]> => {
         if (!drafts?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "drafts" array has been passed to the handleDraft method',
             );
             return [];
@@ -83,8 +83,7 @@ const PostHandler = (superclass: any) => class extends superclass {
 
         // We rely on the posts array; if it is empty, we stop processing
         if (!posts?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "posts" array has been passed to the handlePosts method',
             );
             return [];
@@ -235,8 +234,7 @@ const PostHandler = (superclass: any) => class extends superclass {
      */
     handleFiles = async ({files, prepareRecordsOnly}: HandleFilesArgs): Promise<FileModel[]> => {
         if (!files?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "files" array has been passed to the handleFiles method',
             );
             return [];
@@ -273,8 +271,7 @@ const PostHandler = (superclass: any) => class extends superclass {
      */
     handlePostsInThread = async (postsMap: Record<string, Post[]>, actionType: never, prepareRecordsOnly = false): Promise<PostsInThreadModel[]> => {
         if (!postsMap || !Object.keys(postsMap).length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "postsMap" object has been passed to the handlePostsInThread method',
             );
             return [];
@@ -304,8 +301,7 @@ const PostHandler = (superclass: any) => class extends superclass {
         const permittedActions = Object.values(ActionType.POSTS);
 
         if (!posts.length || !permittedActions.includes(actionType)) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "posts" array or an non-supported actionType has been passed to the handlePostsInChannel method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/posts_in_channel.ts
+++ b/app/database/operator/server_data_operator/handlers/posts_in_channel.ts
@@ -6,6 +6,7 @@ import {Q} from '@nozbe/watermelondb';
 import {Database} from '@constants';
 import {getPostListEdges} from '@database//operator/utils/post';
 import {transformPostsInChannelRecord} from '@database/operator/server_data_operator/transformers/post';
+import {logWarning} from '@utils/log';
 
 import type PostsInChannelModel from '@typings/database/models/servers/posts_in_channel';
 
@@ -58,8 +59,7 @@ const PostsInChannelHandler = (superclass: any) => class extends superclass {
 
     handleReceivedPostsInChannel = async (posts?: Post[], prepareRecordsOnly = false): Promise<PostsInChannelModel[]> => {
         if (!posts?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "posts" array has been passed to the handleReceivedPostsInChannel method',
             );
             return [];
@@ -125,8 +125,7 @@ const PostsInChannelHandler = (superclass: any) => class extends superclass {
 
     handleReceivedPostsInChannelSince = async (posts: Post[], prepareRecordsOnly = false): Promise<PostsInChannelModel[]> => {
         if (!posts?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "posts" array has been passed to the handleReceivedPostsInChannelSince method',
             );
             return [];
@@ -176,8 +175,7 @@ const PostsInChannelHandler = (superclass: any) => class extends superclass {
 
     handleReceivedPostsInChannelBefore = async (posts: Post[], prepareRecordsOnly = false): Promise<PostsInChannelModel[]> => {
         if (!posts?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "posts" array has been passed to the handleReceivedPostsInChannelBefore method',
             );
             return [];
@@ -230,8 +228,7 @@ const PostsInChannelHandler = (superclass: any) => class extends superclass {
 
     handleReceivedPostForChannel = async (posts: Post[], prepareRecordsOnly = false): Promise<PostsInChannelModel[]> => {
         if (!posts?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "posts" array has been passed to the handleReceivedPostForChannel method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/posts_in_thread.ts
+++ b/app/database/operator/server_data_operator/handlers/posts_in_thread.ts
@@ -7,6 +7,7 @@ import {Database} from '@constants';
 import {getPostListEdges} from '@database//operator/utils/post';
 import {transformPostInThreadRecord} from '@database/operator/server_data_operator/transformers/post';
 import {getRawRecordPairs, getValidRecordsForUpdate} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {RecordPair} from '@typings/database/database';
 import type PostsInThreadModel from '@typings/database/models/servers/posts_in_thread';
@@ -20,8 +21,7 @@ const {POSTS_IN_THREAD} = Database.MM_TABLES.SERVER;
 const PostsInThreadHandler = (superclass: any) => class extends superclass {
     handleReceivedPostsInThread = async (postsMap: Record<string, Post[]>, prepareRecordsOnly = false): Promise<PostsInThreadModel[]> => {
         if (!postsMap || !Object.keys(postsMap).length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "postsMap" object has been passed to the handleReceivedPostsInThread method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/reaction.ts
+++ b/app/database/operator/server_data_operator/handlers/reaction.ts
@@ -4,6 +4,7 @@
 import {MM_TABLES} from '@constants/database';
 import {transformReactionRecord} from '@database/operator/server_data_operator/transformers/reaction';
 import {sanitizeReactions} from '@database/operator/utils/reaction';
+import {logWarning} from '@utils/log';
 
 import type {HandleReactionsArgs} from '@typings/database/database';
 import type CustomEmojiModel from '@typings/database/models/servers/custom_emoji';
@@ -29,8 +30,7 @@ const ReactionHandler = (superclass: any) => class extends superclass {
         const batchRecords: ReactionModel[] = [];
 
         if (!postsReactions?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "postsReactions" array has been passed to the handleReactions method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/team.ts
+++ b/app/database/operator/server_data_operator/handlers/team.ts
@@ -16,6 +16,7 @@ import {
     transformTeamSearchHistoryRecord,
 } from '@database/operator/server_data_operator/transformers/team';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {
     HandleMyTeamArgs, HandleTeamArgs,
@@ -54,8 +55,7 @@ const TeamHandler = (superclass: any) => class extends superclass {
      */
     handleTeamMemberships = async ({teamMemberships, prepareRecordsOnly = true}: HandleTeamMembershipArgs): Promise<TeamMembershipModel[]> => {
         if (!teamMemberships?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "teamMemberships" array has been passed to the handleTeamMemberships method',
             );
             return [];
@@ -111,8 +111,7 @@ const TeamHandler = (superclass: any) => class extends superclass {
      */
     handleTeam = async ({teams, prepareRecordsOnly = true}: HandleTeamArgs): Promise<TeamModel[]> => {
         if (!teams?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "teams" array has been passed to the handleTeam method',
             );
             return [];
@@ -162,8 +161,7 @@ const TeamHandler = (superclass: any) => class extends superclass {
      */
     handleTeamChannelHistory = async ({teamChannelHistories, prepareRecordsOnly = true}: HandleTeamChannelHistoryArgs): Promise<TeamChannelHistoryModel[]> => {
         if (!teamChannelHistories?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "teamChannelHistories" array has been passed to the handleTeamChannelHistory method',
             );
             return [];
@@ -190,8 +188,7 @@ const TeamHandler = (superclass: any) => class extends superclass {
      */
     handleTeamSearchHistory = async ({teamSearchHistories, prepareRecordsOnly = true}: HandleTeamSearchHistoryArgs): Promise<TeamSearchHistoryModel[]> => {
         if (!teamSearchHistories?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "teamSearchHistories" array has been passed to the handleTeamSearchHistory method',
             );
             return [];
@@ -219,8 +216,7 @@ const TeamHandler = (superclass: any) => class extends superclass {
      */
     handleMyTeam = async ({myTeams, prepareRecordsOnly = true}: HandleMyTeamArgs): Promise<MyTeamModel[]> => {
         if (!myTeams?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "myTeams" array has been passed to the handleMyTeam method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/thread.ts
+++ b/app/database/operator/server_data_operator/handlers/thread.ts
@@ -11,6 +11,7 @@ import {
 } from '@database/operator/server_data_operator/transformers/thread';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
 import {sanitizeThreadParticipants} from '@database/operator/utils/thread';
+import {logWarning} from '@utils/log';
 
 import type Database from '@nozbe/watermelondb/Database';
 import type {HandleThreadsArgs, HandleThreadParticipantsArgs} from '@typings/database/database';
@@ -38,8 +39,7 @@ const ThreadHandler = (superclass: any) => class extends superclass {
      */
     handleThreads = async ({threads, teamId, loadedInGlobalThreads, prepareRecordsOnly = false}: HandleThreadsArgs): Promise<Model[]> => {
         if (!threads?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "threads" array has been passed to the handleThreads method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/thread_in_team.ts
+++ b/app/database/operator/server_data_operator/handlers/thread_in_team.ts
@@ -6,6 +6,7 @@ import {Q, Database} from '@nozbe/watermelondb';
 import {MM_TABLES} from '@constants/database';
 import {transformThreadInTeamRecord} from '@database/operator/server_data_operator/transformers/thread';
 import {getRawRecordPairs, getValidRecordsForUpdate} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {HandleThreadInTeamArgs, RecordPair} from '@typings/database/database';
 import type ThreadInTeamModel from '@typings/database/models/servers/thread_in_team';
@@ -19,8 +20,7 @@ const {THREADS_IN_TEAM} = MM_TABLES.SERVER;
 const ThreadInTeamHandler = (superclass: any) => class extends superclass {
     handleThreadInTeam = async ({threadsMap, loadedInGlobalThreads, prepareRecordsOnly = false}: HandleThreadInTeamArgs): Promise<ThreadInTeamModel[]> => {
         if (!threadsMap || !Object.keys(threadsMap).length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "threadsMap" object has been passed to the handleReceivedPostForChannel method',
             );
             return [];

--- a/app/database/operator/server_data_operator/handlers/user.ts
+++ b/app/database/operator/server_data_operator/handlers/user.ts
@@ -8,6 +8,7 @@ import {
     transformUserRecord,
 } from '@database/operator/server_data_operator/transformers/user';
 import {getUniqueRawsBy} from '@database/operator/utils/general';
+import {logWarning} from '@utils/log';
 
 import type {
     HandlePreferencesArgs,
@@ -34,8 +35,7 @@ const UserHandler = (superclass: any) => class extends superclass {
      */
     handlePreferences = async ({preferences, prepareRecordsOnly = true, sync = false}: HandlePreferencesArgs): Promise<PreferenceModel[]> => {
         if (!preferences?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "preferences" array has been passed to the handlePreferences method',
             );
             return [];
@@ -106,8 +106,7 @@ const UserHandler = (superclass: any) => class extends superclass {
      */
     handleUsers = async ({users, prepareRecordsOnly = true}: HandleUsersArgs): Promise<UserModel[]> => {
         if (!users?.length) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            logWarning(
                 'An empty or undefined "users" array has been passed to the handleUsers method',
             );
             return [];

--- a/app/hooks/why_did_you_update.ts
+++ b/app/hooks/why_did_you_update.ts
@@ -3,6 +3,8 @@
 
 import {useEffect, useRef} from 'react';
 
+import {logInfo} from '@utils/log';
+
 export function useWhyDidYouUpdate(name: string, props: any) {
     // Get a mutable ref object where we can store props ...
     // ... for comparison next time this hook runs.
@@ -29,8 +31,7 @@ export function useWhyDidYouUpdate(name: string, props: any) {
 
             // If changesObj not empty then output to console
             if (Object.keys(changesObj).length) {
-                // eslint-disable-next-line no-console
-                console.log('[why-did-you-update]', name, changesObj);
+                logInfo('[why-did-you-update]', name, changesObj);
             }
         }
 

--- a/app/i18n/index.ts
+++ b/app/i18n/index.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 import {getLocales} from 'react-native-localize';
 
 import en from '@assets/i18n/en.json';
+import {logError} from '@utils/log';
 
 import availableLanguages from './languages';
 
@@ -189,7 +190,7 @@ function loadTranslation(locale?: string) {
         }
         return translations;
     } catch (e) {
-        console.error('NO Translation found', e); //eslint-disable-line no-console
+        logError('NO Translation found', e);
         return en;
     }
 }

--- a/app/init/credentials.ts
+++ b/app/init/credentials.ts
@@ -6,6 +6,7 @@ import * as KeyChain from 'react-native-keychain';
 
 import DatabaseManager from '@database/manager';
 import * as analytics from '@managers/analytics';
+import {logWarning} from '@utils/log';
 import {getIOSAppGroupDetails} from '@utils/mattermost_managed';
 
 import type {ServerCredential} from '@typings/credentials';
@@ -64,7 +65,7 @@ export const setServerCredentials = (serverUrl: string, token: string) => {
         };
         KeyChain.setInternetCredentials(serverUrl, token, token, options);
     } catch (e) {
-        console.warn('could not set credentials', e); //eslint-disable-line no-console
+        logWarning('could not set credentials', e);
     }
 };
 

--- a/app/init/launch.ts
+++ b/app/init/launch.ts
@@ -15,6 +15,7 @@ import {queryMyTeams} from '@queries/servers/team';
 import {goToScreen, resetToHome, resetToSelectServer, resetToTeams} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {DeepLinkChannel, DeepLinkDM, DeepLinkGM, DeepLinkPermalink, DeepLinkType, DeepLinkWithData, LaunchProps, LaunchType} from '@typings/launch';
+import {logInfo} from '@utils/log';
 import {convertToNotificationData} from '@utils/notification';
 import {parseDeepLink} from '@utils/url';
 
@@ -153,12 +154,10 @@ const launchToHome = async (props: LaunchProps) => {
     }
 
     if (nTeams) {
-        // eslint-disable-next-line no-console
-        console.log('Launch app in Home screen');
+        logInfo('Launch app in Home screen');
         resetToHome(props);
     } else {
-        // eslint-disable-next-line no-console
-        console.log('Launch app in Select Teams screen');
+        logInfo('Launch app in Select Teams screen');
         resetToTeams();
     }
 };

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -29,6 +29,7 @@ import {showOverlay} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import NavigationStore from '@store/navigation_store';
 import {isTablet} from '@utils/helpers';
+import {logInfo} from '@utils/log';
 import {convertToNotificationData} from '@utils/notification';
 
 const CATEGORY = 'CAN_REPLY';
@@ -187,8 +188,7 @@ class PushNotifications {
     };
 
     handleSessionNotification = async (notification: NotificationWithData) => {
-        // eslint-disable-next-line no-console
-        console.log('Session expired notification');
+        logInfo('Session expired notification');
 
         const serverUrl = await this.getServerUrlFromNotification(notification);
 

--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -16,6 +16,7 @@ import {Client} from '@client/rest';
 import * as ClientConstants from '@client/rest/constants';
 import {CERTIFICATE_ERRORS} from '@constants/network';
 import ManagedApp from '@init/managed_app';
+import {logError} from '@utils/log';
 import {getCSRFFromCookie} from '@utils/security';
 
 import type {ServerCredential} from '@typings/credentials';
@@ -55,7 +56,7 @@ class NetworkManager {
             try {
                 await this.createClient(serverUrl, token);
             } catch (error) {
-                console.log('NetworkManager init error', error); //eslint-disable-line no-console
+                logError('NetworkManager init error', error);
             }
         }
     };

--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -14,6 +14,7 @@ import {General} from '@constants';
 import DatabaseManager from '@database/manager';
 import {getCurrentUserId} from '@queries/servers/system';
 import {queryAllUsers} from '@queries/servers/user';
+import {logError} from '@utils/log';
 
 import type {ServerCredential} from '@typings/credentials';
 
@@ -46,7 +47,7 @@ class WebsocketManager {
                     try {
                         this.createClient(serverUrl, token, 0);
                     } catch (error) {
-                        console.log('WebsocketManager init error', error); //eslint-disable-line no-console
+                        logError('WebsocketManager init error', error);
                     }
                 },
             ),

--- a/app/screens/home/account/components/options/settings/index.tsx
+++ b/app/screens/home/account/components/options/settings/index.tsx
@@ -9,6 +9,7 @@ import FormattedText from '@components/formatted_text';
 import MenuItem from '@components/menu_item';
 import Screens from '@constants/screens';
 import {showModal} from '@screens/navigation';
+import {logInfo} from '@utils/log';
 import {preventDoubleTap} from '@utils/tap';
 
 type Props = {
@@ -23,8 +24,7 @@ const Settings = ({isTablet, style, theme}: Props) => {
     const openSettings = useCallback(preventDoubleTap(() => {
         if (isTablet) {
             //todo: https://mattermost.atlassian.net/browse/MM-39711
-            // eslint-disable-next-line no-console
-            console.log('Settings on tablets need to be figured out and implemented - @Avinash');
+            logInfo('Settings on tablets need to be figured out and implemented - @Avinash');
         }
         showModal(
             Screens.SETTINGS,

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -16,6 +16,7 @@ import RoundedHeaderContext from '@components/rounded_header_context';
 import {useServerUrl} from '@context/server';
 import {useCollapsibleHeader} from '@hooks/header';
 import {FileFilter, filterFiles} from '@utils/file';
+import {logInfo} from '@utils/log';
 
 import Results from './results';
 import Header, {SelectTab} from './results/header';
@@ -137,8 +138,7 @@ const SearchScreen = ({teamId}: Props) => {
             <NavigationHeader
                 isLargeTitle={true}
                 onBackPress={() => {
-                    // eslint-disable-next-line no-console
-                    console.log('BACK');
+                    logInfo('BACK');
                 }}
                 showBackButton={false}
                 title={intl.formatMessage({id: 'screen.search.title', defaultMessage: 'Search'})}

--- a/app/screens/mfa/index.tsx
+++ b/app/screens/mfa/index.tsx
@@ -20,6 +20,7 @@ import {useIsTablet} from '@hooks/device';
 import {t} from '@i18n';
 import Background from '@screens/background';
 import {buttonBackgroundStyle, buttonTextStyle} from '@utils/buttonStyles';
+import {logInfo} from '@utils/log';
 import {preventDoubleTap} from '@utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -152,8 +153,7 @@ const MFA = ({config, goToHome, license, loginId, password, serverDisplayName, s
             setError(result.error.message);
         }
         if (!result.hasTeams && !result.error) {
-            // eslint-disable-next-line no-console
-            console.log('GO TO NO TEAMS');
+            logInfo('GO TO NO TEAMS');
             return;
         }
         goToHome(result.time || 0, result.error as never);

--- a/app/screens/sso/index.tsx
+++ b/app/screens/sso/index.tsx
@@ -14,6 +14,7 @@ import {Screens, Sso} from '@constants';
 import NetworkManager from '@managers/network_manager';
 import Background from '@screens/background';
 import {dismissModal, resetToHome, resetToTeams} from '@screens/navigation';
+import {logWarning} from '@utils/log';
 
 import SSOWithRedirectURL from './sso_with_redirect_url';
 import SSOWithWebView from './sso_with_webview';
@@ -82,7 +83,7 @@ const SSO = ({
     }
 
     const onLoadEndError = (e: ClientErrorProps | Error | string) => {
-        console.warn('Failed to set store from local data', e); // eslint-disable-line no-console
+        logWarning('Failed to set store from local data', e);
         if (typeof e === 'string') {
             setLoginError(e);
             return;

--- a/app/utils/error_handling.ts
+++ b/app/utils/error_handling.ts
@@ -14,6 +14,8 @@ import {
     LOGGER_NATIVE,
 } from '@utils/sentry';
 
+import {logWarning} from './log';
+
 class JavascriptAndNativeErrorHandler {
     initializeErrorHandling = () => {
         initializeSentry();
@@ -22,8 +24,7 @@ class JavascriptAndNativeErrorHandler {
     };
 
     nativeErrorHandler = (e: string) => {
-        // eslint-disable-next-line no-console
-        console.warn('Handling native error ' + e);
+        logWarning('Handling native error ' + e);
         captureException(e, LOGGER_NATIVE);
     };
 
@@ -35,8 +36,7 @@ class JavascriptAndNativeErrorHandler {
             return;
         }
 
-        // eslint-disable-next-line no-console
-        console.warn('Handling Javascript error', e, isFatal);
+        logWarning('Handling Javascript error', e, isFatal);
         captureJSException(e, isFatal);
 
         if (isFatal && e instanceof Error) {

--- a/app/utils/log.ts
+++ b/app/utils/log.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export function logError(...args: any[]) {
+    // eslint-disable-next-line no-console
+    console.error('Error:', ...args);
+}
+
+export function logWarning(...args: any[]) {
+    // eslint-disable-next-line no-console
+    console.warn('Warning:', ...args);
+}
+
+export function logInfo(...args: any[]) {
+    // eslint-disable-next-line no-console
+    console.log('Info:', ...args);
+}
+
+export function logDebug(...args: any[]) {
+    // eslint-disable-next-line no-console
+    console.debug('Debug:', ...args);
+}

--- a/app/utils/mattermost_managed.ts
+++ b/app/utils/mattermost_managed.ts
@@ -24,7 +24,7 @@ export const getIOSAppGroupDetails = (): IOSAppGroupDetails => {
         appGroupDatabase: databasePath,
     };
 
-    // console.log('appGroup => ', appGroup.appGroupDatabase);
+    // logInfo('appGroup => ', appGroup.appGroupDatabase);
     return appGroup;
 };
 

--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -7,6 +7,7 @@ import {Platform} from 'react-native';
 import Config from '@assets/config.json';
 
 import {ClientError} from './client_error';
+import {logWarning} from './log';
 
 export const BREADCRUMB_UNCAUGHT_APP_ERROR = 'uncaught-app-error';
 export const BREADCRUMB_UNCAUGHT_NON_ERROR = 'uncaught-non-error';
@@ -28,7 +29,7 @@ export function initializeSentry() {
     const dsn = getDsn();
 
     if (!dsn) {
-        console.warn('Sentry is enabled, but not configured on this platform'); // eslint-disable-line no-console
+        logWarning('Sentry is enabled, but not configured on this platform');
         return;
     }
 
@@ -51,8 +52,7 @@ export function captureException(error: Error | string, logger: string) {
     }
 
     if (!error || !logger) {
-        // eslint-disable-next-line no-console
-        console.warn('captureException called with missing arguments', error, logger);
+        logWarning('captureException called with missing arguments', error, logger);
         return;
     }
 
@@ -69,8 +69,7 @@ export function captureJSException(error: Error | ClientError, isFatal: boolean)
     }
 
     if (!error) {
-        // eslint-disable-next-line no-console
-        console.warn('captureJSException called with missing arguments', error);
+        logWarning('captureJSException called with missing arguments', error);
         return;
     }
 
@@ -117,7 +116,7 @@ function captureClientErrorAsBreadcrumb(error: ClientError, isFatal: boolean) {
         Sentry.addBreadcrumb(breadcrumb);
     } catch (e) {
         // Do nothing since this is only here to make sure we don't crash when handling an exception
-        console.warn('Failed to capture breadcrumb of non-error', e); // eslint-disable-line no-console
+        logWarning('Failed to capture breadcrumb of non-error', e);
     }
 }
 
@@ -147,16 +146,16 @@ function capture(captureFunc: () => void, config?: ClientConfig) {
         }
 
         if (hasUserContext) {
-            console.warn('Capturing with Sentry at ' + getDsn() + '...'); // eslint-disable-line no-console
+            logWarning('Capturing with Sentry at ' + getDsn() + '...');
 
             captureFunc();
         } else {
-            console.warn('No user context, skipping capture'); // eslint-disable-line no-console
+            logWarning('No user context, skipping capture');
         }
     } catch (e) {
         // Don't want this to get into an infinite loop again...
-        console.warn('Exception occured while sending to Sentry'); // eslint-disable-line no-console
-        console.warn(e); // eslint-disable-line no-console
+        logWarning('Exception occured while sending to Sentry');
+        logWarning(e);
     }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ import WebsocketManager from './app/managers/websocket_manager';
 import {registerScreens} from './app/screens';
 import NavigationStore from './app/store/navigation_store';
 import setFontFamily from './app/utils/font_family';
+import {logInfo} from './app/utils/log';
 import './app/utils/emoji'; // Imported to ensure it is loaded when used
 
 declare const global: { HermesInternal: null | {} };
@@ -33,8 +34,7 @@ if (__DEV__) {
 
     // Ignore all notifications if running e2e
     const isRunningE2e = RUNNING_E2E === 'true';
-    // eslint-disable-next-line no-console
-    console.log(`RUNNING_E2E: ${RUNNING_E2E}, isRunningE2e: ${isRunningE2e}`);
+    logInfo(`RUNNING_E2E: ${RUNNING_E2E}, isRunningE2e: ${isRunningE2e}`);
     if (isRunningE2e) {
         LogBox.ignoreAllLogs(true);
     }


### PR DESCRIPTION
#### Summary
In many places we have console.X (log, error, warn...) with the corresponding `eslit-disable no-console`. To avoid that, we have moved all of those to some util functions.

In the future, these util functions can be improved to do something extra in the logging, like adding some extra metadata (like time) or pipe them to sentry or other tools.

#### Ticket Link
None

#### Release Note
```release-note
Improved logging
```
