### PR TITLE
Fix Group Message member count on GraphQL scenario

### DIFF
--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -312,7 +312,6 @@ export async function restDeferredAppEntryActions(
     serverUrl: string, since: number, currentUserId: string, currentUserLocale: string, preferences: PreferenceType[] | undefined,
     config: ClientConfig, license: ClientLicense | undefined, teamData: MyTeamsRequest, chData: MyChannelsRequest | undefined,
     initialTeamId?: string, initialChannelId?: string) {
-
     setTimeout(async () => {
         if (chData?.channels?.length && chData.memberships?.length) {
             // defer fetching posts for unread channels on initial team
@@ -346,8 +345,8 @@ export async function restDeferredAppEntryActions(
     // Fetch groups for current user
     fetchGroupsForMember(serverUrl, currentUserId);
 
-     // defer sidebar DM & GM profiles
-     setTimeout(async () => {
+    // defer sidebar DM & GM profiles
+    setTimeout(async () => {
         const directChannels = chData?.channels?.filter(isDMorGM);
         const channelsToFetchProfiles = new Set<Channel>(directChannels);
         if (channelsToFetchProfiles.size) {

--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -312,13 +312,9 @@ export async function restDeferredAppEntryActions(
     serverUrl: string, since: number, currentUserId: string, currentUserLocale: string, preferences: PreferenceType[] | undefined,
     config: ClientConfig, license: ClientLicense | undefined, teamData: MyTeamsRequest, chData: MyChannelsRequest | undefined,
     initialTeamId?: string, initialChannelId?: string) {
-    // defer sidebar DM & GM profiles
-    let channelsToFetchProfiles: Set<Channel>|undefined;
+
     setTimeout(async () => {
         if (chData?.channels?.length && chData.memberships?.length) {
-            const directChannels = chData.channels.filter(isDMorGM);
-            channelsToFetchProfiles = new Set<Channel>(directChannels);
-
             // defer fetching posts for unread channels on initial team
             fetchPostsForUnreadChannels(serverUrl, chData.channels, chData.memberships, initialChannelId);
         }
@@ -350,8 +346,11 @@ export async function restDeferredAppEntryActions(
     // Fetch groups for current user
     fetchGroupsForMember(serverUrl, currentUserId);
 
-    setTimeout(async () => {
-        if (channelsToFetchProfiles?.size) {
+     // defer sidebar DM & GM profiles
+     setTimeout(async () => {
+        const directChannels = chData?.channels?.filter(isDMorGM);
+        const channelsToFetchProfiles = new Set<Channel>(directChannels);
+        if (channelsToFetchProfiles.size) {
             const teammateDisplayNameSetting = getTeammateNameDisplaySetting(preferences || [], config.LockTeammateNameDisplay, config.TeammateNameDisplay, license);
             fetchMissingDirectChannelsInfo(serverUrl, Array.from(channelsToFetchProfiles), currentUserLocale, teammateDisplayNameSetting, currentUserId);
         }

--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {storeConfigAndLicense} from '@actions/local/systems';
+import {fetchMissingDirectChannelsInfo, MyChannelsRequest} from '@actions/remote/channel';
 import {fetchGroupsForMember} from '@actions/remote/groups';
 import {fetchPostsForUnreadChannels} from '@actions/remote/post';
 import {fetchDataRetentionPolicy} from '@actions/remote/systems';
@@ -23,7 +24,6 @@ import {processIsCRTEnabled} from '@utils/thread';
 
 import {teamsToRemove, FETCH_UNREADS_TIMEOUT, entryRest, EntryResponse, entryInitialChannelId, restDeferredAppEntryActions, getRemoveTeamIds} from './common';
 
-import {fetchMissingDirectChannelsInfo, MyChannelsRequest} from '@actions/remote/channel';
 import type ClientError from '@client/rest/error';
 import type {Database} from '@nozbe/watermelondb';
 import type ChannelModel from '@typings/database/models/servers/channel';
@@ -102,8 +102,8 @@ export async function deferredAppEntryGraphQLActions(
     updateCanJoinTeams(serverUrl);
     updateAllUsersSince(serverUrl, since);
 
-     // defer sidebar GM profiles
-     setTimeout(async () => {
+    // defer sidebar GM profiles
+    setTimeout(async () => {
         const directChannels = chData?.channels?.filter((v) => v?.type === General.GM_CHANNEL);
         const channelsToFetchProfiles = new Set<Channel>(directChannels);
         if (channelsToFetchProfiles.size) {
@@ -111,7 +111,7 @@ export async function deferredAppEntryGraphQLActions(
             fetchMissingDirectChannelsInfo(serverUrl, Array.from(channelsToFetchProfiles), currentUserLocale, teammateDisplayNameSetting, currentUserId);
         }
     }, FETCH_MISSING_GM_TIMEOUT);
-    
+
     return {error: undefined};
 }
 

--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -102,15 +102,14 @@ export async function deferredAppEntryGraphQLActions(
 
     // defer sidebar GM profiles
     setTimeout(async () => {
-        const gmIds = chData?.channels?.reduce<string[]>((acc, v) => {
+        const gmIds = chData?.channels?.reduce<Set<string>>((acc, v) => {
             if (v?.type === General.GM_CHANNEL) {
-                acc.push(v.id);
+                acc.add(v.id);
             }
             return acc;
-        }, []);
-        const channelsToFetchProfiles = new Set<string>(gmIds);
-        if (channelsToFetchProfiles.size) {
-            fetchProfilesInGroupChannels(serverUrl, Array.from(channelsToFetchProfiles));
+        }, new Set<string>());
+        if (gmIds?.size) {
+            fetchProfilesInGroupChannels(serverUrl, Array.from(gmIds));
         }
     }, FETCH_MISSING_GM_TIMEOUT);
 

--- a/app/actions/remote/entry/gql_common.ts
+++ b/app/actions/remote/entry/gql_common.ts
@@ -102,7 +102,12 @@ export async function deferredAppEntryGraphQLActions(
 
     // defer sidebar GM profiles
     setTimeout(async () => {
-        const gmIds = chData?.channels?.filter((v) => v?.type === General.GM_CHANNEL).map((v) => v.id);
+        const gmIds = chData?.channels?.reduce<string[]>((acc, v) => {
+            if (v?.type === General.GM_CHANNEL) {
+                acc.push(v.id);
+            }
+            return acc;
+        }, []);
         const channelsToFetchProfiles = new Set<string>(gmIds);
         if (channelsToFetchProfiles.size) {
             fetchProfilesInGroupChannels(serverUrl, Array.from(channelsToFetchProfiles));


### PR DESCRIPTION
#### Summary
We were not fetching the profiles on the GraphQL scenario since we already had the pretty display name. This caused the member count to be always 0.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50714

#### Release Note
```release-note
Fix Group Message member count showing as 0 on GraphQL enabled instances.
```
