### PR TITLE
[MM-46999] Calls: Start call in speaker mode

### DIFF
--- a/app/products/calls/actions/calls.test.ts
+++ b/app/products/calls/actions/calls.test.ts
@@ -100,6 +100,7 @@ const addFakeCall = (serverUrl: string, channelId: string) => {
 describe('Actions.Calls', () => {
     const {newConnection} = require('@calls/connection/connection');
     InCallManager.setSpeakerphoneOn = jest.fn();
+    InCallManager.setForceSpeakerphoneOn = jest.fn();
     // eslint-disable-next-line
     // @ts-ignore
     NetworkManager.getClient = () => mockClient;

--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -307,7 +307,7 @@ export const sendReaction = (emoji: CallReactionEmoji) => {
 };
 
 export const setSpeakerphoneOn = (speakerphoneOn: boolean) => {
-    InCallManager.setSpeakerphoneOn(speakerphoneOn);
+    InCallManager.setForceSpeakerphoneOn(speakerphoneOn);
     setSpeakerPhone(speakerphoneOn);
 };
 

--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -12,6 +12,7 @@ import {
     mediaDevices,
 } from 'react-native-webrtc';
 
+import {setSpeakerPhone} from '@calls/state';
 import {getICEServersConfigs} from '@calls/utils';
 import {WebsocketEvents} from '@constants';
 import {getServerCredentials} from '@init/credentials';
@@ -203,8 +204,8 @@ export async function newConnection(
             }
         }
 
-        InCallManager.start({media: 'audio'});
-        InCallManager.stopProximitySensor();
+        InCallManager.start({media: 'video'});
+        setSpeakerPhone(true);
 
         peer = new Peer(null, iceConfigs);
         peer.on('signal', (data: any) => {


### PR DESCRIPTION
#### Summary
- Small QoL improvement requested by a customer. Start the call in speaker mode, since you'll likely be looking at your phone when you join a call. 
- When in speaker mode, the phone does not darken when the proximity event fires. If you turn off speaker mode, it does.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46999

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: Calls now start in speaker mode by default.
```
