### PR TITLE
Fix crashes found in NotificationService

### DIFF
--- a/ios/Gekidou/Sources/Gekidou/Networking/Network+Mentions.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/Network+Mentions.swift
@@ -17,8 +17,8 @@ public struct ChannelMemberData: Codable {
         let container = try decoder.container(keyedBy: ChannelMemberKeys.self)
         channel_id = try container.decode(String.self, forKey: .channel_id)
         mention_count = try container.decode(Int.self, forKey: .mention_count)
-        let mentions_root = try? container.decode(Int?.self, forKey: .mention_count_root) ?? 0
-        mention_count_root = mentions_root!
+        let mentions_root = try? container.decode(Int?.self, forKey: .mention_count_root)
+        mention_count_root = mentions_root ?? 0
         user_id = try container.decode(String.self, forKey: .user_id)
         roles = try container.decode(String.self, forKey: .roles)
         last_update_at = try container.decode(Int64.self, forKey: .last_update_at)

--- a/ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift
@@ -182,10 +182,13 @@ extension Database {
         let sortedChainedPosts = chainAndSortPosts(postData)
         try insertOrUpdatePosts(db, sortedChainedPosts, channelId)
         let sortedAndNotDeletedPosts = sortedChainedPosts.filter({$0.delete_at == 0})
-        let earliest = sortedAndNotDeletedPosts.first!.create_at
-        let latest = sortedAndNotDeletedPosts.last!.create_at
+
         if (!receivingThreads) {
-            try handlePostsInChannel(db, channelId, earliest, latest, usedSince)
+            if !sortedAndNotDeletedPosts.isEmpty {
+                let earliest = sortedAndNotDeletedPosts.first!.create_at
+                let latest = sortedAndNotDeletedPosts.last!.create_at
+                try handlePostsInChannel(db, channelId, earliest, latest, usedSince)
+            }
 
             let lastFetchedAt = postData.posts.map({max($0.create_at, $0.update_at, $0.delete_at)}).max()
             try updateMyChannelLastFetchedAt(db, channelId, lastFetchedAt ?? 0)


### PR DESCRIPTION
#### Summary
Fix two crashes
1. When fetching the channel member, `mention_count_root` is not present in older servers and unwrapping was causing a crash
2. When filtering the list of posts and removing the deleted ones, if the list is empty, access to `first` and `last` crash as it returns `nil`
```release-note
NONE
```
