### PR TITLE
[Gekidou MM-47486] Clear the search input after selecting a user

### DIFF
--- a/app/components/search/index.tsx
+++ b/app/components/search/index.tsx
@@ -90,7 +90,7 @@ const Search = forwardRef<SearchRef, SearchProps>((props: SearchProps, ref) => {
     const onClear = useCallback(() => {
         setValue('');
         props.onClear?.();
-    }, []);
+    }, [props.onClear]);
 
     const onChangeText = useCallback((text: string) => {
         setValue(text);
@@ -105,8 +105,8 @@ const Search = forwardRef<SearchRef, SearchProps>((props: SearchProps, ref) => {
     }), [theme]);
 
     useEffect(() => {
-        setValue(props.defaultValue || value || '');
-    }, [props.defaultValue]);
+        setValue(props.defaultValue || props.value || '');
+    }, [props.defaultValue, props.value]);
 
     const clearIcon = (
         <CompassIcon


### PR DESCRIPTION
#### Summary
This PR changes the UX for creating a DM so that text existing in the search input will be cleared after a user selects a user.

Repro Steps
1. `+` button to the right of the team in channels view
2. `Open a Direct Message`
3. Type some text in the `Search` input field to filter users
4. Tap a user
5. Observe the user is added
6. Observe the search input is cleared of the text.

Before: Item 6) was not occurring and the text stayed in the search input.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47486

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
