### PR TITLE
[Gekidou MM-47427 MM-47428] Thread Overview replies count

### DIFF
--- a/app/components/post_list/thread_overview/index.ts
+++ b/app/components/post_list/thread_overview/index.ts
@@ -24,7 +24,7 @@ const enhanced = withObservables(
                 pipe(
                     switchMap((pref) => of$(Boolean(pref[0]?.value === 'true'))),
                 ),
-            repliesCount: queryPostReplies(database, rootId).observeCount(false),
+            repliesCount: queryPostReplies(database, rootId, true, true).observeCount(false),
         };
     });
 

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -101,10 +101,13 @@ export const queryPostsInThread = (database: Database, rootId: string, sorted = 
     return database.get<PostsInThreadModel>(POSTS_IN_THREAD).query(...clauses);
 };
 
-export const queryPostReplies = (database: Database, rootId: string, excludeDeleted = true) => {
+export const queryPostReplies = (database: Database, rootId: string, excludeDeleted = true, excludeSystemMessages = false) => {
     const clauses: Q.Clause[] = [Q.where('root_id', rootId)];
     if (excludeDeleted) {
         clauses.push(Q.where('delete_at', Q.eq(0)));
+    }
+    if (excludeSystemMessages) {
+        clauses.push(Q.where('type', ''));
     }
     return database.get<PostModel>(POST).query(...clauses);
 };

--- a/app/utils/post_list/index.ts
+++ b/app/utils/post_list/index.ts
@@ -58,7 +58,7 @@ function combineUserActivityPosts(orderedPosts: Array<PostModel | string>) {
         const post = orderedPosts[i];
 
         if (typeof post === 'string') {
-            if (post === START_OF_NEW_MESSAGES || post.startsWith(DATE_LINE)) {
+            if (isStartOfNewMessages(post) || isThreadOverview(post) || isDateLine(post)) {
                 // Not a post, so it won't be combined
                 out.push(post);
 


### PR DESCRIPTION
#### Summary
This PR fixes
1. Replies count in the Thread Overview component should exclude system messages.
2. Display the Thread Overview component which was getting hidden due to combining activities.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47428
https://mattermost.atlassian.net/browse/MM-47427

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 16

#### Screenshots
<img src="https://user-images.githubusercontent.com/3680799/195027329-6c496fd9-522d-40e7-847e-2c73986a653b.png" height="420" />


#### Release Note
```release-note
NONE
```