### PR TITLE
MM-51469 - Calls: Fix for app crashes when screen presenter leaves

### DIFF
--- a/app/products/calls/state/actions.test.ts
+++ b/app/products/calls/state/actions.test.ts
@@ -312,6 +312,66 @@ describe('useCallsState', () => {
         assert.deepEqual(result.current[2], expectedCurrentCallState);
     });
 
+    it('leftCall with screensharing on', () => {
+        const initialCallsState: CallsState = {
+            ...DefaultCallsState,
+            calls: {
+                'channel-1': {
+                    ...call1,
+                    screenOn: 'user-1',
+                },
+            },
+        };
+        const initialChannelsWithCallsState = {
+            'channel-1': true,
+        };
+        const initialCurrentCallState: CurrentCall = {
+            ...DefaultCurrentCall,
+            connected: true,
+            serverUrl: 'server1',
+            myUserId: 'myUserId',
+            ...call1,
+            screenOn: 'user-1',
+        };
+        const expectedCallsState = {
+            'channel-1': {
+                participants: {
+                    'user-2': {id: 'user-2', muted: true, raisedHand: 0},
+                },
+                channelId: 'channel-1',
+                startTime: 123,
+                threadId: 'thread-1',
+                ownerId: 'user-1',
+                hostId: 'user-1',
+                screenOn: '',
+            },
+        };
+        const expectedChannelsWithCallsState = initialChannelsWithCallsState;
+        const expectedCurrentCallState: CurrentCall = {
+            ...initialCurrentCallState,
+            ...expectedCallsState['channel-1'],
+        };
+
+        // setup
+        const {result} = renderHook(() => {
+            return [useCallsState('server1'), useChannelsWithCalls('server1'), useCurrentCall()];
+        });
+        act(() => {
+            setCallsState('server1', initialCallsState);
+            setChannelsWithCalls('server1', initialChannelsWithCallsState);
+            setCurrentCall(initialCurrentCallState);
+        });
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], initialChannelsWithCallsState);
+        assert.deepEqual(result.current[2], initialCurrentCallState);
+
+        // test
+        act(() => userLeftCall('server1', 'channel-1', 'user-1'));
+        assert.deepEqual((result.current[0] as CallsState).calls, expectedCallsState);
+        assert.deepEqual(result.current[1], expectedChannelsWithCallsState);
+        assert.deepEqual(result.current[2], expectedCurrentCallState);
+    });
+
     it('callStarted', () => {
         // setup
         const {result} = renderHook(() => {

--- a/app/products/calls/state/actions.ts
+++ b/app/products/calls/state/actions.ts
@@ -141,6 +141,12 @@ export const userLeftCall = (serverUrl: string, channelId: string, userId: strin
         participants: {...callsState.calls[channelId].participants},
     };
     delete nextCall.participants[userId];
+
+    // If they were screensharing, remove that.
+    if (nextCall.screenOn === userId) {
+        nextCall.screenOn = '';
+    }
+
     const nextCalls = {...callsState.calls};
     if (Object.keys(nextCall.participants).length === 0) {
         delete nextCalls[channelId];
@@ -177,6 +183,12 @@ export const userLeftCall = (serverUrl: string, channelId: string, userId: strin
         voiceOn,
     };
     delete nextCurrentCall.participants[userId];
+
+    // If they were screensharing, remove that.
+    if (nextCurrentCall.screenOn === userId) {
+        nextCurrentCall.screenOn = '';
+    }
+
     setCurrentCall(nextCurrentCall);
 };
 


### PR DESCRIPTION
#### Summary
- Reproduction steps from ticket:
1. UserA starts call from browser.
1. UserB joins call from mobile.
1. UserA starts screen sharing.
1. UserB opens call screen.
1. UserA leaves call without explicitly stopping screen sharing.
1. Crash happens for UserB.

- Issue was we were not clearing the screensharing state when user leaves. Missed that. 
- Added a test to make sure it doesn't regress.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51469

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: Fixed a bug that caused a crash when the current presenter leaves the call without stopping screenshare.
```
