### PR TITLE
Fix double tilde by waiting for text values to propagate

### DIFF
--- a/app/hooks/input.ts
+++ b/app/hooks/input.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {useCallback, useRef} from 'react';
+import {Platform} from 'react-native';
+
+export function useInputPropagation(): [(v: string) => void, (v: string) => boolean] {
+    const waitForValue = useRef<string>();
+    const waitToPropagate = useCallback((value: string) => {
+        waitForValue.current = value;
+    }, []);
+    const shouldProcessEvent = useCallback((newValue: string) => {
+        if (Platform.OS === 'android') {
+            return true;
+        }
+        if (waitForValue.current === undefined) {
+            return true;
+        }
+        if (newValue === waitForValue.current) {
+            waitForValue.current = undefined;
+        }
+        return false;
+    }, []);
+
+    return [waitToPropagate, shouldProcessEvent];
+}

--- a/app/screens/create_or_edit_channel/channel_info_form.tsx
+++ b/app/screens/create_or_edit_channel/channel_info_form.tsx
@@ -17,6 +17,7 @@ import {
 import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
+import {useInputPropagation} from '@app/hooks/input';
 import Autocomplete from '@components/autocomplete';
 import ErrorText from '@components/error_text';
 import FloatingTextInput from '@components/floating_text_input_label';
@@ -126,6 +127,8 @@ export default function ChannelInfoForm({
     const dimensions = useWindowDimensions();
     const isTablet = useIsTablet();
 
+    const [propagateValue, shouldProcessEvent] = useInputPropagation();
+
     const keyboardHeight = useKeyboardHeight();
     const [keyboardVisible, setKeyBoardVisible] = useState(false);
     const [scrollPosition, setScrollPosition] = useState(0);
@@ -192,6 +195,18 @@ export default function ChannelInfoForm({
             setKeyBoardVisible(true);
         }
     }, [keyboardHeight]);
+
+    const onHeaderAutocompleteChange = useCallback((value: string) => {
+        onHeaderChange(value);
+        propagateValue(value);
+    }, [onHeaderChange]);
+
+    const onHeaderInputChange = useCallback((value: string) => {
+        if (!shouldProcessEvent(value)) {
+            return;
+        }
+        onHeaderChange(value);
+    }, [onHeaderChange]);
 
     const onLayoutError = useCallback((e: LayoutChangeEvent) => {
         setErrorHeight(e.nativeEvent.layout.height);
@@ -371,7 +386,7 @@ export default function ChannelInfoForm({
                                 enablesReturnKeyAutomatically={true}
                                 label={labelHeader}
                                 placeholder={placeholderHeader}
-                                onChangeText={onHeaderChange}
+                                onChangeText={onHeaderInputChange}
                                 multiline={true}
                                 keyboardAppearance={getKeyboardAppearanceFromTheme(theme)}
                                 returnKeyType='next'
@@ -397,7 +412,7 @@ export default function ChannelInfoForm({
             </KeyboardAwareScrollView>
             <Autocomplete
                 position={animatedAutocompletePosition}
-                updateValue={onHeaderChange}
+                updateValue={onHeaderAutocompleteChange}
                 cursorPosition={header.length}
                 value={header}
                 nestedScrollEnabled={true}


### PR DESCRIPTION
#### Summary
Changes directly added through either the value prop or the `setNativeProp` to the InputText are creating `changeText` events on iOS. That plus some events being lost is creating the "double tilde" issue. The same happens for commands and emojis.

This PR handle this by addressing any change in the value outside from the input as "prioritary", and forcing the change to propagate to the input side before handling any other change text event.

#### Testing details
This can affect any place where the autocomplete is used. Those are:
- Channel screen -> Post input
- Thread screen -> Post input (should be the same component as the previous one)
- Edit Post Screen -> Post input
- Search Screen -> Search input (there should be no changes here)
- Channel Edit / Create screen -> Header input

Android behaviour should have not changed at all. iOS was the only one having the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-50351

#### Release Note
```release-note
Fix double mark character from autocomplete (tilde, slash or colon) on iOS
```
