### PR TITLE
Fixed Interactive dialog radio buttons style

### DIFF
--- a/app/components/settings/radio_setting/radio_entry.tsx
+++ b/app/components/settings/radio_setting/radio_entry.tsx
@@ -32,8 +32,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             color: theme.linkColor,
         },
         text: {          
-            fontSize: 12,  
-            color: theme.centerChannelColor,        
+            fontSize: 12,
+            color: theme.centerChannelColor,
         },
     };
 });

--- a/app/components/settings/radio_setting/radio_entry.tsx
+++ b/app/components/settings/radio_setting/radio_entry.tsx
@@ -31,7 +31,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             fontSize: 12,
             color: theme.linkColor,
         },
-        text: {          
+        text: {
             fontSize: 12,
             color: theme.centerChannelColor,
         },

--- a/app/components/settings/radio_setting/radio_entry.tsx
+++ b/app/components/settings/radio_setting/radio_entry.tsx
@@ -31,6 +31,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             fontSize: 12,
             color: theme.linkColor,
         },
+        text: {          
+            fontSize: 12,  
+            color: theme.centerChannelColor,        
+        },
     };
 });
 
@@ -61,7 +65,7 @@ function RadioEntry({
         >
             <View style={style.container}>
                 <View style={style.rowContainer}>
-                    <Text>{text}</Text>
+                    <Text style={style.text}>{text}</Text>
                 </View>
                 {isSelected && (
                     <CompassIcon


### PR DESCRIPTION
#### Summary
When build interactive dialog radio elements not shown when device use light theme(Android) and difficult to read(iPhone)

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/22326

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: TECNO P8 Android, Samsung Galaxy S7 Edge Android, iPhone 11 Pro

#### Screenshots
before: 

![image](https://user-images.githubusercontent.com/9417743/236458485-ad26c0d6-a089-4591-a0d3-f5a0d29069d5.png)

after:

![image](https://user-images.githubusercontent.com/9417743/236458561-7b804d23-9e70-4b92-af2a-0d8088c791de.png)


#### Release Note
```release-note
Fixed Interactive dialog radio buttons style when light theme use
```




