### PR TITLE
Added missing field to gql query

### DIFF
--- a/app/client/graphQL/entry.ts
+++ b/app/client/graphQL/entry.ts
@@ -234,6 +234,7 @@ query ${QueryNames.QUERY_CHANNELS}($teamId: String!, $perPage: Int!, $exclude: B
             purpose
             type
             createAt
+            updateAt
             creatorId
             deleteAt
             displayName
@@ -283,6 +284,7 @@ query ${QueryNames.QUERY_CHANNELS_NEXT}($teamId: String!, $perPage: Int!, $exclu
             purpose
             type
             createAt
+            updateAt
             creatorId
             deleteAt
             displayName
@@ -317,6 +319,7 @@ query ${QueryNames.QUERY_ALL_CHANNELS}($perPage: Int!){
             purpose
             type
             createAt
+            updateAt
             creatorId
             deleteAt
             displayName
@@ -351,6 +354,7 @@ query ${QueryNames.QUERY_ALL_CHANNELS_NEXT}($perPage: Int!, $cursor: String!) {
             purpose
             type
             createAt
+            updateAt
             creatorId
             deleteAt
             displayName


### PR DESCRIPTION
#### Summary
We were missing the "updateAt" field on the channel queries. When adding channels to the database, we are checking if the delete_at or update_at fields change. Since these were not changing (always defaulted to 0) changes in the channels were not being visible.

#### Ticket Link
None

#### Release Note
```release-note
Fix channel names not changing.
```
