### PR TITLE
Use database data to show users autocomplete

### DIFF
--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -3,12 +3,12 @@
 
 import {Model} from '@nozbe/watermelondb';
 
-import {fetchMissingDirectChannelsInfo, fetchMyChannelsForTeam, MyChannelsRequest} from '@actions/remote/channel';
+import {fetchMissingDirectChannelsInfo, fetchMyChannelsForTeam, getAllChannelMembers, MyChannelsRequest} from '@actions/remote/channel';
 import {fetchPostsForUnreadChannels} from '@actions/remote/post';
 import {MyPreferencesRequest, fetchMyPreferences} from '@actions/remote/preference';
 import {fetchRoles} from '@actions/remote/role';
 import {fetchConfigAndLicense} from '@actions/remote/systems';
-import {fetchAllTeams, fetchMyTeams, fetchTeamsChannelsAndUnreadPosts, MyTeamsRequest} from '@actions/remote/team';
+import {fetchAllTeams, fetchMyTeams, fetchTeamsChannelsAndUnreadPosts, getAllTeamMembers, MyTeamsRequest} from '@actions/remote/team';
 import {fetchNewThreads} from '@actions/remote/thread';
 import {fetchMe, MyUserRequest, updateAllUsersSince} from '@actions/remote/user';
 import {gqlAllChannels} from '@client/graphQL/entry';
@@ -316,6 +316,14 @@ export async function deferredAppEntryActions(
 
     // Fetch groups for current user
     fetchGroupsForMember(serverUrl, currentUserId);
+
+    if (initialTeamId) {
+        getAllTeamMembers(serverUrl, initialTeamId);
+    }
+
+    if (initialChannelId) {
+        getAllChannelMembers(serverUrl, initialChannelId);
+    }
 
     setTimeout(async () => {
         if (channelsToFetchProfiles?.size) {

--- a/app/actions/websocket/teams.ts
+++ b/app/actions/websocket/teams.ts
@@ -14,7 +14,7 @@ import DatabaseManager from '@database/manager';
 import {getActiveServerUrl} from '@queries/app/servers';
 import {prepareCategories, prepareCategoryChannels} from '@queries/servers/categories';
 import {prepareMyChannelsForTeam} from '@queries/servers/channel';
-import {getCurrentTeam, getLastTeam, prepareMyTeams} from '@queries/servers/team';
+import {deleteTeamMembership, getCurrentTeam, getLastTeam, prepareMyTeams} from '@queries/servers/team';
 import {getCurrentUser} from '@queries/servers/user';
 import {dismissAllModals, popToRoot, resetToTeams} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
@@ -60,6 +60,8 @@ export async function handleLeaveTeamEvent(serverUrl: string, msg: WebSocketMess
                 resetToTeams();
             }
         }
+    } else {
+        deleteTeamMembership(database.operator, userId, teamId, false);
     }
 }
 

--- a/app/components/autocomplete/autocomplete_section_header.tsx
+++ b/app/components/autocomplete/autocomplete_section_header.tsx
@@ -34,7 +34,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
 type Props = {
     defaultMessage: string;
     id: string;
-    loading: boolean;
+    loading?: boolean;
 }
 
 const AutocompleteSectionHeader = ({

--- a/app/database/operator/server_data_operator/handlers/channel.test.ts
+++ b/app/database/operator/server_data_operator/handlers/channel.test.ts
@@ -310,6 +310,7 @@ describe('*** Operator: Channel Handlers tests ***', () => {
         expect(spyOnHandleRecords).toHaveBeenCalledWith({
             fieldName: 'user_id',
             createOrUpdateRawValues: channelMemberships,
+            deleteRawValues: [],
             tableName: 'ChannelMembership',
             prepareRecordsOnly: false,
             buildKeyRecordBy: buildChannelMembershipKey,

--- a/app/database/operator/server_data_operator/handlers/team.test.ts
+++ b/app/database/operator/server_data_operator/handlers/team.test.ts
@@ -94,6 +94,7 @@ describe('*** Operator: Team Handlers tests ***', () => {
         expect(spyOnHandleRecords).toHaveBeenCalledWith({
             fieldName: 'user_id',
             createOrUpdateRawValues: memberships,
+            deleteRawValues: [],
             tableName: 'TeamMembership',
             prepareRecordsOnly: false,
             buildKeyRecordBy: buildTeamMembershipKey,

--- a/app/screens/home/search/team_picker_icon/search_team_slideup.tsx
+++ b/app/screens/home/search/team_picker_icon/search_team_slideup.tsx
@@ -3,7 +3,9 @@
 
 import React, {useCallback} from 'react';
 
+import {getAllTeamMembers} from '@actions/remote/team';
 import TeamList from '@components/team_sidebar/add_team/team_list';
+import {useServerUrl} from '@context/server';
 import {useIsTablet} from '@hooks/device';
 import BottomSheetContent from '@screens/bottom_sheet/content';
 import {dismissBottomSheet} from '@screens/navigation';
@@ -20,9 +22,11 @@ type Props = {
 export default function SelectTeamSlideUp({teams, title, setTeamId, teamId}: Props) {
     const isTablet = useIsTablet();
     const showTitle = !isTablet && Boolean(teams.length);
+    const serverUrl = useServerUrl();
 
     const onPress = useCallback((newTeamId: string) => {
         setTeamId(newTeamId);
+        getAllTeamMembers(serverUrl, newTeamId);
         dismissBottomSheet();
     }, [setTeamId]);
 

--- a/types/database/database.ts
+++ b/types/database/database.ts
@@ -257,10 +257,12 @@ export type HandleTeamArgs = PrepareOnly & {
 
 export type HandleChannelMembershipArgs = PrepareOnly & {
   channelMemberships?: Array<Pick<ChannelMembership, 'user_id' | 'channel_id' | 'scheme_admin'>>;
+  sync?: boolean;
 };
 
 export type HandleTeamMembershipArgs = PrepareOnly & {
   teamMemberships?: TeamMembership[];
+  sync?: boolean;
 };
 
 export type HandlePreferencesArgs = PrepareOnly & {


### PR DESCRIPTION
#### Summary
This PR uses always the local data for users autocomplete.

In order to achieve that, several parts has been improved to make sure the data is up to date, mainly deleting and adding the memberships when needed.

There should be no need to use the userAutocomplete endpoint since (if I am not mistaken) all the information should be available in the database. If I am missing anything, please let me know.

#### Ticket Link
None

#### Release Note
```release-note
Improve autocomplete behaviour
```
