### PR TITLE
[Gekidou] apply heading style to hashtags

### DIFF
--- a/app/components/markdown/hashtag/index.tsx
+++ b/app/components/markdown/hashtag/index.tsx
@@ -2,13 +2,13 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Text, TextStyle} from 'react-native';
+import {StyleProp, Text, TextStyle} from 'react-native';
 
 import {popToRoot, dismissAllModals} from '@screens/navigation';
 
 type HashtagProps = {
     hashtag: string;
-    linkStyle: TextStyle;
+    linkStyle: StyleProp<TextStyle>;
 };
 
 const Hashtag = ({hashtag, linkStyle}: HashtagProps) => {

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -284,10 +284,16 @@ const Markdown = ({
             return renderText({context, literal: `#${hashtag}`});
         }
 
+        const linkStyle = [textStyles.link];
+        const headingIndex = context.findIndex((c) => c.includes('heading'));
+        if (headingIndex > -1) {
+            linkStyle.push(textStyles[context[headingIndex]]);
+        }
+
         return (
             <Hashtag
                 hashtag={hashtag}
-                linkStyle={textStyles.link}
+                linkStyle={linkStyle}
             />
         );
     };


### PR DESCRIPTION
#### Summary
When a message include a hashtag in a heading, now the heading style is also applied to the hashtag.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47968

```release-note
NONE
```
