### PR TITLE
iOS notifications badge and posts in channel/thread

### DIFF
--- a/ios/Gekidou/Sources/Gekidou/Storage/Database+Mentions.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database+Mentions.swift
@@ -35,14 +35,25 @@ extension Database {
     }
     
     public func getChannelMentions(_ db: Connection) -> Int {
-        let mentionsCol = Expression<Int?>("mentions_count")
-        let mentions = try? db.scalar(myChannelTable.select(mentionsCol.total))
+        let stmtString = """
+        SELECT SUM(my.mentions_count) \
+        FROM MyChannel my \
+        INNER JOIN Channel c ON c.id=my.id \
+        WHERE c.delete_at = 0
+        """
+        let mentions = try? db.prepare(stmtString).scalar() as? Double
         return Int(mentions ?? 0)
     }
-    
+
     public func getThreadMentions(_ db: Connection) -> Int {
-        let mentionsCol = Expression<Int?>("unread_mentions")
-        let mentions = try? db.scalar(threadTable.select(mentionsCol.total))
+        let stmtString = """
+        SELECT SUM(unread_mentions) \
+        FROM Thread t
+        INNER JOIN Post p ON t.id=p.id \
+        INNER JOIN Channel c ON p.channel_id=c.id
+        WHERE c.delete_at = 0
+        """
+        let mentions = try? db.prepare(stmtString).scalar() as? Double
         return Int(mentions ?? 0)
     }
     

--- a/ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift
@@ -181,8 +181,9 @@ extension Database {
     public func handlePostData(_ db: Connection, _ postData: PostData, _ channelId: String, _ usedSince: Bool = false, _ receivingThreads: Bool = false) throws {
         let sortedChainedPosts = chainAndSortPosts(postData)
         try insertOrUpdatePosts(db, sortedChainedPosts, channelId)
-        let earliest = sortedChainedPosts.first!.create_at
-        let latest = sortedChainedPosts.last!.create_at
+        let sortedAndNotDeletedPosts = sortedChainedPosts.filter({$0.delete_at == 0})
+        let earliest = sortedAndNotDeletedPosts.first!.create_at
+        let latest = sortedAndNotDeletedPosts.last!.create_at
         if (!receivingThreads) {
             try handlePostsInChannel(db, channelId, earliest, latest, usedSince)
 
@@ -564,7 +565,7 @@ extension Database {
         var postsInThread = [String: [Post]]()
         
         for post in posts {
-            if !post.root_id.isEmpty {
+            if !post.root_id.isEmpty && post.delete_at == 0 {
                 var threadPosts = postsInThread[post.root_id] ?? [Post]()
                 threadPosts.append(post)
                 


### PR DESCRIPTION
#### Summary
When a new notification arrives we were:
* setting the posts in channel and posts in thread but did not exclude those posts that could have been deleted by then, thus the edges could be wrong.
* The badge number being set was using the total count of mentions but did not exclude those from archived channels.

```release-note
NONE
```
