### PR TITLE
support WS connection over TLS1.3

### DIFF
--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -283,9 +283,9 @@ export default function PostInput({
         });
         return () => {
             listener.remove();
-            updateDraftMessage(serverUrl, channelId, rootId, value); // safe draft on unmount
+            updateDraftMessage(serverUrl, channelId, rootId, lastNativeValue.current); // safe draft on unmount
         };
-    }, [updateValue, value, channelId, rootId]);
+    }, [updateValue, channelId, rootId]);
 
     useEffect(() => {
         if (value !== lastNativeValue.current) {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -54,7 +54,7 @@ target 'Mattermost' do
   pod 'simdjson', path: '../node_modules/@nozbe/simdjson'
 
   # TODO: Remove this once upstream PR https://github.com/daltoniam/Starscream/pull/871 is merged
-  pod 'Starscream', :git => 'https://github.com/mattermost/Starscream.git', :commit => '2770c931b2758f26e29b937d547a23122e9c6583'
+  pod 'Starscream', :git => 'https://github.com/mattermost/Starscream.git', :commit => '9575b6781d1262247096af73617ae3acb2b139a0'
 
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -709,7 +709,7 @@ DEPENDENCIES:
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - "simdjson (from `../node_modules/@nozbe/simdjson`)"
-  - Starscream (from `https://github.com/mattermost/Starscream.git`, commit `2770c931b2758f26e29b937d547a23122e9c6583`)
+  - Starscream (from `https://github.com/mattermost/Starscream.git`, commit `9575b6781d1262247096af73617ae3acb2b139a0`)
   - "WatermelonDB (from `../node_modules/@nozbe/watermelondb`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -908,7 +908,7 @@ EXTERNAL SOURCES:
   simdjson:
     :path: "../node_modules/@nozbe/simdjson"
   Starscream:
-    :commit: 2770c931b2758f26e29b937d547a23122e9c6583
+    :commit: 9575b6781d1262247096af73617ae3acb2b139a0
     :git: https://github.com/mattermost/Starscream.git
   WatermelonDB:
     :path: "../node_modules/@nozbe/watermelondb"
@@ -917,7 +917,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Starscream:
-    :commit: 2770c931b2758f26e29b937d547a23122e9c6583
+    :commit: 9575b6781d1262247096af73617ae3acb2b139a0
     :git: https://github.com/mattermost/Starscream.git
 
 SPEC CHECKSUMS:
@@ -1033,6 +1033,6 @@ SPEC CHECKSUMS:
   Yoga: 5ed1699acbba8863755998a4245daa200ff3817b
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 9f76739ed16bbdc0f4b1049ecb366fb5d23a0f3a
+PODFILE CHECKSUM: 831b649321a4d14a86a074af619aa779ebc048c4
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
#### Summary
iOS was not connecting the WS over TLS 1.3, the change here https://github.com/mattermost/Starscream/commit/9575b6781d1262247096af73617ae3acb2b139a0 uses the TCPTransport instead of the FoundationTransport which does connect over TLS1.3 which uses [NWConnection](https://developer.apple.com/documentation/network/nwconnection)  instead of [InputStream](https://developer.apple.com/documentation/foundation/inputstream/) and [OutputStream](https://developer.apple.com/documentation/foundation/outputstream)

Also piggyback a fix for saving the draft when the component unmounts, the reason is that there was a race condition when posting a message as the effect was running every time the `value` prop changed

#### Release Note
```release-note
Added support for connecting the WebSocket over TLS1.3
```
