### PR TITLE
[Gekidou MM-46847] allow wrapping long channel text in autocomplete

### DIFF
--- a/app/components/autocomplete/autocomplete.tsx
+++ b/app/components/autocomplete/autocomplete.tsx
@@ -29,16 +29,6 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             borderRadius: 8,
             elevation: 3,
         },
-        searchContainer: {
-            ...Platform.select({
-                android: {
-                    top: 42,
-                },
-                ios: {
-                    top: 55,
-                },
-            }),
-        },
         shadow: {
             shadowColor: '#000',
             shadowOpacity: 0.12,

--- a/app/components/autocomplete/channel_mention_item/channel_mention_item.tsx
+++ b/app/components/autocomplete/channel_mention_item/channel_mention_item.tsx
@@ -27,6 +27,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => {
             alignItems: 'center',
         },
         rowDisplayName: {
+            flex: 1,
             fontSize: 15,
             color: theme.centerChannelColor,
         },
@@ -129,16 +130,17 @@ const ChannelMentionItem = ({
                         style={style.icon}
                     />
                     <Text
+                        numberOfLines={2}
                         style={style.rowDisplayName}
                         testID={`${channelMentionItemTestId}.display_name`}
                     >
                         {displayName}
-                    </Text>
-                    <Text
-                        style={style.rowName}
-                        testID={`${channelMentionItemTestId}.name`}
-                    >
-                        {` ~${channel.name}`}
+                        <Text
+                            style={style.rowName}
+                            testID={`${channelMentionItemTestId}.name`}
+                        >
+                            {` ~${channel.name}`}
+                        </Text>
                     </Text>
                 </View>
             </TouchableWithFeedback>

--- a/app/components/autocomplete/channel_mention_item/channel_mention_item.tsx
+++ b/app/components/autocomplete/channel_mention_item/channel_mention_item.tsx
@@ -130,7 +130,7 @@ const ChannelMentionItem = ({
                         style={style.icon}
                     />
                     <Text
-                        numberOfLines={2}
+                        numberOfLines={1}
                         style={style.rowDisplayName}
                         testID={`${channelMentionItemTestId}.display_name`}
                     >


### PR DESCRIPTION
#### Summary
This PR allows wrapping long channel name text into two lines. @matthewbirtch, if the two lines are not desired, the only other option is to use one line, but none of the slug will be shown with long channel names.

It also removes an unused, but defined styling object

##### Tablet 
<img width="482" alt="image" src="https://user-images.githubusercontent.com/7575921/189505608-c6a10614-86a8-4ddf-afd9-e3786239251f.png">

##### Mobile
<img width="407" alt="image" src="https://user-images.githubusercontent.com/7575921/189505629-dfffd4dd-50b5-46a0-912a-3e751923c9ab.png">


#### Ticket Link


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
