### PR TITLE
[Gekidou] Thread auto follow on receiving new post when user is in a NOT-FOLLOWING thread

### DIFF
--- a/app/screens/thread/thread_post_list/index.ts
+++ b/app/screens/thread/thread_post_list/index.ts
@@ -40,6 +40,7 @@ const enhanced = withObservables(['forceQueryAfterAppState', 'rootPost'], ({data
         teamId: rootPost.channel.observe().pipe(
             switchMap((channel) => of$(channel?.teamId)),
         ),
+        thread: rootPost.thread.observe(),
     };
 });
 

--- a/app/screens/thread/thread_post_list/index.ts
+++ b/app/screens/thread/thread_post_list/index.ts
@@ -7,9 +7,9 @@ import {AppStateStatus} from 'react-native';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {observeMyChannel} from '@queries/servers/channel';
+import {observeMyChannel, observeChannel} from '@queries/servers/channel';
 import {queryPostsChunk, queryPostsInThread} from '@queries/servers/post';
-import {observeIsCRTEnabled} from '@queries/servers/thread';
+import {observeIsCRTEnabled, observeThreadById} from '@queries/servers/thread';
 
 import ThreadPostList from './thread_post_list';
 
@@ -37,10 +37,10 @@ const enhanced = withObservables(['forceQueryAfterAppState', 'rootPost'], ({data
                 return queryPostsChunk(database, rootPost.id, earliest, latest, true).observe();
             }),
         ),
-        teamId: rootPost.channel.observe().pipe(
+        teamId: observeChannel(database, rootPost.channelId).pipe(
             switchMap((channel) => of$(channel?.teamId)),
         ),
-        thread: rootPost.thread.observe(),
+        thread: observeThreadById(database, rootPost.id),
     };
 });
 

--- a/app/screens/thread/thread_post_list/thread_post_list.tsx
+++ b/app/screens/thread/thread_post_list/thread_post_list.tsx
@@ -12,6 +12,7 @@ import {useServerUrl} from '@context/server';
 import {useIsTablet} from '@hooks/device';
 
 import type PostModel from '@typings/database/models/servers/post';
+import type ThreadModel from '@typings/database/models/servers/thread';
 
 type Props = {
     isCRTEnabled: boolean;
@@ -20,6 +21,7 @@ type Props = {
     posts: PostModel[];
     rootPost: PostModel;
     teamId: string;
+    thread: ThreadModel;
 }
 
 const edges: Edge[] = ['bottom'];
@@ -32,7 +34,7 @@ const styles = StyleSheet.create({
 
 const ThreadPostList = ({
     isCRTEnabled, lastViewedAt,
-    nativeID, posts, rootPost, teamId,
+    nativeID, posts, rootPost, teamId, thread,
 }: Props) => {
     const isTablet = useIsTablet();
     const serverUrl = useServerUrl();
@@ -44,11 +46,11 @@ const ThreadPostList = ({
     // If CRT is enabled, When new post arrives and thread modal is open, mark thread as read
     const oldPostsCount = useRef<number>(posts.length);
     useEffect(() => {
-        if (isCRTEnabled && oldPostsCount.current < posts.length) {
+        if (isCRTEnabled && thread.isFollowing && oldPostsCount.current < posts.length) {
             oldPostsCount.current = posts.length;
             markThreadAsRead(serverUrl, teamId, rootPost.id);
         }
-    }, [isCRTEnabled, posts, rootPost, serverUrl, teamId]);
+    }, [isCRTEnabled, posts, rootPost, serverUrl, teamId, thread]);
 
     const postList = (
         <PostList

--- a/app/screens/thread/thread_post_list/thread_post_list.tsx
+++ b/app/screens/thread/thread_post_list/thread_post_list.tsx
@@ -21,7 +21,7 @@ type Props = {
     posts: PostModel[];
     rootPost: PostModel;
     teamId: string;
-    thread: ThreadModel;
+    thread?: ThreadModel;
 }
 
 const edges: Edge[] = ['bottom'];
@@ -46,7 +46,7 @@ const ThreadPostList = ({
     // If CRT is enabled, When new post arrives and thread modal is open, mark thread as read
     const oldPostsCount = useRef<number>(posts.length);
     useEffect(() => {
-        if (isCRTEnabled && thread.isFollowing && oldPostsCount.current < posts.length) {
+        if (isCRTEnabled && thread?.isFollowing && oldPostsCount.current < posts.length) {
             oldPostsCount.current = posts.length;
             markThreadAsRead(serverUrl, teamId, rootPost.id);
         }


### PR DESCRIPTION
#### Summary
When CRT is enabled, In the thread screen, we are marking the thread as read whenever a new post is received. We should only mark the following threads as read.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 15.5

#### Screenshots
```release-note
NONE
```