### PR TITLE
Fix channel added websocket message

### DIFF
--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -286,7 +286,7 @@ export async function handleUserAddedToChannelEvent(serverUrl: string, msg: any)
                 const {models: prepared} = await storePostsForChannel(
                     serverUrl, channelId,
                     posts, order, previousPostId ?? '',
-                    actionType, authors,
+                    actionType, authors, true,
                 );
 
                 if (prepared?.length) {


### PR DESCRIPTION
#### Summary
When receiving the websocket event of the user being added to a channel, we were not passing the correct value to "prepareOnly". This caused call the batching with models with no prepare state.

#### Ticket Link
None

#### Release Note
```release-note
Fix bug when the user is added to a channel from a different client / user.
```
