### PR TITLE
Do not access record children directly to avoid crashes if the child is not present in the db

### DIFF
--- a/app/components/channel_item/index.ts
+++ b/app/components/channel_item/index.ts
@@ -10,7 +10,7 @@ import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 import {observeChannelsWithCalls} from '@calls/state';
 import {General} from '@constants';
 import {withServerUrl} from '@context/server';
-import {observeChannelSettings, observeMyChannel} from '@queries/servers/channel';
+import {observeChannelSettings, observeMyChannel, queryChannelMembers} from '@queries/servers/channel';
 import {queryDraft} from '@queries/servers/drafts';
 import {observeCurrentChannelId, observeCurrentUserId} from '@queries/servers/system';
 import {observeTeam} from '@queries/servers/team';
@@ -67,7 +67,7 @@ const enhance = withObservables(['channel', 'showTeamName'], ({
 
     let membersCount = of$(0);
     if (channel.type === General.GM_CHANNEL) {
-        membersCount = channel.members.observeCount(false);
+        membersCount = queryChannelMembers(database, channel.id).observeCount(false);
     }
 
     const isUnread = myChannel.pipe(

--- a/app/components/common_post_options/copy_permalink_option/index.tsx
+++ b/app/components/common_post_options/copy_permalink_option/index.tsx
@@ -6,6 +6,7 @@ import withObservables from '@nozbe/with-observables';
 import {combineLatest, of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
+import {observeChannel} from '@queries/servers/channel';
 import {observeCurrentTeamId} from '@queries/servers/system';
 import {observeTeam} from '@queries/servers/team';
 
@@ -17,7 +18,7 @@ import type TeamModel from '@typings/database/models/servers/team';
 
 const enhanced = withObservables(['post'], ({post, database}: WithDatabaseArgs & { post: PostModel }) => {
     const currentTeamId = observeCurrentTeamId(database);
-    const channel = post.channel.observe();
+    const channel = observeChannel(database, post.id);
 
     const teamName = combineLatest([channel, currentTeamId]).pipe(
         switchMap(([c, tid]) => {

--- a/app/components/common_post_options/follow_thread_option/index.ts
+++ b/app/components/common_post_options/follow_thread_option/index.ts
@@ -1,18 +1,20 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 
 import {observeTeamIdByThread} from '@queries/servers/thread';
 
 import FollowThreadOption from './follow_thread_option';
 
+import type {WithDatabaseArgs} from '@typings/database/database';
 import type ThreadModel from '@typings/database/models/servers/thread';
 
-const enhanced = withObservables(['thread'], ({thread}: { thread: ThreadModel }) => {
+const enhanced = withObservables(['thread'], ({thread, database}: {thread: ThreadModel} & WithDatabaseArgs) => {
     return {
-        teamId: observeTeamIdByThread(thread),
+        teamId: observeTeamIdByThread(database, thread),
     };
 });
 
-export default enhanced(FollowThreadOption);
+export default withDatabase(enhanced(FollowThreadOption));

--- a/app/components/files/index.ts
+++ b/app/components/files/index.ts
@@ -6,6 +6,7 @@ import withObservables from '@nozbe/with-observables';
 import {combineLatest, of as of$, from as from$} from 'rxjs';
 import {map, switchMap} from 'rxjs/operators';
 
+import {queryFilesForPost} from '@queries/servers/file';
 import {observeConfigBooleanValue, observeLicense} from '@queries/servers/system';
 import {fileExists} from '@utils/file';
 
@@ -47,7 +48,7 @@ const enhance = withObservables(['post'], ({database, post}: EnhanceProps) => {
         map(([download, compliance]) => compliance || download),
     );
 
-    const filesInfo = post.files.observeWithColumns(['local_path']).pipe(
+    const filesInfo = queryFilesForPost(database, post.id).observeWithColumns(['local_path']).pipe(
         switchMap((fs) => from$(filesLocalPathValidation(fs, post.userId))),
     );
 

--- a/app/components/post_draft/post_input/index.ts
+++ b/app/components/post_draft/post_input/index.ts
@@ -7,7 +7,7 @@ import React from 'react';
 import {of as of$} from 'rxjs';
 import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
-import {observeChannel} from '@queries/servers/channel';
+import {observeChannel, observeChannelInfo} from '@queries/servers/channel';
 import {observeConfigBooleanValue, observeConfigIntValue} from '@queries/servers/system';
 
 import PostInput from './post_input';
@@ -31,7 +31,7 @@ const enhanced = withObservables(['channelId'], ({database, channelId}: WithData
     );
 
     const membersInChannel = channel.pipe(
-        switchMap((c) => (c ? c.info.observe() : of$({memberCount: 0}))),
+        switchMap((c) => (c ? observeChannelInfo(database, c.id) : of$({memberCount: 0}))),
         switchMap((i: ChannelInfoModel) => of$(i.memberCount)),
         distinctUntilChanged(),
     );

--- a/app/components/post_draft/send_handler/index.ts
+++ b/app/components/post_draft/send_handler/index.ts
@@ -8,7 +8,7 @@ import {switchMap} from 'rxjs/operators';
 
 import {General, Permissions} from '@constants';
 import {MAX_MESSAGE_LENGTH_FALLBACK} from '@constants/post_draft';
-import {observeChannel, observeCurrentChannel} from '@queries/servers/channel';
+import {observeChannel, observeChannelInfo, observeCurrentChannel} from '@queries/servers/channel';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
 import {observePermissionForChannel} from '@queries/servers/role';
 import {observeConfigBooleanValue, observeConfigIntValue, observeCurrentUserId} from '@queries/servers/system';
@@ -56,7 +56,7 @@ const enhanced = withObservables([], (ownProps: WithDatabaseArgs & OwnProps) => 
         }),
     );
 
-    const channelInfo = channel.pipe(switchMap((c) => (c ? c.info.observe() : of$(undefined))));
+    const channelInfo = channel.pipe(switchMap((c) => (c ? observeChannelInfo(database, c.id) : of$(undefined))));
     const membersCount = channelInfo.pipe(
         switchMap((i) => (i ? of$(i.memberCount) : of$(0))),
     );

--- a/app/components/post_list/post/body/add_members/index.ts
+++ b/app/components/post_list/post/body/add_members/index.ts
@@ -6,19 +6,19 @@ import withObservables from '@nozbe/with-observables';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
+import {observeChannel} from '@queries/servers/channel';
 import {observeCurrentUser} from '@queries/servers/user';
 
 import AddMembers from './add_members';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
-import type ChannelModel from '@typings/database/models/servers/channel';
 import type PostModel from '@typings/database/models/servers/post';
 
 const enhance = withObservables(['post'], ({database, post}: WithDatabaseArgs & {post: PostModel}) => ({
     currentUser: observeCurrentUser(database),
-    channelType: post.channel.observe().pipe(
+    channelType: observeChannel(database, post.channelId).pipe(
         switchMap(
-            (channel: ChannelModel) => (channel ? of$(channel.type) : of$(null)),
+            (channel) => (channel ? of$(channel.type) : of$(null)),
         ),
     ),
 }));

--- a/app/components/post_list/post/body/content/embedded_bindings/button_binding/index.tsx
+++ b/app/components/post_list/post/body/content/embedded_bindings/button_binding/index.tsx
@@ -12,6 +12,7 @@ import {handleBindingClick, postEphemeralCallResponseForPost} from '@actions/rem
 import {handleGotoLocation} from '@actions/remote/command';
 import {AppBindingLocations, AppCallResponseTypes} from '@constants/apps';
 import {useServerUrl} from '@context/server';
+import {observeChannel} from '@queries/servers/channel';
 import {observeCurrentTeamId} from '@queries/servers/system';
 import {showAppForm} from '@screens/navigation';
 import {createCallContext} from '@utils/apps';
@@ -22,7 +23,6 @@ import {makeStyleSheetFromTheme, changeOpacity} from '@utils/theme';
 import ButtonBindingText from './button_binding_text';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
-import type ChannelModel from '@typings/database/models/servers/channel';
 import type PostModel from '@typings/database/models/servers/post';
 
 type Props = {
@@ -135,7 +135,7 @@ const ButtonBinding = ({currentTeamId, binding, post, teamID, theme}: Props) => 
 };
 
 const withTeamId = withObservables(['post'], ({post, database}: {post: PostModel} & WithDatabaseArgs) => ({
-    teamID: post.channel.observe().pipe(map((channel: ChannelModel) => channel.teamId)),
+    teamID: observeChannel(database, post.channelId).pipe(map((channel) => channel?.teamId)),
     currentTeamId: observeCurrentTeamId(database),
 }));
 

--- a/app/components/post_list/post/body/content/embedded_bindings/menu_binding/index.tsx
+++ b/app/components/post_list/post/body/content/embedded_bindings/menu_binding/index.tsx
@@ -10,11 +10,11 @@ import {postEphemeralCallResponseForPost} from '@actions/remote/apps';
 import AutocompleteSelector from '@components/autocomplete_selector';
 import {useServerUrl} from '@context/server';
 import {useAppBinding} from '@hooks/apps';
+import {observeChannel} from '@queries/servers/channel';
 import {observeCurrentTeamId} from '@queries/servers/system';
 import {logDebug} from '@utils/log';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
-import type ChannelModel from '@typings/database/models/servers/channel';
 import type PostModel from '@typings/database/models/servers/post';
 
 type Props = {
@@ -79,7 +79,7 @@ const MenuBinding = ({binding, currentTeamId, post, teamID}: Props) => {
 };
 
 const withTeamId = withObservables(['post'], ({post, database}: {post: PostModel} & WithDatabaseArgs) => ({
-    teamID: post.channel.observe().pipe(map((channel: ChannelModel) => channel.teamId)),
+    teamID: observeChannel(database, post.channelId).pipe(map((channel) => channel?.teamId)),
     currentTeamId: observeCurrentTeamId(database),
 }));
 

--- a/app/components/post_list/post/body/reactions/index.ts
+++ b/app/components/post_list/post/body/reactions/index.ts
@@ -8,6 +8,7 @@ import {map, switchMap} from 'rxjs/operators';
 
 import {General, Permissions} from '@constants';
 import {observeChannel} from '@queries/servers/channel';
+import {observeReactionsForPost} from '@queries/servers/reaction';
 import {observePermissionForPost} from '@queries/servers/role';
 import {observeConfigBooleanValue, observeCurrentUserId} from '@queries/servers/system';
 import {observeUser} from '@queries/servers/user';
@@ -42,7 +43,7 @@ const withReactions = withObservables(['post'], ({database, post}: WithReactions
         currentUserId,
         disabled,
         postId: of$(post.id),
-        reactions: post.reactions.observe(),
+        reactions: observeReactionsForPost(database, post.id),
     };
 });
 

--- a/app/components/post_list/post/footer/index.ts
+++ b/app/components/post_list/post/footer/index.ts
@@ -16,7 +16,7 @@ const enhanced = withObservables(
     ({database, thread}: WithDatabaseArgs & {thread: ThreadModel}) => {
         return {
             participants: queryThreadParticipants(database, thread.id).observe(),
-            teamId: observeTeamIdByThread(thread),
+            teamId: observeTeamIdByThread(database, thread),
         };
     },
 );

--- a/app/components/post_list/post/header/index.ts
+++ b/app/components/post_list/post/header/index.ts
@@ -8,10 +8,10 @@ import {map, switchMap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {getPreferenceAsBool} from '@helpers/api/preference';
-import {observePostAuthor, queryPostReplies} from '@queries/servers/post';
+import {observePost, observePostAuthor, queryPostReplies} from '@queries/servers/post';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeConfigBooleanValue} from '@queries/servers/system';
-import {observeTeammateNameDisplay} from '@queries/servers/user';
+import {observeTeammateNameDisplay, observeUser} from '@queries/servers/user';
 
 import Header from './header';
 
@@ -35,9 +35,9 @@ const withHeaderProps = withObservables(
         const teammateNameDisplay = observeTeammateNameDisplay(database);
         const commentCount = queryPostReplies(database, post.rootId || post.id).observeCount();
         const isCustomStatusEnabled = observeConfigBooleanValue(database, 'EnableCustomUserStatuses');
-        const rootPostAuthor = differentThreadSequence ? post.root.observe().pipe(switchMap((root) => {
-            if (root.length) {
-                return root[0].author.observe();
+        const rootPostAuthor = differentThreadSequence ? observePost(database, post.rootId).pipe(switchMap((root) => {
+            if (root) {
+                return observeUser(database, root.userId);
             }
 
             return of$(null);

--- a/app/components/post_list/post/system_message/index.tsx
+++ b/app/components/post_list/post/system_message/index.tsx
@@ -1,14 +1,18 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
+
+import {observeUser} from '@queries/servers/user';
 
 import SystemMessage from './system_message';
 
+import type {WithDatabaseArgs} from '@typings/database/database';
 import type PostModel from '@typings/database/models/servers/post';
 
-const withPost = withObservables(['post'], ({post}: {post: PostModel}) => ({
-    author: post.author.observe(),
+const enhance = withObservables(['post'], ({post, database}: {post: PostModel} & WithDatabaseArgs) => ({
+    author: observeUser(database, post.userId),
 }));
 
-export default withPost(SystemMessage);
+export default withDatabase(enhance(SystemMessage));

--- a/app/components/post_with_channel_info/channel_info/index.ts
+++ b/app/components/post_with_channel_info/channel_info/index.ts
@@ -1,27 +1,30 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 import {switchMap, of as of$} from 'rxjs';
 
+import {observeChannel} from '@queries/servers/channel';
 import {observeTeam} from '@queries/servers/team';
 
 import ChannelInfo from './channel_info';
 
+import type {WithDatabaseArgs} from '@typings/database/database';
 import type PostModel from '@typings/database/models/servers/post';
 
-const enhance = withObservables(['post'], ({post}: {post: PostModel}) => {
-    const channel = post.channel.observe();
+const enhance = withObservables(['post'], ({post, database}: {post: PostModel} & WithDatabaseArgs) => {
+    const channel = observeChannel(database, post.channelId);
 
     return {
         channelName: channel.pipe(
             switchMap((chan) => (chan ? of$(chan.displayName) : '')),
         ),
         teamName: channel.pipe(
-            switchMap((chan) => (chan && chan.teamId ? observeTeam(post.database, chan.teamId) : of$(null))),
+            switchMap((chan) => (chan && chan.teamId ? observeTeam(database, chan.teamId) : of$(null))),
             switchMap((team) => of$(team?.displayName || null)),
         ),
     };
 });
 
-export default enhance(ChannelInfo);
+export default withDatabase(enhance(ChannelInfo));

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint-disable max-lines */
+
 import {Database, Model, Q, Query, Relation} from '@nozbe/watermelondb';
 import {of as of$, Observable} from 'rxjs';
 import {map as map$, switchMap, distinctUntilChanged} from 'rxjs/operators';
@@ -663,4 +665,14 @@ export const queryChannelsForAutocomplete = (database: Database, matchTerm: stri
     );
 
     return database.get<ChannelModel>(CHANNEL).query(...clauses);
+};
+
+export const queryChannelMembers = (database: Database, channelId: string) => {
+    return database.get<ChannelMembershipModel>(CHANNEL_MEMBERSHIP).query(
+        Q.where('channel_id', channelId),
+    );
+};
+
+export const observeChannelMembers = (database: Database, channelId: string) => {
+    return queryChannelMembers(database, channelId).observe();
 };

--- a/app/queries/servers/file.ts
+++ b/app/queries/servers/file.ts
@@ -1,9 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Database, Q} from '@nozbe/watermelondb';
+
 import {MM_TABLES} from '@constants/database';
 
-import type {Database} from '@nozbe/watermelondb';
 import type FileModel from '@typings/database/models/servers/file';
 
 const {SERVER: {FILE}} = MM_TABLES;
@@ -15,4 +16,14 @@ export const getFileById = async (database: Database, fileId: string) => {
     } catch {
         return undefined;
     }
+};
+
+export const queryFilesForPost = (database: Database, postId: string) => {
+    return database.get<FileModel>(FILE).query(
+        Q.where('post_id', postId),
+    );
+};
+
+export const observeFilesForPost = (database: Database, postId: string) => {
+    return queryFilesForPost(database, postId).observe();
 };

--- a/app/queries/servers/reaction.ts
+++ b/app/queries/servers/reaction.ts
@@ -6,6 +6,7 @@ import {Database, Q} from '@nozbe/watermelondb';
 import {MM_TABLES} from '@constants/database';
 
 import type ReactionModel from '@typings/database/models/servers/reaction';
+
 const {SERVER: {REACTION}} = MM_TABLES;
 
 export const queryReaction = (database: Database, emojiName: string, postId: string, userId: string) => {
@@ -15,3 +16,14 @@ export const queryReaction = (database: Database, emojiName: string, postId: str
         Q.where('user_id', userId),
     );
 };
+
+export const queryReactionsForPost = (database: Database, postId: string) => {
+    return database.get<ReactionModel>(REACTION).query(
+        Q.where('post_id', postId),
+    );
+};
+
+export const observeReactionsForPost = (database: Database, postId: string) => {
+    return queryReactionsForPost(database, postId).observe();
+};
+

--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -9,6 +9,8 @@ import {Config, Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import {processIsCRTAllowed, processIsCRTEnabled} from '@utils/thread';
 
+import {observeChannel} from './channel';
+import {observePost} from './post';
 import {queryPreferencesByCategoryAndName} from './preference';
 import {getConfig, observeConfigValue} from './system';
 
@@ -67,13 +69,13 @@ export const observeThreadById = (database: Database, threadId: string) => {
     );
 };
 
-export const observeTeamIdByThread = (thread: ThreadModel) => {
-    return thread.post.observe().pipe(
+export const observeTeamIdByThread = (database: Database, thread: ThreadModel) => {
+    return observePost(database, thread.id).pipe(
         switchMap((post) => {
             if (!post) {
                 return of$(undefined);
             }
-            return post.channel.observe().pipe(
+            return observeChannel(database, post.channelId).pipe(
                 switchMap((channel) => of$(channel?.teamId)),
             );
         }),

--- a/app/screens/channel/channel_post_list/intro/direct_channel/index.ts
+++ b/app/screens/channel/channel_post_list/intro/direct_channel/index.ts
@@ -7,6 +7,7 @@ import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {General} from '@constants';
+import {observeChannelMembers} from '@queries/servers/channel';
 import {observeCurrentUserId} from '@queries/servers/system';
 import {observeUser} from '@queries/servers/user';
 import {getUserIdFromChannelName} from '@utils/user';
@@ -21,7 +22,7 @@ const observeIsBot = (user: UserModel | undefined) => of$(Boolean(user?.isBot));
 
 const enhanced = withObservables([], ({channel, database}: {channel: ChannelModel} & WithDatabaseArgs) => {
     const currentUserId = observeCurrentUserId(database);
-    const members = channel.members.observe();
+    const members = observeChannelMembers(database, channel.id);
     let isBot = of$(false);
 
     if (channel.type === General.DM_CHANNEL) {

--- a/app/screens/channel/channel_post_list/intro/direct_channel/member/index.ts
+++ b/app/screens/channel/channel_post_list/intro/direct_channel/member/index.ts
@@ -4,12 +4,15 @@
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 
+import {observeUser} from '@queries/servers/user';
+
 import Member from './member';
 
+import type {WithDatabaseArgs} from '@typings/database/database';
 import type ChannelMembershipModel from '@typings/database/models/servers/channel_membership';
 
-const enhanced = withObservables([], ({member}: {member: ChannelMembershipModel}) => ({
-    user: member.memberUser.observe(),
+const enhanced = withObservables([], ({member, database}: {member: ChannelMembershipModel} & WithDatabaseArgs) => ({
+    user: observeUser(database, member.userId),
 }));
 
 export default withDatabase(enhanced(Member));

--- a/app/screens/channel_info/title/group_message/index.ts
+++ b/app/screens/channel_info/title/group_message/index.ts
@@ -6,7 +6,7 @@ import withObservables from '@nozbe/with-observables';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {observeChannel} from '@queries/servers/channel';
+import {observeChannel, observeChannelMembers} from '@queries/servers/channel';
 import {observeCurrentUserId} from '@queries/servers/system';
 
 import GroupMessage from './group_message';
@@ -20,7 +20,7 @@ type Props = WithDatabaseArgs & {
 const enhanced = withObservables(['channelId'], ({channelId, database}: Props) => {
     const currentUserId = observeCurrentUserId(database);
     const channel = observeChannel(database, channelId);
-    const members = channel.pipe(switchMap((c) => (c ? c.members.observe() : of$([]))));
+    const members = channel.pipe(switchMap((c) => (c ? observeChannelMembers(database, channelId) : of$([]))));
 
     return {
         currentUserId,

--- a/app/screens/edit_post/index.tsx
+++ b/app/screens/edit_post/index.tsx
@@ -7,6 +7,7 @@ import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {MAX_MESSAGE_LENGTH_FALLBACK} from '@constants/post_draft';
+import {observeFilesForPost} from '@queries/servers/file';
 import {observeConfigIntValue} from '@queries/servers/system';
 
 import EditPost from './edit_post';
@@ -17,7 +18,7 @@ import type PostModel from '@typings/database/models/servers/post';
 const enhance = withObservables([], ({database, post}: WithDatabaseArgs & { post: PostModel}) => {
     const maxPostSize = observeConfigIntValue(database, 'MaxPostSize', MAX_MESSAGE_LENGTH_FALLBACK);
 
-    const hasFilesAttached = post.files.observe().pipe(switchMap((files) => of$(files?.length > 0)));
+    const hasFilesAttached = observeFilesForPost(database, post.id).pipe(switchMap((files) => of$(files?.length > 0)));
 
     return {
         maxPostSize,

--- a/app/screens/gallery/footer/index.ts
+++ b/app/screens/gallery/footer/index.ts
@@ -43,7 +43,8 @@ const enhanced = withObservables(['item'], ({database, item}: FooterProps) => {
 
     const channel = combineLatest([currentChannelId, post]).pipe(
         switchMap(([cId, p]) => {
-            return p?.channel.observe() || observeChannel(database, cId);
+            const id = p?.channelId || cId;
+            return observeChannel(database, id);
         }),
     );
     const enablePostUsernameOverride = observeConfigBooleanValue(database, 'EnablePostUsernameOverride');

--- a/app/screens/permalink/index.ts
+++ b/app/screens/permalink/index.ts
@@ -6,6 +6,7 @@ import withObservables from '@nozbe/with-observables';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
+import {observeChannel} from '@queries/servers/channel';
 import {observePost} from '@queries/servers/post';
 import {observeCurrentTeamId} from '@queries/servers/system';
 import {queryMyTeamsByIds, queryTeamByName} from '@queries/servers/team';
@@ -32,7 +33,7 @@ const enhance = withObservables([], ({database, postId, teamName}: OwnProps) => 
 
     return {
         channel: post.pipe(
-            switchMap((p) => (p ? p.channel.observe() : of$(undefined))),
+            switchMap((p) => (p ? observeChannel(database, p.channelId) : of$(undefined))),
         ),
         rootId: post.pipe(
             switchMap((p) => of$(p?.rootId)),

--- a/app/screens/reactions/index.ts
+++ b/app/screens/reactions/index.ts
@@ -7,6 +7,7 @@ import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observePost} from '@queries/servers/post';
+import {observeReactionsForPost} from '@queries/servers/reaction';
 
 import Reactions from './reactions';
 
@@ -21,7 +22,7 @@ const enhanced = withObservables([], ({postId, database}: EnhancedProps) => {
 
     return {
         reactions: post.pipe(
-            switchMap((p) => (p ? p.reactions.observe() : of$(undefined))),
+            switchMap((p) => (p ? observeReactionsForPost(database, postId) : of$(undefined))),
         ),
     };
 });

--- a/app/screens/thread_options/index.ts
+++ b/app/screens/thread_options/index.ts
@@ -4,7 +4,7 @@
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
 
-import {observePostSaved} from '@queries/servers/post';
+import {observePost, observePostSaved} from '@queries/servers/post';
 import {observeCurrentTeam} from '@queries/servers/team';
 
 import ThreadOptions from './thread_options';
@@ -19,7 +19,7 @@ type Props = WithDatabaseArgs & {
 const enhanced = withObservables(['thread'], ({database, thread}: Props) => {
     return {
         isSaved: observePostSaved(database, thread.id),
-        post: thread.post.observe(),
+        post: observePost(database, thread.id),
         team: observeCurrentTeam(database),
     };
 });

--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -806,8 +806,8 @@
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			packageReferences = (
-				7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph" */,
-				27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph.git" */,
+				27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */,
 			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
@@ -1531,7 +1531,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+		27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
@@ -1539,7 +1539,7 @@
 				kind = branch;
 			};
 		};
-		7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph" */ = {
+		7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/satoshi-takano/OpenGraph.git";
 			requirement = {
@@ -1552,12 +1552,12 @@
 /* Begin XCSwiftPackageProductDependency section */
 		27C667A229523ECA00E590D5 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
 			productName = Sentry;
 		};
 		27C667A429523F0A00E590D5 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
 			productName = Sentry;
 		};
 		49AE370026D4455D00EF4E52 /* Gekidou */ = {
@@ -1574,7 +1574,7 @@
 		};
 		7FD4822B2864D73300A5B18B /* OpenGraph */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph" */;
+			package = 7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph.git" */;
 			productName = OpenGraph;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/share_extension/components/channel_item/index.ts
+++ b/share_extension/components/channel_item/index.ts
@@ -8,7 +8,7 @@ import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {General} from '@constants';
 import {withServerUrl} from '@context/server';
-import {observeMyChannel} from '@queries/servers/channel';
+import {observeMyChannel, queryChannelMembers} from '@queries/servers/channel';
 import {observeCurrentUserId} from '@queries/servers/system';
 import {observeTeam} from '@queries/servers/team';
 
@@ -37,7 +37,7 @@ const enhance = withObservables(['channel', 'showTeamName'], ({channel, showTeam
 
     let membersCount = of$(0);
     if (channel.type === General.GM_CHANNEL) {
-        membersCount = channel.members.observeCount(false);
+        membersCount = queryChannelMembers(database, channel.id).observeCount(false);
     }
 
     const hasMember = myChannel.pipe(


### PR DESCRIPTION
#### Summary
Replaced all direct access to child record for the corresponding query / observable to avoid crashes caused by the inner `find` when the child record is not present in the database.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49967

Fixes: #6989
Fixes: #7020

#### Release Note
```release-note
Fixed a potential crash when trying access non existent database records.
```