### PR TITLE
MM-51362 - Fix proximity notice engaging after call ended

### DIFF
--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -279,7 +279,6 @@ export const leaveCall = () => {
         connection.disconnect();
         connection = null;
     }
-    setSpeakerphoneOn(false);
 };
 
 export const leaveCallPopCallScreen = async () => {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -500,7 +500,7 @@ PODS:
     - React-perflogger (= 0.71.3)
   - ReactNativeExceptionHandler (2.10.10):
     - React-Core
-  - ReactNativeIncallManager (4.0.0):
+  - ReactNativeIncallManager (4.0.1):
     - React-Core
   - ReactNativeKeyboardTrackingView (5.7.0):
     - React
@@ -999,7 +999,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7bf0dafc7b727d93c8cb94eb00a9d3753c446c3e
   ReactCommon: 6f65ea5b7d84deb9e386f670dd11ce499ded7b40
   ReactNativeExceptionHandler: b11ff67c78802b2f62eed0e10e75cb1ef7947c60
-  ReactNativeIncallManager: b169b57d3064d8f62478f8fc3c485da6c75045d1
+  ReactNativeIncallManager: 0d2cf9f4d50359728a30c08549762fe67a2efb81
   ReactNativeKeyboardTrackingView: 02137fac3b2ebd330d74fa54ead48b14750a2306
   ReactNativeNavigation: d79d9d53e6025851936bb8b3d13760b86302a669
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "react-native-hw-keyboard-event": "0.0.4",
         "react-native-image-picker": "5.0.2",
         "react-native-in-app-review": "4.2.1",
-        "react-native-incall-manager": "github:cpoile/react-native-incall-manager#634c8fc",
+        "react-native-incall-manager": "4.0.1",
         "react-native-keyboard-aware-scroll-view": "0.9.5",
         "react-native-keyboard-tracking-view": "5.7.0",
         "react-native-keychain": "8.1.1",
@@ -18461,8 +18461,8 @@
       "integrity": "sha512-Bny/ukRhkSSzlsbVpB3vsIuWYuOHBPlxguNwZ0TWK+7IQq8/vTRDf17y1P/4+jMIjBO0WNJCzBxHkXdnlhoTmQ=="
     },
     "node_modules/react-native-incall-manager": {
-      "version": "4.0.0",
-      "resolved": "git+ssh://git@github.com/cpoile/react-native-incall-manager.git#6b66ae7bab194c82573c7b3891b0ac3af71d424e",
+      "version": "4.0.1",
+      "resolved": "git+ssh://git@github.com/react-native-webrtc/react-native-incall-manager.git#6d927ef24c6e47c6134177a4bb14a71054f85b65",
       "license": "ISC",
       "peerDependencies": {
         "react-native": ">=0.40.0"
@@ -35891,8 +35891,8 @@
       "integrity": "sha512-Bny/ukRhkSSzlsbVpB3vsIuWYuOHBPlxguNwZ0TWK+7IQq8/vTRDf17y1P/4+jMIjBO0WNJCzBxHkXdnlhoTmQ=="
     },
     "react-native-incall-manager": {
-      "version": "git+ssh://git@github.com/cpoile/react-native-incall-manager.git#6b66ae7bab194c82573c7b3891b0ac3af71d424e",
-      "from": "react-native-incall-manager@github:cpoile/react-native-incall-manager#634c8fc",
+      "version": "git+ssh://git@github.com/react-native-webrtc/react-native-incall-manager.git#6d927ef24c6e47c6134177a4bb14a71054f85b65",
+      "from": "react-native-incall-manager@4.0.1",
       "requires": {}
     },
     "react-native-iphone-x-helper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "react-native-hw-keyboard-event": "0.0.4",
         "react-native-image-picker": "5.0.2",
         "react-native-in-app-review": "4.2.1",
-        "react-native-incall-manager": "github:cpoile/react-native-incall-manager",
+        "react-native-incall-manager": "github:cpoile/react-native-incall-manager#634c8fc",
         "react-native-keyboard-aware-scroll-view": "0.9.5",
         "react-native-keyboard-tracking-view": "5.7.0",
         "react-native-keychain": "8.1.1",
@@ -35892,7 +35892,7 @@
     },
     "react-native-incall-manager": {
       "version": "git+ssh://git@github.com/cpoile/react-native-incall-manager.git#6b66ae7bab194c82573c7b3891b0ac3af71d424e",
-      "from": "react-native-incall-manager@github:cpoile/react-native-incall-manager",
+      "from": "react-native-incall-manager@github:cpoile/react-native-incall-manager#634c8fc",
       "requires": {}
     },
     "react-native-iphone-x-helper": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-native-hw-keyboard-event": "0.0.4",
     "react-native-image-picker": "5.0.2",
     "react-native-in-app-review": "4.2.1",
