### PR TITLE
Detox Report: Add commit hash to report

### DIFF
--- a/detox/save_report.js
+++ b/detox/save_report.js
@@ -12,6 +12,7 @@
  * Environment variables:
  *   BRANCH=[branch]                 : Branch identifier from CI
  *   BUILD_ID=[build_id]             : Build identifier from CI
+ *   COMMIT_HASH=[commit_hash]       : Commit hash from repo
  *   DEVICE_NAME=[device_name]       : Name of the device used for testing
  *   DEVICE_OS_NAME=[device_os_name] : OS of the device used for testing
  *   HEADLESS=[boolean]              : Headed by default (false) or headless (true)

--- a/detox/utils/artifacts.js
+++ b/detox/utils/artifacts.js
@@ -18,6 +18,7 @@ require('dotenv').config();
 const {
     BRANCH,
     BUILD_ID,
+    COMMIT_HASH,
     DETOX_AWS_S3_BUCKET,
     DETOX_AWS_ACCESS_KEY_ID,
     DETOX_AWS_SECRET_ACCESS_KEY,
@@ -42,7 +43,7 @@ async function saveArtifacts() {
         return;
     }
 
-    const s3Folder = `${BUILD_ID}-${BRANCH}`.replace(/\./g, '-');
+    const s3Folder = `${BUILD_ID}-${COMMIT_HASH}-${BRANCH}`.replace(/\./g, '-');
     const uploadPath = path.resolve(__dirname, `../${ARTIFACTS_DIR}`);
     const filesToUpload = await getFiles(uploadPath);
 

--- a/detox/utils/report.js
+++ b/detox/utils/report.js
@@ -308,6 +308,7 @@ function generateTestReport(summary, isUploadedToS3, reportLink, environment, te
 function generateTitle() {
     const {
         BRANCH,
+        COMMIT_HASH,
         IOS,
         PULL_REQUEST,
         RELEASE_BUILD_NUMBER,
@@ -320,7 +321,7 @@ function generateTitle() {
     const lane = `${platform} Build`;
     const appExtension = IOS === 'true' ? 'ipa' : 'apk';
     const appFileName = TYPE === 'GEKIDOU' ? `Mattermost_Beta.${appExtension}` : `Mattermost.${appExtension}`;
-    let buildLink = ` with [${lane}](https://pr-builds.mattermost.com/mattermost-mobile/${BRANCH}/${appFileName})`;
+    let buildLink = ` with [${lane}:${COMMIT_HASH}](https://pr-builds.mattermost.com/mattermost-mobile/${BRANCH}-${COMMIT_HASH}/${appFileName})`;
     if (RELEASE_VERSION && RELEASE_BUILD_NUMBER) {
         const releaseType = TYPE === 'GEKIDOU' ? 'mattermost-mobile-beta' : 'mattermost-mobile';
         buildLink = ` with [${RELEASE_VERSION}:${RELEASE_BUILD_NUMBER}](https://releases.mattermost.com/${releaseType}/${RELEASE_VERSION}/${RELEASE_BUILD_NUMBER}/${appFileName})`;

--- a/detox/utils/test_cases.js
+++ b/detox/utils/test_cases.js
@@ -80,6 +80,7 @@ async function createTestCycle(startDate, endDate) {
     const {
         BRANCH,
         BUILD_ID,
+        COMMIT_HASH,
         JIRA_PROJECT_KEY,
         ZEPHYR_CYCLE_NAME,
         ZEPHYR_FOLDER_ID,
@@ -87,7 +88,7 @@ async function createTestCycle(startDate, endDate) {
 
     const testCycle = {
         projectKey: JIRA_PROJECT_KEY,
-        name: ZEPHYR_CYCLE_NAME ? `${ZEPHYR_CYCLE_NAME} (${BUILD_ID}-${BRANCH})` : `${BUILD_ID}-${BRANCH}`,
+        name: ZEPHYR_CYCLE_NAME ? `${ZEPHYR_CYCLE_NAME} (${BUILD_ID}-${COMMIT_HASH}-${BRANCH})` : `${BUILD_ID}-${COMMIT_HASH}-${BRANCH}`,
         description: `Detox automated test with ${BRANCH}`,
         plannedStartDate: startDate,
         plannedEndDate: endDate,


### PR DESCRIPTION
#### Summary
- Added `COMMIT_HASH` wherever necessary in save report
- Associated pipeline changes: https://git.internal.mattermost.com/qa/mobile-e2e-testing/-/merge_requests/13

The definitions of the environment variables are as follows,
```
BRANCH=<generated_pr_branch>
BUILD_ID=<pipeline_id>
COMMIT_HASH=<short_commit_hash>
```

Also, to disable saving results to zephyr on non-release runs,
```
ZEPHYR_ENABLE='false'
```

With respect to running e2e test against release, the following environment variables would apply,
```
RELEASE_VERSION=<e.g. 2.0.0>
RELEASE_BUILD_NUMBER=<e.g. 466>
RELEASE_DATE=<optional>
```

#### Ticket Link
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```
