### PR TITLE
Fix potential reaction crash

### DIFF
--- a/app/components/post_list/post/body/reactions/reactions.tsx
+++ b/app/components/post_list/post/body/reactions/reactions.tsx
@@ -86,11 +86,11 @@ const Reactions = ({currentUserId, canAddReaction, canRemoveReaction, disabled, 
             if (reaction) {
                 const emojiAlias = getEmojiFirstAlias(reaction.emojiName);
                 if (acc.has(emojiAlias)) {
-                    const rs = acc.get(emojiAlias);
+                    const rs = acc.get(emojiAlias)!;
                     // eslint-disable-next-line max-nested-callbacks
-                    const present = rs!.findIndex((r) => r.userId === reaction.userId) > -1;
+                    const present = rs.findIndex((r) => r.userId === reaction.userId) > -1;
                     if (!present) {
-                        rs!.push(reaction);
+                        rs.push(reaction);
                     }
                 } else {
                     acc.set(emojiAlias, [reaction]);
@@ -105,7 +105,7 @@ const Reactions = ({currentUserId, canAddReaction, canRemoveReaction, disabled, 
         }, new Map<string, ReactionModel[]>());
 
         return {reactionsByName, highlightedReactions};
-    }, [sortedReactions]);
+    }, [sortedReactions, reactions]);
 
     const handleAddReactionToPost = (emoji: string) => {
         addReaction(serverUrl, postId, emoji);
@@ -178,7 +178,7 @@ const Reactions = ({currentUserId, canAddReaction, canRemoveReaction, disabled, 
                     return (
                         <Reaction
                             key={r}
-                            count={reaction!.length}
+                            count={reaction?.length || 1}
                             emojiName={r}
                             highlight={highlightedReactions.includes(r)}
                             onPress={handleReactionPress}

--- a/app/utils/emoji/helpers.ts
+++ b/app/utils/emoji/helpers.ts
@@ -200,7 +200,7 @@ export function doesMatchNamedEmoji(emojiName: string) {
     return false;
 }
 
-export const getEmojiFirstAlias = (emoji: string) => {
+export const getEmojiFirstAlias = (emoji: string): string => {
     return getEmojiByName(emoji, [])?.short_names?.[0] || emoji;
 };
 


### PR DESCRIPTION
#### Summary
Based on this report https://community.mattermost.com/core/pl/7fg4y85hp3y6fx8dxt5nujdixo I was able to find that the cause of it was that we attempted to get the length (as in how many people reacted) for an reaction that is not present caused by a race condition where the `reactionsByName` map is not ready yet.. very very rare, but happened.

```release-note
NONE
```
