### PR TITLE
Make it so a space after autocomplete channels and users closes the autocomplete

### DIFF
--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -146,3 +146,7 @@ export const pluckUnique = (key: string) => (array: Array<{[key: string]: unknow
 export function bottomSheetSnapPoint(itemsCount: number, itemHeight: number, bottomInset = 0) {
     return ((itemsCount + Platform.select({android: 1, default: 0})) * itemHeight) + (bottomInset * 2.5);
 }
+
+export function hasTrailingSpaces(term: string) {
+    return term.length !== term.trimEnd().length;
+}


### PR DESCRIPTION
#### Summary
This brings the way it worked on V1 and web. Since originally we were using redux, we were filtering always the redux results. Now we are using the data provided by the server, so we only filter when there is a trailing space, since the server apparently trim the spaces of the term for the search.

This adds an extra filtering that could be done at the server, but 0/5.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45279

#### Release Note
```release-note
Autocomplete now closes after a space if there are no more results.
```
