### PR TITLE
Pass down client custom headers to native

### DIFF
--- a/app/client/rest/base.ts
+++ b/app/client/rest/base.ts
@@ -256,6 +256,17 @@ export default class ClientBase {
             requestOptions.timeoutInterval = options.timeoutInterval;
         }
 
+        if (options.headers) {
+            if (requestOptions.headers) {
+                requestOptions.headers = {
+                    ...requestOptions.headers,
+                    ...options.headers,
+                };
+            } else {
+                requestOptions.headers = options.headers;
+            }
+        }
+
         let response: ClientResponse;
         try {
             response = await request!(url, requestOptions);

--- a/app/client/rest/users.ts
+++ b/app/client/rest/users.ts
@@ -169,7 +169,12 @@ const ClientUsers = (superclass: any) => class extends superclass {
 
         const {data} = await this.doFetch(
             `${this.getUsersRoute()}/login`,
-            {method: 'post', body},
+            {
+                method: 'post',
+                body,
+                headers: {'Cache-Control': 'no-store'},
+            },
+            false,
         );
 
         return data;
@@ -341,14 +346,21 @@ const ClientUsers = (superclass: any) => class extends superclass {
     getSessions = async (userId: string) => {
         return this.doFetch(
             `${this.getUserRoute(userId)}/sessions`,
-            {method: 'get'},
+            {
+                method: 'get',
+                headers: {'Cache-Control': 'no-store'},
+            },
         );
     };
 
     checkUserMfa = async (loginId: string) => {
         return this.doFetch(
             `${this.getUsersRoute()}/mfa`,
-            {method: 'post', body: {login_id: loginId}},
+            {
+                method: 'post',
+                body: {login_id: loginId},
+                headers: {'Cache-Control': 'no-store'},
+            },
         );
     };
 

--- a/types/api/client.d.ts
+++ b/types/api/client.d.ts
@@ -8,6 +8,7 @@ type ClientOptions = {
     method?: string;
     noRetry?: boolean;
     timeoutInterval?: number;
+    headers?: Record<string, any>;
 };
 
 interface ClientErrorProps extends Error {


### PR DESCRIPTION
#### Summary
Custom headers were not forwarded to the native client to be included in the requests.

```release-note
NONE
```
