### PR TITLE
[MM-43838] Calls: WebSocket reconnection support

### DIFF
--- a/app/products/calls/connection.ts
+++ b/app/products/calls/connection.ts
@@ -47,9 +47,13 @@ export async function newClient(channelID: string, iceServers: ICEServersConfigs
     const ws = new WebSocketClient(Client4.getWebSocketUrl(), Client4.getToken());
 
     const disconnect = () => {
+        if (isClosed) {
+            return;
+        }
+
+        isClosed = true;
         ws.send('leave');
         ws.close();
-        isClosed = true;
 
         if (onCallEnd) {
             onCallEnd.remove();

--- a/app/products/calls/connection.ts
+++ b/app/products/calls/connection.ts
@@ -47,9 +47,7 @@ export async function newClient(channelID: string, iceServers: ICEServersConfigs
     const ws = new WebSocketClient(Client4.getWebSocketUrl(), Client4.getToken());
 
     const disconnect = () => {
-        ws.send('leave', {
-            channelID,
-        });
+        ws.send('leave');
         ws.close();
         isClosed = true;
 

--- a/app/products/calls/connection.ts
+++ b/app/products/calls/connection.ts
@@ -17,7 +17,7 @@ import {WebsocketEvents} from '@constants';
 import {ICEServersConfigs} from '@mmproducts/calls/store/types/calls';
 
 import Peer from './simple-peer';
-import WebSocketClient from './websocket';
+import {WebSocketClient, wsReconnectionTimeoutErr} from './websocket';
 
 export let client: any = null;
 
@@ -47,9 +47,11 @@ export async function newClient(channelID: string, iceServers: ICEServersConfigs
     const ws = new WebSocketClient(Client4.getWebSocketUrl(), Client4.getToken());
 
     const disconnect = () => {
-        if (!isClosed) {
-            ws.close();
-        }
+        ws.send('leave', {
+            channelID,
+        });
+        ws.close();
+        isClosed = true;
 
         if (onCallEnd) {
             onCallEnd.remove();
@@ -124,13 +126,14 @@ export async function newClient(channelID: string, iceServers: ICEServersConfigs
     };
 
     ws.on('error', (err) => {
-        console.log('WS (CALLS) ERROR', err); // eslint-disable-line no-console
-        ws.close();
+        console.log('calls: ws error', err); // eslint-disable-line no-console
+        if (err === wsReconnectionTimeoutErr) {
+            disconnect();
+        }
     });
 
     ws.on('close', () => {
-        isClosed = true;
-        disconnect();
+        console.log('calls: ws close'); // eslint-disable-line no-console
     });
 
     ws.on('join', async () => {
@@ -156,14 +159,30 @@ export async function newClient(channelID: string, iceServers: ICEServersConfigs
         });
 
         peer.on('error', (err: any) => {
-            console.log('PEER ERROR', err); // eslint-disable-line no-console
+            console.log('calls: peer error', err); // eslint-disable-line no-console
+        });
+
+        peer.on('close', () => {
+            console.log('calls: peer closed'); // eslint-disable-line no-console
+            if (!isClosed) {
+                disconnect();
+            }
         });
     });
 
-    ws.on('open', async () => {
-        ws.send('join', {
-            channelID,
-        });
+    ws.on('open', (originalConnID: string, prevConnID: string, isReconnect: boolean) => {
+        if (isReconnect) {
+            console.log('calls: ws reconnect, sending reconnect msg'); // eslint-disable-line no-console
+            ws.send('reconnect', {
+                channelID,
+                originalConnID,
+                prevConnID,
+            });
+        } else {
+            ws.send('join', {
+                channelID,
+            });
+        }
     });
 
     ws.on('message', ({data}) => {

--- a/app/products/calls/websocket.ts
+++ b/app/products/calls/websocket.ts
@@ -43,7 +43,9 @@ export class WebSocketClient extends EventEmitter {
 
         this.ws.onclose = () => {
             this.ws = null;
-            this.close();
+            if (!this.closed) {
+                this.close();
+            }
         };
 
         if (isReconnect) {
@@ -126,7 +128,6 @@ export class WebSocketClient extends EventEmitter {
     close() {
         if (this.ws) {
             this.closed = true;
-            this.ws.onclose = null;
             this.ws.close();
             this.ws = null;
             this.seqNo = 1;

--- a/app/products/calls/websocket.ts
+++ b/app/products/calls/websocket.ts
@@ -5,27 +5,54 @@ import {EventEmitter} from 'events';
 import Calls from '@constants/calls';
 import {encode} from '@msgpack/msgpack/dist';
 
-export default class WebSocketClient extends EventEmitter {
-    private ws: WebSocket | null;
+const wsMinReconnectRetryTimeMs = 1000; // 1 second
+const wsReconnectionTimeout = 30000; // 30 seconds
+const wsReconnectTimeIncrement = 500; // 0.5 seconds
+export const wsReconnectionTimeoutErr = new Error('max disconnected time reached');
+
+export class WebSocketClient extends EventEmitter {
+    private ws: WebSocket | null = null;
+    private wsURL: string;
+    private authToken: string;
     private seqNo = 1;
+    private serverSeqNo = 0;
     private connID = '';
+    private originalConnID = '';
     private eventPrefix = `custom_${Calls.PluginId}`;
+    private lastDisconnect = 0;
+    private reconnectRetryTime = wsMinReconnectRetryTimeMs;
+    private closed = false;
 
-    constructor(connURL: string, authToken: string) {
+    constructor(wsURL: string, authToken: string) {
         super();
+        this.wsURL = wsURL;
+        this.authToken = authToken;
+        this.init(false);
+    }
 
-        this.ws = new WebSocket(connURL, [], {headers: {authorization: `Bearer ${authToken}`}});
+    private init(isReconnect: boolean) {
+        if (this.closed) {
+            return;
+        }
+
+        this.ws = new WebSocket(`${this.wsURL}?connection_id=${this.connID}&sequence_number=${this.serverSeqNo}`, [], {headers: {authorization: `Bearer ${this.authToken}`}});
 
         this.ws.onerror = (err) => {
             this.emit('error', err);
-            this.ws = null;
-            this.close();
         };
 
         this.ws.onclose = () => {
             this.ws = null;
             this.close();
         };
+
+        if (isReconnect) {
+            this.ws.onopen = () => {
+                this.lastDisconnect = 0;
+                this.reconnectRetryTime = wsMinReconnectRetryTimeMs;
+                this.emit('open', this.originalConnID, this.connID, true);
+            };
+        }
 
         this.ws.onmessage = ({data}) => {
             if (!data) {
@@ -35,7 +62,12 @@ export default class WebSocketClient extends EventEmitter {
             try {
                 msg = JSON.parse(data);
             } catch (err) {
-                console.log(err); // eslint-disable-line no-console
+                console.log('calls: ws msg parse error', err); // eslint-disable-line no-console
+                return;
+            }
+
+            if (msg) {
+                this.serverSeqNo = msg.seq + 1;
             }
 
             if (!msg || !msg.event || !msg.data) {
@@ -43,14 +75,22 @@ export default class WebSocketClient extends EventEmitter {
             }
 
             if (msg.event === 'hello') {
-                this.connID = msg.data.connection_id;
-                this.emit('open');
+                if (msg.data.connection_id !== this.connID) {
+                    this.connID = msg.data.connection_id;
+                    this.serverSeqNo = 0;
+                    if (this.originalConnID === '') {
+                        this.originalConnID = this.connID;
+                    }
+                }
+                if (!isReconnect) {
+                    this.emit('open', this.originalConnID, this.connID, false);
+                }
                 return;
             } else if (!this.connID) {
                 return;
             }
 
-            if (msg.data.connID !== this.connID) {
+            if (msg.data.connID !== this.connID && msg.data.connID !== this.originalConnID) {
                 return;
             }
 
@@ -74,7 +114,6 @@ export default class WebSocketClient extends EventEmitter {
             seq: this.seqNo++,
             data,
         };
-
         if (this.ws && this.ws.readyState === WebSocket.OPEN) {
             if (binary) {
                 this.ws.send(encode(msg));
@@ -86,12 +125,36 @@ export default class WebSocketClient extends EventEmitter {
 
     close() {
         if (this.ws) {
+            this.closed = true;
+            this.ws.onclose = null;
             this.ws.close();
             this.ws = null;
+            this.seqNo = 1;
+            this.serverSeqNo = 0;
+            this.connID = '';
+            this.originalConnID = '';
+        } else {
+            this.emit('close');
+
+            const now = Date.now();
+            if (this.lastDisconnect === 0) {
+                this.lastDisconnect = now;
+            }
+
+            if ((now - this.lastDisconnect) >= wsReconnectionTimeout) {
+                this.closed = true;
+                this.emit('error', wsReconnectionTimeoutErr);
+                return;
+            }
+
+            setTimeout(() => {
+                if (!this.ws && !this.closed) {
+                    this.init(true);
+                }
+            }, this.reconnectRetryTime);
+
+            this.reconnectRetryTime += wsReconnectTimeIncrement;
         }
-        this.seqNo = 1;
-        this.connID = '';
-        this.emit('close');
     }
 
     state() {

--- a/app/products/calls/websocket.ts
+++ b/app/products/calls/websocket.ts
@@ -37,6 +37,14 @@ export class WebSocketClient extends EventEmitter {
 
         this.ws = new WebSocket(`${this.wsURL}?connection_id=${this.connID}&sequence_number=${this.serverSeqNo}`, [], {headers: {authorization: `Bearer ${this.authToken}`}});
 
+        if (isReconnect) {
+            this.ws.onopen = () => {
+                this.lastDisconnect = 0;
+                this.reconnectRetryTime = wsMinReconnectRetryTimeMs;
+                this.emit('open', this.originalConnID, this.connID, true);
+            };
+        }
+
         this.ws.onerror = (err) => {
             this.emit('error', err);
         };
@@ -47,14 +55,6 @@ export class WebSocketClient extends EventEmitter {
                 this.close();
             }
         };
-
-        if (isReconnect) {
-            this.ws.onopen = () => {
-                this.lastDisconnect = 0;
-                this.reconnectRetryTime = wsMinReconnectRetryTimeMs;
-                this.emit('open', this.originalConnID, this.connID, true);
-            };
-        }
 
         this.ws.onmessage = ({data}) => {
             if (!data) {


### PR DESCRIPTION
#### Summary

PR adds support for reconnecting the signaling (websocket) client in case of a disconnect.

#### Related PRs

https://github.com/mattermost/mattermost-plugin-calls/pull/145

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43838

#### Release Note

```release-note
Calls: implemented WebSocket reconnection support
```

