### PR TITLE
[Gekidou MM-48200] Update attachment icon to paperclip

### DIFF
--- a/app/components/post_draft/quick_actions/file_quick_action/index.tsx
+++ b/app/components/post_draft/quick_actions/file_quick_action/index.tsx
@@ -63,7 +63,7 @@ export default function FileQuickAction({
         >
             <CompassIcon
                 color={color}
-                name='file-generic-outline'
+                name='paperclip'
                 size={ICON_SIZE}
             />
         </TouchableWithFeedback>


### PR DESCRIPTION
#### Summary
Updates the file attachment icon in the post-draft to a paperclip instead of the document. 
- It aligns better with the webapp
- It better represents a broader set of attachment types
- Current icon represents document file types while we can upload any type of attachment

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-48200

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iPhone 14 Simulator (iOS 16.1)

#### Screenshots
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img width="564" alt="image" src="https://user-images.githubusercontent.com/2040554/200195205-b2fa5428-fa0c-48a2-b888-050a6a788ba4.png"></td>
<td><img width="564" alt="image" src="https://user-images.githubusercontent.com/2040554/200195190-7358cda5-322f-4334-8e08-1adc773407e5.png"></td>
</tr>
</table>

#### Release Note
```release-note
NONE
```
