### PR TITLE
Fix categories where a previously deleted category was not removed

### DIFF
--- a/app/actions/remote/retry.ts
+++ b/app/actions/remote/retry.ts
@@ -7,7 +7,7 @@ import DatabaseManager from '@database/manager';
 import {getPreferenceValue, getTeammateNameDisplaySetting} from '@helpers/api/preference';
 import {selectDefaultTeam} from '@helpers/api/team';
 import NetworkManager from '@managers/network_manager';
-import {prepareCategories, prepareCategoryChannels} from '@queries/servers/categories';
+import {prepareCategoriesAndCategoriesChannels} from '@queries/servers/categories';
 import {prepareMyChannelsForTeam} from '@queries/servers/channel';
 import {prepareMyPreferences, queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {prepareCommonSystemValues, getConfig, getLicense} from '@queries/servers/system';
@@ -105,8 +105,7 @@ export async function retryInitialTeamAndChannel(serverUrl: string) {
             storeConfig(serverUrl, clData.config, true),
             ...prepareMyTeams(operator, teamData.teams!, teamData.memberships!),
             ...await prepareMyChannelsForTeam(operator, initialTeam.id, chData!.channels!, chData!.memberships!),
-            prepareCategories(operator, chData!.categories!),
-            prepareCategoryChannels(operator, chData!.categories!),
+            prepareCategoriesAndCategoriesChannels(operator, chData!.categories!, true),
 
             prepareCommonSystemValues(
                 operator,
@@ -193,8 +192,7 @@ export async function retryInitialChannel(serverUrl: string, teamId: string) {
 
         const models: Model[] = (await Promise.all([
             ...await prepareMyChannelsForTeam(operator, teamId, chData!.channels!, chData!.memberships!),
-            prepareCategories(operator, chData!.categories!),
-            prepareCategoryChannels(operator, chData!.categories!),
+            prepareCategoriesAndCategoriesChannels(operator, chData!.categories!, true),
             prepareCommonSystemValues(operator, {currentChannelId: initialChannel?.id}),
         ])).flat();
 

--- a/app/actions/remote/team.ts
+++ b/app/actions/remote/team.ts
@@ -8,7 +8,7 @@ import {removeUserFromTeam as localRemoveUserFromTeam} from '@actions/local/team
 import {Events} from '@constants';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
-import {prepareCategories, prepareCategoryChannels} from '@queries/servers/categories';
+import {prepareCategoriesAndCategoriesChannels} from '@queries/servers/categories';
 import {prepareMyChannelsForTeam, getDefaultChannelForTeam} from '@queries/servers/channel';
 import {prepareCommonSystemValues, getCurrentTeamId, getCurrentUserId} from '@queries/servers/system';
 import {addTeamToTeamHistory, prepareDeleteTeam, prepareMyTeams, getNthLastChannelFromTeam, queryTeamsById, syncTeamTable} from '@queries/servers/team';
@@ -73,8 +73,7 @@ export async function addUserToTeam(serverUrl: string, teamId: string, userId: s
                     operator.handleMyTeam({myTeams, prepareRecordsOnly: true}),
                     operator.handleTeamMemberships({teamMemberships: [member], prepareRecordsOnly: true}),
                     ...await prepareMyChannelsForTeam(operator, teamId, channels || [], channelMembers || []),
-                    prepareCategories(operator, categories || []),
-                    prepareCategoryChannels(operator, categories || []),
+                    prepareCategoriesAndCategoriesChannels(operator, categories || [], true),
                 ])).flat();
 
                 await operator.batchRecords(models);

--- a/app/actions/websocket/teams.ts
+++ b/app/actions/websocket/teams.ts
@@ -12,7 +12,7 @@ import {updateUsersNoLongerVisible} from '@actions/remote/user';
 import Events from '@constants/events';
 import DatabaseManager from '@database/manager';
 import {getActiveServerUrl} from '@queries/app/servers';
-import {prepareCategories, prepareCategoryChannels} from '@queries/servers/categories';
+import {prepareCategoriesAndCategoriesChannels} from '@queries/servers/categories';
 import {prepareMyChannelsForTeam} from '@queries/servers/channel';
 import {getCurrentTeam, getLastTeam, prepareMyTeams} from '@queries/servers/team';
 import {getCurrentUser} from '@queries/servers/user';
@@ -98,8 +98,7 @@ export async function handleUserAddedToTeamEvent(serverUrl: string, msg: WebSock
     const modelPromises: Array<Promise<Model[]>> = [];
     if (teams?.length && teamMemberships?.length) {
         const {channels, memberships, categories} = await fetchMyChannelsForTeam(serverUrl, teamId, false, 0, true);
-        modelPromises.push(prepareCategories(operator, categories));
-        modelPromises.push(prepareCategoryChannels(operator, categories));
+        modelPromises.push(prepareCategoriesAndCategoriesChannels(operator, categories || [], true));
         modelPromises.push(...await prepareMyChannelsForTeam(operator, teamId, channels || [], memberships || []));
 
         const {roles} = await fetchRoles(serverUrl, teamMemberships, memberships, undefined, true);

--- a/app/queries/servers/entry.ts
+++ b/app/queries/servers/entry.ts
@@ -5,7 +5,7 @@ import {MM_TABLES} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import ServerDataOperator from '@database/operator/server_data_operator';
 
-import {prepareCategories, prepareCategoryChannels} from './categories';
+import {prepareCategoriesAndCategoriesChannels} from './categories';
 import {prepareDeleteChannel, prepareMyChannelsForTeam} from './channel';
 import {prepareMyPreferences} from './preference';
 import {resetWebSocketLastDisconnected} from './system';
@@ -62,8 +62,7 @@ export async function prepareModels({operator, initialTeamId, removeTeams, remov
     }
 
     if (chData?.categories?.length) {
-        modelPromises.push(prepareCategories(operator, chData.categories));
-        modelPromises.push(prepareCategoryChannels(operator, chData.categories));
+        modelPromises.push(prepareCategoriesAndCategoriesChannels(operator, chData.categories, true));
     }
 
     if (chData?.channels?.length && chData.memberships?.length) {


### PR DESCRIPTION
#### Summary
When a category is deleted while the app is not opened it remained in the database as the code path for entry was not pruning the categories that were not present in the response.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48624

#### Release Note
```release-note
NONE
```

@matthewbirtch added you as a reviewer to test the app as you were the reporter of this bug.
