### PR TITLE
Do not show archived dms in the category list

### DIFF
--- a/app/screens/home/channel_list/categories_list/categories/body/category_body.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/body/category_body.tsx
@@ -63,7 +63,7 @@ const CategoryBody = ({sortedChannels, unreadIds, unreadsOnTop, category, limit,
 
     useEffect(() => {
         if (directChannels.length) {
-            fetchDirectChannelsInfo(serverUrl, directChannels);
+            fetchDirectChannelsInfo(serverUrl, directChannels.filter((c) => !c.displayName));
         }
     }, [directChannels.length]);
 


### PR DESCRIPTION
#### Summary
DM's with deactivated users were being displayed in the channel list, now it only shows if it was the last unread channel

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49935

#### Release Note
```release-note
Fixed channel list to not display DM's with people that have been deactivated.
```
