### PR TITLE
Prevent in-app notification and snackbar from blocking gestures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21595,9 +21595,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -26281,7 +26281,7 @@
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "requires": {
-        "@types/react": "^18.0.15",
+        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -38203,9 +38203,9 @@
       }
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "dev": true,
       "peer": true,
       "requires": {

--- a/patches/react-native-navigation+7.32.1.patch
+++ b/patches/react-native-navigation+7.32.1.patch
@@ -162,6 +162,34 @@ index a34598c..b035a76 100644
          if (navigationActivity != null) {
              navigationActivity.onCatalystInstanceDestroy();
          }
+diff --git a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt
+index a79e487..dba9b65 100644
+--- a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt
++++ b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt
+@@ -3,11 +3,20 @@ package com.reactnativenavigation.utils
+ import android.graphics.Rect
+ import android.view.MotionEvent
+ import android.view.View
++import android.view.ViewGroup
+ 
+ val hitRect = Rect()
+ 
+ fun MotionEvent.coordinatesInsideView(view: View?): Boolean {
+     view ?: return false
+-    view.getHitRect(hitRect)
+-    return hitRect.contains(x.toInt(), y.toInt())
++    val viewGroup = (view as ViewGroup).getChildAt(0) as ViewGroup
++    return if (viewGroup.childCount > 0) {
++        val content = viewGroup.getChildAt(0)
++
++        content.getHitRect(hitRect)
++
++        hitRect.contains(x.toInt(), y.toInt())
++    } else {
++        false
++    }
+ }
+\ No newline at end of file
 diff --git a/node_modules/react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/react/ReactGateway.java b/node_modules/react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/react/ReactGateway.java
 index 035ec31..630b8d4 100644
 --- a/node_modules/react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/react/ReactGateway.java


### PR DESCRIPTION
#### Summary
on android, when receiving an in-app notification or the snackbar is shown, the gestures were being captured by the overlay instead of passing down to the screen below.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51389

#### Release Note
```release-note
NONE
```
