### PR TITLE
[MM-47481] Remove Unread Channels From Channels Switcher

### DIFF
--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -469,6 +469,20 @@ export function observeMyChannelMentionCount(database: Database, teamId?: string
         );
 }
 
+export function queryMyRecentChannels(database: Database, take: number) {
+    const count: Q.Clause[] = [];
+
+    if (take > 0) {
+        count.push(Q.take(take));
+    }
+
+    return queryAllMyChannel(database).extend(
+        Q.on(CHANNEL, Q.where('delete_at', Q.eq(0))),
+        Q.sortBy('last_viewed_at', Q.desc),
+        ...count,
+    );
+}
+
 export function queryMyChannelsByUnread(database: Database, isUnread: boolean, sortBy: 'last_viewed_at' | 'last_post_at', take: number, excludeIds?: string[]) {
     const clause: Q.Clause[] = [Q.where('is_unread', Q.eq(isUnread))];
     const count: Q.Clause[] = [];

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -483,26 +483,6 @@ export function queryMyRecentChannels(database: Database, take: number) {
     );
 }
 
-export function queryMyChannelsByUnread(database: Database, isUnread: boolean, sortBy: 'last_viewed_at' | 'last_post_at', take: number, excludeIds?: string[]) {
-    const clause: Q.Clause[] = [Q.where('is_unread', Q.eq(isUnread))];
-    const count: Q.Clause[] = [];
-
-    if (excludeIds?.length) {
-        clause.push(Q.where('id', Q.notIn(excludeIds)));
-    }
-
-    if (take > 0) {
-        count.push(Q.take(take));
-    }
-
-    return queryAllMyChannel(database).extend(
-        Q.on(CHANNEL, Q.where('delete_at', Q.eq(0))),
-        ...clause,
-        Q.sortBy(sortBy, Q.desc),
-        ...count,
-    );
-}
-
 export const observeDirectChannelsByTerm = (database: Database, term: string, take = 20, matchStart = false) => {
     const onlyDMs = term.startsWith('@') ? "AND c.type='D'" : '';
     const value = Q.sanitizeLikeString(term.startsWith('@') ? term.substring(1) : term);

--- a/app/screens/find_channels/unfiltered_list/index.ts
+++ b/app/screens/find_channels/unfiltered_list/index.ts
@@ -1,57 +1,32 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Database} from '@nozbe/watermelondb';
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 import {of as of$} from 'rxjs';
-import {combineLatestWith, map, switchMap} from 'rxjs/operators';
+import {switchMap} from 'rxjs/operators';
 
-import {filterAndSortMyChannels, makeChannelsMap} from '@helpers/database';
-import {observeNotifyPropsByChannels, queryMyChannelsByUnread} from '@queries/servers/channel';
+import {queryMyRecentChannels} from '@queries/servers/channel';
 import {queryJoinedTeams} from '@queries/servers/team';
 import {retrieveChannels} from '@screens/find_channels/utils';
 
 import UnfilteredList from './unfiltered_list';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
-import type ChannelModel from '@typings/database/models/servers/channel';
 
-const MAX_UNREAD_CHANNELS = 10;
 const MAX_CHANNELS = 20;
-
-const observeRecentChannels = (database: Database, unreads: ChannelModel[]) => {
-    const count = MAX_CHANNELS - unreads.length;
-    const unreadIds = unreads.map((u) => u.id);
-    return queryMyChannelsByUnread(database, false, 'last_viewed_at', count, unreadIds).observe().pipe(
-        switchMap((myChannels) => retrieveChannels(database, myChannels, true)),
-    );
-};
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const teamsCount = queryJoinedTeams(database).observeCount();
 
