### PR TITLE
[Bug] Emit boolean with "of" operator

### DIFF
--- a/app/components/autocomplete/index.ts
+++ b/app/components/autocomplete/index.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import withObservables from '@nozbe/with-observables';
+import {of as of$} from 'rxjs';
 
 import AppsManager from '@managers/apps_manager';
 
@@ -12,7 +13,7 @@ type OwnProps = {
 }
 
 const enhanced = withObservables(['serverUrl'], ({serverUrl}: OwnProps) => ({
-    isAppsEnabled: serverUrl ? AppsManager.observeIsAppsEnabled(serverUrl) : false,
+    isAppsEnabled: serverUrl ? AppsManager.observeIsAppsEnabled(serverUrl) : of$(false),
 }));
 
 export default enhanced(Autocomplete);


### PR DESCRIPTION
#### Summary
This fixes a bug in autocomplete where the `false` value needs to be emitted via the `of` operator.

#### Ticket Link
N/A

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iPhone 14

#### Screenshots

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
