### PR TITLE
Substitue rn-device-info by rn-user-agent when fetching the user agent

### DIFF
--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -9,7 +9,7 @@ import {
     RetryTypes,
 } from '@mattermost/react-native-network-client';
 import {DeviceEventEmitter} from 'react-native';
-import DeviceInfo from 'react-native-device-info';
+import UserAgent from 'react-native-user-agent';
 
 import LocalConfig from '@assets/config.json';
 import {Client} from '@client/rest';
@@ -85,7 +85,7 @@ class NetworkManager {
     };
 
     private buildConfig = async () => {
-        const userAgent = await DeviceInfo.getUserAgent();
+        const userAgent = UserAgent.getUserAgent();
         const headers: Record<string, string> = {
             ...this.DEFAULT_CONFIG.headers,
             [ClientConstants.HEADER_USER_AGENT]: userAgent,

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "react-native-section-list-get-item-layout": "2.2.3",
         "react-native-share": "7.4.1",
         "react-native-svg": "12.3.0",
+        "react-native-user-agent": "2.3.1",
         "react-native-vector-icons": "9.1.0",
         "react-native-video": "5.2.0",
         "react-native-webrtc": "github:mattermost/react-native-webrtc",
@@ -22051,6 +22052,14 @@
       "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
       "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw=="
     },
+    "node_modules/react-native-user-agent": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-user-agent/-/react-native-user-agent-2.3.1.tgz",
+      "integrity": "sha512-AIFr1VgJHwgWmMwCOmIGxuBeAaADlouXKc10UyR4fzWneUbt5uIJIoRu2oExlfCtiT8IyCp106khDD5vx7RUjw==",
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-vector-icons": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.1.0.tgz",
@@ -43242,6 +43251,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
       "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw=="
+    },
+    "react-native-user-agent": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-user-agent/-/react-native-user-agent-2.3.1.tgz",
+      "integrity": "sha512-AIFr1VgJHwgWmMwCOmIGxuBeAaADlouXKc10UyR4fzWneUbt5uIJIoRu2oExlfCtiT8IyCp106khDD5vx7RUjw==",
+      "requires": {}
     },
     "react-native-vector-icons": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-native-section-list-get-item-layout": "2.2.3",
     "react-native-share": "7.4.1",
     "react-native-svg": "12.3.0",
+    "react-native-user-agent": "2.3.1",
     "react-native-vector-icons": "9.1.0",
     "react-native-video": "5.2.0",
     "react-native-webrtc": "github:mattermost/react-native-webrtc",

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -225,6 +225,11 @@ jest.mock('react-native-device-info', () => {
         hasNotch: () => true,
         isTablet: () => false,
         getApplicationName: () => 'Mattermost',
+    };
+});
+
+jest.mock('react-native-user-agent', () => {
+    return {
         getUserAgent: () => 'user-agent',
     };
 });


### PR DESCRIPTION
#### Summary
Sometimes, we were having troubles with the app getting stuck on login. The issue was tracked down to `react-native-device-info` implementation of `getUserAgent`. The root cause was not identified, but substituting the library to use `react-native-user-agent` solved the issue.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
