### PR TITLE
Calls: Add mobilev2 param to two requests

### DIFF
--- a/app/products/calls/client/rest.ts
+++ b/app/products/calls/client/rest.ts
@@ -36,14 +36,14 @@ const ClientCalls = (superclass: any) => class extends superclass {
 
     getCalls = async () => {
         return this.doFetch(
-            `${this.getCallsRoute()}/channels`,
+            `${this.getCallsRoute()}/channels?mobilev2=true`,
             {method: 'get'},
         );
     };
 
     getCallForChannel = async (channelId: string) => {
         return this.doFetch(
-            `${this.getCallsRoute()}/${channelId}`,
+            `${this.getCallsRoute()}/${channelId}?mobilev2=true`,
             {method: 'get'},
         );
     };


### PR DESCRIPTION
#### Summary
- This supports backwards compatibility for the new channel state. I feel it's simpler than changing the user agent.
- See the `server/utils.go` and `sever/utils_test.go` for where this is handled: https://github.com/mattermost/mattermost-plugin-calls/pull/259

#### Ticket Link
- n/a

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->


#### Release Note

```release-note
NONE
```
