### PR TITLE
use xcode 14.2.0 on circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ executors:
       NODE_ENV: production
       BABEL_ENV: production
     macos:
-      xcode: "14.0.0"
+      xcode: "14.2.0"
     working_directory: ~/mattermost-mobile
     shell: /bin/bash --login -o pipefail
     resource_class: <<parameters.resource_class>>
@@ -603,6 +603,7 @@ workflows:
             branches:
               only:
                 - /^build-\d+$/
+                - /^build-release-\d+$/
                 - /^build-ios-sim-\d+$/
 
       - github-release:


### PR DESCRIPTION
```release-note
NONE
```

note: in case of a 2.2.1 dot release, this also needs cherry-picking to the release-2.2 branch