### PR TITLE
Gekidou: MM-46531 - CRT observe post and load new threads on load

### DIFF
--- a/app/screens/global_threads/threads_list/thread/index.ts
+++ b/app/screens/global_threads/threads_list/thread/index.ts
@@ -7,6 +7,7 @@ import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observeChannel} from '@queries/servers/channel';
+import {observePost} from '@queries/servers/post';
 import {observeUser} from '@queries/servers/user';
 
 import Thread from './thread';
@@ -15,7 +16,7 @@ import type {WithDatabaseArgs} from '@typings/database/database';
 import type ThreadModel from '@typings/database/models/servers/thread';
 
 const enhanced = withObservables([], ({database, thread}: WithDatabaseArgs & {thread: ThreadModel}) => {
-    const post = thread.post.observe();
+    const post = observePost(database, thread.id);
     return {
         post,
         thread: thread.observe(),

--- a/app/screens/global_threads/threads_list/thread/thread.tsx
+++ b/app/screens/global_threads/threads_list/thread/thread.tsx
@@ -142,6 +142,10 @@ const Thread = ({author, channel, location, post, teammateNameDisplay, testID, t
         }
     }, [isTablet, theme, thread]);
 
+    if (!post || !channel) {
+        return null;
+    }
+
     const threadStarterName = displayUsername(author, intl.locale, teammateNameDisplay);
     const threadItemTestId = `${testID}.thread_item.${thread.id}`;
 
@@ -219,7 +223,7 @@ const Thread = ({author, channel, location, post, teammateNameDisplay, testID, t
                     <View style={styles.header}>
                         <View style={styles.headerInfoContainer}>
                             {name}
-                            {channel && threadStarterName !== channel?.displayName && (
+                            {threadStarterName !== channel?.displayName && (
                                 <View style={styles.channelNameContainer}>
                                     <Text
                                         style={styles.channelName}

--- a/app/screens/global_threads/threads_list/threads_list.tsx
+++ b/app/screens/global_threads/threads_list/threads_list.tsx
@@ -4,7 +4,7 @@
 import React, {useCallback, useEffect, useMemo, useState, useRef} from 'react';
 import {FlatList, ListRenderItemInfo, StyleSheet} from 'react-native';
 
-import {fetchRefreshThreads, fetchThreads} from '@actions/remote/thread';
+import {fetchNewThreads, fetchRefreshThreads, fetchThreads} from '@actions/remote/thread';
 import Loading from '@components/loading';
 import {General, Screens} from '@constants';
 import {useServerUrl} from '@context/server';
@@ -66,7 +66,7 @@ const ThreadsList = ({
     const lastThread = threads?.length > 0 ? threads[threads.length - 1] : null;
 
     useEffect(() => {
-        // this is to be called only when there are no threads
+        // This is to be called only when there are no threads
         if (tab === 'all' && noThreads && !hasFetchedOnce.current) {
             setIsLoading(true);
             fetchThreads(serverUrl, teamId).finally(() => {
@@ -74,7 +74,14 @@ const ThreadsList = ({
                 setIsLoading(false);
             });
         }
-    }, [noThreads, tab]);
+    }, [noThreads, serverUrl, tab]);
+
+    useEffect(() => {
+        // This is to be called when threads already exist locally and to fetch the latest threads
+        if (!noThreads) {
+            fetchNewThreads(serverUrl, teamId);
+        }
+    }, [noThreads, serverUrl, teamId]);
 
     const listEmptyComponent = useMemo(() => {
         if (isLoading) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes the following:
1. Observing the post instead of relatively fetching it to avoid the crashes
2. Loads the newest threads on global threads loading
3. Doesn't render the thread item when a post or channel data doesn't exist (As we are not clearing the threads when the user leaves the channel)

NOTE: Clearing of threads when the user leaves the channel will be addressed in a different PR. This PR only avoids the crashes by not rendering the thread item.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46531
https://mattermost.atlassian.net/browse/MM-46098

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 15.5

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
NONE
```
