### PR TITLE
Detox Reporting: Fix artifact link

### DIFF
--- a/detox/utils/report.js
+++ b/detox/utils/report.js
@@ -308,6 +308,8 @@ function generateTestReport(summary, isUploadedToS3, reportLink, environment, te
 function generateTitle() {
     const {
         BRANCH,
+        BUILD_AWS_S3_BUCKET,
+        BUILD_ID,
         COMMIT_HASH,
         IOS,
         PULL_REQUEST,
@@ -322,13 +324,15 @@ function generateTitle() {
     const appExtension = IOS === 'true' ? 'ipa' : 'apk';
     const appFileName = `Mattermost_Beta.${appExtension}`;
     const appBuildType = 'mattermost-mobile-beta';
+    const s3Folder = `${BUILD_ID}-${COMMIT_HASH}-${BRANCH}`.replace(/\./g, '-');
+    const appFilePath = IOS === 'true' ? 'Mattermost-simulator-x86_64.app.zip' : 'android/app/build/outputs/apk/release/app-release.apk';
     let buildLink = '';
     let releaseDate = '';
     let title;
 
     switch (TYPE) {
         case 'PR':
-            buildLink = ` with [${lane}:${COMMIT_HASH}](https://pr-builds.mattermost.com/${appBuildType}/${BRANCH}-${COMMIT_HASH}/${appFileName})`;
+            buildLink = ` with [${lane}:${COMMIT_HASH}](https://${BUILD_AWS_S3_BUCKET}.s3.amazonaws.com/${platform.toLocaleLowerCase()}/${s3Folder}/${appFilePath})`;
             title = `${platform} E2E for Pull Request Build: [${BRANCH}](${PULL_REQUEST})${buildLink}`;
             break;
         case 'RELEASE':

--- a/detox/utils/report.js
+++ b/detox/utils/report.js
@@ -324,7 +324,7 @@ function generateTitle() {
     const appExtension = IOS === 'true' ? 'ipa' : 'apk';
     const appFileName = `Mattermost_Beta.${appExtension}`;
     const appBuildType = 'mattermost-mobile-beta';
-    const s3Folder = `${BUILD_ID}-${COMMIT_HASH}-${BRANCH}`.replace(/\./g, '-');
+    const s3Folder = `${platform.toLocaleLowerCase()}/${BUILD_ID}-${COMMIT_HASH}-${BRANCH}`.replace(/\./g, '-');
     const appFilePath = IOS === 'true' ? 'Mattermost-simulator-x86_64.app.zip' : 'android/app/build/outputs/apk/release/app-release.apk';
     let buildLink = '';
     let releaseDate = '';
@@ -332,7 +332,7 @@ function generateTitle() {
 
     switch (TYPE) {
         case 'PR':
-            buildLink = ` with [${lane}:${COMMIT_HASH}](https://${BUILD_AWS_S3_BUCKET}.s3.amazonaws.com/${platform.toLocaleLowerCase()}/${s3Folder}/${appFilePath})`;
+            buildLink = ` with [${lane}:${COMMIT_HASH}](https://${BUILD_AWS_S3_BUCKET}.s3.amazonaws.com/${s3Folder}/${appFilePath})`;
             title = `${platform} E2E for Pull Request Build: [${BRANCH}](${PULL_REQUEST})${buildLink}`;
             break;
         case 'RELEASE':


### PR DESCRIPTION
#### Summary
- Fixed reporting build link for `TYPE=PR` so that it points to the build artifact created by the `ios-build-to-s3` job of `mobile-e2e-testing`
- Associated pipeline changes: https://git.internal.mattermost.com/qa/mobile-e2e-testing/-/merge_requests/15

#### Ticket Link
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```
