### PR TITLE
Do not dismiss keyboard when app is brought to the foreground

### DIFF
--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -134,12 +134,8 @@ export default function PostInput({
         return {...style.input, maxHeight};
     }, [maxHeight, style.input]);
 
-    const blur = () => {
-        inputRef.current?.blur();
-    };
-
     const handleAndroidKeyboard = () => {
-        blur();
+        onBlur();
     };
 
     const onBlur = useCallback(() => {


### PR DESCRIPTION
#### Summary
The `KeyboardDidHide` event is being triggered when the AppState changes to active but does not actually dismisses the keyboard, but we were calling to blur the input which in turn did dismissed the keyboard, the fix is about not blurring the input which then keeps the keyboard opened.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50455
Fixes: #7107 

```release-note
NONE
```
