### PR TITLE
MM-44663/tappable-channel-names

### DIFF
--- a/app/components/post_with_channel_info/channel_info/channel_info.tsx
+++ b/app/components/post_with_channel_info/channel_info/channel_info.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useCallback} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 
+import {switchToChannelById} from '@actions/remote/channel';
+import {useServerUrl} from '@app/context/server';
 import {useTheme} from '@context/theme';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -37,14 +39,20 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 }));
 
 type Props = {
+    channelId: ChannelModel['id'];
     channelName: ChannelModel['displayName'];
     teamName: TeamModel['displayName'];
     testID?: string;
 }
 
-function ChannelInfo({channelName, teamName, testID}: Props) {
+function ChannelInfo({channelId, channelName, teamName, testID}: Props) {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
+    const serverUrl = useServerUrl();
+
+    const onChannelSwitch = useCallback(() => {
+        switchToChannelById(serverUrl, channelId);
+    }, [serverUrl]);
 
     return (
         <View
@@ -55,6 +63,7 @@ function ChannelInfo({channelName, teamName, testID}: Props) {
                 style={styles.channel}
                 testID='channel_display_name'
                 numberOfLines={1}
+                onPress={onChannelSwitch}
             >
                 {channelName}
             </Text>

--- a/app/components/post_with_channel_info/channel_info/index.ts
+++ b/app/components/post_with_channel_info/channel_info/index.ts
@@ -14,6 +14,9 @@ const enhance = withObservables(['post'], ({post}: {post: PostModel}) => {
     const channel = post.channel.observe();
 
     return {
+        channelId: channel.pipe(
+            switchMap((chan) => (chan ? of$(chan.id) : '')),
+        ),
         channelName: channel.pipe(
             switchMap((chan) => (chan ? of$(chan.displayName) : '')),
         ),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Made channel names clickable in the post with channel name fields.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-server/issues/21237
https://mattermost.atlassian.net/browse/MM-44663

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> Samsung M11 - Android 12 - One UI Core 4.1

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Channel name clickable in post with channel name fields.
```
