### PR TITLE
use matchDeepLink result for relative links

### DIFF
--- a/app/actions/remote/command.ts
+++ b/app/actions/remote/command.ts
@@ -138,7 +138,7 @@ export const handleGotoLocation = async (serverUrl: string, intl: IntlShape, loc
     const match = matchDeepLink(location, serverUrl, config?.SiteURL);
 
     if (match) {
-        handleDeepLink(location, intl, location);
+        handleDeepLink(match, intl, location);
     } else {
         const {formatMessage} = intl;
         const onError = () => Alert.alert(

--- a/app/components/markdown/markdown_link/markdown_link.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.tsx
@@ -76,9 +76,9 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
         const match = matchDeepLink(url, serverUrl, siteURL);
 
         if (match) {
-            const {error} = await handleDeepLink(url, intl);
+            const {error} = await handleDeepLink(match, intl);
             if (error) {
-                tryOpenURL(url, onError);
+                tryOpenURL(match, onError);
             }
         } else {
             tryOpenURL(url, onError);


### PR DESCRIPTION
#### Summary
for the command action and markdown links we were not using the result of `matchDeepLink` that adds the siteURL to relative links.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49187

```release-note
NONE
```
