### PR TITLE
MM-45456 - Gekidou LoadingUnreads component keeps spinning

### DIFF
--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -58,6 +58,7 @@ export type EntryResponse = {
 }
 
 const FETCH_MISSING_DM_TIMEOUT = 2500;
+const FETCH_UNREADS_TIMEOUT = 2500;
 
 export const teamsToRemove = async (serverUrl: string, removeTeamIds?: string[]) => {
     const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
@@ -260,13 +261,15 @@ export async function deferredAppEntryActions(
     initialTeamId?: string, initialChannelId?: string) {
     // defer sidebar DM & GM profiles
     let channelsToFetchProfiles: Set<Channel>|undefined;
-    if (chData?.channels?.length && chData.memberships?.length) {
-        const directChannels = chData.channels.filter(isDMorGM);
-        channelsToFetchProfiles = new Set<Channel>(directChannels);
+    setTimeout(async () => {
+        if (chData?.channels?.length && chData.memberships?.length) {
+            const directChannels = chData.channels.filter(isDMorGM);
+            channelsToFetchProfiles = new Set<Channel>(directChannels);
 
-        // defer fetching posts for unread channels on initial team
-        fetchPostsForUnreadChannels(serverUrl, chData.channels, chData.memberships, initialChannelId, true);
-    }
+            // defer fetching posts for unread channels on initial team
+            fetchPostsForUnreadChannels(serverUrl, chData.channels, chData.memberships, initialChannelId, true);
+        }
+    }, FETCH_UNREADS_TIMEOUT);
 
     // defer fetch channels and unread posts for other teams
     if (teamData.teams?.length && teamData.memberships?.length) {

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -324,9 +324,6 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
 export const fetchPostsForUnreadChannels = async (serverUrl: string, channels: Channel[], memberships: ChannelMembership[], excludeChannelId?: string, emitEvent = false) => {
     const database = DatabaseManager.serverDatabases[serverUrl]?.database;
     if (!database) {
-        return {error: `${serverUrl} database not found`};
-    }
-
     try {
         const promises = [];
         if (emitEvent) {
@@ -343,6 +340,9 @@ export const fetchPostsForUnreadChannels = async (serverUrl: string, channels: C
             DeviceEventEmitter.emit(Events.FETCHING_POSTS, false);
         }
     } catch (error) {
+        if (emitEvent) {
+            DeviceEventEmitter.emit(Events.FETCHING_POSTS, false);
+        }
         return {error};
     }
 

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -322,8 +322,6 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
 }
 
 export const fetchPostsForUnreadChannels = async (serverUrl: string, channels: Channel[], memberships: ChannelMembership[], excludeChannelId?: string, emitEvent = false) => {
-    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
-    if (!database) {
     try {
         const promises = [];
         if (emitEvent) {

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -9,7 +9,7 @@ import {fetchStatusByIds} from '@actions/remote/user';
 import {Events, Screens, WebsocketEvents} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {getActiveServerUrl, queryActiveServer} from '@queries/app/servers';
+import {queryActiveServer} from '@queries/app/servers';
 import {getCurrentChannel} from '@queries/servers/channel';
 import {getCommonSystemValues, getConfig, getWebSocketLastDisconnected, resetWebSocketLastDisconnected, setCurrentTeamAndChannelId} from '@queries/servers/system';
 import {getCurrentTeam} from '@queries/servers/team';
@@ -99,16 +99,12 @@ async function doReconnect(serverUrl: string) {
     resetWebSocketLastDisconnected(operator);
     const currentTeam = await getCurrentTeam(database);
     const currentChannel = await getCurrentChannel(database);
-    const currentActiveServerUrl = await getActiveServerUrl(DatabaseManager.appDatabase!.database);
 
-    if (serverUrl === currentActiveServerUrl) {
-        DeviceEventEmitter.emit(Events.FETCHING_POSTS, true);
-    }
+    DeviceEventEmitter.emit(Events.FETCHING_POSTS, true);
+
     const entryData = await entry(serverUrl, currentTeam?.id, currentChannel?.id, lastDisconnectedAt);
     if ('error' in entryData) {
-        if (serverUrl === currentActiveServerUrl) {
-            DeviceEventEmitter.emit(Events.FETCHING_POSTS, false);
-        }
+        DeviceEventEmitter.emit(Events.FETCHING_POSTS, false);
         return;
     }
     const {models, initialTeamId, initialChannelId, prefData, teamData, chData} = entryData;

--- a/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
+++ b/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
@@ -40,10 +40,7 @@ const LoadingUnreads = () => {
     useEffect(() => {
         if (loading) {
             opacity.value = 1;
-            rotation.value = withRepeat(
-                withTiming(360, {duration: 750, easing: Easing.ease}),
-                -1,
-            );
+            rotation.value = withRepeat(withTiming(360, {duration: 750, easing: Easing.ease}), -1);
         } else {
             opacity.value = withTiming(0, {duration: 300, easing: Easing.ease});
             cancelAnimation(rotation);
@@ -58,11 +55,12 @@ const LoadingUnreads = () => {
     useEffect(() => {
         const listener = DeviceEventEmitter.addListener(Events.FETCHING_POSTS, (value: boolean) => {
             cancelAnimation(opacity);
+            cancelAnimation(rotation);
             setLoading(value);
         });
 
         return () => listener.remove();
-    }, [loading]);
+    }, []);
 
     if (!loading) {
         return null;

--- a/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
+++ b/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
@@ -26,7 +26,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 const LoadingUnreads = () => {
     const theme = useTheme();
     const style = getStyleSheet(theme);
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(false);
     const opacity = useSharedValue(1);
     const rotation = useSharedValue(0);
 
@@ -55,7 +55,11 @@ const LoadingUnreads = () => {
     useEffect(() => {
         const listener = DeviceEventEmitter.addListener(Events.FETCHING_POSTS, (value: boolean) => {
             cancelAnimation(opacity);
-            cancelAnimation(rotation);
+
+            // Work-around : When the shared value alternates between two values, the cancelAnimation call is not always cancellable
+            // https://github.com/software-mansion/react-native-reanimated/issues/2733
+            opacity.value = withTiming(0, {duration: 300, easing: Easing.ease});
+
             setLoading(value);
         });
 

--- a/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
+++ b/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
@@ -55,11 +55,6 @@ const LoadingUnreads = () => {
     useEffect(() => {
         const listener = DeviceEventEmitter.addListener(Events.FETCHING_POSTS, (value: boolean) => {
             cancelAnimation(opacity);
-
-            // Work-around : When the shared value alternates between two values, the cancelAnimation call is not always cancellable
-            // https://github.com/software-mansion/react-native-reanimated/issues/2733
-            opacity.value = withTiming(0, {duration: 300, easing: Easing.ease});
-
             setLoading(value);
         });
 

--- a/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
+++ b/app/screens/home/channel_list/categories_list/header/loading_unreads.tsx
@@ -26,7 +26,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 const LoadingUnreads = () => {
     const theme = useTheme();
     const style = getStyleSheet(theme);
-    const [loading, setLoading] = useState(false);
+    const [loading, setLoading] = useState(true);
     const opacity = useSharedValue(1);
     const rotation = useSharedValue(0);
 

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -197,6 +197,7 @@ export function resetToHome(passProps: LaunchProps = {launchType: LaunchType.Nor
         dismissModal({componentId: Screens.LOGIN});
         dismissModal({componentId: Screens.SSO});
         dismissModal({componentId: Screens.BOTTOM_SHEET});
+        DeviceEventEmitter.emit(Events.FETCHING_POSTS, false);
         return;
     }
 


### PR DESCRIPTION
#### Summary
As stated in the ticket, the loader next to the server displayname kept spinning when we add a new server.

This PR fixes this issue by: 
1. Ensuring that this component loading state is dictated only when it receives an event, so that it just doesn't spin on mount.
2. Add a workaround on top of the `cancelAnimation` function call due to a bug on reanimated 2.  [The bug](https://github.com/software-mansion/react-native-reanimated/issues/2733) in itself prevents a shared value that switches between two values from being interrupted/cancelled.

@coltoneshaw  - I'm adding you to this PR so that you can verify if the builds work for you.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45456

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Release Note
```release-note
NONE
```