### PR TITLE
Detox/E2E: Pinned Messages e2e tests in Gekidou

### DIFF
--- a/app/screens/pinned_messages/pinned_messages.tsx
+++ b/app/screens/pinned_messages/pinned_messages.tsx
@@ -140,6 +140,7 @@ function SavedMessages({
                 shouldRenderReplyButton={false}
                 skipSavedHeader={true}
                 skipPinnedHeader={true}
+                testID='pinned_messages.post_list.post'
             />
         );
     }, [currentTimezone, isTimezoneEnabled, theme]);
@@ -148,6 +149,7 @@ function SavedMessages({
         <SafeAreaView
             edges={edges}
             style={styles.flex}
+            testID='pinned_messages.screen'
         >
             <FlatList
                 contentContainerStyle={data.length ? styles.list : [styles.empty]}
@@ -158,6 +160,7 @@ function SavedMessages({
                 renderItem={renderItem}
                 scrollToOverflowEnabled={true}
                 onViewableItemsChanged={onViewableItemsChanged}
+                testID='pinned_messages.post_list.flat_list'
             />
         </SafeAreaView>
     );

--- a/detox/e2e/support/ui/screen/index.ts
+++ b/detox/e2e/support/ui/screen/index.ts
@@ -17,6 +17,7 @@ import GlobalThreadsScreen from './global_threads';
 import HomeScreen from './home';
 import LoginScreen from './login';
 import PermalinkScreen from './permalink';
+import PinnedMessagesScreen from './pinned_messages';
 import PostOptionsScreen from './post_options';
 import ReactionsScreen from './reactions';
 import RecentMentionsScreen from './recent_mentions';
@@ -45,6 +46,7 @@ export {
     HomeScreen,
     LoginScreen,
     PermalinkScreen,
+    PinnedMessagesScreen,
     PostOptionsScreen,
     ReactionsScreen,
     RecentMentionsScreen,

--- a/detox/e2e/support/ui/screen/pinned_messages.ts
+++ b/detox/e2e/support/ui/screen/pinned_messages.ts
@@ -1,34 +1,29 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {PostList} from '@support/ui/component';
 import {
-    NavigationHeader,
-    PostList,
-} from '@support/ui/component';
-import {
-    HomeScreen,
+    ChannelInfoScreen,
     PostOptionsScreen,
 } from '@support/ui/screen';
 import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
-class RecentMentionsScreen {
+class PinnedMessagesScreen {
     testID = {
-        recentMentionsScreenPrefix: 'recent_mentions.',
-        recentMentionsScreen: 'recent_mentions.screen',
-        emptyTitle: 'recent_mentions.empty.title',
-        emptyParagraph: 'recent_mentions.empty.paragraph',
+        pinnedMessagesScreenPrefix: 'pinned_messages.',
+        pinnedMessagesScreen: 'pinned_messages.screen',
+        backButton: 'screen.back.button',
+        emptyTitle: 'pinned_messages.empty.title',
+        emptyParagraph: 'pinned_messages.empty.paragraph',
     };
 
-    recentMentionsScreen = element(by.id(this.testID.recentMentionsScreen));
+    pinnedMessagesScreen = element(by.id(this.testID.pinnedMessagesScreen));
+    backButton = element(by.id(this.testID.backButton));
     emptyTitle = element(by.id(this.testID.emptyTitle));
     emptyParagraph = element(by.id(this.testID.emptyParagraph));
 
-    // convenience props
-    largeHeaderTitle = NavigationHeader.largeHeaderTitle;
-    largeHeaderSubtitle = NavigationHeader.largeHeaderSubtitle;
-
-    postList = new PostList(this.testID.recentMentionsScreenPrefix);
+    postList = new PostList(this.testID.pinnedMessagesScreenPrefix);
 
     getFlatPostList = () => {
         return this.postList.getFlatList();
@@ -43,16 +38,21 @@ class RecentMentionsScreen {
     };
 
     toBeVisible = async () => {
-        await waitFor(this.recentMentionsScreen).toExist().withTimeout(timeouts.TEN_SEC);
+        await waitFor(this.pinnedMessagesScreen).toExist().withTimeout(timeouts.TEN_SEC);
 
-        return this.recentMentionsScreen;
+        return this.pinnedMessagesScreen;
     };
 
     open = async () => {
-        // # Open recent mentions screen
-        await HomeScreen.mentionsTab.tap();
+        // # Open pinned messages screen
+        await ChannelInfoScreen.pinnedMessagesOption.tap();
 
         return this.toBeVisible();
+    };
+
+    back = async () => {
+        await this.backButton.tap();
+        await expect(this.pinnedMessagesScreen).not.toBeVisible();
     };
 
     openPostOptionsFor = async (postId: string, text: string) => {
@@ -77,5 +77,5 @@ class RecentMentionsScreen {
     };
 }
 
-const recentMentionsScreen = new RecentMentionsScreen();
-export default recentMentionsScreen;
+const pinnedMessagesScreen = new PinnedMessagesScreen();
+export default pinnedMessagesScreen;

--- a/detox/e2e/support/ui/screen/saved_messages.ts
+++ b/detox/e2e/support/ui/screen/saved_messages.ts
@@ -24,7 +24,7 @@ class SavedMessagesScreen {
     emptyTitle = element(by.id(this.testID.emptyTitle));
     emptyParagraph = element(by.id(this.testID.emptyParagraph));
 
-    // convenience propers
+    // convenience props
     largeHeaderTitle = NavigationHeader.largeHeaderTitle;
     largeHeaderSubtitle = NavigationHeader.largeHeaderSubtitle;
 

--- a/detox/e2e/test/search/pinned_messages.e2e.ts
+++ b/detox/e2e/test/search/pinned_messages.e2e.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {
+    Post,
+    Setup,
+} from '@support/server_api';
+import {
+    serverOneUrl,
+    siteOneUrl,
+} from '@support/test_config';
+import {
+    ChannelListScreen,
+    ChannelScreen,
+    EditPostScreen,
+    HomeScreen,
+    LoginScreen,
+    PermalinkScreen,
+    PostOptionsScreen,
+    PinnedMessagesScreen,
+    SavedMessagesScreen,
+    ServerScreen,
+    ThreadScreen,
+    ChannelInfoScreen,
+} from '@support/ui/screen';
+import {getRandomId} from '@support/utils';
+import {expect} from 'detox';
+
+describe('Search - Pinned Messages', () => {
+    const serverOneDisplayName = 'Server 1';
+    const channelsCategory = 'channels';
+    const pinnedText = 'Pinned';
+    let testChannel: any;
+
+    beforeAll(async () => {
+        const {channel, user} = await Setup.apiInit(siteOneUrl);
+        testChannel = channel;
+
+        // # Log in to server
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await LoginScreen.login(user);
+    });
+
+    beforeEach(async () => {
+        // * Verify on channel list screen
+        await ChannelListScreen.toBeVisible();
+    });
+
+    afterAll(async () => {
+        // # Log out
+        await HomeScreen.logout();
+    });
+
+    it('MM-T4918_1 - should match elements on pinned messages screen', async () => {
+        // # Open a channel screen, open channel info screen, and open pinned messages screen
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify basic elements on pinned messages screen
+        await expect(PinnedMessagesScreen.emptyTitle).toHaveText('No pinned messages yet');
+        await expect(PinnedMessagesScreen.emptyParagraph).toHaveText('To pin important messages, long-press on a message and choose Pin To Channel. Pinned messages will be visible to everyone in this channel.');
+
+        // # Go back to channel list screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
+    });
+
+    it('MM-T4918_2 - should be able to display a pinned message in pinned messages screen and navigate to message channel', async () => {
+        // # Open a channel screen, post a message, open post options for message, and tap on pin to channel option
+        const message = `Message ${getRandomId()}`;
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelScreen.postMessage(message);
+        const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        await ChannelScreen.openPostOptionsFor(post.id, message);
+        await PostOptionsScreen.pinPostOption.tap();
+
+        // * Verify pinned text is displayed on the post pre-header
+        const {postListPostItemPreHeaderText} = ChannelScreen.getPostListPostItem(post.id, message);
+        await expect(postListPostItemPreHeaderText).toHaveText(pinnedText);
+
+        // # Open channel info screen and open pinned messages screen
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify on pinned messages screen and pinned message is displayed
+        await PinnedMessagesScreen.toBeVisible();
+        const {postListPostItem: pinnedMessagesPostListPostItem} = PinnedMessagesScreen.getPostListPostItem(post.id, message);
+        await expect(pinnedMessagesPostListPostItem).toBeVisible();
+
+        // # Tap on post and jump to recent messages
+        await pinnedMessagesPostListPostItem.tap();
+        await PermalinkScreen.jumpToRecentMessages();
+
+        // * Verify on channel screen and pinned message is displayed
+        await ChannelScreen.toBeVisible();
+        const {postListPostItem: channelPostListPostItem} = ChannelScreen.getPostListPostItem(post.id, message);
+        await expect(channelPostListPostItem).toBeVisible();
+
+        // # Go back to channel list screen
+        await ChannelScreen.back();
+    });
+
+    it('MM-T4918_3 - should be able to edit, reply to, and delete a pinned message from pinned messages screen', async () => {
+        // # Open a channel screen, post a message, open post options for message, tap on pin to channel option, open channel info screen, and open pinned messages screen
+        const message = `Message ${getRandomId()}`;
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelScreen.postMessage(message);
+        const {post: pinnedPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        await ChannelScreen.openPostOptionsFor(pinnedPost.id, message);
+        await PostOptionsScreen.pinPostOption.tap();
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify on pinned messages screen
+        await PinnedMessagesScreen.toBeVisible();
+
+        // # Open post options for pinned message and tap on edit option
+        await PinnedMessagesScreen.openPostOptionsFor(pinnedPost.id, message);
+        await PostOptionsScreen.editPostOption.tap();
+
+        // * Verify on edit post screen
+        await EditPostScreen.toBeVisible();
+
+        // # Edit post message and tap save button
+        const updatedMessage = `${message} edit`;
+        await EditPostScreen.messageInput.replaceText(updatedMessage);
+        await EditPostScreen.saveButton.tap();
+
+        // * Verify post message is updated and displays edited indicator '(edited)'
+        const {postListPostItem: updatedPostListPostItem, postListPostItemEditedIndicator} = PinnedMessagesScreen.getPostListPostItem(pinnedPost.id, updatedMessage);
+        await expect(updatedPostListPostItem).toBeVisible();
+        await expect(postListPostItemEditedIndicator).toHaveText('(edited)');
+
+        // # Open post options for updated pinned message and tap on reply option
+        await PinnedMessagesScreen.openPostOptionsFor(pinnedPost.id, updatedMessage);
+        await PostOptionsScreen.replyPostOption.tap();
+
+        // * Verify on thread screen
+        await ThreadScreen.toBeVisible();
+
+        // # Post a reply
+        const replyMessage = `${updatedMessage} reply`;
+        await ThreadScreen.postMessage(replyMessage);
+
+        // * Verify reply is posted
+        const {post: replyPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        const {postListPostItem: replyPostListPostItem} = ThreadScreen.getPostListPostItem(replyPost.id, replyMessage);
+        await expect(replyPostListPostItem).toBeVisible();
+
+        // # Go back to pinned messages screen
+        await ThreadScreen.back();
+
+        // * Verify reply count and following button
+        const {postListPostItem, postListPostItemFooterReplyCount, postListPostItemFooterFollowingButton} = PinnedMessagesScreen.getPostListPostItem(pinnedPost.id, updatedMessage);
+        await expect(postListPostItemFooterReplyCount).toHaveText('1 reply');
+        await expect(postListPostItemFooterFollowingButton).toBeVisible();
+
+        // # Open post options for updated pinned message and delete post
+        await PinnedMessagesScreen.openPostOptionsFor(pinnedPost.id, updatedMessage);
+        await PostOptionsScreen.deletePost({confirm: true});
+
+        // * Verify updated pinned message is deleted
+        await expect(postListPostItem).not.toExist();
+
+        // # Go back to channel list screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
+    });
+
+    it('MM-T4918_4 - should be able to unpin a message from pinned messages screen', async () => {
+        // # Open a channel screen, post a message, open post options for message, tap on pin to channel option, open channel info screen, and open pinned messages screen
+        const message = `Message ${getRandomId()}`;
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelScreen.postMessage(message);
+        const {post: pinnedPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        await ChannelScreen.openPostOptionsFor(pinnedPost.id, message);
+        await PostOptionsScreen.pinPostOption.tap();
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify on pinned messages screen
+        await PinnedMessagesScreen.toBeVisible();
+
+        // # Open post options for pinned message and tap on unpin from channel option
+        await PinnedMessagesScreen.openPostOptionsFor(pinnedPost.id, message);
+        await PostOptionsScreen.unpinPostOption.tap();
+
+        // * Verify pinned message is not displayed anymore
+        const {postListPostItem} = PinnedMessagesScreen.getPostListPostItem(pinnedPost.id, message);
+        await expect(postListPostItem).not.toExist();
+
+        // # Go back to channel list screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
+    });
+
+    it('MM-T4918_5 - should be able to save/unsave a pinned message from pinned messages screen', async () => {
+        // # Open a channel screen, post a message, open post options for message, tap on pin to channel option, open channel info screen, and open pinned messages screen
+        const message = `Message ${getRandomId()}`;
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelScreen.postMessage(message);
+        const {post: pinnedPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        await ChannelScreen.openPostOptionsFor(pinnedPost.id, message);
+        await PostOptionsScreen.pinPostOption.tap();
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify on pinned messages screen
+        await PinnedMessagesScreen.toBeVisible();
+
+        // # Open post options for pinned message, tap on save option, go back to channel list screen, and open saved messages screen
+        await PinnedMessagesScreen.openPostOptionsFor(pinnedPost.id, message);
+        await PostOptionsScreen.savePostOption.tap();
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
+        await SavedMessagesScreen.open();
+
+        // * Verify pinned message is displayed on saved messages screen
+        const {postListPostItem} = SavedMessagesScreen.getPostListPostItem(pinnedPost.id, message);
+        await expect(postListPostItem).toBeVisible();
+
+        // # Go back to pinned messages screen, open post options for pinned message, tap on usave option, go back to channel list screen, and open saved messages screen
+        await ChannelListScreen.open();
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+        await PinnedMessagesScreen.openPostOptionsFor(pinnedPost.id, message);
+        await PostOptionsScreen.unsavePostOption.tap();
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
+        await SavedMessagesScreen.open();
+
+        // * Verify pinned message is not displayed anymore on saved messages screen
+        await expect(postListPostItem).not.toExist();
+
+        // # Go back to channel list screen
+        await ChannelListScreen.open();
+    });
+});

--- a/detox/e2e/test/search/recent_mentions.e2e.ts
+++ b/detox/e2e/test/search/recent_mentions.e2e.ts
@@ -16,12 +16,14 @@ import {
     siteOneUrl,
 } from '@support/test_config';
 import {
+    ChannelInfoScreen,
     ChannelListScreen,
     ChannelScreen,
     EditPostScreen,
     HomeScreen,
     LoginScreen,
     PermalinkScreen,
+    PinnedMessagesScreen,
     PostOptionsScreen,
     RecentMentionsScreen,
     SavedMessagesScreen,
@@ -204,5 +206,50 @@ describe('Search - Recent Mentions', () => {
 
         // # Go back to channel list screen
         await ChannelListScreen.open();
+    });
+
+    it('MM-T4909_5 - should be able to pin/unpin a recent mention from recent mentions screen', async () => {
+        // # Open a channel screen, post a message with at-mention to current user, go back to channel list screen, and open recent mentions screen
+        const message = `@${testUser.username}`;
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelScreen.postMessage(message);
+        await ChannelScreen.back();
+        await RecentMentionsScreen.open();
+
+        // * Verify on recent mentions screen
+        await RecentMentionsScreen.toBeVisible();
+
+        // # Open post options for recent mention, tap on pin to channel option, go back to channel list screen, open the channel screen where recent mention is posted, open channel info screen, and open pinned messages screen
+        const {post: mentionPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        await RecentMentionsScreen.openPostOptionsFor(mentionPost.id, message);
+        await PostOptionsScreen.pinPostOption.tap();
+        await ChannelListScreen.open();
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify recent mention is displayed on pinned messages screen
+        const {postListPostItem} = PinnedMessagesScreen.getPostListPostItem(mentionPost.id, message);
+        await expect(postListPostItem).toBeVisible();
+
+        // # Go back to recent mentions screen, open post options for recent mention, tap on unpin from channel option, go back to channel list screen, open the channel screen where recent mention is posted, open channel info screen, and open pinned messages screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
+        await RecentMentionsScreen.open();
+        await RecentMentionsScreen.openPostOptionsFor(mentionPost.id, message);
+        await PostOptionsScreen.unpinPostOption.tap();
+        await ChannelListScreen.open();
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify recent mention is not displayed anymore on pinned messages screen
+        await expect(postListPostItem).not.toExist();
+
+        // # Go back to channel list screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
     });
 });

--- a/detox/e2e/test/search/saved_messages.e2e.ts
+++ b/detox/e2e/test/search/saved_messages.e2e.ts
@@ -16,12 +16,14 @@ import {
     siteOneUrl,
 } from '@support/test_config';
 import {
+    ChannelInfoScreen,
     ChannelListScreen,
     ChannelScreen,
     EditPostScreen,
     HomeScreen,
     LoginScreen,
     PermalinkScreen,
+    PinnedMessagesScreen,
     PostOptionsScreen,
     SavedMessagesScreen,
     ServerScreen,
@@ -199,5 +201,52 @@ describe('Search - Saved Messages', () => {
 
         // # Go back to channel list screen
         await ChannelListScreen.open();
+    });
+
+    it('MM-T4910_5 - should be able to pin/unpin a saved message from saved messages screen', async () => {
+        // # Open a channel screen, post a message, open post options for message, tap on save option, go back to channel list screen, and open saved messages screen
+        const message = `Message ${getRandomId()}`;
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelScreen.postMessage(message);
+        const {post: savedPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        await ChannelScreen.openPostOptionsFor(savedPost.id, message);
+        await PostOptionsScreen.savePostOption.tap();
+        await ChannelScreen.back();
+        await SavedMessagesScreen.open();
+
+        // * Verify on saved messages screen
+        await SavedMessagesScreen.toBeVisible();
+
+        // # Open post options for saved message, tap on pin to channel option, go back to channel list screen, open the channel screen where saved message is posted, open channel info screen, and open pinned messages screen
+        await SavedMessagesScreen.openPostOptionsFor(savedPost.id, message);
+        await PostOptionsScreen.pinPostOption.tap();
+        await ChannelListScreen.open();
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify saved message is displayed on pinned messages screen
+        const {postListPostItem} = PinnedMessagesScreen.getPostListPostItem(savedPost.id, message);
+        await expect(postListPostItem).toBeVisible();
+
+        // # Go back to saved messages screen, open post options for saved message, tap on unpin from channel option, go back to channel list screen, open the channel screen where saved message is posted, open channel info screen, and open pinned messages screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
+        await SavedMessagesScreen.open();
+        await SavedMessagesScreen.openPostOptionsFor(savedPost.id, message);
+        await PostOptionsScreen.unpinPostOption.tap();
+        await ChannelListScreen.open();
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify saved message is not displayed anymore on pinned messages screen
+        await expect(postListPostItem).not.toExist();
+
+        // # Go back to channel list screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
     });
 });

--- a/detox/e2e/test/smoke_test/search.e2e.ts
+++ b/detox/e2e/test/smoke_test/search.e2e.ts
@@ -16,10 +16,12 @@ import {
     siteOneUrl,
 } from '@support/test_config';
 import {
+    ChannelInfoScreen,
     ChannelListScreen,
     ChannelScreen,
     HomeScreen,
     LoginScreen,
+    PinnedMessagesScreen,
     PostOptionsScreen,
     RecentMentionsScreen,
     SavedMessagesScreen,
@@ -90,5 +92,27 @@ describe('Smoke Test - Search', () => {
 
         // # Go back to channel list screen
         await ChannelListScreen.open();
+    });
+
+    it('MM-T4911_3 - should be able to display a pinned message on pinned messages screen', async () => {
+        // # Open a channel screen, post a message, open post options for message, tap on pin to channel option, open channel info screen, and open pinned messages screen
+        const message = `Message ${getRandomId()}`;
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelScreen.postMessage(message);
+        const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+        await ChannelScreen.openPostOptionsFor(post.id, message);
+        await PostOptionsScreen.pinPostOption.tap();
+        await ChannelInfoScreen.open();
+        await PinnedMessagesScreen.open();
+
+        // * Verify on pinned messages screen and pinned message is displayed
+        await PinnedMessagesScreen.toBeVisible();
+        const {postListPostItem} = PinnedMessagesScreen.getPostListPostItem(post.id, message);
+        await expect(postListPostItem).toBeVisible();
+
+        // # Go back to channel list screen
+        await PinnedMessagesScreen.back();
+        await ChannelInfoScreen.close();
+        await ChannelScreen.back();
     });
 });


### PR DESCRIPTION
#### Summary
- Added e2e for search pinned messages, and associated search smoke test
- Added/fixed some testIDs
- Created associated zephyr test cases under `Mobile V2` folder

Mobile V2/Search:
[MM-T4918](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4918) - Pinned Messages
[MM-T4909_5](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4909) - Recent Mentions - should be able to pin/unpin a recent mention from recent mentions screen
[MM-T4910_5](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4910) - Saved Messages - should be able to pin/unpin a saved message from saved messages screen

Mobile V2/Smoke Test:
[MM-T4911_3](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4911) - Search - should be able to display a pinned message on pinned messages screen

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45550

#### Screenshots
![Screen Shot 2022-07-13 at 11 52 23 PM](https://user-images.githubusercontent.com/487991/178922193-9027feee-3549-40e2-bcc0-b7db9f7edf69.png)
![Screen Shot 2022-07-13 at 11 52 32 PM](https://user-images.githubusercontent.com/487991/178922197-756ac5a4-8be7-472d-9032-7258b1477bdc.png)
![Screen Shot 2022-07-13 at 11 52 44 PM](https://user-images.githubusercontent.com/487991/178922199-e5179d24-5a39-47cb-83c2-b18da7cd4139.png)
![Screen Shot 2022-07-13 at 11 57 03 PM](https://user-images.githubusercontent.com/487991/178922202-dbd0ad30-8f38-42cc-8388-dea369530f58.png)

#### Release Note
```release-note
NONE
```
