### PR TITLE
Fix e2e login error

### DIFF
--- a/app/screens/login/index.tsx
+++ b/app/screens/login/index.tsx
@@ -145,7 +145,7 @@ const LoginOptions = ({
 
     useEffect(() => {
         translateX.value = 0;
-    }, [])
+    }, []);
 
     useEffect(() => {
         const listener = {

--- a/app/screens/login/index.tsx
+++ b/app/screens/login/index.tsx
@@ -144,6 +144,10 @@ const LoginOptions = ({
     }, []);
 
     useEffect(() => {
+        translateX.value = 0;
+    }, [])
+
+    useEffect(() => {
         const listener = {
             componentDidAppear: () => {
                 translateX.value = 0;


### PR DESCRIPTION
#### Summary
The error:
When we add the server, sometimes the login form does not appear.

The assumption:
The detox build, for some reason ends up calling the "componentDidAppear" navigation event before the effect to register the listener is executed.

The solution:
Use an effect that sets the value of translateX to 0 after the first render, effectively starting the animation.

The caveat:
What is done should be the same as doing it on `componentDidAppear`, but not sure whether there is some material difference there, so I kept the `componentDidAppear` event. If we consider the effect is going to be the same, we could remove the `componentDidAppear` event.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
