### PR TITLE
Fix graphQL error

### DIFF
--- a/app/client/graphQL/entry.ts
+++ b/app/client/graphQL/entry.ts
@@ -16,7 +16,7 @@ const doGQLQuery = async (serverUrl: string, query: string, variables: {[name: s
     }
 
     try {
-        const response = await client.doFetch('/api/v5/graphql', {method: 'post', body: JSON.stringify({query, variables, operationName})}) as GQLResponse;
+        const response = await client.doFetch('/api/v5/graphql', {method: 'post', body: {query, variables, operationName}}) as GQLResponse;
         return response;
     } catch (error) {
         return {error};


### PR DESCRIPTION
#### Summary
There was an error when reading the graphQL query from the server. Apparently, we didn't need to stringify the body. Not sure when this changed, since it used to work.

#### Ticket Link
None

#### Release Note
```release-note
Fix graphQL queries
```
