### PR TITLE
set mentionHighlightBg background for mention keywords

### DIFF
--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -492,6 +492,10 @@ const Markdown = ({
             styles = computeTextStyle(textStyles, baseTextStyle, context);
         }
 
+        if (context.includes('mention_highlight')) {
+            styles = concatStyles(styles, {backgroundColor: theme.mentionHighlightBg});
+        }
+
         return (
             <Text
                 testID='markdown_text'


### PR DESCRIPTION
#### Summary
Fix markdown component to add the background color to mention keywords

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48762

```release-note
NONE
```
