### PR TITLE
Fixed exception on accessing 'payload' of undefined in InAppNotification

### DIFF
--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -738,11 +738,10 @@ export function showOverlay(name: AvailableScreens, passProps = {}, options: Opt
 
     Navigation.showOverlay({
         component: {
-            id: name,
             name,
             passProps,
-            options: merge(defaultOptions, options),
-        },
+            options: merge(defaultOptions, options)
+        }
     });
 }
 

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -740,8 +740,8 @@ export function showOverlay(name: AvailableScreens, passProps = {}, options: Opt
         component: {
             name,
             passProps,
-            options: merge(defaultOptions, options)
-        }
+            options: merge(defaultOptions, options),
+        },
     });
 }
 


### PR DESCRIPTION
#### Summary
There is still an issue happening on receiving multiple push notifications. This change is a fix for edge-case scenario, not covered by previous fixes in #7237

```
TypeError: Cannot read property 'payload' of undefined
  at <global>(app/screens/in_app_notification/index.tsx:144:33)
  at <global>(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:3525:22)
```

The issue is caused by usage of the same component id in the following call sequence happened in a short time interval:
- `showOverlay`
- `dismissOverlay` (by timeout)
- `showOverlay`

`dismissOverlay` call schedules the call to release the native component, stored by component id. Creation of second native component as a pending for presentation component with the same id will replace the first one in a storage , so execution of scheduled dismiss task will release the pending component and properties retained by that component.
 
Solution:
Use unique component ids in `showOverlay`/`dismissOverlay` calls. This can be achieved automatically:
```
export interface LayoutComponent<P = {}> {
    /**
     * Component reference id, Auto generated if empty
     */
     id?: string;
```

#### Device Information
This PR was tested on: iOS simulator running iOS 16.2 with simulated push notifications

#### Release Note
```release-note
NONE
```
