### PR TITLE
Remove not member teams on startup

### DIFF
--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -19,16 +19,14 @@ import {queryAllChannels, queryAllChannelsForTeam} from '@queries/servers/channe
 import {prepareModels, truncateCrtRelatedTables} from '@queries/servers/entry';
 import {getHasCRTChanged} from '@queries/servers/preference';
 import {getConfig} from '@queries/servers/system';
-import {queryMyTeams} from '@queries/servers/team';
 import {filterAndTransformRoles, getMemberChannelsFromGQLQuery, getMemberTeamsFromGQLQuery, gqlToClientChannelMembership, gqlToClientPreference, gqlToClientSidebarCategory, gqlToClientTeamMembership, gqlToClientUser} from '@utils/graphql';
 import {logDebug} from '@utils/log';
 import {processIsCRTEnabled} from '@utils/thread';
 
-import {teamsToRemove, FETCH_UNREADS_TIMEOUT, entryRest, EntryResponse, entryInitialChannelId, restDeferredAppEntryActions} from './common';
+import {teamsToRemove, FETCH_UNREADS_TIMEOUT, entryRest, EntryResponse, entryInitialChannelId, restDeferredAppEntryActions, getRemoveTeamIds} from './common';
 
 import type ClientError from '@client/rest/error';
 import type ChannelModel from '@typings/database/models/servers/channel';
-import type TeamModel from '@typings/database/models/servers/team';
 
 export async function deferredAppEntryGraphQLActions(
     serverUrl: string,
@@ -227,23 +225,9 @@ export const entryGQL = async (serverUrl: string, currentTeamId?: string, curren
     const roles = filterAndTransformRoles(gqlRoles);
 
     const initialChannelId = await entryInitialChannelId(database, currentChannelId, currentTeamId, initialTeamId, meData.user.id, chData?.channels, chData?.memberships);
-    let removeTeams: TeamModel[] = [];
     const removeChannels = await getRemoveChannels(database, chData, initialTeamId, true);
-
-    const removeTeamIds = [];
-
-    const removedFromTeam = teamData.memberships?.filter((m) => m.delete_at > 0);
-    if (removedFromTeam?.length) {
-        removeTeamIds.push(...removedFromTeam.map((m) => m.team_id));
-    }
-
-    if (teamData.teams?.length === 0) {
-        // User is no longer a member of any team
-        const myTeams = await queryMyTeams(database).fetch();
-        removeTeamIds.push(...(myTeams?.map((myTeam) => myTeam.id) || []));
-    }
-
-    removeTeams = await teamsToRemove(serverUrl, removeTeamIds);
+    const removeTeamIds = await getRemoveTeamIds(database, teamData);
+    const removeTeams = await teamsToRemove(serverUrl, removeTeamIds);
 
     const modelPromises = await prepareModels({operator, initialTeamId, removeTeams, removeChannels, teamData, chData, prefData, meData}, true);
     if (roles.length) {


### PR DESCRIPTION
#### Summary
If we are no longer a member of a team and the server fails to tell us so (i.e. doesn't return a membership with delete_at > 0) we end up with a not working team in the database. This makes sure there is a cleanup.

#### Ticket Link
None

#### Release Note
```release-note
Make sure non-member teams are removed from the UI.
```
