### PR TITLE
Try to use last_update_at for unread fix

### DIFF
--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -125,9 +125,8 @@ export async function handleChannelViewedEvent(serverUrl: string, msg: any) {
         const {channel_id: channelId} = msg.data;
 
         const activeServerUrl = await DatabaseManager.getActiveServerUrl();
-        const currentChannelId = await getCurrentChannelId(database);
 
-        if (activeServerUrl !== serverUrl || (currentChannelId !== channelId && !EphemeralStore.isSwitchingToChannel(channelId))) {
+        if (activeServerUrl !== serverUrl || (!EphemeralStore.isSwitchingToChannel(channelId))) {
             await markChannelAsViewed(serverUrl, channelId, false);
         }
     } catch {

--- a/app/client/graphQL/entry.ts
+++ b/app/client/graphQL/entry.ts
@@ -226,6 +226,7 @@ query ${QueryNames.QUERY_CHANNELS}($teamId: String!, $perPage: Int!, $exclude: B
         mentionCountRoot
         schemeAdmin
         lastViewedAt
+        lastUpdateAt
         notifyProps
         roles {
             id
@@ -279,6 +280,7 @@ query ${QueryNames.QUERY_CHANNELS_NEXT}($teamId: String!, $perPage: Int!, $exclu
         mentionCountRoot
         schemeAdmin
         lastViewedAt
+        lastUpdateAt
         notifyProps
         roles {
             id
@@ -321,6 +323,7 @@ query ${QueryNames.QUERY_ALL_CHANNELS}($perPage: Int!){
         mentionCountRoot
         schemeAdmin
         lastViewedAt
+        lastUpdateAt
         notifyProps
         roles {
             id
@@ -363,6 +366,7 @@ query ${QueryNames.QUERY_ALL_CHANNELS_NEXT}($perPage: Int!, $cursor: String!) {
         mentionCountRoot
         schemeAdmin
         lastViewedAt
+        lastUpdateAt
         notifyProps
         roles {
             id

--- a/app/database/migration/server/index.ts
+++ b/app/database/migration/server/index.ts
@@ -25,6 +25,17 @@ const {SERVER: {
 
 export default schemaMigrations({migrations: [
     {
+        toVersion: 8,
+        steps: [
+            addColumns({
+                table: MY_CHANNEL,
+                columns: [
+                    {name: 'last_update_at', type: 'number'},
+                ],
+            }),
+        ],
+    },
+    {
         toVersion: 7,
         steps: [
 

--- a/app/database/models/server/my_channel.ts
+++ b/app/database/models/server/my_channel.ts
@@ -34,6 +34,9 @@ export default class MyChannelModel extends Model implements MyChannelModelInter
     /** last_viewed_at : The timestamp showing the user's last viewed post on this channel */
     @field('last_viewed_at') lastViewedAt!: number;
 
+    /** last_update_at : The timestamp showing the last time it was updated on the server */
+    @field('last_update_at') lastUpdateAt!: number;
+
     /** manually_unread : Determine if the user marked a post as unread */
     @field('manually_unread') manuallyUnread!: boolean;
 

--- a/app/database/operator/server_data_operator/handlers/channel.ts
+++ b/app/database/operator/server_data_operator/handlers/channel.ts
@@ -270,11 +270,7 @@ const ChannelHandler = (superclass: any) => class extends superclass {
             }
 
             const chan = channelMap[my.channel_id];
-            const lastPostAt = (isCRT ? chan.last_root_post_at : chan.last_post_at) || 0;
-            if ((chan && e.lastPostAt < lastPostAt) ||
-                e.isUnread !== my.is_unread || e.lastViewedAt < my.last_viewed_at ||
-                e.roles !== my.roles
-            ) {
+            if (chan && (e.lastUpdateAt < my.last_update_at)) {
                 res.push(my);
             }
 

--- a/app/database/operator/server_data_operator/transformers/channel.ts
+++ b/app/database/operator/server_data_operator/transformers/channel.ts
@@ -133,6 +133,7 @@ export const transformMyChannelRecord = async ({action, database, value}: Transf
         myChannel.messageCount = raw.msg_count;
         myChannel.mentionsCount = raw.mention_count;
         myChannel.lastPostAt = raw.last_post_at || 0;
+        myChannel.lastUpdateAt = raw.last_update_at || record.lastUpdateAt;
 
         myChannel.isUnread = Boolean(raw.is_unread);
         myChannel.lastViewedAt = raw.last_viewed_at;

--- a/app/database/schema/server/index.ts
+++ b/app/database/schema/server/index.ts
@@ -39,7 +39,7 @@ import {
 } from './table_schemas';
 
 export const serverSchema: AppSchema = appSchema({
-    version: 7,
+    version: 8,
     tables: [
         CategorySchema,
         CategoryChannelSchema,

--- a/app/database/schema/server/table_schemas/my_channel.ts
+++ b/app/database/schema/server/table_schemas/my_channel.ts
@@ -13,6 +13,7 @@ export default tableSchema({
         {name: 'is_unread', type: 'boolean'},
         {name: 'last_post_at', type: 'number'},
         {name: 'last_viewed_at', type: 'number'},
+        {name: 'last_update_at', type: 'number'},
         {name: 'manually_unread', type: 'boolean'},
         {name: 'mentions_count', type: 'number'},
         {name: 'message_count', type: 'number'},

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -26,9 +26,7 @@ const {SERVER: {CHANNEL, MY_CHANNEL, CHANNEL_MEMBERSHIP, MY_CHANNEL_SETTINGS, CH
 
 export function prepareMissingChannelsForAllTeams(operator: ServerDataOperator, channels: Channel[], channelMembers: ChannelMembership[], isCRTEnabled?: boolean): Array<Promise<Model[]>> {
     const channelInfos: ChannelInfo[] = [];
-    const channelMap: Record<string, Channel> = {};
     for (const c of channels) {
-        channelMap[c.id] = c;
         channelInfos.push({
             id: c.id,
             header: c.header,
@@ -40,12 +38,9 @@ export function prepareMissingChannelsForAllTeams(operator: ServerDataOperator, 
     }
 
     const memberships = channelMembers.map((cm) => {
-        const channel = channelMap[cm.channel_id];
         return {
             ...cm,
             id: cm.channel_id,
-            last_post_at: channel.last_post_at,
-            last_root_post_at: channel.last_root_post_at,
         };
     });
 

--- a/types/database/models/servers/my_channel.ts
+++ b/types/database/models/servers/my_channel.ts
@@ -21,6 +21,9 @@ declare class MyChannelModel extends Model {
     /** last_viewed_at : The timestamp showing the user's last viewed post on this channel */
     lastViewedAt: number;
 
+    /** last_update_at : The timestamp showing the last time it was updated on the server */
+    lastUpdateAt: number;
+
     /** manually_unread : Determine if the user marked a post as unread */
     manuallyUnread: boolean;
 


### PR DESCRIPTION
#### Summary
THIS PR DOES NOT YET SOLVE THE ISSUE. HAS BEEN CREATED TO SHARE THE CURRENT WORK.

This PR tries to use the `last_update_at` field of the membership to solve the race condition (and other offline issues) with channel unreads.

The problems found are:
- MarkChannelAsViewed on the server side sets the `last_update_at` to the `last_post_at`, making it previous to any "mark as unread" related change
- A new post on a channel only updates the channel object, so the `last_update_at` does not get updated.

After those two errors were found, stopped checking the rest of the scenarios.

A comprehensive list of scenarios that should be handled (and potential ways to handle them) are found in this post on community:
https://community.mattermost.com/core/pl/8kkaf94abjdcpdy9w99yr9tc8w

#### Release Note
```release-note
NONE
```
