### PR TITLE
fix option box minHeight so that it fits on iPhone SE

### DIFF
--- a/app/components/option_box/animated.tsx
+++ b/app/components/option_box/animated.tsx
@@ -31,7 +31,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         borderRadius: 4,
         flex: 1,
         maxHeight: OPTIONS_HEIGHT,
-        minWidth: 80,
+        minWidth: 60,
     },
     background: {
         backgroundColor: changeOpacity(theme.centerChannelColor, 0.04),

--- a/app/components/option_box/index.tsx
+++ b/app/components/option_box/index.tsx
@@ -33,7 +33,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         flex: 1,
         maxHeight: OPTIONS_HEIGHT,
         justifyContent: 'center',
-        minWidth: 80,
+        minWidth: 60,
     },
     destructiveContainer: {
         backgroundColor: changeOpacity(theme.dndIndicator, 0.04),


### PR DESCRIPTION
#### Summary
As discussed in #6578 the OptionBox component is now using 60 as minWidth in order to fit on an iPhone SE

#### Screenshots
![image](https://user-images.githubusercontent.com/6757047/185905404-9fdeb99f-bf15-48f1-be03-d4b20b3ae67a.png)

![image](https://user-images.githubusercontent.com/6757047/185905465-1cc9090a-6e79-48b0-9d29-1c133bbb6e01.png)


```release-note
NONE
```
