### PR TITLE
Replaced hardcoded value in Sentry hook with config value

### DIFF
--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -43,6 +43,8 @@ export function initializeSentry() {
         attachStacktrace: isBetaApp, // For Beta, stack traces are automatically attached to all messages logged
     };
 
+    const eventFilter = Array.isArray(Config.SentryOptions?.severityLevelFilter) ? Config.SentryOptions.severityLevelFilter : [];
+
     Sentry.init({
         dsn,
         sendDefaultPii: false,
@@ -58,7 +60,7 @@ export function initializeSentry() {
             }),
         ],
         beforeSend: (event: Event) => {
-            if (isBetaApp || event?.level === 'fatal') {
+            if (isBetaApp || eventFilter.includes(event?.level)) {
                 return event;
             }
 

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -18,7 +18,8 @@
         "autoBreadcrumbs": {
             "xhr": false,
             "console": true
-        }
+        },
+        "severityLevelFilter": ["fatal"]
     },
 
     "ShowReview": false,


### PR DESCRIPTION
#### Summary
Current configuration of Sentry module in app has a hardcoded value in `beforeSend` hook, which prevents sending any events having the severity level other than 'fatal'.
Suggested change introduces ability to configure the severity levels allowing the event being sent to Sentry from app. The default value is placed in `assets/base/config.json` and can be overriden by `assets/override/config.json`.

#### Ticket Link

#### Checklist

#### Device Information
This PR was tested on: iPhone Xs iOS 16.3.1

#### Screenshots

#### Release Note
```release-note
NONE
```
