### PR TITLE
MM-47003 - Calls - Fix for: peer connection timeout

### DIFF
--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -231,7 +231,7 @@ export async function newConnection(serverUrl: string, channelID: string, closeC
 
     ws.on('message', ({data}: { data: string }) => {
         const msg = JSON.parse(data);
-        if (msg.type === 'answer' || msg.type === 'offer') {
+        if (msg.type === 'answer' || msg.type === 'candidate' || msg.type === 'offer') {
             peer?.signal(data);
         }
     });

--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -237,9 +237,9 @@ export async function newConnection(serverUrl: string, channelID: string, closeC
     });
 
     const waitForPeerConnection = () => {
-        const waitForReadyImpl = (callback: () => void, fail: () => void, timeout: number) => {
+        const waitForReadyImpl = (callback: () => void, fail: (reason: string) => void, timeout: number) => {
             if (timeout <= 0) {
-                fail();
+                fail('timed out waiting for peer connection');
                 return;
             }
             setTimeout(() => {

--- a/app/products/calls/connection/simple-peer.ts
+++ b/app/products/calls/connection/simple-peer.ts
@@ -738,6 +738,9 @@ export default class Peer extends stream.Duplex {
             this.pcReady = true;
             this.maybeReady();
         }
+        if (iceConnectionState === 'checking' && this.iceComplete) {
+            this.negotiate();
+        }
         if (iceConnectionState === 'failed') {
             this.destroy(
                 errCode(

--- a/app/products/calls/connection/simple-peer.ts
+++ b/app/products/calls/connection/simple-peer.ts
@@ -738,9 +738,6 @@ export default class Peer extends stream.Duplex {
             this.pcReady = true;
             this.maybeReady();
         }
-        if (iceConnectionState === 'checking' && this.iceComplete) {
-            this.negotiate();
-        }
         if (iceConnectionState === 'failed') {
             this.destroy(
                 errCode(

--- a/app/products/calls/state/actions.ts
+++ b/app/products/calls/state/actions.ts
@@ -131,6 +131,12 @@ export const userLeftCall = (serverUrl: string, channelId: string, userId: strin
         return;
     }
 
+    // Was the user me?
+    if (userId === callsState.myUserId) {
+        myselfLeftCall();
+        return;
+    }
+
     const nextCurrentCall = {
         ...currentCall,
         participants: {...currentCall.participants},


### PR DESCRIPTION
#### Summary
- Handle the candidate message, which we've been forgetting to do. Fixes the problem.
- Tested pre and post on the pixel and iphone.
- Also: Better error reporting, and clean up the currentCall state if we fail to connect to a call.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-47003

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: fixed a bug where a call started from mobile would appear to start, but then fail after 5 seconds.
```

