### PR TITLE
[Gekidou MM-44939] Add observeLicenseBooleanValue and use observer helpers when available

### DIFF
--- a/app/components/autocomplete/at_mention/index.ts
+++ b/app/components/autocomplete/at_mention/index.ts
@@ -9,7 +9,7 @@ import {switchMap} from 'rxjs/operators';
 import {Permissions} from '@constants';
 import {observeChannel} from '@queries/servers/channel';
 import {observePermissionForChannel} from '@queries/servers/role';
-import {observeLicense} from '@queries/servers/system';
+import {observeLicenseBooleanValue} from '@queries/servers/system';
 import {observeCurrentTeam, observeTeam} from '@queries/servers/team';
 import {observeCurrentUser} from '@queries/servers/user';
 
@@ -21,10 +21,7 @@ import type TeamModel from '@typings/database/models/servers/team';
 type OwnProps = {channelId?: string}
 const enhanced = withObservables([], ({database, channelId}: WithDatabaseArgs & OwnProps) => {
     const currentUser = observeCurrentUser(database);
-
-    const hasLicense = observeLicense(database).pipe(
-        switchMap((lcs) => of$(lcs?.IsLicensed === 'true')),
-    );
+    const hasLicense = observeLicenseBooleanValue(database, 'IsLicensed');
 
     let useChannelMentions: Observable<boolean>;
     let useGroupMentions: Observable<boolean>;

--- a/app/components/channel_item/custom_status/index.ts
+++ b/app/components/channel_item/custom_status/index.ts
@@ -4,9 +4,9 @@
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 import {of as of$} from 'rxjs';
-import {map, switchMap} from 'rxjs/operators';
+import {switchMap} from 'rxjs/operators';
 
-import {observeConfig} from '@queries/servers/system';
+import {observeConfigBooleanValue} from '@queries/servers/system';
 import {observeUser} from '@queries/servers/user';
 import {getUserCustomStatus, isCustomStatusExpired} from '@utils/user';
 
@@ -21,9 +21,8 @@ type HeaderInputProps = {
 const enhanced = withObservables(
     ['userId'],
     ({userId, database}: WithDatabaseArgs & HeaderInputProps) => {
-        const config = observeConfig(database);
         const user = observeUser(database, userId);
-        const isCustomStatusEnabled = config.pipe(map((cfg) => cfg?.EnableCustomUserStatuses === 'true'));
+        const isCustomStatusEnabled = observeConfigBooleanValue(database, 'EnableCustomUserStatuses');
         const customStatus = user.pipe(switchMap((u) => (u?.isBot ? of$(undefined) : of$(getUserCustomStatus(u)))));
         const customStatusExpired = user.pipe(switchMap((u) => (u?.isBot ? of$(false) : of$(isCustomStatusExpired(u)))));
 

--- a/app/components/files/index.ts
+++ b/app/components/files/index.ts
@@ -7,7 +7,7 @@ import {of as of$, from as from$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observeCanDownloadFiles} from '@queries/servers/file';
-import {observeConfig} from '@queries/servers/system';
+import {observeConfigBooleanValue} from '@queries/servers/system';
 import {fileExists} from '@utils/file';
 
 import Files from './files';
@@ -37,12 +37,8 @@ const filesLocalPathValidation = async (files: FileModel[], authorId: string) =>
 };
 
 const enhance = withObservables(['post'], ({database, post}: EnhanceProps) => {
-    const config = observeConfig(database);
     const canDownloadFiles = observeCanDownloadFiles(database);
-
-    const publicLinkEnabled = config.pipe(
-        switchMap((cfg) => of$(cfg?.EnablePublicLink !== 'false')),
-    );
+    const publicLinkEnabled = observeConfigBooleanValue(database, 'EnablePublicLink');
 
     const filesInfo = post.files.observeWithColumns(['local_path']).pipe(
         switchMap((fs) => from$(filesLocalPathValidation(fs, post.userId))),

--- a/app/components/markdown/index.ts
+++ b/app/components/markdown/index.ts
@@ -4,19 +4,16 @@
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 import React from 'react';
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
-import {observeConfig} from '@queries/servers/system';
+import {observeConfigBooleanValue} from '@queries/servers/system';
 
 import Markdown from './markdown';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const config = observeConfig(database);
-    const enableLatex = config.pipe(switchMap((c) => of$(c?.EnableLatex === 'true')));
-    const enableInlineLatex = config.pipe(switchMap((c) => of$(c?.EnableInlineLatex === 'true')));
+    const enableLatex = observeConfigBooleanValue(database, 'EnableLatex');
+    const enableInlineLatex = observeConfigBooleanValue(database, 'EnableInlineLatex');
 
     return {
         enableLatex,

--- a/app/components/markdown/markdown_link/index.ts
+++ b/app/components/markdown/markdown_link/index.ts
@@ -3,23 +3,16 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
-import {observeConfig} from '@queries/servers/system';
+import {observeConfigValue} from '@queries/servers/system';
 
 import MarkdownLink from './markdown_link';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhance = withObservables([], ({database}: WithDatabaseArgs) => {
-    const config = observeConfig(database);
-    const experimentalNormalizeMarkdownLinks = config.pipe(
-        switchMap((cfg) => of$(cfg?.ExperimentalNormalizeMarkdownLinks)),
-    );
-    const siteURL = config.pipe(
-        switchMap((cfg) => of$(cfg?.SiteURL)),
-    );
+    const experimentalNormalizeMarkdownLinks = observeConfigValue(database, 'ExperimentalNormalizeMarkdownLinks');
+    const siteURL = observeConfigValue(database, 'SiteURL');
 
     return {
         experimentalNormalizeMarkdownLinks,

--- a/app/components/post_draft/post_input/index.ts
+++ b/app/components/post_draft/post_input/index.ts
@@ -8,7 +8,7 @@ import {of as of$} from 'rxjs';
 import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {observeChannel} from '@queries/servers/channel';
-import {observeConfig} from '@queries/servers/system';
+import {observeConfig, observeConfigBooleanValue} from '@queries/servers/system';
 
 import PostInput from './post_input';
 
@@ -25,9 +25,7 @@ const enhanced = withObservables(['channelId'], ({database, channelId}: WithData
         switchMap((cfg) => of$(parseInt(cfg?.TimeBetweenUserTypingUpdatesMilliseconds || '0', 10))),
     );
 
-    const enableUserTypingMessage = config.pipe(
-        switchMap((cfg) => of$(cfg?.EnableUserTypingMessages === 'true')),
-    );
+    const enableUserTypingMessage = observeConfigBooleanValue(database, 'EnableUserTypingMessages');
 
     const maxNotificationsPerChannel = config.pipe(
         switchMap((cfg) => of$(parseInt(cfg?.MaxNotificationsPerChannel || '0', 10))),

--- a/app/components/post_draft/send_handler/index.ts
+++ b/app/components/post_draft/send_handler/index.ts
@@ -11,7 +11,7 @@ import {MAX_MESSAGE_LENGTH_FALLBACK} from '@constants/post_draft';
 import {observeChannel, observeCurrentChannel} from '@queries/servers/channel';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
 import {observePermissionForChannel} from '@queries/servers/role';
-import {observeConfig, observeCurrentUserId} from '@queries/servers/system';
+import {observeConfig, observeConfigBooleanValue, observeCurrentUserId} from '@queries/servers/system';
 import {observeUser} from '@queries/servers/user';
 
 import SendHandler from './send_handler';
@@ -43,12 +43,8 @@ const enhanced = withObservables([], (ownProps: WithDatabaseArgs & OwnProps) => 
     );
 
     const config = observeConfig(database);
-    const enableConfirmNotificationsToChannel = config.pipe(
-        switchMap((cfg) => of$(Boolean(cfg?.EnableConfirmNotificationsToChannel === 'true'))),
-    );
-    const isTimezoneEnabled = config.pipe(
-        switchMap((cfg) => of$(Boolean(cfg?.ExperimentalTimezone === 'true'))),
-    );
+    const enableConfirmNotificationsToChannel = observeConfigBooleanValue(database, 'EnableConfirmNotificationsToChannel');
+    const isTimezoneEnabled = observeConfigBooleanValue(database, 'ExperimentalTimezone');
     const maxMessageLength = config.pipe(
         switchMap((cfg) => of$(parseInt(cfg?.MaxPostSize || '0', 10) || MAX_MESSAGE_LENGTH_FALLBACK)),
     );

--- a/app/components/system_header/index.tsx
+++ b/app/components/system_header/index.tsx
@@ -12,7 +12,7 @@ import FormattedTime from '@components/formatted_time';
 import {Preferences} from '@constants';
 import {getPreferenceAsBool} from '@helpers/api/preference';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
-import {observeConfig} from '@queries/servers/system';
+import {observeConfigBooleanValue} from '@queries/servers/system';
 import {observeCurrentUser} from '@queries/servers/user';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -80,10 +80,9 @@ const SystemHeader = ({isMilitaryTime, isTimezoneEnabled, createAt, theme, user}
 };
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const config = observeConfig(database);
     const preferences = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time').
         observeWithColumns(['value']);
-    const isTimezoneEnabled = config.pipe(map((cfg) => cfg?.ExperimentalTimezone === 'true'));
+    const isTimezoneEnabled = observeConfigBooleanValue(database, 'ExperimentalTimezone');
     const isMilitaryTime = preferences.pipe(
         map((prefs) => getPreferenceAsBool(prefs, Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time', false)),
     );

--- a/app/components/user_item/index.ts
+++ b/app/components/user_item/index.ts
@@ -3,23 +3,16 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
-import {observeConfig, observeCurrentUserId} from '@queries/servers/system';
+import {observeConfigBooleanValue, observeCurrentUserId} from '@queries/servers/system';
 
 import UserItem from './user_item';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const config = observeConfig(database);
-    const isCustomStatusEnabled = config.pipe(
-        switchMap((cfg) => of$(cfg?.EnableCustomUserStatuses === 'true')),
-    );
-    const showFullName = config.pipe(
-        switchMap((cfg) => of$(cfg?.ShowFullName === 'true')),
-    );
+    const isCustomStatusEnabled = observeConfigBooleanValue(database, 'EnableCustomUserStatuses');
+    const showFullName = observeConfigBooleanValue(database, 'ShowFullName');
     const currentUserId = observeCurrentUserId(database);
     return {
         isCustomStatusEnabled,

--- a/app/queries/servers/file.ts
+++ b/app/queries/servers/file.ts
@@ -1,7 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+import {combineLatest, of as of$} from 'rxjs';
+import {switchMap} from 'rxjs/operators';
 
 import {MM_TABLES} from '@constants/database';
+import {observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
 
 import type {Database} from '@nozbe/watermelondb';
 import type FileModel from '@typings/database/models/servers/file';
@@ -16,3 +19,13 @@ export const getFileById = async (database: Database, fileId: string) => {
         return undefined;
     }
 };
+
+export function observeCanDownloadFiles(database: Database) {
+    const license = observeLicense(database);
+    const enableMobileFileDownload = observeConfigBooleanValue(database, 'EnableMobileFileDownload');
+    const complianceDisabled = license.pipe(switchMap((l) => of$(l?.IsLicensed === 'false' || l?.Compliance === 'false')));
+    const canDownloadFiles = combineLatest([enableMobileFileDownload, complianceDisabled]).pipe(
+        switchMap(([download, compliance]) => of$(compliance || download)),
+    );
+    return canDownloadFiles;
+}

--- a/app/queries/servers/file.ts
+++ b/app/queries/servers/file.ts
@@ -25,12 +25,12 @@ export function observeCanDownloadFiles(database: Database) {
     const isLicened = observeLicenseBooleanValue(database, 'IsLicensed');
     const hasCompliance = observeLicenseBooleanValue(database, 'Compliance');
 
-    const complianceDisabled = combineLatest([isLicened, hasCompliance]).pipe(
+    const complianceEnabled = combineLatest([isLicened, hasCompliance]).pipe(
         switchMap(([licensed, compliance]) => of$(licensed || compliance)),
     );
 
-    const canDownloadFiles = combineLatest([enableMobileFileDownload, complianceDisabled]).pipe(
-        switchMap(([download, compliance]) => of$(compliance || download)),
+    const canDownloadFiles = combineLatest([enableMobileFileDownload, complianceEnabled]).pipe(
+        switchMap(([download, compliance]) => of$(compliance && download)),
     );
     return canDownloadFiles;
 }

--- a/app/queries/servers/file.ts
+++ b/app/queries/servers/file.ts
@@ -30,7 +30,7 @@ export function observeCanDownloadFiles(database: Database) {
     );
 
     const canDownloadFiles = combineLatest([enableMobileFileDownload, complianceEnabled]).pipe(
-        switchMap(([download, compliance]) => of$(compliance && download)),
+        switchMap(([download, compliance]) => of$(!compliance || download)),
     );
     return canDownloadFiles;
 }

--- a/app/queries/servers/system.ts
+++ b/app/queries/servers/system.ts
@@ -3,7 +3,7 @@
 
 import {Database, Q} from '@nozbe/watermelondb';
 import {of as of$, Observable} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {MM_TABLES, SYSTEM_IDENTIFIERS} from '@constants/database';
@@ -177,6 +177,7 @@ export const observeLicense = (database: Database): Observable<ClientLicense | u
 export const observeLicenseBooleanValue = (database: Database, key: keyof ClientLicense) => {
     return observeLicense(database).pipe(
         switchMap((license) => of$(license?.[key] === 'true')),
+        distinctUntilChanged(),
     );
 };
 

--- a/app/queries/servers/system.ts
+++ b/app/queries/servers/system.ts
@@ -174,6 +174,12 @@ export const observeLicense = (database: Database): Observable<ClientLicense | u
     );
 };
 
+export const observeLicenseBooleanValue = (database: Database, key: keyof ClientLicense) => {
+    return observeLicense(database).pipe(
+        switchMap((license) => of$(license?.[key] === 'true')),
+    );
+};
+
 export const getLicense = async (serverDatabase: Database): Promise<ClientLicense | undefined> => {
     try {
         const license = await serverDatabase.get<SystemModel>(SYSTEM).find(SYSTEM_IDENTIFIERS.LICENSE);

--- a/app/screens/browse_channels/index.ts
+++ b/app/screens/browse_channels/index.ts
@@ -9,7 +9,7 @@ import {switchMap} from 'rxjs/operators';
 import {Permissions} from '@constants';
 import {queryAllMyChannel} from '@queries/servers/channel';
 import {queryRolesByNames} from '@queries/servers/role';
-import {observeConfig, observeCurrentTeamId, observeCurrentUserId} from '@queries/servers/system';
+import {observeConfigBooleanValue, observeCurrentTeamId, observeCurrentUserId} from '@queries/servers/system';
 import {observeUser} from '@queries/servers/user';
 import {hasPermission} from '@utils/role';
 
@@ -18,15 +18,8 @@ import SearchHandler from './search_handler';
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const config = observeConfig(database);
-
-    const sharedChannelsEnabled = config.pipe(
-        switchMap((v) => of$(v?.ExperimentalSharedChannels === 'true')),
-    );
-
-    const canShowArchivedChannels = config.pipe(
-        switchMap((v) => of$(v?.ExperimentalViewArchivedChannels === 'true')),
-    );
+    const sharedChannelsEnabled = observeConfigBooleanValue(database, 'ExperimentalSharedChannels');
+    const canShowArchivedChannels = observeConfigBooleanValue(database, 'ExperimentalViewArchivedChannels');
 
     const currentTeamId = observeCurrentTeamId(database);
     const currentUserId = observeCurrentUserId(database);

--- a/app/screens/gallery/document_renderer/index.ts
+++ b/app/screens/gallery/document_renderer/index.ts
@@ -3,26 +3,16 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {combineLatest, of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
-import {observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
+import {observeCanDownloadFiles} from '@queries/servers/file';
 
 import DocumentRenderer from './document_renderer';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const enableMobileFileDownload = observeConfigBooleanValue(database, 'EnableMobileFileDownload');
-    const complianceDisabled = observeLicense(database).pipe(
-        switchMap((lcs) => of$(lcs?.IsLicensed === 'false' || lcs?.Compliance === 'false')),
-    );
-    const canDownloadFiles = combineLatest([enableMobileFileDownload, complianceDisabled]).pipe(
-        switchMap(([download, compliance]) => of$(compliance || download)),
-    );
-
     return {
-        canDownloadFiles,
+        canDownloadFiles: observeCanDownloadFiles(database),
     };
 });
 

--- a/app/screens/gallery/footer/index.ts
+++ b/app/screens/gallery/footer/index.ts
@@ -10,7 +10,7 @@ import {General} from '@constants';
 import {observeChannel} from '@queries/servers/channel';
 import {observeCanDownloadFiles} from '@queries/servers/file';
 import {observePost} from '@queries/servers/post';
-import {observeConfig, observeCurrentChannelId, observeCurrentUserId} from '@queries/servers/system';
+import {observeConfigBooleanValue, observeCurrentChannelId, observeCurrentUserId} from '@queries/servers/system';
 import {observeTeammateNameDisplay, observeUser} from '@queries/servers/user';
 
 import Footer from './footer';
@@ -28,7 +28,6 @@ const enhanced = withObservables(['item'], ({database, item}: FooterProps) => {
     const currentUserId = observeCurrentUserId(database);
     const canDownloadFiles = observeCanDownloadFiles(database);
 
-    const config = observeConfig(database);
     const teammateNameDisplay = observeTeammateNameDisplay(database);
 
     const author = post.pipe(
@@ -47,9 +46,10 @@ const enhanced = withObservables(['item'], ({database, item}: FooterProps) => {
             return p?.channel.observe() || observeChannel(database, cId);
         }),
     );
-    const enablePostUsernameOverride = config.pipe(switchMap((c) => of$(c?.EnablePostUsernameOverride === 'true')));
-    const enablePostIconOverride = config.pipe(switchMap((c) => of$(c?.EnablePostIconOverride === 'true')));
-    const enablePublicLink = config.pipe(switchMap((c) => of$(c?.EnablePublicLink === 'true')));
+
+    const enablePostUsernameOverride = observeConfigBooleanValue(database, 'EnablePostUsernameOverride');
+    const enablePostIconOverride = observeConfigBooleanValue(database, 'EnablePostIconOverride');
+    const enablePublicLink = observeConfigBooleanValue(database, 'EnablePublicLink');
 
     const channelName = channel.pipe(switchMap((c: ChannelModel) => of$(c.displayName)));
     const isDirectChannel = channel.pipe(switchMap((c: ChannelModel) => of$(c.type === General.DM_CHANNEL)));

--- a/app/screens/gallery/footer/index.ts
+++ b/app/screens/gallery/footer/index.ts
@@ -8,8 +8,9 @@ import {switchMap} from 'rxjs/operators';
 
 import {General} from '@constants';
 import {observeChannel} from '@queries/servers/channel';
+import {observeCanDownloadFiles} from '@queries/servers/file';
 import {observePost} from '@queries/servers/post';
-import {observeConfig, observeCurrentChannelId, observeCurrentUserId, observeLicense} from '@queries/servers/system';
+import {observeConfig, observeCurrentChannelId, observeCurrentUserId} from '@queries/servers/system';
 import {observeTeammateNameDisplay, observeUser} from '@queries/servers/user';
 
 import Footer from './footer';
@@ -25,9 +26,9 @@ const enhanced = withObservables(['item'], ({database, item}: FooterProps) => {
     const post = item.postId ? observePost(database, item.postId) : of$(undefined);
     const currentChannelId = observeCurrentChannelId(database);
     const currentUserId = observeCurrentUserId(database);
+    const canDownloadFiles = observeCanDownloadFiles(database);
 
     const config = observeConfig(database);
-    const license = observeLicense(database);
     const teammateNameDisplay = observeTeammateNameDisplay(database);
 
     const author = post.pipe(
@@ -49,11 +50,7 @@ const enhanced = withObservables(['item'], ({database, item}: FooterProps) => {
     const enablePostUsernameOverride = config.pipe(switchMap((c) => of$(c?.EnablePostUsernameOverride === 'true')));
     const enablePostIconOverride = config.pipe(switchMap((c) => of$(c?.EnablePostIconOverride === 'true')));
     const enablePublicLink = config.pipe(switchMap((c) => of$(c?.EnablePublicLink === 'true')));
-    const enableMobileFileDownload = config.pipe(switchMap((c) => of$(c?.EnableMobileFileDownload !== 'false')));
-    const complianceDisabled = license.pipe(switchMap((l) => of$(l?.IsLicensed === 'false' || l?.Compliance === 'false')));
-    const canDownloadFiles = combineLatest([enableMobileFileDownload, complianceDisabled]).pipe(
-        switchMap(([download, compliance]) => of$(compliance || download)),
-    );
+
     const channelName = channel.pipe(switchMap((c: ChannelModel) => of$(c.displayName)));
     const isDirectChannel = channel.pipe(switchMap((c: ChannelModel) => of$(c.type === General.DM_CHANNEL)));
 

--- a/app/screens/home/search/results/file_options/index.ts
+++ b/app/screens/home/search/results/file_options/index.ts
@@ -2,24 +2,17 @@
 // See LICENSE.txt for license information.
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {combineLatest, of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
-import {observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
+import {observeCanDownloadFiles} from '@queries/servers/file';
+import {observeConfigBooleanValue} from '@queries/servers/system';
 
 import FileOptions from './file_options';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const license = observeLicense(database);
     const enablePublicLink = observeConfigBooleanValue(database, 'EnablePublicLink');
-    const enableMobileFileDownload = observeConfigBooleanValue(database, 'EnableMobileFileDownload');
-
-    const complianceDisabled = license.pipe(switchMap((l) => of$(l?.IsLicensed === 'false' || l?.Compliance === 'false')));
-    const canDownloadFiles = combineLatest([enableMobileFileDownload, complianceDisabled]).pipe(
-        switchMap(([download, compliance]) => of$(compliance || download)),
-    );
+    const canDownloadFiles = observeCanDownloadFiles(database);
     return {
         canDownloadFiles,
         enablePublicLink,

--- a/app/screens/in_app_notification/icon.tsx
+++ b/app/screens/in_app_notification/icon.tsx
@@ -5,12 +5,10 @@ import withObservables from '@nozbe/with-observables';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import FastImage, {Source} from 'react-native-fast-image';
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
 import CompassIcon from '@components/compass_icon';
 import NetworkManager from '@managers/network_manager';
-import {observeConfig} from '@queries/servers/system';
+import {observeConfigBooleanValue} from '@queries/servers/system';
 import {observeUser} from '@queries/servers/user';
 
 import type {Client} from '@client/rest';
@@ -89,14 +87,11 @@ const NotificationIcon = ({author, enablePostIconOverride, fromWebhook, override
 };
 
 const enhanced = withObservables([], ({database, senderId}: WithDatabaseArgs & {senderId: string}) => {
-    const config = observeConfig(database);
     const author = observeUser(database, senderId);
 
     return {
         author,
-        enablePostIconOverride: config.pipe(
-            switchMap((cfg) => of$(cfg?.EnablePostIconOverride === 'true')),
-        ),
+        enablePostIconOverride: observeConfigBooleanValue(database, 'EnablePostIconOverride'),
     };
 });
 

--- a/app/screens/post_options/index.ts
+++ b/app/screens/post_options/index.ts
@@ -10,7 +10,7 @@ import {General, Permissions, Post, Screens} from '@constants';
 import {MAX_ALLOWED_REACTIONS} from '@constants/emoji';
 import {observePost, observePostSaved} from '@queries/servers/post';
 import {observePermissionForChannel, observePermissionForPost} from '@queries/servers/role';
-import {observeConfig, observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
+import {observeConfig, observeConfigValue, observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
 import {observeIsCRTEnabled, observeThreadById} from '@queries/servers/thread';
 import {observeCurrentUser} from '@queries/servers/user';
 import {isMinimumServerVersion} from '@utils/helpers';
@@ -75,7 +75,7 @@ const enhanced = withObservables([], ({combinedPost, post, showAddReaction, loca
     const currentUser = observeCurrentUser(database);
     const config = observeConfig(database);
     const isLicensed = observeLicense(database).pipe(switchMap((lcs) => of$(lcs?.IsLicensed === 'true')));
-    const allowEditPost = config.pipe(switchMap((cfg) => of$(cfg?.AllowEditPost)));
+    const allowEditPost = observeConfigValue(database, 'AllowEditPost');
     const serverVersion = config.pipe(switchMap((cfg) => of$(cfg?.Version || '')));
     const postEditTimeLimit = config.pipe(switchMap((cfg) => of$(parseInt(cfg?.PostEditTimeLimit || '-1', 10))));
 

--- a/app/screens/post_options/index.ts
+++ b/app/screens/post_options/index.ts
@@ -10,7 +10,7 @@ import {General, Permissions, Post, Screens} from '@constants';
 import {MAX_ALLOWED_REACTIONS} from '@constants/emoji';
 import {observePost, observePostSaved} from '@queries/servers/post';
 import {observePermissionForChannel, observePermissionForPost} from '@queries/servers/role';
-import {observeConfig, observeLicense} from '@queries/servers/system';
+import {observeConfig, observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
 import {observeIsCRTEnabled, observeThreadById} from '@queries/servers/thread';
 import {observeCurrentUser} from '@queries/servers/user';
 import {isMinimumServerVersion} from '@utils/helpers';
@@ -86,7 +86,7 @@ const enhanced = withObservables([], ({combinedPost, post, showAddReaction, loca
         return observePermissionForPost(database, post, u, isOwner ? Permissions.DELETE_POST : Permissions.DELETE_OTHERS_POSTS, false);
     }));
 
-    const experimentalTownSquareIsReadOnly = config.pipe(switchMap((value) => of$(value?.ExperimentalTownSquareIsReadOnly === 'true')));
+    const experimentalTownSquareIsReadOnly = observeConfigBooleanValue(database, 'ExperimentalTownSquareIsReadOnly');
     const channelIsReadOnly = combineLatest([currentUser, channel, experimentalTownSquareIsReadOnly]).pipe(switchMap(([u, c, readOnly]) => {
         return of$(c?.name === General.DEFAULT_CHANNEL && (u && !isSystemAdmin(u.roles)) && readOnly);
     }));

--- a/app/screens/post_options/index.ts
+++ b/app/screens/post_options/index.ts
@@ -10,7 +10,7 @@ import {General, Permissions, Post, Screens} from '@constants';
 import {MAX_ALLOWED_REACTIONS} from '@constants/emoji';
 import {observePost, observePostSaved} from '@queries/servers/post';
 import {observePermissionForChannel, observePermissionForPost} from '@queries/servers/role';
-import {observeConfig, observeConfigValue, observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
+import {observeConfig, observeConfigValue, observeConfigBooleanValue, observeLicenseBooleanValue} from '@queries/servers/system';
 import {observeIsCRTEnabled, observeThreadById} from '@queries/servers/thread';
 import {observeCurrentUser} from '@queries/servers/user';
 import {isMinimumServerVersion} from '@utils/helpers';
@@ -74,7 +74,7 @@ const enhanced = withObservables([], ({combinedPost, post, showAddReaction, loca
     const channelIsArchived = channel.pipe(switchMap((ch: ChannelModel) => of$(ch.deleteAt !== 0)));
     const currentUser = observeCurrentUser(database);
     const config = observeConfig(database);
-    const isLicensed = observeLicense(database).pipe(switchMap((lcs) => of$(lcs?.IsLicensed === 'true')));
+    const isLicensed = observeLicenseBooleanValue(database, 'IsLicensed');
     const allowEditPost = observeConfigValue(database, 'AllowEditPost');
     const serverVersion = config.pipe(switchMap((cfg) => of$(cfg?.Version || '')));
     const postEditTimeLimit = config.pipe(switchMap((cfg) => of$(parseInt(cfg?.PostEditTimeLimit || '-1', 10))));


### PR DESCRIPTION
#### Summary
This PR does the following:
* adds a `observeLicenseBooleanValue` function to observe boolean license values
* adds a `observeCanDownloadFiles` function to share among multiple files
* use `observeConfigBooleanValue` in multiple locations where it could be used
* use `observeConfigValue` in multiple locations where it could be used


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45617

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
