### PR TITLE
[MM-2287] change emoji picker logic/ui

### DIFF
--- a/app/components/emoji_picker/filtered/index.tsx
+++ b/app/components/emoji_picker/filtered/index.tsx
@@ -3,7 +3,8 @@
 
 import Fuse from 'fuse.js';
 import React, {useCallback, useMemo} from 'react';
-import {FlatList, ListRenderItemInfo, StyleSheet, View} from 'react-native';
+import {ListRenderItemInfo, StyleSheet, View} from 'react-native';
+import {FlatList} from 'react-native-gesture-handler';
 
 import NoResultsWithTerm from '@components/no_results_with_term';
 import {getEmojis, searchEmojis} from '@utils/emoji/helpers';

--- a/app/components/emoji_picker/index.tsx
+++ b/app/components/emoji_picker/index.tsx
@@ -4,7 +4,7 @@
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 import React, {useCallback, useState} from 'react';
-import {LayoutChangeEvent, Platform, StyleSheet, View} from 'react-native';
+import {LayoutChangeEvent, NativeSyntheticEvent, StyleSheet, TextInputFocusEventData, View} from 'react-native';
 import {Edge, SafeAreaView} from 'react-native-safe-area-context';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
@@ -36,12 +36,9 @@ const styles = StyleSheet.create({
     },
     container: {
         flex: 1,
-        marginHorizontal: 12,
     },
     searchBar: {
         paddingVertical: 5,
-        marginLeft: 12,
-        marginRight: Platform.select({ios: 4, default: 12}),
     },
 });
 
@@ -49,12 +46,13 @@ type Props = {
     customEmojis: CustomEmojiModel[];
     customEmojisEnabled: boolean;
     onEmojiPress: (emoji: string) => void;
+    onSearchFocus?: ((e: NativeSyntheticEvent<TextInputFocusEventData>) => void) | undefined;
     recentEmojis: string[];
     skinTone: string;
     testID?: string;
 }
 
-const EmojiPicker = ({customEmojis, customEmojisEnabled, onEmojiPress, recentEmojis, skinTone, testID = ''}: Props) => {
+const EmojiPicker = ({customEmojis, customEmojisEnabled, onEmojiPress, onSearchFocus, recentEmojis, skinTone, testID = ''}: Props) => {
     const theme = useTheme();
     const serverUrl = useServerUrl();
     const keyboardHeight = useKeyboardHeight();
@@ -107,6 +105,7 @@ const EmojiPicker = ({customEmojis, customEmojisEnabled, onEmojiPress, recentEmo
                     autoCapitalize='none'
                     keyboardAppearance={getKeyboardAppearanceFromTheme(theme)}
                     onCancel={onCancelSearch}
+                    onFocus={onSearchFocus}
                     onChangeText={onChangeSearchTerm}
                     testID={`${testID}.search_bar`}
                     value={searchTerm}

--- a/app/components/emoji_picker/sections/icons_bar/icon.tsx
+++ b/app/components/emoji_picker/sections/icons_bar/icon.tsx
@@ -22,6 +22,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         flex: 1,
         justifyContent: 'center',
         zIndex: 10,
+        borderRadius: 4,
+        overflow: 'hidden',
     },
     icon: {
         fontSize: 18,
@@ -29,9 +31,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         padding: 8,
     },
     selected: {
-        borderRadius: 4,
-        borderWidth: 1,
-        borderColor: changeOpacity(theme.buttonBg, 0.08),
         backgroundColor: changeOpacity(theme.buttonBg, 0.08),
         color: theme.buttonBg,
     },

--- a/app/components/emoji_picker/sections/icons_bar/icon.tsx
+++ b/app/components/emoji_picker/sections/icons_bar/icon.tsx
@@ -20,15 +20,20 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     container: {
         alignItems: 'center',
         flex: 1,
-        height: 35,
         justifyContent: 'center',
         zIndex: 10,
     },
     icon: {
+        fontSize: 18,
         color: changeOpacity(theme.centerChannelColor, 0.4),
+        padding: 8,
     },
     selected: {
-        color: theme.centerChannelColor,
+        borderRadius: 4,
+        borderWidth: 1,
+        borderColor: changeOpacity(theme.buttonBg, 0.08),
+        backgroundColor: changeOpacity(theme.buttonBg, 0.08),
+        color: theme.buttonBg,
     },
 }));
 
