### PR TITLE
Fix login not showing the usernames

### DIFF
--- a/app/actions/remote/systems.ts
+++ b/app/actions/remote/systems.ts
@@ -63,7 +63,7 @@ export const fetchConfigAndLicense = async (serverUrl: string, fetchOnly = false
         ]);
 
         if (!fetchOnly) {
-            storeConfigAndLicense(serverUrl, config, license);
+            await storeConfigAndLicense(serverUrl, config, license);
         }
 
         return {config, license};

--- a/app/screens/home/channel_list/categories_list/categories/body/category_body.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/body/category_body.tsx
@@ -62,7 +62,9 @@ const CategoryBody = ({sortedChannels, unreadIds, unreadsOnTop, category, limit,
     }, [category.collapsed]);
 
     useEffect(() => {
-        fetchDirectChannelsInfo(serverUrl, directChannels);
+        if (directChannels.length) {
+            fetchDirectChannelsInfo(serverUrl, directChannels);
+        }
     }, [directChannels.length]);
 
     const height = ids.length ? ids.length * 40 : 0;


### PR DESCRIPTION
#### Summary
Before login, we are getting the config, to decide whether to use GraphQL or REST. A race condition made it so the first entry call was done through the GraphQL path, but the deferred actions through the REST path, creating several problems.

I also noticed the fetch missing dm information call was done more often than needed, so I fixed that also.

#### Ticket Link
None

```release-note
Fix dm names not showing after login
```
