### PR TITLE
Fix muted channels not being filtered out on the categories list

### DIFF
--- a/app/utils/categories.ts
+++ b/app/utils/categories.ts
@@ -191,7 +191,7 @@ export const sortChannels = (sorting: CategorySorting, channelsWithMyChannel: Ch
 
 export const getUnreadIds = (cwms: ChannelWithMyChannel[], notifyPropsPerChannel: Record<string, Partial<ChannelNotifyProps>>, lastUnreadId?: string) => {
     return cwms.reduce<Set<string>>((result, cwm) => {
-        if (isUnreadChannel(cwm.myChannel, notifyPropsPerChannel, lastUnreadId)) {
+        if (isUnreadChannel(cwm.myChannel, notifyPropsPerChannel[cwm.channel.id], lastUnreadId)) {
             result.add(cwm.channel.id);
         }
 


### PR DESCRIPTION
#### Summary
We were passing the `notifyPropsPerChannel` object instead of the proper notify prop of the channel, making all channels "not being muted".

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51384

#### Release Note
```release-note
NONE
```
