### PR TITLE
[Gekidou MM-47224] Don’t show in app notifications for the active thread

### DIFF
--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -117,13 +117,13 @@ class PushNotifications {
             const condition1 = !isInChannelScreen && !isInThreadScreen;
 
             // 2. If is in channel screen,
-            //      - Show notifications of other channels
+            //      - Show notification of other channels
             //        or
-            //      - Show If CRT is enabled, show thread notifications even if it belongs to the same channel
+            //      - Show notification if CRT is enabled and it's a thread notification (doesn't matter if it's the same channel)
             const condition2 = isInChannelScreen && (!isSameChannelNotification || (isCRTEnabled && isThreadNotification));
 
             // 3. If is in thread screen,
-            //      - If notification doesn't belong to the thread, show the notification
+            //      - Show the notification if it doesn't belong to the thread
             const condition3 = isInThreadScreen && !isSameThreadNotification;
 
             if (condition1 || condition2 || condition3) {


### PR DESCRIPTION
#### Summary
This PR fixes the issue with in-app notifications being displayed for the active thread. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47224

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 16, Android 11

#### Release Note
```release-note
NONE
```