### PR TITLE
MM-45972 - Calls: test ws messages when app is in background

### DIFF
--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -179,11 +179,12 @@ async function doReconnect(serverUrl: string) {
 
     const {id: currentUserId, locale: currentUserLocale} = (await getCurrentUser(database))!;
     const {config, license} = await getCommonSystemValues(database);
-    await deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, initialTeamId, switchedToChannel ? initialChannelId : undefined);
 
     if (isSupportedServerCalls(config?.Version)) {
         loadConfigAndCalls(serverUrl, currentUserId);
     }
+
+    await deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, initialTeamId, switchedToChannel ? initialChannelId : undefined);
 
     AppsManager.refreshAppBindings(serverUrl);
 }

--- a/app/products/calls/state/actions.test.ts
+++ b/app/products/calls/state/actions.test.ts
@@ -107,39 +107,68 @@ describe('useCallsState', () => {
         const initialChannelsWithCallsState = {
             'channel-1': true,
         };
+        const initialCurrentCallState: CurrentCall = {
+            serverUrl: 'server1',
+            myUserId: 'myUserId',
+            ...call1,
+            screenShareURL: '',
+            speakerphoneOn: false,
+        };
+        const testNewCall1 = {
+            ...call1,
+            participants: {
+                'user-1': {id: 'user-1', muted: false, raisedHand: 0},
+                'user-2': {id: 'user-2', muted: true, raisedHand: 0},
+                'user-3': {id: 'user-3', muted: false, raisedHand: 123},
+            },
+        };
         const test = {
-            calls: {'channel-1': call2, 'channel-2': call3},
+            calls: {'channel-1': testNewCall1, 'channel-2': call2, 'channel-3': call3},
             enabled: {'channel-2': true},
         };
+
         const expectedCallsState = {
             ...initialCallsState,
             serverUrl: 'server1',
             myUserId: 'myId',
-            calls: {'channel-1': call2, 'channel-2': call3},
+            calls: {'channel-1': testNewCall1, 'channel-2': call2, 'channel-3': call3},
             enabled: {'channel-2': true},
         };
         const expectedChannelsWithCallsState = {
             ...initialChannelsWithCallsState,
             'channel-2': true,
+            'channel-3': true,
+        };
+        const expectedCurrentCallState = {
+            ...initialCurrentCallState,
+            ...testNewCall1,
         };
 
         // setup
         const {result} = renderHook(() => {
-            return [useCallsState('server1'), useCallsState('server1'), useChannelsWithCalls('server1')];
+            return [
+                useCallsState('server1'),
+                useCallsState('server1'),
+                useChannelsWithCalls('server1'),
+                useCurrentCall(),
+            ];
         });
         act(() => {
             setCallsState('server1', initialCallsState);
             setChannelsWithCalls('server1', initialChannelsWithCallsState);
+            setCurrentCall(initialCurrentCallState);
         });
         assert.deepEqual(result.current[0], initialCallsState);
         assert.deepEqual(result.current[1], initialCallsState);
         assert.deepEqual(result.current[2], initialChannelsWithCallsState);
+        assert.deepEqual(result.current[3], initialCurrentCallState);
 
         // test
         act(() => setCalls('server1', 'myId', test.calls, test.enabled));
         assert.deepEqual(result.current[0], expectedCallsState);
         assert.deepEqual(result.current[1], expectedCallsState);
         assert.deepEqual(result.current[2], expectedChannelsWithCallsState);
+        assert.deepEqual(result.current[3], expectedCurrentCallState);
     });
 
     it('joinedCall', () => {
@@ -469,7 +498,8 @@ describe('useCallsState', () => {
         };
         const expectedCallsState = {
             ...initialCallsState,
-            calls: {...initialCallsState.calls,
+            calls: {
+                ...initialCallsState.calls,
                 'channel-1': newCall1,
             },
         };
@@ -589,7 +619,8 @@ describe('useCallsState', () => {
         };
         const expectedCallsState = {
             ...initialCallsState,
-            calls: {...initialCallsState.calls,
+            calls: {
+                ...initialCallsState.calls,
                 'channel-1': newCall1,
             },
         };

--- a/app/products/calls/state/actions.ts
+++ b/app/products/calls/state/actions.ts
@@ -22,6 +22,18 @@ export const setCalls = (serverUrl: string, myUserId: string, calls: Dictionary<
     setChannelsWithCalls(serverUrl, channelsWithCalls);
 
     setCallsState(serverUrl, {serverUrl, myUserId, calls, enabled});
+
+    // Does the current call need to be updated?
+    const currentCall = getCurrentCall();
+    if (!currentCall || !calls[currentCall.channelId]) {
+        return;
+    }
+
+    const nextCall = {
+        ...currentCall,
+        ...calls[currentCall.channelId],
+    };
+    setCurrentCall(nextCall);
 };
 
 export const setCallForChannel = (serverUrl: string, channelId: string, enabled: boolean, call?: Call) => {


### PR DESCRIPTION
#### Summary
- This ticket was an investigation of the behaviour of calls when the app goes into the background. We investigated how the state is handled, how the call's ws connection behaves, which messages get lost, and what happens on bringing the app back from the background.
- The ideal solution would be to move all calls-related ws events to the calls-owned ws, which doesn't close when the app goes to the background. Then the call's state will always be up to date when the user brings the app back. But that's infeasible at the moment (it's a lot of engineering work for only a little user-facing benefit). 
- The compromise we landed on was to make sure the reconnect logic updates all the calls state, and let that sync the app when it's brought to the foreground (same as what the webapp relies on).
- So I tested that behaviour (with the load testing + behavior sim tool), and this PR fixes the remaining issues.
- Now when the app is brought back to the foreground, there is a brief delay while the state is fetched, and then the call's state will be reasonably up-to-date. This works for screensharing as well, since the screen stream will have been created even when the app was in the background.

Notes:
- This is racy. If websocket events are received while waiting for the calls request, that newer data will be overwritten with stale data. But this is a 'good enough' solution.
- Why did the `loadConfigAndCalls` call move above `deferredAppEntryActions`? Because on my dev server the latter was throwing an error every once in awhile: `FetchPostsForChannel [Error: Received invalid response from the server.]`, which prevented the `loadConfigAndCalls` to be run. Let me know if I should I file a bug for that.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-45972

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note

```release-note
Calls: fixed a bug where the current call's state would get out of sync if the app was in the background for a long time.
```
