### PR TITLE
MM-48949 - Calls: Displayname not showing correctly in call screen

### DIFF
--- a/app/products/calls/components/current_call_bar/current_call_bar.tsx
+++ b/app/products/calls/components/current_call_bar/current_call_bar.tsx
@@ -132,7 +132,7 @@ const CurrentCallBar = ({
         talkingMessage = formatMessage({
             id: 'mobile.calls_name_is_talking',
             defaultMessage: '{name} is talking',
-        }, {name: displayUsername(userModelsDict[speaker], teammateNameDisplay)});
+        }, {name: displayUsername(userModelsDict[speaker], intl.locale, teammateNameDisplay)});
     }
 
     const muteUnmute = () => {

--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -455,7 +455,7 @@ const CallScreen = ({
                 <FormattedText
                     id={'mobile.calls_viewing_screen'}
                     defaultMessage={'You are viewing {name}\'s screen'}
-                    values={{name: displayUsername(participantsDict[currentCall.screenOn].userModel, teammateNameDisplay)}}
+                    values={{name: displayUsername(participantsDict[currentCall.screenOn].userModel, intl.locale, teammateNameDisplay)}}
                     style={style.screenShareText}
                 />
             </Pressable>
@@ -493,7 +493,7 @@ const CallScreen = ({
                                     serverUrl={currentCall.serverUrl}
                                 />
                                 <Text style={style.username}>
-                                    {displayUsername(user.userModel, teammateNameDisplay)}
+                                    {displayUsername(user.userModel, intl.locale, teammateNameDisplay)}
                                     {user.id === myParticipant.id &&
                                         ` ${intl.formatMessage({id: 'mobile.calls_you', defaultMessage: '(you)'})}`
                                     }


### PR DESCRIPTION
#### Summary
- Mistake caused the displayname to default to usernames. Fixed now.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-48949

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
NONE
```
