### PR TITLE
Do not display the favorites category when it has no channels

### DIFF
--- a/app/database/models/server/category.ts
+++ b/app/database/models/server/category.ts
@@ -104,11 +104,11 @@ export default class CategoryModel extends Model implements CategoryInterface {
             Q.sortBy('last_post_at', Q.desc),
         );
 
-    observeHasChannels = (canViewArchived: boolean) => {
+    observeHasChannels = (canViewArchived: boolean, channelId: string) => {
         return this.channels.observeWithColumns(['delete_at']).pipe(
             map((channels) => {
                 if (canViewArchived) {
-                    return channels.length > 0;
+                    return channels.filter((c) => c.deleteAt === 0 || c.id === channelId).length > 0;
                 }
 
                 return channels.filter((c) => c.deleteAt === 0).length > 0;

--- a/app/screens/home/channel_list/categories_list/categories/header/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/header/index.ts
@@ -2,9 +2,10 @@
 // See LICENSE.txt for license information.
 
 import withObservables from '@nozbe/with-observables';
+import {combineLatestWith} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {observeConfigBooleanValue} from '@queries/servers/system';
+import {observeConfigBooleanValue, observeCurrentChannelId} from '@queries/servers/system';
 
 import CategoryHeader from './header';
 
@@ -12,11 +13,13 @@ import type CategoryModel from '@typings/database/models/servers/category';
 
 const enhanced = withObservables(['category'], ({category}: {category: CategoryModel}) => {
     const canViewArchived = observeConfigBooleanValue(category.database, 'ExperimentalViewArchivedChannels');
+    const currentChannelId = observeCurrentChannelId(category.database);
 
     return {
         category,
         hasChannels: canViewArchived.pipe(
-            switchMap((canView) => category.observeHasChannels(canView)),
+            combineLatestWith(currentChannelId),
+            switchMap(([canView, channelId]) => category.observeHasChannels(canView, channelId)),
         ),
     };
 });

--- a/types/database/models/servers/category.ts
+++ b/types/database/models/servers/category.ts
@@ -58,7 +58,7 @@ declare class CategoryModel extends Model {
     @lazy myChannels: Query<MyChannelModel>;
 
     /** hasChannels : Whether the category has any channels */
-    observeHasChannels(canViewArchived: boolean): Observable<boolean>;
+    observeHasChannels(canViewArchived: boolean, channelId: string): Observable<boolean>;
 
     /** toCategoryWithChannels returns a map of the Category with an array of ordered channel ids */
     toCategoryWithChannels(): Promise<CategoryWithChannels>;


### PR DESCRIPTION
#### Summary
Hides the favorites category if it has no channels or channels other than the current one have been archived.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48995

```release-note
NONE
```
