### PR TITLE
Update icon badge on Notification

### DIFF
--- a/app/screens/home/tab_bar/home.tsx
+++ b/app/screens/home/tab_bar/home.tsx
@@ -10,6 +10,7 @@ import CompassIcon from '@components/compass_icon';
 import {BOTTOM_TAB_ICON_SIZE} from '@constants/view';
 import {subscribeAllServers} from '@database/subscription/servers';
 import {subscribeUnreadAndMentionsByServer, UnreadObserverArgs} from '@database/subscription/unreads';
+import {useAppState} from '@hooks/device';
 import NativeNotification from '@notifications';
 import {changeOpacity} from '@utils/theme';
 
@@ -41,6 +42,7 @@ const style = StyleSheet.create({
 
 const Home = ({isFocused, theme}: Props) => {
     const [total, setTotal] = useState<UnreadMessages>({mentions: 0, unread: false});
+    const appState = useAppState();
 
     const updateTotal = () => {
         let unread = false;
@@ -118,6 +120,12 @@ const Home = ({isFocused, theme}: Props) => {
             subscriptions.clear();
         };
     }, []);
+
+    useEffect(() => {
+        if (appState === 'background') {
+            updateTotal();
+        }
+    }, [appState]);
 
     let unreadStyle;
     if (total.mentions) {

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -45,6 +45,7 @@ class NotificationService: UNNotificationServiceExtension {
     if (preferences.object(forKey: "ApplicationIsForeground") as? String != "true") {
       Network.default.fetchAndStoreDataForPushNotification(bestAttemptContent, withContentHandler: contentHandler)
     } else if let contentHandler = contentHandler {
+      bestAttemptContent.badge = Gekidou.Database.default.getTotalMentions() as NSNumber
       contentHandler(bestAttemptContent)
     }
   }


### PR DESCRIPTION
#### Summary
When receiving a notification while you are on a thread, the app badge icon was not being updated to match the amount of mentions across all servers while the app was in the background.

A very easy way to reproduce:
* Set the notifications to trigger while offline, away or online
* switch to channel A and then go to the Thread screen
* Have another user send a notification on channel A while you are in the Thread screen

Note: if channel A is a DM, no need to mention the user.

Important: It seems that the server has some code to not send the notification if the user has been active for a period of time https://github.com/mattermost/mattermost-server/blob/master/app/notification_push.go#L548 that appears to be [20 seconds](https://github.com/mattermost/mattermost-server/blob/717a4d04a925d4969fa3a35fbf633c33e0ad308c/model/status.go#L17) not sure why this is there, perhaps someone from server platform should look into that as the [PR that introduced it](https://github.com/mattermost/mattermost-server/pull/3931) is quite old and I'm not sure if that is needed, but maybe I'm missing something.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45682
https://mattermost.atlassian.net/browse/MM-47830

```release-note
NONE
```
