### PR TITLE
Combine fastlane for iOS unsigned and simulator and enable build of iOS simulator both in release and PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,29 +399,29 @@ jobs:
   #     - save:
   #         filename: "*.ipa"
 
-  build-ios-simulator:
-    executor: ios
-    steps:
-      - checkout:
-          path: ~/mattermost-mobile
-      - npm-dependencies
-      - pods-dependencies
-      - assets
-      - fastlane-dependencies:
-          for: ios
-      - run:
-          working_directory: fastlane
-          name: Run fastlane to build unsigned x86_64 iOS app for iPhone simulator
-          no_output_timeout: 30m
-          command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install watchman
-            bundle exec fastlane ios simulator
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - mattermost-mobile/Mattermost-simulator-x86_64.app.zip
-      - save:
-          filename: "Mattermost-simulator-x86_64.app.zip"
+  # build-ios-simulator:
+  #   executor: ios
+  #   steps:
+  #     - checkout:
+  #         path: ~/mattermost-mobile
+  #     - npm-dependencies
+  #     - pods-dependencies
+  #     - assets
+  #     - fastlane-dependencies:
+  #         for: ios
+  #     - run:
+  #         working_directory: fastlane
+  #         name: Run fastlane to build unsigned x86_64 iOS app for iPhone simulator
+  #         no_output_timeout: 30m
+  #         command: |
+  #           HOMEBREW_NO_AUTO_UPDATE=1 brew install watchman
+  #           bundle exec fastlane ios simulator
+  #     - persist_to_workspace:
+  #         root: ~/
+  #         paths:
+  #           - mattermost-mobile/Mattermost-simulator-x86_64.app.zip
+  #     - save:
+  #         filename: "Mattermost-simulator-x86_64.app.zip"
 
   # deploy-android-release:
   #   executor:
@@ -596,18 +596,17 @@ workflows:
       #         only: /^v(\d+\.)(\d+\.)(\d+)(.*)?$/
       #       branches:
       #         only: unsigned
-      - build-ios-simulator:
-          context: mattermost-mobile-simulator
-          requires:
-            - test
-          filters:
-            branches:
-              only:
-                - /^build-\d+$/
-                - /^build-ios-\d+$/
-                - /^build-ios-beta-\d+$/
-                - /^build-ios-sim-\d+$/
-                - /^(build|ios)-pr-.*/
+      # - build-ios-simulator:
+          # context: mattermost-mobile-unsigned
+          # requires:
+          #   - test
+          # filters:
+          #   branches:
+          #     only:
+          #       - /^build-\d+$/
+          #       - /^build-ios-\d+$/
+          #       - /^build-ios-beta-\d+$/
+          #       - /^build-ios-sim-\d+$/
 
       # - github-release:
       #     context: mattermost-mobile-unsigned

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,29 +399,29 @@ jobs:
   #     - save:
   #         filename: "*.ipa"
 
-  # build-ios-simulator:
-  #   executor: ios
-  #   steps:
-  #     - checkout:
-  #         path: ~/mattermost-mobile
-  #     - npm-dependencies
-  #     - pods-dependencies
-  #     - assets
-  #     - fastlane-dependencies:
-  #         for: ios
-  #     - run:
-  #         working_directory: fastlane
-  #         name: Run fastlane to build unsigned x86_64 iOS app for iPhone simulator
-  #         no_output_timeout: 30m
-  #         command: |
-  #           HOMEBREW_NO_AUTO_UPDATE=1 brew install watchman
-  #           bundle exec fastlane ios simulator
-  #     - persist_to_workspace:
-  #         root: ~/
-  #         paths:
-  #           - mattermost-mobile/Mattermost-simulator-x86_64.app.zip
-  #     - save:
-  #         filename: "Mattermost-simulator-x86_64.app.zip"
+  build-ios-simulator:
+    executor: ios
+    steps:
+      - checkout:
+          path: ~/mattermost-mobile
+      - npm-dependencies
+      - pods-dependencies
+      - assets
+      - fastlane-dependencies:
+          for: ios
+      - run:
+          working_directory: fastlane
+          name: Run fastlane to build unsigned x86_64 iOS app for iPhone simulator
+          no_output_timeout: 30m
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install watchman
+            bundle exec fastlane ios simulator
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - mattermost-mobile/Mattermost-simulator-x86_64.app.zip
+      - save:
+          filename: "Mattermost-simulator-x86_64.app.zip"
 
   # deploy-android-release:
   #   executor:
@@ -596,17 +596,18 @@ workflows:
       #         only: /^v(\d+\.)(\d+\.)(\d+)(.*)?$/
       #       branches:
       #         only: unsigned
-      # - build-ios-simulator:
-          # context: mattermost-mobile-unsigned
-          # requires:
-          #   - test
-          # filters:
-          #   branches:
-          #     only:
-          #       - /^build-\d+$/
-          #       - /^build-ios-\d+$/
-          #       - /^build-ios-beta-\d+$/
-          #       - /^build-ios-sim-\d+$/
+      - build-ios-simulator:
+          context: mattermost-mobile-simulator
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - /^build-\d+$/
+                - /^build-ios-\d+$/
+                - /^build-ios-beta-\d+$/
+                - /^build-ios-sim-\d+$/
+                - /^(build|ios)-pr-.*/
 
       # - github-release:
       #     context: mattermost-mobile-unsigned

