### PR TITLE
Android refactor push notifications to store data or send to JS for processing

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/PushNotificationDataHelper.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/PushNotificationDataHelper.kt
@@ -2,8 +2,8 @@ package com.mattermost.helpers
 
 import android.content.Context
 import android.os.Bundle
-import android.text.TextUtils
 import android.util.Log
+import com.facebook.react.bridge.Arguments
 
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -17,13 +17,16 @@ import kotlinx.coroutines.sync.withLock
 
 class PushNotificationDataHelper(private val context: Context) {
     private var coroutineScope = CoroutineScope(Dispatchers.Default)
-    fun fetchAndStoreDataForPushNotification(initialData: Bundle) {
+    fun fetchAndStoreDataForPushNotification(initialData: Bundle, isReactInit: Boolean): Bundle? {
+        var result: Bundle? = null
         val job = coroutineScope.launch(Dispatchers.Default) {
-            PushNotificationDataRunnable.start(context, initialData)
+            result = PushNotificationDataRunnable.start(context, initialData, isReactInit)
         }
         runBlocking {
             job.join()
         }
+
+        return result
     }
 }
 
@@ -33,83 +36,73 @@ class PushNotificationDataRunnable {
         private val dbHelper = DatabaseHelper.instance!!
         private val mutex = Mutex()
 
-        suspend fun start(context: Context, initialData: Bundle) {
+        suspend fun start(context: Context, initialData: Bundle, isReactInit: Boolean): Bundle? {
             // for more info see: https://blog.danlew.net/2020/01/28/coroutines-and-java-synchronization-dont-mix/
             mutex.withLock {
-                val serverUrl: String = initialData.getString("server_url") ?: return
+                val serverUrl: String = initialData.getString("server_url") ?: return null
                 val db = dbHelper.getDatabaseForServer(context, serverUrl)
+                var result: Bundle? = null
 
                 try {
-                    val teamId = initialData.getString("team_id")
-                    val channelId = initialData.getString("channel_id")
-                    val rootId = initialData.getString("root_id")
-                    val isCRTEnabled = initialData.getString("is_crt_enabled") == "true"
-                    Log.i("ReactNative", "Start fetching notification data in server=$serverUrl for channel=$channelId")
-
                     if (db != null) {
-                        var teamData: ReadableMap? = null
-                        var myTeamData: ReadableMap? = null
-                        var channelData: ReadableMap? = null
-                        var myChannelData: ReadableMap? = null
-                        var loadedProfiles: ReadableArray? = null
-                        var postData: ReadableMap?
-                        var posts: ReadableMap? = null
-                        var userIdsToLoad: ReadableArray? = null
-                        var usernamesToLoad: ReadableArray? = null
+                        val teamId = initialData.getString("team_id")
+                        val channelId = initialData.getString("channel_id")
+                        val postId = initialData.getString("post_id")
+                        val rootId = initialData.getString("root_id")
+                        val isCRTEnabled = initialData.getString("is_crt_enabled") == "true"
 
-                        var threads: ReadableArray? = null
-                        var usersFromThreads: ReadableArray? = null
+                        Log.i("ReactNative", "Start fetching notification data in server=$serverUrl for channel=$channelId")
+
                         val receivingThreads = isCRTEnabled && !rootId.isNullOrEmpty()
+                        val writableMap = Arguments.createMap()
 
-                        coroutineScope {
-                            if (teamId != null && !TextUtils.isEmpty(teamId)) {
-                                val res = fetchTeamIfNeeded(db, serverUrl, teamId)
-                                teamData = res.first
-                                myTeamData = res.second
-                            }
-
-                            if (channelId != null) {
-                                val channelRes = fetchMyChannel(db, serverUrl, channelId, isCRTEnabled)
-                                channelData = channelRes.first
-                                myChannelData = channelRes.second
-                                loadedProfiles = channelRes.third
-
-                                postData = fetchPosts(db, serverUrl, channelId, isCRTEnabled, rootId, loadedProfiles)
-
-                                posts = postData?.getMap("posts")
-                                userIdsToLoad = postData?.getArray("userIdsToLoad")
-                                usernamesToLoad = postData?.getArray("usernamesToLoad")
-                                threads = postData?.getArray("threads")
-                                usersFromThreads = postData?.getArray("usersFromThreads")
-
-                                if (userIdsToLoad != null && userIdsToLoad!!.size() > 0) {
-                                    val users = fetchUsersById(serverUrl, userIdsToLoad!!)
-                                    userIdsToLoad = users?.getArray("data")
-                                }
-
-                                if (usernamesToLoad != null && usernamesToLoad!!.size() > 0) {
-                                    val users = fetchUsersByUsernames(serverUrl, usernamesToLoad!!)
-                                    usernamesToLoad = users?.getArray("data")
-                                }
-                            }
+                        if (!teamId.isNullOrEmpty()) {
+                            val res = fetchTeamIfNeeded(db, serverUrl, teamId)
+                            res.first?.let { writableMap.putMap("team", it) }
+                            res.second?.let { writableMap.putMap("myTeam", it) }
                         }
 
-                        db.transaction {
-                            teamData?.let { insertTeam(db, it) }
-                            myTeamData?.let { insertMyTeam(db, it) }
-                            channelData?.let { handleChannel(db, it) }
-                            myChannelData?.let { handleMyChannel(db, it) }
+                        if (channelId != null && postId != null) {
+                            val channelRes = fetchMyChannel(db, serverUrl, channelId, isCRTEnabled)
+                            channelRes.first?.let { writableMap.putMap("channel", it) }
+                            channelRes.second?.let { writableMap.putMap("myChannel", it) }
+                            val loadedProfiles = channelRes.third
 
-                            if (channelId != null) {
-                                dbHelper.handlePosts(db, posts?.getMap("data"), channelId, receivingThreads)
+                            // Fetch categories if needed
+                            if (!teamId.isNullOrEmpty() && writableMap.getMap("myTeam") != null) {
+                                // should load all categories
+                                val res = fetchMyTeamCategories(db, serverUrl, teamId)
+                                res?.let { writableMap.putMap("categories", it) }
+                            } else if (writableMap.getMap("channel") != null) {
+                                // check if the channel is in the category for the team
+                                val res = addToDefaultCategoryIfNeeded(db, writableMap.getMap("channel")!!)
+                                res?.let { writableMap.putArray("categoryChannels", it) }
                             }
 
-                            threads?.let { handleThreads(db, it) }
+                            val postData = fetchPosts(db, serverUrl, channelId, isCRTEnabled, rootId, loadedProfiles)
+                            postData?.getMap("posts")?.let { writableMap.putMap("posts", it) }
 
-                            loadedProfiles?.let { handleUsers(db, it) }
-                            userIdsToLoad?.let { handleUsers(db, it) }
-                            usernamesToLoad?.let { handleUsers(db, it) }
-                            usersFromThreads?.let { handleUsers(db, it) }
+                            var notificationThread: ReadableMap? = null
+                            if (isCRTEnabled && !rootId.isNullOrEmpty()) {
+                                notificationThread = fetchThread(db, serverUrl, rootId, teamId)
+                            }
+
+                            getThreadList(notificationThread, postData?.getArray("threads"))?.let {
+                                val threadsArray = Arguments.createArray()
+                                for(item in it) {
+                                    threadsArray.pushMap(item)
+                                }
+                                writableMap.putArray("threads", threadsArray)
+                            }
+
+                            val userList = fetchNeededUsers(serverUrl, loadedProfiles, postData)
+                            writableMap.putArray("users", ReadableArrayUtils.toWritableArray(userList.toArray()))
+                        }
+
+                        result = Arguments.toBundle(writableMap)
+
+                        if (!isReactInit) {
+                            dbHelper.saveToDatabase(db, writableMap, teamId, channelId, receivingThreads)
                         }
 
                         Log.i("ReactNative", "Done processing push notification=$serverUrl for channel=$channelId")
@@ -120,7 +113,42 @@ class PushNotificationDataRunnable {
                     db?.close()
                     Log.i("ReactNative", "DONE fetching notification data")
                 }
+
+                return result
             }
+        }
+
+        private fun getThreadList(notificationThread: ReadableMap?, threads: ReadableArray?): ArrayList<ReadableMap>? {
+            threads?.let {
+                val threadsArray = ArrayList<ReadableMap>()
+                val threadIds = ArrayList<String>()
+                notificationThread?.let { thread ->
+                    thread.getString("id")?.let { it1 -> threadIds.add(it1) }
+                    threadsArray.add(thread)
+                }
+                for(i in 0 until it.size()) {
+                    val thread = it.getMap(i)
+                    val threadId = thread.getString("id")
+                    if (threadId != null) {
+                        if (threadIds.contains(threadId)) {
+                         // replace the values for participants and is_following
+                            val index = threadsArray.indexOfFirst { el -> el.getString("id") == threadId }
+                            val prev = threadsArray[index]
+                            val merge = Arguments.createMap()
+                            merge.merge(prev)
+                            merge.putBoolean("is_following", thread.getBoolean("is_following"))
+                            merge.putArray("participants", thread.getArray("participants"))
+                            threadsArray[index] = merge
+                        } else {
+                            threadsArray.add(thread)
+                            threadIds.add(threadId)
+                        }
+                    }
+                }
+                return threadsArray
+            }
+
+            return null
         }
     }
 }

--- a/android/app/src/main/java/com/mattermost/helpers/ReadableArrayUtils.java
+++ b/android/app/src/main/java/com/mattermost/helpers/ReadableArrayUtils.java
@@ -2,6 +2,7 @@ package com.mattermost.helpers;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableArray;
 
@@ -109,7 +110,9 @@ public class ReadableArrayUtils {
                 writableArray.pushString((String) value);
             } else if (value instanceof Map) {
                 writableArray.pushMap(ReadableMapUtils.toWritableMap((Map<String, Object>) value));
-            } else if (value.getClass().isArray()) {
+            } else if (value instanceof ReadableMap) {
+                writableArray.pushMap((ReadableMap) value);
+            }else if (value.getClass().isArray()) {
                 writableArray.pushArray(ReadableArrayUtils.toWritableArray((Object[]) value));
             }
         }

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Category.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Category.kt
@@ -1,0 +1,87 @@
+package com.mattermost.helpers.database_extension
+
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.nozbe.watermelondb.Database
+
+fun insertCategory(db: Database, category: ReadableMap) {
+    try {
+        val id = category.getString("id") ?: return
+        val collapsed = false
+        val displayName = category.getString("display_name")
+        val muted = category.getBoolean("muted")
+        val sortOrder = category.getInt("sort_order")
+        val sorting = category.getString("sorting") ?: "recent"
+        val teamId = category.getString("team_id")
+        val type = category.getString("type")
+
+        db.execute(
+                """
+                INSERT INTO Category
+                (id, collapsed, display_name, muted, sort_order, sorting, team_id, type, _changed, _status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', 'created')
+                """.trimIndent(),
+                arrayOf(
+                        id, collapsed, displayName, muted,
+                        sortOrder / 10, sorting, teamId, type
+                )
+        )
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}
+
+fun insertCategoryChannels(db: Database, categoryId: String, teamId: String, channelIds: ReadableArray) {
+    try {
+        for (i in 0 until channelIds.size()) {
+            val channelId = channelIds.getString(i)
+            val id = "${teamId}_$channelId"
+            db.execute(
+                    """
+                    INSERT INTO CategoryChannel
+                    (id, category_id, channel_id, sort_order, _changed, _status)
+                    VALUES (?, ?, ?, ?, '', 'created')
+                    """.trimIndent(),
+                    arrayOf(id, categoryId, channelId, i)
+            )
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}
+
+fun insertCategoriesWithChannels(db: Database, orderCategories: ReadableMap) {
+    val categories = orderCategories.getArray("categories") ?: return
+    for (i in 0 until categories.size()) {
+        val category = categories.getMap(i)
+        val id = category.getString("id")
+        val teamId = category.getString("team_id")
+        val channelIds = category.getArray("channel_ids")
+        insertCategory(db, category)
+        if (id != null && teamId != null) {
+            channelIds?.let { insertCategoryChannels(db, id, teamId, it) }
+        }
+    }
+}
+
+fun insertChannelToDefaultCategory(db: Database, categoryChannels: ReadableArray) {
+    try {
+        for (i in 0 until categoryChannels.size()) {
+            val cc = categoryChannels.getMap(i)
+            val id = cc.getString("id")
+            val categoryId = cc.getString("category_id")
+            val channelId = cc.getString("channel_id")
+            val count = countByColumn(db, "CategoryChannel", "category_id", categoryId)
+            db.execute(
+                    """
+                        INSERT INTO CategoryChannel
+                        (id, category_id, channel_id, sort_order, _changed, _status)
+                        VALUES (?, ?, ?, ?, '', 'created')
+                    """.trimIndent(),
+                    arrayOf(id, categoryId, channelId, if (count > 0) count + 1 else count)
+            )
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/CustomEmoji.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/CustomEmoji.kt
@@ -9,7 +9,7 @@ internal fun insertCustomEmojis(db: Database, customEmojis: JSONArray) {
             val emoji = customEmojis.getJSONObject(i)
             if (find(db, "CustomEmoji", emoji.getString("id")) == null) {
                 db.execute(
-                        "INSERT INTO CustomEmoji (id, name, _status) VALUES (?, ?, 'created')",
+                        "INSERT INTO CustomEmoji (id, name, _changed, _status) VALUES (?, ?, '', 'created')",
                         arrayOf(
                                 emoji.getString("id"),
                                 emoji.getString("name"),

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/File.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/File.kt
@@ -20,8 +20,8 @@ internal fun insertFiles(db: Database, files: JSONArray) {
             db.execute(
                     """
                     INSERT INTO File 
-                    (id, extension, height, image_thumbnail, local_path, mime_type, name, post_id, size, width, _status) 
-                    VALUES (?, ?, ?, ?, '', ?, ?, ?, ?, ?, 'created')
+                    (id, extension, height, image_thumbnail, local_path, mime_type, name, post_id, size, width, _changed, _status) 
+                    VALUES (?, ?, ?, ?, '', ?, ?, ?, ?, ?, '', 'created')
                     """.trimIndent(),
                     arrayOf(
                             id, extension, height, miniPreview,

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/PostsInChannel.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/PostsInChannel.kt
@@ -24,8 +24,8 @@ internal fun insertPostInChannel(db: Database, channelId: String, earliest: Doub
         db.execute(
                 """
                 INSERT INTO PostsInChannel 
-                (id, channel_id, earliest, latest, _status) 
-                VALUES (?, ?, ?, ?, 'created')
+                (id, channel_id, earliest, latest, _changed, _status) 
+                VALUES (?, ?, ?, ?, '', 'created')
                 """.trimIndent(),
                 arrayOf(id, channelId, earliest, latest))
 

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Reaction.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Reaction.kt
@@ -12,8 +12,8 @@ internal fun insertReactions(db: Database, reactions: JSONArray) {
             db.execute(
                     """
                     INSERT INTO Reaction 
-                    (id, create_at, emoji_name, post_id, user_id, _status) 
-                    VALUES (?, ?, ?, ?, ?, 'created')
+                    (id, create_at, emoji_name, post_id, user_id, _changed, _status) 
+                    VALUES (?, ?, ?, ?, ?, '', 'created')
                     """.trimIndent(),
                     arrayOf(
                             id,

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/System.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/System.kt
@@ -4,8 +4,13 @@ import com.nozbe.watermelondb.Database
 import org.json.JSONObject
 
 fun queryCurrentUserId(db: Database): String? {
-    val result = find(db, "System", "currentUserId")!!
-    return result.getString("value")
+    val result = find(db, "System", "currentUserId")
+    return result?.getString("value")?.removeSurrounding("\"")
+}
+
+fun queryCurrentTeamId(db: Database): String? {
+    val result = find(db, "System", "currentTeamId")
+    return result?.getString("value")?.removeSurrounding("\"")
 }
 
 fun queryConfigDisplayNameSetting(db: Database): String? {

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/User.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/User.kt
@@ -11,7 +11,7 @@ fun getLastPictureUpdate(db: Database?, userId: String): Double? {
         if (db != null) {
             var id = userId
             if (userId == "me") {
-                (queryCurrentUserId(db)?.removeSurrounding("\"") ?: userId).also { id = it }
+                (queryCurrentUserId(db) ?: userId).also { id = it }
             }
             val userQuery = "SELECT last_picture_update FROM User WHERE id=?"
             db.rawQuery(userQuery, arrayOf(id)).use { cursor ->
@@ -30,7 +30,7 @@ fun getLastPictureUpdate(db: Database?, userId: String): Double? {
 
 fun getCurrentUserLocale(db: Database): String {
     try {
-        val currentUserId = queryCurrentUserId(db)?.removeSurrounding("\"") ?: return "en"
+        val currentUserId = queryCurrentUserId(db) ?: return "en"
         val userQuery = "SELECT locale FROM User WHERE id=?"
         db.rawQuery(userQuery, arrayOf(currentUserId)).use { cursor ->
             if (cursor.count == 1) {
@@ -62,8 +62,8 @@ fun handleUsers(db: Database, users: ReadableArray) {
                     """
                     INSERT INTO User (id, auth_service, update_at, delete_at, email, first_name, is_bot, is_guest,
                     last_name, last_picture_update, locale, nickname, position, roles, status, username, notify_props, 
-                    props, timezone, _status) 
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'created')
+                    props, timezone, _changed, _status) 
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', 'created')
                     """.trimIndent(),
                     arrayOf(
                             user.getString("id"),

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Category.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Category.kt
@@ -1,0 +1,70 @@
+package com.mattermost.helpers.push_notification
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.mattermost.helpers.PushNotificationDataRunnable
+import com.mattermost.helpers.database_extension.findByColumns
+import com.mattermost.helpers.database_extension.queryCurrentUserId
+import com.mattermost.helpers.database_extension.queryMyTeams
+import com.nozbe.watermelondb.Database
+
+suspend fun PushNotificationDataRunnable.Companion.fetchMyTeamCategories(db: Database, serverUrl: String, teamId: String): ReadableMap? {
+    return try {
+        val userId = queryCurrentUserId(db)
+        val categories = fetch(serverUrl, "/api/v4/users/$userId/teams/$teamId/channels/categories")
+        categories?.getMap("data")
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}
+
+fun PushNotificationDataRunnable.Companion.addToDefaultCategoryIfNeeded(db: Database, channel: ReadableMap): ReadableArray? {
+    val channelId = channel.getString("id") ?: return null
+    val channelType = channel.getString("type")
+    val categoryChannels = Arguments.createArray()
+    if (channelType == "D" || channelType == "G") {
+        val myTeams = queryMyTeams(db)
+        myTeams?.let {
+            for (myTeam in it) {
+                val map = categoryChannelForTeam(db, channelId, myTeam.getString("id"), "direct_messages")
+                if (map != null) {
+                    categoryChannels.pushMap(map)
+                }
+            }
+        }
+    } else {
+        val map = categoryChannelForTeam(db, channelId, channel.getString("team_id"), "channels")
+        if (map != null) {
+            categoryChannels.pushMap(map)
+        }
+    }
+
+    return categoryChannels
+}
+
+private fun categoryChannelForTeam(db: Database, channelId: String, teamId: String?, type: String): ReadableMap? {
+    teamId?.let { id ->
+        val category = findByColumns(db, "Category", arrayOf("type", "team_id"), arrayOf(type, id))
+        val categoryId = category?.getString("id")
+        categoryId?.let { cId ->
+            val cc = findByColumns(
+                    db,
+                    "CategoryChannel",
+                    arrayOf("category_id", "channel_id"),
+                    arrayOf(cId, channelId)
+            )
+            if (cc == null) {
+                val map = Arguments.createMap()
+                map.putString("channel_id", channelId)
+                map.putString("category_id", cId)
+                map.putString("id", "${id}_$channelId")
+                return map
+            }
+        }
+    }
+
+    return null
+}
+

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Post.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Post.kt
@@ -1,6 +1,7 @@
 package com.mattermost.helpers.push_notification
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.NoSuchKeyException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
@@ -10,144 +11,172 @@ import com.mattermost.helpers.ReadableMapUtils
 import com.mattermost.helpers.database_extension.*
 import com.nozbe.watermelondb.Database
 
-internal suspend fun PushNotificationDataRunnable.Companion.fetchPosts(db: Database, serverUrl: String, channelId: String, isCRTEnabled: Boolean, rootId: String?, loadedProfiles: ReadableArray?): ReadableMap? {
-    val regex = Regex("""\B@(([a-z\d-._]*[a-z\d_])[.-]*)""", setOf(RegexOption.IGNORE_CASE))
-    val since = queryPostSinceForChannel(db, channelId)
-    val currentUserId = queryCurrentUserId(db)?.removeSurrounding("\"")
-    val currentUser = find(db, "User", currentUserId)
-    val currentUsername = currentUser?.getString("username")
+internal suspend fun PushNotificationDataRunnable.Companion.fetchPosts(
+        db: Database, serverUrl: String, channelId: String, isCRTEnabled: Boolean,
+        rootId: String?, loadedProfiles: ReadableArray?
+): ReadableMap? {
+    return try {
+        val regex = Regex("""\B@(([a-z\d-._]*[a-z\d_])[.-]*)""", setOf(RegexOption.IGNORE_CASE))
+        val currentUserId = queryCurrentUserId(db)
+        val currentUser = find(db, "User", currentUserId)
+        val currentUsername = currentUser?.getString("username")
 
-    var additionalParams = ""
-    if (isCRTEnabled) {
-        additionalParams = "&collapsedThreads=true&collapsedThreadsExtended=true"
-    }
+        var additionalParams = ""
+        if (isCRTEnabled) {
+            additionalParams = "&collapsedThreads=true&collapsedThreadsExtended=true"
+        }
 
-    val receivingThreads = isCRTEnabled && !rootId.isNullOrEmpty()
-    val endpoint = if (receivingThreads) {
-        val queryParams = "?skipFetchThreads=false&perPage=60&fromCreatedAt=0&direction=up"
-        "/api/v4/posts/$rootId/thread$queryParams$additionalParams"
-    } else {
-        val queryParams = if (since == null) "?page=0&per_page=60" else "?since=${since.toLong()}"
-        "/api/v4/channels/$channelId/posts$queryParams$additionalParams"
-    }
+        val receivingThreads = isCRTEnabled && !rootId.isNullOrEmpty()
+        val endpoint = if (receivingThreads) {
+            val since = rootId?.let { queryLastPostInThread(db, it) }
+            val queryParams = if (since == null) "?perPage=60&fromCreatedAt=0&direction=up" else
+                "?fromCreateAt=${since.toLong()}&direction=down"
 
-    val postsResponse = fetch(serverUrl, endpoint)
-    val results = Arguments.createMap()
+            "/api/v4/posts/$rootId/thread$queryParams$additionalParams"
+        } else {
+            val since = queryPostSinceForChannel(db, channelId)
+            val queryParams = if (since == null) "?page=0&per_page=60" else "?since=${since.toLong()}"
+            "/api/v4/channels/$channelId/posts$queryParams$additionalParams"
+        }
 
-    if (postsResponse != null) {
-        val data = ReadableMapUtils.toMap(postsResponse)
-        results.putMap("posts", postsResponse)
-        val postsData = data["data"] as? Map<*, *>
-        if (postsData != null) {
-            val postsMap = postsData["posts"]
-            if (postsMap != null) {
-                @Suppress("UNCHECKED_CAST")
-                val posts = ReadableMapUtils.toWritableMap(postsMap as? Map<String, Any>)
-                val iterator = posts.keySetIterator()
-                val userIds = mutableListOf<String>()
-                val usernames = mutableListOf<String>()
+        val postsResponse = fetch(serverUrl, endpoint)
+        val postData = postsResponse?.getMap("data")
+        val results = Arguments.createMap()
 
-                val threads = WritableNativeArray()
-                val threadParticipantUserIds = mutableListOf<String>() // Used to exclude the "userIds" present in the thread participants
-                val threadParticipantUsernames = mutableListOf<String>() // Used to exclude the "usernames" present in the thread participants
-                val threadParticipantUsers = HashMap<String, ReadableMap>() // All unique users from thread participants are stored here
-                val userIdsAlreadyLoaded = mutableListOf<String>()
-                if (loadedProfiles != null) {
-                    for( i in 0 until loadedProfiles.size()) {
-                        loadedProfiles.getMap(i).getString("id")?.let { userIdsAlreadyLoaded.add(it) }
+        if (postData != null) {
+            val data = ReadableMapUtils.toMap(postData)
+            results.putMap("posts", postData)
+            if (data != null) {
+                val postsMap = data["posts"]
+                if (postsMap != null) {
+                    @Suppress("UNCHECKED_CAST")
+                    val posts = ReadableMapUtils.toWritableMap(postsMap as? Map<String, Any>)
+                    val iterator = posts.keySetIterator()
+                    val userIds = mutableListOf<String>()
+                    val usernames = mutableListOf<String>()
+
+                    val threads = WritableNativeArray()
+                    val threadParticipantUserIds = mutableListOf<String>() // Used to exclude the "userIds" present in the thread participants
+                    val threadParticipantUsernames = mutableListOf<String>() // Used to exclude the "usernames" present in the thread participants
+                    val threadParticipantUsers = HashMap<String, ReadableMap>() // All unique users from thread participants are stored here
+                    val userIdsAlreadyLoaded = mutableListOf<String>()
+                    if (loadedProfiles != null) {
+                        for (i in 0 until loadedProfiles.size()) {
+                            loadedProfiles.getMap(i).getString("id")?.let { userIdsAlreadyLoaded.add(it) }
+                        }
                     }
-                }
 
-                while(iterator.hasNextKey()) {
-                    val key = iterator.nextKey()
-                    val post = posts.getMap(key)
-                    val userId = post?.getString("user_id")
-                    if (userId != null && userId != currentUserId && !userIdsAlreadyLoaded.contains(userId) && !userIds.contains(userId)) {
-                        userIds.add(userId)
-                    }
-                    val message = post?.getString("message")
-                    if (message != null) {
-                        val matchResults = regex.findAll(message)
-                        matchResults.iterator().forEach {
-                            val username = it.value.removePrefix("@")
-                            if (!usernames.contains(username) && currentUsername != username && !specialMentions.contains(username)) {
-                                usernames.add(username)
+                    while (iterator.hasNextKey()) {
+                        val key = iterator.nextKey()
+                        val post = posts.getMap(key)
+                        val userId = post?.getString("user_id")
+                        if (userId != null && userId != currentUserId && !userIdsAlreadyLoaded.contains(userId) && !userIds.contains(userId)) {
+                            userIds.add(userId)
+                        }
+                        val message = post?.getString("message")
+                        if (message != null) {
+                            val matchResults = regex.findAll(message)
+                            matchResults.iterator().forEach {
+                                val username = it.value.removePrefix("@")
+                                if (!usernames.contains(username) && currentUsername != username && !specialMentions.contains(username)) {
+                                    usernames.add(username)
+                                }
+                            }
+                        }
+
+                        if (isCRTEnabled) {
+                            // Add root post as a thread
+                            val threadId = post?.getString("root_id")
+                            if (threadId.isNullOrEmpty()) {
+                                post?.let {
+                                    val thread = Arguments.createMap()
+                                    thread.putString("id", it.getString("id"))
+                                    thread.putInt("reply_count", it.getInt("reply_count"))
+                                    thread.putDouble("last_reply_at", 0.0)
+                                    thread.putDouble("last_viewed_at", 0.0)
+                                    thread.putArray("participants", it.getArray("participants"))
+                                    thread.putMap("post", it)
+                                    thread.putBoolean("is_following", try {
+                                        it.getBoolean("is_following")
+                                    } catch (e: NoSuchKeyException) {
+                                        false
+                                    })
+                                    thread.putInt("unread_replies", 0)
+                                    thread.putInt("unread_mentions", 0)
+                                    thread.putDouble("delete_at", it.getDouble("delete_at"))
+                                    threads.pushMap(thread)
+                                }
+                            }
+
+                            // Add participant userIds and usernames to exclude them from getting fetched again
+                            val participants = post?.getArray("participants")
+                            participants?.let {
+                                for (i in 0 until it.size()) {
+                                    val participant = it.getMap(i)
+
+                                    val participantId = participant.getString("id")
+                                    if (participantId != currentUserId && participantId != null) {
+                                        if (!threadParticipantUserIds.contains(participantId) && !userIdsAlreadyLoaded.contains(participantId)) {
+                                            threadParticipantUserIds.add(participantId)
+                                        }
+
+                                        if (!threadParticipantUsers.containsKey(participantId)) {
+                                            threadParticipantUsers[participantId] = participant
+                                        }
+                                    }
+
+                                    val username = participant.getString("username")
+                                    if (username != null && username != currentUsername && !threadParticipantUsernames.contains(username)) {
+                                        threadParticipantUsernames.add(username)
+                                    }
+                                }
                             }
                         }
                     }
 
-                    if (isCRTEnabled) {
-                        // Add root post as a thread
-                        val threadId = post?.getString("root_id")
-                        if (threadId.isNullOrEmpty()) {
-                            threads.pushMap(post!!)
-                        }
+                    val existingUserIds = queryIds(db, "User", userIds.toTypedArray())
+                    val existingUsernames = queryByColumn(db, "User", "username", usernames.toTypedArray())
+                    userIds.removeAll { it in existingUserIds }
+                    usernames.removeAll { it in existingUsernames }
 
-                        // Add participant userIds and usernames to exclude them from getting fetched again
-                        val participants = post.getArray("participants")
-                        if (participants != null) {
-                            for (i in 0 until participants.size()) {
-                                val participant = participants.getMap(i)
+                    if (threadParticipantUserIds.size > 0) {
+                        // Do not fetch users found in thread participants as we get the user's data in the posts response already
+                        userIds.removeAll { it in threadParticipantUserIds }
+                        usernames.removeAll { it in threadParticipantUsernames }
 
-                                val participantId = participant.getString("id")
-                                if (participantId != currentUserId && participantId != null) {
-                                    if (!threadParticipantUserIds.contains(participantId) && !userIdsAlreadyLoaded.contains(participantId)) {
-                                        threadParticipantUserIds.add(participantId)
-                                    }
+                        // Get users from thread participants
+                        val existingThreadParticipantUserIds = queryIds(db, "User", threadParticipantUserIds.toTypedArray())
 
-                                    if (!threadParticipantUsers.containsKey(participantId)) {
-                                        threadParticipantUsers[participantId] = participant
-                                    }
-                                }
-
-                                val username = participant.getString("username")
-                                if (username != null && username != currentUsername && !threadParticipantUsernames.contains(username)) {
-                                    threadParticipantUsernames.add(username)
-                                }
+                        // Exclude the thread participants already present in the DB from getting inserted again
+                        val usersFromThreads = WritableNativeArray()
+                        threadParticipantUsers.forEach { (userId, user) ->
+                            if (!existingThreadParticipantUserIds.contains(userId)) {
+                                usersFromThreads.pushMap(user)
                             }
                         }
-                    }
-                }
 
-                val existingUserIds = queryIds(db, "User", userIds.toTypedArray())
-                val existingUsernames = queryByColumn(db, "User", "username", usernames.toTypedArray())
-                userIds.removeAll { it in existingUserIds }
-                usernames.removeAll { it in existingUsernames }
-
-                if (threadParticipantUserIds.size > 0) {
-                    // Do not fetch users found in thread participants as we get the user's data in the posts response already
-                    userIds.removeAll { it in threadParticipantUserIds }
-                    usernames.removeAll { it in threadParticipantUsernames }
-
-                    // Get users from thread participants
-                    val existingThreadParticipantUserIds = queryIds(db, "User", threadParticipantUserIds.toTypedArray())
-
-                    // Exclude the thread participants already present in the DB from getting inserted again
-                    val usersFromThreads = WritableNativeArray()
-                    threadParticipantUsers.forEach{ (userId, user) ->
-                        if (!existingThreadParticipantUserIds.contains(userId)) {
-                            usersFromThreads.pushMap(user)
+                        if (usersFromThreads.size() > 0) {
+                            results.putArray("usersFromThreads", usersFromThreads)
                         }
                     }
 
-                    if (usersFromThreads.size() > 0) {
-                        results.putArray("usersFromThreads", usersFromThreads)
+                    if (userIds.size > 0) {
+                        results.putArray("userIdsToLoad", ReadableArrayUtils.toWritableArray(userIds.toTypedArray()))
                     }
-                }
 
-                if (userIds.size > 0) {
-                    results.putArray("userIdsToLoad", ReadableArrayUtils.toWritableArray(userIds.toTypedArray()))
-                }
+                    if (usernames.size > 0) {
+                        results.putArray("usernamesToLoad", ReadableArrayUtils.toWritableArray(usernames.toTypedArray()))
+                    }
 
-                if (usernames.size > 0) {
-                    results.putArray("usernamesToLoad", ReadableArrayUtils.toWritableArray(usernames.toTypedArray()))
-                }
-
-                if (threads.size() > 0) {
-                    results.putArray("threads", threads)
+                    if (threads.size() > 0) {
+                        results.putArray("threads", threads)
+                    }
                 }
             }
         }
+        results
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
     }
-    return results
 }

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Team.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Team.kt
@@ -7,17 +7,22 @@ import com.mattermost.helpers.database_extension.findTeam
 import com.nozbe.watermelondb.Database
 
 suspend fun PushNotificationDataRunnable.Companion.fetchTeamIfNeeded(db: Database, serverUrl: String, teamId: String): Pair<ReadableMap?, ReadableMap?> {
-    var team: ReadableMap? = null
-    var myTeam: ReadableMap? = null
-    val teamExists = findTeam(db, teamId)
-    val myTeamExists = findMyTeam(db, teamId)
-    if (!teamExists) {
-        team = fetch(serverUrl, "/api/v4/teams/$teamId")
-    }
+    return try {
+        var team: ReadableMap? = null
+        var myTeam: ReadableMap? = null
+        val teamExists = findTeam(db, teamId)
+        val myTeamExists = findMyTeam(db, teamId)
+        if (!teamExists) {
+            team = fetch(serverUrl, "/api/v4/teams/$teamId")
+        }
 
-    if (!myTeamExists) {
-        myTeam = fetch(serverUrl, "/api/v4/teams/$teamId/members/me")
-    }
+        if (!myTeamExists) {
+            myTeam = fetch(serverUrl, "/api/v4/teams/$teamId/members/me")
+        }
 
-    return Pair(team, myTeam)
+        Pair(team, myTeam)
+    } catch (e: Exception) {
+        e.printStackTrace()
+        Pair(null, null)
+    }
 }

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Thread.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Thread.kt
@@ -1,0 +1,19 @@
+package com.mattermost.helpers.push_notification
+
+import com.facebook.react.bridge.ReadableMap
+import com.mattermost.helpers.PushNotificationDataRunnable
+import com.mattermost.helpers.database_extension.*
+import com.nozbe.watermelondb.Database
+
+internal suspend fun PushNotificationDataRunnable.Companion.fetchThread(db: Database, serverUrl: String, threadId: String, teamId: String?): ReadableMap? {
+    val currentUserId = queryCurrentUserId(db) ?: return null
+    val threadTeamId = (if (teamId.isNullOrEmpty()) queryCurrentTeamId(db) else teamId) ?: return null
+
+    return try {
+        val thread = fetch(serverUrl, "/api/v4/users/$currentUserId/teams/${threadTeamId}/threads/$threadId")
+        thread?.getMap("data")
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/User.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/User.kt
@@ -6,16 +6,56 @@ import com.facebook.react.bridge.ReadableMap
 import com.mattermost.helpers.PushNotificationDataRunnable
 import com.mattermost.helpers.ReadableArrayUtils
 
-internal suspend fun PushNotificationDataRunnable.Companion.fetchUsersById(serverUrl: String, userIds: ReadableArray): ReadableMap? {
-    val endpoint = "api/v4/users/ids"
-    val options = Arguments.createMap()
-    options.putArray("body", ReadableArrayUtils.toWritableArray(ReadableArrayUtils.toArray(userIds)))
-    return fetchWithPost(serverUrl, endpoint, options)
+internal suspend fun PushNotificationDataRunnable.Companion.fetchUsersById(serverUrl: String, userIds: ReadableArray): ReadableArray? {
+    return try {
+        val endpoint = "api/v4/users/ids"
+        val options = Arguments.createMap()
+        options.putArray("body", ReadableArrayUtils.toWritableArray(ReadableArrayUtils.toArray(userIds)))
+        val result = fetchWithPost(serverUrl, endpoint, options)
+        result?.getArray("data")
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
 }
 
-internal suspend fun PushNotificationDataRunnable.Companion.fetchUsersByUsernames(serverUrl: String, usernames: ReadableArray): ReadableMap? {
-    val endpoint = "api/v4/users/usernames"
-    val options = Arguments.createMap()
-    options.putArray("body", ReadableArrayUtils.toWritableArray(ReadableArrayUtils.toArray(usernames)))
-    return fetchWithPost(serverUrl, endpoint, options)
+internal suspend fun PushNotificationDataRunnable.Companion.fetchUsersByUsernames(serverUrl: String, usernames: ReadableArray): ReadableArray? {
+    return try {
+        val endpoint = "api/v4/users/usernames"
+        val options = Arguments.createMap()
+        options.putArray("body", ReadableArrayUtils.toWritableArray(ReadableArrayUtils.toArray(usernames)))
+        val result = fetchWithPost(serverUrl, endpoint, options)
+        result?.getArray("data")
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}
+
+internal suspend fun PushNotificationDataRunnable.Companion.fetchNeededUsers(serverUrl: String, loadedUsers: ReadableArray?, data: ReadableMap?): ArrayList<Any> {
+    val userList = ArrayList<Any>()
+    loadedUsers?.let { PushNotificationDataRunnable.addUsersToList(it, userList) }
+    data?.getArray("userIdsToLoad")?.let { ids ->
+        if (ids.size() > 0) {
+            val result = fetchUsersById(serverUrl, ids)
+            result?.let { PushNotificationDataRunnable.addUsersToList(it, userList) }
+        }
+    }
+
+    data?.getArray("usernamesToLoad")?.let { ids ->
+        if (ids.size() > 0) {
+            val result = fetchUsersByUsernames(serverUrl, ids)
+            result?.let { PushNotificationDataRunnable.addUsersToList(it, userList) }
+        }
+    }
+
+    data?.getArray("usersFromThreads")?.let { PushNotificationDataRunnable.addUsersToList(it, userList) }
+
+    return userList
+}
+
+internal fun PushNotificationDataRunnable.Companion.addUsersToList(users: ReadableArray, list: ArrayList<Any>) {
+    for (i in 0 until users.size()) {
+        list.add(users.getMap(i))
+    }
 }

--- a/patches/@nozbe+watermelondb+0.25.5.patch
+++ b/patches/@nozbe+watermelondb+0.25.5.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@nozbe/watermelondb/Database/index.js b/node_modules/@nozbe/watermelondb/Database/index.js
-index 8d71c6f..30832c8 100644
+index 8d71c6f..7a4b570 100644
 --- a/node_modules/@nozbe/watermelondb/Database/index.js
 +++ b/node_modules/@nozbe/watermelondb/Database/index.js
 @@ -91,7 +91,9 @@ var Database = /*#__PURE__*/function () {
@@ -38,7 +38,7 @@ index 96114ec..ecfe3c1 100644
  
    prepareDestroyPermanently(): this
 diff --git a/node_modules/@nozbe/watermelondb/Model/index.js b/node_modules/@nozbe/watermelondb/Model/index.js
-index b0e3a83..1bbce74 100644
+index b0e3a83..d7ead09 100644
 --- a/node_modules/@nozbe/watermelondb/Model/index.js
 +++ b/node_modules/@nozbe/watermelondb/Model/index.js
 @@ -81,7 +81,17 @@ var Model = /*#__PURE__*/function () {
@@ -101,9 +101,18 @@ index b0e3a83..1bbce74 100644
      this.__ensureNotDisposable("Model.prepareDestroyPermanently()");
  
 diff --git a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/Database.kt b/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
-index ca31e20..b45c753 100644
+index ca31e20..764519f 100644
 --- a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
 +++ b/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+@@ -11,7 +11,7 @@ import java.io.File
+ class Database(
+     private val name: String,
+     private val context: Context,
+-    private val openFlags: Int = SQLiteDatabase.CREATE_IF_NECESSARY or SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING
++    private val openFlags: Int = SQLiteDatabase.CREATE_IF_NECESSARY
+ ) {
+ 
+     private val db: SQLiteDatabase by lazy {
 @@ -22,6 +22,21 @@ class Database(
              if (name == ":memory:" || name.contains("mode=memory")) {
                  context.cacheDir.delete()
@@ -127,9 +136,18 @@ index ca31e20..b45c753 100644
                  // On some systems there is some kind of lock on `/databases` folder ¯\_(ツ)_/¯
                  context.getDatabasePath("$name.db").path.replace("/databases", "")
 diff --git a/node_modules/@nozbe/watermelondb/native/shared/Database.cpp b/node_modules/@nozbe/watermelondb/native/shared/Database.cpp
-index 1a1cabf..01bbb2b 100644
+index 1a1cabf..c4459c8 100644
 --- a/node_modules/@nozbe/watermelondb/native/shared/Database.cpp
 +++ b/node_modules/@nozbe/watermelondb/native/shared/Database.cpp
+@@ -21,7 +21,7 @@ Database::Database(jsi::Runtime *runtime, std::string path, bool usesExclusiveLo
+     executeMultiple("pragma temp_store = memory;");
+     #endif
+ 
+-    executeMultiple("pragma journal_mode = WAL;");
++//    executeMultiple("pragma journal_mode = WAL;");
+ 
+     #ifdef ANDROID
+     // NOTE: This was added in an attempt to fix mysterious `database disk image is malformed` issue when using
 @@ -54,6 +54,7 @@ void Database::destroy() {
      const std::lock_guard<std::mutex> lock(mutex_);
  


### PR DESCRIPTION
#### Summary
This PR refactors the push notification handling on Android and does the following:
1. Avoids crashes by handling the data correctly
2. When the app is running in the background, we send all the needed data related to the notification to the JS thread (separate PR for JS handling) so that it can be added to the database by watermelonDB thus making sure all observables update accordingly
3. When the app is not running data related to the push notification is stored directly to the database.
4. Added missing cases for data needed to be fetched and included in the database (either directly or from JS)
5. Patched WDB so that the database does not become malformed when access is done from the native thread. (This will also allow us to use the Database plugin for Flipper without corrupting the database.

```release-note
NONE
```
