### PR TITLE
Detox/E2E Maintenance: Fix broken iOS e2e tests

### DIFF
--- a/app/screens/settings/report_problem/report_problem.tsx
+++ b/app/screens/settings/report_problem/report_problem.tsx
@@ -61,7 +61,7 @@ const ReportProblem = ({buildNumber, currentTeamId, currentUserId, siteName, sup
             onPress={openEmailClient}
             optionName='report_problem'
             separator={false}
-            testID='settings.report.problem'
+            testID='settings.report_problem.option'
             type='default'
         />
     );

--- a/detox/e2e/support/ui/screen/settings.ts
+++ b/detox/e2e/support/ui/screen/settings.ts
@@ -15,6 +15,7 @@ class SettingsScreen {
         advancedSettingsOption: 'settings.advanced_settings.option',
         aboutOption: 'settings.about.option',
         helpOption: 'settings.help.option',
+        reportProblemOption: 'settings.report_problem.option',
     };
 
     settingsScreen = element(by.id(this.testID.settingsScreen));
@@ -25,6 +26,7 @@ class SettingsScreen {
     advancedSettingsOption = element(by.id(this.testID.advancedSettingsOption));
     aboutOption = element(by.id(this.testID.aboutOption));
     helpOption = element(by.id(this.testID.helpOption));
+    reportProblemOption = element(by.id(this.testID.reportProblemOption));
 
     toBeVisible = async () => {
         await waitFor(this.settingsScreen).toExist().withTimeout(timeouts.TEN_SEC);

--- a/detox/e2e/test/account/custom_status.e2e.ts
+++ b/detox/e2e/test/account/custom_status.e2e.ts
@@ -154,7 +154,7 @@ describe('Account - Custom Status', () => {
         await AccountScreen.customStatusClearButton.tap();
 
         // * Verify custom status is cleared from account screen
-        const defaultStatusText = 'Set a Status';
+        const defaultStatusText = 'Set a custom status';
         const {accountCustomStatusEmoji, accountCustomStatusText, accountCustomStatusExpiry} = AccountScreen.getCustomStatus(customStatusEmojiName, customStatusDuration);
         await expect(accountCustomStatusEmoji).not.toExist();
         await expect(accountCustomStatusText).toHaveText(defaultStatusText);

--- a/detox/e2e/test/account/settings.e2e.ts
+++ b/detox/e2e/test/account/settings.e2e.ts
@@ -58,6 +58,7 @@ describe('Account - Settings', () => {
         await expect(SettingsScreen.advancedSettingsOption).toBeVisible();
         await expect(SettingsScreen.aboutOption).toBeVisible();
         await expect(SettingsScreen.helpOption).toBeVisible();
+        await expect(SettingsScreen.reportProblemOption).toBeVisible();
     });
 
     it('MM-T4991_2 - should be able to go to notification settings screen', async () => {

--- a/detox/e2e/test/channels/channel_info.e2e.ts
+++ b/detox/e2e/test/channels/channel_info.e2e.ts
@@ -59,11 +59,9 @@ describe('Channels - Channel Info', () => {
         await expect(element(by.text(`Channel header: ${testChannel.display_name.toLowerCase()}`))).toBeVisible();
         await expect(ChannelInfoScreen.favoriteAction).toBeVisible();
         await expect(ChannelInfoScreen.muteAction).toBeVisible();
-        await expect(ChannelInfoScreen.addPeopleAction).toBeVisible();
         await expect(ChannelInfoScreen.joinStartCallAction).toBeVisible();
         await expect(ChannelInfoScreen.ignoreMentionsOptionToggledOff).toBeVisible();
         await expect(ChannelInfoScreen.pinnedMessagesOption).toBeVisible();
-        await expect(ChannelInfoScreen.membersOption).toBeVisible();
         await expect(ChannelInfoScreen.copyChannelLinkOption).toBeVisible();
         await expect(ChannelInfoScreen.editChannelOption).toBeVisible();
         await expect(ChannelInfoScreen.leaveChannelOption).toBeVisible();

--- a/detox/e2e/test/channels/channel_post_list.e2e.ts
+++ b/detox/e2e/test/channels/channel_post_list.e2e.ts
@@ -57,7 +57,6 @@ describe('Channels - Channel Post List', () => {
         await expect(ChannelScreen.backButton).toBeVisible();
         await expect(ChannelScreen.headerTitle).toHaveText(testChannel.display_name);
         await expect(ChannelScreen.introDisplayName).toHaveText(testChannel.display_name);
-        await expect(ChannelScreen.introAddPeopleAction).toBeVisible();
         await expect(ChannelScreen.introSetHeaderAction).toBeVisible();
         await expect(ChannelScreen.introChannelInfoAction).toBeVisible();
         await expect(ChannelScreen.postList.getFlatList()).toBeVisible();

--- a/detox/e2e/test/smoke_test/account.e2e.ts
+++ b/detox/e2e/test/smoke_test/account.e2e.ts
@@ -88,7 +88,7 @@ describe('Smoke Test - Account', () => {
         await AccountScreen.customStatusClearButton.tap();
 
         // * Verify custom status is cleared from account screen
-        const defaultStatusText = 'Set a Status';
+        const defaultStatusText = 'Set a custom status';
         await expect(accountCustomStatusEmoji).not.toExist();
         await expect(accountCustomStatusText).toHaveText(defaultStatusText);
         await expect(accountCustomStatusExpiry).not.toExist();


### PR DESCRIPTION
#### Summary
- Added/updated test IDs
- Fixed and stabilized failing e2e based on latest code
- Associated test management changes here:
https://github.com/mattermost/mattermost-test-management/pull/41
https://github.com/mattermost/mattermost-test-management/pull/43

#### Ticket Link
NA

#### Screenshots
![Screenshot 2022-12-30 at 11 01 47 AM](https://user-images.githubusercontent.com/487991/210106001-9cb64c3b-81df-49ae-8f2d-5b9661408160.png)
![Screenshot 2022-12-30 at 11 03 32 AM](https://user-images.githubusercontent.com/487991/210106004-e403021d-965e-461a-875f-b31069521a95.png)
![Screenshot 2022-12-30 at 11 07 28 AM](https://user-images.githubusercontent.com/487991/210106005-04718ed0-8856-4a73-be8a-256d9118abea.png)
![Screenshot 2022-12-30 at 11 08 49 AM](https://user-images.githubusercontent.com/487991/210106006-231054b1-1a0a-4877-8d79-f6c47ab6a75e.png)
![Screenshot 2022-12-30 at 11 11 28 AM](https://user-images.githubusercontent.com/487991/210106008-a69881b5-f6c4-4cfc-842d-cda128ef27ff.png)

#### Release Note
```release-note
NONE
```