### PR TITLE
Fix loading unreads not stopping with GraphQL

### DIFF
--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -57,7 +57,7 @@ export async function deferredAppEntryGraphQLActions(
     setTimeout(() => {
         if (chData?.channels?.length && chData.memberships?.length) {
             // defer fetching posts for unread channels on initial team
-            fetchPostsForUnreadChannels(serverUrl, chData.channels, chData.memberships, initialChannelId);
+            fetchPostsForUnreadChannels(serverUrl, chData.channels, chData.memberships, initialChannelId, true);
         }
     }, FETCH_UNREADS_TIMEOUT);
 


### PR DESCRIPTION
#### Summary
When using GraphQL we were not stopping the loading unreads spinner.

This was due to the relevant call to load unreads didn't have the "send event" parameter set.

#### Ticket Link
None

#### Release Note
```release-note
Fix loading spinner not disappearing on GraphQL
```
