### PR TITLE
[MM-47516] Persist globalThreadsTab to System Table

### DIFF
--- a/app/actions/local/systems.ts
+++ b/app/actions/local/systems.ts
@@ -89,6 +89,21 @@ export async function setLastServerVersionCheck(serverUrl: string, reset = false
     }
 }
 
+export async function setGlobalThreadsTab(serverUrl: string, globalThreadsTab: GlobalThreadsTab) {
+    try {
+        const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        await operator.handleSystem({
+            systems: [{
+                id: SYSTEM_IDENTIFIERS.GLOBAL_THREADS_TAB,
+                value: globalThreadsTab,
+            }],
+            prepareRecordsOnly: false,
+        });
+    } catch (error) {
+        logError('setGlobalThreadsTab', error);
+    }
+}
+
 export async function dismissAnnouncement(serverUrl: string, announcementText: string) {
     try {
         const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);

--- a/app/constants/database.ts
+++ b/app/constants/database.ts
@@ -59,6 +59,7 @@ export const SYSTEM_IDENTIFIERS = {
     CURRENT_USER_ID: 'currentUserId',
     DATA_RETENTION_POLICIES: 'dataRetentionPolicies',
     EXPANDED_LINKS: 'expandedLinks',
+    GLOBAL_THREADS_TAB: 'globalThreadsTab',
     LAST_DISMISSED_BANNER: 'lastDismissedBanner',
     LAST_SERVER_VERSION_CHECK: 'LastServerVersionCheck',
     LICENSE: 'license',

--- a/app/queries/servers/system.ts
+++ b/app/queries/servers/system.ts
@@ -77,6 +77,13 @@ export const observeCurrentUserId = (database: Database): Observable<string> => 
     );
 };
 
+export const observeGlobalThreadsTab = (database: Database): Observable<string> => {
+    return querySystemValue(database, SYSTEM_IDENTIFIERS.GLOBAL_THREADS_TAB).observe().pipe(
+        switchMap((result) => (result.length ? result[0].observe() : of$({value: 'all'}))),
+        switchMap((model) => of$(model.value)),
+    );
+};
+
 export const getPushVerificationStatus = async (serverDatabase: Database): Promise<string> => {
     try {
         const status = await serverDatabase.get<SystemModel>(SYSTEM).find(SYSTEM_IDENTIFIERS.PUSH_VERIFICATION_STATUS);

--- a/app/screens/global_threads/global_threads.tsx
+++ b/app/screens/global_threads/global_threads.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useIntl} from 'react-intl';
+import {Keyboard, StyleSheet, View} from 'react-native';
+import {Edge, SafeAreaView} from 'react-native-safe-area-context';
+
+import {setGlobalThreadsTab} from '@actions/local/systems';
+import NavigationHeader from '@components/navigation_header';
+import RoundedHeaderContext from '@components/rounded_header_context';
+import {useServerUrl} from '@context/server';
+import {useAppState, useIsTablet} from '@hooks/device';
+import {useDefaultHeaderHeight} from '@hooks/header';
+import {useTeamSwitch} from '@hooks/team_switch';
+import {popTopScreen} from '@screens/navigation';
+
+import ThreadsList from './threads_list';
+
+type Props = {
+    componentId?: string;
+    globalThreadsTab: GlobalThreadsTab;
+};
+
+const edges: Edge[] = ['left', 'right'];
+
+const styles = StyleSheet.create({
+    flex: {
+        flex: 1,
+    },
+});
+
+const GlobalThreads = ({componentId, globalThreadsTab}: Props) => {
+    const appState = useAppState();
+    const serverUrl = useServerUrl();
+    const intl = useIntl();
+    const switchingTeam = useTeamSwitch();
+    const isTablet = useIsTablet();
+
+    const defaultHeight = useDefaultHeaderHeight();
+
+    const [tab, setTab] = useState<GlobalThreadsTab>(globalThreadsTab);
+    const mounted = useRef(false);
+
+    const containerStyle = useMemo(() => {
+        const marginTop = defaultHeight;
+        return {flex: 1, marginTop};
+    }, [defaultHeight]);
+
+    useEffect(() => {
+        mounted.current = true;
+        return () => {
+            setGlobalThreadsTab(serverUrl, tab);
+            mounted.current = false;
+        };
+    }, [serverUrl, tab]);
+
+    const contextStyle = useMemo(() => ({
+        top: defaultHeight,
+    }), [defaultHeight]);
+
+    const onBackPress = useCallback(() => {
+        Keyboard.dismiss();
+        popTopScreen(componentId);
+    }, [componentId]);
+
+    return (
+        <SafeAreaView
+            edges={edges}
+            mode='margin'
+            style={styles.flex}
+            testID='global_threads.screen'
+        >
+            <NavigationHeader
+                showBackButton={!isTablet}
+                isLargeTitle={false}
+                onBackPress={onBackPress}
+                title={
+                    intl.formatMessage({
+                        id: 'threads',
+                        defaultMessage: 'Threads',
+                    })
+                }
+            />
+            <View style={contextStyle}>
+                <RoundedHeaderContext/>
+            </View>
+            {!switchingTeam &&
+            <View style={containerStyle}>
+                <ThreadsList
+                    forceQueryAfterAppState={appState}
+                    setTab={setTab}
+                    tab={tab}
+                    testID={'global_threads.threads_list'}
+                />
+            </View>
+            }
+        </SafeAreaView>
+    );
+};
+
+export default GlobalThreads;


### PR DESCRIPTION
- save the lastview globalThreadsTab to the database after unmounting the threads view
- default to all on first opening of the threads view

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR persists the global thread tab (`All Your Threads` or `Unreads`) to the system table
* the default record value is `all` 
* the value is updated after unmounting the Threads screen

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-47516

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
