### PR TITLE
Update README to point to gekidou

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Note: development on this repository has primarily moved to the `gekidou` branch
-This `master` branch is mostly in maintenance mode while we're working to getting our "v2" (code named "gekidou") to the GA stage. To contribute check out the `gekidou` branch in this repository.
+This `master` branch is mostly in maintenance mode while we're working to getting our "v2" (code named "gekidou") to the GA stage. To contribute check out the [gekidou](https://github.com/mattermost/mattermost-mobile/tree/gekidou) branch in this repository.
 
 # Mattermost Mobile App
 [![Mattermost](https://user-images.githubusercontent.com/7205829/136108314-75cd2e1f-4147-4cfa-a16c-9b3b0313ea25.png)](https://mattermost.com)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Note: development on this repository has primarily moved to the `gekidou` branch
+This `master` branch is mostly in maintenance mode while we're working to getting our "v2" (code named "gekidou") to the GA stage. To contribute check out the `gekidou` branch in this repository.
+
 # Mattermost Mobile App
 [![Mattermost](https://user-images.githubusercontent.com/7205829/136108314-75cd2e1f-4147-4cfa-a16c-9b3b0313ea25.png)](https://mattermost.com)
 


### PR DESCRIPTION
Few people realize that active development moved to that branch, so let's but a giant notice at the top of the readme.

