### PR TITLE
Fix links to channels closing the channel

### DIFF
--- a/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
+++ b/app/components/autocomplete/slash_suggestion/app_command_parser/app_command_parser.ts
@@ -1320,7 +1320,7 @@ export class AppCommandParser {
                 }
                 case AppFieldTypes.CHANNEL: {
                     const getFieldChannel = async (channelName: string) => {
-                        let channel: ChannelModel | Channel | undefined = await getChannelByName(this.database, channelName);
+                        let channel: ChannelModel | Channel | undefined = await getChannelByName(this.database, this.teamID, channelName);
                         if (!channel) {
                             const res = await fetchChannelByName(this.serverUrl, this.teamID, channelName);
                             if ('error' in res) {

--- a/app/components/markdown/markdown_link/markdown_link.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.tsx
@@ -15,7 +15,7 @@ import SlideUpPanelItem, {ITEM_HEIGHT} from '@components/slide_up_panel_item';
 import DeepLinkTypes from '@constants/deep_linking';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
-import {bottomSheet, dismissAllModals, dismissBottomSheet, popToRoot} from '@screens/navigation';
+import {bottomSheet, dismissBottomSheet} from '@screens/navigation';
 import {errorBadChannel} from '@utils/draft';
 import {bottomSheetSnapPoint} from '@utils/helpers';
 import {preventDoubleTap} from '@utils/tap';
@@ -69,11 +69,7 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
 
         if (match && match.data?.teamName) {
             if (match.type === DeepLinkTypes.CHANNEL) {
-                const result = await switchToChannelByName(serverUrl, (match?.data as DeepLinkChannel).channelName, match.data?.teamName, errorBadChannel, intl);
-                if (!result.error) {
-                    await dismissAllModals();
-                    await popToRoot();
-                }
+                await switchToChannelByName(serverUrl, (match?.data as DeepLinkChannel).channelName, match.data?.teamName, errorBadChannel, intl);
             } else if (match.type === DeepLinkTypes.PERMALINK) {
                 showPermalink(serverUrl, match.data.teamName, (match.data as DeepLinkPermalink).postId, intl);
             }

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -22,7 +22,7 @@ import type MyChannelModel from '@typings/database/models/servers/my_channel';
 import type MyChannelSettingsModel from '@typings/database/models/servers/my_channel_settings';
 import type UserModel from '@typings/database/models/servers/user';
 
-const {SERVER: {CHANNEL, MY_CHANNEL, CHANNEL_MEMBERSHIP, MY_CHANNEL_SETTINGS, CHANNEL_INFO, USER}} = MM_TABLES;
+const {SERVER: {CHANNEL, MY_CHANNEL, CHANNEL_MEMBERSHIP, MY_CHANNEL_SETTINGS, CHANNEL_INFO, USER, TEAM}} = MM_TABLES;
 
 export function prepareMissingChannelsForAllTeams(operator: ServerDataOperator, channels: Channel[], channelMembers: ChannelMembership[], isCRTEnabled?: boolean): Array<Promise<Model[]>> {
     const channelInfos: ChannelInfo[] = [];
@@ -211,8 +211,8 @@ export const observeChannel = (database: Database, channelId: string) => {
     );
 };
 
-export const getChannelByName = async (database: Database, channelName: string) => {
-    const channels = await database.get<ChannelModel>(CHANNEL).query(Q.where('name', channelName)).fetch();
+export const getChannelByName = async (database: Database, teamId: string, channelName: string) => {
+    const channels = await database.get<ChannelModel>(CHANNEL).query(Q.on(TEAM, 'id', teamId), Q.where('name', channelName)).fetch();
 
     // Check done to force types
     if (channels.length) {

--- a/app/utils/channel/index.ts
+++ b/app/utils/channel/index.ts
@@ -28,6 +28,11 @@ export function isDMorGM(channel: Channel | ChannelModel): boolean {
     return directTypes.includes(channel.type);
 }
 
+export function isArchived(channel: Channel | ChannelModel): boolean {
+    const deleteAt = 'delete_at' in channel ? channel.delete_at : channel.deleteAt;
+    return deleteAt > 0;
+}
+
 export function selectDefaultChannelForTeam<T extends Channel|ChannelModel>(channels: T[], memberships: ChannelMembership[], teamId: string, roles?: Role[], locale = DEFAULT_LOCALE) {
     let channel: T|undefined;
     let canIJoinPublicChannelsInTeam = false;

--- a/index.ts
+++ b/index.ts
@@ -102,10 +102,6 @@ function screenDidDisappearListener({componentId}: ComponentDidDisappearEvent) {
             DeviceEventEmitter.emit(Events.PAUSE_KEYBOARD_TRACKING_VIEW, false);
         }
 
-        if (NavigationStore.getNavigationTopComponentId() === componentId) {
-            NavigationStore.removeNavigationComponentId(componentId);
-        }
-
         if (NavigationStore.getNavigationTopComponentId() === Screens.HOME) {
             DeviceEventEmitter.emit(Events.TAB_BAR_VISIBLE, true);
         }


### PR DESCRIPTION
#### Summary
Tapping on a channel link closed the current channel, instead of navigate. Doing so in a thread generated some errors because it was trying to instantiate a new channel screen.

This PR tries to solve that problem, by not removing the channel screen from the stack, and not dismissing to root.

There is still two outstanding issues that will be handled in a different ticket:
- Changing to another channel, even if the channel is loaded in the database and needs no network actions, is taking too long.
- Taking too long to move to another channel (be it because of network issues or performance issues) has no feedback at all, making the user think the app is unresponsive.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45217

#### Release Note
```release-note
Fix issue with channel links
```
