### PR TITLE
Fix notification entry on graphQL

### DIFF
--- a/app/actions/remote/entry/app.ts
+++ b/app/actions/remote/entry/app.ts
@@ -35,7 +35,7 @@ export async function appEntry(serverUrl: string, since = 0, isUpgrade = false) 
     let result;
     if (config?.FeatureFlagGraphQL === 'true') {
         const {currentTeamId, currentChannelId} = await getCommonSystemValues(database);
-        result = await graphQLCommon(serverUrl, true, currentTeamId, currentChannelId, isUpgrade);
+        result = await graphQLCommon(serverUrl, true, currentTeamId, currentChannelId, '', isUpgrade);
         if (result.error) {
             logDebug('Error using GraphQL, trying REST', result.error);
             result = restAppEntry(serverUrl, since, isUpgrade);

--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -24,7 +24,7 @@ import {filterAndTransformRoles, getMemberChannelsFromGQLQuery, getMemberTeamsFr
 import {isTablet} from '@utils/helpers';
 import {processIsCRTEnabled} from '@utils/thread';
 
-import {teamsToRemove, FETCH_UNREADS_TIMEOUT} from './common';
+import {teamsToRemove, FETCH_UNREADS_TIMEOUT, handleNotificationNavigation} from './common';
 
 import type ClientError from '@client/rest/error';
 import type ChannelModel from '@typings/database/models/servers/channel';
@@ -158,7 +158,7 @@ const getChannelData = async (serverUrl: string, initialTeamId: string, userId: 
     return {chData, roles};
 };
 
-export const graphQLCommon = async (serverUrl: string, syncDatabase: boolean, currentTeamId: string, currentChannelId: string, isUpgrade = false) => {
+export const graphQLCommon = async (serverUrl: string, syncDatabase: boolean, currentTeamId: string, currentChannelId: string, rootId?: string, isUpgrade = false, isNotificationEntry = false) => {
     const dt = Date.now();
 
     const operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
@@ -301,6 +301,10 @@ export const graphQLCommon = async (serverUrl: string, syncDatabase: boolean, cu
     const models = await Promise.all(modelPromises);
     if (models.length) {
         await operator.batchRecords(models.flat());
+    }
+
+    if (isNotificationEntry) {
+        await handleNotificationNavigation(serverUrl, initialChannelId, initialTeamId, currentChannelId, currentTeamId, rootId);
     }
 
     const isCRTEnabled = Boolean(prefData.preferences && processIsCRTEnabled(prefData.preferences, config));


### PR DESCRIPTION
#### Summary
Notification entry is doing more logic, mainly around navigating to the correct channel / thread, that was not ported to the graphQL entry logic.

This led to notifications not opening the correct channel when opening the app from them.

#### Ticket Link
None

#### Release Note
```release-note
Fix notification entry not opening the correct channel
```
