### PR TITLE
Detox/E2E: Fix android detox build and upgrade simulator to iPhone 14

### DIFF
--- a/android/app/src/androidTest/java/com/mattermost/rnbeta/DetoxTest.java
+++ b/android/app/src/androidTest/java/com/mattermost/rnbeta/DetoxTest.java
@@ -1,6 +1,7 @@
 package com.mattermost.rnbeta;
 
 import com.wix.detox.Detox;
+import com.wix.detox.config.DetoxConfig;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,10 +20,11 @@ public class DetoxTest {
 
     @Test
     public void runDetoxTests() {
-        Detox.DetoxIdlePolicyConfig idlePolicyConfig = new Detox.DetoxIdlePolicyConfig();
-        idlePolicyConfig.masterTimeoutSec = 60;
-        idlePolicyConfig.idleResourceTimeoutSec = 30;
+        DetoxConfig detoxConfig = new DetoxConfig();
+        detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
+        detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
+        detoxConfig.rnContextLoadTimeoutSec = (BuildConfig.DEBUG ? 180 : 60);
 
-        Detox.runTests(mActivityRule, idlePolicyConfig);
+        Detox.runTests(mActivityRule, detoxConfig);
     }
 }

--- a/detox/.detoxrc.json
+++ b/detox/.detoxrc.json
@@ -30,7 +30,7 @@
     "ios.simulator": {
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 13"
+        "type": "iPhone 14"
       }
     },
     "android.emulator": {


### PR DESCRIPTION
#### Summary
- Update `DetoxTest.java` to fix the android detox build based on latest https://wix.github.io/Detox/docs/introduction/project-setup#42-adding-an-auxiliary-android-test
- Upgrade detox simulator to iPhone 14

#### Ticket Link
NA

#### Release Note
```release-note
NONE
```