### PR TITLE
Fix push notification token registration race/missing

### DIFF
--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -37,22 +37,22 @@ class PushNotifications {
     configured = false;
 
     init(register: boolean) {
-        if (register) {
-            this.registerIfNeeded();
-        }
-
         Notifications.events().registerNotificationOpened(this.onNotificationOpened);
         Notifications.events().registerRemoteNotificationsRegistered(this.onRemoteNotificationsRegistered);
         Notifications.events().registerNotificationReceivedBackground(this.onNotificationReceivedBackground);
         Notifications.events().registerNotificationReceivedForeground(this.onNotificationReceivedForeground);
+
+        if (register) {
+            this.registerIfNeeded();
+        }
     }
 
     async registerIfNeeded() {
         const isRegistered = await Notifications.isRegisteredForRemoteNotifications();
         if (!isRegistered) {
             await requestNotifications(['alert', 'sound', 'badge']);
-            Notifications.registerRemoteNotifications();
         }
+        Notifications.registerRemoteNotifications();
     }
 
     createReplyCategory = () => {


### PR DESCRIPTION
#### Summary
Fixes potential race condition when registering the device to receive push notifications by adding the event handlers before invoking the registration for notifications as well as always call register for notifications in case the token is refreshed.

#### Ticket Link
https://community.mattermost.com/core/pl/7cnpp6ydepycjx9u6nmfe4r1ja

#### Release Note
```release-note
NONE
```
