### PR TITLE
Consider unread when mentions are present regardless of muted state

### DIFF
--- a/app/utils/categories.ts
+++ b/app/utils/categories.ts
@@ -24,7 +24,7 @@ export function makeCategoryChannelId(teamId: string, channelId: string) {
 
 export const isUnreadChannel = (myChannel: MyChannelModel, notifyProps?: Partial<ChannelNotifyProps>, lastUnreadChannelId?: string) => {
     const isMuted = notifyProps?.mark_unread === General.MENTION;
-    return (isMuted && myChannel.mentionsCount) || (!isMuted && myChannel.isUnread) || (myChannel.id === lastUnreadChannelId);
+    return myChannel.mentionsCount || (!isMuted && myChannel.isUnread) || (myChannel.id === lastUnreadChannelId);
 };
 
 export const filterArchivedChannels = (channelsWithMyChannel: ChannelWithMyChannel[], currentChannelId: string) => {


### PR DESCRIPTION
#### Summary
The `isUnreadChannel` was using the `isMuted` value to check in the mentions, when it doesn't matter whether the channel is muted or not: if it has mentions, it is unread.

This change was made after seeing an issue where a channel was properly showing the mentions, but it was being filtered on the collapsed categories. My guess is that something else is setting the mentions without properly updating the `isUnread` value, but haven't looked into it.

The issue got solved with restarting the app, so probably has nothing to do with other "phantom notification" issues we have seen around.

#### Ticket Link
None

#### Release Note
```release-note
Fix some notifications not showing when the category is collapsed.
```
