### PR TITLE
fix Mark as unread a post on non-crt

### DIFF
--- a/app/screens/post_options/options/mark_unread_option/index.ts
+++ b/app/screens/post_options/options/mark_unread_option/index.ts
@@ -5,6 +5,7 @@ import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 
 import {observeCurrentTeamId} from '@queries/servers/system';
+import {observeIsCRTEnabled} from '@queries/servers/thread';
 
 import MarkAsUnreadOption from './mark_unread_option';
 
@@ -13,6 +14,7 @@ import type {WithDatabaseArgs} from '@typings/database/database';
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     return {
         teamId: observeCurrentTeamId(database),
+        isCRTEnabled: observeIsCRTEnabled(database),
     };
 });
 

--- a/app/screens/post_options/options/mark_unread_option/mark_unread_option.tsx
+++ b/app/screens/post_options/options/mark_unread_option/mark_unread_option.tsx
@@ -14,17 +14,18 @@ import {dismissBottomSheet} from '@screens/navigation';
 import type PostModel from '@typings/database/models/servers/post';
 
 type Props = {
+    isCRTEnabled: boolean;
     sourceScreen: typeof Screens[keyof typeof Screens];
     post: PostModel;
     teamId: string;
 }
 
-const MarkAsUnreadOption = ({sourceScreen, post, teamId}: Props) => {
+const MarkAsUnreadOption = ({isCRTEnabled, sourceScreen, post, teamId}: Props) => {
     const serverUrl = useServerUrl();
 
     const onPress = useCallback(async () => {
         await dismissBottomSheet(Screens.POST_OPTIONS);
-        if (sourceScreen === Screens.THREAD) {
+        if (sourceScreen === Screens.THREAD && isCRTEnabled) {
             const threadId = post.rootId || post.id;
             markThreadAsUnread(serverUrl, teamId, threadId, post.id);
         } else {


### PR DESCRIPTION
#### Summary
For non-CRT while on the Thread screen marking a post as unread was marking the thread as unread instead of the channel, now we check that the user is using CRT to mark the thread as unread or the channel accordingly

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48548

```release-note
NONE
```
