### PR TITLE
update team sidebar's background color to match with the theme color …

### DIFF
--- a/app/components/team_sidebar/team_sidebar.tsx
+++ b/app/components/team_sidebar/team_sidebar.tsx
@@ -28,7 +28,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             paddingTop: 10,
         },
         listContainer: {
-            backgroundColor: theme.sidebarTeamBarBg,
+            backgroundColor: theme.sidebarHeaderBg,
             borderTopRightRadius: 12,
             flex: 1,
         },


### PR DESCRIPTION
#### Summary
To match the webapp, this PR changes the team sidebar background to use the `sidebarHeaderBg` theme color instead of the `sidebarTeamBarBg` color. 

Eventually we will rename the theme colors to properly represent the area they affect, but when the global header was introduced, the `sidebarTeamBarBg` theme color was used for the global header and then the `sidebarHeaderBg` color was used for the team sidebar background. This was done to ensure backwards compatibility with themes and older versions of the webapp (pre-global header).

The change is very subtle for most themes, but is necessary to properly match.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-48011

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS Simulator

#### Screenshots
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="564" alt="image" src="https://user-images.githubusercontent.com/2040554/198589499-8444c580-6484-4960-b1f1-c20c4d6f02c1.png">
</td>
<td>
<img width="564" alt="image" src="https://user-images.githubusercontent.com/2040554/198589332-4d81681a-a254-4da5-9a7a-b5cc4b99630c.png">
</td>
</tr>

#### Release Note
```release-note
NONE
```
