### PR TITLE
MM-50533 - Calls: Prioritize raised hand when ordering participants

### DIFF
--- a/app/products/calls/utils.ts
+++ b/app/products/calls/utils.ts
@@ -40,18 +40,18 @@ const sortByState = (presenterID?: string) => {
             return 1;
         }
 
-        if (!a.muted && b.muted) {
-            return -1;
-        } else if (!b.muted && a.muted) {
-            return 1;
-        }
-
         if (a.raisedHand && !b.raisedHand) {
             return -1;
         } else if (b.raisedHand && !a.raisedHand) {
             return 1;
         } else if (a.raisedHand && b.raisedHand) {
             return a.raisedHand - b.raisedHand;
+        }
+
+        if (!a.muted && b.muted) {
+            return -1;
+        } else if (!b.muted && a.muted) {
+            return 1;
         }
 
         return 0;


### PR DESCRIPTION
#### Summary
- Participants who raised their hands first will always be ordered first, maintaining the raised hand order regardless of other states (e.g., voice on).

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-50533
- Related on webapp: https://github.com/mattermost/mattermost-plugin-calls/pull/380

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: Raised hand will take precedence when ordering participants in the call screen.
```
