### PR TITLE
Fix iOS push notification when set as generic message with sender name

### DIFF
--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -83,8 +83,9 @@ class NotificationService: UNNotificationServiceExtension {
 
       let isCRTEnabled = notification.userInfo["is_crt_enabled"] as? Bool ?? false
       let rootId = notification.userInfo["root_id"] as? String ?? ""
-      let channelName = notification.userInfo["channel_name"] as? String ?? ""
-      let message = (notification.userInfo["message"] as? String ?? "")
+      let senderName = notification.userInfo["sender_name"] as? String
+      let channelName = notification.userInfo["channel_name"] as? String
+      var message = (notification.userInfo["message"] as? String ?? "")
       let overrideUsername = notification.userInfo["override_username"] as? String
       let senderId = notification.userInfo["sender_id"] as? String
       let senderIdentifier = overrideUsername ?? senderId
@@ -94,11 +95,18 @@ class NotificationService: UNNotificationServiceExtension {
       if isCRTEnabled && !rootId.isEmpty {
         conversationId = rootId
       }
+      
+      if channelName == nil && message == "",
+         let senderName = senderName,
+         let body = bestAttemptContent?.body {
+        message = body.replacingOccurrences(of: "\(senderName) ", with: "")
+        bestAttemptContent?.body = message
+      }
 
       let handle = INPersonHandle(value: senderIdentifier, type: .unknown)
       let sender = INPerson(personHandle: handle,
                             nameComponents: nil,
-                            displayName: channelName,
+                            displayName: channelName ?? senderName,
                             image: avatar,
                             contactIdentifier: nil,
                             customIdentifier: nil)


### PR DESCRIPTION
#### Summary
When the server is set to send push notifications with a generic message and only the sender name, on iOS the title of the notification was showing the sender Id as the channel name is empty

Now we default to the senderName when the channel name is empty (the channel name is empty only in this scenario) so that the title shows the sender name and then modify the message content to remove the sender name from the generic message (this is already done on Android)

Thus the notification is shown as
```
Sender name (title)
mentioned you. (content)
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50477

#### Release Note
```release-note
Fixed push notification display when set as generic message with sender only
```