### PR TITLE
[MM-47406] Exclude muted channel's mentions count

### DIFF
--- a/app/database/models/server/my_channel.ts
+++ b/app/database/models/server/my_channel.ts
@@ -23,6 +23,7 @@ export default class MyChannelModel extends Model implements MyChannelModelInter
     static associations: Associations = {
         [CHANNEL]: {type: 'belongs_to', key: 'id'},
         [CATEGORY_CHANNEL]: {type: 'has_many', foreignKey: 'channel_id'},
+        [MY_CHANNEL_SETTINGS]: {type: 'has_many', foreignKey: 'id'},
     };
 
     /** last_post_at : The timestamp for any last post on this channel */

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -465,6 +465,7 @@ export function observeMyChannelMentionCount(database: Database, teamId?: string
         Q.on(CHANNEL, Q.and(
             ...conditions,
         )),
+        Q.on(MY_CHANNEL_SETTINGS, Q.where('notify_props', Q.notLike('%"mark_unread":"mention"%'))),
     ).
         observeWithColumns(columns).
         pipe(

--- a/app/screens/home/channel_list/servers/index.tsx
+++ b/app/screens/home/channel_list/servers/index.tsx
@@ -63,7 +63,7 @@ const Servers = React.forwardRef<ServersRef>((props, ref) => {
             let unread = Boolean(threadUnreads);
             for (const myChannel of myChannels) {
                 const isMuted = settings?.[myChannel.id]?.mark_unread === 'mention';
-                mentions += myChannel.mentionsCount;
+                mentions += isMuted ? 0 : myChannel.mentionsCount;
                 unread = unread || (myChannel.isUnread && !isMuted);
             }
 

--- a/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/server_item.tsx
@@ -171,7 +171,7 @@ const ServerItem = ({
         let isUnread = Boolean(threadUnreads);
         for (const myChannel of myChannels) {
             const isMuted = settings?.[myChannel.id]?.mark_unread === 'mention';
-            mentions += myChannel.mentionsCount;
+            mentions += isMuted ? 0 : myChannel.mentionsCount;
             isUnread = isUnread || (myChannel.isUnread && !isMuted);
         }
         mentions += threadMentionCount;

--- a/app/screens/home/tab_bar/home.tsx
+++ b/app/screens/home/tab_bar/home.tsx
@@ -71,7 +71,7 @@ const Home = ({isFocused, theme}: Props) => {
             let unread = false;
             for (const myChannel of myChannels) {
                 const isMuted = settings?.[myChannel.id]?.mark_unread === 'mention';
-                mentions += myChannel.mentionsCount;
+                mentions += isMuted ? 0 : myChannel.mentionsCount;
                 unread = unread || (myChannel.isUnread && !isMuted);
             }
 

--- a/ios/Gekidou/Sources/Gekidou/Storage/Database+Mentions.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database+Mentions.swift
@@ -38,8 +38,9 @@ extension Database {
         let stmtString = """
         SELECT SUM(my.mentions_count) \
         FROM MyChannel my \
+        INNER JOIN MyChannelSettings mys ON mys.id=my.id \
         INNER JOIN Channel c ON c.id=my.id \
-        WHERE c.delete_at = 0
+        WHERE c.delete_at = 0 AND mys.notify_props NOT LIKE '%"mark_unread":"mention"%'
         """
         let mentions = try? db.prepare(stmtString).scalar() as? Double
         return Int(mentions ?? 0)


### PR DESCRIPTION
#### Summary
This PR excludes the mentions count from the muted channels in the badges displayed in:
1. Servers list
2. Teams list
3. Server Icon
4. Home Icon on the footer bar
5. iOS badge when notification is received

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47406

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iOS 16

#### Release Note
```release-note
NONE
```