### PR TITLE
photo permission alert is not displayed properly

### DIFF
--- a/app/utils/file/file_picker/index.ts
+++ b/app/utils/file/file_picker/index.ts
@@ -16,7 +16,7 @@ import type {IntlShape} from 'react-intl';
 
 const MattermostManaged = NativeModules.MattermostManaged;
 
-type PermissionSource = 'camera' | 'storage' | 'denied_android' | 'denied_ios' | 'photo';
+type PermissionSource = 'camera' | 'storage' | 'photo_android' | 'photo_ios' | 'photo';
 
 export default class FilePickerUtil {
     private readonly uploadFiles: (files: ExtractedFileInfo[]) => void;
@@ -64,7 +64,7 @@ export default class FilePickerUtil {
                         'Upload files to your server. Open Settings to grant {applicationName} Read and Write access to files on this device.',
                 }, {applicationName}),
             },
-            denied_ios: {
+            photo_ios: {
                 title: formatMessage(
                     {
                         id: 'mobile.ios.photos_permission_denied_title',
@@ -79,7 +79,7 @@ export default class FilePickerUtil {
                         'Upload photos and videos to your server or save them to your device. Open Settings to grant {applicationName} Read and Write access to your photo and video library.',
                 }, {applicationName}),
             },
-            denied_android: {
+            photo_android: {
                 title: formatMessage(
                     {
                         id: 'mobile.android.photos_permission_denied_title',
@@ -110,7 +110,7 @@ export default class FilePickerUtil {
 
     private getPermissionDeniedMessage = (source?: PermissionSource) => {
         const sources = ['camera', 'storage'];
-        const deniedSource: PermissionSource = Platform.select({android: 'denied_android', ios: 'denied_ios'})!;
+        const deniedSource: PermissionSource = Platform.select({android: 'photo_android', ios: 'photo_ios'})!;
         const msgForSource = source && sources.includes(source) ? source : deniedSource;
 
         return this.getPermissionMessages(msgForSource);

--- a/app/utils/file/file_picker/index.ts
+++ b/app/utils/file/file_picker/index.ts
@@ -109,7 +109,7 @@ export default class FilePickerUtil {
     };
 
     private getPermissionDeniedMessage = (source?: PermissionSource) => {
-        const sources = ['camera', 'storage', 'photo'];
+        const sources = ['camera', 'storage'];
         const deniedSource: PermissionSource = Platform.select({android: 'denied_android', ios: 'denied_ios'})!;
         const msgForSource = source && sources.includes(source) ? source : deniedSource;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Once the user has been denied permission to access the camera roll, when they try to access it again, the alert is not being displayed 
(Images attached)

The following error is displayed in the Metro debug:

TypeError: Cannot read property 'title' of undefined
TypeError: Cannot read property 'title' of undefined


In my opinion the problem starts in:

https://github.com/mattermost/mattermost-mobile/blob/main/app/utils/file/file_picker/index.ts#L296

  attachFileFromPhotoGallery()
  at line 304=> await this.hasPhotoPermission('photo');

hasPhotoPermission()
 at line 173=> this.getPermissionDeniedMessage(source)

getPermissionDeniedMessage()
 at line 116=> this.getPermissionMessages(msgForSource);

at getPermissionMessages()
 from line 36=>
 There is no 'photo' : {title,text} element defined in the permissions Record


so... options:
1) define a new 'photo' element with its respective {title, text} but it will have the same value as 'denied_xxx'
2) (this PR) use `denied_ios`/`denied_android` for it, as it already has a proper value for this specific case, the simplest way to do this is removing the 'photo' element from the available permissions sources at:
https://github.com/mattermost/mattermost-mobile/blob/main/app/utils/file/file_picker/index.ts#L112

3) or by adjusting the `if` to the specific case of 'photo'

I hope this summary is clear for you, thanks, Eduardo.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: Simulator iOS16.2, iPhone11Pro 16.3.1 <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
![Recording 2023-03-22 at 12 50 32](https://user-images.githubusercontent.com/5940718/226994120-30116b5a-865b-493c-9ce8-be8b32aa31fb.gif)

![Recording 2023-03-22 at 13 54 33](https://user-images.githubusercontent.com/5940718/226994857-4835f469-0308-4c05-8d5a-a9f6b0bbd3cb.gif)



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
