### PR TITLE
MM-52173 Add setting to delay channel autocomplete

### DIFF
--- a/app/components/autocomplete/channel_mention/index.ts
+++ b/app/components/autocomplete/channel_mention/index.ts
@@ -81,7 +81,7 @@ const withTeamId = withObservables(['teamId', 'channelId'], ({teamId, channelId,
     };
 });
 
-function getMatchPattern(isSearch: boolean, database: Database) {
+function observeMatchPattern(isSearch: boolean, database: Database) {
     let matchPattern;
 
     if (isSearch) {
@@ -96,8 +96,9 @@ function getMatchPattern(isSearch: boolean, database: Database) {
 }
 
 const enhanced = withObservables(['value', 'isSearch', 'teamId', 'cursorPosition'], ({value, isSearch, teamId, cursorPosition, database}: OwnProps) => {
-    const matchPattern = getMatchPattern(isSearch, database);
-    const matchTerm = matchPattern.pipe(map((regexp) => getMatchTermForChannelMention(value.substring(0, cursorPosition), regexp, isSearch)));
+    const matchTerm = observeMatchPattern(isSearch, database).pipe(map((regexp) => {
+        return getMatchTermForChannelMention(value.substring(0, cursorPosition), regexp, isSearch);
+    }));
 
     const localChannels = matchTerm.pipe(switchMap((term) => {
         return term === null ? of$(emptyChannelList) : queryChannelsForAutocomplete(database, term, isSearch, teamId).observe();

--- a/app/constants/autocomplete.ts
+++ b/app/constants/autocomplete.ts
@@ -9,6 +9,8 @@ export const AT_MENTION_SEARCH_REGEX = /\bfrom:\s*(\S*)$/i;
 
 export const CHANNEL_MENTION_REGEX = /\B(~([^~\r\n]*))$/i;
 
+export const CHANNEL_MENTION_REGEX_DELAYED = /\B(~([^~\r\n]{2,}))$/i;
+
 export const CHANNEL_MENTION_SEARCH_REGEX = /\b(?:in|channel):\s*(\S*)$/i;
 
 export const DATE_MENTION_SEARCH_REGEX = /\b(?:on|before|after):\s*(\S*)$/i;
@@ -26,6 +28,7 @@ export default {
     AT_MENTION_REGEX_GLOBAL,
     AT_MENTION_SEARCH_REGEX,
     CHANNEL_MENTION_REGEX,
+    CHANNEL_MENTION_REGEX_DELAYED,
     CHANNEL_MENTION_SEARCH_REGEX,
     CODE_REGEX,
     DATE_MENTION_SEARCH_REGEX,

--- a/types/api/config.d.ts
+++ b/types/api/config.d.ts
@@ -34,6 +34,7 @@ interface ClientConfig {
     DataRetentionMessageRetentionDays: string;
     DefaultClientLocale: string;
     DefaultTheme: string;
+    DelayChannelAutocomplete: 'true' | 'false';
     DesktopLatestVersion: string;
     DesktopMinVersion: string;
     DiagnosticId: string;


### PR DESCRIPTION
#### Summary
The channel autocomplete can be a bit obtrusive in certain cultures such as Korean where tildes are used more regularly in messages, so we've added a setting to make it require typing two letters after the tilde before the autocomplete triggers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52173

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/22952

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
https://user-images.githubusercontent.com/3277310/233412110-1ee2e9f3-a469-4e8c-9fa4-3ab466332cd9.mp4

#### Release Note
```release-note
Added support for ExperimentalSettings.DelayChannelAutocomplete
```
