### PR TITLE
[Gekidou] gallery footer and video

### DIFF
--- a/app/components/post_draft/typing/index.tsx
+++ b/app/components/post_draft/typing/index.tsx
@@ -34,6 +34,7 @@ function Typing({
     const typingHeight = useSharedValue(0);
     const typing = useRef<Array<{id: string; now: number; username: string}>>([]);
     const timeoutToDisappear = useRef<NodeJS.Timeout>();
+    const mounted = useRef(false);
     const [refresh, setRefresh] = useState(0);
 
     const theme = useTheme();
@@ -63,7 +64,9 @@ function Typing({
             clearTimeout(timeoutToDisappear.current);
             timeoutToDisappear.current = undefined;
         }
-        setRefresh(Date.now());
+        if (mounted.current) {
+            setRefresh(Date.now());
+        }
     }, [channelId, rootId]);
 
     const onUserStopTyping = useCallback((msg: any) => {
@@ -85,12 +88,21 @@ function Typing({
 
         if (typing.current.length === 0) {
             timeoutToDisappear.current = setTimeout(() => {
-                setRefresh(Date.now());
+                if (mounted.current) {
+                    setRefresh(Date.now());
+                }
                 timeoutToDisappear.current = undefined;
             }, 500);
-        } else {
+        } else if (mounted.current) {
             setRefresh(Date.now());
         }
+    }, []);
+
+    useEffect(() => {
+        mounted.current = true;
+        return () => {
+            mounted.current = false;
+        };
     }, []);
 
     useEffect(() => {

--- a/app/screens/gallery/footer/copy_public_link/index.tsx
+++ b/app/screens/gallery/footer/copy_public_link/index.tsx
@@ -6,6 +6,7 @@ import React, {useEffect, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {StyleSheet} from 'react-native';
 import {useAnimatedStyle, withTiming} from 'react-native-reanimated';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {fetchPublicLink} from '@actions/remote/file';
 import Toast from '@components/toast';
@@ -29,13 +30,14 @@ const styles = StyleSheet.create({
 const CopyPublicLink = ({item, setAction}: Props) => {
     const {formatMessage} = useIntl();
     const serverUrl = useServerUrl();
+    const insets = useSafeAreaInsets();
     const [showToast, setShowToast] = useState<boolean|undefined>();
     const [error, setError] = useState('');
     const mounted = useRef(false);
 
     const animatedStyle = useAnimatedStyle(() => ({
         position: 'absolute',
-        bottom: GALLERY_FOOTER_HEIGHT + 8,
+        bottom: GALLERY_FOOTER_HEIGHT + 8 + insets.bottom,
         opacity: withTiming(showToast ? 1 : 0, {duration: 300}),
     }));
 

--- a/app/screens/gallery/footer/download_with_action/index.tsx
+++ b/app/screens/gallery/footer/download_with_action/index.tsx
@@ -10,6 +10,7 @@ import FileViewer from 'react-native-file-viewer';
 import FileSystem from 'react-native-fs';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {useAnimatedStyle, withTiming} from 'react-native-reanimated';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Share from 'react-native-share';
 
 import {downloadFile} from '@actions/remote/file';
@@ -66,6 +67,7 @@ const styles = StyleSheet.create({
 const DownloadWithAction = ({action, item, onDownloadSuccess, setAction}: Props) => {
     const intl = useIntl();
     const serverUrl = useServerUrl();
+    const insets = useSafeAreaInsets();
     const [showToast, setShowToast] = useState<boolean|undefined>();
     const [error, setError] = useState('');
     const [saved, setSaved] = useState(false);
@@ -110,7 +112,7 @@ const DownloadWithAction = ({action, item, onDownloadSuccess, setAction}: Props)
 
     const animatedStyle = useAnimatedStyle(() => ({
         position: 'absolute',
-        bottom: GALLERY_FOOTER_HEIGHT + 8,
+        bottom: GALLERY_FOOTER_HEIGHT + 8 + insets.bottom,
         opacity: withTiming(showToast ? 1 : 0, {duration: 300}),
     }));
 

--- a/app/screens/gallery/video_renderer/index.tsx
+++ b/app/screens/gallery/video_renderer/index.tsx
@@ -140,16 +140,20 @@ const VideoRenderer = ({height, index, initialIndex, item, isPageActive, onShoul
     const animatedStyle = useAnimatedStyle(() => {
         let w = width;
         let h = height - (VIDEO_INSET + GALLERY_FOOTER_HEIGHT + bottom);
+
         if (fullscreen.value) {
             w = dimensions.width;
             h = dimensions.height;
+        } else if (dimensions.width > dimensions.height) {
+            w = h;
+            h = width;
         }
 
         return {
             width: withTiming(w, timingConfig),
             height: withTiming(h, timingConfig),
         };
-    }, [dimensions.height]);
+    }, [dimensions]);
 
     useEffect(() => {
         if (initialIndex === index && videoReady) {


### PR DESCRIPTION
#### Summary
* fixes the position of the toast inside the gallery to respect the safe area insets on iOS devices
* fixes the video dimensions when rotating the device
* during video playback it allows the footer and header to be shown/hidden by tapping anywhere on the video
* Fixes a small memory leak in the `<Typing>` component

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45680
https://mattermost.atlassian.net/browse/MM-45681

```release-note
NONE
```
