### PR TITLE
[MM-48010] Threads since value change

### DIFF
--- a/app/actions/remote/thread.ts
+++ b/app/actions/remote/thread.ts
@@ -360,7 +360,7 @@ export const syncTeamThreads = async (serverUrl: string, teamId: string, prepare
             const allNewThreads = await fetchThreads(
                 serverUrl,
                 teamId,
-                {deleted: true, since: syncData.latest},
+                {deleted: true, since: syncData.latest + 1},
             );
             if (allNewThreads.error) {
                 return {error: allNewThreads.error};

--- a/app/screens/global_threads/threads_list/index.ts
+++ b/app/screens/global_threads/threads_list/index.ts
@@ -30,7 +30,7 @@ const enhanced = withObservables(['tab', 'teamId', 'forceQueryAfterAppState'], (
     const teamThreadsSyncObserver = queryTeamThreadsSync(database, teamId).observeWithColumns(['earliest']);
 
     return {
-        unreadsCount: queryThreadsInTeam(database, teamId, true).observeCount(false),
+        unreadsCount: queryThreadsInTeam(database, teamId, true, true, true).observeCount(false),
         teammateNameDisplay: observeTeammateNameDisplay(database),
         threads: teamThreadsSyncObserver.pipe(
             switchMap((teamThreadsSync) => {


### PR DESCRIPTION
#### Summary
Since was using `last_reply_at` to sync the latest threads. Now that we have a fix on the server side in which queries with `Greater than or equal`, we will add `+1` to the value to prevent loading the same threads again.

This PR also fixes phantom unread dot.

https://github.com/mattermost/mattermost-server/pull/22228

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48010

#### Device Information
This PR was tested on: iOS 16

#### Release Note
```release-note
NONE
```
