### PR TITLE
Gekidou: Create patches for node modules failing on android build

### DIFF
--- a/patches/jail-monkey+2.7.0.patch
+++ b/patches/jail-monkey+2.7.0.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/jail-monkey/android/build.gradle b/node_modules/jail-monkey/android/build.gradle
+index 2a7a12e..27b1b66 100644
+--- a/node_modules/jail-monkey/android/build.gradle
++++ b/node_modules/jail-monkey/android/build.gradle
+@@ -1,12 +1,12 @@
+ apply plugin: 'com.android.library'
+ 
+ android {
+-    compileSdkVersion 28
+-    buildToolsVersion "28.0.3"
++    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : 28
++    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : "28.0.3"
+ 
+     defaultConfig {
+-        minSdkVersion 21
+-        targetSdkVersion 28
++        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 21
++        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : 28
+         versionCode 1
+         versionName "1.0"
+     }

--- a/patches/react-native-hw-keyboard-event+0.0.4.patch
+++ b/patches/react-native-hw-keyboard-event+0.0.4.patch
@@ -1,16 +1,22 @@
 diff --git a/node_modules/react-native-hw-keyboard-event/android/build.gradle b/node_modules/react-native-hw-keyboard-event/android/build.gradle
-index a70aace..6443899 100644
+index a70aace..9c2c876 100644
 --- a/node_modules/react-native-hw-keyboard-event/android/build.gradle
 +++ b/node_modules/react-native-hw-keyboard-event/android/build.gradle
-@@ -4,7 +4,7 @@ android {
-     compileSdkVersion 28
+@@ -1,11 +1,11 @@
+ apply plugin: 'com.android.library'
+ 
+ android {
+-    compileSdkVersion 28
++    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : 28
  
      defaultConfig {
 -        minSdkVersion 16
+-        targetSdkVersion 28
 +        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 21
-         targetSdkVersion 28
++        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : 28
          versionCode 1
          versionName "1.0"
+         ndk {
 diff --git a/node_modules/react-native-hw-keyboard-event/index.d.ts b/node_modules/react-native-hw-keyboard-event/index.d.ts
 index 91999f1..116b725 100644
 --- a/node_modules/react-native-hw-keyboard-event/index.d.ts


### PR DESCRIPTION
#### Summary
- Created patches for `jail-monkey` and `react-native-hw-keyboard-event` to fix android build using `./gradlew assembleAndroidTest`

#### Ticket Link
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```
