### PR TITLE
Automated cherry pick of #6961

### DIFF
--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -157,7 +157,7 @@ class NotificationService: UNNotificationServiceExtension {
           os_log(
             OSLogType.default,
             "Mattermost Notifications: notification receipt failed with status %{public}@. Will call sendMessageIntent",
-            httpResponse.statusCode
+            String(describing: httpResponse.statusCode)
           )
           self.sendMessageIntent(notification: self.bestAttemptContent!)
           return
@@ -172,7 +172,7 @@ class NotificationService: UNNotificationServiceExtension {
               os_log(
                 OSLogType.default,
                 "Mattermost Notifications: receipt retrieval failed. Retry %{public}@",
-                self.retryIndex
+                String(describing: self.retryIndex)
               )
               self.fetchReceipt(ackNotification)
             })


### PR DESCRIPTION
Cherry pick of #6961 on release-2.0.

/cc  @enahum

```release-note
NONE
```