### PR TITLE
Fix Thread button crash

### DIFF
--- a/app/components/selected_users/index.tsx
+++ b/app/components/selected_users/index.tsx
@@ -121,7 +121,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             shadowRadius: 24,
         },
         toast: {
-            backgroundColor: theme.centerChannelColor,
+            backgroundColor: theme.errorTextColor,
         },
         usersScroll: {
             marginTop: SCROLL_MARGIN_TOP,
@@ -133,7 +133,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             flexWrap: 'wrap',
         },
         message: {
-            color: changeOpacity(theme.centerChannelColor, 0.6),
+            color: theme.centerChannelBg,
             fontSize: 12,
             marginRight: 5,
             marginTop: 10,
@@ -250,11 +250,11 @@ export default function SelectedUsers({
 
     const animatedToastStyle = useAnimatedStyle(() => {
         return {
-            bottom: TOAST_BOTTOM_MARGIN + totalPanelHeight.value,
+            bottom: TOAST_BOTTOM_MARGIN + totalPanelHeight.value + insets.bottom,
             opacity: withTiming(showToast ? 1 : 0, {duration: 250}),
             position: 'absolute',
         };
-    }, [showToast, keyboard]);
+    }, [showToast, insets.bottom]);
 
     const animatedViewStyle = useAnimatedStyle(() => ({
         height: withTiming(totalPanelHeight.value, {duration: 250}),

--- a/app/screens/thread/thread.tsx
+++ b/app/screens/thread/thread.tsx
@@ -55,7 +55,6 @@ const Thread = ({componentId, isCRTEnabled, rootId, rootPost, isInACall}: Thread
             setButtons(componentId, {rightButtons: [{
                 id: `${componentId}-${rootId}`,
                 component: {
-                    id: rootId,
                     name: Screens.THREAD_FOLLOW_BUTTON,
                     passProps: {
                         threadId: rootId,

--- a/app/screens/thread/thread.tsx
+++ b/app/screens/thread/thread.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {uniqueId} from 'lodash';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {type LayoutChangeEvent, StyleSheet, View} from 'react-native';
 import {type Edge, SafeAreaView} from 'react-native-safe-area-context';
-import uuid from 'uuid';
 
 import CurrentCallBar from '@calls/components/current_call_bar';
 import FloatingCallContainer from '@calls/components/floating_call_container';
@@ -53,10 +53,12 @@ const Thread = ({componentId, isCRTEnabled, rootId, rootPost, isInACall}: Thread
 
     useEffect(() => {
         if (isCRTEnabled && rootId) {
+            const id = `${componentId}-${rootId}-${uniqueId()}`;
+            const name = Screens.THREAD_FOLLOW_BUTTON;
             setButtons(componentId, {rightButtons: [{
-                id: `${componentId}-${rootId}-${uuid.v4()}`,
+                id,
                 component: {
-                    name: Screens.THREAD_FOLLOW_BUTTON,
+                    name,
                     passProps: {
                         threadId: rootId,
                     },

--- a/app/screens/thread/thread.tsx
+++ b/app/screens/thread/thread.tsx
@@ -4,6 +4,7 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {type LayoutChangeEvent, StyleSheet, View} from 'react-native';
 import {type Edge, SafeAreaView} from 'react-native-safe-area-context';
+import uuid from 'uuid';
 
 import CurrentCallBar from '@calls/components/current_call_bar';
 import FloatingCallContainer from '@calls/components/floating_call_container';
@@ -53,7 +54,7 @@ const Thread = ({componentId, isCRTEnabled, rootId, rootPost, isInACall}: Thread
     useEffect(() => {
         if (isCRTEnabled && rootId) {
             setButtons(componentId, {rightButtons: [{
-                id: `${componentId}-${rootId}`,
+                id: `${componentId}-${rootId}-${uuid.v4()}`,
                 component: {
                     name: Screens.THREAD_FOLLOW_BUTTON,
                     passProps: {

--- a/app/screens/thread/thread_follow_button/index.ts
+++ b/app/screens/thread/thread_follow_button/index.ts
@@ -19,14 +19,21 @@ type Props = WithDatabaseArgs & {
 
 const enhanced = withObservables(['threadId'], ({threadId, database}: Props) => {
     const thId = threadId || EphemeralStore.getCurrentThreadId();
-    const tId = observeTeamIdByThreadId(database, thId).pipe(
-        switchMap((t) => of$(t || '')),
-    );
+    let tId = of$('');
+    let isFollowing = of$(false);
+
+    if (thId) {
+        tId = observeTeamIdByThreadId(database, thId).pipe(
+            switchMap((t) => of$(t || '')),
+        );
+
+        isFollowing = observeThreadById(database, thId).pipe(
+            switchMap((thread) => of$(thread?.isFollowing)),
+        );
+    }
 
     return {
-        isFollowing: observeThreadById(database, thId).pipe(
-            switchMap((thread) => of$(thread?.isFollowing)),
-        ),
+        isFollowing,
         threadId: of$(thId),
         teamId: tId,
     };

--- a/app/screens/thread/thread_follow_button/thread_follow_button.tsx
+++ b/app/screens/thread/thread_follow_button/thread_follow_button.tsx
@@ -59,6 +59,10 @@ function ThreadFollow({isFollowing, teamId, threadId}: Props) {
         updateThreadFollowing(serverUrl, teamId, threadId, !isFollowing, false);
     });
 
+    if (!threadId) {
+        return null;
+    }
+
     const containerStyle: StyleProp<ViewStyle> = [styles.container];
     let followTextProps = {
         id: t('threads.follow'),


### PR DESCRIPTION
#### Summary
Same as in https://github.com/mattermost/mattermost-mobile/pull/7317 the `threadId` is not available as a prop due to a bug in the navigation library, which causes the app to crash when attempting to query the database with an `undefined` value.

The idea here is so that a totally new component is created for the right button.

#### Ticket Link
Also fixes https://mattermost.atlassian.net/browse/MM-49383 which is related to the `selected_users` component

#### Checklist
- [x] Has UI changes

#### Release Note
```release-note
Fixed a crash when opening a push notification for a Thread on CRT when the Thread screen was already opened in the background
```