### PR TITLE
Fix issues when removing a user from a team

### DIFF
--- a/app/actions/remote/team.ts
+++ b/app/actions/remote/team.ts
@@ -12,7 +12,7 @@ import {getActiveServerUrl} from '@queries/app/servers';
 import {prepareCategoriesAndCategoriesChannels} from '@queries/servers/categories';
 import {prepareMyChannelsForTeam, getDefaultChannelForTeam} from '@queries/servers/channel';
 import {prepareCommonSystemValues, getCurrentTeamId, getCurrentUserId} from '@queries/servers/system';
-import {addTeamToTeamHistory, prepareDeleteTeam, prepareMyTeams, getNthLastChannelFromTeam, queryTeamsById, syncTeamTable, getLastTeam, getTeamById} from '@queries/servers/team';
+import {addTeamToTeamHistory, prepareDeleteTeam, prepareMyTeams, getNthLastChannelFromTeam, queryTeamsById, syncTeamTable, getLastTeam, getTeamById, removeTeamFromTeamHistory} from '@queries/servers/team';
 import {dismissAllModals, popToRoot, resetToTeams} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {isTablet} from '@utils/helpers';
@@ -330,7 +330,7 @@ export async function handleTeamChange(serverUrl: string, teamId: string) {
 
 export async function handleKickFromTeam(serverUrl: string, teamId: string) {
     try {
-        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const currentTeamId = await getCurrentTeamId(database);
         if (currentTeamId !== teamId) {
             return;
@@ -344,7 +344,8 @@ export async function handleKickFromTeam(serverUrl: string, teamId: string) {
             await popToRoot();
         }
 
-        const teamToJumpTo = await getLastTeam(database);
+        await removeTeamFromTeamHistory(operator, teamId);
+        const teamToJumpTo = await getLastTeam(database, teamId);
         if (teamToJumpTo) {
             await handleTeamChange(serverUrl, teamToJumpTo);
         } else if (currentServer === serverUrl) {

--- a/app/components/team_sidebar/team_list/team_item/team_item.tsx
+++ b/app/components/team_sidebar/team_list/team_item/team_item.tsx
@@ -16,7 +16,7 @@ import TeamIcon from './team_icon';
 import type TeamModel from '@typings/database/models/servers/team';
 
 type Props = {
-    team: TeamModel;
+    team?: TeamModel;
     hasUnreads: boolean;
     mentionCount: number;
     selected: boolean;
@@ -61,6 +61,10 @@ export default function TeamItem({team, hasUnreads, mentionCount, selected}: Pro
     const theme = useTheme();
     const styles = getStyleSheet(theme);
     const serverUrl = useServerUrl();
+
+    if (!team) {
+        return null;
+    }
 
     const hasBadge = Boolean(mentionCount || hasUnreads);
     let badgeStyle = styles.unread;

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -256,7 +256,7 @@ export const getDefaultChannelForTeam = async (database: Database, teamId: strin
 
     const clauses = [
         Q.where('team_id', teamId),
-        Q.where('delete_at', 0),
+        Q.where('delete_at', Q.eq(0)),
         Q.where('type', General.OPEN_CHANNEL),
     ];
 

--- a/app/queries/servers/team.ts
+++ b/app/queries/servers/team.ts
@@ -84,7 +84,7 @@ export const getTeamChannelHistory = async (database: Database, teamId: string) 
     }
 };
 
-export const getNthLastChannelFromTeam = async (database: Database, teamId: string, n = 0) => {
+export const getNthLastChannelFromTeam = async (database: Database, teamId: string, n = 0, ignoreIdForDefault?: string) => {
     let channelId = '';
 
     try {
@@ -98,7 +98,7 @@ export const getNthLastChannelFromTeam = async (database: Database, teamId: stri
 
     if (!channelId) {
         // No channel history for the team
-        const channel = await getDefaultChannelForTeam(database, teamId);
+        const channel = await getDefaultChannelForTeam(database, teamId, ignoreIdForDefault);
         if (channel) {
             channelId = channel.id;
         }
@@ -156,13 +156,13 @@ export const removeTeamFromTeamHistory = async (operator: ServerDataOperator, te
     return patchTeamHistory(operator, teamIds, prepareRecordsOnly);
 };
 
-export const getLastTeam = async (database: Database) => {
+export const getLastTeam = async (database: Database, ignoreIdForDefault?: string) => {
     const teamHistory = (await getTeamHistory(database));
     if (teamHistory.length > 0) {
         return teamHistory[0];
     }
 
-    return getDefaultTeamId(database);
+    return getDefaultTeamId(database, ignoreIdForDefault);
 };
 
 export async function syncTeamTable(operator: ServerDataOperator, teams: Team[]) {
@@ -190,7 +190,7 @@ export async function syncTeamTable(operator: ServerDataOperator, teams: Team[])
     }
 }
 
-export const getDefaultTeamId = async (database: Database) => {
+export const getDefaultTeamId = async (database: Database, ignoreId?: string) => {
     const user = await getCurrentUser(database);
     const config = await getConfig(database);
     const teamOrderPreferences = await queryPreferencesByCategoryAndName(database, Preferences.TEAMS_ORDER, '').fetch();
@@ -199,7 +199,13 @@ export const getDefaultTeamId = async (database: Database) => {
         teamOrderPreference = teamOrderPreferences[0].value;
     }
 
-    const teamModels = await database.get<TeamModel>(TEAM).query(Q.on(MY_TEAM, Q.where('id', Q.notEq('')))).fetch();
+    const clauses: Q.Clause[] = [Q.on(MY_TEAM, Q.where('id', Q.notEq('')))];
+
+    if (ignoreId) {
+        clauses.push(Q.where('id', Q.notEq(ignoreId)));
+    }
+
+    const teamModels = await database.get<TeamModel>(TEAM).query(...clauses).fetch();
 
     const defaultTeam = selectDefaultTeam(teamModels, user?.locale || DEFAULT_LOCALE, teamOrderPreference, config?.ExperimentalPrimaryTeam);
     return defaultTeam?.id;


### PR DESCRIPTION
#### Summary
This PR solves the issues on the ticket and a few others:
- Race condition on team_item that fetches from the database an undefined team before being removed from the flatlist (id undefined issue)
- Navigation issue where we were navigating to the last team (which was the one were removing). This provoked the issue of re-entering the app and seeing "couldn't load this server".
- Similar issue when navigating to the last channel. This would only be observable on tablets, since they are the ones that show several channels.
- Corner case issue on both teams and channels where the "default channel to join" was the channel we were deleting.
- Minor refactoring to accommodate the case of archived channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48948

#### Release Note
```release-note
Fix issue when being removed from teams or channels.
```
