### PR TITLE
MM-46050 MM-46302 - Fix for call screen popping errors

### DIFF
--- a/app/products/calls/connection/websocket_event_handlers.ts
+++ b/app/products/calls/connection/websocket_event_handlers.ts
@@ -68,11 +68,11 @@ export const handleCallStarted = (serverUrl: string, msg: WebSocketMessage) => {
 };
 
 export const handleCallEnded = (serverUrl: string, msg: WebSocketMessage) => {
-    callEnded(serverUrl, msg.broadcast.channel_id);
-
     DeviceEventEmitter.emit(WebsocketEvents.CALLS_CALL_END, {
         channelId: msg.broadcast.channel_id,
     });
+
+    callEnded(serverUrl, msg.broadcast.channel_id);
 };
 
 export const handleCallChannelEnabled = (serverUrl: string, msg: WebSocketMessage) => {


### PR DESCRIPTION
#### Summary
- We were getting errors for `Popping component failed` (see https://mattermost.atlassian.net/browse/MM-46302), found that the call screen seems to "render" even after it's been popped.
- This relates to the question @enahum had about why we are rendering the call screen when the `currentCall` is `null` (https://mattermost.atlassian.net/browse/MM-46050). Now I understand why we can get to that point in the code and have a null `currentCall`. The call screen renders a few times after it's been popped, and by that time the `currentCall` has been set to `null`. So just return a null because the screen will be unmounted async shortly.
  - I am keeping the pop there, just in case, but we're ignoring the error because it's expected. 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46302
- https://mattermost.atlassian.net/browse/MM-46050

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Release Note

```release-note
NONE
```