-    const myUnreadChannels = queryMyChannelsByUnread(database, true, 'last_post_at', 0).
-        observeWithColumns(['last_post_at']);
-    const notifyProps = myUnreadChannels.pipe(switchMap((cs) => observeNotifyPropsByChannels(database, cs)));
-    const channels = myUnreadChannels.pipe(
-        switchMap((myChannels) => retrieveChannels(database, myChannels)),
-    );
-    const channelsMap = channels.pipe(switchMap((cs) => of$(makeChannelsMap(cs))));
-    const unreadChannels = myUnreadChannels.pipe(
-        combineLatestWith(channelsMap, notifyProps),
-        map(filterAndSortMyChannels),
-        switchMap((cs) => of$(cs.slice(0, MAX_UNREAD_CHANNELS))),
-    );
-
-    const recentChannels = unreadChannels.pipe(
-        switchMap((unreads) => observeRecentChannels(database, unreads)),
-    );
+    const recentChannels = queryMyRecentChannels(database, MAX_CHANNELS).
+        observeWithColumns(['last_viewed_at']).pipe(
+            switchMap((myChannels) => retrieveChannels(database, myChannels, true)),
+        );
 
     return {
         recentChannels,
         showTeamName: teamsCount.pipe(switchMap((count) => of$(count > 1))),
-        unreadChannels,
     };
 });
 

--- a/app/screens/find_channels/unfiltered_list/unfiltered_list.tsx
+++ b/app/screens/find_channels/unfiltered_list/unfiltered_list.tsx
@@ -20,15 +20,10 @@ type Props = {
     keyboardHeight: number;
     recentChannels: ChannelModel[];
     showTeamName: boolean;
-    unreadChannels: ChannelModel[];
     testID?: string;
 }
 
 const sectionNames = {
-    unreads: {
-        id: t('mobile.channel_list.unreads'),
-        defaultMessage: 'Unreads',
-    },
     recent: {
         id: t('mobile.channel_list.recent'),
         defaultMessage: 'Recent',
@@ -39,15 +34,8 @@ const style = StyleSheet.create({
     flex: {flex: 1},
 });
 
-const buildSections = (unreadChannels: ChannelModel[], recentChannels: ChannelModel[]) => {
+const buildSections = (recentChannels: ChannelModel[]) => {
     const sections = [];
-    if (unreadChannels.length) {
-        sections.push({
-            ...sectionNames.unreads,
-            data: unreadChannels,
-        });
-    }
-
     if (recentChannels.length) {
         sections.push({
             ...sectionNames.recent,
@@ -58,10 +46,10 @@ const buildSections = (unreadChannels: ChannelModel[], recentChannels: ChannelMo
     return sections;
 };
 
-const UnfilteredList = ({close, keyboardHeight, recentChannels, showTeamName, unreadChannels, testID}: Props) => {
+const UnfilteredList = ({close, keyboardHeight, recentChannels, showTeamName, testID}: Props) => {
     const intl = useIntl();
     const serverUrl = useServerUrl();
-    const [sections, setSections] = useState(buildSections(unreadChannels, recentChannels));
+    const [sections, setSections] = useState(buildSections(recentChannels));
     const sectionListStyle = useMemo(() => ({paddingBottom: keyboardHeight}), [keyboardHeight]);
 
     const onPress = useCallback(async (channelId: string) => {
@@ -86,8 +74,8 @@ const UnfilteredList = ({close, keyboardHeight, recentChannels, showTeamName, un
     }, [onPress, showTeamName]);
 
     useEffect(() => {
-        setSections(buildSections(unreadChannels, recentChannels));
-    }, [unreadChannels, recentChannels]);
+        setSections(buildSections(recentChannels));
+    }, [recentChannels]);
 
     return (
         <Animated.View


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Removes the unreads section from the channel switcher. Only recent channels are listed with unread channels retaining the bolded formatting.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

[MM-47481](https://mattermost.atlassian.net/browse/MM-47481)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Has UI changes

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
- iPhone 14 Pro, iOS 16
- Pixel 5, Android 13

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
|iOS|![MM-47481 (iPhone)](https://user-images.githubusercontent.com/23694620/199076478-17d3ca9d-f51b-4dab-aa7a-c81f0d6c01f6.png)|
|--|--|
|Android|<img width="440" alt="MM-47481 (Android)" src="https://user-images.githubusercontent.com/23694620/199076553-b721347d-d98e-400a-8037-658aca7e6272.png">|

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
