### PR TITLE
Fix permissions defaulting to true

### DIFF
--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -251,7 +251,7 @@ export const getDefaultChannelForTeam = async (database: Database, teamId: strin
     const roles = await queryRoles(database).fetch();
 
     if (roles.length) {
-        canIJoinPublicChannelsInTeam = hasPermission(roles, Permissions.JOIN_PUBLIC_CHANNELS, true);
+        canIJoinPublicChannelsInTeam = hasPermission(roles, Permissions.JOIN_PUBLIC_CHANNELS);
     }
 
     const myChannels = await database.get<ChannelModel>(CHANNEL).query(

--- a/app/queries/servers/role.ts
+++ b/app/queries/servers/role.ts
@@ -53,7 +53,7 @@ export function observePermissionForChannel(database: Database, channel: Channel
             rolesArray.push(...mt.roles.split(' '));
         }
         return queryRolesByNames(database, rolesArray).observeWithColumns(['permissions']).pipe(
-            switchMap((r) => of$(hasPermission(r, permission, defaultValue))),
+            switchMap((r) => of$(hasPermission(r, permission))),
         );
     }),
     distinctUntilChanged(),
@@ -74,7 +74,7 @@ export function observePermissionForTeam(database: Database, team: TeamModel | u
             }
 
             return queryRolesByNames(database, rolesArray).observeWithColumns(['permissions']).pipe(
-                switchMap((roles) => of$(hasPermission(roles, permission, defaultValue))),
+                switchMap((roles) => of$(hasPermission(roles, permission))),
             );
         }),
         distinctUntilChanged(),

--- a/app/screens/browse_channels/index.ts
+++ b/app/screens/browse_channels/index.ts
@@ -39,7 +39,7 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
         switchMap((values) => queryRolesByNames(database, values).observeWithColumns(['permissions'])),
     );
 
-    const canCreateChannels = roles.pipe(switchMap((r) => of$(hasPermission(r, Permissions.CREATE_PUBLIC_CHANNEL, false))));
+    const canCreateChannels = roles.pipe(switchMap((r) => of$(hasPermission(r, Permissions.CREATE_PUBLIC_CHANNEL))));
 
     return {
         canCreateChannels,

--- a/app/screens/channel/channel_post_list/intro/public_or_private_channel/public_or_private_channel.tsx
+++ b/app/screens/channel/channel_post_list/intro/public_or_private_channel/public_or_private_channel.tsx
@@ -74,12 +74,12 @@ const PublicOrPrivateChannel = ({channel, creator, roles, theme}: Props) => {
 
     const canManagePeople = useMemo(() => {
         const permission = channel.type === General.OPEN_CHANNEL ? Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS : Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS;
-        return hasPermission(roles, permission, false);
+        return hasPermission(roles, permission);
     }, [channel.type, roles]);
 
     const canSetHeader = useMemo(() => {
         const permission = channel.type === General.OPEN_CHANNEL ? Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES : Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES;
-        return hasPermission(roles, permission, false);
+        return hasPermission(roles, permission);
     }, [channel.type, roles]);
 
     const createdBy = useMemo(() => {

--- a/app/screens/channel/channel_post_list/intro/townsquare/index.tsx
+++ b/app/screens/channel/channel_post_list/intro/townsquare/index.tsx
@@ -60,7 +60,7 @@ const TownSquare = ({channelId, displayName, roles, theme}: Props) => {
             />
             <IntroOptions
                 channelId={channelId}
-                header={hasPermission(roles, Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES, false)}
+                header={hasPermission(roles, Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES)}
             />
         </View>
     );

--- a/app/utils/channel/index.ts
+++ b/app/utils/channel/index.ts
@@ -43,7 +43,7 @@ export function selectDefaultChannelForTeam<T extends Channel|ChannelModel>(chan
     let canIJoinPublicChannelsInTeam = false;
 
     if (roles) {
-        canIJoinPublicChannelsInTeam = hasPermission(roles, Permissions.JOIN_PUBLIC_CHANNELS, true);
+        canIJoinPublicChannelsInTeam = hasPermission(roles, Permissions.JOIN_PUBLIC_CHANNELS);
     }
     const defaultChannel = channels?.find((c) => c.name === General.DEFAULT_CHANNEL);
     const membershipIds = new Set(memberships.map((m) => m.channel_id));

--- a/app/utils/role/index.ts
+++ b/app/utils/role/index.ts
@@ -3,12 +3,11 @@
 
 import type RoleModel from '@typings/database/models/servers/role';
 
-export function hasPermission(roles: RoleModel[] | Role[], permission: string, defaultValue: boolean) {
+export function hasPermission(roles: RoleModel[] | Role[], permission: string) {
     const permissions = new Set<string>();
     for (const role of roles) {
         role.permissions.forEach(permissions.add, permissions);
     }
 
-    const exists = permissions.has(permission);
-    return defaultValue === true || exists;
+    return permissions.has(permission);
 }


### PR DESCRIPTION
#### Summary
Permissions defaulted to true (like the one for read only channels) were not respecting at all the permissions.

#### Ticket Link
None
#### Release Note
```release-note
Fix permissions defaulted to true.
```
