### PR TITLE
Detox/E2E Maintenance: Fix broken iOS e2e tests

### DIFF
--- a/app/components/selected_users/index.tsx
+++ b/app/components/selected_users/index.tsx
@@ -68,6 +68,11 @@ type Props = {
     teammateNameDisplay: string;
 
     /**
+     * test ID
+     */
+    testID?: string;
+
+    /**
      * toast Icon
      */
     toastIcon?: string;
@@ -130,7 +135,7 @@ export default function SelectedUsers({
     buttonIcon, buttonText, containerHeight = 0,
     modalPosition = 0, onPress, onRemove,
     selectedIds, setShowToast, showToast = false,
-    teammateNameDisplay, toastIcon, toastMessage,
+    teammateNameDisplay, testID, toastIcon, toastMessage,
 }: Props) {
     const theme = useTheme();
     const style = getStyleFromTheme(theme);
@@ -157,7 +162,7 @@ export default function SelectedUsers({
                     user={selectedIds[id]}
                     teammateNameDisplay={teammateNameDisplay}
                     onRemove={onRemove}
-                    testID='create_direct_message.selected_user'
+                    testID={`${testID}.selected_user`}
                 />,
             );
         }
@@ -276,6 +281,7 @@ export default function SelectedUsers({
                         icon={buttonIcon}
                         text={buttonText}
                         disabled={numberSelectedIds > General.MAX_USERS_IN_GM}
+                        testID={`${testID}.start.button`}
                     />
                 </Animated.View>
             </Animated.View>

--- a/app/components/tutorial_highlight/long_press.tsx
+++ b/app/components/tutorial_highlight/long_press.tsx
@@ -48,6 +48,7 @@ const TutorialSwipeLeft = ({containerStyle, message, style, textStyles}: Props) 
         <View
             pointerEvents='none'
             style={[styles.container, containerStyle]}
+            testID='tutorial_swipe_left'
         >
             <View style={[styles.view, style]}>
                 <LongPressIllustration/>

--- a/app/components/tutorial_highlight/swipe_left.tsx
+++ b/app/components/tutorial_highlight/swipe_left.tsx
@@ -48,6 +48,7 @@ const TutorialSwipeLeft = ({containerStyle, message, style, textStyles}: Props) 
         <View
             pointerEvents='none'
             style={[styles.container, containerStyle]}
+            testID='tutorial_swipe_left'
         >
             <View style={[styles.view, style]}>
                 <HandSwipeLeft fillColor={theme.centerChannelColor}/>

--- a/app/products/calls/components/channel_info_start/channel_info_start_button.tsx
+++ b/app/products/calls/components/channel_info_start/channel_info_start_button.tsx
@@ -69,7 +69,7 @@ const ChannelInfoStartButton = ({
             destructiveText={leaveText}
             destructiveIconName={'phone-hangup'}
             isDestructive={alreadyInCall}
-            testID='channel_info.options.join_start_call.option'
+            testID='channel_info.channel_actions.join_start_call.action'
         />
     );
 };

--- a/app/screens/channel_info/options/index.tsx
+++ b/app/screens/channel_info/options/index.tsx
@@ -32,7 +32,10 @@ const Options = ({channelId, type, callsEnabled}: Props) => {
                 <Members channelId={channelId}/>
             }
             {callsEnabled && !isDMorGM && // if calls is not enabled, copy link will show in the channel actions
-                <CopyChannelLinkOption channelId={channelId}/>
+                <CopyChannelLinkOption
+                    channelId={channelId}
+                    testID='channel_info.options.copy_channel_link.option'
+                />
             }
             {type !== General.DM_CHANNEL && type !== General.GM_CHANNEL &&
                 <EditChannel channelId={channelId}/>

--- a/app/screens/create_direct_message/create_direct_message.tsx
+++ b/app/screens/create_direct_message/create_direct_message.tsx
@@ -396,6 +396,7 @@ export default function CreateDirectMessage({
                 onPress={startConversation}
                 buttonIcon={'forum-outline'}
                 buttonText={formatMessage(messages.buttonText)}
+                testID='create_direct_message'
             />
         </SafeAreaView>
     );

--- a/app/screens/settings/advanced/index.tsx
+++ b/app/screens/settings/advanced/index.tsx
@@ -99,7 +99,7 @@ const AdvancedSettings = ({componentId}: AdvancedSettingsProps) => {
                     icon='trash-can-outline'
                     info={getFormattedFileSize(dataSize || 0)}
                     label={intl.formatMessage({id: 'settings.advanced.delete_data', defaultMessage: 'Delete local files'})}
-                    testID='settings.advanced.delete_data.option'
+                    testID='advanced_settings.delete_data.option'
                     type='none'
                 />
                 <SettingSeparator/>

--- a/detox/e2e/support/ui/screen/browse_channels.ts
+++ b/detox/e2e/support/ui/screen/browse_channels.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {ChannelListScreen} from '@support/ui/screen';
-import {timeouts} from '@support/utils';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 class BrowseChannelsScreen {
@@ -50,6 +50,7 @@ class BrowseChannelsScreen {
     open = async () => {
         // # Open browse channels screen
         await ChannelListScreen.headerPlusButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelListScreen.browseChannelsItem.tap();
 
         return this.toBeVisible();

--- a/detox/e2e/support/ui/screen/channel_info.ts
+++ b/detox/e2e/support/ui/screen/channel_info.ts
@@ -25,6 +25,7 @@ class ChannelInfoScreen {
         setHeaderAction: 'channel_info.channel_actions.set_header.action',
         addPeopleAction: 'channel_info.channel_actions.add_people.action',
         copyChannelLinkAction: 'channel_info.channel_actions.copy_channel_link.action',
+        joinStartCallAction: 'channel_info.channel_actions.join_start_call.action',
         extraHeader: 'channel_info.extra.header',
         extraCreatedBy: 'channel_info.extra.created_by',
         extraCreatedOn: 'channel_info.extra.created_on',
@@ -33,6 +34,7 @@ class ChannelInfoScreen {
         notificationPreferenceOption: 'channel_info.options.notification_preference.option',
         pinnedMessagesOption: 'channel_info.options.pinned_messages.option',
         membersOption: 'channel_info.options.members.option',
+        copyChannelLinkOption: 'channel_info.options.copy_channel_link.option',
         editChannelOption: 'channel_info.options.edit_channel.option',
         convertPrivateOption: 'channel_info.options.convert_private.option',
         leaveChannelOption: 'channel_info.options.leave_channel.option',
@@ -53,6 +55,7 @@ class ChannelInfoScreen {
     setHeaderAction = element(by.id(this.testID.setHeaderAction));
     addPeopleAction = element(by.id(this.testID.addPeopleAction));
     copyChannelLinkAction = element(by.id(this.testID.copyChannelLinkAction));
+    joinStartCallAction = element(by.id(this.testID.joinStartCallAction));
     extraHeader = element(by.id(this.testID.extraHeader));
     extraCreatedBy = element(by.id(this.testID.extraCreatedBy));
     extraCreatedOn = element(by.id(this.testID.extraCreatedOn));
@@ -61,6 +64,7 @@ class ChannelInfoScreen {
     notificationPreferenceOption = element(by.id(this.testID.notificationPreferenceOption));
     pinnedMessagesOption = element(by.id(this.testID.pinnedMessagesOption));
     membersOption = element(by.id(this.testID.membersOption));
+    copyChannelLinkOption = element(by.id(this.testID.copyChannelLinkOption));
     editChannelOption = element(by.id(this.testID.editChannelOption));
     convertPrivateOption = element(by.id(this.testID.convertPrivateOption));
     leaveChannelOption = element(by.id(this.testID.leaveChannelOption));

--- a/detox/e2e/support/ui/screen/channel_list.ts
+++ b/detox/e2e/support/ui/screen/channel_list.ts
@@ -17,7 +17,6 @@ class ChannelListScreen {
         serverIcon: 'channel_list.servers.server_icon',
         headerTeamDisplayName: 'channel_list_header.team_display_name',
         headerServerDisplayName: 'channel_list_header.server_display_name',
-        headerChevronButton: 'channel_list_header.chevron.button',
         headerPlusButton: 'channel_list_header.plus.button',
         subheaderSearchFieldButton: 'channel_list_subheader.search_field.button',
         findChannelsInput: 'channel_list.search_field.find_channels.input',
@@ -28,7 +27,6 @@ class ChannelListScreen {
     serverIcon = element(by.id(this.testID.serverIcon));
     headerTeamDisplayName = element(by.id(this.testID.headerTeamDisplayName));
     headerServerDisplayName = element(by.id(this.testID.headerServerDisplayName));
-    headerChevronButton = element(by.id(this.testID.headerChevronButton));
     headerPlusButton = element(by.id(this.testID.headerPlusButton));
     subheaderSearchFieldButton = element(by.id(this.testID.subheaderSearchFieldButton));
     findChannelsInput = element(by.id(this.testID.findChannelsInput));

--- a/detox/e2e/support/ui/screen/create_direct_message.ts
+++ b/detox/e2e/support/ui/screen/create_direct_message.ts
@@ -3,7 +3,7 @@
 
 import {ProfilePicture} from '@support/ui/component';
 import {ChannelListScreen} from '@support/ui/screen';
-import {timeouts} from '@support/utils';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 class CreateDirectMessageScreen {
@@ -19,6 +19,7 @@ class CreateDirectMessageScreen {
         flatUserList: 'create_direct_message.user_list.flat_list',
         sectionUserList: 'create_direct_message.user_list.section_list',
         tutorialHighlight: 'tutorial_highlight',
+        tutorialSwipeLeft: 'tutorial_swipe_left',
     };
 
     createDirectMessageScreen = element(by.id(this.testID.createDirectMessageScreen));
@@ -30,6 +31,7 @@ class CreateDirectMessageScreen {
     flatUserList = element(by.id(this.testID.flatUserList));
     sectionUserList = element(by.id(this.testID.sectionUserList));
     tutorialHighlight = element(by.id(this.testID.tutorialHighlight));
+    tutorialSwipeLeft = element(by.id(this.testID.tutorialSwipeLeft));
 
     getSelectedUser = (userId: string) => {
         return element(by.id(`${this.testID.selectedUserPrefix}${userId}`));
@@ -64,6 +66,7 @@ class CreateDirectMessageScreen {
     open = async () => {
         // # Open create direct message screen
         await ChannelListScreen.headerPlusButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelListScreen.openDirectMessageItem.tap();
 
         return this.toBeVisible();
@@ -76,7 +79,7 @@ class CreateDirectMessageScreen {
 
     closeTutorial = async () => {
         await expect(this.tutorialHighlight).toExist();
-        await this.closeButton.tap();
+        await this.tutorialSwipeLeft.tap();
         await expect(this.tutorialHighlight).not.toExist();
     };
 }

--- a/detox/e2e/support/ui/screen/create_or_edit_channel.ts
+++ b/detox/e2e/support/ui/screen/create_or_edit_channel.ts
@@ -6,7 +6,7 @@ import {
     ChannelScreen,
     ChannelListScreen,
 } from '@support/ui/screen';
-import {timeouts} from '@support/utils';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 class CreateOrEditChannelScreen {
@@ -51,6 +51,7 @@ class CreateOrEditChannelScreen {
     openCreateChannel = async () => {
         // # Open create channel screen
         await ChannelListScreen.headerPlusButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelListScreen.createNewChannelItem.tap();
 
         return this.toBeVisible();

--- a/detox/e2e/support/ui/screen/login.ts
+++ b/detox/e2e/support/ui/screen/login.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {ServerScreen} from '@support/ui/screen';
-import {timeouts} from '@support/utils';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 class LoginScreen {
@@ -62,6 +62,7 @@ class LoginScreen {
         await this.usernameInput.replaceText(user.username);
         await this.passwordInput.replaceText(user.password);
         await this.signinButton.tap();
+        await wait(timeouts.ONE_SEC);
     };
 }
 

--- a/detox/e2e/support/ui/screen/server_list.ts
+++ b/detox/e2e/support/ui/screen/server_list.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {ChannelListScreen} from '@support/ui/screen';
-import {timeouts, wait} from '@support/utils';
+import {timeouts} from '@support/utils';
 import {expect} from 'detox';
 
 class ServerListScreen {
@@ -11,12 +11,16 @@ class ServerListScreen {
         serverListBackdrop: 'server_list.backdrop',
         serverListTitle: 'server_list.title',
         addServerButton: 'server_list.add_a_server.button',
+        tutorialHighlight: 'tutorial_highlight',
+        tutorialSwipeLeft: 'tutorial_swipe_left',
     };
 
     serverListScreen = element(by.id(this.testID.serverListScreen));
     serverListBackdrop = element(by.id(this.testID.serverListBackdrop));
     serverListTitle = element(by.id(this.testID.serverListTitle));
     addServerButton = element(by.id(this.testID.addServerButton));
+    tutorialHighlight = element(by.id(this.testID.tutorialHighlight));
+    tutorialSwipeLeft = element(by.id(this.testID.tutorialSwipeLeft));
 
     toServerItemTestIdPrefix = (serverDisplayName: string) => {
         return `server_list.server_item.${serverDisplayName.replace(/ /g, '_').toLocaleLowerCase()}`;
@@ -60,16 +64,18 @@ class ServerListScreen {
         // # Open server list screen
         await ChannelListScreen.serverIcon.tap();
 
-        // # Close tip overlay
-        await wait(timeouts.FOUR_SEC);
-        await this.serverListScreen.tap({x: 5, y: 10});
-
         return this.toBeVisible();
     };
 
     close = async () => {
         await this.serverListBackdrop.tap({x: 5, y: 10});
         await expect(this.serverListScreen).not.toBeVisible();
+    };
+
+    closeTutorial = async () => {
+        await expect(this.tutorialHighlight).toExist();
+        await this.tutorialSwipeLeft.tap();
+        await expect(this.tutorialHighlight).not.toExist();
     };
 }
 

--- a/detox/e2e/test/autocomplete/create_channel.e2e.ts
+++ b/detox/e2e/test/autocomplete/create_channel.e2e.ts
@@ -20,6 +20,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
+import {timeouts} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Autocomplete - Create Channel', () => {
@@ -58,7 +59,7 @@ describe('Autocomplete - Create Channel', () => {
         await CreateOrEditChannelScreen.headerInput.typeText('@');
 
         // * Verify at-mention list is displayed
-        await expect(Autocomplete.sectionAtMentionList).toBeVisible();
+        await waitFor(Autocomplete.sectionAtMentionList).toBeVisible().withTimeout(timeouts.ONE_SEC);
     });
 
     it('MM-T4904_2 - should render channel mention autocomplete in header input', async () => {

--- a/detox/e2e/test/autocomplete/edit_channel.e2e.ts
+++ b/detox/e2e/test/autocomplete/edit_channel.e2e.ts
@@ -22,6 +22,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
+import {timeouts} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Autocomplete - Edit Channel', () => {
@@ -65,7 +66,7 @@ describe('Autocomplete - Edit Channel', () => {
         await CreateOrEditChannelScreen.headerInput.typeText('@');
 
         // * Verify at-mention list is displayed
-        await expect(Autocomplete.sectionAtMentionList).toBeVisible();
+        await waitFor(Autocomplete.sectionAtMentionList).toBeVisible().withTimeout(timeouts.ONE_SEC);
     });
 
     it('MM-T4885_2 - should render channel mention autocomplete in header input', async () => {

--- a/detox/e2e/test/channels/channel_info.e2e.ts
+++ b/detox/e2e/test/channels/channel_info.e2e.ts
@@ -20,6 +20,7 @@ import {
     ServerScreen,
     ChannelInfoScreen,
 } from '@support/ui/screen';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Channels - Channel Info', () => {
@@ -59,11 +60,11 @@ describe('Channels - Channel Info', () => {
         await expect(ChannelInfoScreen.favoriteAction).toBeVisible();
         await expect(ChannelInfoScreen.muteAction).toBeVisible();
         await expect(ChannelInfoScreen.addPeopleAction).toBeVisible();
-        await expect(ChannelInfoScreen.copyChannelLinkAction).toBeVisible();
+        await expect(ChannelInfoScreen.joinStartCallAction).toBeVisible();
         await expect(ChannelInfoScreen.ignoreMentionsOptionToggledOff).toBeVisible();
-        await expect(ChannelInfoScreen.notificationPreferenceOption).toBeVisible();
         await expect(ChannelInfoScreen.pinnedMessagesOption).toBeVisible();
         await expect(ChannelInfoScreen.membersOption).toBeVisible();
+        await expect(ChannelInfoScreen.copyChannelLinkOption).toBeVisible();
         await expect(ChannelInfoScreen.editChannelOption).toBeVisible();
         await expect(ChannelInfoScreen.leaveChannelOption).toBeVisible();
         await expect(ChannelInfoScreen.archiveChannelOption).toBeVisible();
@@ -90,6 +91,7 @@ describe('Channels - Channel Info', () => {
         // # Open a channel screen, tap on channel quick actions button, and tap on channel info action
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.channelQuickActionsButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelScreen.channelInfoQuickAction.tap();
 
         // * Verify on channel info screen

--- a/detox/e2e/test/channels/channel_list.e2e.ts
+++ b/detox/e2e/test/channels/channel_list.e2e.ts
@@ -27,6 +27,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Channels - Channel List', () => {
@@ -65,7 +66,6 @@ describe('Channels - Channel List', () => {
         await expect(ChannelListScreen.serverIcon).toBeVisible();
         await expect(ChannelListScreen.headerTeamDisplayName).toHaveText(testTeam.display_name);
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverOneDisplayName);
-        await expect(ChannelListScreen.headerChevronButton).toBeVisible();
         await expect(ChannelListScreen.headerPlusButton).toBeVisible();
         await expect(ChannelListScreen.threadsButton).toBeVisible();
         await expect(ChannelListScreen.getCategoryHeaderDisplayName(channelsCategory)).toHaveText('CHANNELS');
@@ -128,6 +128,7 @@ describe('Channels - Channel List', () => {
     it('MM-T4728_4 - should be able to go to browse channels screen', async () => {
         // # Tap on plus menu button and tap on browse channels item
         await ChannelListScreen.headerPlusButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelListScreen.browseChannelsItem.tap();
 
         // * Verify on browse channels screen
@@ -140,6 +141,7 @@ describe('Channels - Channel List', () => {
     it('MM-T4728_5 - should be able to go to create direct message screen', async () => {
         // # Tap on plus menu button and tap on open a direct message item
         await ChannelListScreen.headerPlusButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelListScreen.openDirectMessageItem.tap();
 
         // * Verify on create direct message screen
@@ -153,6 +155,7 @@ describe('Channels - Channel List', () => {
     it('MM-T4728_6 - should be able to go to create channel screen', async () => {
         // # Tap on plus menu button and tap on create new channel item
         await ChannelListScreen.headerPlusButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelListScreen.createNewChannelItem.tap();
 
         // * Verify on create channel screen
@@ -193,7 +196,7 @@ describe('Channels - Channel List', () => {
         // * Verify on first team and team sidebar item is selected and has correct display name abbreviation
         await expect(ChannelListScreen.headerTeamDisplayName).toHaveText(testTeam.display_name);
         await expect(ChannelListScreen.getTeamItemSelected(testTeam.id)).toBeVisible();
-        await expect(ChannelListScreen.getTeamItemDisplayNameAbbreviation(testTeam.id)).toHaveText(testTeam.display_name.substring(0, 2));
+        await expect(ChannelListScreen.getTeamItemDisplayNameAbbreviation(testTeam.id)).toHaveText(testTeam.display_name.substring(0, 2).toUpperCase());
 
         // # Tap on second team item from team sidebar
         await ChannelListScreen.getTeamItemNotSelected(testTeamTwo.id).tap();
@@ -201,7 +204,7 @@ describe('Channels - Channel List', () => {
         // * Verify on second team and team sidebar item is selected and has correct display name abbreviation
         await expect(ChannelListScreen.headerTeamDisplayName).toHaveText(testTeamTwo.display_name);
         await expect(ChannelListScreen.getTeamItemSelected(testTeamTwo.id)).toBeVisible();
-        await expect(ChannelListScreen.getTeamItemDisplayNameAbbreviation(testTeamTwo.id)).toHaveText(testTeamTwo.display_name.substring(0, 2));
+        await expect(ChannelListScreen.getTeamItemDisplayNameAbbreviation(testTeamTwo.id)).toHaveText(testTeamTwo.display_name.substring(0, 2).toUpperCase());
 
         // # Tap back on first team item from team sidebar
         await ChannelListScreen.getTeamItemNotSelected(testTeam.id).tap();

--- a/detox/e2e/test/channels/create_direct_message.e2e.ts
+++ b/detox/e2e/test/channels/create_direct_message.e2e.ts
@@ -60,7 +60,6 @@ describe('Channels - Create Direct Message', () => {
 
         // * Verify basic elements on create direct message screen
         await expect(CreateDirectMessageScreen.closeButton).toBeVisible();
-        await expect(CreateDirectMessageScreen.startButton).toBeVisible();
         await expect(CreateDirectMessageScreen.searchInput).toBeVisible();
         await expect(CreateDirectMessageScreen.sectionUserList).toBeVisible();
 

--- a/detox/e2e/test/channels/leave_channel.e2e.ts
+++ b/detox/e2e/test/channels/leave_channel.e2e.ts
@@ -23,6 +23,7 @@ import {
     ServerScreen,
     ChannelInfoScreen,
 } from '@support/ui/screen';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Channels - Leave Channel', () => {
@@ -89,6 +90,7 @@ describe('Channels - Leave Channel', () => {
         await device.reloadReactNative();
         await ChannelScreen.open(channelsCategory, channel.name);
         await ChannelScreen.channelQuickActionsButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelScreen.leaveChannel({confirm: true});
 
         // * Verify on channel list screen and the channel left by the user does not appear on the list

--- a/detox/e2e/test/channels/mute_and_unmute_channel.e2e.ts
+++ b/detox/e2e/test/channels/mute_and_unmute_channel.e2e.ts
@@ -20,6 +20,7 @@ import {
     ServerScreen,
     ChannelInfoScreen,
 } from '@support/ui/screen';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Channels - Mute and Unmute Channel', () => {
@@ -50,16 +51,20 @@ describe('Channels - Mute and Unmute Channel', () => {
         // # Open a channel screen, tap on channel quick actions button, and tap on mute quick action to mute the channel
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.channelQuickActionsButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelScreen.muteQuickAction.tap();
 
         // * Verify muted toast message appears
+        await wait(timeouts.ONE_SEC);
         await expect(ChannelScreen.toastMessage).toHaveText('This channel was muted');
 
         // # Tap on channel quick actions button and tap on muted quick action to unmute the channel
         await ChannelScreen.channelQuickActionsButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ChannelScreen.unmuteQuickAction.tap();
 
         // * Verify unmuted toast message appears
+        await wait(timeouts.ONE_SEC);
         await expect(ChannelScreen.toastMessage).toHaveText('This channel was unmuted');
 
         // # Go back to channel list screen

--- a/detox/e2e/test/messaging/save_and_unsave_message.e2e.ts
+++ b/detox/e2e/test/messaging/save_and_unsave_message.e2e.ts
@@ -24,7 +24,7 @@ import {
     ServerScreen,
     ThreadScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Messaging - Save and Unsave Message', () => {
@@ -102,6 +102,7 @@ describe('Messaging - Save and Unsave Message', () => {
         await PostOptionsScreen.unsavePostOption.tap();
 
         // * Verify saved text is not displayed on the post pre-header
+        await wait(timeouts.ONE_SEC);
         await expect(postListPostItemPreHeaderText).not.toBeVisible();
 
         // # Go back to channel list screen

--- a/detox/e2e/test/server_login/connect_to_server.e2e.ts
+++ b/detox/e2e/test/server_login/connect_to_server.e2e.ts
@@ -12,6 +12,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Server Login - Connect to Server', () => {
@@ -91,6 +92,7 @@ describe('Server Login - Connect to Server', () => {
         await connectButton.tap();
 
         // * Verify connection error
+        await wait(timeouts.ONE_SEC);
         await expect(serverUrlInputError).toHaveText(connectionError);
     });
 

--- a/detox/e2e/test/server_login/server_list.e2e.ts
+++ b/detox/e2e/test/server_login/server_list.e2e.ts
@@ -30,6 +30,7 @@ import {
     ServerScreen,
     ServerListScreen,
 } from '@support/ui/screen';
+import {timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Server Login - Server List', () => {
@@ -61,6 +62,7 @@ describe('Server Login - Server List', () => {
     it('MM-T4691_1 - should match elements on server list screen', async () => {
         // # Open server list screen
         await ServerListScreen.open();
+        await ServerListScreen.closeTutorial();
 
         // * Verify basic elements on server list screen
         await expect(ServerListScreen.serverListTitle).toHaveText('Your servers');
@@ -91,7 +93,6 @@ describe('Server Login - Server List', () => {
 
         // * Verify on channel list screen of the second server
         await ChannelListScreen.toBeVisible();
-        await device.reloadReactNative();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverTwoDisplayName);
 
         // # Open server list screen
@@ -195,6 +196,7 @@ describe('Server Login - Server List', () => {
 
         // # Tap on remove button and go back to server list screen
         await Alert.removeButton.tap();
+        await wait(timeouts.ONE_SEC);
         await ServerListScreen.open();
 
         // * Verify first server is removed

--- a/detox/e2e/test/smoke_test/messaging.e2e.ts
+++ b/detox/e2e/test/smoke_test/messaging.e2e.ts
@@ -27,7 +27,7 @@ import {
     ServerScreen,
     ThreadScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Smoke Test - Messaging', () => {
@@ -189,6 +189,7 @@ describe('Smoke Test - Messaging', () => {
         await PostOptionsScreen.pinPostOption.tap();
 
         // * Verify pinned text is displayed on the post pre-header
+        await wait(timeouts.ONE_SEC);
         const {postListPostItemPreHeaderText: threadPostListPostItemPreHeaderText} = ThreadScreen.getPostListPostItem(post.id, message);
         await expect(threadPostListPostItemPreHeaderText).toHaveText(pinnedText);
 

--- a/detox/e2e/test/smoke_test/server_login.e2e.ts
+++ b/detox/e2e/test/smoke_test/server_login.e2e.ts
@@ -59,6 +59,7 @@ describe('Smoke Test - Server Login', () => {
     it('MM-T4675_2 - should be able to add a new server and log-in-to/log-out-from the new server', async () => {
         // # Open server list screen
         await ServerListScreen.open();
+        await ServerListScreen.closeTutorial();
 
         // * Verify on server list screen
         await ServerListScreen.toBeVisible();
@@ -73,7 +74,6 @@ describe('Smoke Test - Server Login', () => {
 
         // * Verify on channel list screen of the second server
         await ChannelListScreen.toBeVisible();
-        await device.reloadReactNative();
         await expect(ChannelListScreen.headerServerDisplayName).toHaveText(serverTwoDisplayName);
 
         // # Go back to first server, open server list screen, swipe left on second server and tap on logout option

--- a/detox/e2e/test/smoke_test/threads.e2e.ts
+++ b/detox/e2e/test/smoke_test/threads.e2e.ts
@@ -26,7 +26,7 @@ import {
     ThreadOptionsScreen,
     ThreadScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Smoke Test - Threads', () => {
@@ -91,6 +91,7 @@ describe('Smoke Test - Threads', () => {
         await ThreadOptionsScreen.markAsReadOption.tap();
 
         // * Verify thread is not displayed anymore in unread threads section
+        await wait(timeouts.ONE_SEC);
         await expect(GlobalThreadsScreen.getThreadItem(parentPost.id)).not.toBeVisible();
 
         // # Tap on all your threads button, tap on the thread, and add new reply to thread
@@ -133,6 +134,7 @@ describe('Smoke Test - Threads', () => {
         await ThreadScreen.back();
         await GlobalThreadsScreen.openThreadOptionsFor(parentPost.id);
         await ThreadOptionsScreen.unsaveThreadOption.tap();
+        await wait(timeouts.ONE_SEC);
         await GlobalThreadsScreen.getThreadItem(parentPost.id).tap();
 
         // * Verify saved text is not displayed on the post pre-header

--- a/detox/e2e/test/smoke_test/threads.e2e.ts
+++ b/detox/e2e/test/smoke_test/threads.e2e.ts
@@ -133,6 +133,7 @@ describe('Smoke Test - Threads', () => {
         // # Go back to global threads screen, open thread options for thread, tap on save option, and tap on thread
         await ThreadScreen.back();
         await GlobalThreadsScreen.openThreadOptionsFor(parentPost.id);
+        await wait(timeouts.ONE_SEC);
         await ThreadOptionsScreen.unsaveThreadOption.tap();
         await wait(timeouts.ONE_SEC);
         await GlobalThreadsScreen.getThreadItem(parentPost.id).tap();

--- a/detox/e2e/test/teams/invite_people.e2e.ts
+++ b/detox/e2e/test/teams/invite_people.e2e.ts
@@ -18,7 +18,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
-import {isIos} from '@support/utils';
+import {isIos, timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 function systemDialog(label: string) {
@@ -51,9 +51,6 @@ describe('Teams - Invite people', () => {
     });
 
     afterAll(async () => {
-        // # Close share dialog
-        await ChannelListScreen.headerTeamDisplayName.tap();
-
         // # Log out
         await HomeScreen.logout();
     });
@@ -63,6 +60,7 @@ describe('Teams - Invite people', () => {
         await ChannelListScreen.headerPlusButton.tap();
 
         // * Verify invite people to team item is available
+        await wait(timeouts.ONE_SEC);
         await expect(ChannelListScreen.invitePeopleToTeamItem).toExist();
 
         // # Tap on invite people to team item
@@ -71,6 +69,9 @@ describe('Teams - Invite people', () => {
         if (isIos()) {
             // * Verify share dialog is open
             await expect(systemDialog(`Join the ${testTeam.display_name} team`)).toExist();
+
+            // # Close share dialog
+            await device.reloadReactNative();
         }
     });
 });

--- a/detox/e2e/test/threads/mark_thread_as_read_and_unread.e2e.ts
+++ b/detox/e2e/test/threads/mark_thread_as_read_and_unread.e2e.ts
@@ -26,7 +26,7 @@ import {
     ThreadOptionsScreen,
     ThreadScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Threads - Mark Thread as Read and Unread', () => {
@@ -119,6 +119,7 @@ describe('Threads - Mark Thread as Read and Unread', () => {
         await ThreadOptionsScreen.markAsReadOption.tap();
 
         // * Verify thread is not displayed anymore in unread threads section
+        await wait(timeouts.ONE_SEC);
         await expect(GlobalThreadsScreen.getThreadItem(parentPost.id)).not.toBeVisible();
 
         // # Tap on all your threads button


### PR DESCRIPTION
#### Summary
- Added/updated test IDs
- Fixed and stabilized failing e2e based on latest code
- Associated test management changes here: https://github.com/mattermost/mattermost-test-management/pull/36

Note: This is built and tested using XCode 14.2 (iOS 16.2 and iPhone 14). To build and run ios locally for a specific simulator you can append the simulator of choice, so that
```
npm run ios --simulator='iPhone 14'
```

#### Ticket Link
NA

#### Release Note
```release-note
NONE
```