### PR TITLE
Fix other name showing on typing

### DIFF
--- a/app/components/post_draft/typing/index.tsx
+++ b/app/components/post_draft/typing/index.tsx
@@ -96,7 +96,7 @@ function Typing({
         } else if (mounted.current) {
             setRefresh(Date.now());
         }
-    }, []);
+    }, [channelId, rootId]);
 
     useEffect(() => {
         mounted.current = true;
@@ -122,6 +122,15 @@ function Typing({
     useEffect(() => {
         typingHeight.value = typing.current.length ? TYPING_HEIGHT : 0;
     }, [refresh]);
+
+    useEffect(() => {
+        typing.current = [];
+        typingHeight.value = 0;
+        if (timeoutToDisappear.current) {
+            clearTimeout(timeoutToDisappear.current);
+            timeoutToDisappear.current = undefined;
+        }
+    }, [channelId, rootId]);
 
     const renderTyping = () => {
         const nextTyping = typing.current.map(({username}) => username);


### PR DESCRIPTION
#### Summary
When we see a user is typing, if we switch channels, in certain circumstances it still showed the user typing from a different channel. This PR makes sure that on channelId change, all relevant states are cleared.

Disclaimer: I was not able to reproduce the original issue, so not sure if this solves it 100%, but the code seems sound.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45393

#### Release Note
```release-note
None
```
