### PR TITLE
Fix iOS programmatically orientation crash on OS below 16

### DIFF
--- a/ios/Mattermost/Modules/SplitViewModule.swift
+++ b/ios/Mattermost/Modules/SplitViewModule.swift
@@ -59,7 +59,7 @@ class SplitViewModule: RCTEventEmitter {
     DispatchQueue.main.async {
       let appDelegate = UIApplication.shared.delegate as! AppDelegate
       appDelegate.allowRotation = true
-      UIDevice.current.setValue(UIInterfaceOrientation.unknown, forKey: "orientation")
+      UIDevice.current.setValue(UIInterfaceOrientation.unknown.rawValue, forKey: "orientation")
     }
   }
   
@@ -68,8 +68,8 @@ class SplitViewModule: RCTEventEmitter {
     DispatchQueue.main.async {
       let appDelegate = UIApplication.shared.delegate as! AppDelegate
       appDelegate.allowRotation = false
-      UIDevice.current.setValue(UIInterfaceOrientation.unknown, forKey: "orientation")
-      UIDevice.current.setValue(UIInterfaceOrientation.portrait, forKey: "orientation")
+      UIDevice.current.setValue(UIInterfaceOrientation.unknown.rawValue, forKey: "orientation")
+      UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
     }
   }
 }


### PR DESCRIPTION
#### Summary
Fixes a crash on iOS lower than 16 when opening any item in the gallery was attempting to set the allowed orientations of the device.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50457
Fixes: #7106 

#### Device Information
This PR was tested on: iPhone 7 iOS 15.5

#### Release Note
```release-note
Fixed a crash on iOS lower than 16.x when opening an item in the gallery
```