### PR TITLE
Fix at mention that triggers ephemeral message

### DIFF
--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -130,30 +130,9 @@ export async function createPost(serverUrl: string, post: Partial<Post>, files: 
 
     const isCRTEnabled = await getIsCRTEnabled(database);
 
+    let created;
     try {
-        const created = await client.createPost(newPost);
-        const models = await operator.handlePosts({
-            actionType: ActionType.POSTS.RECEIVED_NEW,
-            order: [created.id],
-            posts: [created],
-            prepareRecordsOnly: true,
-        });
-        const isCrtReply = isCRTEnabled && created.root_id !== '';
-        if (!isCrtReply) {
-            const {member} = await updateLastPostAt(serverUrl, created.channel_id, created.create_at, true);
-            if (member) {
-                models.push(member);
-            }
-        }
-        if (isCRTEnabled) {
-            const {models: threadModels} = await createThreadFromNewPost(serverUrl, created, true);
-            if (threadModels?.length) {
-                models.push(...threadModels);
-            }
-        }
-        await operator.batchRecords(models);
-
-        newPost = created;
+        created = await client.createPost(newPost);
     } catch (error: any) {
         const errorPost = {
             ...newPost,
@@ -187,7 +166,32 @@ export async function createPost(serverUrl: string, post: Partial<Post>, files: 
             }
             await operator.batchRecords(models);
         }
+
+        return {data: true};
     }
+
+    const models = await operator.handlePosts({
+        actionType: ActionType.POSTS.RECEIVED_NEW,
+        order: [created.id],
+        posts: [created],
+        prepareRecordsOnly: true,
+    });
+    const isCrtReply = isCRTEnabled && created.root_id !== '';
+    if (!isCrtReply) {
+        const {member} = await updateLastPostAt(serverUrl, created.channel_id, created.create_at, true);
+        if (member) {
+            models.push(member);
+        }
+    }
+    if (isCRTEnabled) {
+        const {models: threadModels} = await createThreadFromNewPost(serverUrl, created, true);
+        if (threadModels?.length) {
+            models.push(...threadModels);
+        }
+    }
+    await operator.batchRecords(models);
+
+    newPost = created;
 
     return {data: true};
 }

--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -52,17 +52,6 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
         return;
     }
 
-    const models: Model[] = [];
-
-    const postModels = await operator.handlePosts({
-        actionType: ActionType.POSTS.RECEIVED_NEW,
-        order: [post.id],
-        posts: [post],
-        prepareRecordsOnly: true,
-    });
-
-    models.push(...postModels);
-
     const isCRTEnabled = await getIsCRTEnabled(database);
     if (isCRTEnabled) {
         await createThreadFromNewPost(serverUrl, post, false);
@@ -118,6 +107,8 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
         };
         DeviceEventEmitter.emit(Events.USER_STOP_TYPING, data);
     }
+
+    const models: Model[] = [];
 
     const {authors} = await fetchPostAuthors(serverUrl, [post], true);
     if (authors?.length) {
@@ -175,6 +166,15 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
             }
         }
     }
+
+    const postModels = await operator.handlePosts({
+        actionType: ActionType.POSTS.RECEIVED_NEW,
+        order: [post.id],
+        posts: [post],
+        prepareRecordsOnly: true,
+    });
+
+    models.push(...postModels);
 
     operator.batchRecords(models);
 }

--- a/app/components/post_list/post/body/index.tsx
+++ b/app/components/post_list/post/body/index.tsx
@@ -8,7 +8,7 @@ import FormattedText from '@components/formatted_text';
 import JumboEmoji from '@components/jumbo_emoji';
 import {Screens} from '@constants';
 import {THREAD} from '@constants/screens';
-import {isEdited as postEdited} from '@utils/post';
+import {isEdited as postEdited, isPostFailed} from '@utils/post';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 
 import AddMembers from './add_members';
@@ -80,6 +80,7 @@ const Body = ({
 }: BodyProps) => {
     const style = getStyleSheet(theme);
     const isEdited = postEdited(post);
+    const isFailed = isPostFailed(post);
     const [layoutWidth, setLayoutWidth] = useState(0);
     const hasBeenDeleted = Boolean(post.deleteAt);
     let body;
@@ -171,7 +172,7 @@ const Body = ({
                 }
                 {filesCount > 0 &&
                 <Files
-                    failed={post.props?.failed}
+                    failed={isFailed}
                     layoutWidth={layoutWidth}
                     location={location}
                     post={post}
@@ -197,7 +198,7 @@ const Body = ({
         >
             <View style={replyBarStyle()}/>
             {body}
-            {post.props?.failed &&
+            {isFailed &&
             <Failed
                 post={post}
                 theme={theme}

--- a/app/database/operator/server_data_operator/handlers/posts_in_channel.ts
+++ b/app/database/operator/server_data_operator/handlers/posts_in_channel.ts
@@ -98,6 +98,13 @@ const PostsInChannelHandler = (superclass: any) => class extends superclass {
         }
 
         if (targetChunk) {
+            if (
+                targetChunk.earliest <= earliest &&
+                targetChunk.latest >= latest
+            ) {
+                return [];
+            }
+
             // If the chunk was found, Update the chunk and return
             if (prepareRecordsOnly) {
                 targetChunk.prepareUpdate((record) => {
@@ -202,6 +209,10 @@ const PostsInChannelHandler = (superclass: any) => class extends superclass {
 
         let targetChunk = chunks[0];
         if (targetChunk) {
+            if (targetChunk.earliest <= earliest) {
+                return [];
+            }
+
             // If the chunk was found, Update the chunk and return
             if (prepareRecordsOnly) {
                 targetChunk.prepareUpdate((record) => {
@@ -258,6 +269,10 @@ const PostsInChannelHandler = (superclass: any) => class extends superclass {
 
         let targetChunk = chunks[0];
         if (targetChunk) {
+            if (targetChunk.latest >= latest) {
+                return [];
+            }
+
             // If the chunk was found, Update the chunk and return
             if (prepareRecordsOnly) {
                 targetChunk.prepareUpdate((record) => {


### PR DESCRIPTION
#### Summary
When sending an at-mention, if that at-mention triggers an ephemeral (to add certain person to the channel) there was a race condition giving us problem in the postsInChannel table.

Two "fixes" has been provided together in this PR. Moving the post handling nearer the batch, and not updating postsInChannel if there is no need to update.

Both fixes will make this more reliable, but may not be enough.

There was also a minor error regarding pending posts not showing as failed after the expected time. That has been also solved.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45191

#### Release Note
```release-note
Fix at mentions when it triggers a "add person to channel" message.
Old not send messages will now appear as failed.
```
