### PR TITLE
[Gekidou MM-48281] Fix issue with single image result extending to full height of the image

### DIFF
--- a/app/components/files/file.tsx
+++ b/app/components/files/file.tsx
@@ -25,7 +25,7 @@ type FileProps = {
     galleryIdentifier: string;
     index: number;
     inViewPort: boolean;
-    isSingleImage: boolean;
+    isSingleImage?: boolean;
     nonVisibleImagesCount: number;
     onPress: (index: number) => void;
     publicLinkEnabled: boolean;

--- a/app/screens/home/search/results/file_result.tsx
+++ b/app/screens/home/search/results/file_result.tsx
@@ -92,7 +92,6 @@ const FileResult = ({
                     galleryIdentifier={galleryIdentifier}
                     inViewPort={true}
                     index={index}
-                    isSingleImage={false}
                     nonVisibleImagesCount={0}
                     onOptionsPress={handleOptionsPress}
                     onPress={onPress}

--- a/app/screens/home/search/results/file_result.tsx
+++ b/app/screens/home/search/results/file_result.tsx
@@ -25,7 +25,6 @@ type Props = {
     channelName: string | undefined;
     fileInfo: FileInfo;
     index: number;
-    isSingleImage: boolean;
     numOptions: number;
     onOptionsPress: (finfo: FileInfo) => void;
     onPress: (idx: number) => void;
@@ -41,7 +40,6 @@ const FileResult = ({
     channelName,
     fileInfo,
     index,
-    isSingleImage,
     numOptions,
     onOptionsPress,
     onPress,
@@ -94,7 +92,7 @@ const FileResult = ({
                     galleryIdentifier={galleryIdentifier}
                     inViewPort={true}
                     index={index}
-                    isSingleImage={isSingleImage}
+                    isSingleImage={false}
                     nonVisibleImagesCount={0}
                     onOptionsPress={handleOptionsPress}
                     onPress={onPress}

--- a/app/screens/home/search/results/file_results.tsx
+++ b/app/screens/home/search/results/file_results.tsx
@@ -10,7 +10,6 @@ import {useImageAttachments} from '@app/hooks/files';
 import NoResultsWithTerm from '@components/no_results_with_term';
 import {useTheme} from '@context/theme';
 import {GalleryAction} from '@typings/screens/gallery';
-import {isImage, isVideo} from '@utils/file';
 import {
     getChannelNamesWithID,
     getFileInfosIndexes,
@@ -89,14 +88,12 @@ const FileResults = ({
     }, [insets, isTablet, numOptions, theme]);
 
     const renderItem = useCallback(({item}: ListRenderItemInfo<FileInfo>) => {
-        const isSingleImage = orderedFileInfos.length === 1 && (isImage(orderedFileInfos[0]) || isVideo(orderedFileInfos[0]));
         return (
             <FileResult
                 canDownloadFiles={canDownloadFiles}
                 channelName={channelNames[item.channel_id!]}
                 fileInfo={item}
                 index={fileInfosIndexes[item.id!] || 0}
-                isSingleImage={isSingleImage}
                 numOptions={numOptions}
                 onOptionsPress={onOptionsPress}
                 onPress={onPreviewPress}


### PR DESCRIPTION
#### Summary
This PR fixes an issue when the file search results are returned with only one image. There is possibly a bug in the `calculateDimensions` function, but I chose to fix it in the file_results so that I don't have the possibility of messing up some other components that use that function.

| Before | After |
| -- | -- |
|  <img width="300" alt="image" src="https://user-images.githubusercontent.com/7575921/200678113-0b795e3f-3e47-443a-b3ef-8147921df235.png"> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/7575921/200678014-c78011fa-062b-49a4-a610-8244db98c7d8.png"> |


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48281

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
