### PR TITLE
Remove copy link from DMs and GMs

### DIFF
--- a/app/components/channel_actions/channel_actions.tsx
+++ b/app/components/channel_actions/channel_actions.tsx
@@ -10,13 +10,13 @@ import CopyChannelLinkBox from '@components/channel_actions/copy_channel_link_bo
 import FavoriteBox from '@components/channel_actions/favorite_box';
 import MutedBox from '@components/channel_actions/mute_box';
 import SetHeaderBox from '@components/channel_actions/set_header_box';
-import {General} from '@constants';
 import {useServerUrl} from '@context/server';
 import {dismissBottomSheet} from '@screens/navigation';
+import {isTypeDMorGM} from '@utils/channel';
 
 type Props = {
     channelId: string;
-    channelType?: string;
+    channelType?: ChannelType;
     inModal?: boolean;
     dismissChannelInfo: () => void;
     callsEnabled: boolean;
@@ -24,7 +24,6 @@ type Props = {
 }
 
 const OPTIONS_HEIGHT = 62;
-const DIRECT_CHANNELS: string[] = [General.DM_CHANNEL, General.GM_CHANNEL];
 
 const styles = StyleSheet.create({
     wrapper: {
@@ -47,7 +46,7 @@ const ChannelActions = ({channelId, channelType, inModal = false, dismissChannel
         }
     }, [inModal]);
 
-    const notDM = Boolean(channelType && !DIRECT_CHANNELS.includes(channelType));
+    const isDM = isTypeDMorGM(channelType);
 
     return (
         <View style={styles.wrapper}>
@@ -63,21 +62,21 @@ const ChannelActions = ({channelId, channelType, inModal = false, dismissChannel
                 testID={testID}
             />
             <View style={styles.separator}/>
-            {channelType && DIRECT_CHANNELS.includes(channelType) &&
+            {isDM &&
                 <SetHeaderBox
                     channelId={channelId}
                     inModal={inModal}
                     testID={`${testID}.set_header.action`}
                 />
             }
-            {notDM &&
+            {!isDM &&
                 <AddPeopleBox
                     channelId={channelId}
                     inModal={inModal}
                     testID={`${testID}.add_people.action`}
                 />
             }
-            {notDM && !callsEnabled &&
+            {!isDM && !callsEnabled &&
                 <>
                     <View style={styles.separator}/>
                     <CopyChannelLinkBox

--- a/app/screens/channel/header/header.tsx
+++ b/app/screens/channel/header/header.tsx
@@ -17,6 +17,7 @@ import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
 import {useDefaultHeaderHeight} from '@hooks/header';
 import {bottomSheet, popTopScreen, showModal} from '@screens/navigation';
+import {isTypeDMorGM} from '@utils/channel';
 import {preventDoubleTap} from '@utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -74,6 +75,7 @@ const ChannelHeader = ({
     const defaultHeight = useDefaultHeaderHeight();
     const insets = useSafeAreaInsets();
 
+    const isDMorGM = isTypeDMorGM(channelType);
     const contextStyle = useMemo(() => ({
         top: defaultHeight + insets.top,
     }), [defaultHeight, insets.top]);
@@ -127,13 +129,14 @@ const ChannelHeader = ({
         }
 
         // When calls is enabled, we need space to move the "Copy Link" from a button to an option
-        const height = QUICK_OPTIONS_HEIGHT + (callsEnabled ? ITEM_HEIGHT : 0);
+        const height = QUICK_OPTIONS_HEIGHT + (callsEnabled && !isDMorGM ? ITEM_HEIGHT : 0);
 
         const renderContent = () => {
             return (
                 <QuickActions
                     channelId={channelId}
                     callsEnabled={callsEnabled}
+                    isDMorGM={isDMorGM}
                 />
             );
         };
@@ -145,7 +148,7 @@ const ChannelHeader = ({
             theme,
             closeButtonId: 'close-channel-quick-actions',
         });
-    }, [channelId, channelType, isTablet, onTitlePress, theme, callsEnabled]);
+    }, [channelId, isDMorGM, isTablet, onTitlePress, theme, callsEnabled]);
 
     const rightButtons: HeaderRightButton[] = useMemo(() => ([
 

--- a/app/screens/channel/header/quick_actions/index.tsx
+++ b/app/screens/channel/header/quick_actions/index.tsx
@@ -16,6 +16,7 @@ import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 type Props = {
     channelId: string;
     callsEnabled: boolean;
+    isDMorGM: boolean;
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
@@ -35,7 +36,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const ChannelQuickAction = ({channelId, callsEnabled}: Props) => {
+const ChannelQuickAction = ({channelId, callsEnabled, isDMorGM}: Props) => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
 
@@ -54,7 +55,7 @@ const ChannelQuickAction = ({channelId, callsEnabled}: Props) => {
                 showAsLabel={true}
                 testID='channel.quick_actions.channel_info.action'
             />
-            {callsEnabled &&
+            {callsEnabled && !isDMorGM && // if calls is not enabled, copy link will show in the channel actions
                 <CopyChannelLinkOption
                     channelId={channelId}
                     showAsLabel={true}

--- a/app/screens/channel_info/options/index.tsx
+++ b/app/screens/channel_info/options/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import CopyChannelLinkOption from '@components/channel_actions/copy_channel_link_option';
 import {General} from '@constants';
+import {isTypeDMorGM} from '@utils/channel';
 
 import EditChannel from './edit_channel';
 import IgnoreMentions from './ignore_mentions';
@@ -19,6 +20,8 @@ type Props = {
 }
 
 const Options = ({channelId, type, callsEnabled}: Props) => {
+    const isDMorGM = isTypeDMorGM(type);
+
     return (
         <>
             {type !== General.DM_CHANNEL &&
@@ -29,7 +32,7 @@ const Options = ({channelId, type, callsEnabled}: Props) => {
             {type !== General.DM_CHANNEL &&
                 <Members channelId={channelId}/>
             }
-            {callsEnabled &&
+            {callsEnabled && !isDMorGM && // if calls is not enabled, copy link will show in the channel actions
                 <CopyChannelLinkOption channelId={channelId}/>
             }
             {type !== General.DM_CHANNEL && type !== General.GM_CHANNEL &&

--- a/app/utils/channel/index.ts
+++ b/app/utils/channel/index.ts
@@ -24,8 +24,13 @@ export function getDirectChannelName(id: string, otherId: string): string {
 }
 
 export function isDMorGM(channel: Channel | ChannelModel): boolean {
-    const directTypes: string[] = [General.GM_CHANNEL, General.DM_CHANNEL];
-    return directTypes.includes(channel.type);
+    return isTypeDMorGM(channel.type);
+}
+
+const DIRECT_TYPES: string[] = [General.GM_CHANNEL, General.DM_CHANNEL];
+
+export function isTypeDMorGM(channelType: ChannelType | undefined): boolean {
+    return Boolean(channelType && DIRECT_TYPES.includes(channelType));
 }
 
 export function isArchived(channel: Channel | ChannelModel): boolean {


### PR DESCRIPTION
#### Summary
The links to the DMs and GMs was not working correctly, and we actually don't want to show it, so we removed it.

#### Ticket Link
None

#### Release Note
```release-note
Remove copy channel link from DMs and GMS.
```
