### PR TITLE
Do not show favorites category if it only contain archived channels

### DIFF
--- a/app/database/models/server/category.ts
+++ b/app/database/models/server/category.ts
@@ -104,11 +104,18 @@ export default class CategoryModel extends Model implements CategoryInterface {
             Q.sortBy('last_post_at', Q.desc),
         );
 
-    /** hasChannels : Returns a boolean indicating if the category has channels */
-    @lazy hasChannels = this.categoryChannels.observeCount().pipe(
-        map((c) => c > 0),
-        distinctUntilChanged(),
-    );
+    observeHasChannels = (canViewArchived: boolean) => {
+        return this.channels.observeWithColumns(['delete_at']).pipe(
+            map((channels) => {
+                if (canViewArchived) {
+                    return channels.length > 0;
+                }
+
+                return channels.filter((c) => c.deleteAt === 0).length > 0;
+            }),
+            distinctUntilChanged(),
+        );
+    };
 
     toCategoryWithChannels = async (): Promise<CategoryWithChannels> => {
         const categoryChannels = await this.categoryChannels.fetch();

--- a/app/screens/home/channel_list/categories_list/categories/header/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/header/index.ts
@@ -2,14 +2,23 @@
 // See LICENSE.txt for license information.
 
 import withObservables from '@nozbe/with-observables';
+import {switchMap} from 'rxjs/operators';
+
+import {observeConfigBooleanValue} from '@queries/servers/system';
 
 import CategoryHeader from './header';
 
 import type CategoryModel from '@typings/database/models/servers/category';
 
-const enhanced = withObservables(['category'], ({category}: {category: CategoryModel}) => ({
-    category,
-    hasChannels: category.hasChannels,
-}));
+const enhanced = withObservables(['category'], ({category}: {category: CategoryModel}) => {
+    const canViewArchived = observeConfigBooleanValue(category.database, 'ExperimentalViewArchivedChannels');
+
+    return {
+        category,
+        hasChannels: canViewArchived.pipe(
+            switchMap((canView) => category.observeHasChannels(canView)),
+        ),
+    };
+});
 
 export default enhanced(CategoryHeader);

--- a/types/database/models/servers/category.ts
+++ b/types/database/models/servers/category.ts
@@ -58,7 +58,7 @@ declare class CategoryModel extends Model {
     @lazy myChannels: Query<MyChannelModel>;
 
     /** hasChannels : Whether the category has any channels */
-    @lazy hasChannels: Observable<boolean>;
+    observeHasChannels(canViewArchived: boolean): Observable<boolean>;
 
     /** toCategoryWithChannels returns a map of the Category with an array of ordered channel ids */
     toCategoryWithChannels(): Promise<CategoryWithChannels>;


### PR DESCRIPTION
#### Summary
The hasChannels lazy query, only used to determine if the favorites category should render the header was not taking into account archived channels, so this PR changes the lazy query for an observable function on the model to account for the archived channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48995

```release-note
NONE
```
