### PR TITLE
Fix race condition when the same websocket gets initialized twice

### DIFF
--- a/app/utils/config.ts
+++ b/app/utils/config.ts
@@ -3,10 +3,10 @@
 
 import {isMinimumServerVersion} from './helpers';
 
-export function hasReliableWebsocket(config: ClientConfig) {
-    if (isMinimumServerVersion(config.Version, 6, 5)) {
+export function hasReliableWebsocket(version?: string, reliableWebsocketsConfig?: string) {
+    if (version && isMinimumServerVersion(version, 6, 5)) {
         return true;
     }
 
-    return config.EnableReliableWebSockets === 'true';
+    return reliableWebsocketsConfig === 'true';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@gorhom/bottom-sheet": "4.4.5",
         "@mattermost/compass-icons": "0.1.35",
         "@mattermost/react-native-emm": "1.3.5",
-        "@mattermost/react-native-network-client": "1.3.1",
+        "@mattermost/react-native-network-client": "1.3.2",
         "@mattermost/react-native-paste-input": "0.6.2",
         "@mattermost/react-native-turbo-log": "0.2.3",
         "@mattermost/react-native-turbo-mailer": "0.2.4",
@@ -3241,9 +3241,9 @@
       }
     },
     "node_modules/@mattermost/react-native-network-client": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.1.tgz",
-      "integrity": "sha512-DtwVLV/NUE6MkXOlVZG+4QJXou6nHMdmsxnP1+RqhOeSw5jJlQvxmQgxzxvxLpaWOag+wgB1zpDulGNbr/Cz6Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.2.tgz",
+      "integrity": "sha512-3GFNzMXZWlIXXDYQLIJlKRf+HUZKP0F7mpZ1rSTgoTmUeFdqde4uRiU/L96COg34rAdeFRFrgpk0DxEnT7NiVg==",
       "dependencies": {
         "validator": "13.9.0",
         "zod": "3.20.6"
@@ -24297,9 +24297,9 @@
       "requires": {}
     },
     "@mattermost/react-native-network-client": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.1.tgz",
-      "integrity": "sha512-DtwVLV/NUE6MkXOlVZG+4QJXou6nHMdmsxnP1+RqhOeSw5jJlQvxmQgxzxvxLpaWOag+wgB1zpDulGNbr/Cz6Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.2.tgz",
+      "integrity": "sha512-3GFNzMXZWlIXXDYQLIJlKRf+HUZKP0F7mpZ1rSTgoTmUeFdqde4uRiU/L96COg34rAdeFRFrgpk0DxEnT7NiVg==",
       "requires": {
         "validator": "13.9.0",
         "zod": "3.20.6"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@gorhom/bottom-sheet": "4.4.5",
     "@mattermost/compass-icons": "0.1.35",
     "@mattermost/react-native-emm": "1.3.5",
-    "@mattermost/react-native-network-client": "1.3.1",
+    "@mattermost/react-native-network-client": "1.3.2",
     "@mattermost/react-native-paste-input": "0.6.2",
     "@mattermost/react-native-turbo-log": "0.2.3",
     "@mattermost/react-native-turbo-mailer": "0.2.4",


### PR DESCRIPTION
#### Summary
There are rare cases where initialize can be called twice at the same time, leading to `conn.open` to be called twice. This creates two connections on the native side, handled by the same client on javascript, creating several issues.

This still needs some changes on the network library, that should be either patched here, or version pumped here.

#### Ticket Link
Related to: https://github.com/mattermost/react-native-network-client/pull/114

#### Release Note
```release-note
Improve behaviour of websocket connections
```
