### PR TITLE
MM-48605: Calls - Fix for start time in join call banner is incorrect

### DIFF
--- a/app/products/calls/actions/calls.test.ts
+++ b/app/products/calls/actions/calls.test.ts
@@ -97,7 +97,7 @@ const addFakeCall = (serverUrl: string, channelId: string) => {
         hostId: 'xohi8cki9787fgiryne716u84o',
     } as Call;
     act(() => {
-        State.setCallsState(serverUrl, {serverUrl, myUserId: 'myUserId', calls: {}, enabled: {}});
+        State.setCallsState(serverUrl, {myUserId: 'myUserId', calls: {}, enabled: {}});
         State.callStarted(serverUrl, call);
     });
 };
@@ -277,7 +277,6 @@ describe('Actions.Calls', () => {
 
     it('loadCalls fails from server', async () => {
         const expectedCallsState: CallsState = {
-            serverUrl: 'server1',
             myUserId: 'userId1',
             calls: {},
             enabled: {},

--- a/app/products/calls/components/join_call_banner/index.ts
+++ b/app/products/calls/components/join_call_banner/index.ts
@@ -3,6 +3,7 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
+import moment from 'moment-timezone';
 import {of as of$} from 'rxjs';
 import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
@@ -24,16 +25,19 @@ const enhanced = withObservables(['serverUrl', 'channelId'], ({
     channelId,
     database,
 }: OwnProps & WithDatabaseArgs) => {
-    const callsState = observeCallsState(serverUrl);
-    const participants = callsState.pipe(
+    const callsState = observeCallsState(serverUrl).pipe(
         switchMap((state) => of$(state.calls[channelId])),
+    );
+    const participants = callsState.pipe(
         distinctUntilChanged((prev, curr) => prev?.participants === curr?.participants), // Did the participants object ref change?
         switchMap((call) => (call ? of$(Object.keys(call.participants)) : of$([]))),
         distinctUntilChanged((prev, curr) => idsAreEqual(prev, curr)), // Continue only if we have a different set of participant ids
         switchMap((ids) => (ids.length > 0 ? queryUsersById(database, ids).observeWithColumns(['last_picture_update']) : of$([]))),
     );
     const channelCallStartTime = callsState.pipe(
-        switchMap((cs) => of$(cs.calls[channelId]?.startTime || 0)),
+
+        // if for some reason we don't have a startTime, use 'a few seconds ago' instead of '53 years ago'
+        switchMap((state) => of$(state && state.startTime ? state.startTime : moment.now())),
         distinctUntilChanged(),
     );
 

--- a/app/products/calls/state/actions.test.ts
+++ b/app/products/calls/state/actions.test.ts
@@ -152,7 +152,6 @@ describe('useCallsState', () => {
 
         const expectedCallsState = {
             ...initialCallsState,
-            serverUrl: 'server1',
             myUserId: 'myId',
             calls: {'channel-1': testNewCall1, 'channel-2': call2, 'channel-3': call3},
             enabled: {'channel-2': true},
@@ -758,7 +757,6 @@ describe('useCallsState', () => {
     it('voiceOn and Off', () => {
         const initialCallsState = {
             ...DefaultCallsState,
-            serverUrl: 'server1',
             myUserId: 'myUserId',
             calls: {'channel-1': call1, 'channel-2': call2},
         };

--- a/app/products/calls/state/actions.ts
+++ b/app/products/calls/state/actions.ts
@@ -35,7 +35,7 @@ export const setCalls = (serverUrl: string, myUserId: string, calls: Dictionary<
         }, {} as ChannelsWithCalls);
     setChannelsWithCalls(serverUrl, channelsWithCalls);
 
-    setCallsState(serverUrl, {serverUrl, myUserId, calls, enabled});
+    setCallsState(serverUrl, {myUserId, calls, enabled});
 
     // Does the current call need to be updated?
     const currentCall = getCurrentCall();

--- a/app/products/calls/types/calls.ts
+++ b/app/products/calls/types/calls.ts
@@ -13,14 +13,12 @@ export const DefaultGlobalCallsState: GlobalCallsState = {
 };
 
 export type CallsState = {
-    serverUrl: string;
     myUserId: string;
     calls: Dictionary<Call>;
     enabled: Dictionary<boolean>;
 }
 
 export const DefaultCallsState: CallsState = {
-    serverUrl: '',
     myUserId: '',
     calls: {},
     enabled: {},


### PR DESCRIPTION
#### Summary
- This is a weird one. The problem: the join call banner startTime appears to be unset, and so defaults to `0`, creating a `53 years ago` message.
- I traced the code paths that update the call state's `startTime` and I can't see how it would be `0` or `undefined` and yet the participants are populated (as can be seen in the screenshot in the ticket). So either:
  1. there's a problem on the server and it didn't send the `start_at` field in the `call_start` ws event (unlikely, given how straightforward that code is), or 
  2. there's a problem where the CallState observer, or `BehaviorSubject` is failing to update (those are RxJS internals, which I don't fully understand), or 
  3. there's a problem with how I was piping the calls state, and the second pipe (the one that produced `channelCallStartTime`) didn't get the right data passed in?

So, I tried to simplify the piping. And, if this rare event does happen, I'm proposing we use a "reasonable default" of `now` for the start time. I realize it's an unsatisfactory non-fix. But at least it won't result in a crazy "53 years ago" message.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-48605

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: Fixed a rare case where the Join Call banner showed that a call started "53 years ago"
```

