### PR TITLE
[MM-47428] Thread overview is not visible when system message is visible

### DIFF
--- a/app/utils/post_list/index.ts
+++ b/app/utils/post_list/index.ts
@@ -59,7 +59,7 @@ function combineUserActivityPosts(orderedPosts: Array<PostModel | string>) {
         const post = orderedPosts[i];
 
         if (typeof post === 'string') {
-            if (post === START_OF_NEW_MESSAGES || post.startsWith(DATE_LINE)) {
+            if (isStartOfNewMessages(post) || isDateLine(post) || isThreadOverview(post)) {
                 // Not a post, so it won't be combined
                 out.push(post);
 


### PR DESCRIPTION
#### Summary
Fixes the issue where ThreadOverview is not displayed when the system message is displayed

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47428

#### Device Information
This PR was tested on: iOS 16

#### Release Note
```release-note
NONE
```