### PR TITLE
Fix crash when dismissing notification on android

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
@@ -182,7 +182,7 @@ public class CustomPushNotificationHelper {
         setNotificationGroup(notification, groupId, createSummary);
         setNotificationBadgeType(notification);
 
-        setNotificationChannel(notification, bundle);
+        setNotificationChannel(context, notification, bundle);
         setNotificationDeleteIntent(context, notification, bundle, notificationId);
         addNotificationReplyAction(context, notification, bundle, notificationId);
 
@@ -365,12 +365,15 @@ public class CustomPushNotificationHelper {
         }
     }
 
-    private static void setNotificationChannel(NotificationCompat.Builder notification, Bundle bundle) {
+    private static void setNotificationChannel(Context context, NotificationCompat.Builder notification, Bundle bundle) {
         // If Android Oreo or above we need to register a channel
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return;
         }
 
+        if (mHighImportanceChannel == null) {
+            createNotificationChannels(context);
+        }
         NotificationChannel notificationChannel = mHighImportanceChannel;
         notification.setChannelId(notificationChannel.getId());
     }

--- a/android/app/src/main/java/com/mattermost/helpers/NotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/helpers/NotificationHelper.java
@@ -145,9 +145,9 @@ public class NotificationHelper {
             for (final StatusBarNotification status : statusNotifications) {
                 Bundle bundle = status.getNotification().extras;
                 if (isThreadNotification) {
-                    hasMore = bundle.getString("root_id").equals(rootId);
+                    hasMore = bundle.containsKey("root_id") && bundle.getString("root_id").equals(rootId);
                 } else {
-                    hasMore = bundle.getString("channel_id").equals(channelId);
+                    hasMore = bundle.containsKey("channel_id") && bundle.getString("channel_id").equals(channelId);
                 }
                 if (hasMore) break;
             }

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -31,7 +31,6 @@ public class CustomPushNotification extends PushNotification {
 
     public CustomPushNotification(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
-        CustomPushNotificationHelper.createNotificationChannels(context);
         dataHelper = new PushNotificationDataHelper(context);
 
         try {


### PR DESCRIPTION
#### Summary
The bundle stored in the extra may not contain a `root_id` causing the `bundle.getString` to return null and thus accessing a null pointer was causing a crash.

Also ensures that the notification channels are created before getting the identifier

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49985
https://mattermost.atlassian.net/browse/MM-49953

#### Release Note
```release-note
Fixed a crash when dismissing a notification on android
```
