### PR TITLE
Add back wrongly removed Ephemeral.theme assignment

### DIFF
--- a/app/utils/theme/index.ts
+++ b/app/utils/theme/index.ts
@@ -278,6 +278,7 @@ export function setThemeDefaults(theme: ExtendedTheme): Theme {
 export const updateThemeIfNeeded = (theme: Theme, force = false) => {
     const storedTheme = EphemeralStore.theme;
     if (!deepEqual(theme, storedTheme) || force) {
+        EphemeralStore.theme = theme;
         requestAnimationFrame(() => {
             setNavigationStackStyles(theme);
         });


### PR DESCRIPTION
#### Summary
In PR #6946 was wrongly removed the `EphemeralStore.theme` assignment

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49622

```release-note
NONE
```
