### PR TITLE
Returning earlier instead of throwing a locally caught error

### DIFF
--- a/app/actions/local/user.ts
+++ b/app/actions/local/user.ts
@@ -18,7 +18,7 @@ export async function setCurrentUserStatusOffline(serverUrl: string) {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const user = await getCurrentUser(database);
         if (!user) {
-            throw new Error(`No current user for ${serverUrl}`);
+            return null;
         }
 
         user.prepareStatus(General.OFFLINE);


### PR DESCRIPTION
#### Summary
 Looking at the Sentry issue [Failed setCurrentUserStatusOffline](https://sentry.io/organizations/mattermost-mr/issues/3869868887/?query=is%3Aunresolved+release.version%3A2.0.0&referrer=issue-stream&statsPeriod=14d) - I found that an error is thrown and caught locally if the  current user is not found while trying to execute the `setCurrentUserStatusOffline` action.  This action is called by the WS `onWebsocketClose`callback.  I'm not sure if this [line](https://github.com/mattermost/mattermost-mobile/blob/0222504cc9d19f0bccdc057c197150114d9ea389/app/actions/local/user.ts#L21) should be throwing an error at all... since the WebSocket manager isn't using the error. 

#### Release Note
 ```release-note
NONE
```
