### PR TITLE
Fix the animation that occurs in login flow

### DIFF
--- a/app/screens/forgot_password/index.tsx
+++ b/app/screens/forgot_password/index.tsx
@@ -255,6 +255,10 @@ const ForgotPassword = ({serverUrl, theme}: Props) => {
     }, []);
 
     useEffect(() => {
+        translateX.value = 0;
+    }, []);
+
+    useEffect(() => {
         const listener = {
             componentDidAppear: () => {
                 translateX.value = 0;

--- a/app/screens/login/index.tsx
+++ b/app/screens/login/index.tsx
@@ -133,6 +133,10 @@ const LoginOptions = ({
     }, []);
 
     useEffect(() => {
+        translateX.value = 0;
+    }, []);
+
+    useEffect(() => {
         const navigationEvents = Navigation.events().registerNavigationButtonPressedListener(({buttonId}) => {
             if (closeButtonId && buttonId === closeButtonId) {
                 NetworkManager.invalidateClient(serverUrl);

--- a/app/screens/mfa/index.tsx
+++ b/app/screens/mfa/index.tsx
@@ -181,6 +181,10 @@ const MFA = ({config, goToHome, license, loginId, password, serverDisplayName, s
         return () => unsubscribe.remove();
     }, [dimensions]);
 
+    useEffect(() => {
+        translateX.value = 0;
+    }, []);
+
     return (
         <View style={styles.flex}>
             <Background theme={theme}/>

--- a/app/screens/onboarding/index.tsx
+++ b/app/screens/onboarding/index.tsx
@@ -111,6 +111,10 @@ const Onboarding = ({
         };
     }, []);
 
+    useEffect(() => {
+        translateX.value = 0;
+    }, []);
+
     return (
         <View
             style={styles.onBoardingContainer}

--- a/app/screens/server/index.tsx
+++ b/app/screens/server/index.tsx
@@ -320,6 +320,10 @@ const Server = ({
         };
     }, []);
 
+    useEffect(() => {
+        translateX.value = 0;
+    }, []);
+
     return (
         <View
             style={styles.flex}

--- a/app/screens/sso/index.tsx
+++ b/app/screens/sso/index.tsx
@@ -122,6 +122,10 @@ const SSO = ({
     }, []);
 
     useEffect(() => {
+        translateX.value = 0;
+    }, []);
+
+    useEffect(() => {
         const listener = {
             componentDidAppear: () => {
                 translateX.value = 0;


### PR DESCRIPTION
#### Summary
When the component mounts set the translation to 0 so that the forms moves to the correct position, in screens of the login flow. This fixes the issue when users turn off animations in their device settings.

#### Ticket Link
Fixes: #7053

#### Release Note
```release-note
Fixed some screens in the login flow not showing the content when animations are turned off in the device settings
```
