### PR TITLE
[Gekidou] Fix switch to channel when notification is dismissed

### DIFF
--- a/app/constants/screens.ts
+++ b/app/constants/screens.ts
@@ -149,6 +149,12 @@ export const SCREENS_WITH_TRANSPARENT_BACKGROUND = new Set<string>([
     USER_PROFILE,
 ]);
 
+export const OVERLAY_SCREENS = new Set<string>([
+    IN_APP_NOTIFICATION,
+    GALLERY,
+    SNACK_BAR,
+]);
+
 export const NOT_READY = [
     CHANNEL_ADD_PEOPLE,
     CHANNEL_MENTION,

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -113,7 +113,6 @@ class PushNotifications {
                 const screen = Screens.IN_APP_NOTIFICATION;
                 const passProps = {
                     notification,
-                    overlay: true,
                     serverName,
                     serverUrl,
                 };

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -615,10 +615,7 @@ export function showOverlay(name: string, passProps = {}, options = {}) {
         component: {
             id: name,
             name,
-            passProps: {
-                ...passProps,
-                overlay: true,
-            },
+            passProps,
             options: merge(defaultOptions, options),
         },
     });

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import 'react-native-gesture-handler';
 import {ComponentDidAppearEvent, ComponentDidDisappearEvent, ModalDismissedEvent, Navigation, ScreenPoppedEvent} from 'react-native-navigation';
 
 import {Events, Screens} from './app/constants';
+import {OVERLAY_SCREENS} from './app/constants/screens';
 import DatabaseManager from './app/database/manager';
 import {getAllServerCredentials} from './app/init/credentials';
 import {initialLaunch} from './app/init/launch';
@@ -98,8 +99,8 @@ function screenWillAppear({componentId}: ComponentDidAppearEvent) {
     }
 }
 
-function screenDidAppearListener({componentId, passProps, componentType}: ComponentDidAppearEvent) {
-    if (!(passProps as any)?.overlay && componentType === 'Component') {
+function screenDidAppearListener({componentId, componentType}: ComponentDidAppearEvent) {
+    if (!OVERLAY_SCREENS.has(componentId) && componentType === 'Component') {
         NavigationStore.addNavigationComponentId(componentId);
     }
 }


### PR DESCRIPTION
#### Summary
When we receive notifications while the app is in the foreground, and in-app notification overlay is being presented, this overlay is kept out of the navigation stack in order to be able to push and pop screens on top of the current screen.

The way we were keeping the overlay out of the stack is by checking the screen props in the `registerComponentDidAppearListener` event, there is a bug in the navigation library (I did not try and figure it out as there is too much code involved) where the props are missing in the event (normally when the same screen is triggered repeatedly aka: 3 consecutive notifications) thus the overlay being registered as part of the stack, when attempting to open a channel, the top screen `InAppNotification` was already dismissed thus nothing can be push on top of it.

On this PR we define which screens open as an overlay and we check that the screen being displayed is not part of the overlay ones.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47161

```release-note
NONE
```
