### PR TITLE
Automated cherry pick of #7029

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
@@ -181,7 +181,7 @@ public class CustomPushNotificationHelper {
         setNotificationGroup(notification, groupId, createSummary);
         setNotificationBadgeType(notification);
 
-        setNotificationChannel(notification, bundle);
+        setNotificationChannel(context, notification, bundle);
         setNotificationDeleteIntent(context, notification, bundle, notificationId);
         addNotificationReplyAction(context, notification, bundle, notificationId);
 
@@ -363,12 +363,15 @@ public class CustomPushNotificationHelper {
         }
     }
 
-    private static void setNotificationChannel(NotificationCompat.Builder notification, Bundle bundle) {
+    private static void setNotificationChannel(Context context, NotificationCompat.Builder notification, Bundle bundle) {
         // If Android Oreo or above we need to register a channel
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return;
         }
 
+        if (mHighImportanceChannel == null) {
+            createNotificationChannels(context);
+        }
         NotificationChannel notificationChannel = mHighImportanceChannel;
         notification.setChannelId(notificationChannel.getId());
     }

--- a/android/app/src/main/java/com/mattermost/helpers/NotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/helpers/NotificationHelper.java
@@ -145,9 +145,9 @@ public class NotificationHelper {
             for (final StatusBarNotification status : statusNotifications) {
                 Bundle bundle = status.getNotification().extras;
                 if (isThreadNotification) {
-                    hasMore = bundle.getString("root_id").equals(rootId);
+                    hasMore = bundle.containsKey("root_id") && bundle.getString("root_id").equals(rootId);
                 } else {
-                    hasMore = bundle.getString("channel_id").equals(channelId);
+                    hasMore = bundle.containsKey("channel_id") && bundle.getString("channel_id").equals(channelId);
                 }
                 if (hasMore) break;
             }

--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java
@@ -31,7 +31,6 @@ public class CustomPushNotification extends PushNotification {
 
     public CustomPushNotification(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
-        CustomPushNotificationHelper.createNotificationChannels(context);
         dataHelper = new PushNotificationDataHelper(context);
 
         try {


### PR DESCRIPTION
Cherry pick of #7029 on release-2.0.

/cc  @enahum

```release-note
NONE
```