### PR TITLE
Use timeout defaults for iOS Share Extension and Notification Service

### DIFF
--- a/ios/Gekidou/Sources/Gekidou/Networking/Network.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/Network.swift
@@ -24,8 +24,6 @@ public class Network: NSObject {
         let config = URLSessionConfiguration.default
         config.httpAdditionalHeaders = ["X-Requested-With": "XMLHttpRequest"]
         config.allowsCellularAccess = true
-        config.timeoutIntervalForRequest = 10
-        config.timeoutIntervalForResource = 10
         config.httpMaximumConnectionsPerHost = 10
         
         self.session = URLSession.init(

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
@@ -15,8 +15,6 @@ extension ShareExtension: URLSessionDataDelegate {
         config.waitsForConnectivity = true
         config.httpAdditionalHeaders = ["X-Requested-With": "XMLHttpRequest"]
         config.allowsCellularAccess = true
-        config.timeoutIntervalForRequest = 10
-        config.timeoutIntervalForResource = 10
         config.httpMaximumConnectionsPerHost = 10
 
         self.backgroundSession = URLSession.init(

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
@@ -72,15 +72,17 @@ extension ShareExtension: URLSessionDataDelegate {
             if let fileInfos = json.object(forKey: "file_infos") as? NSArray,
                fileInfos.count > 0 {
                 let fileData = fileInfos[0] as! NSDictionary
-                let fileId = fileData.object(forKey: "id") as! String
+                let fileId = fileData.object(forKey: "id") as? String ?? "no file id"
+                let filename = fileData.object(forKey: "name") as? String ?? "no file name"
                 appendCompletedUploadToSession(id: id, fileId: fileId)
                 let total = uploadData.totalFiles
                 let count = uploadData.fileIds.count + 1
                 
                 os_log(
                     OSLogType.default,
-                    "Mattermost BackgroundSession: identifier=%{public}@ did upload file %{public}@ total files %{public}@ of %{public}@",
+                    "Mattermost BackgroundSession: identifier=%{public}@ did upload file %{public}@ with ID %{public}@ total files %{public}@ of %{public}@",
                     id,
+                    filename,
                     fileId,
                     "\(count)",
                     "\(total)"
@@ -88,8 +90,9 @@ extension ShareExtension: URLSessionDataDelegate {
                 
                 os_log(
                     OSLogType.default,
-                    "Mattermost BackgroundSession: Append file to session identifier=%{public}@ file=%{public}@",
+                    "Mattermost BackgroundSession: Append file to session identifier=%{public}@ file=%{public}@ with ID %{public}@",
                     id,
+                    filename,
                     fileId
                 )
             } else {

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
@@ -119,7 +119,7 @@ extension ShareExtension: URLSessionDataDelegate {
             else {
                 os_log(
                     OSLogType.default,
-                    "Mattermost BackgroundSession: didCompleteWithError failed to getUploadSessionData identifier=%{public}@",
+                    "Mattermost BackgroundSession: didCompleteWithError delegate failed to getUploadSessionData identifier=%{public}@",
                     session.configuration.identifier ?? "no identifier"
                 )
                 return
@@ -130,7 +130,7 @@ extension ShareExtension: URLSessionDataDelegate {
             let count = data.fileIds.count
             os_log(
                 OSLogType.default,
-                "Mattermost BackgroundSession: didCompleteWithError for identifier=%{public}@ total files %{public}@ of %{public}@",
+                "Mattermost BackgroundSession: didCompleteWithError delegate for identifier=%{public}@ total files %{public}@ of %{public}@",
                 id,
                 "\(count)",
                 "\(total)"
@@ -150,7 +150,7 @@ extension ShareExtension: URLSessionDataDelegate {
         } else if error != nil {
             os_log(
                 OSLogType.default,
-                "Mattermost BackgroundSession: didCompleteWithError failed identifier=%{public}@ with error %{public}@",
+                "Mattermost BackgroundSession: didCompleteWithError delegate failed identifier=%{public}@ with error %{public}@",
                 session.configuration.identifier ?? "no identifier",
                 error?.localizedDescription ?? "no error description available"
             )

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
@@ -10,7 +10,7 @@ import os.log
 
 extension ShareExtension {
     public func uploadFiles(serverUrl: String, channelId: String, message: String,
-files: [String], completionHandler: @escaping () -> Void) -> String? {
+                            files: [String], completionHandler: @escaping () -> Void) -> String? {
         let id = "mattermost-share-upload-\(UUID().uuidString)"
         
         createUploadSessionData(
@@ -26,31 +26,54 @@ files: [String], completionHandler: @escaping () -> Void) -> String? {
             os_log(
                 OSLogType.default,
                 "Mattermost BackgroundSession: uploading %{public}@ files for identifier=%{public}@",
-                files.count,
+                String(files.count),
                 id
             )
             for file in files {
                 if let fileUrl = URL(string: file),
                    fileUrl.isFileURL {
                     let filename = fileUrl.lastPathComponent
-                    if let url = URL(string: "\(serverUrl)/api/v4/files?channel_id=\(channelId)&filename=\(filename)") {
+                    let safeFilename = filename.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                    if let safeFilename = safeFilename,
+                       let url = URL(string: "\(serverUrl)/api/v4/files?channel_id=\(channelId)&filename=\(safeFilename)") {
                         var uploadRequest = URLRequest(url: url)
                         uploadRequest.httpMethod = "POST"
                         uploadRequest.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
-                        if let task = backgroundSession?.uploadTask(
-                            with: uploadRequest,
-                            fromFile: fileUrl
-                        ) {
+                        if let task = backgroundSession?.uploadTask(with: uploadRequest, fromFile: fileUrl) {
                             os_log(
                                 OSLogType.default,
                                 "Mattermost BackgroundSession: Start uploading file %{public}@ for identifier=%{public}@",
                                 filename,
                                 id
                             )
+
                             task.resume()
+                        } else {
+                            os_log(
+                                OSLogType.default,
+                                "Mattermost BackgroundSession: Task not created to upload file %{public}@ for identifier=%{public}@",
+                                filename,
+                                id
+                            )
                         }
+                    } else {
+                        os_log(
+                            OSLogType.default,
+                            "Mattermost BackgroundSession: The file %{public}@ for identifier=%{public}@ could not be processed for upload",
+                            filename,
+                            id
+                        )
+                        return "The file \(filename) could not be processed for upload"
                     }
+                } else {
+                    os_log(
+                        OSLogType.default,
+                        "Mattermost BackgroundSession: File %{public}@ for identifier=%{public}@ not found or is not a valid URL",
+                        file,
+                        id
+                    )
+                    return "File not found \(file)"
                 }
             }
             completionHandler()

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
@@ -23,11 +23,16 @@ files: [String], completionHandler: @escaping () -> Void) -> String? {
 
         if !files.isEmpty {
             createBackroundSession(id: id)
+            os_log(
+                OSLogType.default,
+                "Mattermost BackgroundSession: uploading %{public}@ files for identifier=%{public}@",
+                files.count,
+                id
+            )
             for file in files {
                 if let fileUrl = URL(string: file),
                    fileUrl.isFileURL {
                     let filename = fileUrl.lastPathComponent
-                    
                     if let url = URL(string: "\(serverUrl)/api/v4/files?channel_id=\(channelId)&filename=\(filename)") {
                         var uploadRequest = URLRequest(url: url)
                         uploadRequest.httpMethod = "POST"
@@ -37,6 +42,12 @@ files: [String], completionHandler: @escaping () -> Void) -> String? {
                             with: uploadRequest,
                             fromFile: fileUrl
                         ) {
+                            os_log(
+                                OSLogType.default,
+                                "Mattermost BackgroundSession: Start uploading file %{public}@ for identifier=%{public}@",
+                                filename,
+                                id
+                            )
                             task.resume()
                         }
                     }


### PR DESCRIPTION
#### Summary
Sharing files with the Share extension on a bad network would silently fail after the request times out

##### No code changes (see how it hits the timeout)
![LTE no code changes](https://user-images.githubusercontent.com/6757047/215263046-c8d3fcb2-cd75-45ff-af75-ab7d14c0d529.png)

By using the default timeout settings that sets the `timeoutIntervalForRequest` 30 seconds and `timeoutIntervalForResource` for 7 days, now the extension is able to complete the process of sharing the files as seen in the following results

##### On a 3G network while the phone is locked
![3G phone locked](https://user-images.githubusercontent.com/6757047/215263155-cfa8ea40-db1e-48a8-8f60-2bf3f930f112.png)

##### On a LTE network while the phone is locked
![LTE phone locked](https://user-images.githubusercontent.com/6757047/215263179-cf0c54a5-81d5-4f9d-b8e8-5b25ebce5d10.png)

##### Switching from a very bad network to LTE after some minutes (sharing two files)
![Very bad to LTE 2 files](https://user-images.githubusercontent.com/6757047/215263216-3e712788-c936-423a-8057-59fcf2ca0e80.png)

##### Start with the phone in Airplane mode then switch to wifi after 5 mins (sharing two files)
![Airplane mode to normal after 5 mins](https://user-images.githubusercontent.com/6757047/215263240-544ea63e-c159-4832-930b-bd303dee04a9.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50009

#### Release Note
```release-note
NONE
```
