### PR TITLE
Add Swipe up&down on TeamList to change teams

### DIFF
--- a/app/components/team_sidebar/team_list/index.ts
+++ b/app/components/team_sidebar/team_list/index.ts
@@ -8,6 +8,7 @@ import withObservables from '@nozbe/with-observables';
 import {of as of$, combineLatest} from 'rxjs';
 import {switchMap, map} from 'rxjs/operators';
 
+import {observeCurrentTeamId} from '@app/queries/servers/system';
 import {Preferences} from '@constants';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {queryJoinedTeams, queryMyTeams} from '@queries/servers/team';
@@ -52,8 +53,10 @@ const withTeams = withObservables([], ({database}: WithDatabaseArgs) => {
             });
         }),
     );
+    const currentTeam = observeCurrentTeamId(database);
     return {
         myOrderedTeams,
+        currentTeam,
     };
 });
 

--- a/app/components/team_sidebar/team_list/team_list.tsx
+++ b/app/components/team_sidebar/team_list/team_list.tsx
@@ -2,13 +2,20 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FlatList, ListRenderItemInfo, StyleSheet, View} from 'react-native';
+import {FlatList, ListRenderItemInfo, StyleSheet} from 'react-native';
+import {PanGestureHandler} from 'react-native-gesture-handler';
+import Animated, {runOnJS, useAnimatedGestureHandler, useSharedValue} from 'react-native-reanimated';
+
+import {handleTeamChange} from '@actions/remote/team';
+import {useServerUrl} from '@app/context/server';
 
 import TeamItem from './team_item';
 
 import type MyTeamModel from '@typings/database/models/servers/my_team';
+import type {Int32} from 'react-native/Libraries/Types/CodegenTypes';
 
 type Props = {
+	currentTeam: string;
     myOrderedTeams: MyTeamModel[];
     testID?: string;
 }
@@ -23,26 +30,76 @@ const renderTeam = ({item: t}: ListRenderItemInfo<MyTeamModel>) => {
     );
 };
 
-export default function TeamList({myOrderedTeams, testID}: Props) {
+export default function TeamList({myOrderedTeams, currentTeam, testID}: Props) {
+    const swipePixelDistance = 50; //Random assumption, short to feel snappy, long enough to prevent false positives
+    const swipeStartY = useSharedValue(0);
+    const didSwipeFireAlready = useSharedValue(false);
+    const serverUrl = useServerUrl();
+
+    /**
+	 * Switch to the next team in the myOrderedTeams list
+	 * @param nextIndex index to jump: 1 = 1 down, -1 = 1 up
+	 */
+    function switchToNextTeam(nextIndex: Int32) {
+        const currentTeamIdIndex = myOrderedTeams.findIndex((t) => t.id === currentTeam);
+        if (currentTeamIdIndex >= 0) {
+            let newTeamIndex = currentTeamIdIndex + nextIndex;
+
+            //Handle out of bounce
+            if (newTeamIndex >= myOrderedTeams.length) {
+                newTeamIndex = 0;
+            }
+            if (newTeamIndex < 0) {
+                newTeamIndex = myOrderedTeams.length - 1;
+            }
+            handleTeamChange(serverUrl, myOrderedTeams[newTeamIndex].id);
+        } else {
+            //current Team was not found in myOrderedTeams, we should error log.
+            // console.error(`Current TeamID ${teamId.value} not found in myOrderedTeams`);
+        }
+    }
+
+    const panGesture = useAnimatedGestureHandler({
+        onStart: (event) => {
+            //Reset to get a fresh start
+            didSwipeFireAlready.value = false;
+            swipeStartY.value = event.y;
+        },
+        onActive: (event) => {
+            if (!didSwipeFireAlready.value && event.y > (swipeStartY.value + swipePixelDistance)) {
+                //swiped down
+                didSwipeFireAlready.value = true;
+                runOnJS(switchToNextTeam)(1);
+            }
+            if (!didSwipeFireAlready.value && event.y < (swipeStartY.value - swipePixelDistance)) {
+                //swiped up
+                runOnJS(switchToNextTeam)(-1);
+                didSwipeFireAlready.value = true;
+            }
+        },
+    });
+
     return (
-        <View style={styles.container}>
-            <FlatList
-                bounces={false}
-                contentContainerStyle={styles.contentContainer}
-                data={myOrderedTeams}
-                fadingEdgeLength={30}
-                keyExtractor={keyExtractor}
-                renderItem={renderTeam}
-                showsVerticalScrollIndicator={false}
-                testID={`${testID}.flat_list`}
-            />
-        </View>
+        <PanGestureHandler onGestureEvent={panGesture}>
+            <Animated.View style={styles.container}>
+                <FlatList
+                    bounces={false}
+                    contentContainerStyle={styles.contentContainer}
+                    data={myOrderedTeams}
+                    fadingEdgeLength={30}
+                    keyExtractor={keyExtractor}
+                    renderItem={renderTeam}
+                    showsVerticalScrollIndicator={false}
+                    testID={`${testID}.flat_list`}
+                />
+            </Animated.View>
+        </PanGestureHandler>
     );
 }
 
 const styles = StyleSheet.create({
     container: {
-        flexShrink: 1,
+        flex: 1,
     },
     contentContainer: {
         alignItems: 'center',


### PR DESCRIPTION
#### Summary
Add Swipe up and down on the Team List to easily change teams


#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: Android Pixel 6, API 33

#### Release Note
```release-note
Added a swipe gesture to the team list to easily change teams with an up & down swipe
```
