### PR TITLE
Reduce minimum NPM version to match web app

### DIFF
--- a/.solidarity
+++ b/.solidarity
@@ -14,7 +14,7 @@
       {
         "rule": "cli",
         "binary": "npm",
-        "semver": ">=8.5.5 <9.0.0",
+        "semver": ">=7.24.0 <9.0.0",
         "error": "install npm 8.5.5 `npm i -g npm@8.5.5"
       }
     ],


### PR DESCRIPTION
#### Summary
Just what it says in the title. I was able to build and run the iOS app in the simulator with this version of NPM, so I figured it would be fine to have it match that while still recommending the newer version of NPM

These are the versions of Node and NPM that we use for web
```
harrison-mm:mattermost-mobile harrison $ npm --version
7.24.0
harrison-mm:mattermost-mobile harrison $ node --version
v16.10.0
```

#### Release Note
```release-note
NONE
```