-    "react-native-incall-manager": "github:cpoile/react-native-incall-manager#634c8fc",
+    "react-native-incall-manager": "4.0.1",
     "react-native-keyboard-aware-scroll-view": "0.9.5",
     "react-native-keyboard-tracking-view": "5.7.0",
     "react-native-keychain": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-native-hw-keyboard-event": "0.0.4",
     "react-native-image-picker": "5.0.2",
     "react-native-in-app-review": "4.2.1",
-    "react-native-incall-manager": "github:cpoile/react-native-incall-manager",
+    "react-native-incall-manager": "github:cpoile/react-native-incall-manager#634c8fc",
     "react-native-keyboard-aware-scroll-view": "0.9.5",
     "react-native-keyboard-tracking-view": "5.7.0",
     "react-native-keychain": "8.1.1",

--- a/types/modules/react-native-incall-manager.d.ts
+++ b/types/modules/react-native-incall-manager.d.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Type definitions for react-native-incall-manager 3.2
+// Project: https://github.com/zxcpoiu/react-native-incall-manager#readme
+// Definitions by: Carlos Quiroga <https://github.com/KarlosQ>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+declare module 'react-native-incall-manager' {
+    export interface StartSetup {
+        media?: string | undefined;
+        auto?: boolean | undefined;
+        ringback?: string | undefined;
+    }
+
+    export interface StopSetup {
+        busytone?: string | undefined;
+    }
+
+    export class InCallManager {
+        start(setup?: StartSetup): void;
+
+        stop(setup?: StopSetup): void;
+
+        turnScreenOff(): void;
+
+        turnScreenOn(): void;
+
+        getIsWiredHeadsetPluggedIn(): Promise<any>;
+
+        setFlashOn(enable?: boolean, brightness?: number): number;
+
+        setKeepScreenOn(enable?: boolean): void;
+
+        setSpeakerphoneOn(enable?: boolean): void;
+
+        setForceSpeakerphoneOn(_flag?: boolean): void;
+
+        setMicrophoneMute(enable?: boolean): void;
+
+        startRingtone(
+            ringtone?: string,
+            vibrate_pattern?: any[],
+            ios_category?: string,
+            seconds?: number
+        ): void;
+
+        stopRingtone(): void;
+
+        startProximitySensor(): void;
+
+        stopProximitySensor(): void;
+
+        startRingback(ringback?: string): void;
+
+        stopRingback(): void;
+
+        pokeScreen(_timeout?: number): void;
+
+        getAudioUri(audioType: string, fileType: string): any;
+
+        chooseAudioRoute(route: any): any;
+
+        requestAudioFocus(): void;
+
+        abandonAudioFocus(): void;
+    }
+
+    declare const _default: InCallManager;
+
+    export default _default;
+}


### PR DESCRIPTION
#### Summary
- By manually turning off the speakerphone, we were inadvertently starting the proximity sensor/notice (i.e., the screen would turn dark, to prevent the caller from pressing buttons with their face while on a call). 
- Also updating the in-call manager while we're at it.
- Found this while investigating the racy connection issue (https://mattermost.atlassian.net/browse/MM-49663)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51362

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
NONE
```
