### PR TITLE
Remove lineHeight from post so that it does not break inline images

### DIFF
--- a/app/components/markdown/markdown_image/index.tsx
+++ b/app/components/markdown/markdown_image/index.tsx
@@ -59,7 +59,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         height: 24,
     },
     container: {
-        marginBottom: 5,
+        marginVertical: 5,
+        top: 5,
     },
     svg: {
         backgroundColor: changeOpacity(theme.centerChannelColor, 0.06),

--- a/app/components/post_list/post/body/message/message.tsx
+++ b/app/components/post_list/post/body/message/message.tsx
@@ -44,6 +44,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         message: {
             color: theme.centerChannelColor,
             ...typography('Body', 200),
+            lineHeight: undefined, // remove line height, not needed and causes problems with md images
         },
         pendingPost: {
             opacity: 0.5,


### PR DESCRIPTION
#### Summary
Setting a line height while having an image inside a `<Text>` component conflicts with image placement, while leaving the line height undefined allows Yoga to run the calculations for us.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49188

```release-note
NONE
```
