### PR TITLE
[Gekidou] [Migration] Adds member_count to groups table

### DIFF
--- a/app/database/migration/server/index.ts
+++ b/app/database/migration/server/index.ts
@@ -9,11 +9,23 @@ import {schemaMigrations, addColumns} from '@nozbe/watermelondb/Schema/migration
 import {MM_TABLES} from '@constants/database';
 
 const {SERVER: {
+    GROUP,
     MY_CHANNEL,
     THREAD,
 }} = MM_TABLES;
 
 export default schemaMigrations({migrations: [
+    {
+        toVersion: 3,
+        steps: [
+            addColumns({
+                table: GROUP,
+                columns: [
+                    {name: 'member_count', type: 'number'},
+                ],
+            }),
+        ],
+    },
     {
         toVersion: 2,
         steps: [
@@ -31,4 +43,5 @@ export default schemaMigrations({migrations: [
             }),
         ],
     },
+
 ]});

--- a/app/database/migration/server/index.ts
+++ b/app/database/migration/server/index.ts
@@ -43,5 +43,4 @@ export default schemaMigrations({migrations: [
             }),
         ],
     },
-
 ]});

--- a/app/database/models/server/group.ts
+++ b/app/database/models/server/group.ts
@@ -57,6 +57,9 @@ export default class GroupModel extends Model implements GroupInterface {
     /** remote_id : The remote id for the group (i.e. in a shared channel) */
     @field('remote_id') remoteId!: string;
 
+    /** member_count : The number of members in the group */
+    @field('member_count') memberCount!: number;
+
     /** created_at : The creation date for this row */
     @field('created_at') createdAt!: number;
 

--- a/app/database/operator/server_data_operator/transformers/group.test.ts
+++ b/app/database/operator/server_data_operator/transformers/group.test.ts
@@ -23,6 +23,7 @@ describe('*** GROUP Prepare Records Test ***', () => {
                     name: 'recent',
                     source: 'custom',
                     remote_id: 'custom',
+                    member_count: 10,
                 } as Group,
             },
         });

--- a/app/database/operator/server_data_operator/transformers/group.ts
+++ b/app/database/operator/server_data_operator/transformers/group.ts
@@ -35,6 +35,7 @@ export const transformGroupRecord = ({action, database, value}: TransformerArgs)
         group.displayName = raw.display_name;
         group.source = raw.source;
         group.remoteId = raw.remote_id;
+        group.memberCount = raw.member_count || 0;
     };
 
     return prepareBaseRecord({

--- a/app/database/schema/server/index.ts
+++ b/app/database/schema/server/index.ts
@@ -37,7 +37,7 @@ import {
 } from './table_schemas';
 
 export const serverSchema: AppSchema = appSchema({
-    version: 2,
+    version: 3,
     tables: [
         CategorySchema,
         CategoryChannelSchema,

--- a/app/database/schema/server/table_schemas/group.ts
+++ b/app/database/schema/server/table_schemas/group.ts
@@ -18,5 +18,6 @@ export default tableSchema({
         {name: 'created_at', type: 'number'},
         {name: 'updated_at', type: 'number'},
         {name: 'deleted_at', type: 'number'},
+        {name: 'member_count', type: 'number'},
     ],
 });

--- a/app/database/schema/server/test.ts
+++ b/app/database/schema/server/test.ts
@@ -43,7 +43,7 @@ const {
 describe('*** Test schema for SERVER database ***', () => {
     it('=> The SERVER SCHEMA should strictly match', () => {
         expect(serverSchema).toEqual({
-            version: 2,
+            version: 3,
             tables: {
                 [CATEGORY]: {
                     name: CATEGORY,
@@ -257,6 +257,7 @@ describe('*** Test schema for SERVER database ***', () => {
                         created_at: {name: 'created_at', type: 'number'},
                         updated_at: {name: 'updated_at', type: 'number'},
                         deleted_at: {name: 'deleted_at', type: 'number'},
+                        member_count: {name: 'member_count', type: 'number'},
                     },
                     columnArray: [
                         {name: 'display_name', type: 'string'},
@@ -267,6 +268,7 @@ describe('*** Test schema for SERVER database ***', () => {
                         {name: 'created_at', type: 'number'},
                         {name: 'updated_at', type: 'number'},
                         {name: 'deleted_at', type: 'number'},
+                        {name: 'member_count', type: 'number'},
                     ],
                 },
                 [GROUP_CHANNEL]: {

--- a/types/api/groups.d.ts
+++ b/types/api/groups.d.ts
@@ -8,7 +8,7 @@ type Group = {
     description: string;
     source: string;
     remote_id: string;
-    member_count: number;
+    member_count?: number;
     allow_reference: boolean;
     create_at: number;
     update_at: number;

--- a/types/database/models/servers/group.d.ts
+++ b/types/database/models/servers/group.d.ts
@@ -43,6 +43,9 @@ export default class GroupModel extends Model {
     /** deleted_at : The timestamp for when it was deleted */
     deletedAt: number;
 
+    /** member_count : The number of members in the group */
+    memberCount: number;
+
     /** channels : All the channels associated with this group */
     @lazy channels: Query<ChannelModel>;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Introduces new 'member_count' field in the Groups table for https://github.com/mattermost/mattermost-mobile/pull/6460

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44759

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
