### PR TITLE
Fix connection banner showing when not needed

### DIFF
--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -33,6 +33,7 @@ export default class WebSocketClient {
     private firstConnectCallback?: () => void;
     private missedEventsCallback?: () => void;
     private reconnectCallback?: () => void;
+    private reliableReconnectCallback?: () => void;
     private errorCallback?: Function;
     private closeCallback?: (connectFailCount: number, lastDisconnect: number) => void;
     private connectingCallback?: () => void;
@@ -148,8 +149,11 @@ export default class WebSocketClient {
                 logInfo('websocket re-established connection to', this.url);
                 if (!reliableWebSockets && this.reconnectCallback) {
                     this.reconnectCallback();
-                } else if (reliableWebSockets && this.serverSequence && this.missedEventsCallback) {
-                    this.missedEventsCallback();
+                } else if (reliableWebSockets) {
+                    this.reliableReconnectCallback?.();
+                    if (this.serverSequence && this.missedEventsCallback) {
+                        this.missedEventsCallback();
+                    }
                 }
             } else if (this.firstConnectCallback) {
                 logInfo('websocket connected to', this.url);
@@ -293,6 +297,10 @@ export default class WebSocketClient {
 
     public setReconnectCallback(callback: () => void) {
         this.reconnectCallback = callback;
+    }
+
+    public setReliableReconnectCallback(callback: () => void) {
+        this.reliableReconnectCallback = callback;
     }
 
     public setErrorCallback(callback: Function) {

--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -81,6 +81,7 @@ class WebsocketManager {
 
         //client.setMissedEventsCallback(() => {}) Nothing to do on missedEvents callback
         client.setReconnectCallback(() => this.onReconnect(serverUrl));
+        client.setReliableReconnectCallback(() => this.onReliableReconnect(serverUrl));
         client.setCloseCallback((connectFailCount: number, lastDisconnect: number) => this.onWebsocketClose(serverUrl, connectFailCount, lastDisconnect));
 
         if (this.netConnected && ['unknown', 'active'].includes(AppState.currentState)) {
@@ -153,13 +154,17 @@ class WebsocketManager {
 
     private onFirstConnect = (serverUrl: string) => {
         this.startPeriodicStatusUpdates(serverUrl);
-        handleFirstConnect(serverUrl);
         this.getConnectedSubject(serverUrl).next('connected');
+        handleFirstConnect(serverUrl);
     };
 
     private onReconnect = async (serverUrl: string) => {
         this.startPeriodicStatusUpdates(serverUrl);
+        this.getConnectedSubject(serverUrl).next('connected');
         await handleReconnect(serverUrl);
+    };
+
+    private onReliableReconnect = async (serverUrl: string) => {
         this.getConnectedSubject(serverUrl).next('connected');
     };
 


### PR DESCRIPTION
#### Summary
We were saying the websocket connected after we did the whole entry logic. Because of this, if the entry logic took long (+3 seconds) we were showing momentarily the "not connected" banner. Now we set the websocket as connected as soon as it is connected.

I also piggybacked a fix for reliable websockets scenarios, where it shouldn't be working.

TESTING NOTES:
- In order to reproduce this on the current version, you need a slow enough connection / mobile so the reconnect logic takes longer than 3 seconds. In that scenario, at the 3 seconds mark, you will see the "not connected" banner showing, and shortly after, the "connected" green banner. With the fix, this should not happen, no matter how long it takes to run the reconnect logic.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49568


#### Release Note
```release-note
Improved connection banner behaviour.
```
