### PR TITLE
MM-46228 - Calls: endcall should not send the slash command

### DIFF
--- a/app/components/post_draft/send_handler/send_handler.tsx
+++ b/app/components/post_draft/send_handler/send_handler.tsx
@@ -175,8 +175,9 @@ export default function SendHandler({
     const sendCommand = useCallback(async () => {
         if (value.trim() === '/call end') {
             await handleEndCall();
-
-            // NOTE: fallthrough because the server may want to handle the command as well
+            setSendingMessage(false);
+            clearDraft();
+            return;
         }
 
         const status = DraftUtils.getStatusFromSlashCommand(value);


### PR DESCRIPTION
#### Summary
- We were "falling through" the slash command, but we shouldn't because the user could cancel their end call command in the dialog box. So just stop the slash command from being sent, since we do all the end call logic client side anyway.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46228

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Release Note
```release-note
NONE
```
