### PR TITLE
MM-46685 MM-45753 - Fix voice activity indicator and Android speakerphone

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <!-- Request legacy Bluetooth permissions on older devices. -->
     <uses-permission android:name="android.permission.BLUETOOTH"

--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -277,7 +277,7 @@ const CallScreen = ({componentId, currentCall, participantsDict, teammateNameDis
             }
         };
         const handleVoiceOff = (data: VoiceEventData) => {
-            if (data.channelId === currentCall?.channelId && speakers.hasOwnProperty(data.userId) && speakers[data.userId]) {
+            if (data.channelId === currentCall?.channelId && speakers.hasOwnProperty(data.userId)) {
                 setSpeakers((prev) => {
                     const next = {...prev};
                     delete next[data.userId];
@@ -292,7 +292,7 @@ const CallScreen = ({componentId, currentCall, participantsDict, teammateNameDis
             onVoiceOn.remove();
             onVoiceOff.remove();
         };
-    }, []);
+    }, [speakers, currentCall?.channelId]);
 
     const leaveCallHandler = useCallback(() => {
         popTopScreen();

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -438,7 +438,7 @@ PODS:
     - React
   - ReactNativeExceptionHandler (2.10.10):
     - React-Core
-  - ReactNativeIncallManager (3.3.0):
+  - ReactNativeIncallManager (4.0.0):
     - React-Core
   - ReactNativeKeyboardTrackingView (5.7.0):
     - React
@@ -923,7 +923,7 @@ SPEC CHECKSUMS:
   ReactCommon: af7636436b382db7cde4583bbd642f0978e6e3ed
   ReactNativeART: 78edc68dd4a1e675338cd0cd113319cf3a65f2ab
   ReactNativeExceptionHandler: b11ff67c78802b2f62eed0e10e75cb1ef7947c60
-  ReactNativeIncallManager: 642c22630caadff0a0619413aff4a9da08d63df9
+  ReactNativeIncallManager: b169b57d3064d8f62478f8fc3c485da6c75045d1
   ReactNativeKeyboardTrackingView: 02137fac3b2ebd330d74fa54ead48b14750a2306
   ReactNativeNavigation: 3b09d0b7a64326dbcea7e64231287c766b18adf0
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495

--- a/package-lock.json
+++ b/package-lock.json
@@ -20585,8 +20585,8 @@
       }
     },
     "node_modules/react-native-incall-manager": {
-      "version": "3.3.0",
-      "resolved": "git+ssh://git@github.com/cpoile/react-native-incall-manager.git#8c55b9dac0a2ab25d651fb54b504d384f9989b36",
+      "version": "4.0.0",
+      "resolved": "git+ssh://git@github.com/cpoile/react-native-incall-manager.git#6b66ae7bab194c82573c7b3891b0ac3af71d424e",
       "license": "ISC",
       "peerDependencies": {
         "react-native": ">=0.40.0"
@@ -41214,7 +41214,7 @@
       "requires": {}
     },
     "react-native-incall-manager": {
-      "version": "git+ssh://git@github.com/cpoile/react-native-incall-manager.git#8c55b9dac0a2ab25d651fb54b504d384f9989b36",
+      "version": "git+ssh://git@github.com/cpoile/react-native-incall-manager.git#6b66ae7bab194c82573c7b3891b0ac3af71d424e",
       "from": "react-native-incall-manager@github:cpoile/react-native-incall-manager",
       "requires": {}
     },


### PR DESCRIPTION
#### Summary
- Two quick fixes:
  - MM-46685 - adding the correct dependencies in the useEffect
  - MM-45753 - Android 11 changed it's permissions and looks like it broke the speakerphone, had to hunt down which one we were missing, this looks like it was it. Also updated our react-native-incall-manager fork.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46685
- https://mattermost.atlassian.net/browse/MM-45753

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Release Note
```release-note
Calls: Fix for Android speakerphone button.
```
