### PR TITLE
revert changes made to in_app_notifications

### DIFF
--- a/app/screens/in_app_notification/index.tsx
+++ b/app/screens/in_app_notification/index.tsx
@@ -30,7 +30,6 @@ type InAppNotificationProps = {
 }
 
 const AUTO_DISMISS_TIME_MILLIS = 5000;
-const noInsets = {top: 0, bottom: 0, left: 0, right: 0};
 
 const styles = StyleSheet.create({
     container: {
@@ -70,10 +69,11 @@ const InAppNotification = ({componentId, serverName, serverUrl, notification}: I
     const dismissTimerRef = useRef<NodeJS.Timeout | null>(null);
     const initial = useSharedValue(-130);
     const isTablet = useIsTablet();
-    let insets = useSafeAreaInsets();
-    if (Platform.OS === 'android') {
+    let insets = {top: 0};
+    if (Platform.OS === 'ios') {
         // on Android we disable the safe area provider as it conflicts with the gesture system
-        insets = noInsets;
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        insets = useSafeAreaInsets();
     }
 
     const tapped = useRef<boolean>(false);


### PR DESCRIPTION
#### Summary
The Safe Area context is not available for in-app-notifications on android, this was done on purpose as it forces the layout to not start where it should. Reverting the changes to avoid the crash caused by not having the context available.

credit goes to @ Muhammadqasim001 for the find

```release-note
NONE
```
