### PR TITLE
MM-47003 - Calls - Fix for: peer connection timeout (v1)

### DIFF
--- a/app/products/calls/connection.ts
+++ b/app/products/calls/connection.ts
@@ -203,7 +203,7 @@ export async function newClient(channelID: string, iceServers: ICEServersConfigs
 
     ws.on('message', ({data}) => {
         const msg = JSON.parse(data);
-        if (msg.type === 'answer' || msg.type === 'offer') {
+        if (msg.type === 'answer' || msg.type === 'candidate' || msg.type === 'offer') {
             peer?.signal(data);
         }
     });


### PR DESCRIPTION
#### Summary
- Handle the candidate message, which we've been forgetting to do. Fixes the problem.
- Tested pre and post on the pixel and iphone.
- v2 fix: #6658 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-47003

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: fixed a bug where a call started from mobile would appear to start, but then fail after 30 seconds.
```
