### PR TITLE
[Gekidou MM-47765] Add horizontal padding to empty results 

### DIFF
--- a/app/components/no_results_with_term/index.tsx
+++ b/app/components/no_results_with_term/index.tsx
@@ -29,6 +29,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => {
             justifyContent: 'center' as const,
         },
         result: {
+            textAlign: 'center',
             color: theme.centerChannelColor,
             ...typography('Heading', 400, 'SemiBold'),
         },

--- a/app/components/no_results_with_term/index.tsx
+++ b/app/components/no_results_with_term/index.tsx
@@ -23,6 +23,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         container: {
             flexGrow: 1,
+            paddingHorizontal: 32,
             height: '100%',
             alignItems: 'center' as const,
             justifyContent: 'center' as const,


### PR DESCRIPTION
#### Summary

This PR fixes a styling issue when no results exist for Messages or FIles searches. 

Before : 

<img width="350" alt="image" src="https://user-images.githubusercontent.com/7575921/200371499-a6380131-5c93-440d-b454-1eaa52ca2767.png">
After : 
<img width="350" alt="image" src="https://user-images.githubusercontent.com/7575921/200393639-be88f40b-ce08-479d-83f2-e65e16ea30d9.png">

<details>
<summary>Details</summary>



</details>


#### Ticket Link

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
