### PR TITLE
[MM-48420] Use virtualized list on selected users.

### DIFF
--- a/app/screens/integration_selector/selected_options/index.tsx
+++ b/app/screens/integration_selector/selected_options/index.tsx
@@ -28,11 +28,6 @@ const getStyleFromTheme = makeStyleSheetFromTheme(() => {
             flexGrow: 0,
             flexDirection: 'row',
         },
-        users: {
-            alignItems: 'flex-start',
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-        },
     };
 });
 

--- a/app/screens/integration_selector/selected_options/index.tsx
+++ b/app/screens/integration_selector/selected_options/index.tsx
@@ -1,13 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-import {View, ScrollView} from 'react-native';
+import React, {useCallback} from 'react';
+import {FlatList, ListRenderItemInfo, View} from 'react-native';
 
 import {View as ViewConstants} from '@constants';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 
 import SelectedOption from '../selected_option';
+
+type SelectedOption = DialogOption | UserProfile | Channel
 
 type Props = {
     theme: Theme;
@@ -19,10 +21,12 @@ type Props = {
 const getStyleFromTheme = makeStyleSheetFromTheme(() => {
     return {
         container: {
-            marginLeft: 5,
+            marginHorizontal: 5,
+            marginRight: 5,
             marginBottom: 5,
             maxHeight: 100,
             flexGrow: 0,
+            flexDirection: 'row',
         },
         users: {
             alignItems: 'flex-start',
@@ -36,43 +40,47 @@ const SelectedOptions = ({
     theme, selectedOptions, onRemove, dataSource,
 }: Props) => {
     const style = getStyleFromTheme(theme);
-    const options: React.ReactNode[] = selectedOptions.map((optionItem) => {
-        let key: string;
 
-        switch (dataSource) {
-            case ViewConstants.DATA_SOURCE_USERS:
-                key = (optionItem as UserProfile).id;
-                break;
-            case ViewConstants.DATA_SOURCE_CHANNELS:
-                key = (optionItem as Channel).id;
-                break;
-            default:
-                key = (optionItem as DialogOption).value;
-                break;
-        }
-
+    const renderItem = useCallback(({item}: ListRenderItemInfo<SelectedOption>) => {
         return (
             <SelectedOption
-                key={key}
-                option={optionItem}
+                option={item}
                 theme={theme}
                 dataSource={dataSource}
                 onRemove={onRemove}
             />);
-    });
+    }, [dataSource, onRemove, theme]);
 
-    // eslint-disable-next-line no-warning-comments
-    // TODO Consider using a Virtualized List since the number of elements is potentially unbounded.
-    // https://mattermost.atlassian.net/browse/MM-48420
+    const extractKey = useCallback((item: SelectedOption) => {
+        let key: string;
+
+        switch (dataSource) {
+            case ViewConstants.DATA_SOURCE_USERS:
+                key = (item as UserProfile)?.id;
+                break;
+            case ViewConstants.DATA_SOURCE_CHANNELS:
+                key = (item as Channel).id;
+                break;
+            default:
+                key = (item as DialogOption).value;
+                break;
+        }
+        return key;
+    }, [dataSource]);
+
     return (
-        <ScrollView
-            style={style.container}
-            contentContainerStyle={style.scrollViewContent}
-        >
-            <View style={style.users}>
-                {options}
-            </View>
-        </ScrollView>
+        <View style={[style.container]}>
+            <FlatList
+                numColumns={3}
+                data={selectedOptions}
+                initialNumToRender={3}
+                renderItem={renderItem}
+                keyExtractor={extractKey}
+            />
+
+        </View>
+
+    // </>
     );
 };
 


### PR DESCRIPTION
#### Summary

@enahum, @javaguirre, @larkox, I pushed this PR for the sake of discussion and what I found. 

1) While using a flatlist in theory makes, sense, I wonder if it is needed in this case. The only way this list grows is from the user tapping users in the user list.  While this is unbounded, it seems like it wouldn't be that likely the number of users selected would reach an amount that causes problems. (this is only a theory)

2) Trying to convert the list to a FlatList has it's own issues, mainly the styling of the component and wrapping. The flatlist complains with the use of `flexWrap: wrap` and wants to use `numberColumns`, which isn't a dynamic value. So, setting it to 3 might make sense for some phones, it wouldn't make sense for tablets (even the same tablet in portrait / landscape)

It seem flatlist is better suited for data that will display in some number of predetermined columns, where we are trying to have one row of data (users) that wraps when the component is outside the bounds of the component screen. 

I'm curious on your thoughts before continuing on this PR. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48420

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
