### PR TITLE
Receiving multiple In-app notifications is blocking the navigation

### DIFF
--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -25,7 +25,7 @@ import NativeNotifications from '@notifications';
 import {queryServerName} from '@queries/app/servers';
 import {getCurrentChannelId} from '@queries/servers/system';
 import {getIsCRTEnabled, getThreadById} from '@queries/servers/thread';
-import {showOverlay} from '@screens/navigation';
+import {dismissOverlay, showOverlay} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import NavigationStore from '@store/navigation_store';
 import {isTablet} from '@utils/helpers';
@@ -125,6 +125,9 @@ class PushNotifications {
                     serverName,
                     serverUrl,
                 };
+
+                // Dismiss the screen if it's already visible or else it blocks the navigation
+                await dismissOverlay(screen);
 
                 showOverlay(screen, passProps);
             }


### PR DESCRIPTION
#### Summary
Receiving multiple In-app notifications is blocking the navigation. To solve the issue, before showing the in-app notification, we dismiss the previous notification.

[More information at ](https://community.mattermost.com/core/pl/8b85e9e45pgh3er3wycnpciu6a)

#### Ticket Link


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 15.6.1

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
