### PR TITLE
[Gekidou MM-45046] Always show threads button when filtered and unfiltered

### DIFF
--- a/app/screens/home/channel_list/categories_list/threads_button/__snapshots__/threads_button.test.tsx.snap
+++ b/app/screens/home/channel_list/categories_list/threads_button/__snapshots__/threads_button.test.tsx.snap
@@ -83,3 +83,85 @@ exports[`Thread item in the channel list Threads Component should match snapshot
 `;
 
 exports[`Thread item in the channel list Threads Component should match snapshot with only unreads filter 1`] = `null`;
+
+exports[`Thread item in the channel list Threads Component should match snapshot, groupUnreadsSeparately false, always show 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "opacity": 1,
+    }
+  }
+  testID="channel_list.threads.button"
+>
+  <View
+    style={
+      Object {
+        "marginLeft": -18,
+        "marginRight": -20,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "minHeight": 40,
+            "paddingHorizontal": 20,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Icon
+        name="message-text-outline"
+        style={
+          Array [
+            Object {
+              "color": "rgba(255,255,255,0.5)",
+              "fontSize": 24,
+            },
+            undefined,
+          ]
+        }
+      />
+      <Text
+        style={
+          Array [
+            Object {
+              "flex": 1,
+            },
+            Object {
+              "fontFamily": "OpenSans",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "lineHeight": 24,
+            },
+            Object {
+              "color": "rgba(255,255,255,0.72)",
+              "marginTop": -1,
+              "paddingLeft": 12,
+              "paddingRight": 20,
+            },
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        Threads
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/app/screens/home/channel_list/categories_list/threads_button/index.ts
+++ b/app/screens/home/channel_list/categories_list/threads_button/index.ts
@@ -3,8 +3,13 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
+import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
+import Preferences from '@app/constants/preferences';
+import {PreferenceModel} from '@app/database/models/server';
+import {queryPreferencesByCategoryAndName} from '@app/queries/servers/preference';
+import {getPreferenceAsBool} from '@helpers/api/preference';
 import {observeCurrentChannelId, observeCurrentTeamId, observeOnlyUnreads} from '@queries/servers/system';
 import {observeUnreadsAndMentionsInTeam} from '@queries/servers/thread';
 
@@ -17,6 +22,11 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
 
     return {
         currentChannelId: observeCurrentChannelId(database),
+        groupUnreadsSeparately: queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS).
+            observeWithColumns(['value']).
+            pipe(
+                switchMap((prefs: PreferenceModel[]) => of$(getPreferenceAsBool(prefs, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS, false))),
+            ),
         onlyUnreads: observeOnlyUnreads(database),
         unreadsAndMentions: currentTeamId.pipe(
             switchMap(

--- a/app/screens/home/channel_list/categories_list/threads_button/threads_button.test.tsx
+++ b/app/screens/home/channel_list/categories_list/threads_button/threads_button.test.tsx
@@ -7,31 +7,41 @@ import {renderWithIntlAndTheme} from '@test/intl-test-helper';
 
 import Threads from './threads_button';
 
+const baseProps = {
+    currentChannelId: 'someChannelId',
+    groupUnreadsSeparately: true,
+    onlyUnreads: false,
+    unreadsAndMentions: {
+        unreads: false,
+        mentions: 0,
+    },
+};
+
 describe('Thread item in the channel list', () => {
     test('Threads Component should match snapshot', () => {
         const {toJSON} = renderWithIntlAndTheme(
-            <Threads
-                currentChannelId='someChannelId'
-                onlyUnreads={false}
-                unreadsAndMentions={{
-                    unreads: false,
-                    mentions: 0,
-                }}
-            />,
+            <Threads {...baseProps}/>,
         );
-
         expect(toJSON()).toMatchSnapshot();
     });
 
     test('Threads Component should match snapshot with only unreads filter', () => {
         const {toJSON} = renderWithIntlAndTheme(
             <Threads
-                currentChannelId='someChannelId'
+                {...baseProps}
                 onlyUnreads={true}
-                unreadsAndMentions={{
-                    unreads: false,
-                    mentions: 0,
-                }}
+            />,
+        );
+
+        expect(toJSON()).toMatchSnapshot();
+    });
+
+    test('Threads Component should match snapshot, groupUnreadsSeparately false, always show', () => {
+        const {toJSON} = renderWithIntlAndTheme(
+            <Threads
+                {...baseProps}
+                groupUnreadsSeparately={false}
+                onlyUnreads={true}
             />,
         );
 

--- a/app/screens/home/channel_list/categories_list/threads_button/threads_button.tsx
+++ b/app/screens/home/channel_list/categories_list/threads_button/threads_button.tsx
@@ -38,13 +38,14 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 type Props = {
     currentChannelId: string;
     onlyUnreads: boolean;
+    groupUnreadsSeparately: boolean;
     unreadsAndMentions: {
         unreads: boolean;
         mentions: number;
     };
 };
 
-const ThreadsButton = ({currentChannelId, onlyUnreads, unreadsAndMentions}: Props) => {
+const ThreadsButton = ({currentChannelId, groupUnreadsSeparately, onlyUnreads, unreadsAndMentions}: Props) => {
     const isTablet = useIsTablet();
     const serverUrl = useServerUrl();
 
@@ -81,7 +82,7 @@ const ThreadsButton = ({currentChannelId, onlyUnreads, unreadsAndMentions}: Prop
         return [container, icon, text];
     }, [customStyles, isActive, styles, unreads]);
 
-    if (onlyUnreads && !isActive && !unreads && !mentions) {
+    if (groupUnreadsSeparately && (onlyUnreads && !isActive && !unreads && !mentions)) {
         return null;
     }
 


### PR DESCRIPTION
#### Summary
This PR pins the `Threads` button to the top of the channel list sidebar when `unread` filters is on.  This is the same behavior when unread filters is off. 

As describe in the ticket, this only occurs when the user has the `Settings` > `Sidebar` > `Group unread channels separately` set to `false`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45046

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots


| unread filters on, no unreads | unread filters on, with unreads | unread filters off |
| -- | --- | -- |
| <img width="455" alt="image" src="https://user-images.githubusercontent.com/7575921/189466734-c0177370-5b70-42ae-a6d5-80629cb68374.png"> | <img width="439" alt="image" src="https://user-images.githubusercontent.com/7575921/189466777-2a92ef22-d814-4256-993d-2fba3895b44c.png">  | <img width="460" alt="image" src="https://user-images.githubusercontent.com/7575921/189466813-bd4d1dee-a9d6-4032-ac1c-a85127508a8a.png"> | 


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
