### PR TITLE
Remove posts in thread only when removing root posts

### DIFF
--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -18,12 +18,26 @@ const {SERVER: {POST, POSTS_IN_CHANNEL, POSTS_IN_THREAD}} = MM_TABLES;
 
 export const prepareDeletePost = async (post: PostModel): Promise<Model[]> => {
     const preparedModels: Model[] = [post.prepareDestroyPermanently()];
-    const relations: Array<Query<Model>> = [post.drafts, post.postsInThread, post.files, post.reactions];
+    const relations: Array<Query<Model>> = [post.drafts, post.files, post.reactions];
     for await (const models of relations) {
         try {
             models.forEach((m) => {
                 preparedModels.push(m.prepareDestroyPermanently());
             });
+        } catch {
+            // Record not found, do nothing
+        }
+    }
+
+    // If the post is a root post, delete the postsInThread model
+    if (!post.rootId) {
+        try {
+            const postsInThread = await post.postsInThread.fetch();
+            if (postsInThread) {
+                postsInThread.forEach((m) => {
+                    preparedModels.push(m.prepareDestroyPermanently());
+                });
+            }
         } catch {
             // Record not found, do nothing
         }


### PR DESCRIPTION
#### Summary
When deleting a post, we were always deleting the `postsInThread` model. This caused the thread view to show no posts when we delete one.

This PR only delete the `postsInThread` model on root posts.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-50492

#### Release Note
```release-note
Fix missing posts in a thread when a post get deleted
```
