### PR TITLE
Fix MFA when introducing wrong token or having no teams

### DIFF
--- a/app/screens/mfa/index.tsx
+++ b/app/screens/mfa/index.tsx
@@ -19,8 +19,8 @@ import {Screens} from '@constants';
 import {useIsTablet} from '@hooks/device';
 import {t} from '@i18n';
 import Background from '@screens/background';
+import {resetToTeams} from '@screens/navigation';
 import {buttonBackgroundStyle, buttonTextStyle} from '@utils/buttonStyles';
-import {logInfo} from '@utils/log';
 import {preventDoubleTap} from '@utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -151,9 +151,10 @@ const MFA = ({config, goToHome, license, loginId, password, serverDisplayName, s
             }
 
             setError(result.error.message);
+            return;
         }
         if (!result.hasTeams && !result.error) {
-            logInfo('GO TO NO TEAMS');
+            resetToTeams();
             return;
         }
         goToHome(result.time || 0, result.error as never);


### PR DESCRIPTION
#### Summary
In the MFA screen, when we submit, we check for the errors. We were checking different errors to show them in different ways, but the last error, we did not return. That made the app to go to the home screen, which was either empty (if you had no other servers) or the last server you were on.

Also noticed a "GO TO NO TEAMS" log, so I fixed it too. Before, if we had no teams in the server, it would have just stayed there doing nothing. Now it properly moves to the teams screen.

#### Ticket Link
None

#### Release Note
```release-note
Fix MFA login for wrong tokens and no teams.
```
