### PR TITLE
MM-48447 - Calls: guard against possible bad response from server (null)

### DIFF
--- a/app/products/calls/actions/calls.test.ts
+++ b/app/products/calls/actions/calls.test.ts
@@ -268,6 +268,36 @@ describe('Actions.Calls', () => {
         assert.equal((result.current[2] as CurrentCall | null), null);
     });
 
+    it('loadCalls fails from server', async () => {
+        const expectedCallsState: CallsState = {
+            serverUrl: 'server1',
+            myUserId: 'userId1',
+            calls: {},
+            enabled: {},
+        };
+
+        // setup
+        const oldGetCalls = mockClient.getCalls;
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        mockClient.getCalls = jest.fn(() => null);
+
+        const {result} = renderHook(() => {
+            return [useCallsState('server1'), useChannelsWithCalls('server1'), useCurrentCall()];
+        });
+
+        await act(async () => {
+            await CallsActions.loadCalls('server1', 'userId1');
+        });
+        expect(mockClient.getCalls).toBeCalled();
+        assert.deepEqual((result.current[0] as CallsState), expectedCallsState);
+        assert.deepEqual((result.current[1] as ChannelsWithCalls), {});
+        assert.equal((result.current[2] as CurrentCall | null), null);
+
+        mockClient.getCalls = oldGetCalls;
+    });
+
     it('loadConfig', async () => {
         // setup
         const {result} = renderHook(() => useCallsConfig('server1'));

--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -86,7 +86,7 @@ export const loadCalls = async (serverUrl: string, userId: string) => {
     }
     let resp: ServerChannelState[] = [];
     try {
-        resp = await client.getCalls();
+        resp = await client.getCalls() || [];
     } catch (error) {
         await forceLogoutIfNecessary(serverUrl, error as ClientError);
         return {error};


### PR DESCRIPTION
#### Summary
- report from Sentry.
- This is odd, because the server should return an empty slice if there are no calls. If the calls plugin isn't running, the `loadCalls` fn shouldn't be run. I suspect the calls plugin crashed.
- This change at least means the mobile app won't crash if this happens again.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-48447

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
