### PR TITLE
[Gekidou MM-45178] Improve wording about url not being a valid one

### DIFF
--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -77,9 +77,14 @@ class NetworkManager {
 
     public createClient = async (serverUrl: string, bearerToken?: string) => {
         const config = await this.buildConfig();
-        const {client} = await getOrCreateAPIClient(serverUrl, config, this.clientErrorEventHandler);
+        let client;
+        try {
+            client = await getOrCreateAPIClient(serverUrl, config, this.clientErrorEventHandler);
+        } catch (error) {
+            throw new Error('Can’t find this server. Check spelling and URL format.');
+        }
         const csrfToken = await getCSRFFromCookie(serverUrl);
-        this.clients[serverUrl] = new Client(client, serverUrl, bearerToken, csrfToken);
+        this.clients[serverUrl] = new Client(client.client, serverUrl, bearerToken, csrfToken);
 
         return this.clients[serverUrl];
     };

--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -78,9 +78,10 @@ class NetworkManager {
 
     public createClient = async (serverUrl: string, bearerToken?: string) => {
         const config = await this.buildConfig();
-        let client;
         try {
-            client = await getOrCreateAPIClient(serverUrl, config, this.clientErrorEventHandler);
+            const {client} = await getOrCreateAPIClient(serverUrl, config, this.clientErrorEventHandler);
+            const csrfToken = await getCSRFFromCookie(serverUrl);
+            this.clients[serverUrl] = new Client(client, serverUrl, bearerToken, csrfToken);
         } catch (error) {
             throw new ClientError(serverUrl, {
                 message: 'Can’t find this server. Check spelling and URL format.',
@@ -91,8 +92,6 @@ class NetworkManager {
                 url: serverUrl,
             });
         }
-        const csrfToken = await getCSRFFromCookie(serverUrl);
-        this.clients[serverUrl] = new Client(client.client, serverUrl, bearerToken, csrfToken);
 
         return this.clients[serverUrl];
     };

--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -14,6 +14,7 @@ import DeviceInfo from 'react-native-device-info';
 import LocalConfig from '@assets/config.json';
 import {Client} from '@client/rest';
 import * as ClientConstants from '@client/rest/constants';
+import ClientError from '@client/rest/error';
 import {CERTIFICATE_ERRORS} from '@constants/network';
 import ManagedApp from '@init/managed_app';
 import {logError} from '@utils/log';
@@ -81,7 +82,14 @@ class NetworkManager {
         try {
             client = await getOrCreateAPIClient(serverUrl, config, this.clientErrorEventHandler);
         } catch (error) {
-            throw new Error('Can’t find this server. Check spelling and URL format.');
+            throw new ClientError(serverUrl, {
+                message: 'Can’t find this server. Check spelling and URL format.',
+                intl: {
+                    id: 'apps.error.network.no_server',
+                    defaultMessage: 'Can’t find this server. Check spelling and URL format.',
+                },
+                url: serverUrl,
+            });
         }
         const csrfToken = await getCSRFFromCookie(serverUrl);
         this.clients[serverUrl] = new Client(client.client, serverUrl, bearerToken, csrfToken);

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -45,6 +45,7 @@
   "apps.error.form.submit.pretext": "There has been an error submitting the modal. Contact the app developer. Details: {details}",
   "apps.error.lookup.error_preparing_request": "Error preparing lookup request: {errorMessage}",
   "apps.error.malformed_binding": "This binding is not properly formed. Contact the App developer.",
+  "apps.error.network.no_server": "Can’t find this server. Check spelling and URL format.",
   "apps.error.parser": "Parsing error: {error}",
   "apps.error.parser.empty_value": "Empty values are not allowed.",
   "apps.error.parser.execute_non_leaf": "You must select a subcommand.",


### PR DESCRIPTION
#### Summary
This ticket replaces the message to the user when they have entered an invalidly formatted server URL.

**Before**
<img width="666" alt="image" src="https://user-images.githubusercontent.com/7575921/176717324-071eabab-3e3a-4648-a688-2eec16365c27.png">

**After**
<img width="512" alt="image" src="https://user-images.githubusercontent.com/7575921/176717479-b53c647a-9d65-4edd-9675-50eb37aa60a8.png">


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45178

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
