### PR TITLE
Start spinner on websocket reconnect

### DIFF
--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Database, Model} from '@nozbe/watermelondb';
+import {DeviceEventEmitter} from 'react-native';
 
 import {fetchMissingDirectChannelsInfo, fetchMyChannelsForTeam, MyChannelsRequest} from '@actions/remote/channel';
 import {fetchGroupsForMember} from '@actions/remote/groups';
@@ -13,7 +14,7 @@ import {fetchAllTeams, fetchMyTeams, fetchTeamsChannelsAndUnreadPosts, MyTeamsRe
 import {fetchNewThreads} from '@actions/remote/thread';
 import {autoUpdateTimezone, fetchMe, MyUserRequest, updateAllUsersSince} from '@actions/remote/user';
 import {gqlAllChannels} from '@client/graphQL/entry';
-import {General, Preferences, Screens} from '@constants';
+import {Events, General, Preferences, Screens} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import {PUSH_PROXY_RESPONSE_NOT_AVAILABLE, PUSH_PROXY_RESPONSE_UNKNOWN, PUSH_PROXY_STATUS_NOT_AVAILABLE, PUSH_PROXY_STATUS_UNKNOWN, PUSH_PROXY_STATUS_VERIFIED} from '@constants/push_proxy';
 import DatabaseManager from '@database/manager';
@@ -317,6 +318,8 @@ export async function restDeferredAppEntryActions(
 
             // defer fetching posts for unread channels on initial team
             fetchPostsForUnreadChannels(serverUrl, chData.channels, chData.memberships, initialChannelId, true);
+        } else {
+            DeviceEventEmitter.emit(Events.FETCHING_POSTS, false);
         }
     }, FETCH_UNREADS_TIMEOUT);
 

--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Database} from '@nozbe/watermelondb';
+import {DeviceEventEmitter} from 'react-native';
 
 import {storeConfigAndLicense} from '@actions/local/systems';
 import {MyChannelsRequest} from '@actions/remote/channel';
@@ -11,7 +12,7 @@ import {MyTeamsRequest} from '@actions/remote/team';
 import {fetchNewThreads} from '@actions/remote/thread';
 import {autoUpdateTimezone, updateAllUsersSince} from '@actions/remote/user';
 import {gqlEntry, gqlEntryChannels, gqlOtherChannels} from '@client/graphQL/entry';
-import {Preferences} from '@constants';
+import {Events, Preferences} from '@constants';
 import DatabaseManager from '@database/manager';
 import {getPreferenceValue} from '@helpers/api/preference';
 import {selectDefaultTeam} from '@helpers/api/team';
@@ -49,6 +50,8 @@ export async function deferredAppEntryGraphQLActions(
         if (chData?.channels?.length && chData.memberships?.length) {
             // defer fetching posts for unread channels on initial team
             fetchPostsForUnreadChannels(serverUrl, chData.channels, chData.memberships, initialChannelId, true);
+        } else {
+            DeviceEventEmitter.emit(Events.FETCHING_POSTS, false);
         }
     }, FETCH_UNREADS_TIMEOUT);
 

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -137,6 +137,9 @@ async function doReconnect(serverUrl: string) {
     const currentChannel = await getCurrentChannel(database);
     const currentActiveServerUrl = await getActiveServerUrl();
 
+    if (serverUrl === currentActiveServerUrl) {
+        DeviceEventEmitter.emit(Events.FETCHING_POSTS, true);
+    }
     const entryData = await entry(serverUrl, currentTeam?.id, currentChannel?.id, lastDisconnectedAt);
     if ('error' in entryData) {
         if (serverUrl === currentActiveServerUrl) {


### PR DESCRIPTION
#### Summary
Show spinner when we start a websocket reconnect on the current server, to show that the app is doing something on the background.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48776

#### Release Note
```release-note
Improve loading spinner behaviour
```
