### PR TITLE
MM-45754 - Calls: Add current call bar to thread screen

### DIFF
--- a/app/products/calls/components/floating_call_container.tsx
+++ b/app/products/calls/components/floating_call_container.tsx
@@ -29,12 +29,13 @@ const style = StyleSheet.create({
 
 type Props = {
     children: React.ReactNode;
+    threadScreen?: boolean;
 }
 
-const FloatingCallContainer = (props: Props) => {
+const FloatingCallContainer = ({threadScreen, ...props}: Props) => {
     const insets = useSafeAreaInsets();
     const wrapperTop = {
-        top: topBarHeight + insets.top,
+        top: insets.top + (threadScreen ? 0 : topBarHeight),
     };
 
     return (

--- a/app/screens/channel/channel.tsx
+++ b/app/screens/channel/channel.tsx
@@ -28,7 +28,6 @@ type ChannelProps = {
     serverUrl: string;
     channelId: string;
     componentId?: string;
-    isCallsPluginEnabled: boolean;
     isCallInCurrentChannel: boolean;
     isInACall: boolean;
     isInCurrentChannelCall: boolean;
@@ -47,7 +46,6 @@ const Channel = ({
     serverUrl,
     channelId,
     componentId,
-    isCallsPluginEnabled,
     isCallInCurrentChannel,
     isInACall,
     isInCurrentChannelCall,
@@ -120,7 +118,7 @@ const Channel = ({
 
     let callsComponents: JSX.Element | null = null;
     const showJoinCallBanner = isCallInCurrentChannel && !isInCurrentChannelCall;
-    if (isCallsPluginEnabled && (showJoinCallBanner || isInACall)) {
+    if (showJoinCallBanner || isInACall) {
         callsComponents = (
             <FloatingCallContainer>
                 {showJoinCallBanner &&

--- a/app/screens/channel/index.tsx
+++ b/app/screens/channel/index.tsx
@@ -20,10 +20,6 @@ type EnhanceProps = WithDatabaseArgs & {
 
 const enhanced = withObservables([], ({database, serverUrl}: EnhanceProps) => {
     const channelId = observeCurrentChannelId(database);
-    const isCallsPluginEnabled = observeCallsConfig(serverUrl).pipe(
-        switchMap((config) => of$(config.pluginEnabled)),
-        distinctUntilChanged(),
-    );
     const isCallInCurrentChannel = combineLatest([channelId, observeChannelsWithCalls(serverUrl)]).pipe(
         switchMap(([id, calls]) => of$(Boolean(calls[id]))),
         distinctUntilChanged(),
@@ -60,7 +56,6 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhanceProps) => {
 
     return {
         channelId,
-        isCallsPluginEnabled,
         isCallInCurrentChannel,
         isInACall,
         isInCurrentChannelCall,

--- a/app/screens/thread/index.tsx
+++ b/app/screens/thread/index.tsx
@@ -3,7 +3,11 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
+import {of as of$} from 'rxjs';
+import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
+import {observeCurrentCall} from '@calls/state';
+import {withServerUrl} from '@context/server';
 import {observePost} from '@queries/servers/post';
 
 import Thread from './thread';
@@ -11,9 +15,15 @@ import Thread from './thread';
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables(['rootId'], ({database, rootId}: WithDatabaseArgs & {rootId: string}) => {
+    const isInACall = observeCurrentCall().pipe(
+        switchMap((call) => of$(Boolean(call))),
+        distinctUntilChanged(),
+    );
+
     return {
         rootPost: observePost(database, rootId),
+        isInACall,
     };
 });
 
-export default withDatabase(enhanced(Thread));
+export default withDatabase(withServerUrl(enhanced(Thread)));

--- a/app/screens/thread/thread.tsx
+++ b/app/screens/thread/thread.tsx
@@ -6,6 +6,8 @@ import {DeviceEventEmitter, LayoutChangeEvent, StyleSheet, View} from 'react-nat
 import {KeyboardTrackingViewRef} from 'react-native-keyboard-tracking-view';
 import {Edge, SafeAreaView} from 'react-native-safe-area-context';
 
+import CurrentCallBar from '@calls/components/current_call_bar';
+import FloatingCallContainer from '@calls/components/floating_call_container';
 import FreezeScreen from '@components/freeze_screen';
 import PostDraft from '@components/post_draft';
 import RoundedHeaderContext from '@components/rounded_header_context';
@@ -23,6 +25,7 @@ import type PostModel from '@typings/database/models/servers/post';
 type ThreadProps = {
     componentId: string;
     rootPost?: PostModel;
+    isInACall: boolean;
 };
 
 const edges: Edge[] = ['left', 'right'];
@@ -31,7 +34,7 @@ const styles = StyleSheet.create({
     flex: {flex: 1},
 });
 
-const Thread = ({componentId, rootPost}: ThreadProps) => {
+const Thread = ({componentId, rootPost, isInACall}: ThreadProps) => {
     const appState = useAppState();
     const postDraftRef = useRef<KeyboardTrackingViewRef>(null);
     const [containerHeight, setContainerHeight] = useState(0);
@@ -95,6 +98,11 @@ const Thread = ({componentId, rootPost}: ThreadProps) => {
                         isChannelScreen={false}
                     />
                 </>
+                }
+                {isInACall &&
+                    <FloatingCallContainer threadScreen={true}>
+                        <CurrentCallBar/>
+                    </FloatingCallContainer>
                 }
             </SafeAreaView>
         </FreezeScreen>


### PR DESCRIPTION
#### Summary
- Add the current call bar to the thread screen
- The floating container doesn't need the header_height added for the thread screen -- is this expected @enahum ?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-45754

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 12, Pixel 6
- iOS: 15.3.1, iPhone 7 plus

#### Screenshots
<img width="543" alt="image" src="https://user-images.githubusercontent.com/1490756/188985936-f3a1ef0e-0dc1-4219-bec2-dc5812ff2ab2.png">


#### Release Note
```release-note
Calls: Current call bar is now shown on the Thread screen
```
