### PR TITLE
[MM-47498] Don't bold muted channels

### DIFF
--- a/app/components/channel_icon/index.tsx
+++ b/app/components/channel_icon/index.tsx
@@ -103,7 +103,7 @@ const ChannelIcon = ({
     let unreadGroup;
     let mutedStyle;
 
-    if (isUnread) {
+    if (isUnread && !isMuted) {
         unreadIcon = styles.iconUnread;
         unreadGroupBox = styles.groupBoxUnread;
         unreadGroup = styles.groupUnread;
@@ -116,7 +116,7 @@ const ChannelIcon = ({
     }
 
     if (isInfo) {
-        activeIcon = isUnread ? styles.iconInfoUnread : styles.iconInfo;
+        activeIcon = isUnread && !isMuted ? styles.iconInfoUnread : styles.iconInfo;
         activeGroupBox = styles.groupBoxInfo;
         activeGroup = isUnread ? styles.groupInfoUnread : styles.groupInfo;
     }

--- a/app/components/channel_item/channel_item.tsx
+++ b/app/components/channel_item/channel_item.tsx
@@ -151,7 +151,7 @@ const ChannelListItem = ({
     }, [channel.id]);
 
     const textStyles = useMemo(() => [
-        isBolded ? textStyle.bold : textStyle.regular,
+        isBolded && !isMuted ? textStyle.bold : textStyle.regular,
         styles.text,
         isBolded && styles.highlight,
         isActive && isTablet && !isInfo ? styles.textActive : null,


### PR DESCRIPTION
#### Summary
Prevent bolding on muted channels when unread

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-47498](https://mattermost.atlassian.net/browse/MM-47498)
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: ios
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
<img width="381" alt="CleanShot 2022-10-28 at 15 51 15@2x" src="https://user-images.githubusercontent.com/1515906/198624018-d8d8bdf5-63c4-423f-aff3-c08feb33317f.png">


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
fixed bold channel when unread and muted
```
