### PR TITLE
center highlighted post in permalink view

### DIFF
--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -348,8 +348,13 @@ const PostList = ({
                 scrolledToHighlighted.current = true;
                 // eslint-disable-next-line max-nested-callbacks
                 const index = orderedPosts.findIndex((p) => typeof p !== 'string' && p.id === highlightedId);
-                if (index >= 0) {
-                    scrollToIndex(index, true);
+                if (index >= 0 && listRef.current) {
+                    listRef.current?.scrollToIndex({
+                        animated: true,
+                        index,
+                        viewOffset: 0,
+                        viewPosition: 0.5, // 0 is at bottom
+                    });
                 }
             }
         }, 500);


### PR DESCRIPTION
#### Summary
The highlighted post when opening the permalink view was setting is offset to the top of the view instead of centering it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47862

```release-note
NONE
```
