### PR TITLE
[Gekidou MM-48006] Show keyboard when select a modifier

### DIFF
--- a/app/components/navigation_header/index.tsx
+++ b/app/components/navigation_header/index.tsx
@@ -41,24 +41,22 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const NavigationHeader = forwardRef<SearchRef, Props>((props: Props, ref) => {
-    const {
-        hasSearch = false,
-        isLargeTitle = false,
-        leftComponent,
-        onBackPress,
-        onTitlePress,
-        rightButtons,
-        scrollValue,
-        lockValue,
-        showBackButton,
-        subtitle,
-        subtitleCompanion,
-        title = '',
-        hideHeader,
-    } = props;
-    const searchProps = props;
-
+const NavigationHeader = forwardRef<SearchRef, Props>(({
+    hasSearch = false,
+    isLargeTitle = false,
+    leftComponent,
+    onBackPress,
+    onTitlePress,
+    rightButtons,
+    scrollValue,
+    lockValue,
+    showBackButton,
+    subtitle,
+    subtitleCompanion,
+    title = '',
+    hideHeader,
+    ...searchProps
+}: Props, ref) => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
 

--- a/app/components/navigation_header/index.tsx
+++ b/app/components/navigation_header/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {forwardRef, useImperativeHandle, useRef} from 'react';
 import Animated, {useAnimatedStyle, useDerivedValue} from 'react-native-reanimated';
 
 import {SEARCH_INPUT_HEIGHT, SEARCH_INPUT_MARGIN} from '@constants/view';
@@ -14,7 +14,7 @@ import Header, {HeaderRightButton} from './header';
 import NavigationHeaderLargeTitle from './large';
 import NavigationSearch from './search';
 
-import type {SearchProps} from '@components/search';
+import type {SearchProps, SearchRef} from '@components/search';
 
 type Props = SearchProps & {
     hasSearch?: boolean;
@@ -41,24 +41,33 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const NavigationHeader = ({
-    hasSearch = false,
-    isLargeTitle = false,
-    leftComponent,
-    onBackPress,
-    onTitlePress,
-    rightButtons,
-    scrollValue,
-    lockValue,
-    showBackButton,
-    subtitle,
-    subtitleCompanion,
-    title = '',
-    hideHeader,
-    ...searchProps
-}: Props) => {
+const NavigationHeader = forwardRef<SearchRef, Props>((props: Props, ref) => {
+    const {
+        hasSearch = false,
+        isLargeTitle = false,
+        leftComponent,
+        onBackPress,
+        onTitlePress,
+        rightButtons,
+        scrollValue,
+        lockValue,
+        showBackButton,
+        subtitle,
+        subtitleCompanion,
+        title = '',
+        hideHeader,
+    } = props;
+    const searchProps = props;
+
     const theme = useTheme();
     const styles = getStyleSheet(theme);
+    const searchRef = useRef<SearchRef>(null);
+
+    useImperativeHandle(ref, () => ({
+        focus: () => {
+            searchRef.current?.focus?.();
+        },
+    }), [searchRef]);
 
     const {largeHeight, defaultHeight, headerOffset} = useHeaderHeight();
     const containerHeight = useAnimatedStyle(() => {
@@ -125,12 +134,14 @@ const NavigationHeader = ({
                     hideHeader={hideHeader}
                     theme={theme}
                     topStyle={searchTopStyle}
+                    ref={searchRef}
                 />
                 }
             </Animated.View>
         </>
     );
-};
+});
 
+NavigationHeader.displayName = 'NavHeader';
 export default NavigationHeader;
 

--- a/app/components/navigation_header/index.tsx
+++ b/app/components/navigation_header/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {forwardRef, useImperativeHandle, useRef} from 'react';
+import React, {forwardRef} from 'react';
 import Animated, {useAnimatedStyle, useDerivedValue} from 'react-native-reanimated';
 
 import {SEARCH_INPUT_HEIGHT, SEARCH_INPUT_MARGIN} from '@constants/view';
@@ -61,13 +61,6 @@ const NavigationHeader = forwardRef<SearchRef, Props>((props: Props, ref) => {
 
     const theme = useTheme();
     const styles = getStyleSheet(theme);
-    const searchRef = useRef<SearchRef>(null);
-
-    useImperativeHandle(ref, () => ({
-        focus: () => {
-            searchRef.current?.focus?.();
-        },
-    }), [searchRef]);
 
     const {largeHeight, defaultHeight, headerOffset} = useHeaderHeight();
     const containerHeight = useAnimatedStyle(() => {
@@ -134,7 +127,7 @@ const NavigationHeader = forwardRef<SearchRef, Props>((props: Props, ref) => {
                     hideHeader={hideHeader}
                     theme={theme}
                     topStyle={searchTopStyle}
-                    ref={searchRef}
+                    ref={ref}
                 />
                 }
             </Animated.View>

--- a/app/components/navigation_header/search.tsx
+++ b/app/components/navigation_header/search.tsx
@@ -31,8 +31,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const NavigationSearch = forwardRef<SearchRef, Props>((searchProps: Props, ref) => {
-    const {theme, hideHeader, topStyle} = searchProps;
+const NavigationSearch = forwardRef<SearchRef, Props>(({
+    theme,
+    hideHeader,
+    topStyle,
+    ...searchProps
+}: Props, ref) => {
     const styles = getStyleSheet(theme);
 
     const cancelButtonProps: SearchProps['cancelButtonProps'] = useMemo(() => ({

--- a/app/components/navigation_header/search.tsx
+++ b/app/components/navigation_header/search.tsx
@@ -72,7 +72,7 @@ const NavigationSearch = forwardRef<SearchRef, Props>(({
             hide.remove();
             show.remove();
         };
-    }, []);
+    }, [hideEmitter, showEmitter]);
 
     return (
         <Animated.View style={[styles.container, topStyle]}>

--- a/app/components/navigation_header/search.tsx
+++ b/app/components/navigation_header/search.tsx
@@ -31,9 +31,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const NavigationSearch = forwardRef<SearchRef, Props>((props: Props, ref) => {
-    const {theme, hideHeader, topStyle} = props;
-    const searchProps = props;
+const NavigationSearch = forwardRef<SearchRef, Props>((searchProps: Props, ref) => {
+    const {theme, hideHeader, topStyle} = searchProps;
     const searchRef = useRef<SearchRef>(null);
     const styles = getStyleSheet(theme);
 
@@ -53,8 +52,8 @@ const NavigationSearch = forwardRef<SearchRef, Props>((props: Props, ref) => {
 
     const onFocus = useCallback((e: NativeSyntheticEvent<TextInputFocusEventData>) => {
         hideHeader?.();
-        props.onFocus?.(e);
-    }, [hideHeader, props.onFocus]);
+        searchProps.onFocus?.(e);
+    }, [hideHeader, searchProps.onFocus]);
 
     useEffect(() => {
         const show = Keyboard.addListener('keyboardDidShow', () => {

--- a/app/components/navigation_header/search.tsx
+++ b/app/components/navigation_header/search.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useEffect, useMemo} from 'react';
+import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef} from 'react';
 import {DeviceEventEmitter, Keyboard, NativeSyntheticEvent, Platform, TextInputFocusEventData, ViewStyle} from 'react-native';
 import Animated, {AnimatedStyleProp} from 'react-native-reanimated';
 
-import Search, {SearchProps} from '@components/search';
+import Search, {SearchProps, SearchRef} from '@components/search';
 import {Events} from '@constants';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -31,13 +31,17 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const NavigationSearch = ({
-    hideHeader,
-    theme,
-    topStyle,
-    ...searchProps
-}: Props) => {
+const NavigationSearch = forwardRef<SearchRef, Props>((props: Props, ref) => {
+    const {theme, hideHeader, topStyle} = props;
+    const searchProps = props;
+    const searchRef = useRef<SearchRef>(null);
     const styles = getStyleSheet(theme);
+
+    useImperativeHandle(ref, () => ({
+        focus: () => {
+            searchRef.current?.focus?.();
+        },
+    }), [searchRef]);
 
     const cancelButtonProps: SearchProps['cancelButtonProps'] = useMemo(() => ({
         buttonTextStyle: {
@@ -49,8 +53,8 @@ const NavigationSearch = ({
 
     const onFocus = useCallback((e: NativeSyntheticEvent<TextInputFocusEventData>) => {
         hideHeader?.();
-        searchProps.onFocus?.(e);
-    }, [hideHeader, searchProps.onFocus]);
+        props.onFocus?.(e);
+    }, [hideHeader, props.onFocus]);
 
     useEffect(() => {
         const show = Keyboard.addListener('keyboardDidShow', () => {
@@ -83,10 +87,12 @@ const NavigationSearch = ({
                 placeholderTextColor={changeOpacity(theme.sidebarText, Platform.select({android: 0.56, default: 0.72}))}
                 searchIconColor={theme.sidebarText}
                 selectionColor={theme.sidebarText}
+                ref={searchRef}
             />
         </Animated.View>
     );
-};
+});
 
+NavigationSearch.displayName = 'NavSearch';
 export default NavigationSearch;
 

--- a/app/components/navigation_header/search.tsx
+++ b/app/components/navigation_header/search.tsx
@@ -32,8 +32,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 }));
 
 const NavigationSearch = forwardRef<SearchRef, Props>(({
-    theme,
     hideHeader,
+    theme,
     topStyle,
     ...searchProps
 }: Props, ref) => {

--- a/app/components/search/index.tsx
+++ b/app/components/search/index.tsx
@@ -43,10 +43,10 @@ export type SearchProps = TextInputProps & {
 };
 
 export type SearchRef = {
-    blur?: () => void;
-    cancel?: () => void;
-    clear?: () => void;
-    focus?: () => void;
+    blur: () => void;
+    cancel: () => void;
+    clear: () => void;
+    focus: () => void;
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({

--- a/app/components/search/index.tsx
+++ b/app/components/search/index.tsx
@@ -151,7 +151,6 @@ const Search = forwardRef<SearchRef, SearchProps>((props: SearchProps, ref) => {
         focus: () => {
             searchRef.current?.focus();
         },
-
     }), [searchRef]);
 
     return (

--- a/app/components/search/index.tsx
+++ b/app/components/search/index.tsx
@@ -42,11 +42,14 @@ export type SearchProps = TextInputProps & {
     showLoading?: boolean;
 };
 
-type SearchRef = {
-    blur: () => void;
-    cancel: () => void;
-    clear: () => void;
-    focus: () => void;
+export type SearchRef = {
+    blur?: () => void;
+    cancel?: () => void;
+    clear?: () => void;
+    focus?: () => void;
+
+    // onSelectionChange: () => void;
+    // selection: {start: number; end: number};
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({

--- a/app/components/search/index.tsx
+++ b/app/components/search/index.tsx
@@ -47,9 +47,6 @@ export type SearchRef = {
     cancel?: () => void;
     clear?: () => void;
     focus?: () => void;
-
-    // onSelectionChange: () => void;
-    // selection: {start: number; end: number};
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({

--- a/app/screens/home/index.tsx
+++ b/app/screens/home/index.tsx
@@ -20,9 +20,8 @@ import Account from './account';
 import ChannelList from './channel_list';
 import RecentMentions from './recent_mentions';
 import SavedMessages from './saved_messages';
+import Search from './search';
 import TabBar from './tab_bar';
-
-// import Search from './search';
 
 import type {LaunchProps} from '@typings/launch';
 
@@ -125,11 +124,11 @@ export default function HomeScreen(props: HomeProps) {
                 >
                     {() => <ChannelList {...props}/>}
                 </Tab.Screen>
-                {/* <Tab.Screen
+                <Tab.Screen
                     name={Screens.SEARCH}
                     component={Search}
                     options={{unmountOnBlur: false, lazy: true, tabBarTestID: 'tab_bar.search.tab', freezeOnBlur: true}}
-                /> */}
+                />
                 <Tab.Screen
                     name={Screens.MENTIONS}
                     component={RecentMentions}

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -143,10 +143,10 @@ const SearchScreen = ({teamId}: Props) => {
     }, [resetToInitial]);
 
     const handleTextChange = useCallback((newValue: string) => {
+        searchRef.current?.focus?.();
         setSearchValue(newValue);
         setCursorPosition(newValue.length);
     }, []);
-        searchRef.current?.focus?.();
 
     const handleLoading = useCallback((show: boolean) => {
         (showResults ? setResultsLoading : setLoading)(show);

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -4,7 +4,7 @@
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
-import {FlatList, LayoutChangeEvent, Platform, StyleSheet, TextInput, ViewProps} from 'react-native';
+import {FlatList, LayoutChangeEvent, Platform, StyleSheet, ViewProps} from 'react-native';
 import Animated, {useAnimatedStyle, useDerivedValue, withTiming} from 'react-native-reanimated';
 import {Edge, SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
@@ -17,6 +17,7 @@ import FreezeScreen from '@components/freeze_screen';
 import Loading from '@components/loading';
 import NavigationHeader from '@components/navigation_header';
 import RoundedHeaderContext from '@components/rounded_header_context';
+import {SearchRef} from '@components/search';
 import {BOTTOM_TAB_HEIGHT} from '@constants/view';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
@@ -84,7 +85,7 @@ const SearchScreen = ({teamId}: Props) => {
 
     const clearRef = useRef<boolean>(false);
     const cancelRef = useRef<boolean>(false);
-    const searchRef = useRef<TextInput>(null);
+    const searchRef = useRef<SearchRef>(null);
 
     const [cursorPosition, setCursorPosition] = useState(searchTerm?.length || 0);
     const [searchValue, setSearchValue] = useState<string>(searchTerm || '');
@@ -143,9 +144,9 @@ const SearchScreen = ({teamId}: Props) => {
 
     const handleTextChange = useCallback((newValue: string) => {
         setSearchValue(newValue);
-        searchRef.current?.focus();
         setCursorPosition(newValue.length);
     }, []);
+        searchRef.current?.focus?.();
 
     const handleLoading = useCallback((show: boolean) => {
         (showResults ? setResultsLoading : setLoading)(show);

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -4,7 +4,7 @@
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
-import {FlatList, LayoutChangeEvent, Platform, StyleSheet, ViewProps} from 'react-native';
+import {FlatList, LayoutChangeEvent, Platform, StyleSheet, TextInput, ViewProps} from 'react-native';
 import Animated, {useAnimatedStyle, useDerivedValue, withTiming} from 'react-native-reanimated';
 import {Edge, SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
@@ -84,6 +84,8 @@ const SearchScreen = ({teamId}: Props) => {
 
     const clearRef = useRef<boolean>(false);
     const cancelRef = useRef<boolean>(false);
+    const searchRef = useRef<TextInput>(null);
+
     const [cursorPosition, setCursorPosition] = useState(searchTerm?.length || 0);
     const [searchValue, setSearchValue] = useState<string>(searchTerm || '');
     const [searchTeamId, setSearchTeamId] = useState<string>(teamId);
@@ -141,6 +143,7 @@ const SearchScreen = ({teamId}: Props) => {
 
     const handleTextChange = useCallback((newValue: string) => {
         setSearchValue(newValue);
+        searchRef.current?.focus();
         setCursorPosition(newValue.length);
     }, []);
 
@@ -318,6 +321,7 @@ const SearchScreen = ({teamId}: Props) => {
                 onClear={handleClearSearch}
                 onCancel={handleCancelSearch}
                 defaultValue={searchValue}
+                ref={searchRef}
             />
             <SafeAreaView
                 style={styles.flex}

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -143,10 +143,14 @@ const SearchScreen = ({teamId}: Props) => {
     }, [resetToInitial]);
 
     const handleTextChange = useCallback((newValue: string) => {
-        searchRef.current?.focus?.();
         setSearchValue(newValue);
         setCursorPosition(newValue.length);
     }, []);
+
+    const handleModifierTextChange = useCallback((newValue: string) => {
+        searchRef.current?.focus?.();
+        handleTextChange(newValue);
+    }, [handleTextChange]);
 
     const handleLoading = useCallback((show: boolean) => {
         (showResults ? setResultsLoading : setLoading)(show);
@@ -222,7 +226,7 @@ const SearchScreen = ({teamId}: Props) => {
                 scrollEnabled={scrollEnabled}
                 searchValue={searchValue}
                 setRecentValue={handleRecentSearch}
-                setSearchValue={handleTextChange}
+                setSearchValue={handleModifierTextChange}
                 setTeamId={setSearchTeamId}
                 teamId={searchTeamId}
             />


### PR DESCRIPTION
#### Summary

This PR makes a change so that when a user clicks a modifier in the search screen, they search input gets focussed and the keyboard shows.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48006

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
