### PR TITLE
Fix add to default category code for dms and gms

### DIFF
--- a/app/actions/local/category.ts
+++ b/app/actions/local/category.ts
@@ -9,7 +9,6 @@ import {queryMyTeams} from '@queries/servers/team';
 import {isDMorGM} from '@utils/channel';
 import {logError} from '@utils/log';
 
-import type {Model} from '@nozbe/watermelondb';
 import type ChannelModel from '@typings/database/models/servers/channel';
 
 export const deleteCategory = async (serverUrl: string, categoryId: string) => {
@@ -80,7 +79,6 @@ export async function addChannelToDefaultCategory(serverUrl: string, channel: Ch
             return {error: 'no current user id'};
         }
 
-        const models: Model[] = [];
         const categoriesWithChannels: CategoryWithChannels[] = [];
 
         if (isDMorGM(channel)) {
@@ -100,10 +98,9 @@ export async function addChannelToDefaultCategory(serverUrl: string, channel: Ch
                 cwc.channel_ids.unshift(channel.id);
                 categoriesWithChannels.push(cwc);
             }
-
-            const ccModels = await prepareCategoryChannels(operator, categoriesWithChannels);
-            models.push(...ccModels);
         }
+
+        const models = await prepareCategoryChannels(operator, categoriesWithChannels);
 
         if (models.length && !prepareRecordsOnly) {
             await operator.batchRecords(models);


### PR DESCRIPTION
#### Summary
When adding a channel to the default category, we were taking in consideration the DMs/GMs, but we were only calling the prepare on the non DM/GM branch. This fix the issue.

#### Ticket Link
Fix #6976 
https://mattermost.atlassian.net/browse/MM-49693

#### Release Note
```release-note
Fix issue where new DMs/GMs may not appear in the channel list until reopening the app.
```
