### PR TITLE
Fix the query undefined comparison when threadId prop is not set by the nav library

### DIFF
--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -101,6 +101,14 @@ export const switchToThread = async (serverUrl: string, rootId: string, isFromNo
             }
         }
 
+        if (isFromNotification) {
+            await dismissAllModalsAndPopToRoot();
+            await NavigationStore.waitUntilScreenIsTop(Screens.HOME);
+            if (switchingTeams && isTabletDevice) {
+                DeviceEventEmitter.emit(Navigation.NAVIGATION_HOME, Screens.GLOBAL_THREADS);
+            }
+        }
+
         // Modal right buttons
         const rightButtons = [];
 
@@ -137,13 +145,6 @@ export const switchToThread = async (serverUrl: string, rootId: string, isFromNo
 
         EphemeralStore.setCurrentThreadId(rootId);
 
-        if (isFromNotification) {
-            await dismissAllModalsAndPopToRoot();
-            await NavigationStore.waitUntilScreenIsTop(Screens.HOME);
-            if (switchingTeams && isTabletDevice) {
-                DeviceEventEmitter.emit(Navigation.NAVIGATION_HOME, Screens.GLOBAL_THREADS);
-            }
-        }
         goToScreen(Screens.THREAD, '', {rootId}, {
             topBar: {
                 title: {

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -21,7 +21,7 @@ import {queryDisplayNamePreferences} from '@queries/servers/preference';
 import {getCommonSystemValues, getConfig, getCurrentChannelId, getCurrentTeamId, getCurrentUserId, getLicense, setCurrentChannelId, setCurrentTeamAndChannelId} from '@queries/servers/system';
 import {getNthLastChannelFromTeam, getMyTeamById, getTeamByName, queryMyTeams, removeChannelFromTeamHistory} from '@queries/servers/team';
 import {getCurrentUser} from '@queries/servers/user';
-import {dismissAllModals, popToRoot} from '@screens/navigation';
+import {dismissAllModalsAndPopToRoot} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {setTeamLoading} from '@store/team_load_store';
 import {generateChannelNameFromDisplayName, getDirectChannelName, isDMorGM} from '@utils/channel';
@@ -1423,8 +1423,7 @@ export const handleKickFromChannel = async (serverUrl: string, channelId: string
         if (currentServer?.url === serverUrl) {
             const channel = await getChannelById(database, channelId);
             DeviceEventEmitter.emit(event, channel?.displayName);
-            await dismissAllModals();
-            await popToRoot();
+            await dismissAllModalsAndPopToRoot();
         }
 
         const tabletDevice = await isTablet();

--- a/app/actions/remote/team.ts
+++ b/app/actions/remote/team.ts
@@ -13,7 +13,7 @@ import {prepareCategoriesAndCategoriesChannels} from '@queries/servers/categorie
 import {prepareMyChannelsForTeam, getDefaultChannelForTeam} from '@queries/servers/channel';
 import {prepareCommonSystemValues, getCurrentTeamId, getCurrentUserId} from '@queries/servers/system';
 import {addTeamToTeamHistory, prepareDeleteTeam, prepareMyTeams, getNthLastChannelFromTeam, queryTeamsById, getLastTeam, getTeamById, removeTeamFromTeamHistory, queryMyTeams} from '@queries/servers/team';
-import {dismissAllModals, popToRoot} from '@screens/navigation';
+import {dismissAllModalsAndPopToRoot} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {setTeamLoading} from '@store/team_load_store';
 import {isTablet} from '@utils/helpers';
@@ -461,8 +461,7 @@ export async function handleKickFromTeam(serverUrl: string, teamId: string) {
         if (currentServer === serverUrl) {
             const team = await getTeamById(database, teamId);
             DeviceEventEmitter.emit(Events.LEAVE_TEAM, team?.displayName);
-            await dismissAllModals();
-            await popToRoot();
+            await dismissAllModalsAndPopToRoot();
         }
 
         await removeTeamFromTeamHistory(operator, teamId);

--- a/app/components/channel_actions/leave_channel_label/leave_channel_label.tsx
+++ b/app/components/channel_actions/leave_channel_label/leave_channel_label.tsx
@@ -12,7 +12,7 @@ import SlideUpPanelItem from '@components/slide_up_panel_item';
 import {General} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useIsTablet} from '@hooks/device';
-import {dismissAllModals, dismissBottomSheet, popToRoot} from '@screens/navigation';
+import {dismissAllModalsAndPopToRoot, dismissBottomSheet} from '@screens/navigation';
 
 type Props = {
     isOptionItem?: boolean;
@@ -31,8 +31,7 @@ const LeaveChannelLabel = ({canLeave, channelId, displayName, isOptionItem, type
     const close = async () => {
         await dismissBottomSheet();
         if (!isTablet) {
-            await dismissAllModals();
-            popToRoot();
+            await dismissAllModalsAndPopToRoot();
         }
     };
 

--- a/app/components/markdown/hashtag/index.tsx
+++ b/app/components/markdown/hashtag/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {DeviceEventEmitter, StyleProp, Text, TextStyle} from 'react-native';
 
 import {Navigation, Screens} from '@constants';
-import {popToRoot, dismissAllModals} from '@screens/navigation';
+import {dismissAllModalsAndPopToRoot} from '@screens/navigation';
 
 type HashtagProps = {
     hashtag: string;
@@ -15,8 +15,7 @@ type HashtagProps = {
 const Hashtag = ({hashtag, linkStyle}: HashtagProps) => {
     const handlePress = async () => {
         // Close thread view, permalink view, etc
-        await dismissAllModals();
-        await popToRoot();
+        await dismissAllModalsAndPopToRoot();
 
         DeviceEventEmitter.emit(Navigation.NAVIGATE_TO_TAB, {
             screen: Screens.SEARCH,

--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -69,8 +69,8 @@ export const observeThreadById = (database: Database, threadId: string) => {
     );
 };
 
-export const observeTeamIdByThread = (database: Database, thread: ThreadModel) => {
-    return observePost(database, thread.id).pipe(
+export const observeTeamIdByThreadId = (database: Database, threadId: string) => {
+    return observePost(database, threadId).pipe(
         switchMap((post) => {
             if (!post) {
                 return of$(undefined);
@@ -80,6 +80,10 @@ export const observeTeamIdByThread = (database: Database, thread: ThreadModel) =
             );
         }),
     );
+};
+
+export const observeTeamIdByThread = (database: Database, thread: ThreadModel) => {
+    return observeTeamIdByThreadId(database, thread.id);
 };
 
 export const observeUnreadsAndMentionsInTeam = (database: Database, teamId?: string, includeDmGm?: boolean): Observable<{unreads: boolean; mentions: number}> => {

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -518,6 +518,7 @@ export async function popToRoot() {
 
 export async function dismissAllModalsAndPopToRoot() {
     await dismissAllModals();
+    await dismissAllOverlays();
     await popToRoot();
 }
 
@@ -531,6 +532,7 @@ export async function dismissAllModalsAndPopToRoot() {
  */
 export async function dismissAllModalsAndPopToScreen(screenId: AvailableScreens, title: string, passProps = {}, options = {}) {
     await dismissAllModals();
+    await dismissAllOverlays();
     if (NavigationStore.getScreensInStack().includes(screenId)) {
         let mergeOptions = options;
         if (title) {
@@ -750,6 +752,14 @@ export async function dismissOverlay(componentId: AvailableScreens) {
     } catch (error) {
         // RNN returns a promise rejection if there is no modal with
         // this componentId to dismiss. We'll do nothing in this case.
+    }
+}
+
+export async function dismissAllOverlays() {
+    try {
+        await Navigation.dismissAllOverlays();
+    } catch {
+        // do nothing
     }
 }
 

--- a/app/screens/thread/thread_follow_button/index.ts
+++ b/app/screens/thread/thread_follow_button/index.ts
@@ -6,17 +6,31 @@ import withObservables from '@nozbe/with-observables';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {observeThreadById} from '@queries/servers/thread';
+import {observeTeamIdByThreadId, observeThreadById} from '@queries/servers/thread';
+import EphemeralStore from '@store/ephemeral_store';
 
 import ThreadFollowButton from './thread_follow_button';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
-const enhanced = withObservables(['threadId'], ({threadId, database}: {threadId: string} & WithDatabaseArgs) => {
+type Props = WithDatabaseArgs & {
+    teamId?: string;
+    threadId?: string;
+};
+
+const enhanced = withObservables(['threadId'], ({teamId, threadId, database}: Props) => {
+    // Fallback in case teamId or threadId are not defined per navigation not setting the props bug.
+    const thId = threadId || EphemeralStore.getCurrentThreadId();
+    const tId = teamId ? of$(teamId) : observeTeamIdByThreadId(database, thId).pipe(
+        switchMap((t) => of$(t || '')),
+    );
+
     return {
-        isFollowing: observeThreadById(database, threadId).pipe(
+        isFollowing: observeThreadById(database, thId).pipe(
             switchMap((thread) => of$(thread?.isFollowing)),
         ),
+        threadId: of$(thId),
+        teamId: tId,
     };
 });
 

--- a/app/utils/error_handling.ts
+++ b/app/utils/error_handling.ts
@@ -9,7 +9,7 @@ import {
 } from 'react-native-exception-handler';
 
 import {DEFAULT_LOCALE, getTranslations, t} from '@i18n';
-import {dismissAllModals} from '@screens/navigation';
+import {dismissAllModals, dismissAllOverlays} from '@screens/navigation';
 import {isBetaApp} from '@utils/general';
 import {
     captureException,
@@ -58,6 +58,7 @@ class JavascriptAndNativeErrorHandler {
                     text: translations[t('mobile.error_handler.button')],
                     onPress: async () => {
                         await dismissAllModals();
+                        await dismissAllOverlays();
                     },
                 }],
                 {cancelable: false},


### PR DESCRIPTION
#### Summary
The navigation library seems to have a bug that causes the props not being set when opening in succession a screen with the same id, so when the Thread screen is already opened and a notification for the same Thread is tapped, the app attempts to reopen the same screen and the bug is hit causing the following crash

![image](https://user-images.githubusercontent.com/6757047/233642121-f1d6fc87-fc76-4318-942a-2b18e259f69f.png)

There is a double fix here:
1. Dismiss the previous screens earlier to give enough time to the library to reset its values
2. In the case where the props that the screen receives are undefined, then we use the value we set in the Ephemeral store as a fallback to prevent the crash and use the correct values.

Additionally combined dismissAllModals and popToRoot calls into `dismissAllModalsAndPopToRoot` as well as added `dismissAllOverlays` as the Gallery screen is in fact an overlay that should also be dismissed when the popping to root.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52150
Fixes: #7281 

#### Release Note
```release-note
Fixed a crash on iOS when attempting to open a Thread by tapping on the notification
```
