### PR TITLE
Handle lastFetchAt, retrieve threads on init and properly observe thread unreads

### DIFF
--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -188,7 +188,7 @@ export async function createThreadFromNewPost(serverUrl: string, post: Post, pre
             });
             models.push(...threadParticipantModels);
         } else { // If the post is a root post, then we need to add it to the thread table
-            const threadModels = await prepareThreadsFromReceivedPosts(operator, [post]);
+            const threadModels = await prepareThreadsFromReceivedPosts(operator, [post], false);
             models.push(...threadModels);
         }
 
@@ -211,6 +211,7 @@ export async function processReceivedThreads(serverUrl: string, threads: Thread[
 
         const posts: Post[] = [];
         const users: UserProfile[] = [];
+        const threadsToHandle: ThreadWithLastFetchedAt[] = [];
 
         // Extract posts & users from the received threads
         for (let i = 0; i < threads.length; i++) {
@@ -221,6 +222,7 @@ export async function processReceivedThreads(serverUrl: string, threads: Thread[
                     users.push(participant);
                 }
             });
+            threadsToHandle.push({...threads[i], lastFetchedAt: post.create_at});
         }
 
         const postModels = await operator.handlePosts({
@@ -231,7 +233,7 @@ export async function processReceivedThreads(serverUrl: string, threads: Thread[
         });
 
         const threadModels = await operator.handleThreads({
-            threads,
+            threads: threadsToHandle,
             teamId,
             prepareRecordsOnly: true,
             loadedInGlobalThreads,

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -345,7 +345,7 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
             }
 
             if (isCRTEnabled) {
-                const threadModels = await prepareThreadsFromReceivedPosts(operator, data.posts);
+                const threadModels = await prepareThreadsFromReceivedPosts(operator, data.posts, false);
                 if (threadModels?.length) {
                     models.push(...threadModels);
                 }
@@ -421,7 +421,7 @@ export async function fetchPosts(serverUrl: string, channelId: string, page = 0,
             }
 
             if (isCRTEnabled) {
-                const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts);
+                const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts, false);
                 if (threadModels?.length) {
                     models.push(...threadModels);
                 }
@@ -479,7 +479,7 @@ export async function fetchPostsBefore(serverUrl: string, channelId: string, pos
                 }
 
                 if (isCRTEnabled) {
-                    const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts);
+                    const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts, false);
                     if (threadModels?.length) {
                         models.push(...threadModels);
                     }
@@ -535,7 +535,7 @@ export async function fetchPostsSince(serverUrl: string, channelId: string, sinc
             }
 
             if (isCRTEnabled) {
-                const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts);
+                const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts, false);
                 if (threadModels?.length) {
                     models.push(...threadModels);
                 }
@@ -649,7 +649,7 @@ export async function fetchPostThread(serverUrl: string, postId: string, fetchOn
             }
 
             if (isCRTEnabled) {
-                const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts);
+                const threadModels = await prepareThreadsFromReceivedPosts(operator, result.posts, true);
                 if (threadModels?.length) {
                     models.push(...threadModels);
                 }
@@ -719,7 +719,7 @@ export async function fetchPostsAround(serverUrl: string, channelId: string, pos
             models.push(...posts);
 
             if (isCRTEnabled) {
-                const threadModels = await prepareThreadsFromReceivedPosts(operator, data.posts);
+                const threadModels = await prepareThreadsFromReceivedPosts(operator, data.posts, false);
                 if (threadModels?.length) {
                     models.push(...threadModels);
                 }
@@ -830,7 +830,7 @@ export async function fetchPostById(serverUrl: string, postId: string, fetchOnly
 
             const isCRTEnabled = await getIsCRTEnabled(operator.database);
             if (isCRTEnabled) {
-                const threadModels = await prepareThreadsFromReceivedPosts(operator, [post]);
+                const threadModels = await prepareThreadsFromReceivedPosts(operator, [post], false);
                 if (threadModels?.length) {
                     models.push(...threadModels);
                 }
@@ -1052,7 +1052,7 @@ export async function fetchSavedPosts(serverUrl: string, teamId?: string, channe
 
         const isCRTEnabled = await getIsCRTEnabled(operator.database);
         if (isCRTEnabled) {
-            promises.push(prepareThreadsFromReceivedPosts(operator, postsArray));
+            promises.push(prepareThreadsFromReceivedPosts(operator, postsArray, false));
         }
 
         const modelArrays = await Promise.all(promises);
@@ -1134,7 +1134,7 @@ export async function fetchPinnedPosts(serverUrl: string, channelId: string) {
         );
 
         if (isCRTEnabled) {
-            promises.push(prepareThreadsFromReceivedPosts(operator, postsArray));
+            promises.push(prepareThreadsFromReceivedPosts(operator, postsArray, false));
         }
 
         const modelArrays = await Promise.all(promises);

--- a/app/actions/remote/search.ts
+++ b/app/actions/remote/search.ts
@@ -77,7 +77,7 @@ export const searchPosts = async (serverUrl: string, params: PostSearchParams): 
         if (postsArray.length) {
             const isCRTEnabled = await getIsCRTEnabled(operator.database);
             if (isCRTEnabled) {
-                promises.push(prepareThreadsFromReceivedPosts(operator, postsArray));
+                promises.push(prepareThreadsFromReceivedPosts(operator, postsArray, false));
             }
 
             const {authors} = await fetchPostAuthors(serverUrl, postsArray, true);

--- a/app/database/operator/server_data_operator/handlers/thread.test.ts
+++ b/app/database/operator/server_data_operator/handlers/thread.test.ts
@@ -46,8 +46,9 @@ describe('*** Operator: Thread Handlers tests ***', () => {
                 is_following: true,
                 unread_replies: 0,
                 unread_mentions: 0,
+                lastFetchedAt: 0,
             },
-        ] as Thread[];
+        ] as ThreadWithLastFetchedAt[];
 
         const threadsMap = {team_id_1: threads};
         await operator.handleThreads({threads, loadedInGlobalThreads: false, prepareRecordsOnly: false, teamId: 'team_id_1'});

--- a/app/database/operator/server_data_operator/transformers/thread.ts
+++ b/app/database/operator/server_data_operator/transformers/thread.ts
@@ -24,7 +24,7 @@ const {
  * @returns {Promise<ThreadModel>}
  */
 export const transformThreadRecord = ({action, database, value}: TransformerArgs): Promise<ThreadModel> => {
-    const raw = value.raw as Thread;
+    const raw = value.raw as ThreadWithLastFetchedAt;
     const record = value.record as ThreadModel;
     const isCreateAction = action === OperationType.CREATE;
 
@@ -38,6 +38,7 @@ export const transformThreadRecord = ({action, database, value}: TransformerArgs
         thread.unreadReplies = raw.unread_replies ?? record?.unreadReplies ?? 0;
         thread.unreadMentions = raw.unread_mentions ?? record?.unreadMentions ?? 0;
         thread.viewedAt = record?.viewedAt || 0;
+        thread.lastFetchedAt = Math.max(record?.lastFetchedAt || 0, raw.lastFetchedAt || 0);
     };
 
     return prepareBaseRecord({

--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -66,15 +66,15 @@ export const observeTeamIdByThread = (thread: ThreadModel) => {
     );
 };
 
-export const observeUnreadsAndMentionsInTeam = (database: Database, teamId?: string, includeDmGm?: boolean): Observable<{unreads: number; mentions: number}> => {
+export const observeUnreadsAndMentionsInTeam = (database: Database, teamId?: string, includeDmGm?: boolean): Observable<{unreads: boolean; mentions: number}> => {
     const observeThreads = () => queryThreads(database, teamId, true, includeDmGm).
         observeWithColumns(['unread_replies', 'unread_mentions']).
         pipe(
             switchMap((threads) => {
-                let unreads = 0;
+                let unreads = false;
                 let mentions = 0;
                 for (const thread of threads) {
-                    unreads += thread.unreadReplies;
+                    unreads = unreads || Boolean(thread.unreadReplies);
                     mentions += thread.unreadMentions;
                 }
 
@@ -83,14 +83,16 @@ export const observeUnreadsAndMentionsInTeam = (database: Database, teamId?: str
         );
 
     return observeIsCRTEnabled(database).pipe(
-        switchMap((hasCRT) => (hasCRT ? observeThreads() : of$({unreads: 0, mentions: 0}))),
+        switchMap((hasCRT) => (hasCRT ? observeThreads() : of$({unreads: false, mentions: 0}))),
+        distinctUntilChanged((x, y) => x.mentions === y.mentions && x.unreads === y.unreads),
     );
 };
 
 // On receiving "posts", Save the "root posts" as "threads"
-export const prepareThreadsFromReceivedPosts = async (operator: ServerDataOperator, posts: Post[]) => {
+export const prepareThreadsFromReceivedPosts = async (operator: ServerDataOperator, posts: Post[], updateLastFetchAt: boolean) => {
     const models: Model[] = [];
-    const threads: Thread[] = [];
+    const threads: ThreadWithLastFetchedAt[] = [];
+    const toUpdate: {[rootId: string]: number | undefined} = {};
     posts.forEach((post: Post) => {
         if (!post.root_id && post.type === '') {
             threads.push({
@@ -99,12 +101,27 @@ export const prepareThreadsFromReceivedPosts = async (operator: ServerDataOperat
                 reply_count: post.reply_count,
                 last_reply_at: post.last_reply_at,
                 is_following: post.is_following,
-            } as Thread);
+                lastFetchedAt: post.create_at,
+            } as ThreadWithLastFetchedAt);
+        } else if (post.root_id && updateLastFetchAt) {
+            toUpdate[post.root_id] = Math.max(toUpdate[post.root_id] || 0, post.create_at, post.update_at, post.delete_at);
         }
     });
     if (threads.length) {
         const threadModels = await operator.handleThreads({threads, prepareRecordsOnly: true});
         models.push(...threadModels);
+    }
+    const toUpdateKeys = Object.keys(toUpdate);
+    if (toUpdateKeys.length) {
+        const toUpdateThreads = await Promise.all(toUpdateKeys.map((key) => getThreadById(operator.database, key)));
+        for (const thread of toUpdateThreads) {
+            if (thread) {
+                const model = thread.prepareUpdate((record) => {
+                    record.lastFetchedAt = Math.max(record.lastFetchedAt, toUpdate[thread.id] || 0);
+                });
+                models.push(model);
+            }
+        }
     }
 
     return models;

--- a/app/screens/home/channel_list/categories_list/categories/unreads/unreads.test.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/unreads/unreads.test.tsx
@@ -23,7 +23,7 @@ describe('components/channel_list/categories/body', () => {
                 unreadChannels={[]}
                 onChannelSwitch={() => undefined}
                 onlyUnreads={false}
-                unreadThreads={{unreads: 0, mentions: 0}}
+                unreadThreads={{unreads: false, mentions: 0}}
             />,
             {database},
         );

--- a/app/screens/home/channel_list/categories_list/categories/unreads/unreads.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/unreads/unreads.tsx
@@ -35,7 +35,7 @@ type UnreadCategoriesProps = {
     onChannelSwitch: (channelId: string) => void;
     onlyUnreads: boolean;
     unreadChannels: ChannelModel[];
-    unreadThreads: {unreads: number; mentions: number};
+    unreadThreads: {unreads: boolean; mentions: number};
 }
 
 const extractKey = (item: ChannelModel) => item.id;
@@ -62,7 +62,7 @@ const UnreadCategories = ({onChannelSwitch, onlyUnreads, unreadChannels, unreadT
         <Empty onlyUnreads={onlyUnreads}/>
     ) : undefined;
 
-    if (!unreadChannels.length && !unreadThreads.mentions && !unreadThreads.mentions && !onlyUnreads) {
+    if (!unreadChannels.length && !unreadThreads.mentions && !unreadThreads.unreads && !onlyUnreads) {
         return null;
     }
 

--- a/app/screens/home/channel_list/categories_list/threads_button/threads_button.test.tsx
+++ b/app/screens/home/channel_list/categories_list/threads_button/threads_button.test.tsx
@@ -14,7 +14,7 @@ describe('Thread item in the channel list', () => {
                 currentChannelId='someChannelId'
                 onlyUnreads={false}
                 unreadsAndMentions={{
-                    unreads: 0,
+                    unreads: false,
                     mentions: 0,
                 }}
             />,
@@ -29,7 +29,7 @@ describe('Thread item in the channel list', () => {
                 currentChannelId='someChannelId'
                 onlyUnreads={true}
                 unreadsAndMentions={{
-                    unreads: 0,
+                    unreads: false,
                     mentions: 0,
                 }}
             />,

--- a/app/screens/home/channel_list/categories_list/threads_button/threads_button.tsx
+++ b/app/screens/home/channel_list/categories_list/threads_button/threads_button.tsx
@@ -39,7 +39,7 @@ type Props = {
     currentChannelId: string;
     onlyUnreads: boolean;
     unreadsAndMentions: {
-        unreads: number;
+        unreads: boolean;
         mentions: number;
     };
 };

--- a/app/screens/home/channel_list/servers/index.tsx
+++ b/app/screens/home/channel_list/servers/index.tsx
@@ -69,11 +69,11 @@ const Servers = React.forwardRef<ServersRef>((props, ref) => {
         setTotal({mentions, unread});
     };
 
-    const unreadsSubscription = (serverUrl: string, {myChannels, settings, threadMentionCount}: UnreadObserverArgs) => {
+    const unreadsSubscription = (serverUrl: string, {myChannels, settings, threadMentionCount, threadUnreads}: UnreadObserverArgs) => {
         const unreads = subscriptions.get(serverUrl);
         if (unreads) {
             let mentions = 0;
-            let unread = false;
+            let unread = Boolean(threadUnreads);
             for (const myChannel of myChannels) {
                 const isMuted = settings?.[myChannel.id]?.mark_unread === 'mention';
                 mentions += myChannel.mentionsCount;
@@ -101,14 +101,14 @@ const Servers = React.forwardRef<ServersRef>((props, ref) => {
 
         for (const server of servers) {
             const {lastActiveAt, url} = server;
-            if (lastActiveAt && url !== currentServerUrl && !subscriptions.has(url)) {
+            if (lastActiveAt && (url !== currentServerUrl) && !subscriptions.has(url)) {
                 const unreads: UnreadSubscription = {
                     mentions: 0,
                     unread: false,
                 };
                 subscriptions.set(url, unreads);
                 unreads.subscription = subscribeUnreadAndMentionsByServer(url, unreadsSubscription);
-            } else if ((!lastActiveAt || url === currentServerUrl) && subscriptions.has(url)) {
+            } else if ((!lastActiveAt || (url === currentServerUrl)) && subscriptions.has(url)) {
                 subscriptions.get(url)?.subscription?.unsubscribe();
                 subscriptions.delete(url);
                 updateTotal();

--- a/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
@@ -165,9 +165,9 @@ const ServerItem = ({
         displayName = intl.formatMessage({id: 'servers.default', defaultMessage: 'Default Server'});
     }
 
-    const unreadsSubscription = ({myChannels, settings, threadMentionCount}: UnreadObserverArgs) => {
+    const unreadsSubscription = ({myChannels, settings, threadMentionCount, threadUnreads}: UnreadObserverArgs) => {
         let mentions = 0;
-        let isUnread = false;
+        let isUnread = Boolean(threadUnreads);
         for (const myChannel of myChannels) {
             const isMuted = settings?.[myChannel.id]?.mark_unread === 'mention';
             mentions += myChannel.mentionsCount;

--- a/types/api/threads.d.ts
+++ b/types/api/threads.d.ts
@@ -14,6 +14,10 @@ type Thread = {
     delete_at: number;
 };
 
+type ThreadWithLastFetchedAt = Thread & {
+    lastFetchedAt: number;
+}
+
 type ThreadParticipant = {
     id: $ID<User>;
     thread_id: $ID<Thread>;

--- a/types/database/database.d.ts
+++ b/types/database/database.d.ts
@@ -89,7 +89,7 @@ export type HandlePostsArgs = {
 };
 
 export type HandleThreadsArgs = {
-  threads?: Thread[];
+  threads?: ThreadWithLastFetchedAt[];
   prepareRecordsOnly?: boolean;
   teamId?: string;
   loadedInGlobalThreads?: boolean;

--- a/types/database/raw_values.d.ts
+++ b/types/database/raw_values.d.ts
@@ -116,7 +116,7 @@ type RawValue =
   | TeamChannelHistory
   | TeamMembership
   | TeamSearchHistory
-  | Thread
+  | ThreadWithLastFetchedAt
   | ThreadInTeam
   | ThreadParticipant
   | UserProfile


### PR DESCRIPTION
#### Summary
Handle lastFetchAt to be properly updated. Since we are no using since on fetchPostThread, we are not using it yet.

Also, sync the threads on all servers on init to avoid gaps.

Finally, piggybacked some minor changes in thread observables to properly observe the unreads of other servers.

#### Ticket Link
None

#### Release Note
```release-note
Improve threads handling to avoid missing messages or unread notifications.
```
