### PR TITLE
Add column last_fetched_at to MyChannel & Thread tables and the migration

### DIFF
--- a/app/database/manager/index.ts
+++ b/app/database/manager/index.ts
@@ -25,6 +25,7 @@ import {serverSchema} from '@database/schema/server';
 import {queryActiveServer, queryServer, queryServerByIdentifier} from '@queries/app/servers';
 import {DatabaseType} from '@typings/database/enums';
 import {emptyFunction} from '@utils/general';
+import {logDebug, logError} from '@utils/log';
 import {deleteIOSDatabase, getIOSAppGroupDetails} from '@utils/mattermost_managed';
 import {hashCode} from '@utils/security';
 import {removeProtocol} from '@utils/url';
@@ -157,6 +158,8 @@ class DatabaseManager {
                 return serverDatabase;
             } catch (e) {
                 // TODO : report to sentry? Show something on the UI ?
+
+                logError('Error initializing database', e);
             }
         }
 
@@ -461,16 +464,19 @@ class DatabaseManager {
     private buildMigrationCallbacks = (dbName: string) => {
         const migrationEvents = {
             onSuccess: () => {
+                logDebug('DB Migration success', dbName);
                 return DeviceEventEmitter.emit(MIGRATION_EVENTS.MIGRATION_SUCCESS, {
                     dbName,
                 });
             },
             onStart: () => {
+                logDebug('DB Migration start', dbName);
                 return DeviceEventEmitter.emit(MIGRATION_EVENTS.MIGRATION_STARTED, {
                     dbName,
                 });
             },
             onError: (error: Error) => {
+                logDebug('DB Migration error', dbName);
                 return DeviceEventEmitter.emit(MIGRATION_EVENTS.MIGRATION_ERROR, {
                     dbName,
                     error,

--- a/app/database/migration/server/index.ts
+++ b/app/database/migration/server/index.ts
@@ -1,9 +1,34 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {schemaMigrations} from '@nozbe/watermelondb/Schema/migrations';
-
 // NOTE : To implement migration, please follow this document
 // https://nozbe.github.io/WatermelonDB/Advanced/Migrations.html
 
-export default schemaMigrations({migrations: []});
+import {schemaMigrations, addColumns} from '@nozbe/watermelondb/Schema/migrations';
+
+import {MM_TABLES} from '@constants/database';
+
+const {SERVER: {
+    MY_CHANNEL,
+    THREAD,
+}} = MM_TABLES;
+
+export default schemaMigrations({migrations: [
+    {
+        toVersion: 2,
+        steps: [
+            addColumns({
+                table: MY_CHANNEL,
+                columns: [
+                    {name: 'last_fetched_at', type: 'number', isIndexed: true},
+                ],
+            }),
+            addColumns({
+                table: THREAD,
+                columns: [
+                    {name: 'last_fetched_at', type: 'number', isIndexed: true},
+                ],
+            }),
+        ],
+    },
+]});

--- a/app/database/models/server/my_channel.ts
+++ b/app/database/models/server/my_channel.ts
@@ -28,6 +28,9 @@ export default class MyChannelModel extends Model implements MyChannelModelInter
     /** last_post_at : The timestamp for any last post on this channel */
     @field('last_post_at') lastPostAt!: number;
 
+    /** last_last_fetched_at_at : The timestamp when we successfully last fetched post on this channel */
+    @field('last_fetched_at') lastFetchedAt!: number;
+
     /** last_viewed_at : The timestamp showing the user's last viewed post on this channel */
     @field('last_viewed_at') lastViewedAt!: number;
 

--- a/app/database/models/server/thread.ts
+++ b/app/database/models/server/thread.ts
@@ -37,6 +37,9 @@ export default class ThreadModel extends Model implements ThreadModelInterface {
     /** last_reply_at : The timestamp of when user last replied to the thread. */
     @field('last_reply_at') lastReplyAt!: number;
 
+    /** last_last_fetched_at_at : The timestamp when we successfully last fetched post on this thread */
+    @field('last_fetched_at') lastFetchedAt!: number;
+
     /** last_viewed_at : The timestamp of when user last viewed the thread. */
     @field('last_viewed_at') lastViewedAt!: number;
 

--- a/app/database/schema/server/index.ts
+++ b/app/database/schema/server/index.ts
@@ -37,7 +37,7 @@ import {
 } from './table_schemas';
 
 export const serverSchema: AppSchema = appSchema({
-    version: 1,
+    version: 2,
     tables: [
         CategorySchema,
         CategoryChannelSchema,

--- a/app/database/schema/server/table_schemas/my_channel.ts
+++ b/app/database/schema/server/table_schemas/my_channel.ts
@@ -18,6 +18,7 @@ export default tableSchema({
         {name: 'message_count', type: 'number'},
         {name: 'roles', type: 'string'},
         {name: 'viewed_at', type: 'number'},
+        {name: 'last_fetched_at', type: 'number', isIndexed: true},
     ],
 });
 

--- a/app/database/schema/server/table_schemas/thread.ts
+++ b/app/database/schema/server/table_schemas/thread.ts
@@ -17,6 +17,7 @@ export default tableSchema({
         {name: 'unread_mentions', type: 'number'},
         {name: 'unread_replies', type: 'number'},
         {name: 'viewed_at', type: 'number'},
+        {name: 'last_fetched_at', type: 'number', isIndexed: true},
     ],
 });
 

--- a/types/database/models/servers/my_channel.d.ts
+++ b/types/database/models/servers/my_channel.d.ts
@@ -17,6 +17,9 @@ export default class MyChannelModel extends Model {
     /** last_post_at : The timestamp for any last post on this channel */
     lastPostAt: number;
 
+    /** last_fetched_at : The timestamp when we successfully last fetched post on this channel */
+    lastFetchedAt: number;
+
     /** last_viewed_at : The timestamp showing the user's last viewed post on this channel */
     lastViewedAt: number;
 

--- a/types/database/models/servers/thread.d.ts
+++ b/types/database/models/servers/thread.d.ts
@@ -20,6 +20,9 @@ export default class ThreadModel extends Model {
     /** lastReplyAt : The timestamp of when user last replied to the thread. */
     lastReplyAt: number;
 
+    /** last_last_fetched_at_at : The timestamp when we successfully last fetched post on this channel */
+    lastFetchedAt: number;
+
     /** lastViewedAt : The timestamp of when user last viewed the thread. */
     lastViewedAt: number;
 


### PR DESCRIPTION
#### Summary
This is the PR to tackle the issue with missing messages by using `last_fetched_at` as the `since` value when fetching posts.

```release-note
NONE
```
