### PR TITLE
[Gekidou MM-46237] Correct spelling for log messages

### DIFF
--- a/app/actions/remote/session.ts
+++ b/app/actions/remote/session.ts
@@ -173,7 +173,7 @@ export const logout = async (serverUrl: string, skipServerLogout = false, remove
             await client.logout();
         } catch (error) {
             // We want to log the user even if logging out from the server failed
-            logWarning('An error ocurred loging out from the server', serverUrl, error);
+            logWarning('An error occurred logging out from the server', serverUrl, error);
         }
     }
 

--- a/app/actions/remote/systems.ts
+++ b/app/actions/remote/systems.ts
@@ -44,7 +44,7 @@ export const fetchDataRetentionPolicy = async (serverUrl: string) => {
 
         operator.handleSystem({systems, prepareRecordsOnly: false}).
             catch((error) => {
-                logError('An error ocurred while saving data retention policies', error);
+                logError('An error occurred while saving data retention policies', error);
             });
     }
 
@@ -89,7 +89,7 @@ export const fetchConfigAndLicense = async (serverUrl: string, fetchOnly = false
                 if (systems.length) {
                     await operator.handleSystem({systems, prepareRecordsOnly: false}).
                         catch((error) => {
-                            logError('An error ocurred while saving config & license', error);
+                            logError('An error occurred while saving config & license', error);
                         });
                 }
             }

--- a/app/init/launch.ts
+++ b/app/init/launch.ts
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
 import Emm from '@mattermost/react-native-emm';
@@ -100,7 +100,7 @@ const launchApp = async (props: LaunchProps, resetNavigation = true) => {
                 if (result.error) {
                     Alert.alert(
                         'Error Upgrading',
-                        `An error ocurred while upgrading the app to the new version.\n\nDetails: ${result.error}\n\nThe app will now quit.`,
+                        `An error occurred while upgrading the app to the new version.\n\nDetails: ${result.error}\n\nThe app will now quit.`,
                         [{
                             text: 'OK',
                             onPress: async () => {

--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -154,7 +154,7 @@ function capture(captureFunc: () => void, config?: ClientConfig) {
         }
     } catch (e) {
         // Don't want this to get into an infinite loop again...
-        logError('Exception occured while sending to Sentry');
+        logError('Exception occurred while sending to Sentry');
         logError(e);
     }
 }


### PR DESCRIPTION
#### Summary
This PR just fixes some logging mispellings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46237

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
