### PR TITLE
MM-52342 - Use CallState and CallChannelState from @mattermost/calls

### DIFF
--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -47,12 +47,10 @@ import type {
     Call,
     CallParticipant,
     CallsConnection,
-    ServerCallState,
-    ServerChannelState,
 } from '@calls/types/calls';
 import type {Client} from '@client/rest';
 import type ClientError from '@client/rest/error';
-import type {CallRecordingState, EmojiData} from '@mattermost/calls/lib/types';
+import type {CallChannelState, CallRecordingState, CallState, EmojiData} from '@mattermost/calls/lib/types';
 import type {IntlShape} from 'react-intl';
 
 let connection: CallsConnection | null = null;
@@ -96,7 +94,7 @@ export const loadCalls = async (serverUrl: string, userId: string) => {
     } catch (error) {
         return {error};
     }
-    let resp: ServerChannelState[] = [];
+    let resp: CallChannelState[] = [];
     try {
         resp = await client.getCalls() || [];
     } catch (error) {
@@ -136,7 +134,7 @@ export const loadCallForChannel = async (serverUrl: string, channelId: string) =
         return {error};
     }
 
-    let resp: ServerChannelState;
+    let resp: CallChannelState;
     try {
         resp = await client.getCallForChannel(channelId);
     } catch (error) {
@@ -160,7 +158,7 @@ export const loadCallForChannel = async (serverUrl: string, channelId: string) =
     return {data: {call, enabled: resp.enabled}};
 };
 
-const createCallAndAddToIds = (channelId: string, call: ServerCallState, ids: Set<string>) => {
+const createCallAndAddToIds = (channelId: string, call: CallState, ids: Set<string>) => {
     return {
         participants: call.users.reduce((accum, cur, curIdx) => {
             // Add the id to the set of UserModels we want to ensure are loaded.

--- a/app/products/calls/client/rest.ts
+++ b/app/products/calls/client/rest.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ServerChannelState, ApiResp} from '@calls/types/calls';
-import type {CallRecordingState, CallsConfig} from '@mattermost/calls/lib/types';
+import type {ApiResp} from '@calls/types/calls';
+import type {CallChannelState, CallRecordingState, CallsConfig} from '@mattermost/calls/lib/types';
 import type {RTCIceServer} from 'react-native-webrtc';
 
 export interface ClientCallsMix {
     getEnabled: () => Promise<Boolean>;
-    getCalls: () => Promise<ServerChannelState[]>;
-    getCallForChannel: (channelId: string) => Promise<ServerChannelState>;
+    getCalls: () => Promise<CallChannelState[]>;
+    getCallForChannel: (channelId: string) => Promise<CallChannelState>;
     getCallsConfig: () => Promise<CallsConfig>;
-    enableChannelCalls: (channelId: string, enable: boolean) => Promise<ServerChannelState>;
+    enableChannelCalls: (channelId: string, enable: boolean) => Promise<CallChannelState>;
     endCall: (channelId: string) => Promise<ApiResp>;
     genTURNCredentials: () => Promise<RTCIceServer[]>;
     startCallRecording: (callId: string) => Promise<ApiResp | CallRecordingState>;

--- a/app/products/calls/types/calls.ts
+++ b/app/products/calls/types/calls.ts
@@ -90,29 +90,6 @@ export type CallParticipant = {
 
 export type ChannelsWithCalls = Dictionary<boolean>;
 
-export type ServerChannelState = {
-    channel_id: string;
-    enabled?: boolean;
-    call?: ServerCallState;
-}
-
-export type ServerUserState = {
-    unmuted: boolean;
-    raised_hand: number;
-}
-
-export type ServerCallState = {
-    id: string;
-    start_at: number;
-    users: string[];
-    states: ServerUserState[];
-    thread_id: string;
-    screen_sharing_id: string;
-    owner_id: string;
-    host_id: string;
-    recording: CallRecordingState;
-}
-
 export type CallsConnection = {
     disconnect: () => void;
     mute: () => void;
@@ -143,6 +120,7 @@ export const DefaultCallsConfig: CallsConfigState = {
     EnableRecordings: false,
     MaxRecordingDuration: 60,
     AllowScreenSharing: true,
+    EnableSimulcast: false,
 };
 
 export type ApiResp = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@formatjs/intl-pluralrules": "5.2.1",
         "@formatjs/intl-relativetimeformat": "11.2.1",
         "@gorhom/bottom-sheet": "4.4.5",
-        "@mattermost/calls": "github:mattermost/calls-common#v0.12.0",
+        "@mattermost/calls": "github:mattermost/calls-common#v0.14.0",
         "@mattermost/compass-icons": "0.1.36",
         "@mattermost/react-native-emm": "1.3.5",
         "@mattermost/react-native-network-client": "1.3.3",
@@ -3391,8 +3391,8 @@
     },
     "node_modules/@mattermost/calls": {
       "name": "@calls/common",
-      "version": "0.12.0",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#02c52be3b71080023803621877ab96a7fe306fba"
+      "version": "0.14.0",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#d539eb36f9549075b0a0a6578174db31297c45ae"
     },
     "node_modules/@mattermost/commonmark": {
       "version": "0.30.1-0",
@@ -24248,8 +24248,8 @@
       }
     },
     "@mattermost/calls": {
-      "version": "git+ssh://git@github.com/mattermost/calls-common.git#02c52be3b71080023803621877ab96a7fe306fba",
-      "from": "@mattermost/calls@github:mattermost/calls-common#v0.12.0"
+      "version": "git+ssh://git@github.com/mattermost/calls-common.git#d539eb36f9549075b0a0a6578174db31297c45ae",
+      "from": "@mattermost/calls@git://github.com/mattermost/calls-common.git#v0.14.0"
     },
     "@mattermost/commonmark": {
       "version": "0.30.1-0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@formatjs/intl-pluralrules": "5.2.1",
     "@formatjs/intl-relativetimeformat": "11.2.1",
     "@gorhom/bottom-sheet": "4.4.5",
-    "@mattermost/calls": "github:mattermost/calls-common#v0.12.0",
+    "@mattermost/calls": "github:mattermost/calls-common#v0.14.0",
     "@mattermost/compass-icons": "0.1.36",
     "@mattermost/react-native-emm": "1.3.5",
     "@mattermost/react-native-network-client": "1.3.3",


### PR DESCRIPTION
#### Summary
- This continues the migration to using a common set of types between the plugin and the mobile code.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-52342

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

```release-note
NONE
```
