### PR TITLE
Fix convert to private

### DIFF
--- a/app/client/rest/channels.ts
+++ b/app/client/rest/channels.ts
@@ -112,12 +112,7 @@ const ClientChannels = (superclass: any) => class extends superclass {
     };
 
     convertChannelToPrivate = async (channelId: string) => {
-        this.analytics.trackAPI('api_channels_convert_to_private', {channel_id: channelId});
-
-        return this.doFetch(
-            `${this.getChannelRoute(channelId)}/convert`,
-            {method: 'post'},
-        );
+        this.updateChannelPrivacy(channelId, 'P');
     };
 
     updateChannelPrivacy = async (channelId: string, privacy: any) => {


### PR DESCRIPTION
#### Summary
When converting a channel to private, we were using a non existing API. Now we are using the correct one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46005

#### Release Note
```release-note
Fix converting a channel to private.
```
