### PR TITLE
Fix open channel of existing DM

### DIFF
--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -17,6 +17,7 @@ import {observeCurrentChannelId, getCurrentChannelId, observeCurrentUserId} from
 import {observeTeammateNameDisplay} from './user';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
+import type {Clause} from '@nozbe/watermelondb/QueryDescription';
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type ChannelInfoModel from '@typings/database/models/servers/channel_info';
 import type ChannelMembershipModel from '@typings/database/models/servers/channel_membership';
@@ -225,7 +226,12 @@ export const observeChannel = (database: Database, channelId: string) => {
 };
 
 export const getChannelByName = async (database: Database, teamId: string, channelName: string) => {
-    const channels = await database.get<ChannelModel>(CHANNEL).query(Q.on(TEAM, 'id', teamId), Q.where('name', channelName)).fetch();
+    const clauses: Clause[] = [];
+    if (teamId) {
+        clauses.push(Q.on(TEAM, 'id', teamId));
+    }
+    clauses.push(Q.where('name', channelName));
+    const channels = await database.get<ChannelModel>(CHANNEL).query(...clauses).fetch();
 
     // Check done to force types
     if (channels.length) {


### PR DESCRIPTION
#### Summary
The query to get a channel by name was forcing a match with a teamId, thus DMs and GM's that were using the query were never found.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50484

#### Release Note
```release-note
Fixed open a DM with a user by tapping "Send Message" in their user profile bottom sheet
```
