### PR TITLE
iOS: Perform the split view check in main queue. (Some call paths caused the check to be done in a background thread)

### DIFF
--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -51,12 +51,19 @@ RCT_EXPORT_MODULE();
 }
 
 RCT_EXPORT_METHOD(isRunningInSplitView:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-  BOOL isRunningInFullScreen = CGRectEqualToRect(
-                                                 [UIApplication sharedApplication].delegate.window.frame,
-                                                 [UIApplication sharedApplication].delegate.window.screen.bounds);
-  resolve(@{
-            @"isSplitView": @(!isRunningInFullScreen)
-            });
+  dispatch_block_t splitViewCheck = ^{
+    BOOL isRunningInFullScreen = CGRectEqualToRect(
+                                                   [UIApplication sharedApplication].delegate.window.frame,
+                                                   [UIApplication sharedApplication].delegate.window.screen.bounds);
+    resolve(@{
+              @"isSplitView": @(!isRunningInFullScreen)
+              });
+  };
+  if (dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL) == dispatch_queue_get_label(dispatch_get_main_queue())) {
+    splitViewCheck();
+  } else {
+    dispatch_async(dispatch_get_main_queue(), splitViewCheck);
+  }
 }
 
 RCT_EXPORT_METHOD(deleteDatabaseDirectory: (NSString *)databaseName  shouldRemoveDirectory: (BOOL) shouldRemoveDirectory callback: (RCTResponseSenderBlock)callback){


### PR DESCRIPTION
#### Summary

On iOS, make sure the react-native exported `isRunningInSplitView` executes the split view check in the main queue. Some call paths on the react native side seem to call the check from a background thread.

#### Ticket Link

None

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iPhone 13 Pro, iOS 15.6.1

#### Screenshots

n/a

#### Release Note


```release-note
NONE
```
