### PR TITLE
MM-51227 - Calls: Landscape mode optimizations for screensharing

### DIFF
--- a/app/products/calls/components/reaction_bar.tsx
+++ b/app/products/calls/components/reaction_bar.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback} from 'react';
-import {Pressable, StyleSheet, View} from 'react-native';
+import {Pressable, StyleSheet, useWindowDimensions, View} from 'react-native';
 
 import {raiseHand, unraiseHand} from '@calls/actions';
 import {sendReaction} from '@calls/actions/calls';
@@ -16,11 +16,13 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         alignItems: 'flex-end',
         justifyContent: 'space-between',
-        backgroundColor: 'rgba(255,255,255,0.16)',
         width: '100%',
         height: 64,
         paddingLeft: 16,
         paddingRight: 16,
+    },
+    containerInLandscape: {
+        paddingBottom: 6,
     },
     button: {
         display: 'flex',
@@ -54,6 +56,9 @@ interface Props {
 }
 
 const ReactionBar = ({raisedHand}: Props) => {
+    const {width, height} = useWindowDimensions();
+    const isLandscape = width > height;
+
     const LowerHandText = (
         <FormattedText
             id={'mobile.calls_lower_hand'}
@@ -77,7 +82,7 @@ const ReactionBar = ({raisedHand}: Props) => {
     }, [raisedHand]);
 
     return (
-        <View style={styles.container}>
+        <View style={[styles.container, isLandscape && styles.containerInLandscape]}>
             <Pressable
                 style={[styles.button, Boolean(raisedHand) && styles.buttonPressed]}
                 onPress={toggleRaiseHand}

--- a/app/products/calls/components/reaction_bar.tsx
+++ b/app/products/calls/components/reaction_bar.tsx
@@ -23,6 +23,7 @@ const styles = StyleSheet.create({
     },
     containerInLandscape: {
         paddingBottom: 6,
+        justifyContent: 'center',
     },
     button: {
         display: 'flex',
@@ -34,6 +35,10 @@ const styles = StyleSheet.create({
         maxWidth: 160,
         paddingLeft: 10,
         paddingRight: 10,
+    },
+    buttonLandscape: {
+        marginRight: 12,
+        marginLeft: 12,
     },
     buttonPressed: {
         backgroundColor: 'rgba(245, 171, 0, 0.24)',
@@ -84,7 +89,7 @@ const ReactionBar = ({raisedHand}: Props) => {
     return (
         <View style={[styles.container, isLandscape && styles.containerInLandscape]}>
             <Pressable
-                style={[styles.button, Boolean(raisedHand) && styles.buttonPressed]}
+                style={[styles.button, isLandscape && styles.buttonLandscape, Boolean(raisedHand) && styles.buttonPressed]}
                 onPress={toggleRaiseHand}
             >
                 <CompassIcon
@@ -99,7 +104,7 @@ const ReactionBar = ({raisedHand}: Props) => {
                     <EmojiButton
                         key={name}
                         emojiName={name}
-                        style={styles.button}
+                        style={[styles.button, isLandscape && styles.buttonLandscape]}
                         onPress={() => sendReaction({name, unified})}
                     />
                 ))

--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -163,14 +163,13 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         }),
     },
     buttonsLandscape: {
-        height: 128,
+        height: 110,
         position: 'absolute',
         backgroundColor: 'rgba(0,0,0,0.64)',
         bottom: 0,
-        justifyContent: 'center',
     },
     buttonsLandscapeWithReactions: {
-        height: 192,
+        height: 174,
     },
     buttonsLandscapeNoControls: {
         bottom: 1000,
@@ -179,6 +178,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         flexDirection: 'column',
         alignItems: 'center',
         flex: 1,
+    },
+    buttonLandscape: {
+        flex: 0,
     },
     mute: {
         flexDirection: 'column',
@@ -205,7 +207,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     otherButtons: {
         flexDirection: 'row',
         alignItems: 'center',
-        alignContent: 'space-between',
+    },
+    otherButtonsLandscape: {
+        justifyContent: 'center',
     },
     collapseIcon: {
         color: theme.sidebarText,
@@ -236,6 +240,17 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         height: 68,
         margin: 10,
         overflow: 'hidden',
+    },
+    buttonIconLandscape: {
+        borderRadius: 26,
+        paddingTop: 14,
+        paddingRight: 16,
+        paddingBottom: 16,
+        paddingLeft: 14,
+        width: 52,
+        height: 52,
+        marginLeft: 12,
+        marginRight: 12,
     },
     hangUpIcon: {
         backgroundColor: Preferences.THEMES.denim.dndIndicator,
@@ -279,7 +294,6 @@ const CallScreen = ({
 
     const style = getStyleSheet(theme);
     const isLandscape = width > height;
-    const showControls = !isLandscape || showControlsInLandscape;
     const myParticipant = currentCall?.participants[currentCall.myUserId];
     const micPermissionsError = !micPermissionsGranted && !currentCall?.micPermissionsErrorDismissed;
 
@@ -567,7 +581,11 @@ const CallScreen = ({
         <SafeAreaView style={style.wrapper}>
             <View style={style.container}>
                 <View
-                    style={[style.header, isLandscape && style.headerLandscape, !showControls && style.headerLandscapeNoControls]}
+                    style={[
+                        style.header,
+                        isLandscape && style.headerLandscape,
+                        isLandscape && !showControlsInLandscape && style.headerLandscapeNoControls,
+                    ]}
                 >
                     {waitingForRecording && <CallsBadge type={CallsBadgeType.Waiting}/>}
                     {recording && <CallsBadge type={CallsBadgeType.Rec}/>}
@@ -595,7 +613,7 @@ const CallScreen = ({
                         style.buttons,
                         isLandscape && style.buttonsLandscape,
                         isLandscape && showReactions && style.buttonsLandscapeWithReactions,
-                        !showControls && style.buttonsLandscapeNoControls,
+                        isLandscape && !showControlsInLandscape && style.buttonsLandscapeNoControls,
                     ]}
                 >
                     {showReactions &&
@@ -615,17 +633,18 @@ const CallScreen = ({
                                 style={style.muteIcon}
                             />
                             {myParticipant.muted ? UnmuteText : MuteText}
-                        </Pressable>}
-                    <View style={style.otherButtons}>
+                        </Pressable>
+                    }
+                    <View style={[style.otherButtons, isLandscape && style.otherButtonsLandscape]}>
                         <Pressable
                             testID='leave'
-                            style={style.button}
+                            style={[style.button, isLandscape && style.buttonLandscape]}
                             onPress={leaveCallHandler}
                         >
                             <CompassIcon
                                 name='phone-hangup'
                                 size={24}
-                                style={{...style.buttonIcon, ...style.hangUpIcon}}
+                                style={[style.buttonIcon, isLandscape && style.buttonIconLandscape, style.hangUpIcon]}
                             />
                             <FormattedText
                                 id={'mobile.calls_leave'}
@@ -635,13 +654,18 @@ const CallScreen = ({
                         </Pressable>
                         <Pressable
                             testID={'toggle-speakerphone'}
-                            style={style.button}
+                            style={[style.button, isLandscape && style.buttonLandscape]}
                             onPress={toggleSpeakerPhone}
                         >
                             <CompassIcon
                                 name={'volume-high'}
                                 size={24}
-                                style={[style.buttonIcon, style.speakerphoneIcon, currentCall.speakerphoneOn && style.buttonOn]}
+                                style={[
+                                    style.buttonIcon,
+                                    isLandscape && style.buttonIconLandscape,
+                                    style.speakerphoneIcon,
+                                    currentCall.speakerphoneOn && style.buttonOn,
+                                ]}
                             />
                             <FormattedText
                                 id={'mobile.calls_speaker'}
@@ -650,13 +674,13 @@ const CallScreen = ({
                             />
                         </Pressable>
                         <Pressable
-                            style={style.button}
+                            style={[style.button, isLandscape && style.buttonLandscape]}
                             onPress={toggleReactions}
                         >
                             <CompassIcon
                                 name={'emoticon-happy-outline'}
                                 size={24}
-                                style={[style.buttonIcon, showReactions && style.buttonOn]}
+                                style={[style.buttonIcon, isLandscape && style.buttonIconLandscape, showReactions && style.buttonOn]}
                             />
                             <FormattedText
                                 id={'mobile.calls_react'}
@@ -665,13 +689,13 @@ const CallScreen = ({
                             />
                         </Pressable>
                         <Pressable
-                            style={style.button}
+                            style={[style.button, isLandscape && style.buttonLandscape]}
                             onPress={showOtherActions}
                         >
                             <CompassIcon
                                 name='dots-horizontal'
                                 size={24}
-                                style={style.buttonIcon}
+                                style={[style.buttonIcon, isLandscape && style.buttonIconLandscape]}
                             />
                             <FormattedText
                                 id={'mobile.calls_more'}
@@ -682,16 +706,22 @@ const CallScreen = ({
                         {isLandscape &&
                             <Pressable
                                 testID='mute-unmute'
-                                style={style.button}
+                                style={[style.button, style.buttonLandscape]}
                                 onPress={muteUnmuteHandler}
                             >
                                 <CompassIcon
                                     name={myParticipant.muted ? 'microphone-off' : 'microphone'}
                                     size={24}
-                                    style={[style.buttonIcon, style.muteIconLandscape, myParticipant?.muted && style.muteIconLandscapeMuted]}
+                                    style={[
+                                        style.buttonIcon,
+                                        isLandscape && style.buttonIconLandscape,
+                                        style.muteIconLandscape,
+                                        myParticipant?.muted && style.muteIconLandscapeMuted,
+                                    ]}
                                 />
                                 {myParticipant.muted ? UnmuteText : MuteText}
-                            </Pressable>}
+                            </Pressable>
+                        }
                     </View>
                 </View>
             </View>

--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -110,7 +110,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         position: 'absolute',
         top: 0,
         backgroundColor: 'rgba(0,0,0,0.64)',
-        height: 64,
+        height: 52,
         paddingTop: 0,
     },
     headerLandscapeNoControls: {
@@ -218,6 +218,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         backgroundColor: 'rgba(255,255,255,0.12)',
         borderRadius: 4,
         overflow: 'hidden',
+    },
+    collapseIconLandscape: {
+        margin: 10,
+        padding: 0,
+        backgroundColor: 'transparent',
+        borderRadius: 0,
     },
     muteIcon: {
         color: theme.sidebarText,
@@ -598,7 +604,7 @@ const CallScreen = ({
                         <CompassIcon
                             name='arrow-collapse'
                             size={24}
-                            style={style.collapseIcon}
+                            style={[style.collapseIcon, isLandscape && style.collapseIconLandscape]}
                         />
                     </Pressable>
                 </View>


### PR DESCRIPTION
#### Summary
- There was pretty bad UX in landscape mode on Android, and iOS didn't support it. 
- Expanded the screensharing view to fill all available space. The goal was to optimize for viewing screensharing, so: removed reactions and "viewing x's screen".
- The reaction bar was originally showing under the controls (it could be pressed while also watching screensharing). Changed that to be part of the buttons, which toggle when pressing the screensharing video. (see screenshots)
- Tweaked the header bar in landscape mode to show the time and collapse buttons more clearly.
- @tanmay-des Can you take a look at these and let us know what you'd like tweaked? Thank you.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51227

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Screenshots

#### Before:
Android:
![Screenshot_20230321-181124](https://user-images.githubusercontent.com/1490756/226755800-aa71d329-80da-4e26-8023-777ab1aa20bb.png)
![Screenshot_20230321-181136](https://user-images.githubusercontent.com/1490756/226755818-7382326d-9ce8-4063-84ba-ce1e09ef132e.png)
![Screenshot_20230321-181147](https://user-images.githubusercontent.com/1490756/226755831-509b286d-e3d1-4303-800e-d21bdbeb1314.png)
![Screenshot_20230321-181623](https://user-images.githubusercontent.com/1490756/226755851-e2d76252-a878-46d2-8b40-7346100b5407.png)

iOS:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1490756/226756461-40dd35b9-58d1-4afc-92f5-06c361d388ad.png">

#### After:
<img width="659" alt="image" src="https://user-images.githubusercontent.com/1490756/226756483-c4be767d-02d9-4de3-9d26-aec913da6a7e.png">
<img width="662" alt="image" src="https://user-images.githubusercontent.com/1490756/226757186-348d0079-fbbd-4f0c-8d5d-05aad04951e8.png">
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1490756/226756553-662b660d-e1b6-4f79-a799-5b8f5264736b.png">


#### Release Note
```release-note
Calls: Optimized screensharing in landscape mode for Android and iOS; unlocked landscape mode for iOS phone devices.
```

