### PR TITLE
MM-44652 : Temporarily hides NotificationPreferences

### DIFF
--- a/app/screens/channel_info/options/index.tsx
+++ b/app/screens/channel_info/options/index.tsx
@@ -10,7 +10,6 @@ import {isTypeDMorGM} from '@utils/channel';
 import EditChannel from './edit_channel';
 import IgnoreMentions from './ignore_mentions';
 import Members from './members';
-import NotificationPreference from './notification_preference';
 import PinnedMessages from './pinned_messages';
 
 type Props = {
@@ -27,7 +26,7 @@ const Options = ({channelId, type, callsEnabled}: Props) => {
             {type !== General.DM_CHANNEL &&
                 <IgnoreMentions channelId={channelId}/>
             }
-            <NotificationPreference channelId={channelId}/>
+            {/*<NotificationPreference channelId={channelId}/>*/}
             <PinnedMessages channelId={channelId}/>
             {type !== General.DM_CHANNEL &&
                 <Members channelId={channelId}/>


### PR DESCRIPTION
#### Summary
We are going to hide the "mobile notification preferences" option under channel info until MM-44652 is implemented.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44652

#### Release Note
```release-note
NONE
```
