### PR TITLE
fix Cannot read property id of undefined

### DIFF
--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -156,7 +156,15 @@ async function doReconnect(serverUrl: string) {
 
     await fetchPostDataIfNeeded(serverUrl);
 
-    const {id: currentUserId, locale: currentUserLocale} = (await getCurrentUser(database))!;
+    let currentUserId = '';
+    let currentUserLocale = '';
+
+    const user = await getCurrentUser(database);
+    if (user) {
+        currentUserId = user.id;
+        currentUserLocale = user.locale;
+    }
+
     const license = await getLicense(database);
     const config = await getConfig(database);
 
@@ -164,7 +172,9 @@ async function doReconnect(serverUrl: string) {
         loadConfigAndCalls(serverUrl, currentUserId);
     }
 
-    await deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, initialTeamId);
+    if (currentUserId && currentUserLocale) {
+        await deferredAppEntryActions(serverUrl, lastDisconnectedAt, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, initialTeamId);
+    }
 
     AppsManager.refreshAppBindings(serverUrl);
 }


### PR DESCRIPTION
#### Summary

The below issue has been reported by Sentry.

The `currentUserId` is found to be `undefined` when the Websocket manager calls  the `handleReconnect` function.

[Cannot read property 'id' of undefined](https://sentry.io/organizations/mattermost-mr/issues/3869854264/?query=is%3Aunresolved+release.version%3A2.0.0&referrer=issue-stream&statsPeriod=14d)

#### Release Note
```release-note
NONE
```
