### PR TITLE
Fix permalink not entering loading status after join channel and fix button functionality after joining the channel.

### DIFF
--- a/app/screens/permalink/permalink.tsx
+++ b/app/screens/permalink/permalink.tsx
@@ -271,7 +271,7 @@ function Permalink({
         if (channel) {
             switchToChannelById(serverUrl, channel.id, channel.teamId);
         }
-    }), [channel]);
+    }), [channel?.id, channel?.teamId]);
 
     const handleJoin = useCallback(preventDoubleTap(async () => {
         setLoading(true);

--- a/app/screens/permalink/permalink.tsx
+++ b/app/screens/permalink/permalink.tsx
@@ -162,7 +162,7 @@ function Permalink({
                 if (data.error) {
                     setError({unreachable: true});
                 }
-                if (data?.posts) {
+                if (data.posts) {
                     setPosts(loadThreadPosts ? processThreadPosts(data.posts, postId) : data.posts);
                 }
                 setLoading(false);
@@ -269,19 +269,21 @@ function Permalink({
 
     const handlePress = useCallback(preventDoubleTap(() => {
         if (channel) {
-            switchToChannelById(serverUrl, channel?.id, channel?.teamId);
+            switchToChannelById(serverUrl, channel.id, channel.teamId);
         }
-    }), []);
+    }), [channel]);
 
     const handleJoin = useCallback(preventDoubleTap(async () => {
+        setLoading(true);
+        setError(undefined);
         if (error?.teamId && error.channelId) {
             const {error: joinError} = await joinChannel(serverUrl, currentUserId, error.teamId, error.channelId);
             if (joinError) {
                 Alert.alert('Error joining the channel', 'There was an error trying to join the channel');
+                setLoading(false);
+                setError(error);
                 return;
             }
-            setLoading(true);
-            setError(undefined);
             setChannelId(error.channelId);
         }
     }), [error, serverUrl, currentUserId]);


### PR DESCRIPTION
#### Summary
When on the permalink view, if you click to join a channel, and the connection is slow, it just stays there until the response comes.

After joining, the "Jump to recent messages" button did not update, so it was not responsive.

This fix both.

#### Ticket Link
None

#### Release Note
```release-note
Improve UX on Permalink view.
Fix unresponsive "Jump to recent messages" just after joining the channel through the Permalink view.
```