--- a/detox/.detoxrc.json
+++ b/detox/.detoxrc.json
@@ -13,7 +13,7 @@
     "ios.release": {
       "type": "ios.app",
       "binaryPath": "../ios/Build/Products/Release-iphonesimulator/Mattermost.app",
-      "build": "cd ../fastlane && NODE_ENV=production bundle exec fastlane ios simulator && cd ../detox"
+      "build": "cd .. && npm run build:ios-sim && cd detox"
     },
     "android.debug": {
       "type": "android.apk",

--- a/detox/package.json
+++ b/detox/package.json
@@ -52,7 +52,7 @@
     "e2e:android-test-release": "detox test -c android.emu.release --record-logs failing --take-screenshots failing",
     "e2e:ios-test": "IOS=true detox test -c ios.sim.debug",
     "e2e:ios-build-release": "detox build -c ios.sim.release",
-    "e2e:ios-test-release": "IOS=true detox test -c ios.sim.release --headless --record-logs failing --take-screenshots failing",
+    "e2e:ios-test-release": "IOS=true detox test -c ios.sim.release --record-logs failing --take-screenshots failing",
     "check": "npm run lint && npm run tsc",
     "lint": "eslint --ignore-path .gitignore --ignore-pattern node_modules --quiet .",
     "start:webhook": "node webhook_server.js",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -355,39 +355,27 @@ platform :ios do
     update_identifiers
     replace_assets
 
-    sh 'rm -rf ../build-ios/'
-    sh 'cd ../ios/ && xcodebuild -workspace Mattermost.xcworkspace/ -scheme Mattermost -sdk iphoneos -configuration Release -parallelizeTargets -resultBundlePath ../build-ios/result -derivedDataPath ../build-ios/ CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO'
-    sh 'cd ../build-ios/ && mkdir -p Payload && cp -R ../build-ios/Build/Products/Release-iphoneos/Mattermost.app Payload/ && zip -r Mattermost-unsigned.ipa Payload/'
-    sh 'mv ../build-ios/Mattermost-unsigned.ipa ../'
-    sh 'rm -rf ../build-ios/'
+    build_ios_unsigned_or_simulator(
+      more_xc_args: "-sdk iphoneos CODE_SIGNING_ALLOWED=NO",
+      rel_build_dir: "Release-iphoneos",
+      output_file: "Mattermost-unsigned.ipa",
+    )
   end
 
   lane :simulator do
     UI.success('Building iOS app for simulator')
 
-    ENV['APP_NAME'] = 'Mattermost'
-    ENV['REPLACE_ASSETS'] = 'true'
-    ENV['BUILD_FOR_RELEASE'] = 'true'
-    ENV['APP_SCHEME'] = 'mattermost'
+    output_file = "Mattermost-simulator-x86_64.app.zip"
 
-    update_identifiers
-    replace_assets
-
-    data_path = 'ios'
-    if ENV['CIRCLECI'] == 'true'
-      data_path = 'build-ios'
-    end
-
-    sh 'rm -rf ../ios/build/'
-    sh 'rm -rf ../build-ios/'
-    sh "cd ../ios && xcodebuild -workspace Mattermost.xcworkspace -scheme Mattermost -arch x86_64 -sdk iphonesimulator -configuration Release -parallelizeTargets -derivedDataPath ../#{data_path} ENABLE_BITCODE=NO CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO ENABLE_BITCODE=NO"
-    sh "cd ../#{data_path}/Build/Products/Release-iphonesimulator && zip -r Mattermost-simulator-x86_64.app.zip Mattermost.app"
-    sh "mv ../#{data_path}/Build/Products/Release-iphonesimulator/Mattermost-simulator-x86_64.app.zip ../"
-    sh 'rm -rf ../build-ios/'
+    build_ios_unsigned_or_simulator(
+      more_xc_args: "-sdk iphonesimulator -arch x86_64",
+      rel_build_dir: "Release-iphonesimulator",
+      output_file: output_file,
+    )
 
     upload_file_to_s3({
       :os_type => "ios",
-      :file => "Mattermost-simulator-x86_64.app.zip"
+      :file => output_file
     })
   end
 
@@ -597,6 +585,24 @@ platform :ios do
             iCloudContainerEnvironment: 'Production'
         }
     )
+  end
+
+  def build_ios_unsigned_or_simulator(more_xc_args:, rel_build_dir:, output_file:)
+    root_dir = Dir[File.expand_path('..')].first
+    ios_build_dir = "#{root_dir}/ios/Build/Products"
+
+    ENV['APP_NAME'] = 'Mattermost'
+    ENV['REPLACE_ASSETS'] = 'true'
+    ENV['BUILD_FOR_RELEASE'] = 'true'
+    ENV['APP_SCHEME'] = 'mattermost'
+
+    update_identifiers
+    replace_assets
+
+    sh "rm -rf #{ios_build_dir}/"
+    sh "cd #{root_dir}/ios && xcodebuild -workspace Mattermost.xcworkspace -scheme Mattermost -configuration Release -parallelizeTargets CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO SYMROOT='#{ios_build_dir}' #{more_xc_args} "
+    sh "cd #{ios_build_dir}/#{rel_build_dir} && zip -r #{output_file} Mattermost.app"
+    sh "mv #{ios_build_dir}/#{rel_build_dir}/#{output_file} #{root_dir}"
   end
 
 end


### PR DESCRIPTION
#### Summary
- Combined fastlane for iOS unsigned and simulator
- Enabled build of iOS simulator both in release and PR
  - release build will be useful for RainforestQA testing
  - PR build will be useful for mobile E2E tests so that the pipeline in GitLab will take advantage of just picking up the artifacts from S3.

#### Ticket Link
none, from channel discussion - https://community.mattermost.com/core/pl/nrn7p4uq1igbinwxitccoqifsa

#### Release Note
```release-note
NONE
```