@@ -43,7 +48,6 @@ const SectionIcon = ({currentIndex, icon, index, scrollToIndex, theme}: Props) =
         >
             <CompassIcon
                 name={icon}
-                size={20}
                 style={[style.icon, currentIndex === index ? style.selected : undefined]}
             />
         </TouchableOpacity>

--- a/app/components/emoji_picker/sections/icons_bar/index.tsx
+++ b/app/components/emoji_picker/sections/icons_bar/index.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 import {View} from 'react-native';
-import {KeyboardTrackingView} from 'react-native-keyboard-tracking-view';
 
+import {Device} from '@app/constants';
 import {useTheme} from '@context/theme';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
@@ -14,23 +14,16 @@ export const SCROLLVIEW_NATIVE_ID = 'emojiSelector';
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     container: {
-        bottom: 10,
-        height: 35,
-        position: 'absolute',
-        width: '100%',
-    },
-    background: {
+        alignItems: 'center',
         backgroundColor: theme.centerChannelBg,
-    },
-    pane: {
+        borderColor: changeOpacity(theme.centerChannelColor, 0.08),
+        borderTopWidth: 1,
+        bottom: 0,
         flexDirection: 'row',
-        borderRadius: 10,
-        paddingHorizontal: 10,
-        width: '100%',
-        borderColor: changeOpacity(theme.centerChannelColor, 0.3),
-        backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
-        borderWidth: 1,
+        height: Device.IS_TABLET ? 55 : 43,
         justifyContent: 'space-between',
+        width: '100%',
+        position: 'absolute',
     },
 }));
 
@@ -49,27 +42,22 @@ const EmojiSectionBar = ({currentIndex, sections, scrollToIndex}: Props) => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
     return (
-        <KeyboardTrackingView
-            scrollViewNativeID={SCROLLVIEW_NATIVE_ID}
-            normalList={true}
+        <View
+            nativeID={SCROLLVIEW_NATIVE_ID}
             style={styles.container}
             testID='emoji_picker.emoji_sections.section_bar'
         >
-            <View style={styles.background}>
-                <View style={styles.pane}>
-                    {sections.map((section, index) => (
-                        <SectionIcon
-                            currentIndex={currentIndex}
-                            key={section.key}
-                            icon={section.icon}
-                            index={index}
-                            scrollToIndex={scrollToIndex}
-                            theme={theme}
-                        />
-                    ))}
-                </View>
-            </View>
-        </KeyboardTrackingView>
+            {sections.map((section, index) => (
+                <SectionIcon
+                    currentIndex={currentIndex}
+                    key={section.key}
+                    icon={section.icon}
+                    index={index}
+                    scrollToIndex={scrollToIndex}
+                    theme={theme}
+                />
+            ))}
+        </View>
     );
 };
 

--- a/app/components/emoji_picker/sections/index.tsx
+++ b/app/components/emoji_picker/sections/index.tsx
@@ -19,8 +19,9 @@ import TouchableEmoji from './touchable_emoji';
 
 import type CustomEmojiModel from '@typings/database/models/servers/custom_emoji';
 
-export const EMOJI_SIZE = 30;
+export const EMOJI_SIZE = 32;
 export const EMOJI_GUTTER = 8;
+export const EMOJI_FULL_SIZE = EMOJI_SIZE + EMOJI_GUTTER;
 
 const ICONS: Record<string, string> = {
     recent: 'clock-outline',
@@ -48,9 +49,8 @@ const styles = StyleSheet.create(({
         marginBottom: EMOJI_GUTTER,
     },
     emoji: {
-        height: EMOJI_SIZE + EMOJI_GUTTER,
-        marginHorizontal: 7,
-        width: EMOJI_SIZE + EMOJI_GUTTER,
+        height: EMOJI_FULL_SIZE,
+        minWidth: EMOJI_FULL_SIZE,
     },
 }));
 
