### PR TITLE
Fix channel not marked as unread on notification entry

### DIFF
--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -44,7 +44,7 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
     }
     const currentUserId = await getCurrentUserId(database);
 
-    const existing = await getPostById(database, post.pending_post_id);
+    const existing = await getPostById(database, post.pending_post_id) || await getPostById(database, post.id);
 
     if (existing) {
         return;


### PR DESCRIPTION
#### Summary
When we enter through the notification entry, first we navigate to the channel, then we connect the websockets. When we connect the websockets, if there are reliable websockets, we get the missing events. One of the missing events is "message posted".

If we already fetched the channel, these events will be considered after marking the channel as read. This was causing the channel to become once more unread, and remove the New posts lines.

Not handling the websocket event if we have already the post in the system fixes the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51243

#### Release Note
```release-note
NONE
```
