### PR TITLE
MM-46252 : Gekidou - Settings - Fixes Advanced Settings

### DIFF
--- a/app/screens/settings/advanced/index.tsx
+++ b/app/screens/settings/advanced/index.tsx
@@ -5,6 +5,7 @@ import React, {useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {TouchableOpacity} from 'react-native';
 
+import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
 import {popTopScreen} from '@screens/navigation';
@@ -28,7 +29,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
 });
 
 const EMPTY_FILES: ReadDirItem[] = [];
-const EMPTY_SERVERS: string[] = [];
 
 type AdvancedSettingsProps = {
     componentId: string;
@@ -36,30 +36,25 @@ type AdvancedSettingsProps = {
 const AdvancedSettings = ({componentId}: AdvancedSettingsProps) => {
     const theme = useTheme();
     const intl = useIntl();
+    const serverUrl = useServerUrl();
     const [dataSize, setDataSize] = useState<number|undefined>(0);
     const [files, setFiles] = useState<ReadDirItem[]>(EMPTY_FILES);
-    const [serverUrls, setServerUrls] = useState<string[]>(EMPTY_SERVERS);
     const styles = getStyleSheet(theme);
 
     const getAllCachedFiles = async () => {
-        const {totalSize, files: cachedFiles, serverUrls: allServerUrls} = await getAllFilesInCachesDirectory();
+        const {totalSize, files: cachedFiles} = await getAllFilesInCachesDirectory(serverUrl);
         setDataSize(totalSize);
         setFiles(cachedFiles || EMPTY_FILES);
-        setServerUrls(allServerUrls || EMPTY_SERVERS);
     };
 
     const onPressDeleteData = preventDoubleTap(async () => {
         try {
             if (files.length > 0) {
-                const deletePromises = [];
-                for (const server of serverUrls) {
-                    deletePromises.push(deleteFileCache(server));
-                }
-                await Promise.all(deletePromises);
+                await deleteFileCache(serverUrl);
+                await getAllCachedFiles();
             }
-            await getAllCachedFiles();
         } catch (e) {
-            //todo: show toast if error https://mattermost.atlassian.net/browse/MM-44926
+            //do nothing
         }
     });
 
@@ -70,14 +65,14 @@ const AdvancedSettings = ({componentId}: AdvancedSettingsProps) => {
     const close = () => popTopScreen(componentId);
     useAndroidHardwareBackHandler(componentId, close);
 
-    const disabled = Boolean(dataSize && (dataSize > 0));
+    const hasData = Boolean(dataSize && (dataSize > 0));
 
     return (
         <SettingContainer>
             <TouchableOpacity
                 onPress={onPressDeleteData}
-                disabled={disabled}
-                activeOpacity={disabled ? 0 : 1}
+                disabled={!hasData}
+                activeOpacity={hasData ? 1 : 0}
             >
                 <SettingOption
                     containerStyle={styles.itemStyle}

--- a/app/utils/file/index.ts
+++ b/app/utils/file/index.ts
@@ -14,8 +14,6 @@ import {Asset} from 'react-native-image-picker';
 import Permissions, {PERMISSIONS} from 'react-native-permissions';
 
 import {Files} from '@constants';
-import DatabaseManager from '@database/manager';
-import {queryAllServers} from '@queries/app/servers';
 import {generateId} from '@utils/general';
 import keyMirror from '@utils/key_mirror';
 import {logError} from '@utils/log';

--- a/app/utils/file/index.ts
+++ b/app/utils/file/index.ts
@@ -502,30 +502,17 @@ export const hasWriteStoragePermission = async (intl: IntlShape) => {
     }
 };
 
-export const getAllFilesInCachesDirectory = async () => {
+export const getAllFilesInCachesDirectory = async (serverUrl: string) => {
     try {
-        const appDatabase = DatabaseManager.appDatabase;
-        const servers = await queryAllServers(appDatabase!.database);
-        if (!servers.length) {
-            return {error: 'No servers'};
-        }
-
-        const serverUrls = [];
         const files: FileSystem.ReadDirItem[][] = [];
 
-        for await (const server of servers) {
-            const directoryFiles = await FileSystem.readDir(`${FileSystem.CachesDirectoryPath}/${hashCode(server.url)}`);
-            files.push(directoryFiles);
-            serverUrls.push(server.url);
-        }
-
+        const directoryFiles = await FileSystem.readDir(`${FileSystem.CachesDirectoryPath}/${hashCode(serverUrl)}`);
+        files.push(directoryFiles);
         const flattenedFiles = files.flat();
         const totalSize = flattenedFiles.reduce((acc, file) => acc + file.size, 0);
-
         return {
             files: flattenedFiles,
             totalSize,
-            serverUrls,
         };
     } catch (error) {
         logError('Failed getAllFilesInCachesDirectory', error);


### PR DESCRIPTION
#### Summary
This is part of a series of fixes - but to speed things up, this PR fixes the advanced settings by properly deleting all files in the cache directory.  Another fix to this PR is when we delete the 'data' for a server, then only that server's data is now being deleted.

I tested it on both iOS (simulator) and Android (device) by placing all kinds of file types in that directory.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46252


#### Release Note
```release-note
NONE
```
