### PR TITLE
[Gekidou] Get theme from useTheme

### DIFF
--- a/app/components/files/document_file.tsx
+++ b/app/components/files/document_file.tsx
@@ -12,6 +12,7 @@ import tinyColor from 'tinycolor2';
 import ProgressBar from '@components/progress_bar';
 import {DOWNLOAD_TIMEOUT} from '@constants/network';
 import {useServerUrl} from '@context/server';
+import {useTheme} from '@context/theme';
 import NetworkManager from '@managers/network_manager';
 import {alertDownloadDocumentDisabled, alertDownloadFailed, alertFailedToOpenDocument} from '@utils/document';
 import {fileExists, getLocalFilePathFromFile} from '@utils/file';
@@ -29,7 +30,6 @@ type DocumentFileProps = {
     backgroundColor?: string;
     canDownloadFiles: boolean;
     file: FileInfo;
-    theme: Theme;
 }
 
 const styles = StyleSheet.create({
@@ -42,9 +42,10 @@ const styles = StyleSheet.create({
     },
 });
 
-const DocumentFile = forwardRef<DocumentFileRef, DocumentFileProps>(({backgroundColor, canDownloadFiles, file, theme}: DocumentFileProps, ref) => {
+const DocumentFile = forwardRef<DocumentFileRef, DocumentFileProps>(({backgroundColor, canDownloadFiles, file}: DocumentFileProps, ref) => {
     const intl = useIntl();
     const serverUrl = useServerUrl();
+    const theme = useTheme();
     const [didCancel, setDidCancel] = useState(false);
     const [downloading, setDownloading] = useState(false);
     const [preview, setPreview] = useState(false);

--- a/app/components/files/file.tsx
+++ b/app/components/files/file.tsx
@@ -6,6 +6,7 @@ import {View, TouchableWithoutFeedback} from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import TouchableWithFeedback from '@components/touchable_with_feedback';
+import {useTheme} from '@context/theme';
 import {useGalleryItem} from '@hooks/gallery';
 import {isDocument, isImage, isVideo} from '@utils/file';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
@@ -30,7 +31,6 @@ type FileProps = {
     publicLinkEnabled: boolean;
     channelName?: string;
     onOptionsPress?: (index: number) => void;
-    theme: Theme;
     wrapperWidth?: number;
     showDate?: boolean;
     updateFileForGallery: (idx: number, file: FileInfo) => void;
@@ -76,11 +76,11 @@ const File = ({
     onPress,
     publicLinkEnabled,
     showDate = false,
-    theme,
     updateFileForGallery,
     wrapperWidth = 300,
 }: FileProps) => {
     const document = useRef<DocumentFileRef>(null);
+    const theme = useTheme();
     const style = getStyleSheet(theme);
 
     const handlePreviewPress = useCallback(() => {
@@ -114,13 +114,11 @@ const File = ({
             showDate={showDate}
             channelName={channelName}
             onPress={handlePreviewPress}
-            theme={theme}
         />
     );
 
     const renderImageFileOverlay = (
         <ImageFileOverlay
-            theme={theme}
             value={nonVisibleImagesCount}
         />
     );
@@ -165,7 +163,6 @@ const File = ({
                 ref={document}
                 canDownloadFiles={canDownloadFiles}
                 file={file}
-                theme={theme}
             />
         </View>
     );

--- a/app/components/files/file_info.tsx
+++ b/app/components/files/file_info.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {Text, TouchableOpacity, View} from 'react-native';
 
 import FormattedDate from '@components/formatted_date';
+import {useTheme} from '@context/theme';
 import {getFormattedFileSize} from '@utils/file';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -14,7 +15,6 @@ type FileInfoProps = {
     showDate: boolean;
     channelName?: string ;
     onPress: () => void;
-    theme: Theme;
 }
 const FORMAT = ' • MMM DD HH:MM A';
 
@@ -58,7 +58,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-const FileInfo = ({file, channelName, showDate, onPress, theme}: FileInfoProps) => {
+const FileInfo = ({file, channelName, showDate, onPress}: FileInfoProps) => {
+    const theme = useTheme();
     const style = getStyleSheet(theme);
     return (
         <View style={style.attachmentContainer}>

--- a/app/components/files/files.tsx
+++ b/app/components/files/files.tsx
@@ -25,7 +25,6 @@ type FilesProps = {
     isReplyPost: boolean;
     postId: string;
     publicLinkEnabled: boolean;
-    theme: Theme;
 }
 
 const MAX_VISIBLE_ROW_IMAGES = 4;
@@ -46,7 +45,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, location, postId, publicLinkEnabled, theme}: FilesProps) => {
+const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, location, postId, publicLinkEnabled}: FilesProps) => {
     const galleryIdentifier = `${postId}-fileAttachments-${location}`;
     const [inViewPort, setInViewPort] = useState(false);
     const isTablet = useIsTablet();
@@ -99,7 +98,6 @@ const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, l
                         file={file}
                         index={attachmentIndex(file.id!)}
                         onPress={handlePreviewPress}
-                        theme={theme}
                         isSingleImage={singleImage}
                         nonVisibleImagesCount={nonVisibleImagesCount}
                         publicLinkEnabled={publicLinkEnabled}

--- a/app/components/files/image_file_overlay.tsx
+++ b/app/components/files/image_file_overlay.tsx
@@ -4,11 +4,11 @@
 import React, {useMemo} from 'react';
 import {PixelRatio, StyleSheet, Text, useWindowDimensions, View} from 'react-native';
 
+import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 
 type ImageFileOverlayProps = {
-    theme: Theme;
     value: number;
 }
 
@@ -27,9 +27,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const ImageFileOverlay = ({theme, value}: ImageFileOverlayProps) => {
+const ImageFileOverlay = ({value}: ImageFileOverlayProps) => {
     const dimensions = useWindowDimensions();
     const isTablet = useIsTablet();
+    const theme = useTheme();
     const style = getStyleSheet(theme);
     const textStyles = useMemo(() => {
         const scale = isTablet ? dimensions.scale : 1;

--- a/app/components/post_list/date_separator/index.tsx
+++ b/app/components/post_list/date_separator/index.tsx
@@ -6,6 +6,7 @@ import {StyleProp, View, ViewStyle} from 'react-native';
 
 import FormattedDate from '@components/formatted_date';
 import FormattedText from '@components/formatted_text';
+import {useTheme} from '@context/theme';
 import {isSameYear, isToday, isYesterday} from '@utils/datetime';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -13,7 +14,6 @@ import {typography} from '@utils/typography';
 type DateSeparatorProps = {
     date: number | Date;
     style?: StyleProp<ViewStyle>;
-    theme: Theme;
     timezone?: string | null;
 };
 
@@ -72,7 +72,8 @@ const RecentDate = (props: DateSeparatorProps) => {
 };
 
 const DateSeparator = (props: DateSeparatorProps) => {
-    const styles = getStyleSheet(props.theme);
+    const theme = useTheme();
+    const styles = getStyleSheet(theme);
 
     return (
         <View style={[styles.container, props.style]}>

--- a/app/components/post_list/post/body/index.tsx
+++ b/app/components/post_list/post/body/index.tsx
@@ -177,7 +177,6 @@ const Body = ({
                     location={location}
                     post={post}
                     isReplyPost={isReplyPost}
-                    theme={theme}
                 />
                 }
                 {hasReactions && showAddReaction &&

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -229,7 +229,6 @@ const PostList = ({
                 return (
                     <DateSeparator
                         date={getDateForDateLine(item)}
-                        theme={theme}
                         style={styles.scale}
                         timezone={isTimezoneEnabled ? currentTimezone : null}
                     />

--- a/app/screens/home/recent_mentions/recent_mentions.tsx
+++ b/app/screens/home/recent_mentions/recent_mentions.tsx
@@ -145,7 +145,6 @@ const RecentMentionsScreen = ({mentions, currentTimezone, isTimezoneEnabled}: Pr
                 return (
                     <DateSeparator
                         date={getDateForDateLine(item)}
-                        theme={theme}
                         timezone={isTimezoneEnabled ? currentTimezone : null}
                     />
                 );

--- a/app/screens/home/saved_messages/saved_messages.tsx
+++ b/app/screens/home/saved_messages/saved_messages.tsx
@@ -146,7 +146,6 @@ function SavedMessages({posts, currentTimezone, isTimezoneEnabled}: Props) {
                 return (
                     <DateSeparator
                         date={getDateForDateLine(item)}
-                        theme={theme}
                         timezone={isTimezoneEnabled ? currentTimezone : null}
                     />
                 );

--- a/app/screens/home/search/results/results.tsx
+++ b/app/screens/home/search/results/results.tsx
@@ -201,7 +201,6 @@ const SearchResults = ({
                     index={filesForGalleryIndexes[item.id!] || 0}
                     onPress={handlePreviewPress}
                     onOptionsPress={handleOptionsPress}
-                    theme={theme}
                     isSingleImage={isSingleImage}
                     showDate={true}
                     publicLinkEnabled={publicLinkEnabled}

--- a/app/screens/home/search/results/results.tsx
+++ b/app/screens/home/search/results/results.tsx
@@ -161,7 +161,6 @@ const SearchResults = ({
                 return (
                     <DateSeparator
                         date={getDateForDateLine(item)}
-                        theme={theme}
                         timezone={isTimezoneEnabled ? currentTimezone : null}
                     />
                 );

--- a/app/screens/pinned_messages/pinned_messages.tsx
+++ b/app/screens/pinned_messages/pinned_messages.tsx
@@ -120,7 +120,6 @@ function SavedMessages({
                 return (
                     <DateSeparator
                         date={getDateForDateLine(item)}
-                        theme={theme}
                         timezone={isTimezoneEnabled ? currentTimezone : null}
                     />
                 );


### PR DESCRIPTION
#### Summary
There are several components I encountered during the search screen design that pass theme as props. This PR removes the props and makes use of the `useTheme` hook. There are many other components where `theme` is being passed in as a prop.  This PR only focused on components that were used with the Search Screen.

#### Ticket Link
N/A 

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
