### PR TITLE
Add webhook image to notification in missing scenarios

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
@@ -58,6 +58,7 @@ public class CustomPushNotificationHelper {
         String senderId = bundle.getString("sender_id");
         String serverUrl = bundle.getString("server_url");
         String type = bundle.getString("type");
+        String urlOverride = bundle.getString("override_icon_url");
         if (senderId == null) {
             senderId = "sender_id";
         }
@@ -74,7 +75,7 @@ public class CustomPushNotificationHelper {
 
         if (serverUrl != null && !type.equals(CustomPushNotificationHelper.PUSH_TYPE_SESSION)) {
             try {
-                Bitmap avatar = userAvatar(context, serverUrl, senderId, null);
+                Bitmap avatar = userAvatar(context, serverUrl, senderId, urlOverride);
                 if (avatar != null) {
                     sender.setIcon(IconCompat.createWithBitmap(avatar));
                 }
@@ -266,6 +267,7 @@ public class CustomPushNotificationHelper {
         final String senderId = "me";
         final String serverUrl = bundle.getString("server_url");
         final String type = bundle.getString("type");
+        String urlOverride = bundle.getString("override_icon_url");
 
         Person.Builder sender = new Person.Builder()
                 .setKey(senderId)
@@ -273,7 +275,7 @@ public class CustomPushNotificationHelper {
 
         if (serverUrl != null && !type.equals(CustomPushNotificationHelper.PUSH_TYPE_SESSION)) {
             try {
-                Bitmap avatar = userAvatar(context, serverUrl, "me", null);
+                Bitmap avatar = userAvatar(context, serverUrl, "me", urlOverride);
                 if (avatar != null) {
                     sender.setIcon(IconCompat.createWithBitmap(avatar));
                 }

--- a/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
@@ -428,7 +428,7 @@ public class CustomPushNotificationHelper {
             final OkHttpClient client = new OkHttpClient();
             Request request;
             String url;
-            if (urlOverride != null) {
+            if (!TextUtils.isEmpty(urlOverride)) {
                 request = new Request.Builder().url(urlOverride).build();
                 Log.i("ReactNative", String.format("Fetch override profile image %s", urlOverride));
             } else {


### PR DESCRIPTION
#### Summary
For some reason I misinterpreted the if and thought that those avatar where for the session notifications, which is not true at all.

This PR adds the urlOverride to all instances of userAvatar, as it should.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38660

#### Release Note
```release-note
Android: Properly show webhook avatar instead of user avatar in notifications.
```
