### PR TITLE
Check if group exist before fetching the mention

### DIFF
--- a/app/actions/remote/user.ts
+++ b/app/actions/remote/user.ts
@@ -451,7 +451,7 @@ export const fetchUsersByUsernames = async (serverUrl: string, usernames: string
 
         const users = await client.getProfilesByUsernames([...new Set(usersToLoad)]);
 
-        if (!fetchOnly) {
+        if (users.length && !fetchOnly) {
             await operator.handleUsers({
                 users,
                 prepareRecordsOnly: false,

--- a/app/components/markdown/at_mention/at_mention.tsx
+++ b/app/components/markdown/at_mention/at_mention.tsx
@@ -142,7 +142,7 @@ const AtMention = ({
     // Effects
     useEffect(() => {
         // Fetches and updates the local db store with the mention
-        if (!user.username) {
+        if (!user.username && !group?.name) {
             fetchUserOrGroupsByMentionsInBatch(serverUrl, mentionName);
         }
     }, []);


### PR DESCRIPTION
#### Summary
We were fetching the user mentions even if we already had the group in the database.

#### Ticket Link
None

#### Release Note
```release-note
Avoid unneeded communication with the server with group mentions
```
