### PR TITLE
[Gekidou] Fix for crash caused due to accessing "priority" property

### DIFF
--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -222,7 +222,7 @@ const Post = ({
     let header: ReactNode;
     let postAvatar: ReactNode;
     let consecutiveStyle: StyleProp<ViewStyle>;
-    const isProrityPost = isPostPriorityEnabled && post.props.priority;
+    const isProrityPost = Boolean(isPostPriorityEnabled && post.props?.priority);
     const sameSequence = hasReplies ? (hasReplies && post.rootId) : !post.rootId;
     if (!isProrityPost && hasSameRoot && isConsecutivePost && sameSequence) {
         consecutiveStyle = styles.consective;


### PR DESCRIPTION
#### Summary
This PR fixes the crashes caused by accessing the `priority` property.
https://community.mattermost.com/core/pl/6na9ynzab3fy8d3ie3pb4cjrtc

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 15.5

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
NONE
```