### PR TITLE
Detox Reporting: Prepare for release and main

### DIFF
--- a/detox/utils/report.js
+++ b/detox/utils/report.js
@@ -320,32 +320,30 @@ function generateTitle() {
     const platform = IOS === 'true' ? 'iOS' : 'Android';
     const lane = `${platform} Build`;
     const appExtension = IOS === 'true' ? 'ipa' : 'apk';
-    const appFileName = TYPE === 'GEKIDOU' ? `Mattermost_Beta.${appExtension}` : `Mattermost.${appExtension}`;
-    let buildLink = ` with [${lane}:${COMMIT_HASH}](https://pr-builds.mattermost.com/mattermost-mobile/${BRANCH}-${COMMIT_HASH}/${appFileName})`;
-    if (RELEASE_VERSION && RELEASE_BUILD_NUMBER) {
-        const releaseType = TYPE === 'GEKIDOU' ? 'mattermost-mobile-beta' : 'mattermost-mobile';
-        buildLink = ` with [${RELEASE_VERSION}:${RELEASE_BUILD_NUMBER}](https://releases.mattermost.com/${releaseType}/${RELEASE_VERSION}/${RELEASE_BUILD_NUMBER}/${appFileName})`;
-    }
-
-    let releaseDate = '';
-    if (RELEASE_DATE) {
-        releaseDate = ` for ${RELEASE_DATE}`;
-    }
-
+    const appFileName = `Mattermost_Beta.${appExtension}`;
+    const appBuildType = 'mattermost-mobile-beta';
+    let buildLink = '';
     let title;
 
     switch (TYPE) {
         case 'PR':
+            buildLink = ` with [${lane}:${COMMIT_HASH}](https://pr-builds.mattermost.com/${appBuildType}/${BRANCH}-${COMMIT_HASH}/${appFileName})`;
             title = `${platform} E2E for Pull Request Build: [${BRANCH}](${PULL_REQUEST})${buildLink}`;
             break;
         case 'RELEASE':
+            if (RELEASE_VERSION && RELEASE_BUILD_NUMBER) {
+                buildLink = ` with [${RELEASE_VERSION}:${RELEASE_BUILD_NUMBER}](https://releases.mattermost.com/${appBuildType}/${RELEASE_VERSION}/${RELEASE_BUILD_NUMBER}/${appFileName})`;
+            }
+        
+            let releaseDate = '';
+            if (RELEASE_DATE) {
+                releaseDate = ` for ${RELEASE_DATE}`;
+            }
+
             title = `${platform} E2E for Release Build${buildLink}${releaseDate}`;
             break;
-        case 'MASTER':
-            title = `${platform} E2E for Master Nightly Build (Prod tests)${buildLink}`;
-            break;
-        case 'GEKIDOU':
-            title = `${platform} E2E for Gekidou Nightly Build (Prod tests)${buildLink}`;
+        case 'MAIN':
+            title = `${platform} E2E for Main Nightly Build (Prod tests)${buildLink}`;
             break;
         default:
             title = `${platform} E2E for Build${buildLink}`;


### PR DESCRIPTION
#### Summary
- Cleanup reporting types and prepare for TYPE='RELEASE' and TYPE='MAIN'

Note: I will update `appFileName` and `appBuildType` in the future once v2 has graduated from beta

#### Ticket Link
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```
