### PR TITLE
Automated cherry pick of #6701

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This `master` branch is mostly in maintenance mode while we're working to gettin
 # Mattermost Mobile App
 [![Mattermost](https://user-images.githubusercontent.com/7205829/136108314-75cd2e1f-4147-4cfa-a16c-9b3b0313ea25.png)](https://mattermost.com)
 
-- **Minimum Server versions:** Current ESR version (6.3.0)
+- **Minimum Server versions:** Current ESR version (7.1.0)
 - **Supported iOS versions:** 12.1+
 - **Supported Android versions:** 7.0+
 

--- a/app/constants/calls.ts
+++ b/app/constants/calls.ts
@@ -4,9 +4,9 @@
 const RefreshConfigMillis = 20 * 60 * 1000; // Refresh config after 20 minutes
 
 const RequiredServer = {
-    FULL_VERSION: '6.3.0',
-    MAJOR_VERSION: 6,
-    MIN_VERSION: 3,
+    FULL_VERSION: '7.1.0',
+    MAJOR_VERSION: 7,
+    MIN_VERSION: 1,
     PATCH_VERSION: 0,
 };
 

--- a/app/constants/view.js
+++ b/app/constants/view.js
@@ -115,9 +115,9 @@ const ViewTypes = keyMirror({
 });
 
 const RequiredServer = {
-    FULL_VERSION: '5.37.0',
-    MAJOR_VERSION: 5,
-    MIN_VERSION: 37,
+    FULL_VERSION: '7.1.0',
+    MAJOR_VERSION: 7,
+    MIN_VERSION: 1,
     PATCH_VERSION: 0,
 };
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Requires Mattermost Server v6.3.0+. Older servers may not be able to connect or have unexpected behavior.
+Requires Mattermost Server v7.1.0+. Older servers may not be able to connect or have unexpected behavior.
 
 -------
 

--- a/fastlane/metadata/changelog
+++ b/fastlane/metadata/changelog
@@ -1,4 +1,4 @@
-This version is compatible with Mattermost servers v6.3.0+.
+This version is compatible with Mattermost servers v7.1.0+.
 
 Please see [changelog](https://docs.mattermost.com/administration/mobile-changelog.html) for full release notes. If you're interested in helping beta test upcoming versions before they are released, please see our [documentation](https://github.com/mattermost/mattermost-mobile#testing).
 


### PR DESCRIPTION
Cherry pick of #6701 on release-1.56.

/cc  @amyblais

```release-note
NONE
```