### PR TITLE
Add missing GQL fields

### DIFF
--- a/app/client/graphQL/entry.ts
+++ b/app/client/graphQL/entry.ts
@@ -188,6 +188,7 @@ query ${QueryNames.QUERY_ENTRY} {
     }
     teamMembers(userId:"me") {
         deleteAt
+        schemeAdmin
         roles {
             id
             name
@@ -221,6 +222,8 @@ query ${QueryNames.QUERY_CHANNELS}($teamId: String!, $perPage: Int!, $exclude: B
         msgCount
         msgCountRoot
         mentionCount
+        mentionCountRoot
+        schemeAdmin
         lastViewedAt
         notifyProps
         roles {
@@ -254,6 +257,7 @@ query ${QueryNames.QUERY_CHANNELS}($teamId: String!, $perPage: Int!, $exclude: B
     sidebarCategories(userId:"me", teamId:$teamId, excludeTeam:$exclude) {
         displayName
         id
+        sortOrder
         sorting
         type
         muted
@@ -271,6 +275,8 @@ query ${QueryNames.QUERY_CHANNELS_NEXT}($teamId: String!, $perPage: Int!, $exclu
         msgCount
         msgCountRoot
         mentionCount
+        mentionCountRoot
+        schemeAdmin
         lastViewedAt
         notifyProps
         roles {
@@ -311,6 +317,8 @@ query ${QueryNames.QUERY_ALL_CHANNELS}($perPage: Int!){
         msgCount
         msgCountRoot
         mentionCount
+        mentionCountRoot
+        schemeAdmin
         lastViewedAt
         notifyProps
         channel {
@@ -346,6 +354,8 @@ query ${QueryNames.QUERY_ALL_CHANNELS_NEXT}($perPage: Int!, $cursor: String!) {
         msgCount
         msgCountRoot
         mentionCount
+        mentionCountRoot
+        schemeAdmin
         lastViewedAt
         notifyProps
         channel {

--- a/app/utils/graphql.ts
+++ b/app/utils/graphql.ts
@@ -124,6 +124,7 @@ export const gqlToClientChannelMembership = (m: Partial<GQLChannelMembership>, u
         last_update_at: m.lastUpdateAt || 0,
         last_viewed_at: m.lastViewedAt || 0,
         mention_count: m.mentionCount || 0,
+        mention_count_root: m.mentionCountRoot || 0,
         msg_count: m.msgCount || 0,
         msg_count_root: m.msgCountRoot || 0,
         notify_props: m.notifyProps || {},


### PR DESCRIPTION
#### Summary
There were still some fields missing in some parts of the queries. I did a check to find what other fields that we are using may be missing, but not sure 100% everything is in place.

For ChannelMembership LastPostAt there seems to be no gql endpoint, but should not be a problem, because we are using the channel last post at to calculate this.

#### Ticket Link
None

#### Release Note
```release-note
Add missing fields on entry logic.
```
