### PR TITLE
V2 unsigned build fix for ios

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -357,7 +357,7 @@ platform :ios do
 
     sh 'rm -rf ../build-ios/'
     sh 'cd ../ios/ && xcodebuild -workspace Mattermost.xcworkspace/ -scheme Mattermost -sdk iphoneos -configuration Release -parallelizeTargets -resultBundlePath ../build-ios/result -derivedDataPath ../build-ios/ CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO'
-    sh 'cd ../build-ios/ && mkdir -p Payload && cp -R ../ios/Build/Products/Release-iphoneos/Mattermost.app Payload/ && zip -r Mattermost-unsigned.ipa Payload/'
+    sh 'cd ../build-ios/ && mkdir -p Payload && cp -R ../build-ios/Build/Products/Release-iphoneos/Mattermost.app Payload/ && zip -r Mattermost-unsigned.ipa Payload/'
     sh 'mv ../build-ios/Mattermost-unsigned.ipa ../'
     sh 'rm -rf ../build-ios/'
   end


### PR DESCRIPTION
#### Summary
Small change to a path in the `Fastfile` to allow for the unsigned ios builds to complete.
