### PR TITLE
[MM-41749] Fixed SettingsSidebar component added back to navigation stack

### DIFF
--- a/app/mattermost.js
+++ b/app/mattermost.js
@@ -140,18 +140,16 @@ export function componentDidDisappearListener({componentId}) {
 
     if (componentId === 'MainSidebar') {
         EventEmitter.emit(NavigationTypes.MAIN_SIDEBAR_DID_CLOSE);
-    }
-
-    if (componentId === THREAD) {
-        if (EphemeralStore.hasModalsOpened()) {
-            for (const modal of EphemeralStore.navigationModalStack) {
-                const enableSwipe = {
-                    modal: {
-                        swipeToDismiss: true,
-                    },
-                };
-                Navigation.mergeOptions(modal, enableSwipe);
-            }
+    } else if (componentId === 'SettingsSidebar') {
+        EventEmitter.emit(NavigationTypes.CLOSE_SETTINGS_SIDEBAR);
+    } else if (componentId === THREAD && EphemeralStore.hasModalsOpened()) {
+        for (const modal of EphemeralStore.navigationModalStack) {
+            const enableSwipe = {
+                modal: {
+                    swipeToDismiss: true,
+                },
+            };
+            Navigation.mergeOptions(modal, enableSwipe);
         }
     }
 }

--- a/app/store/ephemeral_store.js
+++ b/app/store/ephemeral_store.js
@@ -41,7 +41,7 @@ class EphemeralStore {
 
     addToNavigationComponentIdStack = (componentId) => {
         const index = this.navigationComponentIdStack.indexOf(componentId);
-        if (index > 0) {
+        if (index >= 0) {
             this.navigationComponentIdStack.slice(index, 1);
         }
 


### PR DESCRIPTION
#### Summary
When a screen navigated from Settings Sidebar is dismissed, Settings Sidebar component is added back to the navigation stack, even though it is not visible. This results in `popToRoot()` to not work properly when the user tries to navigate to a new screen. This PR fixes this issue.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/19561
Which is linked to this Jira ticket: https://mattermost.atlassian.net/browse/MM-41749
Note that the issue mentions clicking on the hashtag from Saved Messages. However, the issue also occurs if you go to Settings Sidebar > Recent Mentions / Edit Profile / Settings, dismiss that screen, and try to click on the post's hashtag.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: Huawei P40 lite, Android 10

#### Screenshots
None

#### Release Note
```release-note
NONE
```