### PR TITLE
Detox Maintenance: Fix failing Android e2e

### DIFF
--- a/detox/e2e/support/ui/screen/server.ts
+++ b/detox/e2e/support/ui/screen/server.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {timeouts} from '@support/utils';
+import {isAndroid, timeouts} from '@support/utils';
 import {expect} from 'detox';
 
 class ServerScreen {
@@ -47,12 +47,19 @@ class ServerScreen {
         await this.serverUrlInput.replaceText(serverUrl);
         await this.serverUrlInput.tapReturnKey();
         await this.serverDisplayNameInput.replaceText(serverDisplayName);
-        await this.connectButton.tap();
+        await this.tapConnectButton();
     };
 
     close = async () => {
         await this.closeButton.tap();
         await expect(this.serverScreen).not.toBeVisible();
+    };
+
+    tapConnectButton = async () => {
+        if (isAndroid()) {
+            await device.pressBack();
+        }
+        await this.connectButton.tap();
     };
 }
 

--- a/detox/e2e/test/account/about.e2e.ts
+++ b/detox/e2e/test/account/about.e2e.ts
@@ -72,7 +72,7 @@ describe('Account - Settings - About', () => {
         await expect(AboutScreen.termsOfService).toHaveText('Terms of Service');
         await expect(AboutScreen.privacyPolicy).toHaveText('Privacy Policy');
         await expect(AboutScreen.noticeText).toHaveText('Mattermost is made possible by the open source software used in our server and mobile apps.');
-        await AboutScreen.scrollView.scrollTo('bottom');
+        await waitFor(AboutScreen.buildDateTitle).toBeVisible().whileElement(by.id(AboutScreen.testID.scrollView)).scroll(50, 'down');
         await expect(AboutScreen.buildHashTitle).toHaveText('Build Hash:');
         await expect(AboutScreen.buildHashValue).toBeVisible();
         await expect(AboutScreen.buildHashEnterpriseTitle).toHaveText('EE Build Hash:');

--- a/detox/e2e/test/account/auto_responder_notification_settings.e2e.ts
+++ b/detox/e2e/test/account/auto_responder_notification_settings.e2e.ts
@@ -21,7 +21,7 @@ import {
     ServerScreen,
     SettingsScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, isIos} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Account - Settings - Auto-Responder Notification Settings', () => {
@@ -77,7 +77,11 @@ describe('Account - Settings - Auto-Responder Notification Settings', () => {
 
         // * Verify enable automatic replies option is toggled on and message is saved
         await expect(AutoResponderNotificationSettingsScreen.enableAutomaticRepliesOptionToggledOn).toBeVisible();
-        await expect(AutoResponderNotificationSettingsScreen.messageInput).toHaveValue(message);
+        if (isIos()) {
+            await expect(AutoResponderNotificationSettingsScreen.messageInput).toHaveValue(message);
+        } else {
+            await expect(AutoResponderNotificationSettingsScreen.messageInput).toHaveText(message);
+        }
 
         // # Toggle enable automatic replies option off and tap on back button
         await AutoResponderNotificationSettingsScreen.toggleEnableAutomaticRepliesOptionOff();

--- a/detox/e2e/test/account/custom_status.e2e.ts
+++ b/detox/e2e/test/account/custom_status.e2e.ts
@@ -20,7 +20,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
-import {getRandomId, timeouts, wait} from '@support/utils';
+import {getRandomId, isIos, timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Account - Custom Status', () => {
@@ -84,7 +84,11 @@ describe('Account - Custom Status', () => {
 
         // * Verify custom status is set on the field, shown under recent, and removed from suggestions
         await expect(CustomStatusScreen.getCustomStatusEmoji(customStatusEmojiName)).toBeVisible();
-        await expect(CustomStatusScreen.statusInput).toHaveValue(customStatusText);
+        if (isIos()) {
+            await expect(CustomStatusScreen.statusInput).toHaveValue(customStatusText);
+        } else {
+            await expect(CustomStatusScreen.statusInput).toHaveText(customStatusText);
+        }
         const {customStatusSuggestion: recentCustomStatus, customStatusClearButton: recentCustomStatusClearButton} = CustomStatusScreen.getRecentCustomStatus(customStatusEmojiName, customStatusText, customStatusDuration);
         await expect(recentCustomStatus).toBeVisible();
         const {customStatusSuggestion: suggestedCustomStatus} = CustomStatusScreen.getSuggestedCustomStatus(customStatusEmojiName, customStatusText, customStatusDuration);
@@ -123,7 +127,11 @@ describe('Account - Custom Status', () => {
 
         // * Verify custom status is set on the field and shown under recent
         await expect(CustomStatusScreen.getCustomStatusEmoji(customStatusEmojiName)).toBeVisible();
-        await expect(CustomStatusScreen.statusInput).toHaveValue(customStatusText);
+        if (isIos()) {
+            await expect(CustomStatusScreen.statusInput).toHaveValue(customStatusText);
+        } else {
+            await expect(CustomStatusScreen.statusInput).toHaveText(customStatusText);
+        }
         const {customStatusSuggestion: recentCustomStatus, customStatusClearButton: recentCustomStatusClearButton} = CustomStatusScreen.getRecentCustomStatus(customStatusEmojiName, customStatusText, customStatusDuration);
         await expect(recentCustomStatus).toBeVisible();
 
@@ -166,7 +174,11 @@ describe('Account - Custom Status', () => {
 
         // * Verify custom status is cleared from input field
         await expect(CustomStatusScreen.getCustomStatusEmoji('default')).toBeVisible();
-        await expect(CustomStatusScreen.statusInput).toHaveValue(defaultStatusText);
+        if (isIos()) {
+            await expect(CustomStatusScreen.statusInput).toHaveValue(defaultStatusText);
+        } else {
+            await expect(CustomStatusScreen.statusInput).toHaveText(defaultStatusText);
+        }
 
         // # Go back to account screen
         await CustomStatusScreen.close();

--- a/detox/e2e/test/account/edit_profile.e2e.ts
+++ b/detox/e2e/test/account/edit_profile.e2e.ts
@@ -19,7 +19,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, isIos} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Account - Edit Profile', () => {
@@ -54,13 +54,22 @@ describe('Account - Edit Profile', () => {
         await expect(EditProfileScreen.closeButton).toBeVisible();
         await expect(EditProfileScreen.saveButton).toBeVisible();
         await expect(EditProfileScreen.getEditProfilePicture(testUser.id)).toBeVisible();
-        await expect(EditProfileScreen.firstNameInput).toHaveValue(testUser.first_name);
-        await expect(EditProfileScreen.lastNameInput).toHaveValue(testUser.last_name);
-        await expect(EditProfileScreen.usernameInput).toHaveValue(testUser.username);
-        await expect(EditProfileScreen.emailInputDisabled).toHaveValue(testUser.email);
+        if (isIos()) {
+            await expect(EditProfileScreen.firstNameInput).toHaveValue(testUser.first_name);
+            await expect(EditProfileScreen.lastNameInput).toHaveValue(testUser.last_name);
+            await expect(EditProfileScreen.usernameInput).toHaveValue(testUser.username);
+            await expect(EditProfileScreen.emailInputDisabled).toHaveValue(testUser.email);
+            await expect(EditProfileScreen.nicknameInput).toHaveValue(testUser.nickname);
+            await expect(EditProfileScreen.positionInput).toHaveValue(testUser.position);
+        } else {
+            await expect(EditProfileScreen.firstNameInput).toHaveText(testUser.first_name);
+            await expect(EditProfileScreen.lastNameInput).toHaveText(testUser.last_name);
+            await expect(EditProfileScreen.usernameInput).toHaveText(testUser.username);
+            await expect(EditProfileScreen.emailInputDisabled).toHaveText(testUser.email);
+            await expect(EditProfileScreen.nicknameInput).toHaveText(testUser.nickname);
+            await expect(EditProfileScreen.positionInput).toHaveText(testUser.position);
+        }
         await expect(EditProfileScreen.emailInputDescription).toHaveText('Email must be updated using a web client or desktop application.');
-        await expect(EditProfileScreen.nicknameInput).toHaveValue(testUser.nickname);
-        await expect(EditProfileScreen.positionInput).toHaveValue(testUser.position);
 
         // # Go back to account screen
         await EditProfileScreen.close();
@@ -93,12 +102,21 @@ describe('Account - Edit Profile', () => {
         await EditProfileScreen.open();
 
         // * Verify edited profile fields contain the updated values
-        await expect(EditProfileScreen.firstNameInput).toHaveValue(`${testUser.first_name}${suffix}`);
-        await expect(EditProfileScreen.lastNameInput).toHaveValue(`${testUser.last_name}${suffix}`);
-        await expect(EditProfileScreen.usernameInput).toHaveValue(`${testUser.username}${suffix}`);
-        await expect(EditProfileScreen.emailInputDisabled).toHaveValue(testUser.email);
-        await expect(EditProfileScreen.nicknameInput).toHaveValue(`${testUser.nickname}${suffix}`);
-        await expect(EditProfileScreen.positionInput).toHaveValue(`${testUser.position}${suffix}`);
+        if (isIos()) {
+            await expect(EditProfileScreen.firstNameInput).toHaveValue(`${testUser.first_name}${suffix}`);
+            await expect(EditProfileScreen.lastNameInput).toHaveValue(`${testUser.last_name}${suffix}`);
+            await expect(EditProfileScreen.usernameInput).toHaveValue(`${testUser.username}${suffix}`);
+            await expect(EditProfileScreen.emailInputDisabled).toHaveValue(testUser.email);
+            await expect(EditProfileScreen.nicknameInput).toHaveValue(`${testUser.nickname}${suffix}`);
+            await expect(EditProfileScreen.positionInput).toHaveValue(`${testUser.position}${suffix}`);
+        } else {
+            await expect(EditProfileScreen.firstNameInput).toHaveText(`${testUser.first_name}${suffix}`);
+            await expect(EditProfileScreen.lastNameInput).toHaveText(`${testUser.last_name}${suffix}`);
+            await expect(EditProfileScreen.usernameInput).toHaveText(`${testUser.username}${suffix}`);
+            await expect(EditProfileScreen.emailInputDisabled).toHaveText(testUser.email);
+            await expect(EditProfileScreen.nicknameInput).toHaveText(`${testUser.nickname}${suffix}`);
+            await expect(EditProfileScreen.positionInput).toHaveText(`${testUser.position}${suffix}`);
+        }
 
         // # Go back to account screen
         await EditProfileScreen.close();

--- a/detox/e2e/test/account/mention_notification_settings.e2e.ts
+++ b/detox/e2e/test/account/mention_notification_settings.e2e.ts
@@ -21,7 +21,7 @@ import {
     ServerScreen,
     SettingsScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, isIos} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Account - Settings - Mention Notification Settings', () => {
@@ -78,7 +78,11 @@ describe('Account - Settings - Mention Notification Settings', () => {
         await expect(MentionNotificationSettingsScreen.caseSensitiveFirstNameOptionToggledOn).toBeVisible();
         await expect(MentionNotificationSettingsScreen.nonCaseSensitiveUsernameOptionToggledOn).toBeVisible();
         await expect(MentionNotificationSettingsScreen.channelWideMentionsOptionToggledOff).toBeVisible();
-        await expect(MentionNotificationSettingsScreen.keywordsInput).toHaveValue(keywords.replace(/ /g, '').toLowerCase());
+        if (isIos()) {
+            await expect(MentionNotificationSettingsScreen.keywordsInput).toHaveValue(keywords.replace(/ /g, '').toLowerCase());
+        } else {
+            await expect(MentionNotificationSettingsScreen.keywordsInput).toHaveText(keywords.replace(/ /g, '').toLowerCase());
+        }
 
         // # Switch toggles back to original state, clear keywords, tap on back button, and go back to mention notifications screen
         await MentionNotificationSettingsScreen.toggleCaseSensitiveFirstNameOptionOff();

--- a/detox/e2e/test/channels/create_channel_and_edit_channel_header.e2e.ts
+++ b/detox/e2e/test/channels/create_channel_and_edit_channel_header.e2e.ts
@@ -20,7 +20,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, isIos} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Channels - Create Channel and Edit Channel Header', () => {
@@ -85,7 +85,11 @@ describe('Channels - Create Channel and Edit Channel Header', () => {
         await ChannelScreen.introSetHeaderAction.tap();
 
         // * Verify channel header is correct
-        await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(header);
+        if (isIos()) {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(header);
+        } else {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveText(header);
+        }
 
         // # Edit the channel header, save, and re-open edit channel header screen
         await CreateOrEditChannelScreen.headerInput.replaceText(`${header} edit`);
@@ -93,7 +97,11 @@ describe('Channels - Create Channel and Edit Channel Header', () => {
         await CreateOrEditChannelScreen.openEditChannelHeader();
 
         // * Verify channel header has new value
-        await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(`${header} edit`);
+        if (isIos()) {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(`${header} edit`);
+        } else {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveText(`${header} edit`);
+        }
 
         // # Go back to channel list screen
         await CreateOrEditChannelScreen.close();
@@ -122,7 +130,11 @@ describe('Channels - Create Channel and Edit Channel Header', () => {
         await ChannelScreen.introSetHeaderAction.tap();
 
         // * Verify channel header is correct
-        await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(header);
+        if (isIos()) {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(header);
+        } else {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveText(header);
+        }
 
         // # Edit the channel header, save, and re-open edit channel header screen
         await CreateOrEditChannelScreen.headerInput.replaceText(`${header} edit`);
@@ -130,7 +142,11 @@ describe('Channels - Create Channel and Edit Channel Header', () => {
         await CreateOrEditChannelScreen.openEditChannelHeader();
 
         // * Verify channel header has new value
-        await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(`${header} edit`);
+        if (isIos()) {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(`${header} edit`);
+        } else {
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveText(`${header} edit`);
+        }
 
         // # Go back to channel list screen
         await CreateOrEditChannelScreen.close();

--- a/detox/e2e/test/channels/edit_channel.e2e.ts
+++ b/detox/e2e/test/channels/edit_channel.e2e.ts
@@ -26,6 +26,7 @@ import {
     LoginScreen,
     ServerScreen,
 } from '@support/ui/screen';
+import {isIos} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Channels - Edit Channel', () => {
@@ -91,9 +92,15 @@ describe('Channels - Edit Channel', () => {
         await CreateOrEditChannelScreen.openEditChannel();
 
         // * Verify current values of fields
-        await expect(CreateOrEditChannelScreen.displayNameInput).toHaveValue(testChannel.display_name);
-        await expect(CreateOrEditChannelScreen.purposeInput).toHaveValue(`Channel purpose: ${testChannel.display_name.toLowerCase()}`);
-        await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(`Channel header: ${testChannel.display_name.toLowerCase()}`);
+        if (isIos()) {
+            await expect(CreateOrEditChannelScreen.displayNameInput).toHaveValue(testChannel.display_name);
+            await expect(CreateOrEditChannelScreen.purposeInput).toHaveValue(`Channel purpose: ${testChannel.display_name.toLowerCase()}`);
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveValue(`Channel header: ${testChannel.display_name.toLowerCase()}`);
+        } else {
+            await expect(CreateOrEditChannelScreen.displayNameInput).toHaveText(testChannel.display_name);
+            await expect(CreateOrEditChannelScreen.purposeInput).toHaveText(`Channel purpose: ${testChannel.display_name.toLowerCase()}`);
+            await expect(CreateOrEditChannelScreen.headerInput).toHaveText(`Channel header: ${testChannel.display_name.toLowerCase()}`);
+        }
 
         // # Edit channel info and save changes
         await CreateOrEditChannelScreen.displayNameInput.typeText(' name');

--- a/detox/e2e/test/messaging/markdown_code.e2e.ts
+++ b/detox/e2e/test/messaging/markdown_code.e2e.ts
@@ -62,7 +62,7 @@ describe('Messaging - Markdown Code', () => {
         // * Verify markdown code block is displayed
         const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
         const {postListPostItemCodeBlock} = ChannelScreen.getPostListPostItem(post.id);
-        await ChannelScreen.getFlatPostList().scrollTo('bottom');
+        await waitFor(postListPostItemCodeBlock).toBeVisible().whileElement(by.id(ChannelScreen.postList.testID.flatList)).scroll(50, 'down');
         await expect(postListPostItemCodeBlock).toBeVisible();
 
         // # Go back to channel list screen
@@ -79,7 +79,7 @@ describe('Messaging - Markdown Code', () => {
         // * Verify markdown html is displayed
         const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
         const {postListPostItemCodeBlock} = ChannelScreen.getPostListPostItem(post.id);
-        await ChannelScreen.getFlatPostList().scrollTo('bottom');
+        await waitFor(postListPostItemCodeBlock).toBeVisible().whileElement(by.id(ChannelScreen.postList.testID.flatList)).scroll(50, 'down');
         await expect(postListPostItemCodeBlock).toBeVisible();
 
         // # Go back to channel list screen

--- a/detox/e2e/test/messaging/markdown_latex.e2e.ts
+++ b/detox/e2e/test/messaging/markdown_latex.e2e.ts
@@ -59,7 +59,7 @@ describe('Messaging - Markdown Latex', () => {
         // * Verify markdown latex code block is displayed
         const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
         const {postListPostItemLatexCodeBlock} = ChannelScreen.getPostListPostItem(post.id);
-        await ChannelScreen.getFlatPostList().scrollTo('bottom');
+        await waitFor(postListPostItemLatexCodeBlock).toBeVisible().whileElement(by.id(ChannelScreen.postList.testID.flatList)).scroll(50, 'down');
         await expect(postListPostItemLatexCodeBlock).toBeVisible();
 
         // # Go back to channel list screen

--- a/detox/e2e/test/messaging/markdown_table.e2e.ts
+++ b/detox/e2e/test/messaging/markdown_table.e2e.ts
@@ -95,7 +95,7 @@ describe('Messaging - Markdown Table', () => {
         await expect(element(by.text('Right text that wraps row'))).toBeVisible();
 
         // # Expand to full view
-        await ChannelScreen.getFlatPostList().scrollTo('bottom');
+        await waitFor(postListPostItemTableExpandButton).toBeVisible().whileElement(by.id(ChannelScreen.postList.testID.flatList)).scroll(50, 'down');
         await postListPostItemTableExpandButton.tap();
 
         // * Verify on table screen with the markdown table
@@ -133,7 +133,7 @@ describe('Messaging - Markdown Table', () => {
         await expect(element(by.text('Right HS last'))).not.toBeVisible();
 
         // # Expand to full view
-        await ChannelScreen.getFlatPostList().scrollTo('bottom');
+        await waitFor(postListPostItemTableExpandButton).toBeVisible().whileElement(by.id(ChannelScreen.postList.testID.flatList)).scroll(50, 'down');
         await postListPostItemTableExpandButton.tap();
         await TableScreen.toBeVisible();
         await expect(element(by.text('Header HS last'))).not.toBeVisible();
@@ -170,16 +170,17 @@ describe('Messaging - Markdown Table', () => {
         await expect(element(by.text('Right VS last'))).not.toBeVisible();
 
         // # Expand to full view
-        await ChannelScreen.getFlatPostList().scrollTo('bottom');
+        await waitFor(postListPostItemTableExpandButton).toBeVisible().whileElement(by.id(ChannelScreen.postList.testID.flatList)).scroll(50, 'down');
         await postListPostItemTableExpandButton.tap();
         await TableScreen.toBeVisible();
         await expect(element(by.text('Header VS last'))).toBeVisible();
         await expect(element(by.text('Right VS last'))).not.toBeVisible();
 
         // * Verify table screen is scrollable to the bottom
-        await TableScreen.tableScrollView.scrollTo('bottom');
+        const expectedElement = element(by.text('Right VS last'));
+        await waitFor(expectedElement).toBeVisible().whileElement(by.id(TableScreen.testID.tableScrollView)).scroll(50, 'down');
         await expect(element(by.text('Header VS last'))).not.toBeVisible();
-        await expect(element(by.text('Right VS last'))).toBeVisible();
+        await expect(expectedElement).toBeVisible();
 
         // # Go back to channel list screen
         await TableScreen.back();
@@ -207,7 +208,7 @@ describe('Messaging - Markdown Table', () => {
         await expect(element(by.text('Right last'))).not.toBeVisible();
 
         // # Expand to full view
-        await ChannelScreen.getFlatPostList().scrollTo('bottom');
+        await waitFor(postListPostItemTableExpandButton).toBeVisible().whileElement(by.id(ChannelScreen.postList.testID.flatList)).scroll(50, 'down');
         await postListPostItemTableExpandButton.tap();
         await TableScreen.toBeVisible();
         await expect(element(by.text('Header last'))).not.toBeVisible();
@@ -217,9 +218,10 @@ describe('Messaging - Markdown Table', () => {
         await TableScreen.tableScrollView.scrollTo('right');
         await expect(element(by.text('Header last'))).toBeVisible();
         await expect(element(by.text('Right last'))).not.toBeVisible();
-        await TableScreen.tableScrollView.scrollTo('bottom');
+        const expectedElement = element(by.text('Right last'));
+        await waitFor(expectedElement).toBeVisible().whileElement(by.id(TableScreen.testID.tableScrollView)).scroll(50, 'down');
         await expect(element(by.text('Header last'))).not.toBeVisible();
-        await expect(element(by.text('Right last'))).toBeVisible();
+        await expect(expectedElement).toBeVisible();
 
         // # Go back to channel list screen
         await TableScreen.back();

--- a/detox/e2e/test/messaging/message_draft.e2e.ts
+++ b/detox/e2e/test/messaging/message_draft.e2e.ts
@@ -24,7 +24,7 @@ import {
     ServerScreen,
     ThreadScreen,
 } from '@support/ui/screen';
-import {getRandomId} from '@support/utils';
+import {getRandomId, isIos} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Messaging - Message Draft', () => {
@@ -60,7 +60,11 @@ describe('Messaging - Message Draft', () => {
         await ChannelScreen.postInput.replaceText(message);
 
         // * Verify message exists in post draft and is not yet added to post list
-        await expect(ChannelScreen.postInput).toHaveValue(message);
+        if (isIos()) {
+            await expect(ChannelScreen.postInput).toHaveValue(message);
+        } else {
+            await expect(ChannelScreen.postInput).toHaveText(message);
+        }
         const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
         const {postListPostItem} = ChannelScreen.getPostListPostItem(post.id, message);
         await expect(postListPostItem).not.toExist();
@@ -72,7 +76,11 @@ describe('Messaging - Message Draft', () => {
         await ChannelScreen.open(channelsCategory, testChannel.name);
 
         // * Verify message draft still exists in post draft
-        await expect(ChannelScreen.postInput).toHaveValue(message);
+        if (isIos()) {
+            await expect(ChannelScreen.postInput).toHaveValue(message);
+        } else {
+            await expect(ChannelScreen.postInput).toHaveText(message);
+        }
 
         // # Clear post draft and go back to channel list screen
         await ChannelScreen.postInput.clearText();
@@ -87,14 +95,22 @@ describe('Messaging - Message Draft', () => {
         await ChannelScreen.postInput.replaceText(message);
 
         // * Verify message draft exists in post draft
-        await expect(ChannelScreen.postInput).toHaveValue(message);
+        if (isIos()) {
+            await expect(ChannelScreen.postInput).toHaveValue(message);
+        } else {
+            await expect(ChannelScreen.postInput).toHaveText(message);
+        }
 
         // # Send app to home and re-open
         await device.sendToHome();
         await device.launchApp({newInstance: false});
 
         // * Verify message draft still exists in post draft
-        await expect(ChannelScreen.postInput).toHaveValue(message);
+        if (isIos()) {
+            await expect(ChannelScreen.postInput).toHaveValue(message);
+        } else {
+            await expect(ChannelScreen.postInput).toHaveText(message);
+        }
 
         // # Clear post draft and go back to channel list screen
         await ChannelScreen.postInput.clearText();
@@ -146,7 +162,11 @@ describe('Messaging - Message Draft', () => {
         await ThreadScreen.postInput.replaceText(replyMessage);
 
         // * Verify reply message exists in post draft and is not yet added to post list
-        await expect(ThreadScreen.postInput).toHaveValue(replyMessage);
+        if (isIos()) {
+            await expect(ThreadScreen.postInput).toHaveValue(replyMessage);
+        } else {
+            await expect(ThreadScreen.postInput).toHaveText(replyMessage);
+        }
         const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
         const {postListPostItem: replyPostListPostItem} = ThreadScreen.getPostListPostItem(post.id, replyMessage);
         await expect(replyPostListPostItem).not.toExist();
@@ -156,7 +176,11 @@ describe('Messaging - Message Draft', () => {
         await parentPostListPostItem.tap();
 
         // * Verify reply message draft still exists in post draft
-        await expect(ThreadScreen.postInput).toHaveValue(replyMessage);
+        if (isIos()) {
+            await expect(ThreadScreen.postInput).toHaveValue(replyMessage);
+        } else {
+            await expect(ThreadScreen.postInput).toHaveText(replyMessage);
+        }
 
         // # Clear reply post draft and go back to channel list screen
         await ThreadScreen.postInput.clearText();

--- a/detox/e2e/test/server_login/connect_to_server.e2e.ts
+++ b/detox/e2e/test/server_login/connect_to_server.e2e.ts
@@ -17,7 +17,6 @@ import {expect} from 'detox';
 
 describe('Server Login - Connect to Server', () => {
     const {
-        connectButton,
         connectButtonDisabled,
         displayHelp,
         headerDescription,
@@ -26,6 +25,7 @@ describe('Server Login - Connect to Server', () => {
         serverDisplayNameInput,
         serverUrlInput,
         serverUrlInputError,
+        tapConnectButton,
     } = ServerScreen;
 
     beforeEach(async () => {
@@ -69,7 +69,7 @@ describe('Server Login - Connect to Server', () => {
         const invalidServerUrl = 'invalid';
         await serverUrlInput.replaceText(invalidServerUrl);
         await serverDisplayNameInput.replaceText('Server 1');
-        await connectButton.tap();
+        await tapConnectButton();
 
         // * Verify invalid url error
         await waitFor(serverUrlInputError).toExist().withTimeout(timeouts.TEN_SEC);
@@ -81,7 +81,7 @@ describe('Server Login - Connect to Server', () => {
         const connectionError = 'Cannot connect to the server.';
         await serverUrlInput.replaceText('expired.badssl.com');
         await serverDisplayNameInput.replaceText('Server 1');
-        await connectButton.tap();
+        await tapConnectButton();
 
         // * Verify connection error
         await waitFor(serverUrlInputError).toExist().withTimeout(timeouts.TEN_SEC);
@@ -91,7 +91,7 @@ describe('Server Login - Connect to Server', () => {
         await device.reloadReactNative();
         await serverUrlInput.replaceText('wrong.host.badssl.com');
         await serverDisplayNameInput.replaceText('Server 1');
-        await connectButton.tap();
+        await tapConnectButton();
 
         // * Verify connection error
         await waitFor(serverUrlInputError).toExist().withTimeout(timeouts.TEN_SEC);
@@ -102,7 +102,7 @@ describe('Server Login - Connect to Server', () => {
         // # Connect to server with valid server url and non-empty server display name
         await serverUrlInput.replaceText(serverOneUrl);
         await serverDisplayNameInput.replaceText('Server 1');
-        await connectButton.tap();
+        await tapConnectButton();
 
         // * Verify on login screen
         await LoginScreen.toBeVisible();

--- a/detox/e2e/test/server_login/server_list.e2e.ts
+++ b/detox/e2e/test/server_login/server_list.e2e.ts
@@ -258,7 +258,7 @@ describe('Server Login - Server List', () => {
         await expect(ServerScreen.headerTitleAddServer).toBeVisible();
         await ServerScreen.serverUrlInput.replaceText(serverTwoUrl);
         await ServerScreen.serverDisplayNameInput.replaceText(serverTwoDisplayName);
-        await ServerScreen.connectButton.tap();
+        await ServerScreen.tapConnectButton();
 
         // * Verify same name server error
         const sameNameServerError = 'You are using this name for another server.';
@@ -267,7 +267,7 @@ describe('Server Login - Server List', () => {
         // # Attempt to add a server already logged in and with active session, with the same server display name
         await ServerScreen.serverUrlInput.replaceText(serverOneUrl);
         await ServerScreen.serverDisplayNameInput.replaceText(serverOneDisplayName);
-        await ServerScreen.connectButton.tap();
+        await ServerScreen.tapConnectButton();
 
         // * Verify same name server error
         await expect(ServerScreen.serverDisplayNameInputError).toHaveText(sameNameServerError);

--- a/detox/e2e/test/setup.ts
+++ b/detox/e2e/test/setup.ts
@@ -21,4 +21,5 @@ beforeAll(async () => {
             photos: 'YES',
         },
     });
+    await device.reloadReactNative();
 });

--- a/detox/e2e/test/smoke_test/account.e2e.ts
+++ b/detox/e2e/test/smoke_test/account.e2e.ts
@@ -29,7 +29,7 @@ import {
     SettingsScreen,
     ThemeDisplaySettingsScreen,
 } from '@support/ui/screen';
-import {getRandomId, timeouts, wait} from '@support/utils';
+import {getRandomId, isIos, timeouts, wait} from '@support/utils';
 import {expect} from 'detox';
 
 describe('Smoke Test - Account', () => {
@@ -140,7 +140,11 @@ describe('Smoke Test - Account', () => {
         await MentionNotificationSettingsScreen.open();
 
         // * Verify keywords are saved
-        await expect(MentionNotificationSettingsScreen.keywordsInput).toHaveValue(keywords.toLowerCase());
+        if (isIos()) {
+            await expect(MentionNotificationSettingsScreen.keywordsInput).toHaveValue(keywords.toLowerCase());
+        } else {
+            await expect(MentionNotificationSettingsScreen.keywordsInput).toHaveText(keywords.toLowerCase());
+        }
 
         // # Go back to notification settings screen, open push notification settings screen, tap on mentions only option, tap on mobile away option, tap on back button, and go back to notification settings screen
         await MentionNotificationSettingsScreen.back();


### PR DESCRIPTION
#### Summary
- Added keyboard dismissal on server screen for android before tapping on connect button
- Used `toHaveText` for android text input verification (as opposed to `toHaveValue` in iOS)
- Changed `scrollTo('bottom')` to instead wait for element to be visible while scrolling down

#### Ticket Link
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```