### PR TITLE
MM-46301 MM-45973: Refactor currentCall logic; fix CurrentCallBar bug

### DIFF
--- a/app/products/calls/actions/calls.test.ts
+++ b/app/products/calls/actions/calls.test.ts
@@ -19,6 +19,7 @@ import {
     useCallsState,
     useChannelsWithCalls,
     useCurrentCall,
+    userJoinedCall,
 } from '@calls/state';
 import {
     Call,
@@ -88,6 +89,7 @@ const addFakeCall = (serverUrl: string, channelId: string) => {
         ownerId: 'xohi8cki9787fgiryne716u84o',
     } as Call;
     act(() => {
+        State.setCallsState(serverUrl, {serverUrl, myUserId: 'myUserId', calls: {}, enabled: {}});
         State.callStarted(serverUrl, call);
     });
 };
@@ -138,6 +140,7 @@ describe('Actions.Calls', () => {
         let response: { data?: string };
         await act(async () => {
             response = await CallsActions.joinCall('server1', 'channel-id');
+            userJoinedCall('server1', 'channel-id', 'myUserId');
         });
 
         assert.equal(response!.data, 'channel-id');
@@ -161,6 +164,7 @@ describe('Actions.Calls', () => {
         let response: { data?: string };
         await act(async () => {
             response = await CallsActions.joinCall('server1', 'channel-id');
+            userJoinedCall('server1', 'channel-id', 'myUserId');
         });
         assert.equal(response!.data, 'channel-id');
         assert.equal((result.current[1] as CurrentCall | null)?.channelId, 'channel-id');
@@ -188,6 +192,7 @@ describe('Actions.Calls', () => {
         let response: { data?: string };
         await act(async () => {
             response = await CallsActions.joinCall('server1', 'channel-id');
+            userJoinedCall('server1', 'channel-id', 'myUserId');
         });
         assert.equal(response!.data, 'channel-id');
         assert.equal((result.current[1] as CurrentCall | null)?.channelId, 'channel-id');
@@ -214,6 +219,7 @@ describe('Actions.Calls', () => {
         let response: { data?: string };
         await act(async () => {
             response = await CallsActions.joinCall('server1', 'channel-id');
+            userJoinedCall('server1', 'channel-id', 'myUserId');
         });
         assert.equal(response!.data, 'channel-id');
         assert.equal((result.current[1] as CurrentCall | null)?.channelId, 'channel-id');

--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -7,7 +7,6 @@ import {forceLogoutIfNecessary} from '@actions/remote/session';
 import {fetchUsersByIds} from '@actions/remote/user';
 import {
     getCallsConfig, getCallsState,
-    myselfJoinedCall,
     myselfLeftCall,
     setCalls,
     setChannelEnabled,
@@ -201,7 +200,6 @@ export const joinCall = async (serverUrl: string, channelId: string): Promise<{ 
 
     try {
         await connection.waitForReady();
-        myselfJoinedCall(serverUrl, channelId);
         return {data: channelId};
     } catch (e) {
         connection.disconnect();


### PR DESCRIPTION
#### Summary
- This fixes a bug reported by a community member and observed every now and then while using the app:
  - https://mattermost.atlassian.net/browse/MM-46301 happens when we try to connect to a call but the connection fails. Happens less often, now that we're sending an explicit leave ws message, but it could still happen for certain edge cases. Now we don't initialize the currentCall until we receive the userJoin event for the current user.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46301
- https://mattermost.atlassian.net/browse/MM-45973

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Release Note

```release-note
Calls: Fix for CurrentCallBar appearing when call failed to connect
```
