### PR TITLE
[MM-48855] Remove CRT feature flag from 7.6

### DIFF
--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -149,7 +149,7 @@ export const fetchAppEntryData = async (serverUrl: string, sinceArg: number, ini
 
     const confReq = await fetchConfigAndLicense(serverUrl);
     const prefData = await fetchMyPreferences(serverUrl, fetchOnly);
-    const isCRTEnabled = Boolean(prefData.preferences && processIsCRTEnabled(prefData.preferences, confReq.config?.CollapsedThreads, confReq.config?.FeatureFlagCollapsedThreads));
+    const isCRTEnabled = Boolean(prefData.preferences && processIsCRTEnabled(prefData.preferences, confReq.config?.CollapsedThreads, confReq.config?.FeatureFlagCollapsedThreads, confReq.config?.Version));
     if (prefData.preferences) {
         const crtToggled = await getHasCRTChanged(database, prefData.preferences);
         if (crtToggled) {
@@ -331,7 +331,7 @@ export async function restDeferredAppEntryActions(
         fetchTeamsChannelsAndUnreadPosts(serverUrl, since, teamData.teams, teamData.memberships, initialTeamId);
     }
 
-    if (preferences && processIsCRTEnabled(preferences, config.CollapsedThreads, config.FeatureFlagCollapsedThreads)) {
+    if (preferences && processIsCRTEnabled(preferences, config.CollapsedThreads, config.FeatureFlagCollapsedThreads, config.Version)) {
         if (initialTeamId) {
             await syncTeamThreads(serverUrl, initialTeamId);
         }
@@ -465,7 +465,7 @@ const restSyncAllChannelMembers = async (serverUrl: string) => {
         for await (const myTeam of myTeams) {
             fetchMyChannelsForTeam(serverUrl, myTeam.id, false, 0, false, excludeDirect);
             excludeDirect = true;
-            if (preferences && processIsCRTEnabled(preferences, config.CollapsedThreads, config.FeatureFlagCollapsedThreads)) {
+            if (preferences && processIsCRTEnabled(preferences, config.CollapsedThreads, config.FeatureFlagCollapsedThreads, config.Version)) {
                 // need to await here since GM/DM threads in different teams overlap
                 await syncTeamThreads(serverUrl, myTeam.id);
             }

--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -55,7 +55,7 @@ export async function deferredAppEntryGraphQLActions(
         }
     }, FETCH_UNREADS_TIMEOUT);
 
-    if (preferences && processIsCRTEnabled(preferences, config.CollapsedThreads, config.FeatureFlagCollapsedThreads)) {
+    if (preferences && processIsCRTEnabled(preferences, config.CollapsedThreads, config.FeatureFlagCollapsedThreads, config.Version)) {
         if (initialTeamId) {
             await syncTeamThreads(serverUrl, initialTeamId);
         }

--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -23,7 +23,7 @@ const {SERVER: {CHANNEL, POST, THREAD, THREADS_IN_TEAM, THREAD_PARTICIPANT, TEAM
 export const getIsCRTEnabled = async (database: Database): Promise<boolean> => {
     const config = await getConfig(database);
     const preferences = await queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS).fetch();
-    return processIsCRTEnabled(preferences, config?.CollapsedThreads, config?.FeatureFlagCollapsedThreads);
+    return processIsCRTEnabled(preferences, config?.CollapsedThreads, config?.FeatureFlagCollapsedThreads, config?.Version);
 };
 
 export const getThreadById = async (database: Database, threadId: string) => {
@@ -43,10 +43,11 @@ export const getTeamThreadsSyncData = async (database: Database, teamId: string)
 export const observeIsCRTEnabled = (database: Database) => {
     const cfgValue = observeConfigValue(database, 'CollapsedThreads');
     const featureFlag = observeConfigValue(database, 'FeatureFlagCollapsedThreads');
+    const version = observeConfigValue(database, 'Version');
     const preferences = queryPreferencesByCategoryAndName(database, Preferences.CATEGORY_DISPLAY_SETTINGS).observeWithColumns(['value']);
-    return combineLatest([cfgValue, featureFlag, preferences]).pipe(
+    return combineLatest([cfgValue, featureFlag, preferences, version]).pipe(
         map(
-            ([cfgV, ff, prefs]) => processIsCRTEnabled(prefs, cfgV, ff),
+            ([cfgV, ff, prefs, ver]) => processIsCRTEnabled(prefs, cfgV, ff, ver),
         ),
         distinctUntilChanged(),
     );

--- a/app/utils/thread/index.ts
+++ b/app/utils/thread/index.ts
@@ -3,18 +3,22 @@
 
 import {Config, Preferences} from '@constants';
 import {getPreferenceValue} from '@helpers/api/preference';
+import {isMinimumServerVersion} from '@utils/helpers';
 
 import type PreferenceModel from '@typings/database/models/servers/preference';
 
-export function processIsCRTEnabled(preferences: PreferenceModel[]|PreferenceType[], configValue?: string, featureFlag?: string): boolean {
+export function processIsCRTEnabled(preferences: PreferenceModel[]|PreferenceType[], configValue?: string, featureFlag?: string, version?: string): boolean {
     let preferenceDefault = Preferences.COLLAPSED_REPLY_THREADS_OFF;
     if (configValue === Config.DEFAULT_ON) {
         preferenceDefault = Preferences.COLLAPSED_REPLY_THREADS_ON;
     }
     const preference = getPreferenceValue(preferences, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSED_REPLY_THREADS, preferenceDefault);
 
+    // CRT Feature flag removed in 7.6
+    const isFeatureFlagEnabled = version && isMinimumServerVersion(version, 7, 6) ? true : featureFlag === Config.TRUE;
+
     const isAllowed = (
-        featureFlag === Config.TRUE &&
+        isFeatureFlagEnabled &&
         configValue !== Config.DISABLED
     );
 


### PR DESCRIPTION
#### Summary
CRT feature flag is removed from Server 7.6. This PR removes the check if the server version is 7.6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48855

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 16

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
NONE
```