### PR TITLE
Fix channels showing empty

### DIFF
--- a/app/client/rest/posts.ts
+++ b/app/client/rest/posts.ts
@@ -111,7 +111,7 @@ const ClientPosts = <TBase extends Constructor<ClientBase>>(superclass: TBase) =
         );
     };
 
-    getPostsBefore = async (channelId: string, postId: string, page = 0, perPage = PER_PAGE_DEFAULT, collapsedThreads = false, collapsedThreadsExtended = false) => {
+    getPostsBefore = async (channelId: string, postId = '', page = 0, perPage = PER_PAGE_DEFAULT, collapsedThreads = false, collapsedThreadsExtended = false) => {
         this.analytics?.trackAPI('api_posts_get_before', {channel_id: channelId});
 
         return this.doFetch(

--- a/app/client/rest/posts.ts
+++ b/app/client/rest/posts.ts
@@ -16,7 +16,7 @@ export interface ClientPostsMix {
     getPostThread: (postId: string, options: FetchPaginatedThreadOptions) => Promise<PostResponse>;
     getPosts: (channelId: string, page?: number, perPage?: number, collapsedThreads?: boolean, collapsedThreadsExtended?: boolean) => Promise<PostResponse>;
     getPostsSince: (channelId: string, since: number, collapsedThreads?: boolean, collapsedThreadsExtended?: boolean) => Promise<PostResponse>;
-    getPostsBefore: (channelId: string, postId: string, page?: number, perPage?: number, collapsedThreads?: boolean, collapsedThreadsExtended?: boolean) => Promise<PostResponse>;
+    getPostsBefore: (channelId: string, postId?: string, page?: number, perPage?: number, collapsedThreads?: boolean, collapsedThreadsExtended?: boolean) => Promise<PostResponse>;
     getPostsAfter: (channelId: string, postId: string, page?: number, perPage?: number, collapsedThreads?: boolean, collapsedThreadsExtended?: boolean) => Promise<PostResponse>;
     getFileInfosForPost: (postId: string) => Promise<FileInfo[]>;
     getSavedPosts: (userId: string, channelId?: string, teamId?: string, page?: number, perPage?: number) => Promise<PostResponse>;

--- a/app/screens/channel/channel_post_list/channel_post_list.tsx
+++ b/app/screens/channel/channel_post_list/channel_post_list.tsx
@@ -55,14 +55,14 @@ const ChannelPostList = ({
     }, [isCRTEnabled, posts, channelId, serverUrl, appState === 'active']);
 
     const onEndReached = useCallback(debounce(async () => {
-        if (!fetchingPosts.current && canLoadPosts.current && posts.length) {
+        if (!fetchingPosts.current && canLoadPosts.current) {
             fetchingPosts.current = true;
             const lastPost = posts[posts.length - 1];
-            const result = await fetchPostsBefore(serverUrl, channelId, lastPost.id);
+            const result = await fetchPostsBefore(serverUrl, channelId, lastPost?.id || '');
             fetchingPosts.current = false;
             canLoadPosts.current = false;
             if (!('error' in result)) {
-                canLoadPosts.current = (result.posts?.length ?? 1) > 0;
+                canLoadPosts.current = (result.posts?.length ?? 0) > 0;
             }
         }
     }, 500), [channelId, posts]);


### PR DESCRIPTION
#### Summary
Sometimes, channels appear as empty when they are not. I forced the issue by adding an "empty chunk" at the end of the channel (with `earliest` and `latest` as `Date.now() + 1`). Part of the issue is in that we don't load new posts for that channel, and even if we do, the posts don't intersect with the empty chunk. New posts in the channel fix this, but until new posts are made, it won't trigger.

To fix it, we are removing a couple of safeguards.
- We allow `getPostBefore` to receive an empty postId. That will just take the latest posts.
- We consider that `lastPost` may be empty on an empty chunk.
- Even if the channel has no posts, we try to get posts, just in case.

The only thing I am not sure about this PR is the change on `canLoadPosts.current = (result.posts?.length ?? 1) > 0;`. My guess is that if there is no `result.posts` we also want to stop loading posts, but I may be missing something.

DISCLAIMER: The reason of the issue has not yet been found. I theorize that we are adding some posts with the `RECEIVED_IN_CHANNEL` action (mainly used for notifications and threads) and then one of those posts gets deleted, leaving an empty chunk at the top.

#### Ticket Link
Partly fix https://mattermost.atlassian.net/browse/MM-49968

#### Release Note
```release-note
Fix issue where some channels would appear as if no messages were there.
```
