### PR TITLE
MM-46465 - Calls: Fix for unable to see >1 participant speaking at same time

### DIFF
--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -257,6 +257,7 @@ const CallScreen = ({componentId, currentCall, participantsDict, teammateNameDis
     const myParticipant = currentCall?.participants[currentCall.myUserId];
     const style = getStyleSheet(theme);
     const showControls = !isLandscape || showControlsInLandscape;
+    const [speakers, setSpeakers] = useState<Dictionary<boolean>>({});
 
     useEffect(() => {
         mergeNavigationOptions('Call', {
@@ -269,16 +270,19 @@ const CallScreen = ({componentId, currentCall, participantsDict, teammateNameDis
         });
     }, []);
 
-    const [speaker, setSpeaker] = useState('');
     useEffect(() => {
         const handleVoiceOn = (data: VoiceEventData) => {
             if (data.channelId === currentCall?.channelId) {
-                setSpeaker(data.userId);
+                setSpeakers((prev) => ({...prev, [data.userId]: true}));
             }
         };
         const handleVoiceOff = (data: VoiceEventData) => {
-            if (data.channelId === currentCall?.channelId && ((speaker === data.userId) || !speaker)) {
-                setSpeaker('');
+            if (data.channelId === currentCall?.channelId && speakers.hasOwnProperty(data.userId) && speakers[data.userId]) {
+                setSpeakers((prev) => {
+                    const next = {...prev};
+                    delete next[data.userId];
+                    return next;
+                });
             }
         };
 
@@ -424,7 +428,7 @@ const CallScreen = ({componentId, currentCall, participantsDict, teammateNameDis
                             >
                                 <CallAvatar
                                     userModel={user.userModel}
-                                    volume={speaker === user.id ? 1 : 0}
+                                    volume={speakers[user.id] ? 1 : 0}
                                     muted={user.muted}
                                     sharingScreen={user.id === currentCall.screenOn}
                                     raisedHand={Boolean(user.raisedHand)}


### PR DESCRIPTION
#### Summary
- Finished the load test behavior simulator, which made me realize we only allow one speaker to be highlighted at once on mobile. So fixing that.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46465

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Screenshots
- Before:
<img width="229" alt="image" src="https://user-images.githubusercontent.com/1490756/185482728-2d18d2e1-6126-4dec-b62f-b4aadc8564ad.png">

- After:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/1490756/185482536-d0329778-a36c-479f-8a94-3d71f90f2426.png">


#### Release Note
```release-note
Calls: Display speaking indicator for multiple participants at the same time
```
