### PR TITLE
Fix file attachment limited to one file

### DIFF
--- a/app/components/post_draft/quick_actions/file_quick_action/index.tsx
+++ b/app/components/post_draft/quick_actions/file_quick_action/index.tsx
@@ -47,7 +47,7 @@ export default function FileQuickAction({
         const picker = new PickerUtil(intl,
             onUploadFiles);
 
-        picker.attachFileFromFiles();
+        picker.attachFileFromFiles(undefined, true);
     }, [onUploadFiles]);
 
     const actionTestID = disabled ? `${testID}.disabled` : testID;


### PR DESCRIPTION
#### Summary
Fix file attachment only allowing for one file, instead of many files.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-52145
Fix #7273 

#### Release Note
```release-note
Now you can select several files when attaching files to a message.
```