@@ -81,11 +81,12 @@ const EmojiSections = ({customEmojis, customEmojisEnabled, onEmojiPress, recentE
     const [fetchingCustomEmojis, setFetchingCustomEmojis] = useState(false);
     const [loadedAllCustomEmojis, setLoadedAllCustomEmojis] = useState(false);
 
+    const chunkSize = Math.floor(width / EMOJI_FULL_SIZE);
+
     const sections: EmojiSection[] = useMemo(() => {
         if (!width) {
             return [];
         }
-        const chunkSize = Math.floor(width / (EMOJI_SIZE + EMOJI_GUTTER));
 
         return CategoryNames.map((category) => {
             const emojiIndices = EmojiIndicesByCategory.get(skinTone)?.get(category);
@@ -193,7 +194,7 @@ const EmojiSections = ({customEmojis, customEmojisEnabled, onEmojiPress, recentE
     const renderItem = useCallback(({item}: ListRenderItemInfo<EmojiAlias[]>) => {
         return (
             <View style={styles.row}>
-                {item.map((emoji: EmojiAlias) => {
+                {item.map((emoji) => {
                     return (
                         <TouchableEmoji
                             key={emoji.name}

--- a/app/components/post_list/post/body/reactions/reactions.tsx
+++ b/app/components/post_list/post/body/reactions/reactions.tsx
@@ -12,7 +12,7 @@ import {MAX_ALLOWED_REACTIONS} from '@constants/emoji';
 import {useServerUrl} from '@context/server';
 import {useIsTablet} from '@hooks/device';
 import useDidUpdate from '@hooks/did_update';
-import {bottomSheetModalOptions, showModal, showModalOverCurrentContext} from '@screens/navigation';
+import {bottomSheetModalOptions, openAsBottomSheet, showModal, showModalOverCurrentContext} from '@screens/navigation';
 import {getEmojiFirstAlias} from '@utils/emoji/helpers';
 import {preventDoubleTap} from '@utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
@@ -111,16 +111,20 @@ const Reactions = ({currentUserId, canAddReaction, canRemoveReaction, disabled, 
         addReaction(serverUrl, postId, emoji);
     };
 
-    const handleAddReaction = useCallback(preventDoubleTap(() => {
+    const handleAddReaction = useCallback(preventDoubleTap(async () => {
+        const closeButtonId = 'close-emoji-picker';
+        const screen = Screens.EMOJI_PICKER;
         const title = intl.formatMessage({id: 'mobile.post_info.add_reaction', defaultMessage: 'Add Reaction'});
-
         const closeButton = CompassIcon.getImageSourceSync('close', 24, theme.sidebarHeaderTextColor);
         const passProps = {
+            sourceScreen: Screens.REACTIONS,
             closeButton,
+            closeButtonId,
             onEmojiPress: handleAddReactionToPost,
+            location: screen,
         };
 
-        showModal(Screens.EMOJI_PICKER, title, passProps);
+        openAsBottomSheet({closeButtonId, screen, props: passProps, title, theme});
     }), [intl, theme]);
 
     const handleReactionPress = useCallback(async (emoji: string, remove: boolean) => {

--- a/app/constants/screens.ts
+++ b/app/constants/screens.ts
@@ -132,7 +132,6 @@ export const MODAL_SCREENS_WITHOUT_BACK = new Set<string>([
     EDIT_POST,
     EDIT_PROFILE,
     EDIT_SERVER,
-    EMOJI_PICKER,
     FIND_CHANNELS,
     GALLERY,
     PERMALINK,

--- a/app/screens/bottom_sheet/index.tsx
+++ b/app/screens/bottom_sheet/index.tsx
@@ -31,6 +31,7 @@ export interface BottomSheetRef {
     snapTo: (index: number) => void;
 }
 
+export const CONTAINER_PADDING_HORIZONTAL = 20;
 export const PADDING_TOP_MOBILE = 20;
 
 const BottomSheet = forwardRef<BottomSheetRef, SlideUpPanelProps>(({closeButtonId, componentId, initialSnapIndex = 0, renderContent, snapPoints = ['90%', '50%', 50], testID}: SlideUpPanelProps, ref) => {
@@ -135,7 +136,7 @@ const BottomSheet = forwardRef<BottomSheetRef, SlideUpPanelProps>(({closeButtonI
             style={{
                 backgroundColor: theme.centerChannelBg,
                 opacity: 1,
-                paddingHorizontal: 20,
+                paddingHorizontal: CONTAINER_PADDING_HORIZONTAL,
                 paddingTop: isTablet ? 0 : PADDING_TOP_MOBILE,
                 height: '100%',
                 width: isTablet ? '100%' : Math.min(dimensions.width, 450),

--- a/app/screens/custom_status/index.tsx
+++ b/app/screens/custom_status/index.tsx
@@ -22,7 +22,7 @@ import {withServerUrl} from '@context/server';
 import {withTheme} from '@context/theme';
 import {observeConfig, observeRecentCustomStatus} from '@queries/servers/system';
 import {observeCurrentUser} from '@queries/servers/user';
-import {dismissModal, goToScreen, showModal} from '@screens/navigation';
+import {dismissModal, goToScreen, openAsBottomSheet, showModal} from '@screens/navigation';
 import NavigationStore from '@store/navigation_store';
 import {getCurrentMomentForTimezone, getRoundedTime, isCustomStatusExpirySupported} from '@utils/helpers';
 import {logDebug} from '@utils/log';
@@ -286,10 +286,10 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
         const {theme, intl} = this.props;
         CompassIcon.getImageSource('close', 24, theme.sidebarHeaderTextColor).then((source) => {
             const screen = Screens.EMOJI_PICKER;
+            const closeButtonId = 'close-emoji-picker';
             const title = intl.formatMessage({id: 'mobile.custom_status.choose_emoji', defaultMessage: 'Choose an emoji'});
             const passProps = {closeButton: source, onEmojiPress: this.handleEmojiClick};
-
-            showModal(screen, title, passProps);
+            openAsBottomSheet({closeButtonId, screen, props: passProps, title, theme});
         });
     });
 

--- a/app/screens/emoji_picker/index.tsx
+++ b/app/screens/emoji_picker/index.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useEffect, useRef} from 'react';
-import {Keyboard} from 'react-native';
+import {View, Keyboard, StyleSheet} from 'react-native';
 import RNBottomSheet from 'reanimated-bottom-sheet';
 
 import {Device, Screens} from '@app/constants';
@@ -10,7 +10,13 @@ import EmojiPicker from '@components/emoji_picker';
 import useNavButtonPressed from '@hooks/navigation_button_pressed';
 import {dismissBottomSheet, dismissModal, setButtons} from '@screens/navigation';
 
-import BottomSheet from '../bottom_sheet';
+import BottomSheet, {CONTAINER_PADDING_HORIZONTAL} from '../bottom_sheet';
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1, paddingHorizontal: CONTAINER_PADDING_HORIZONTAL,
+    },
+});
 
 type Props = {
     componentId: string;
@@ -53,13 +59,13 @@ const EmojiPickerScreen = ({closeButton, componentId, onEmojiPress}: Props) => {
         close();
     }, []);
 
-    const onSearchFocus = () => {
+    const onSearchFocus = useCallback(() => {
         if (!Device.IS_TABLET) {
             bottomSheetRef?.current?.snapTo(0);
         }
-    };
+    }, []);
 
-    const renderContent = () => {
+    const renderContent = useCallback(() => {
         return (
             <EmojiPicker
                 onEmojiPress={handleEmojiPress}
@@ -67,7 +73,15 @@ const EmojiPickerScreen = ({closeButton, componentId, onEmojiPress}: Props) => {
                 testID='emoji_picker'
             />
         );
-    };
+    }, []);
+
+    if (Device.IS_TABLET) {
+        return (
+            <View style={styles.container}>
+                {renderContent()}
+            </View>
+        );
+    }
 
     return (
         <BottomSheet

--- a/app/screens/post_options/reaction_bar/reaction_bar.tsx
+++ b/app/screens/post_options/reaction_bar/reaction_bar.tsx
@@ -58,10 +58,10 @@ const ReactionBar = ({recentEmojis = [], postId}: QuickReactionProps) => {
         await dismissBottomSheet(Screens.POST_OPTIONS);
 
         const closeButton = CompassIcon.getImageSourceSync('close', 24, theme.sidebarHeaderTextColor);
-        const title = intl.formatMessage({id: 'mobile.post_info.add_reaction', defaultMessage: 'Add Reaction'});
-        const passProps = {closeButton, onEmojiPress: handleEmojiPress};
         const closeButtonId = 'close-emoji-picker';
+        const passProps = {closeButton, onEmojiPress: handleEmojiPress};
         const screen = Screens.EMOJI_PICKER;
+        const title = intl.formatMessage({id: 'mobile.post_info.add_reaction', defaultMessage: 'Add Reaction'});
         openAsBottomSheet({closeButtonId, screen, props: passProps, title, theme});
     }, [intl, theme]);
 

--- a/app/screens/post_options/reaction_bar/reaction_bar.tsx
+++ b/app/screens/post_options/reaction_bar/reaction_bar.tsx
@@ -18,7 +18,7 @@ import {
 } from '@constants/reaction_picker';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
-import {dismissBottomSheet, showModal} from '@screens/navigation';
+import {openAsBottomSheet, dismissBottomSheet} from '@screens/navigation';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 
 import PickReaction from './pick_reaction';
@@ -58,11 +58,11 @@ const ReactionBar = ({recentEmojis = [], postId}: QuickReactionProps) => {
         await dismissBottomSheet(Screens.POST_OPTIONS);
 
         const closeButton = CompassIcon.getImageSourceSync('close', 24, theme.sidebarHeaderTextColor);
-        const screen = Screens.EMOJI_PICKER;
         const title = intl.formatMessage({id: 'mobile.post_info.add_reaction', defaultMessage: 'Add Reaction'});
         const passProps = {closeButton, onEmojiPress: handleEmojiPress};
-
-        showModal(screen, title, passProps);
+        const closeButtonId = 'close-emoji-picker';
+        const screen = Screens.EMOJI_PICKER;
+        openAsBottomSheet({closeButtonId, screen, props: passProps, title, theme});
     }, [intl, theme]);
 
     let containerSize = LARGE_CONTAINER_SIZE;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
Change of emoji picker structure, replace component to bottomSheet implementation, added lol
-->

#### Ticket Link
JIRA ticket: https://mattermost.atlassian.net/browse/MM-22847

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
Emulators: IPad 12,9 inch (5th generation), Iphone 13mini, Iphone 13 Pro Max

#### Screenshots
![image](https://user-images.githubusercontent.com/20551843/186035290-26f7f7f3-3d3a-4e7c-9440-3d36cf44cfd2.png)![image](https://user-images.githubusercontent.com/20551843/186035594-4bd6cc97-8dc3-49a2-b1f4-eab2ae944071.png)
#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
- [x] Typing in the search field triggers the autocomplete items to replace the grid of emojis
- [x] If opening the emoji picker from the long press menu, the long press menu will slide down, then the emoji picker bottom sheet will slide up
- [x] Tablet layout opens in a modal rather than a bottom sheet (bottom sheets are much less common on tablet)
- [x] Tapping search also opens the modal at full-height and opens the keyboard
- [x] Tapping on the ‘add reaction’ icon on any post opens up the emoji picker initially at half-height
- [x] Swiping the modal up will open it up in full-height (similar to Slack behaviour)
- [x] Use the new modal style we’re currently using for long-press post actions
```

```release-note
NONE
```
-->

```release-note
There are a few unsolved issues:
1. Bottom sheet doesn't allow to render static absolute component at the bottom. There is a problem to display emoji section in case of initial render.
2. openAsBottomSheet has no props to modify standard UI of the window.
3. Backdrop background of EmojiPicker disappears in case of change snap point to initial one after full height size.
4. (fixed) App freezes after close modal (known issue for bottom sheet library)
 
```
P.S. @enahum I'm aware about leftovers, but unfortunately it's out of scope 4-6 hours, we can discuss it after review or before. Thank You.