### PR TITLE
Fix guest badge not appearing on member list

### DIFF
--- a/app/components/user_list/index.tsx
+++ b/app/components/user_list/index.tsx
@@ -78,10 +78,8 @@ export function createProfilesSections(intl: IntlShape, profiles: UserProfile[],
             const member = membersDictionary.get(p.id);
             if (member) {
                 const sectionKey = sectionRoleKeyExtractor(member.scheme_admin!).id;
-                const sectionValue = membersSections.get(sectionKey) || [];
-
-                // combine UserProfile and ChannelMember roles
-                const section = [...sectionValue, {...p, roles: `${p.roles} ${member.roles}`}];
+                const section = membersSections.get(sectionKey) || [];
+                section.push(p);
                 membersSections.set(sectionKey, section);
             }
         });

--- a/app/screens/manage_channel_members/manage_channel_members.tsx
+++ b/app/screens/manage_channel_members/manage_channel_members.tsx
@@ -218,6 +218,7 @@ export default function ManageChannelMembers({
 
     useEffect(() => {
         mounted.current = true;
+        getProfiles();
         return () => {
             mounted.current = false;
         };
@@ -262,7 +263,6 @@ export default function ManageChannelMembers({
             {/* fix flashing No Results page when results are present */}
             <UserList
                 currentUserId={currentUserId}
-                fetchMore={getProfiles}
                 handleSelectProfile={handleSelectProfile}
                 loading={loading}
                 manageMode={true} // default true to change row select icon to a dropdown


### PR DESCRIPTION
#### Summary
Members list was merging the profiles with the membership. Probably this was meant to be done in early implementations to get the scheme_admin and scheme_guest values into the profile, but that is no longer used. ~~Just in case, I merged the roles, since they are indeed different (system_guest on the user, channel_guest on the member).~~

Removed the composition between member and profile because it is not used and was generating some performance issues on change (re-rendering all elements on the list).

Also piggybacked a performance fix that had to do with getting to the end of the member list. When we get to the end of the member list, we continually are fetching the same set of members. That has been solved not passing the `fetchMore` prop, since, at the moment, we are not paginating the members screen. Along with this I added some typing corrections.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-50291
Fix https://mattermost.atlassian.net/browse/MM-49673

#### Release Note
```release-note
Fix guest badge not appearing on the member list
Minor performance fix on the member list screen
```
