### PR TITLE
Detox/E2E: Channel Info Unarchive e2e tests in Gekidou

### DIFF
--- a/detox/e2e/test/channels/unarchive_channel.e2e.ts
+++ b/detox/e2e/test/channels/unarchive_channel.e2e.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {serverOneUrl} from '@support/test_config';
+import {
+    ChannelScreen,
+    ChannelListScreen,
+    CreateOrEditChannelScreen,
+    HomeScreen,
+    LoginScreen,
+    ServerScreen,
+    ChannelInfoScreen,
+} from '@support/ui/screen';
+import {getAdminAccount, getRandomId} from '@support/utils';
+import {expect} from 'detox';
+
+describe('Channels - Unarchive Channel', () => {
+    const serverOneDisplayName = 'Server 1';
+    const channelsCategory = 'channels';
+
+    beforeAll(async () => {
+        // # Log in to server as admin
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await LoginScreen.login(getAdminAccount());
+    });
+
+    beforeEach(async () => {
+        // * Verify on channel list screen
+        await ChannelListScreen.toBeVisible();
+    });
+
+    afterAll(async () => {
+        // # Log out
+        await HomeScreen.logout();
+    });
+
+    it('MM-T4944_1 - should be able to unarchive a public channel and confirm', async () => {
+        // # Create a public channel screen, open channel info screen, and tap on archive channel option and confirm
+        const channelDisplayName = `Channel ${getRandomId()}`;
+        const channelName = channelDisplayName.replace(/ /, '-').toLowerCase();
+        await CreateOrEditChannelScreen.openCreateChannel();
+        await CreateOrEditChannelScreen.displayNameInput.replaceText(channelDisplayName);
+        await CreateOrEditChannelScreen.createButton.tap();
+        await ChannelInfoScreen.open();
+        await ChannelInfoScreen.archivePublicChannel({confirm: true});
+
+        // * Verify on public channel screen and archived post draft is displayed
+        await ChannelScreen.toBeVisible();
+        await expect(ChannelScreen.postDraftArchived).toBeVisible();
+
+        // # Open channel info screen, tap on unarchive channel and confirm, close and re-open app to reload, and re-open unarchived public channel
+        await ChannelInfoScreen.open();
+        await ChannelInfoScreen.unarchivePublicChannel({confirm: true});
+        await device.reloadReactNative();
+        await ChannelScreen.open(channelsCategory, channelName);
+
+        // * Verify on unarchived public channel screen and active post draft is displayed
+        await ChannelScreen.toBeVisible();
+        await expect(ChannelScreen.postDraft).toBeVisible();
+
+        // # Go back to channel list screen
+        await ChannelScreen.back();
+    });
+
+    it('MM-T4944_2 - should be able to unarchive a private channel and confirm', async () => {
+        // # Create a private channel screen, open channel info screen, and tap on archive channel option and confirm
+        const channelDisplayName = `Channel ${getRandomId()}`;
+        const channelName = channelDisplayName.replace(/ /, '-').toLowerCase();
+        await CreateOrEditChannelScreen.openCreateChannel();
+        await CreateOrEditChannelScreen.toggleMakePrivateOn();
+        await CreateOrEditChannelScreen.displayNameInput.replaceText(channelDisplayName);
+        await CreateOrEditChannelScreen.createButton.tap();
+        await ChannelInfoScreen.open();
+        await ChannelInfoScreen.archivePrivateChannel({confirm: true});
+
+        // * Verify on private channel screen and archived post draft is displayed
+        await ChannelScreen.toBeVisible();
+        await expect(ChannelScreen.postDraftArchived).toBeVisible();
+
+        // # Open channel info screen, tap on unarchive channel and confirm, close and re-open app to reload, and re-open unarchived private channel
+        await ChannelInfoScreen.open();
+        await ChannelInfoScreen.unarchivePrivateChannel({confirm: true});
+        await device.reloadReactNative();
+        await ChannelScreen.open(channelsCategory, channelName);
+
+        // * Verify on unarchived private channel screen and active post draft is displayed
+        await ChannelScreen.toBeVisible();
+        await expect(ChannelScreen.postDraft).toBeVisible();
+
+        // # Go back to channel list screen
+        await ChannelScreen.back();
+    });
+});

--- a/env.d.ts
+++ b/env.d.ts
@@ -4,3 +4,7 @@
 // So that typescript doesn't complain about importing `@env` through react-native-dotenv
 declare module '@env' {
 }
+
+declare module 'react-native-dotenv' {
+    export const RUNNING_E2E: string;
+}


### PR DESCRIPTION
#### Summary
- Added e2e for channels unarchive channel
- Also fixed `react-native-dotenv` typescript import warning
- Created associated zephyr test cases under `Mobile V2` folder

Mobile V2/Channels:
[MM-T4944](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4944) - Unarchive Channel

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45822

#### Screenshots
![Screen Shot 2022-07-26 at 1 16 24 PM](https://user-images.githubusercontent.com/487991/181105181-e0302aa4-51e6-45d5-ad32-2fd74e2666dd.png)

#### Release Note
```release-note
NONE
```
