### PR TITLE
Fix search results order

### DIFF
--- a/app/actions/local/post.ts
+++ b/app/actions/local/post.ts
@@ -15,6 +15,7 @@ import {getPostIdsForCombinedUserActivityPost} from '@utils/post_list';
 
 import {updateLastPostAt, updateMyChannelLastFetchedAt} from './channel';
 
+import type {Q} from '@nozbe/watermelondb';
 import type MyChannelModel from '@typings/database/models/servers/my_channel';
 import type PostModel from '@typings/database/models/servers/post';
 import type UserModel from '@typings/database/models/servers/user';
@@ -239,10 +240,10 @@ export async function storePostsForChannel(
     }
 }
 
-export async function getPosts(serverUrl: string, ids: string[]) {
+export async function getPosts(serverUrl: string, ids: string[], sort?: Q.SortOrder) {
     try {
         const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        return queryPostsById(database, ids).fetch();
+        return queryPostsById(database, ids, sort).fetch();
     } catch (error) {
         return [];
     }

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -190,7 +190,7 @@ const SearchScreen = ({teamId, teams}: Props) => {
 
         setFileInfos(files?.length ? files : emptyFileResults);
         if (postResults.order) {
-            const postModels = await getPosts(serverUrl, postResults.order);
+            const postModels = await getPosts(serverUrl, postResults.order, 'asc');
             setPosts(postModels.length ? postModels : emptyPosts);
         }
         setFileChannelIds(channels?.length ? channels : emptyChannelIds);


### PR DESCRIPTION
#### Summary
Fixes the search results that were being shown in a random order based on the way the database was returning those results, now they are sorted by `create_at``

#### Ticket Link
Fixes: #7260

#### Release Note
```release-note
Fixed the sort order of the search results, showing from newest to oldest
```