### PR TITLE
[Gekidou] Handles Group Channel WebSocket Events

### DIFF
--- a/app/actions/websocket/group.ts
+++ b/app/actions/websocket/group.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {fetchGroupsForChannel, fetchGroupsForMember, fetchGroupsForTeam} from '@actions/remote/groups';
-import {deleteGroupMembershipById, deleteGroupTeamById} from '@app/queries/servers/group';
+import {deleteGroupChannelById, deleteGroupMembershipById, deleteGroupTeamById} from '@app/queries/servers/group';
 import {generateGroupAssociationId} from '@app/utils/groups';
 import DatabaseManager from '@database/manager';
 import {logError} from '@utils/log';
@@ -19,7 +19,13 @@ type WebsocketGroupTeamMessage = WebSocketMessage<{
     group_team?: string; // type GroupMember
 }>
 
-const handleError = (serverUrl: string, e: unknown, msg: WebsocketGroupMessage | WebsocketGroupMemberMessage | WebsocketGroupTeamMessage) => {
+type WebsocketGroupChannelMessage = WebSocketMessage<{
+    group_channel?: string; // type GroupMember
+}>
+
+type WSMessage = WebsocketGroupMessage | WebsocketGroupMemberMessage | WebsocketGroupTeamMessage | WebsocketGroupChannelMessage
+
+const handleError = (serverUrl: string, e: unknown, msg: WSMessage) => {
     logError(`Group WS: ${msg.event}`, e, msg);
 
     const {team_id, channel_id, user_id} = msg.broadcast;
@@ -105,6 +111,37 @@ export async function handleGroupTeamDissociateEvent(serverUrl: string, msg: Web
             groupTeam = JSON.parse(msg.data.group_team);
 
             await deleteGroupTeamById(database, generateGroupAssociationId(groupTeam.group_id, groupTeam.team_id));
+        }
+    } catch (e) {
+        handleError(serverUrl, e, msg);
+    }
+}
+
+export async function handleGroupChannelAssociatedEvent(serverUrl: string, msg: WebsocketGroupChannelMessage) {
+    let groupChannel: GroupChannel;
+
+    try {
+        if (msg?.data?.group_channel) {
+            const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+            groupChannel = JSON.parse(msg.data.group_channel);
+            const group = {id: groupChannel.group_id};
+
+            operator.handleGroupChannelsForChannel({channelId: groupChannel.channel_id, groups: [group], prepareRecordsOnly: false});
+        }
+    } catch (e) {
+        handleError(serverUrl, e, msg);
+    }
+}
+
+export async function handleGroupChannelDissociateEvent(serverUrl: string, msg: WebsocketGroupChannelMessage) {
+    let groupChannel: GroupChannel;
+
+    try {
+        if (msg?.data?.group_channel) {
+            const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+            groupChannel = JSON.parse(msg.data.group_channel);
+
+            await deleteGroupChannelById(database, generateGroupAssociationId(groupChannel.group_id, groupChannel.channel_id));
         }
     } catch (e) {
         handleError(serverUrl, e, msg);

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -418,5 +418,9 @@ export async function handleEvent(serverUrl: string, msg: WebSocketMessage) {
         case WebsocketEvents.GROUP_DISSOCIATED_TO_TEAM:
             handleGroupTeamDissociateEvent(serverUrl, msg);
             break;
+        case WebsocketEvents.GROUP_ASSOCIATED_TO_CHANNEL:
+            break;
+        case WebsocketEvents.GROUP_DISSOCIATED_TO_CHANNEL:
+            break;
     }
 }

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -71,5 +71,7 @@ const WebsocketEvents = {
     GROUP_MEMBER_DELETE: 'group_member_delete',
     GROUP_ASSOCIATED_TO_TEAM: 'received_group_associated_to_team',
     GROUP_DISSOCIATED_TO_TEAM: 'received_group_not_associated_to_team',
+    GROUP_ASSOCIATED_TO_CHANNEL: 'received_group_associated_to_channel',
+    GROUP_DISSOCIATED_TO_CHANNEL: 'received_group_not_associated_to_channel',
 };
 export default WebsocketEvents;

--- a/app/queries/servers/group.ts
+++ b/app/queries/servers/group.ts
@@ -63,3 +63,7 @@ export const deleteGroupMembershipById = (database: Database, id: string) => {
 export const deleteGroupTeamById = (database: Database, id: string) => {
     return database.collections.get<GroupTeamModel>(GROUP_TEAM).find(id).then((model) => model.destroyPermanently());
 };
+
+export const deleteGroupChannelById = (database: Database, id: string) => {
+    return database.collections.get<GroupChannelModel>(GROUP_CHANNEL).find(id).then((model) => model.destroyPermanently());
+};

--- a/types/database/database.d.ts
+++ b/types/database/database.d.ts
@@ -224,7 +224,7 @@ export type HandleGroupArgs = PrepareOnly & {
 
 export type HandleGroupChannelsForChannelArgs = PrepareOnly & {
   channelId: string;
-  groups?: Group[];
+  groups?: Array<Pick<Group, 'id'>>;
 }
 
 export type HandleGroupMembershipForMemberArgs = PrepareOnly & {


### PR DESCRIPTION
#### Summary

This PR handles the websocket events for groups being associated / dissociated with Channels.

NOTE: Awaiting https://github.com/mattermost/mattermost-mobile/pull/6529 to be merged in first.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45533


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on:

iPad Mini / iOS 15.5 (Device)
Pixel 5 / API30 (Sim)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
