### PR TITLE
MM-51226 - Calls: Emojis not showing in reaction stream

### DIFF
--- a/app/products/calls/components/call_avatar.tsx
+++ b/app/products/calls/components/call_avatar.tsx
@@ -152,6 +152,7 @@ const CallAvatar = ({userModel, volume, serverUrl, sharingScreen, size, muted, r
             <View style={[style.reaction, style.emoji]}>
                 <Emoji
                     emojiName={reaction.name}
+                    literal={reaction.literal}
                     size={iconSize - 3}
                 />
             </View>

--- a/app/products/calls/components/emoji_list.tsx
+++ b/app/products/calls/components/emoji_list.tsx
@@ -50,6 +50,7 @@ const EmojiList = ({reactionStream}: Props) => {
                     <EmojiPill
                         key={e.latestTimestamp}
                         name={e.name}
+                        literal={e.literal}
                         count={e.count}
                     />
                 ))}

--- a/app/products/calls/components/emoji_pill.tsx
+++ b/app/products/calls/components/emoji_pill.tsx
@@ -29,13 +29,15 @@ const styles = StyleSheet.create({
 interface Props {
     name: string;
     count: number;
+    literal?: string;
 }
 
-const EmojiPill = ({name, count}: Props) => {
+const EmojiPill = ({name, literal, count}: Props) => {
     return (
         <View style={styles.pill}>
             <Emoji
                 emojiName={name}
+                literal={literal}
                 size={18}
             />
             <Text style={styles.count}>{count}</Text>

--- a/app/products/calls/state/actions.test.ts
+++ b/app/products/calls/state/actions.test.ts
@@ -845,8 +845,8 @@ describe('useCallsState', () => {
         const expectedCurrentCallState: CurrentCall = {
             ...initialCurrentCallState,
             reactionStream: [
-                {name: 'smile', latestTimestamp: 202, count: 1},
-                {name: '+1', latestTimestamp: 145, count: 2},
+                {name: 'smile', latestTimestamp: 202, count: 1, literal: undefined},
+                {name: '+1', latestTimestamp: 145, count: 2, literal: undefined},
             ],
             participants: {
                 ...initialCurrentCallState.participants,

--- a/app/products/calls/state/actions.ts
+++ b/app/products/calls/state/actions.ts
@@ -446,6 +446,7 @@ export const userReacted = (serverUrl: string, channelId: string, reaction: Call
     } else {
         const newReaction: ReactionStreamEmoji = {
             name: reaction.emoji.name,
+            literal: reaction.emoji.literal,
             count: 1,
             latestTimestamp: reaction.timestamp,
         };

--- a/app/products/calls/types/calls.ts
+++ b/app/products/calls/types/calls.ts
@@ -153,6 +153,7 @@ export type CallReactionEmoji = {
     name: string;
     skin?: string;
     unified: string;
+    literal?: string;
 }
 
 export type CallReaction = {
@@ -165,6 +166,7 @@ export type ReactionStreamEmoji = {
     name: string;
     latestTimestamp: number;
     count: number;
+    literal?: string;
 };
 
 export type RecordingState = {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
     - React-Core
   - react-native-netinfo (9.3.7):
     - React-Core
-  - react-native-network-client (1.3.1):
+  - react-native-network-client (1.3.2):
     - Alamofire (~> 5.6.4)
     - React-Core
     - Starscream (~> 4.0.4)
@@ -977,7 +977,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: a5dddebb4d2955ac4712a4ed66b00a85f62a63ac
   react-native-in-app-review: a073f67c5f3392af6ea7fb383217cdb1aa2aa726
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
-  react-native-network-client: 116ec02566020bff98cddd9c4825e7665306ad6c
+  react-native-network-client: 08bf5a8ad300192768ffa2c6fc929d2bba9a27aa
   react-native-notifications: 83b4fd4a127a6c918fc846cae90da60f84819e44
   react-native-paste-input: 3392800944a47c00dddbff23c31c281482209679
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc


### PR DESCRIPTION
#### Summary
- The change to `emoji-picker-react` on the webapp side changed the emoji names a bit, and some emojis are not in the emoji name map on the mobile side. 
- So, we're changing the name being sent, and for the names that aren't in the map we're now sending the literal as a fallback. This PR passes along that literal.

An example is the nesting dolls that needed the `_` in the name, and the eye in a speech balloon, whos name is not in the map so the literal is being used:
<img width="318" alt="image" src="https://user-images.githubusercontent.com/1490756/224132786-80ca225c-b1c1-4884-96cf-ee37e5822529.png">

Paired webapp PR: https://github.com/mattermost/mattermost-plugin-calls/pull/357

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51226

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: Fix emoji rendering for rare emojis
```
