### PR TITLE
[MM-50806] Calls: fix crash on joining call

### DIFF
--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -234,8 +234,10 @@ export async function newConnection(
         });
 
         peer.on('stream', (remoteStream: MediaStream) => {
-            logDebug('new remote stream received', remoteStream);
-            logDebug('remote tracks', remoteStream.getTracks());
+            logDebug('new remote stream received', remoteStream.id);
+            for (const track of remoteStream.getTracks()) {
+                logDebug('remote track', track.id);
+            }
 
             streams.push(remoteStream);
             if (remoteStream.getVideoTracks().length > 0) {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -409,7 +409,7 @@ PODS:
     - react-native-video/Video (= 5.2.1)
   - react-native-video/Video (5.2.1):
     - React-Core
-  - react-native-webrtc (106.0.5):
+  - react-native-webrtc (106.0.6):
     - JitsiWebRTC (~> 106.0.0)
     - React-Core
   - react-native-webview (11.26.1):
@@ -983,7 +983,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-turbo-mailer: dec932ffe8c20dfd22b43c23ee5890ceea909620
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
-  react-native-webrtc: ef315d8adb68e78298b22100377d12ef168efdb5
+  react-native-webrtc: 22ac6c64a1e38552bb173dde81ffea6979a58ef3
   react-native-webview: 9f111dfbcfc826084d6c507f569e5e03342ee1c1
   React-perflogger: af8a3d31546077f42d729b949925cc4549f14def
   React-RCTActionSheet: 57cc5adfefbaaf0aae2cf7e10bccd746f2903673

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "react-native-vector-icons": "9.2.0",
         "react-native-video": "5.2.1",
         "react-native-walkthrough-tooltip": "1.5.0",
-        "react-native-webrtc": "106.0.5",
+        "react-native-webrtc": "106.0.6",
         "react-native-webview": "11.26.1",
         "react-syntax-highlighter": "15.5.0",
         "readable-stream": "3.6.0",
@@ -18829,9 +18829,9 @@
       }
     },
     "node_modules/react-native-webrtc": {
-      "version": "106.0.5",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-106.0.5.tgz",
-      "integrity": "sha512-EINzYpTZh6zXb2lcGH13Ieli1ur3M1FaT8R8WMqfUZEW8/y0WV6yBeQQVz55OA4LtWnBUX0RZyaYQ4aZN4e1Sw==",
+      "version": "106.0.6",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-106.0.6.tgz",
+      "integrity": "sha512-mxRqR/sNZfVnbTM8cd90Y+A23H53jvZ/j0W7MSSFAbsQrj9Jdew1+7tJVTcBieF1S4ytTLI/R95scOQ4+qeE2Q==",
       "hasInstallScript": true,
       "dependencies": {
         "adm-zip": "0.5.9",
@@ -36143,9 +36143,9 @@
       }
     },
     "react-native-webrtc": {
-      "version": "106.0.5",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-106.0.5.tgz",
-      "integrity": "sha512-EINzYpTZh6zXb2lcGH13Ieli1ur3M1FaT8R8WMqfUZEW8/y0WV6yBeQQVz55OA4LtWnBUX0RZyaYQ4aZN4e1Sw==",
+      "version": "106.0.6",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-106.0.6.tgz",
+      "integrity": "sha512-mxRqR/sNZfVnbTM8cd90Y+A23H53jvZ/j0W7MSSFAbsQrj9Jdew1+7tJVTcBieF1S4ytTLI/R95scOQ4+qeE2Q==",
       "requires": {
         "adm-zip": "0.5.9",
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-vector-icons": "9.2.0",
     "react-native-video": "5.2.1",
     "react-native-walkthrough-tooltip": "1.5.0",
-    "react-native-webrtc": "106.0.5",
+    "react-native-webrtc": "106.0.6",
     "react-native-webview": "11.26.1",
     "react-syntax-highlighter": "15.5.0",
     "readable-stream": "3.6.0",


### PR DESCRIPTION
#### Summary

PR fixes a crash when receiving tracks. It took forever to debug mostly because the error was so confusing (see https://github.com/react-native-webrtc/react-native-webrtc/issues/1333 for context). Turns out logging complex objects like tracks and streams is not a good idea so I changed it to simply log their ids.

I am also bumping `react-native-webrtc` version to fix another unrelated bug (https://github.com/react-native-webrtc/react-native-webrtc/issues/1309).

Fixes #7155 

/cc @cpoile 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50806

#### Release Note

```release-note
Calls: fixed crash on joining calls.
```

