### PR TITLE
standardize user-agent

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2638,42 +2638,6 @@ SOFTWARE.
 
 ---
 
-## react-native-user-agent
-
-This product contains 'react-native-user-agent' by Bebnev Anton.
-
-Library that helps you to get mobile application user agent and web view user agent strings.
-
-* HOMEPAGE:
-  * https://github.com/bebnev/react-native-user-agent
-
-* LICENSE: MIT
-
-MIT License
-
-Copyright (c) 2018 Anton Bebnev
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
----
-
 ## react-native-vector-icons
 
 This product contains 'react-native-vector-icons' by Joel Arvidsson.

--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -9,7 +9,7 @@ import {
     RetryTypes,
 } from '@mattermost/react-native-network-client';
 import {DeviceEventEmitter} from 'react-native';
-import UserAgent from 'react-native-user-agent';
+import DeviceInfo from 'react-native-device-info';
 
 import LocalConfig from '@assets/config.json';
 import {Client} from '@client/rest';
@@ -95,11 +95,11 @@ class NetworkManager {
     };
 
     private buildConfig = async () => {
-        const userAgent = UserAgent.getUserAgent();
+        const userAgent = `Mattermost Mobile/${DeviceInfo.getVersion()}+${DeviceInfo.getBuildNumber()} (${DeviceInfo.getSystemName()}; ${DeviceInfo.getSystemVersion()}; ${DeviceInfo.getModel()})`;
         const managedConfig = ManagedApp.enabled ? Emm.getManagedConfig<ManagedConfig>() : undefined;
         const headers: Record<string, string> = {
-            ...this.DEFAULT_CONFIG.headers,
             [ClientConstants.HEADER_USER_AGENT]: userAgent,
+            ...this.DEFAULT_CONFIG.headers,
         };
 
         const config = {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -369,8 +369,6 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-turbo-mailer (0.2.0):
     - React-Core
-  - react-native-user-agent (2.3.1):
-    - React
   - react-native-video (5.2.1):
     - React-Core
     - react-native-video/Video (= 5.2.1)
@@ -618,7 +616,6 @@ DEPENDENCIES:
   - "react-native-paste-input (from `../node_modules/@mattermost/react-native-paste-input`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-turbo-mailer (from `../node_modules/@mattermost/react-native-turbo-mailer`)"
-  - react-native-user-agent (from `../node_modules/react-native-user-agent`)
   - react-native-video (from `../node_modules/react-native-video`)
   - react-native-webrtc (from `../node_modules/react-native-webrtc`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -776,8 +773,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-turbo-mailer:
     :path: "../node_modules/@mattermost/react-native-turbo-mailer"
-  react-native-user-agent:
-    :path: "../node_modules/react-native-user-agent"
   react-native-video:
     :path: "../node_modules/react-native-video"
   react-native-webrtc:
@@ -928,7 +923,6 @@ SPEC CHECKSUMS:
   react-native-paste-input: 88709b4fd586ea8cc56ba5e2fc4cdfe90597730c
   react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
   react-native-turbo-mailer: 226fc3533d16500fb4ad08cf8ab2cfc7bb1ef593
-  react-native-user-agent: a90a1e839b99801baad67a73dd6f361a52aa3cf1
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
   react-native-webrtc: 86d841823e66d68cc1f86712db1c2956056bf0c2
   react-native-webview: 91a6bd643c6c298f6dfac309231c15d60b8e9505

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,6 @@
         "react-native-shadow-2": "7.0.6",
         "react-native-share": "8.0.0",
         "react-native-svg": "13.6.0",
-        "react-native-user-agent": "2.3.1",
         "react-native-vector-icons": "9.2.0",
         "react-native-video": "5.2.1",
         "react-native-webrtc": "github:mattermost/react-native-webrtc",
@@ -18733,14 +18732,6 @@
       "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
       "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw=="
     },
-    "node_modules/react-native-user-agent": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-native-user-agent/-/react-native-user-agent-2.3.1.tgz",
-      "integrity": "sha512-AIFr1VgJHwgWmMwCOmIGxuBeAaADlouXKc10UyR4fzWneUbt5uIJIoRu2oExlfCtiT8IyCp106khDD5vx7RUjw==",
-      "peerDependencies": {
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-vector-icons": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
@@ -36078,12 +36069,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
       "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw=="
-    },
-    "react-native-user-agent": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-native-user-agent/-/react-native-user-agent-2.3.1.tgz",
-      "integrity": "sha512-AIFr1VgJHwgWmMwCOmIGxuBeAaADlouXKc10UyR4fzWneUbt5uIJIoRu2oExlfCtiT8IyCp106khDD5vx7RUjw==",
-      "requires": {}
     },
     "react-native-vector-icons": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "react-native-shadow-2": "7.0.6",
     "react-native-share": "8.0.0",
     "react-native-svg": "13.6.0",
-    "react-native-user-agent": "2.3.1",
     "react-native-vector-icons": "9.2.0",
     "react-native-video": "5.2.1",
     "react-native-webrtc": "github:mattermost/react-native-webrtc",

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -236,12 +236,6 @@ jest.mock('react-native-device-info', () => {
     };
 });
 
-jest.mock('react-native-user-agent', () => {
-    return {
-        getUserAgent: () => 'user-agent',
-    };
-});
-
 jest.mock('react-native-localize', () => ({
     getTimeZone: () => 'World/Somewhere',
     getLocales: () => ([


### PR DESCRIPTION
#### Summary
This PR makes it so that the user-agent sent by the mobile app always follows the same format regardless of the platform with the following format: `Mattermost Mobile/version+build (OS; OSVersion; Device Model)`

E.g
Android: `Mattermost Mobile/2.0.0+443 (Android; 13; Pixel 4)`
iOS: `Mattermost Mobile/2.0.0+443 (iOS; 16.2; iPhone 12)`

```release-note
NONE
```
