### PR TITLE
Detox/E2E: Fix broken iOS e2e tests in Gekidou

### DIFF
--- a/detox/e2e/support/server_api/default_config.json
+++ b/detox/e2e/support/server_api/default_config.json
@@ -73,6 +73,7 @@
         "ExperimentalGroupUnreadChannels": "disabled",
         "ExperimentalChannelOrganization": false,
         "ExperimentalChannelSidebarOrganization": "disabled",
+        "EnableAPIChannelDeletion": true,
         "EnableAPITeamDeletion": true,
         "ExperimentalEnableHardenedMode": false,
         "DisableLegacyMFA": true,
@@ -81,7 +82,9 @@
         "DisableBotsWhenOwnerIsDeactivated": true,
         "EnableBotAccountCreation": true,
         "EnableSVGs": true,
-        "EnableLatex": false
+        "EnableLatex": true,
+        "EnableInlineLatex": true,
+        "CollapsedThreads": "always_on"
     },
     "TeamSettings": {
         "SiteName": "Mattermost",
@@ -110,7 +113,7 @@
         "MaxNotificationsPerChannel": 1000,
         "EnableConfirmNotificationsToChannel": true,
         "TeammateNameDisplay": "username",
-        "ExperimentalViewArchivedChannels": false,
+        "ExperimentalViewArchivedChannels": true,
         "ExperimentalEnableAutomaticReplies": false,
         "ExperimentalHideTownSquareinLHS": false,
         "ExperimentalTownSquareIsReadOnly": false,

--- a/detox/e2e/test/autocomplete/channel_mention.e2e.ts
+++ b/detox/e2e/test/autocomplete/channel_mention.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Channel,
     Setup,
-    System,
     Team,
 } from '@support/server_api';
 import {
@@ -38,12 +37,6 @@ describe('Autocomplete - Channel Mention', () => {
     let otherChannelMentionAutocomplete: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                EnableAPIChannelDeletion: true,
-            },
-        });
-
         const {channel, team, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
         testTeam = team;
@@ -197,7 +190,7 @@ describe('Autocomplete - Channel Mention', () => {
         await expect(Autocomplete.sectionChannelMentionList).toBeVisible();
     });
 
-    it('MM-T4879_8 - should not be able to autocomplete archived channel', async () => {
+    it('MM-T4879_8 - should be able to autocomplete archived channel', async () => {
         // # Archive another team channel and type in "~" to activate channel mention autocomplete
         await Channel.apiDeleteChannel(siteOneUrl, testOtherChannel.id);
         await ChannelScreen.postInput.typeText('~');
@@ -209,8 +202,8 @@ describe('Autocomplete - Channel Mention', () => {
         // # Type in channel name of archived channel
         await ChannelScreen.postInput.typeText(testOtherChannel.name);
 
-        // * Verify channel mention autocomplete does not contain associated channel suggestion
-        await expect(otherChannelMentionAutocomplete).not.toBeVisible();
+        // * Verify channel mention autocomplete contains associated channel suggestion
+        await expect(otherChannelMentionAutocomplete).toBeVisible();
 
         // # Unarchive channel, clear post input, and type in "~" to activate channel mention list
         await Channel.apiRestoreChannel(siteOneUrl, testOtherChannel.id);

--- a/detox/e2e/test/channels/archive_channel.e2e.ts
+++ b/detox/e2e/test/channels/archive_channel.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Channel,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -35,12 +34,6 @@ describe('Channels - Archive Channel', () => {
     let testUser: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            TeamSettings: {
-                ExperimentalViewArchivedChannels: true,
-            },
-        });
-
         const {team, user} = await Setup.apiInit(siteOneUrl);
         testTeam = team;
         testUser = user;

--- a/detox/e2e/test/channels/browse_channels.e2e.ts
+++ b/detox/e2e/test/channels/browse_channels.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Channel,
     Setup,
-    System,
     Team,
     User,
 } from '@support/server_api';
@@ -36,15 +35,6 @@ describe('Channels - Browse Channels', () => {
     let testUser: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                EnableAPIChannelDeletion: true,
-            },
-            TeamSettings: {
-                ExperimentalViewArchivedChannels: true,
-            },
-        });
-
         const {team, user} = await Setup.apiInit(siteOneUrl);
         testTeam = team;
         testUser = user;

--- a/detox/e2e/test/channels/channel_list.e2e.ts
+++ b/detox/e2e/test/channels/channel_list.e2e.ts
@@ -9,7 +9,6 @@
 
 import {
     Setup,
-    System,
     Team,
 } from '@support/server_api';
 import {
@@ -41,12 +40,6 @@ describe('Channels - Channel List', () => {
     let testUser: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, team, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
         testTeam = team;

--- a/detox/e2e/test/channels/find_channels.e2e.ts
+++ b/detox/e2e/test/channels/find_channels.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Channel,
     Setup,
-    System,
     Team,
     User,
 } from '@support/server_api';
@@ -35,15 +34,6 @@ describe('Channels - Find Channels', () => {
     let testUser: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                EnableAPIChannelDeletion: true,
-            },
-            TeamSettings: {
-                ExperimentalViewArchivedChannels: true,
-            },
-        });
-
         const {channel, team, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
         testTeam = team;

--- a/detox/e2e/test/messaging/markdown_latex.e2e.ts
+++ b/detox/e2e/test/messaging/markdown_latex.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -31,13 +30,6 @@ describe('Messaging - Markdown Latex', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                EnableLatex: true,
-                EnableInlineLatex: true,
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
 

--- a/detox/e2e/test/server_login/server_list.e2e.ts
+++ b/detox/e2e/test/server_login/server_list.e2e.ts
@@ -212,25 +212,23 @@ describe('Server Login - Server List', () => {
         // * Verify on channel list screen of the first server
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
 
-        // # Open server list screen, swipe left on first server and tap on logout option
+        // # Open server list screen, swipe left on third server and tap on logout option
         await ServerListScreen.open();
-        await ServerListScreen.getServerItemActive(serverOneDisplayName).swipe('left');
-        await ServerListScreen.getServerItemLogoutOption(serverOneDisplayName).tap();
+        await ServerListScreen.getServerItemInactive(serverThreeDisplayName).swipe('left');
+        await ServerListScreen.getServerItemLogoutOption(serverThreeDisplayName).tap();
 
         // * Verify logout server alert is displayed
-        await expect(Alert.logoutTitle(serverOneDisplayName)).toBeVisible();
+        await expect(Alert.logoutTitle(serverThreeDisplayName)).toBeVisible();
 
-        // # Tap on logout button and go back to server list screen
+        // # Tap on logout button
         await Alert.logoutButton.tap();
-        await ServerListScreen.open();
 
-        // * Verify first server is logged out
-        await ServerListScreen.getServerItemInactive(serverOneDisplayName).swipe('left');
-        await expect(ServerListScreen.getServerItemLoginOption(serverOneDisplayName)).toBeVisible();
+        // * Verify third server is logged out
+        await ServerListScreen.getServerItemInactive(serverThreeDisplayName).swipe('left');
+        await expect(ServerListScreen.getServerItemLoginOption(serverThreeDisplayName)).toBeVisible();
 
-        // # Log back in to first server
-        await ServerListScreen.getServerItemLoginOption(serverOneDisplayName).tap();
-        await LoginScreen.login(serverOneUser);
+        // # Go back to first server
+        await ServerListScreen.getServerItemActive(serverOneDisplayName).tap();
     });
 
     it('MM-T4691_7 - should not be able to add server for an already existing server', async () => {
@@ -257,7 +255,12 @@ describe('Server Login - Server List', () => {
         // * Verify same name server error
         await expect(ServerScreen.serverDisplayNameInputError).toHaveText(sameNameServerError);
 
-        // # Close server screen to go back to first server
+        // # Close server screen, open server list screen, log out of second server, and go back to first server
         await ServerScreen.close();
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemInactive(serverTwoDisplayName).swipe('left');
+        await ServerListScreen.getServerItemLogoutOption(serverTwoDisplayName).tap();
+        await Alert.logoutButton.tap();
+        await ServerListScreen.getServerItemActive(serverOneDisplayName).tap();
     });
 });

--- a/detox/e2e/test/smoke_test/channels.e2e.ts
+++ b/detox/e2e/test/smoke_test/channels.e2e.ts
@@ -11,7 +11,6 @@ import {
     Channel,
     Post,
     Setup,
-    System,
     Team,
     User,
 } from '@support/server_api';
@@ -42,12 +41,6 @@ describe('Smoke Test - Channels', () => {
     let testUser: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            TeamSettings: {
-                ExperimentalViewArchivedChannels: true,
-            },
-        });
-
         const {channel, team, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
         testTeam = team;

--- a/detox/e2e/test/smoke_test/server_login.e2e.ts
+++ b/detox/e2e/test/smoke_test/server_login.e2e.ts
@@ -17,6 +17,7 @@ import {
     serverTwoUrl,
     siteTwoUrl,
 } from '@support/test_config';
+import {Alert} from '@support/ui/component';
 import {
     ChannelListScreen,
     HomeScreen,
@@ -55,7 +56,7 @@ describe('Smoke Test - Server Login', () => {
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
     });
 
-    it('MM-T4675_2 - should be able to add a new server and log in to the new server', async () => {
+    it('MM-T4675_2 - should be able to add a new server and log-in-to/log-out-from the new server', async () => {
         // # Open server list screen
         await ServerListScreen.open();
 
@@ -75,8 +76,24 @@ describe('Smoke Test - Server Login', () => {
         await device.reloadReactNative();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverTwoDisplayName);
 
-        // # Go back to first server
+        // # Go back to first server, open server list screen, swipe left on second server and tap on logout option
         await ServerListScreen.open();
         await ServerListScreen.getServerItemInactive(serverOneDisplayName).tap();
+        await ServerListScreen.open();
+        await ServerListScreen.getServerItemInactive(serverTwoDisplayName).swipe('left');
+        await ServerListScreen.getServerItemLogoutOption(serverTwoDisplayName).tap();
+
+        // * Verify logout server alert is displayed
+        await expect(Alert.logoutTitle(serverTwoDisplayName)).toBeVisible();
+
+        // # Tap on logout button
+        await Alert.logoutButton.tap();
+
+        // * Verify second server is logged out
+        await ServerListScreen.getServerItemInactive(serverTwoDisplayName).swipe('left');
+        await expect(ServerListScreen.getServerItemLoginOption(serverTwoDisplayName)).toBeVisible();
+
+        // # Go back to first server
+        await ServerListScreen.getServerItemActive(serverOneDisplayName).tap();
     });
 });

--- a/detox/e2e/test/smoke_test/threads.e2e.ts
+++ b/detox/e2e/test/smoke_test/threads.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -37,12 +36,6 @@ describe('Smoke Test - Threads', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
 

--- a/detox/e2e/test/threads/follow_and_unfollow_thread.e2e.ts
+++ b/detox/e2e/test/threads/follow_and_unfollow_thread.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -36,12 +35,6 @@ describe('Threads - Follow and Unfollow Thread', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
 

--- a/detox/e2e/test/threads/global_threads.e2e.ts
+++ b/detox/e2e/test/threads/global_threads.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -35,12 +34,6 @@ describe('Threads - Global Threads', () => {
     let testUser: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
         testUser = user;
@@ -75,7 +68,7 @@ describe('Threads - Global Threads', () => {
     });
 
     it('MM-T4805_2 - should be able to go to a thread a user started and followed', async () => {
-        // # Create a thread started by the current user
+        // # Create a thread started by the current user which current user replied to
         const parentMessage = `Message ${getRandomId()}`;
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.postMessage(parentMessage);
@@ -100,7 +93,7 @@ describe('Threads - Global Threads', () => {
         await expect(GlobalThreadsScreen.getThreadItem(parentPost.id)).toBeVisible();
         await expect(GlobalThreadsScreen.getThreadItemThreadStarterUserDisplayName(parentPost.id)).toHaveText(testUser.username);
         await expect(GlobalThreadsScreen.getThreadItemThreadStarterChannelDisplayName(parentPost.id)).toHaveText(testChannel.display_name.toUpperCase());
-        await expect(GlobalThreadsScreen.getThreadItemFooterUnreadReplies(parentPost.id)).toHaveText('1 new reply');
+        await expect(GlobalThreadsScreen.getThreadItemFooterReplyCount(parentPost.id)).toHaveText('1 reply');
 
         // # Tap on the thread
         await GlobalThreadsScreen.getThreadItem(parentPost.id).tap();
@@ -168,7 +161,7 @@ describe('Threads - Global Threads', () => {
         await expect(GlobalThreadsScreen.getThreadItem(parentPost.id)).toBeVisible();
         await expect(GlobalThreadsScreen.getThreadItemThreadStarterUserDisplayName(parentPost.id)).toHaveText('sysadmin');
         await expect(GlobalThreadsScreen.getThreadItemThreadStarterChannelDisplayName(parentPost.id)).toHaveText(testChannel.display_name.toUpperCase());
-        await expect(GlobalThreadsScreen.getThreadItemFooterUnreadReplies(parentPost.id)).toHaveText('1 new reply');
+        await expect(GlobalThreadsScreen.getThreadItemFooterReplyCount(parentPost.id)).toHaveText('1 reply');
 
         // # Tap on the thread
         await GlobalThreadsScreen.getThreadItem(parentPost.id).tap();

--- a/detox/e2e/test/threads/mark_thread_as_read_and_unread.e2e.ts
+++ b/detox/e2e/test/threads/mark_thread_as_read_and_unread.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -36,12 +35,6 @@ describe('Threads - Mark Thread as Read and Unread', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
 
@@ -61,15 +54,16 @@ describe('Threads - Mark Thread as Read and Unread', () => {
     });
 
     it('MM-T4807_1 - should be able to mark a thread as read by opening thread', async () => {
-        // # Create a thread, go back to channel list screen, then go to global threads screen, and tap on unread threads button
+        // # Create a thread started by the current user which another user replied to, go back to channel list screen, then go to global threads screen, and tap on unread threads button
         const parentMessage = `Message ${getRandomId()}`;
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.postMessage(parentMessage);
         const {post: parentPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
-        await ChannelScreen.openReplyThreadFor(parentPost.id, parentMessage);
-        const replyMessage = `${parentMessage} reply`;
-        await ThreadScreen.postMessage(replyMessage);
-        await ThreadScreen.back();
+        await Post.apiCreatePost(siteOneUrl, {
+            channelId: testChannel.id,
+            message: `${parentMessage} reply`,
+            rootId: parentPost.id,
+        });
         await ChannelScreen.back();
         await device.reloadReactNative();
         await GlobalThreadsScreen.open();
@@ -100,15 +94,16 @@ describe('Threads - Mark Thread as Read and Unread', () => {
     });
 
     it('MM-T4807_2 - should be able to mark a thread as read/unread via thread options', async () => {
-        // # Create a thread, go back to channel list screen, then go to global threads screen, and tap on unread threads button
+        // # Create a thread started by the current user which another user replied to, go back to channel list screen, then go to global threads screen, and tap on unread threads button
         const parentMessage = `Message ${getRandomId()}`;
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.postMessage(parentMessage);
         const {post: parentPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
-        await ChannelScreen.openReplyThreadFor(parentPost.id, parentMessage);
-        const replyMessage = `${parentMessage} reply`;
-        await ThreadScreen.postMessage(replyMessage);
-        await ThreadScreen.back();
+        await Post.apiCreatePost(siteOneUrl, {
+            channelId: testChannel.id,
+            message: `${parentMessage} reply`,
+            rootId: parentPost.id,
+        });
         await ChannelScreen.back();
         await device.reloadReactNative();
         await GlobalThreadsScreen.open();
@@ -148,15 +143,16 @@ describe('Threads - Mark Thread as Read and Unread', () => {
     });
 
     it('MM-T4807_3 - should be able to mark all threads as read', async () => {
-        // # Create a thread, go back to channel list screen, then go to global threads screen, and tap on unread threads button
+        // # Create a thread started by the current user which another user replied to, go back to channel list screen, then go to global threads screen, and tap on unread threads button
         const parentMessage = `Message ${getRandomId()}`;
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.postMessage(parentMessage);
         const {post: parentPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
-        await ChannelScreen.openReplyThreadFor(parentPost.id, parentMessage);
-        const replyMessage = `${parentMessage} reply`;
-        await ThreadScreen.postMessage(replyMessage);
-        await ThreadScreen.back();
+        await Post.apiCreatePost(siteOneUrl, {
+            channelId: testChannel.id,
+            message: `${parentMessage} reply`,
+            rootId: parentPost.id,
+        });
         await ChannelScreen.back();
         await device.reloadReactNative();
         await GlobalThreadsScreen.open();

--- a/detox/e2e/test/threads/open_thread_in_channel.e2e.ts
+++ b/detox/e2e/test/threads/open_thread_in_channel.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -36,12 +35,6 @@ describe('Threads - Open Thread in Channel', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
 

--- a/detox/e2e/test/threads/reply_to_thread.e2e.ts
+++ b/detox/e2e/test/threads/reply_to_thread.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -35,12 +34,6 @@ describe('Threads - Reply to Thread', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
 

--- a/detox/e2e/test/threads/save_and_unsave_thread.e2e.ts
+++ b/detox/e2e/test/threads/save_and_unsave_thread.e2e.ts
@@ -10,7 +10,6 @@
 import {
     Post,
     Setup,
-    System,
 } from '@support/server_api';
 import {
     serverOneUrl,
@@ -36,12 +35,6 @@ describe('Threads - Save and Unsave Thread', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        System.apiUpdateConfig(siteOneUrl, {
-            ServiceSettings: {
-                CollapsedThreads: 'default_on',
-            },
-        });
-
         const {channel, user} = await Setup.apiInit(siteOneUrl);
         testChannel = channel;
 


### PR DESCRIPTION
#### Summary
- Fixed e2e for channel mention, server list, global threads, mark thread as read and unread, and server login
- Updated `default_config.json` with pertinent default settings and removed redundant setup from affected tests
- Updated associated zephyr test cases under `Mobile V2` folder

Mobile V2/Autocomplete:
[MM-T4879_8](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4879) - Channel Mention - should be able to autocomplete archived channel

Mobile V2/Server Login:
[MM-T4691_6](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4691) - Server List - should be able to log out a server from the list
[MM-T4691_7](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4691) - Server List - should not be able to add server for an already existing server

Mobile V2/Threads:
[MM-T4807](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4807) - Mark Thread as Read and Unread
[MM-T4805_2](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4805) - Global Threads - should be able to go to a thread a user started and followed
[MM-T4805_4](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4691) - Global Threads - should be able to go to a thread a user replied to and followed

Mobile V2/Smoke Test:
[MM-T4675_2](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4675) - Server Login - should be able to add a new server and log-in-to/log-out-from the new server

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45823

#### Screenshots
![Screen Shot 2022-07-18 at 11 15 07 PM](https://user-images.githubusercontent.com/487991/179692224-7607a91f-7fde-4e3e-b9fe-8c86f350294b.png)
![Screen Shot 2022-07-18 at 11 17 17 PM](https://user-images.githubusercontent.com/487991/179692227-6c635d72-21b1-400b-9d3e-53231fcfc6b1.png)
![Screen Shot 2022-07-18 at 11 38 58 PM](https://user-images.githubusercontent.com/487991/179692229-9a80aa16-0183-472a-b2b7-0061b01448c7.png)
![Screen Shot 2022-07-18 at 11 58 48 PM](https://user-images.githubusercontent.com/487991/179692230-68f7369d-9d85-4050-b304-20d1aec92182.png)
![Screen Shot 2022-07-19 at 12 01 31 AM](https://user-images.githubusercontent.com/487991/179692231-6f29cb58-49a8-489c-ab2c-4b356e6b4293.png)

#### Release Note
```release-note
NONE
```
