### PR TITLE
MM-46325: Improve Calls mobile state sync

### DIFF
--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -15,6 +15,7 @@ import {fetchMissingDirectChannelsInfo, fetchMyChannel, fetchChannelStats, fetch
 import {fetchPostsForChannel} from '@actions/remote/post';
 import {fetchRolesIfNeeded} from '@actions/remote/role';
 import {fetchUsersByIds, updateUsersNoLongerVisible} from '@actions/remote/user';
+import {loadCallForChannel} from '@calls/actions/calls';
 import {Events, Screens} from '@constants';
 import DatabaseManager from '@database/manager';
 import {queryActiveServer} from '@queries/app/servers';
@@ -293,6 +294,8 @@ export async function handleUserAddedToChannelEvent(serverUrl: string, msg: any)
                     models.push(...prepared);
                 }
             }
+
+            loadCallForChannel(serverUrl, channelId);
         } else {
             const addedUser = getUserById(database, userId);
             if (!addedUser) {

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -11,7 +11,8 @@ import {fetchStatusByIds} from '@actions/remote/user';
 import {loadConfigAndCalls} from '@calls/actions/calls';
 import {
     handleCallChannelDisabled,
-    handleCallChannelEnabled, handleCallEnded,
+    handleCallChannelEnabled,
+    handleCallEnded,
     handleCallScreenOff,
     handleCallScreenOn,
     handleCallStarted,
@@ -175,10 +176,6 @@ async function doReconnectRest(serverUrl: string, operator: ServerDataOperator, 
     const {locale: currentUserLocale} = (await getCurrentUser(database))!;
     await deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, initialTeamId, switchedToChannel ? initialChannelId : undefined);
 
-    if (isSupportedServerCalls(config?.Version)) {
-        loadConfigAndCalls(serverUrl, currentUserId);
-    }
-
     // https://mattermost.atlassian.net/browse/MM-41520
 }
 
@@ -206,6 +203,11 @@ async function doReconnect(serverUrl: string) {
         await graphQLCommon(serverUrl, true, system.currentTeamId, system.currentChannelId);
     } else {
         await doReconnectRest(serverUrl, operator, system.currentTeamId, system.currentUserId, config, license, lastDisconnectedAt);
+    }
+
+    // Calls is not set up for GraphQL yet
+    if (isSupportedServerCalls(config?.Version)) {
+        loadConfigAndCalls(serverUrl, system.currentUserId);
     }
 }
 

--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -6,7 +6,8 @@ import InCallManager from 'react-native-incall-manager';
 import {forceLogoutIfNecessary} from '@actions/remote/session';
 import {fetchUsersByIds} from '@actions/remote/user';
 import {
-    getCallsConfig, getCallsState,
+    getCallsConfig,
+    getCallsState,
     myselfLeftCall,
     setCalls,
     setChannelEnabled,
@@ -14,6 +15,7 @@ import {
     setPluginEnabled,
     setScreenShareURL,
     setSpeakerPhone,
+    setCallForChannel,
 } from '@calls/state';
 import {General, Preferences} from '@constants';
 import Calls from '@constants/calls';
@@ -33,6 +35,7 @@ import type {
     Call,
     CallParticipant,
     CallsConnection,
+    ServerCallState,
     ServerChannelState,
 } from '@calls/types/calls';
 import type {Client} from '@client/rest';
@@ -94,24 +97,7 @@ export const loadCalls = async (serverUrl: string, userId: string) => {
 
     for (const channel of resp) {
         if (channel.call) {
-            const call = channel.call;
-            callsResults[channel.channel_id] = {
-                participants: channel.call.users.reduce((accum, cur, curIdx) => {
-                    // Add the id to the set of UserModels we want to ensure are loaded.
-                    ids.add(cur);
-
-                    // Create the CallParticipant
-                    const muted = call.states && call.states[curIdx] ? !call.states[curIdx].unmuted : true;
-                    const raisedHand = call.states && call.states[curIdx] ? call.states[curIdx].raised_hand : 0;
-                    accum[cur] = {id: cur, muted, raisedHand};
-                    return accum;
-                }, {} as Dictionary<CallParticipant>),
-                channelId: channel.channel_id,
-                startTime: call.start_at,
-                screenOn: call.screen_sharing_id,
-                threadId: call.thread_id,
-                ownerId: call.owner_id,
-            };
+            callsResults[channel.channel_id] = createCallAndAddToIds(channel.channel_id, channel.call, ids);
         }
         enabledChannels[channel.channel_id] = channel.enabled;
     }
@@ -124,6 +110,58 @@ export const loadCalls = async (serverUrl: string, userId: string) => {
     setCalls(serverUrl, userId, callsResults, enabledChannels);
 
     return {data: {calls: callsResults, enabled: enabledChannels}};
+};
+
+export const loadCallForChannel = async (serverUrl: string, channelId: string) => {
+    let client: Client;
+    try {
+        client = NetworkManager.getClient(serverUrl);
+    } catch (error) {
+        return {error};
+    }
+
+    let resp: ServerChannelState;
+    try {
+        resp = await client.getCallForChannel(channelId);
+    } catch (error) {
+        await forceLogoutIfNecessary(serverUrl, error as ClientError);
+        return {error};
+    }
+
+    let call: Call | undefined;
+    const ids = new Set<string>();
+    if (resp.call) {
+        call = createCallAndAddToIds(channelId, resp.call, ids);
+    }
+
+    // Batch load user models async because we'll need them later
+    if (ids.size > 0) {
+        fetchUsersByIds(serverUrl, Array.from(ids));
+    }
+
+    setCallForChannel(serverUrl, channelId, resp.enabled, call);
+
+    return {data: {call, enabled: resp.enabled}};
+};
+
+const createCallAndAddToIds = (channelId: string, call: ServerCallState, ids: Set<string>) => {
+    return {
+        participants: call.users.reduce((accum, cur, curIdx) => {
+            // Add the id to the set of UserModels we want to ensure are loaded.
+            ids.add(cur);
+
+            // Create the CallParticipant
+            const muted = call.states && call.states[curIdx] ? !call.states[curIdx].unmuted : true;
+            const raisedHand = call.states && call.states[curIdx] ? call.states[curIdx].raised_hand : 0;
+            accum[cur] = {id: cur, muted, raisedHand};
+            return accum;
+        }, {} as Dictionary<CallParticipant>),
+        channelId,
+        startTime: call.start_at,
+        screenOn: call.screen_sharing_id,
+        threadId: call.thread_id,
+        ownerId: call.owner_id,
+    } as Call;
 };
 
 export const loadConfigAndCalls = async (serverUrl: string, userId: string) => {

--- a/app/products/calls/client/rest.ts
+++ b/app/products/calls/client/rest.ts
@@ -6,6 +6,7 @@ import type {ServerChannelState, ServerCallsConfig, ApiResp, ICEServersConfigs} 
 export interface ClientCallsMix {
     getEnabled: () => Promise<Boolean>;
     getCalls: () => Promise<ServerChannelState[]>;
+    getCallForChannel: (channelId: string) => Promise<ServerChannelState>;
     getCallsConfig: () => Promise<ServerCallsConfig>;
     enableChannelCalls: (channelId: string, enable: boolean) => Promise<ServerChannelState>;
     endCall: (channelId: string) => Promise<ApiResp>;
@@ -28,6 +29,13 @@ const ClientCalls = (superclass: any) => class extends superclass {
     getCalls = async () => {
         return this.doFetch(
             `${this.getCallsRoute()}/channels`,
+            {method: 'get'},
+        );
+    };
+
+    getCallForChannel = async (channelId: string) => {
+        return this.doFetch(
+            `${this.getCallsRoute()}/${channelId}`,
             {method: 'get'},
         );
     };


### PR DESCRIPTION
#### Summary
This is an important improvement:
- Reconnect wasn't working (we were missing servers that have GraphQL enabled)
- We are now fetching the channel call state when joining a channel. This fixes the weird state noted in the ticket.
  - Note: this is the mobile-friendly version of what the webapp does (which is to fetch the current channel's call state whenever you switch to that channel). We're relying on websocket events to keep our channel state up to date on mobile.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46325

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
NONE
```
