### PR TITLE
Fix Android crash when push notification is received and app not initialized

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -81,7 +81,8 @@ public class CustomPushNotification extends PushNotification {
         switch (type) {
             case CustomPushNotificationHelper.PUSH_TYPE_MESSAGE:
             case CustomPushNotificationHelper.PUSH_TYPE_SESSION:
-                String currentActivityName = ShareModule.getInstance().getCurrentActivityName();
+                ShareModule shareModule = ShareModule.getInstance();
+                String currentActivityName = shareModule != null ? shareModule.getCurrentActivityName() : "";
                 Log.i("ReactNative", currentActivityName);
                 if (!mAppLifecycleFacade.isAppVisible() || !currentActivityName.equals("MainActivity")) {
                     boolean createSummary = type.equals(CustomPushNotificationHelper.PUSH_TYPE_MESSAGE);


### PR DESCRIPTION
#### Summary
when the Android app has not been initialized, the ShareModule is null, thus throwing an exception, here in that case we can assume that the app is not in the MainActivity as it hasn't been started yet.


```release-note
NONE
```
