### PR TITLE
Handle undefined metadata on Markdown Table Images

### DIFF
--- a/app/components/markdown/markdown_table_image/index.tsx
+++ b/app/components/markdown/markdown_table_image/index.tsx
@@ -18,7 +18,7 @@ import type {GalleryItemType} from '@typings/screens/gallery';
 
 type MarkdownTableImageProps = {
     disabled?: boolean;
-    imagesMetadata: Record<string, PostImage>;
+    imagesMetadata: Record<string, PostImage | undefined>;
     location?: string;
     postId: string;
     serverURL?: string;
@@ -55,7 +55,8 @@ const MarkTableImage = ({disabled, imagesMetadata, location, postId, serverURL, 
     };
 
     const getFileInfo = () => {
-        const {height, width} = metadata;
+        const height = metadata?.height || 0;
+        const width = metadata?.width || 0;
         const link = decodeURIComponent(getImageSource());
         let filename = parseUrl(link.substr(link.lastIndexOf('/'))).pathname.replace('/', '');
         let extension = filename.split('.').pop();
@@ -109,7 +110,7 @@ const MarkTableImage = ({disabled, imagesMetadata, location, postId, serverURL, 
             />
         );
     } else {
-        const {height, width} = calculateDimensions(metadata.height, metadata.width, 100, 100);
+        const {height, width} = calculateDimensions(metadata?.height, metadata?.width, 100, 100);
         image = (
             <TouchableWithoutFeedback
                 disabled={disabled}

--- a/app/utils/images/index.ts
+++ b/app/utils/images/index.ts
@@ -7,7 +7,7 @@ import 'react-native-reanimated';
 import {View} from '@constants';
 import {IMAGE_MAX_HEIGHT, IMAGE_MIN_DIMENSION, MAX_GIF_SIZE, VIEWPORT_IMAGE_OFFSET, VIEWPORT_IMAGE_REPLY_OFFSET} from '@constants/image';
 
-export const calculateDimensions = (height: number, width: number, viewPortWidth = 0, viewPortHeight = 0) => {
+export const calculateDimensions = (height?: number, width?: number, viewPortWidth = 0, viewPortHeight = 0) => {
     'worklet';
 
     if (!height || !width) {


### PR DESCRIPTION
#### Summary
Handle undefined metadata on Markdown Table Images.

Here is another PR with more thorough check on the undefined metadata all over the app: https://github.com/mattermost/mattermost-mobile/pull/7244

#### Ticket Link
Partially Fix https://mattermost.atlassian.net/browse/MM-51731

#### Release Note
```release-note
Fix crash on some instances of markdown table images
```
