### PR TITLE
MM-48664 - Calls: Profiles cut off sometimes

### DIFF
--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -118,10 +118,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         flex: 1,
         flexDirection: 'row',
         flexWrap: 'wrap',
-        width: '100%',
-        height: '100%',
-        alignContent: 'center',
-        alignItems: 'flex-start',
+        alignContent: 'flex-start',
     },
     usersScrollLandscapeScreenOn: {
         position: 'absolute',


### PR DESCRIPTION
#### Summary
- This occurred rarely, but it was reproducible on the iPhone 13 sim using the exact profiles as in the ticket.
- Also, filling up the call with 20 profiles would sometimes cause the scrollview to stop before it had scolled to the last row (last row was only visible if you swiped and held up, and would scroll back below the screen after letting go).
- Both issues are fixed now

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-48664

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus
- sims

#### Screenshots
- Before:
![21c29109-b18b-4e4a-8935-605a93cde3e0](https://user-images.githubusercontent.com/1490756/206552155-3b28bf3d-c58c-41f1-810c-c2c33e97759d.png)
- After:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/1490756/206552364-6136fb00-4043-498c-986d-25939ddf73f6.png">


#### Release Note
```release-note
NONE
```
