### PR TITLE
Fix server unreachable message showing too often

### DIFF
--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -86,7 +86,7 @@ export async function handleFirstConnect(serverUrl: string) {
 
     // ESR: 5.37
     if (lastDisconnect && config?.EnableReliableWebSockets !== 'true' && alreadyConnected.has(serverUrl)) {
-        handleReconnect(serverUrl);
+        await handleReconnect(serverUrl);
         return;
     }
 
@@ -100,8 +100,8 @@ export async function handleFirstConnect(serverUrl: string) {
     }
 }
 
-export function handleReconnect(serverUrl: string) {
-    doReconnect(serverUrl);
+export async function handleReconnect(serverUrl: string) {
+    await doReconnect(serverUrl);
 }
 
 export async function handleClose(serverUrl: string, lastDisconnect: number) {

--- a/app/components/connection_banner/connection_banner.tsx
+++ b/app/components/connection_banner/connection_banner.tsx
@@ -20,7 +20,7 @@ import {makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 
 type Props = {
-    isConnected: boolean;
+    websocketState: WebsocketConnectedState;
 }
 
 const getStyle = makeStyleSheetFromTheme((theme: Theme) => {
@@ -74,7 +74,7 @@ const TIME_TO_OPEN = toMilliseconds({seconds: 3});
 const TIME_TO_CLOSE = toMilliseconds({seconds: 1});
 
 const ConnectionBanner = ({
-    isConnected,
+    websocketState,
 }: Props) => {
     const intl = useIntl();
     const closeTimeout = useRef<NodeJS.Timeout | null>();
@@ -85,6 +85,8 @@ const ConnectionBanner = ({
     const style = getStyle(theme);
     const appState = useAppState();
     const netInfo = useNetInfo();
+
+    const isConnected = websocketState === 'connected';
 
     const openCallback = useCallback(() => {
         setVisible(true);
@@ -97,7 +99,9 @@ const ConnectionBanner = ({
     }, []);
 
     useEffect(() => {
-        if (!isConnected) {
+        if (websocketState === 'connecting') {
+            openCallback();
+        } else if (!isConnected) {
             openTimeout.current = setTimeout(openCallback, TIME_TO_OPEN);
         }
         return () => {
@@ -158,6 +162,8 @@ const ConnectionBanner = ({
     let text;
     if (isConnected) {
         text = intl.formatMessage({id: 'connection_banner.connected', defaultMessage: 'Connection restored'});
+    } else if (websocketState === 'connecting') {
+        text = intl.formatMessage({id: 'connection_banner.connecting', defaultMessage: 'Connecting...'});
     } else if (netInfo.isInternetReachable) {
         text = intl.formatMessage({id: 'connection_banner.not_reachable', defaultMessage: 'The server is not reachable'});
     } else {

--- a/app/components/connection_banner/index.ts
+++ b/app/components/connection_banner/index.ts
@@ -9,7 +9,7 @@ import websocket_manager from '@managers/websocket_manager';
 import ConnectionBanner from './connection_banner';
 
 const enhanced = withObservables(['serverUrl'], ({serverUrl}: {serverUrl: string}) => ({
-    isConnected: websocket_manager.observeConnected(serverUrl),
+    websocketState: websocket_manager.observeWebsocketState(serverUrl),
 }));
 
 export default withServerUrl(enhanced(ConnectionBanner));

--- a/app/screens/home/channel_list/servers/servers_list/server_item/websocket/index.ts
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/websocket/index.ts
@@ -8,7 +8,7 @@ import WebsocketManager from '@managers/websocket_manager';
 import WebSocket from './websocket';
 
 const enhanced = withObservables(['serverUrl'], ({serverUrl}: {serverUrl: string}) => ({
-    isConnected: WebsocketManager.observeConnected(serverUrl),
+    websocketState: WebsocketManager.observeWebsocketState(serverUrl),
 }));
 
 export default enhanced(WebSocket);

--- a/app/screens/home/channel_list/servers/servers_list/server_item/websocket/websocket.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/websocket/websocket.tsx
@@ -11,7 +11,7 @@ import {makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 
 type Props = {
-    isConnected: boolean;
+    websocketState: WebsocketConnectedState;
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
@@ -28,10 +28,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const WebSocket = ({isConnected}: Props) => {
+const WebSocket = ({websocketState}: Props) => {
     const theme = useTheme();
 
-    if (isConnected) {
+    if (websocketState === 'connected' || websocketState === 'connecting') {
         return null;
     }
 

--- a/types/global/websocket.d.ts
+++ b/types/global/websocket.d.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+type WebsocketConnectedState = 'not_connected' | 'connected' | 'connecting';


### PR DESCRIPTION
#### Summary
We were only taking in account whether the websocket was connected or not to show the server unreachable state. Now we take into account whether it is waiting to connect after coming back from the background.

The changes are:
- The time to connect other servers websockets is now 5 instead of 20 seconds
- The connection banner has a connecting state (only viewable if after coming from the background you switch to a different ~~team~~ server within 5 seconds)
- The connection banner shows automatically if we are connecting (instead of wait for a few seconds)
- The server list won't show anything if we are in the connecting state (same as if connected)

Some of these decisions were discussed here: https://community.mattermost.com/core/pl/gowtbtm3sf8cbyrsyxnjie69fr

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49068

#### Release Note
```release-note
Fix "server unreachable" message showing more often than needed.
```
