### PR TITLE
[MM-48526] Switch teamname display from 'capitalize' -> 'uppercase'

### DIFF
--- a/app/components/team_sidebar/team_list/team_item/team_icon.tsx
+++ b/app/components/team_sidebar/team_list/team_item/team_icon.tsx
@@ -31,7 +31,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         text: {
             color: theme.sidebarText,
-            textTransform: 'capitalize',
+            textTransform: 'uppercase',
         },
         image: {
             borderRadius: 8,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Switch teamname display from 'capitalize' -> 'uppercase' like it happens in webapp.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48526
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
**before**:
![after](https://user-images.githubusercontent.com/22407757/203743811-959fdd64-8656-4f6a-bf5a-595a7000aa76.jpeg)

**after**:
![before](https://user-images.githubusercontent.com/22407757/203743836-933c59a6-e214-4a27-9ca6-70cd6b8caea7.jpeg)

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Modified team initials display to uppercase
```

```release-note
NONE
```
-->

```release-note
Modified team initials display to uppercase
```
