### PR TITLE
[Gekidou MM-43992] Display message priority labels for the posts 

### DIFF
--- a/app/components/post_list/post/header/header.tsx
+++ b/app/components/post_list/post/header/header.tsx
@@ -131,7 +131,7 @@ const Header = (props: HeaderProps) => {
                         style={style.time}
                         testID='post_header.date_time'
                     />
-                    {isPostPriorityEnabled && post.props?.priority && (
+                    {Boolean(isPostPriorityEnabled && post.props?.priority) && (
                         <View style={style.postPriority}>
                             <PostPriorityLabel
                                 label={post.props?.priority}

--- a/app/components/post_list/post/header/header.tsx
+++ b/app/components/post_list/post/header/header.tsx
@@ -6,6 +6,7 @@ import {View} from 'react-native';
 
 import CustomStatusEmoji from '@components/custom_status/custom_status_emoji';
 import FormattedTime from '@components/formatted_time';
+import PostPriorityLabel from '@components/post_priority/post_priority_label';
 import {CHANNEL, THREAD} from '@constants/screens';
 import {useTheme} from '@context/theme';
 import {postUserDisplayName} from '@utils/post';
@@ -31,6 +32,7 @@ type HeaderProps = {
     isEphemeral: boolean;
     isMilitaryTime: boolean;
     isPendingOrFailed: boolean;
+    isPostPriorityEnabled: boolean;
     isSystemPost: boolean;
     isTimezoneEnabled: boolean;
     isWebHook: boolean;
@@ -58,8 +60,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             color: theme.centerChannelColor,
             marginTop: 5,
             opacity: 0.5,
-            flex: 1,
             ...typography('Body', 75, 'Regular'),
+        },
+        postPriority: {
+            alignSelf: 'center',
+            marginLeft: 6,
         },
         customStatusEmoji: {
             color: theme.centerChannelColor,
@@ -72,7 +77,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
 const Header = (props: HeaderProps) => {
     const {
         author, commentCount = 0, currentUser, enablePostUsernameOverride, isAutoResponse, isCRTEnabled,
-        isEphemeral, isMilitaryTime, isPendingOrFailed, isSystemPost, isTimezoneEnabled, isWebHook,
+        isEphemeral, isMilitaryTime, isPendingOrFailed, isPostPriorityEnabled, isSystemPost, isTimezoneEnabled, isWebHook,
         location, post, rootPostAuthor, shouldRenderReplyButton, teammateNameDisplay,
     } = props;
     const theme = useTheme();
@@ -126,6 +131,13 @@ const Header = (props: HeaderProps) => {
                         style={style.time}
                         testID='post_header.date_time'
                     />
+                    {isPostPriorityEnabled && post.props?.priority && (
+                        <View style={style.postPriority}>
+                            <PostPriorityLabel
+                                label={post.props?.priority}
+                            />
+                        </View>
+                    )}
                     {!isCRTEnabled && showReply && commentCount > 0 &&
                         <HeaderReply
                             commentCount={commentCount}

--- a/app/components/post_list/post/header/reply/index.tsx
+++ b/app/components/post_list/post/header/reply/index.tsx
@@ -32,7 +32,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             justifyContent: 'flex-end',
             minWidth: 40,
             paddingTop: 2,
-            paddingBottom: 10,
             flex: 1,
         },
         replyText: {

--- a/app/components/post_list/post/index.ts
+++ b/app/components/post_list/post/index.ts
@@ -9,7 +9,7 @@ import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {Permissions, Preferences} from '@constants';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
-import {queryPostsBetween} from '@queries/servers/post';
+import {observeIsPostPriorityEnabled, queryPostsBetween} from '@queries/servers/post';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeCanManageChannelMembers, observePermissionForPost} from '@queries/servers/role';
 import {observeConfigBooleanValue} from '@queries/servers/system';
@@ -168,6 +168,7 @@ const withPost = withObservables(
             isJumboEmoji,
             isLastReply,
             isPostAddChannelMember,
+            isPostPriorityEnabled: observeIsPostPriorityEnabled(database),
             post: post.observe(),
             thread: isCRTEnabled ? observeThreadById(database, post.id) : of$(undefined),
             hasReactions,

--- a/app/components/post_list/post/index.ts
+++ b/app/components/post_list/post/index.ts
@@ -9,10 +9,10 @@ import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {Permissions, Preferences} from '@constants';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
-import {observeIsPostPriorityEnabled, queryPostsBetween} from '@queries/servers/post';
+import {queryPostsBetween} from '@queries/servers/post';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeCanManageChannelMembers, observePermissionForPost} from '@queries/servers/role';
-import {observeConfigBooleanValue} from '@queries/servers/system';
+import {observeIsPostPriorityEnabled, observeConfigBooleanValue} from '@queries/servers/system';
 import {observeThreadById} from '@queries/servers/thread';
 import {observeCurrentUser} from '@queries/servers/user';
 import {hasJumboEmojiOnly} from '@utils/emoji/helpers';

--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -53,6 +53,7 @@ type PostProps = {
     isJumboEmoji: boolean;
     isLastReply?: boolean;
     isPostAddChannelMember: boolean;
+    isPostPriorityEnabled: boolean;
     location: string;
     post: PostModel;
     rootId?: string;
@@ -107,7 +108,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
 
 const Post = ({
     appsEnabled, canDelete, currentUser, differentThreadSequence, hasFiles, hasReplies, highlight, highlightPinnedOrSaved = true, highlightReplyBar,
-    isCRTEnabled, isConsecutivePost, isEphemeral, isFirstReply, isSaved, isJumboEmoji, isLastReply, isPostAddChannelMember,
+    isCRTEnabled, isConsecutivePost, isEphemeral, isFirstReply, isSaved, isJumboEmoji, isLastReply, isPostAddChannelMember, isPostPriorityEnabled,
     location, post, rootId, hasReactions, searchPatterns, shouldRenderReplyButton, skipSavedHeader, skipPinnedHeader, showAddReaction = true, style,
     testID, thread, previousPost,
 }: PostProps) => {
@@ -221,8 +222,9 @@ const Post = ({
     let header: ReactNode;
     let postAvatar: ReactNode;
     let consecutiveStyle: StyleProp<ViewStyle>;
-    const sameSecuence = hasReplies ? (hasReplies && post.rootId) : !post.rootId;
-    if (hasSameRoot && isConsecutivePost && sameSecuence) {
+    const isProrityPost = isPostPriorityEnabled && post.props.priority;
+    const sameSequence = hasReplies ? (hasReplies && post.rootId) : !post.rootId;
+    if (!isProrityPost && hasSameRoot && isConsecutivePost && sameSequence) {
         consecutiveStyle = styles.consective;
         postAvatar = <View style={styles.consecutivePostContainer}/>;
     } else {
@@ -254,6 +256,7 @@ const Post = ({
                     differentThreadSequence={differentThreadSequence}
                     isAutoResponse={isAutoResponder}
                     isCRTEnabled={isCRTEnabled}
+                    isPostPriorityEnabled={isPostPriorityEnabled}
                     isEphemeral={isEphemeral}
                     isPendingOrFailed={isPendingOrFailed}
                     isSystemPost={isSystemPost}

--- a/app/components/post_priority/post_priority_label.tsx
+++ b/app/components/post_priority/post_priority_label.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {useIntl} from 'react-intl';
+import {StyleProp, StyleSheet, Text, View, ViewStyle} from 'react-native';
+
+import CompassIcon from '@components/compass_icon';
+import {PostPriorityTypes} from '@constants/post';
+import {typography} from '@utils/typography';
+
+const style = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        borderRadius: 4,
+        alignItems: 'center',
+        height: 16,
+        paddingHorizontal: 4,
+    },
+    label: {
+        color: '#fff',
+        ...typography('Body', 25, 'SemiBold'),
+    },
+    icon: {
+        color: '#fff',
+        fontSize: 12,
+        marginRight: 4,
+    },
+});
+
+type Props = {
+    label: string;
+};
+
+const PostPriorityLabel = ({label}: Props) => {
+    const intl = useIntl();
+
+    const containerStyle: StyleProp<ViewStyle> = [style.container];
+    let iconName = '';
+    let labelText = '';
+    if (label === PostPriorityTypes.URGENT) {
+        containerStyle.push({backgroundColor: '#D24B4E'});
+        iconName = 'alert-outline';
+        labelText = intl.formatMessage({id: 'post_priority.label.urgent', defaultMessage: 'URGENT'});
+    } else {
+        containerStyle.push({backgroundColor: '#5D89EA'});
+        iconName = 'alert-circle-outline';
+        labelText = intl.formatMessage({id: 'post_priority.label.important', defaultMessage: 'IMPORTANT'});
+    }
+    return (
+        <View style={containerStyle}>
+            <CompassIcon
+                name={iconName}
+                style={style.icon}
+            />
+            <Text style={style.label}>{labelText}</Text>
+        </View>
+    );
+};
+
+export default PostPriorityLabel;

--- a/app/components/post_priority/post_priority_label.tsx
+++ b/app/components/post_priority/post_priority_label.tsx
@@ -17,6 +17,12 @@ const style = StyleSheet.create({
         height: 16,
         paddingHorizontal: 4,
     },
+    urgent: {
+        backgroundColor: '#D24B4E',
+    },
+    important: {
+        backgroundColor: '#5D89EA',
+    },
     label: {
         color: '#fff',
         ...typography('Body', 25, 'SemiBold'),
@@ -39,11 +45,11 @@ const PostPriorityLabel = ({label}: Props) => {
     let iconName = '';
     let labelText = '';
     if (label === PostPriorityTypes.URGENT) {
-        containerStyle.push({backgroundColor: '#D24B4E'});
+        containerStyle.push(style.urgent);
         iconName = 'alert-outline';
         labelText = intl.formatMessage({id: 'post_priority.label.urgent', defaultMessage: 'URGENT'});
     } else {
-        containerStyle.push({backgroundColor: '#5D89EA'});
+        containerStyle.push(style.important);
         iconName = 'alert-circle-outline';
         labelText = intl.formatMessage({id: 'post_priority.label.important', defaultMessage: 'IMPORTANT'});
     }

--- a/app/constants/post.ts
+++ b/app/constants/post.ts
@@ -34,11 +34,17 @@ export const PostTypes: Record<string, string> = {
     CUSTOM_CALLS: 'custom_calls',
 };
 
+export const PostPriorityTypes: Record<string, string> = {
+    URGENT: 'urgent',
+    IMPORTANT: 'important',
+};
+
 export const POST_TIME_TO_FAIL = 10000;
 
 export default {
     POST_COLLAPSE_TIMEOUT: 1000 * 60 * 5,
     POST_TYPES: PostTypes,
+    POST_PRIORITY_TYPES: PostPriorityTypes,
     USER_ACTIVITY_POST_TYPES: [
         PostTypes.ADD_TO_CHANNEL,
         PostTypes.JOIN_CHANNEL,

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -5,10 +5,11 @@ import {Database, Model, Q, Query} from '@nozbe/watermelondb';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {Preferences} from '@constants';
+import {Config, Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
 
 import {queryPreferencesByCategoryAndName} from './preference';
+import {observeConfig} from './system';
 
 import type PostModel from '@typings/database/models/servers/post';
 import type PostInChannelModel from '@typings/database/models/servers/posts_in_channel';
@@ -64,6 +65,15 @@ export const getPostById = async (database: Database, postId: string) => {
     } catch {
         return undefined;
     }
+};
+
+export const observeIsPostPriorityEnabled = (database: Database) => {
+    const config = observeConfig(database);
+    return config.pipe(
+        switchMap(
+            (cfg) => of$(cfg?.FeatureFlagPostPriority === Config.TRUE && cfg?.PostPriority === Config.TRUE),
+        ),
+    );
 };
 
 export const observePost = (database: Database, postId: string) => {

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -5,11 +5,10 @@ import {Database, Model, Q, Query} from '@nozbe/watermelondb';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {Config, Preferences} from '@constants';
+import {Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
 
 import {queryPreferencesByCategoryAndName} from './preference';
-import {observeConfig} from './system';
 
 import type PostModel from '@typings/database/models/servers/post';
 import type PostInChannelModel from '@typings/database/models/servers/posts_in_channel';
@@ -65,15 +64,6 @@ export const getPostById = async (database: Database, postId: string) => {
     } catch {
         return undefined;
     }
-};
-
-export const observeIsPostPriorityEnabled = (database: Database) => {
-    const config = observeConfig(database);
-    return config.pipe(
-        switchMap(
-            (cfg) => of$(cfg?.FeatureFlagPostPriority === Config.TRUE && cfg?.PostPriority === Config.TRUE),
-        ),
-    );
 };
 
 export const observePost = (database: Database, postId: string) => {

--- a/app/queries/servers/system.ts
+++ b/app/queries/servers/system.ts
@@ -5,7 +5,7 @@ import {Database, Q} from '@nozbe/watermelondb';
 import {of as of$, Observable} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {Preferences} from '@constants';
+import {Config, Preferences} from '@constants';
 import {MM_TABLES, SYSTEM_IDENTIFIERS} from '@constants/database';
 import {PUSH_PROXY_STATUS_UNKNOWN} from '@constants/push_proxy';
 
@@ -164,6 +164,15 @@ export const observeConfigBooleanValue = (database: Database, key: keyof ClientC
 export const observeConfigIntValue = (database: Database, key: keyof ClientConfig, defaultValue = 0) => {
     return observeConfig(database).pipe(
         switchMap((cfg) => of$((parseInt(cfg?.[key] || '0', 10) || defaultValue))),
+    );
+};
+
+export const observeIsPostPriorityEnabled = (database: Database) => {
+    const config = observeConfig(database);
+    return config.pipe(
+        switchMap(
+            (cfg) => of$(cfg?.FeatureFlagPostPriority === Config.TRUE && cfg?.PostPriority === Config.TRUE),
+        ),
     );
 };
 

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -701,6 +701,8 @@
   "post_info.system": "System",
   "post_message_view.edited": "(edited)",
   "post.options.title": "Options",
+  "post_priority.label.important": "IMPORTANT",
+  "post_priority.label.urgent": "URGENT",
   "post.reactions.title": "Reactions",
   "posts_view.newMsg": "New Messages",
   "public_link_copied": "Link copied to clipboard",

--- a/types/api/config.d.ts
+++ b/types/api/config.d.ts
@@ -119,6 +119,7 @@ interface ClientConfig {
     FeatureFlagAppsEnabled?: string;
     FeatureFlagCollapsedThreads?: string;
     FeatureFlagGraphQL?: string;
+    FeatureFlagPostPriority?: string;
     GfycatApiKey: string;
     GfycatApiSecret: string;
     GoogleDeveloperKey: string;
@@ -151,6 +152,7 @@ interface ClientConfig {
     PasswordRequireUppercase: string;
     PluginsEnabled: string;
     PostEditTimeLimit: string;
+    PostPriority: string;
     PrivacyPolicyLink: string;
     ReportAProblemLink: string;
     RequireEmailVerification: string;


### PR DESCRIPTION
#### Summary
Implements phase 1 of the Message Priority feature displaying only the labels beside the post.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46584

Works with server PR:  https://github.com/mattermost/mattermost-server/pull/20875

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 15.5, Android 11

#### Screenshots
<table>
 <tr>
  <th> With CRT </th>
  <th> Without CRT </th>
 </tr>
 <tr>
  <td>
    <img src="https://user-images.githubusercontent.com/3680799/188654810-2ac09c38-f8f3-4130-9d04-cb65c3f3b3b2.png" />
  </td>
  <td>
    <img src="https://user-images.githubusercontent.com/3680799/188654869-f0cd9781-07f0-4447-bcb4-09b312c852a5.png" />
  </td>
 </tr>
 <tr>
  <td>
   <img src="https://user-images.githubusercontent.com/3680799/188654939-410ec0a9-d5c9-4166-a13e-f52a25bb9bae.jpeg" />
  </td>
  <td>
    <img src="https://user-images.githubusercontent.com/3680799/188654973-c1f7af34-539f-44c4-a386-32993f77c3ce.jpeg" />
  </td>
 </tr>
</table>

#### Release Note
```release-note
Added labels for message priority.
```