### PR TITLE
[Gekidou MM-45506] Do not include empty DM and GMs in Channel List

### DIFF
--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -436,6 +436,12 @@ export const queryMyChannelUnreads = (database: Database, currentTeamId: string)
     );
 };
 
+export const queryEmptyDirectChannels = (database: Database) => {
+    return database.get<MyChannelModel>(MY_CHANNEL).query(
+        Q.where('last_post_at', Q.eq(0)),
+    );
+};
+
 export function observeMyChannelMentionCount(database: Database, teamId?: string, columns = ['mentions_count', 'is_unread']): Observable<number> {
     const conditions: Q.Condition[] = [
         Q.where('delete_at', Q.eq(0)),

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -436,8 +436,12 @@ export const queryMyChannelUnreads = (database: Database, currentTeamId: string)
     );
 };
 
-export const queryEmptyDirectChannels = (database: Database) => {
+export const queryEmptyDirectAndGroupChannels = (database: Database) => {
     return database.get<MyChannelModel>(MY_CHANNEL).query(
+        Q.on(
+            CHANNEL,
+            Q.where('team_id', Q.eq('')),
+        ),
         Q.where('last_post_at', Q.eq(0)),
     );
 };

--- a/app/screens/home/channel_list/categories_list/categories/body/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/body/index.ts
@@ -112,16 +112,13 @@ const enhance = withObservables(['category', 'isTablet', 'locale'], ({category, 
         switchMap(mapChannelIds),
     );
 
-    const hiddenOrEmptyDmIds = hiddenDmIds.pipe(
-        combineLatestWith(emptyDmIds),
-        map(([hidden, empty]) => hidden.concat(empty)),
-    );
-
     const hiddenChannelIds = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, undefined, 'false').
         observeWithColumns(['value']).pipe(
             switchMap(mapPrefName),
-            combineLatestWith(hiddenOrEmptyDmIds),
-            switchMap(([a, b]) => of$(new Set(a.concat(b)))),
+            combineLatestWith(hiddenDmIds, emptyDmIds),
+            switchMap(([hIds, hiddenDms, emptyDms]) => {
+                return of$(new Set(hIds.concat(hiddenDms, emptyDms)));
+            }),
         );
 
     const sortedChannels = hiddenChannelIds.pipe(

--- a/app/screens/home/channel_list/categories_list/categories/body/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/body/index.ts
@@ -12,7 +12,7 @@ import {General, Preferences} from '@constants';
 import {DMS_CATEGORY} from '@constants/categories';
 import {getPreferenceAsBool} from '@helpers/api/preference';
 import {observeChannelsByCategoryChannelSortOrder, observeChannelsByLastPostAtInCategory} from '@queries/servers/categories';
-import {observeNotifyPropsByChannels, queryChannelsByNames, queryEmptyDirectChannels} from '@queries/servers/channel';
+import {observeNotifyPropsByChannels, queryChannelsByNames, queryEmptyDirectAndGroupChannels} from '@queries/servers/channel';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeCurrentChannelId, observeCurrentUserId, observeLastUnreadChannelId} from '@queries/servers/system';
 import {getDirectChannelName} from '@utils/channel';
@@ -108,7 +108,7 @@ const enhance = withObservables(['category', 'isTablet', 'locale'], ({category, 
             }),
         );
 
-    const emptyDmIds = queryEmptyDirectChannels(database).observe().pipe(
+    const emptyDmIds = queryEmptyDirectAndGroupChannels(database).observeWithColumns(['last_post_at']).pipe(
         switchMap(mapChannelIds),
     );
 

--- a/app/screens/home/channel_list/categories_list/categories/body/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/body/index.ts
@@ -7,11 +7,12 @@ import withObservables from '@nozbe/with-observables';
 import {combineLatest, of as of$} from 'rxjs';
 import {map, switchMap, combineLatestWith} from 'rxjs/operators';
 
+import {MyChannelModel} from '@app/database/models/server';
 import {General, Preferences} from '@constants';
 import {DMS_CATEGORY} from '@constants/categories';
 import {getPreferenceAsBool} from '@helpers/api/preference';
 import {observeChannelsByCategoryChannelSortOrder, observeChannelsByLastPostAtInCategory} from '@queries/servers/categories';
-import {observeNotifyPropsByChannels, queryChannelsByNames} from '@queries/servers/channel';
+import {observeNotifyPropsByChannels, queryChannelsByNames, queryEmptyDirectChannels} from '@queries/servers/channel';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeCurrentChannelId, observeCurrentUserId, observeLastUnreadChannelId} from '@queries/servers/system';
 import {getDirectChannelName} from '@utils/channel';
@@ -86,7 +87,7 @@ const observeSortedChannels = (database: Database, category: CategoryModel, excl
 
 const mapPrefName = (prefs: PreferenceModel[]) => of$(prefs.map((p) => p.name));
 
-const mapChannelIds = (channels: ChannelModel[]) => of$(channels.map((c) => c.id));
+const mapChannelIds = (channels: ChannelModel[] | MyChannelModel[]) => of$(channels.map((c) => c.id));
 
 const withUserId = withObservables([], ({database}: WithDatabaseArgs) => ({currentUserId: observeCurrentUserId(database)}));
 
@@ -107,10 +108,19 @@ const enhance = withObservables(['category', 'isTablet', 'locale'], ({category, 
             }),
         );
 
+    const emptyDmIds = queryEmptyDirectChannels(database).observe().pipe(
+        switchMap(mapChannelIds),
+    );
+
+    const hiddenOrEmptyDmIds = hiddenDmIds.pipe(
+        combineLatestWith(emptyDmIds),
+        map(([hidden, empty]) => hidden.concat(empty)),
+    );
+
     const hiddenChannelIds = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, undefined, 'false').
         observeWithColumns(['value']).pipe(
             switchMap(mapPrefName),
-            combineLatestWith(hiddenDmIds),
+            combineLatestWith(hiddenOrEmptyDmIds),
             switchMap(([a, b]) => of$(new Set(a.concat(b)))),
         );
 

--- a/app/screens/home/channel_list/categories_list/categories/body/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/body/index.ts
@@ -116,8 +116,8 @@ const enhance = withObservables(['category', 'isTablet', 'locale'], ({category, 
         observeWithColumns(['value']).pipe(
             switchMap(mapPrefName),
             combineLatestWith(hiddenDmIds, emptyDmIds),
-            switchMap(([hIds, hiddenDms, emptyDms]) => {
-                return of$(new Set(hIds.concat(hiddenDms, emptyDms)));
+            switchMap(([hIds, hDmIds, eDmIds]) => {
+                return of$(new Set(hIds.concat(hDmIds, eDmIds)));
             }),
         );
 


### PR DESCRIPTION
#### Summary
This PR excludes showing DMs that are created, but not have any posts, in the LHS channel list.

#### Testing

* Log into mobile as User-A
* From another client, login with User-B
    * add a DM with User-A, but do not add any posts to the DM
    * **OBSERVE:** User-A does not show DM with User-B in the channel list
* From User-B client, add a post to the DM with User-A
    * **OBSERVE:** User-A now sees the DM show up in the channel list

Repeat the above test, but have User-B create a GM. **OBSERVE** User-A sees the same observations from above

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45506

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
