### PR TITLE
Refactor how keyboard tracking is resumed & paused

### DIFF
--- a/app/constants/events.ts
+++ b/app/constants/events.ts
@@ -16,7 +16,6 @@ export default keyMirror({
     LEAVE_TEAM: null,
     LOADING_CHANNEL_POSTS: null,
     NOTIFICATION_ERROR: null,
-    PAUSE_KEYBOARD_TRACKING_VIEW: null,
     SERVER_LOGOUT: null,
     SERVER_VERSION_CHANGED: null,
     SESSION_EXPIRED: null,

--- a/app/hooks/keyboard_tracking.ts
+++ b/app/hooks/keyboard_tracking.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {RefObject, useEffect, useRef} from 'react';
+import {KeyboardTrackingViewRef} from 'react-native-keyboard-tracking-view';
+import {Navigation} from 'react-native-navigation';
+
+import NavigationStore from '@store/navigation_store';
+
+export const useKeyboardTrackingPaused = (keyboardTrackingRef: RefObject<KeyboardTrackingViewRef>, trackerId: string, screens: string[]) => {
+    const isPostDraftPaused = useRef(false);
+
+    useEffect(() => {
+        const commandListener = Navigation.events().registerCommandListener(() => {
+            if (!isPostDraftPaused.current) {
+                isPostDraftPaused.current = true;
+                keyboardTrackingRef.current?.pauseTracking(trackerId);
+            }
+        });
+
+        const commandCompletedListener = Navigation.events().registerCommandCompletedListener(() => {
+            const id = NavigationStore.getNavigationTopComponentId();
+            if (screens.includes(id) && isPostDraftPaused.current) {
+                isPostDraftPaused.current = false;
+                keyboardTrackingRef.current?.resumeTracking(trackerId);
+            }
+        });
+
+        return () => {
+            commandListener.remove();
+            commandCompletedListener.remove();
+        };
+    }, [trackerId]);
+};

--- a/app/init/app.ts
+++ b/app/init/app.ts
@@ -58,8 +58,6 @@ function registerNavigationListeners() {
 function screenWillAppear({componentId}: ComponentDidAppearEvent) {
     if (componentId === Screens.HOME) {
         DeviceEventEmitter.emit(Events.TAB_BAR_VISIBLE, true);
-    } else if ([Screens.EDIT_POST, Screens.THREAD].includes(componentId)) {
-        DeviceEventEmitter.emit(Events.PAUSE_KEYBOARD_TRACKING_VIEW, true);
     }
 }
 
@@ -71,10 +69,6 @@ function screenDidAppearListener({componentId, componentType}: ComponentDidAppea
 
 function screenDidDisappearListener({componentId}: ComponentDidDisappearEvent) {
     if (componentId !== Screens.HOME) {
-        if ([Screens.EDIT_POST, Screens.THREAD].includes(componentId)) {
-            DeviceEventEmitter.emit(Events.PAUSE_KEYBOARD_TRACKING_VIEW, false);
-        }
-
         if (NavigationStore.getNavigationTopComponentId() === Screens.HOME) {
             DeviceEventEmitter.emit(Events.TAB_BAR_VISIBLE, true);
         }

--- a/app/screens/find_channels/index.tsx
+++ b/app/screens/find_channels/index.tsx
@@ -2,11 +2,10 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {DeviceEventEmitter, Keyboard, View} from 'react-native';
+import {Keyboard, View} from 'react-native';
 import {Navigation} from 'react-native-navigation';
 
 import SearchBar from '@components/search';
-import {Events} from '@constants';
 import {useTheme} from '@context/theme';
 import {useKeyboardHeight} from '@hooks/device';
 import {dismissModal} from '@screens/navigation';
@@ -57,7 +56,6 @@ const FindChannels = ({closeButtonId, componentId}: Props) => {
 
     const close = useCallback(() => {
         Keyboard.dismiss();
-        DeviceEventEmitter.emit(Events.PAUSE_KEYBOARD_TRACKING_VIEW, false);
         return dismissModal({componentId});
     }, []);
 

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -788,7 +788,6 @@ export async function findChannels(title: string, theme: Theme) {
         }],
     };
 
-    DeviceEventEmitter.emit(Events.PAUSE_KEYBOARD_TRACKING_VIEW, true);
     showModal(
         Screens.FIND_CHANNELS,
         title,


### PR DESCRIPTION
#### Summary
The way we were tracking screens to issue an event to resume/pause the keyboard tracking view was checking only for certain screens, but some other were omitted causing the problem.

With this new approach, every time the component is not at the top of the stack we pause the tracking and resume otherwise. This is accomplish with the `commandListener` and `commandCompleteListener` from the navigation library and then we don't need to use the event emitter.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48494

#### Release Note
```release-note
NONE
```
