### PR TITLE
[MM-48192, MM-48279] Search - don't reset file filter when a user changes teams.

### DIFF
--- a/app/screens/home/search/results/header.tsx
+++ b/app/screens/home/search/results/header.tsx
@@ -118,7 +118,7 @@ const Header = ({
             theme,
             title,
         });
-    }, [selectedFilter]);
+    }, [onFilterChanged, selectedFilter]);
 
     const filterStyle = useMemo(() => ({marginRight: teams.length > 1 ? 0 : 10}), [teams.length > 1]);
 

--- a/app/screens/home/search/results/results.tsx
+++ b/app/screens/home/search/results/results.tsx
@@ -74,7 +74,10 @@ const Results = ({
                 {translateX: withTiming(translateX, {duration})},
             ],
         };
-    }, [selectedTab, dimensions.width]);
+
+        // Do not transform if loading new data. Causes a case where post
+        // results show up in Files results when the team is changed
+    }, [selectedTab, dimensions.width, !loading]);
 
     const paddingTop = useMemo(() => (
         {paddingTop: scrollPaddingTop, flexGrow: 1}

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -159,14 +159,13 @@ const SearchScreen = ({teamId, teams}: Props) => {
     }, [showResults]);
 
     const handleSearch = useCallback(async (newSearchTeamId: string, term: string) => {
-        const searchParams = getSearchParams(term);
+        const searchParams = getSearchParams(term, filter);
         if (!searchParams.terms) {
             handleClearSearch();
             return;
         }
         hideHeader(true);
         handleLoading(true);
-        setFilter(FileFilters.ALL);
         setLastSearchedValue(term);
         addSearchToTeamSearchHistory(serverUrl, newSearchTeamId, term);
         const [postResults, {files, channels}] = await Promise.all([
@@ -182,7 +181,7 @@ const SearchScreen = ({teamId, teams}: Props) => {
         setFileChannelIds(channels?.length ? channels : emptyChannelIds);
         handleLoading(false);
         setShowResults(true);
-    }, [handleClearSearch, handleLoading]);
+    }, [filter, handleClearSearch, handleLoading]);
 
     const onSubmit = useCallback(() => {
         handleSearch(searchTeamId, searchValue);


### PR DESCRIPTION
#### Summary
This PR resolves two search bugs. 

#### 1) MM-48280 When a user has selected a file filter the filter should remain after switching the search team

Repro (using Community)
* from `Contributors` search for `File`
* change file filter to `Presentations` 
  * observe: files reduced to only presentations
* change search team from `Contributors` to `Staff`
  * observe: filter `Presentations` still selected
  * observe: files reduced to only `Presentation` files on `Staff` team.

#### 2) MM-48279 Search results for posts are showing in when the Files tab is selected

This issue was caused by transforming x-translation while still loading results.  To try to repro:

* search for a term
* switch to files team before the results come in

Expected: view files results or tab changes to messages 
Observed: view messages results while in file tab.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48280
https://mattermost.atlassian.net/browse/MM-48279
https://mattermost.atlassian.net/browse/MM-48192

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
