### PR TITLE
Update members count on remove users

### DIFF
--- a/app/components/channel_actions/manage_members_label/manage_members_label.tsx
+++ b/app/components/channel_actions/manage_members_label/manage_members_label.tsx
@@ -63,7 +63,11 @@ const ManageMembersLabel = ({canRemoveUser, channelId, manageOption, testID, use
 
     const handleRemoveUser = useCallback(async () => {
         removeMemberFromChannel(serverUrl, channelId, userId).then(
-            () => fetchChannelStats(serverUrl, channelId, false),
+            (res) => {
+                if (!res.error) {
+                    fetchChannelStats(serverUrl, channelId, false);
+                }
+            },
         );
         await dismissBottomSheet();
         DeviceEventEmitter.emit(Events.REMOVE_USER_FROM_CHANNEL, userId);

--- a/app/components/channel_actions/manage_members_label/manage_members_label.tsx
+++ b/app/components/channel_actions/manage_members_label/manage_members_label.tsx
@@ -62,8 +62,9 @@ const ManageMembersLabel = ({canRemoveUser, channelId, manageOption, testID, use
     const serverUrl = useServerUrl();
 
     const handleRemoveUser = useCallback(async () => {
-        removeMemberFromChannel(serverUrl, channelId, userId);
-        fetchChannelStats(serverUrl, channelId, false);
+        removeMemberFromChannel(serverUrl, channelId, userId).then(
+            () => fetchChannelStats(serverUrl, channelId, false),
+        );
         await dismissBottomSheet();
         DeviceEventEmitter.emit(Events.REMOVE_USER_FROM_CHANNEL, userId);
     }, [channelId, serverUrl, userId]);


### PR DESCRIPTION
#### Summary
When a member was removed from the channel, we refetched the channel stats, but before actually removing the user, so the value would stay the same until we refetch it again.

This makes sure we fetch the channel stats only after the user is removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50289

#### Release Note
```release-note
Members count gets updated after removing users.
```
