### PR TITLE
Bump react-native-network-client to version 1.3.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
     - React-Core
   - react-native-netinfo (9.3.7):
     - React-Core
-  - react-native-network-client (1.3.2):
+  - react-native-network-client (1.3.3):
     - Alamofire (~> 5.6.4)
     - React-Core
     - Starscream (~> 4.0.4)
@@ -977,7 +977,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: a5dddebb4d2955ac4712a4ed66b00a85f62a63ac
   react-native-in-app-review: a073f67c5f3392af6ea7fb383217cdb1aa2aa726
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
-  react-native-network-client: 08bf5a8ad300192768ffa2c6fc929d2bba9a27aa
+  react-native-network-client: 8435c8ba294738b52988144151e6144dbf125ce8
   react-native-notifications: 83b4fd4a127a6c918fc846cae90da60f84819e44
   react-native-paste-input: 3392800944a47c00dddbff23c31c281482209679
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mattermost/calls": "github:mattermost/calls-common#v0.12.0",
         "@mattermost/compass-icons": "0.1.35",
         "@mattermost/react-native-emm": "1.3.5",
-        "@mattermost/react-native-network-client": "1.3.2",
+        "@mattermost/react-native-network-client": "1.3.3",
         "@mattermost/react-native-paste-input": "0.6.2",
         "@mattermost/react-native-turbo-log": "0.2.3",
         "@mattermost/react-native-turbo-mailer": "0.2.4",
@@ -3248,9 +3248,9 @@
       }
     },
     "node_modules/@mattermost/react-native-network-client": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.2.tgz",
-      "integrity": "sha512-3GFNzMXZWlIXXDYQLIJlKRf+HUZKP0F7mpZ1rSTgoTmUeFdqde4uRiU/L96COg34rAdeFRFrgpk0DxEnT7NiVg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.3.tgz",
+      "integrity": "sha512-ANGV0UImroX/sPf6+K2knfflSniTdKPe4SmW7vNPKzs3sU+aadbktI9CjUTAszlOHILi7Na4Y9o7L/jh3+lUdQ==",
       "dependencies": {
         "validator": "13.9.0",
         "zod": "3.20.6"
@@ -24314,9 +24314,9 @@
       "requires": {}
     },
     "@mattermost/react-native-network-client": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.2.tgz",
-      "integrity": "sha512-3GFNzMXZWlIXXDYQLIJlKRf+HUZKP0F7mpZ1rSTgoTmUeFdqde4uRiU/L96COg34rAdeFRFrgpk0DxEnT7NiVg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.3.tgz",
+      "integrity": "sha512-ANGV0UImroX/sPf6+K2knfflSniTdKPe4SmW7vNPKzs3sU+aadbktI9CjUTAszlOHILi7Na4Y9o7L/jh3+lUdQ==",
       "requires": {
         "validator": "13.9.0",
         "zod": "3.20.6"
@@ -26281,7 +26281,7 @@
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "requires": {
-        "@types/react": "*",
+        "@types/react": "^18.0.15",
         "hoist-non-react-statics": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@mattermost/calls": "github:mattermost/calls-common#v0.12.0",
     "@mattermost/compass-icons": "0.1.35",
     "@mattermost/react-native-emm": "1.3.5",
-    "@mattermost/react-native-network-client": "1.3.2",
+    "@mattermost/react-native-network-client": "1.3.3",
     "@mattermost/react-native-paste-input": "0.6.2",
     "@mattermost/react-native-turbo-log": "0.2.3",
     "@mattermost/react-native-turbo-mailer": "0.2.4",


### PR DESCRIPTION
#### Summary
Bump react-native-network-client to fix issues with reconnecting websockets

#### Release Note
```release-note
Fix websocket not connecting on rare scenarios
```
