### PR TITLE
[Gekidou] Fix touch not responding on some posts

### DIFF
--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -84,10 +84,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             backgroundColor: changeOpacity(theme.mentionHighlightBg, 0.2),
         },
         pendingPost: {opacity: 0.5},
+        postContent: {paddingHorizontal: 16},
         postStyle: {
             overflow: 'hidden',
             flex: 1,
-            paddingHorizontal: 16,
         },
         profilePictureContainer: {
             marginBottom: 5,
@@ -99,7 +99,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             flexDirection: 'column',
         },
         rightColumnPadding: {paddingBottom: 3},
-        touchableContainer: {marginHorizontal: -16, paddingHorizontal: 16},
     };
 });
 
@@ -324,7 +323,7 @@ const Post = ({
                 onLongPress={showPostOptions}
                 delayLongPress={200}
                 underlayColor={changeOpacity(theme.centerChannelColor, 0.1)}
-                style={styles.touchableContainer}
+                style={styles.postContent}
             >
                 <>
                     <PreHeader


### PR DESCRIPTION
#### Summary
There have been some reports (and I've seen it myself) when at times when we scroll in the post list there are some posts that are not responding to taps. After some investigation this could be cause of the use of a negative margin inside a FlatList.

This PR aims to keep the UX the same but changes the way styling is done and removes the need of the negative margin.

```release-note
NONE
```
