### PR TITLE
Use Promise.allSettle when fetching emojis

### DIFF
--- a/app/components/emoji/emoji.tsx
+++ b/app/components/emoji/emoji.tsx
@@ -57,7 +57,7 @@ const Emoji = (props: EmojiProps) => {
             } catch {
                 // do nothing
             }
-        } else if (name && !isUnicodeEmoji(name)) {
+        } else if (name && (name.length > 1 || !isUnicodeEmoji(name))) {
             fetchCustomEmojiInBatch(serverUrl, name);
         }
     }

--- a/app/init/app.ts
+++ b/app/init/app.ts
@@ -16,6 +16,20 @@ import {registerNavigationListeners} from '@screens/navigation';
 let alreadyInitialized = false;
 let serverCredentials: ServerCredential[];
 
+// Fallback Polyfill for Promise.allSettle
+Promise.allSettled = Promise.allSettled || (<T>(promises: Array<Promise<T>>) => Promise.all(
+    promises.map((p) => p.
+        then((value) => ({
+            status: 'fulfilled',
+            value,
+        })).
+        catch((reason) => ({
+            status: 'rejected',
+            reason,
+        })),
+    ),
+));
+
 export async function initialize() {
     if (!alreadyInitialized) {
         alreadyInitialized = true;


### PR DESCRIPTION
#### Summary
Use Promise.allSettle so that when fetching custom emojis if one of them does not exist instead of failing the entire operation, those that do exist and are retrieved get stored in the database

Also consider custom emojis that end in `/-\d$/` to not be unicode

```release-note
NONE
```
