### PR TITLE
[MM-48328] Use the width as a dependency instead of dimensions reference

### DIFF
--- a/app/screens/home/search/results/results.tsx
+++ b/app/screens/home/search/results/results.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useMemo} from 'react';
-import {ScaledSize, StyleSheet, useWindowDimensions, View} from 'react-native';
+import {StyleSheet, useWindowDimensions, View} from 'react-native';
 import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
 
 import Loading from '@components/loading';
@@ -17,21 +17,21 @@ import type PostModel from '@typings/database/models/servers/post';
 
 const duration = 250;
 
-const getStyles = (dimensions: ScaledSize) => {
+const getStyles = (width: number) => {
     return StyleSheet.create({
         container: {
             flex: 1,
             flexDirection: 'row',
-            width: dimensions.width * 2,
+            width: width * 2,
         },
         result: {
             flex: 1,
-            width: dimensions.width,
+            width,
         },
         loading: {
             justifyContent: 'center',
             flex: 1,
-            width: dimensions.width,
+            width,
         },
     });
 };
@@ -63,18 +63,18 @@ const Results = ({
     searchValue,
     selectedTab,
 }: Props) => {
-    const dimensions = useWindowDimensions();
+    const {width} = useWindowDimensions();
     const theme = useTheme();
-    const styles = useMemo(() => getStyles(dimensions), [dimensions]);
+    const styles = useMemo(() => getStyles(width), [width]);
 
     const transform = useAnimatedStyle(() => {
-        const translateX = selectedTab === TabTypes.MESSAGES ? 0 : -dimensions.width;
+        const translateX = selectedTab === TabTypes.MESSAGES ? 0 : -width;
         return {
             transform: [
                 {translateX: withTiming(translateX, {duration})},
             ],
         };
-    }, [selectedTab, dimensions.width]);
+    }, [selectedTab, width]);
 
     const paddingTop = useMemo(() => (
         {paddingTop: scrollPaddingTop, flexGrow: 1}


### PR DESCRIPTION
#### Summary
This PR fixes and issue where rotating a tablet does not recalculate the sceen width. The dimensions reference as a dependency does not change, even though its values do.  use the width as a dependency instead.

#### Ticket Link


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
