### PR TITLE
[Gekidou MM-46899 MM-45205] Thread sync issue

### DIFF
--- a/app/actions/websocket/threads.ts
+++ b/app/actions/websocket/threads.ts
@@ -11,7 +11,7 @@ export async function handleThreadUpdatedEvent(serverUrl: string, msg: WebSocket
 
         // Mark it as following
         thread.is_following = true;
-        processReceivedThreads(serverUrl, [thread], teamId, true);
+        processReceivedThreads(serverUrl, [thread], teamId);
     } catch (error) {
         // Do nothing
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
We are saving the threads received through the WebSockets with "loaded in global threads" flag as true. In case there is a delay in sync or we receive a thread through the WebSocket during the sync, next sync will send the new thread's `lastReplyAt` and it can create gaps in the thread or result in stale threads. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45205
https://mattermost.atlassian.net/browse/MM-46899

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 15.5

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
NONE
```
