### PR TITLE
MM-14305: Autofocus text input if external keyboard is attached

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
@@ -141,6 +141,11 @@ public class MattermostManagedModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void isHwKeyboardActive(final Promise promise) {
+        promise.resolve(false);
+    }
+
+    @ReactMethod
     public void saveFile(String path, final Promise promise) {
         Uri contentUri;
         String filename = "";

--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -302,8 +302,14 @@ export default function PostInput({
      */
     useEffect(() => {
         (async () => {
+            if (Platform.OS !== 'ios') {
+                return;
+            }
+
             const isHwKeyboardActive = await MattermostManaged.isHwKeyboardActive();
-            if (isHwKeyboardActive && !input.current?.isFocused) {
+            const isInputAlreadyFocused = input.current?.isFocused;
+
+            if (isHwKeyboardActive && !isInputAlreadyFocused) {
                 input.current?.focus();
             }
         })();

--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -7,7 +7,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {IntlShape, useIntl} from 'react-intl';
 import {
     Alert, AppState, AppStateStatus, DeviceEventEmitter, EmitterSubscription, Keyboard,
-    KeyboardTypeOptions, NativeSyntheticEvent, Platform, TextInputSelectionChangeEventData,
+    KeyboardTypeOptions, NativeModules, NativeSyntheticEvent, Platform, TextInputSelectionChangeEventData,
 } from 'react-native';
 import HWKeyboardEvent from 'react-native-hw-keyboard-event';
 
@@ -22,6 +22,8 @@ import NavigationStore from '@store/navigation_store';
 import {extractFileInfo} from '@utils/file';
 import {switchKeyboardForCodeBlocks} from '@utils/markdown';
 import {changeOpacity, makeStyleSheetFromTheme, getKeyboardAppearanceFromTheme} from '@utils/theme';
+
+const {MattermostManaged} = NativeModules;
 
 type Props = {
     testID?: string;
@@ -294,6 +296,18 @@ export default function PostInput({
             listener.remove();
         };
     }, [handleHardwareEnterPress]);
+
+    /**
+     * Auto-focus input if hardware keyboard is connected.
+     */
+    useEffect(() => {
+        (async () => {
+            const isHwKeyboardActive = await MattermostManaged.isHwKeyboardActive();
+            if (isHwKeyboardActive && !input.current?.isFocused) {
+                input.current?.focus();
+            }
+        })();
+    }, []);
 
     return (
         <PasteableTextInput

--- a/ios/Mattermost/MattermostManaged.h
+++ b/ios/Mattermost/MattermostManaged.h
@@ -8,6 +8,7 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
+#import <GameController/GameController.h>
 
 @interface MattermostManaged : NSObject <RCTBridgeModule>
 @property (nonatomic) NSUserDefaults *sharedUserDefaults;

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -8,6 +8,7 @@
 
 #import "AppDelegate.h"
 #import "MattermostManaged.h"
+#import <GameController/GameController.h>
 
 @implementation MattermostManaged
 
@@ -57,6 +58,15 @@ RCT_EXPORT_METHOD(isRunningInSplitView:(RCTPromiseResolveBlock)resolve rejecter:
   resolve(@{
             @"isSplitView": @(!isRunningInFullScreen)
             });
+}
+
+RCT_EXPORT_METHOD(isHwKeyboardActive:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  if (@available(iOS 14.0, *)) {
+    
+    resolve(@(GCKeyboard.coalescedKeyboard != nil));
+  } else {
+    resolve(@(NO));
+  }
 }
 
 RCT_EXPORT_METHOD(deleteDatabaseDirectory: (NSString *)databaseName  shouldRemoveDirectory: (BOOL) shouldRemoveDirectory callback: (RCTResponseSenderBlock)callback){


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Adds a call to the native Obj-C method `GCKeyboard *coalescedKeyboard` to query whether an external keyboard has been connected. If so, the post input is automatically focused every time a new channel or thread is opened, similar to the behaviour on the web app.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/11811
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
iPad Mini, iOS 15.5

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Auto-focusses text input if an external keyboard is connected to iPad.
```
