### PR TITLE
[MM-49619] Channel doesn't show the posts

### DIFF
--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -164,8 +164,13 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
         }
     }
 
+    let actionType: string = ActionType.POSTS.RECEIVED_NEW;
+    if (isCRTEnabled && post.root_id) {
+        actionType = ActionType.POSTS.RECEIVED_IN_THREAD;
+    }
+
     const postModels = await operator.handlePosts({
-        actionType: ActionType.POSTS.RECEIVED_NEW,
+        actionType,
         order: [post.id],
         posts: [post],
         prepareRecordsOnly: true,
@@ -203,8 +208,14 @@ export async function handlePostEdited(serverUrl: string, msg: WebSocketMessage)
         models.push(...authorsModels);
     }
 
+    let actionType: string = ActionType.POSTS.RECEIVED_NEW;
+    const isCRTEnabled = await getIsCRTEnabled(operator.database);
+    if (isCRTEnabled && post.root_id) {
+        actionType = ActionType.POSTS.RECEIVED_IN_THREAD;
+    }
+
     const postModels = await operator.handlePosts({
-        actionType: ActionType.POSTS.RECEIVED_NEW,
+        actionType,
         order: [post.id],
         posts: [post],
         prepareRecordsOnly: true,


### PR DESCRIPTION
#### Summary
1. When CRT is enabled, On receiving a thread post (new post/edited) are being saved as channel posts, and on navigating to the channel, the channel looks empty as the saved posts are of a thread and no root posts are there but `since` parameter uses this updated value and doesn't load previous posts.

2. DM threads will not have a team_id, so use the `currentTeamId` to save the thread in `threadsInTeam` table. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49619

#### Release Note
```release-note
NONE
```