### PR TITLE
[MM-48825] - Move search results number text below tab button

### DIFF
--- a/app/components/files_search/file_results.tsx
+++ b/app/components/files_search/file_results.tsx
@@ -32,7 +32,7 @@ type Props = {
     canDownloadFiles: boolean;
     fileChannels: ChannelModel[];
     fileInfos: FileInfo[];
-    paddingTop: StyleProp<ViewStyle>;
+    paddingTop?: StyleProp<ViewStyle>;
     publicLinkEnabled: boolean;
     searchValue: string;
     isChannelFiles?: boolean;

--- a/app/screens/home/search/results/header.tsx
+++ b/app/screens/home/search/results/header.tsx
@@ -27,8 +27,6 @@ type Props = {
     onFilterChanged: (filter: FileFilter) => void;
     selectedTab: TabType;
     selectedFilter: FileFilter;
-    numberMessages: number;
-    numberFiles: number;
     setTeamId: (id: string) => void;
     teamId: string;
     teams: TeamModel[];
@@ -65,8 +63,6 @@ const Header = ({
     setTeamId,
     onTabSelect,
     onFilterChanged,
-    numberMessages,
-    numberFiles,
     selectedTab,
     selectedFilter,
     teams,
@@ -130,12 +126,12 @@ const Header = ({
                 <SelectButton
                     selected={selectedTab === TabTypes.MESSAGES}
                     onPress={handleMessagesPress}
-                    text={`${messagesText} (${numberMessages})`}
+                    text={messagesText}
                 />
                 <SelectButton
                     selected={selectedTab === TabTypes.FILES}
                     onPress={handleFilesPress}
-                    text={`${filesText} (${numberFiles})`}
+                    text={filesText}
                 />
                 <View style={styles.iconsContainer}>
                     {showFilterIcon &&

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -20,7 +20,7 @@ type Props = {
     currentTimezone: string;
     isTimezoneEnabled: boolean;
     posts: PostModel[];
-    paddingTop: StyleProp<ViewStyle>;
+    paddingTop?: StyleProp<ViewStyle>;
     searchValue: string;
 }
 

--- a/app/screens/home/search/results/results.tsx
+++ b/app/screens/home/search/results/results.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useMemo} from 'react';
-import {StyleSheet, useWindowDimensions, View} from 'react-native';
+import {StyleSheet, Text, useWindowDimensions, View} from 'react-native';
 import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
 
 import FileResults from '@components/files_search/file_results';
@@ -17,7 +17,7 @@ import type PostModel from '@typings/database/models/servers/post';
 
 const duration = 250;
 
-const getStyles = (width: number) => {
+const getStyles = (width: number, theme: Theme) => {
     return StyleSheet.create({
         container: {
             flex: 1,
@@ -27,6 +27,14 @@ const getStyles = (width: number) => {
         result: {
             flex: 1,
             width,
+        },
+        text: {
+            padding: 20,
+            paddingBottom: 2,
+            fontSize: 18,
+            fontWeight: 'bold',
+            marginTop: 60,
+            color: theme.centerChannelColor,
         },
         loading: {
             justifyContent: 'center',
@@ -50,6 +58,8 @@ type Props = {
     scrollPaddingTop: number;
     searchValue: string;
     selectedTab: TabType;
+    numberMessages: number;
+    numberFiles: number;
 }
 
 const Results = ({
@@ -66,10 +76,12 @@ const Results = ({
     scrollPaddingTop,
     searchValue,
     selectedTab,
+    numberMessages,
+    numberFiles,
 }: Props) => {
     const {width} = useWindowDimensions();
     const theme = useTheme();
-    const styles = useMemo(() => getStyles(width), [width]);
+    const styles = useMemo(() => getStyles(width, theme), [width]);
 
     const transform = useAnimatedStyle(() => {
         const translateX = selectedTab === TabTypes.MESSAGES ? 0 : -width;
@@ -99,22 +111,22 @@ const Results = ({
             {!loading &&
             <Animated.View style={[styles.container, transform]}>
                 <View style={styles.result} >
+                    <Text style={styles.text}>{`${numberMessages} search results` }</Text>
                     <PostResults
                         appsEnabled={appsEnabled}
                         currentTimezone={currentTimezone}
                         customEmojiNames={customEmojiNames}
                         isTimezoneEnabled={isTimezoneEnabled}
                         posts={posts}
-                        paddingTop={paddingTop}
                         searchValue={searchValue}
                     />
                 </View>
                 <View style={styles.result} >
+                    <Text style={styles.text}>{`${numberFiles} search results`}</Text>
                     <FileResults
                         canDownloadFiles={canDownloadFiles}
                         fileChannels={fileChannels}
                         fileInfos={fileInfos}
-                        paddingTop={paddingTop}
                         publicLinkEnabled={publicLinkEnabled}
                         searchValue={searchValue}
                     />

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -369,9 +369,7 @@ const SearchScreen = ({teamId, teams}: Props) => {
                                 setTeamId={handleResultsTeamChange}
                                 onTabSelect={setSelectedTab}
                                 onFilterChanged={handleFilterChange}
-                                numberMessages={posts.length}
                                 selectedTab={selectedTab}
-                                numberFiles={fileInfos.length}
                                 selectedFilter={filter}
                                 teams={teams}
                             />
@@ -404,6 +402,8 @@ const SearchScreen = ({teamId, teams}: Props) => {
                             fileInfos={fileInfos}
                             scrollPaddingTop={lockValue.value}
                             fileChannelIds={fileChannelIds}
+                            numberMessages={posts.length}
+                            numberFiles={fileInfos.length}
                         />
                     }
                 </Animated.View>


### PR DESCRIPTION
#### Summary
This PR submits a fix for the cases when there are lots of files and messages and the Files tab extends into the filter icon.
It moves the text below into the Results screen as proposed by UX 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48225

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: iPhone 8, iOS 15.2 / Pixel 3a, Android 12.1

#### Screenshots
<img width="413" alt="Screenshot 2023-05-09 at 14 35 36" src="https://user-images.githubusercontent.com/16692883/237027873-d30e8e0f-793c-4997-b877-778065fe3d65.png">
<img width="426" alt="Screenshot 2023-05-09 at 14 35 43" src="https://user-images.githubusercontent.com/16692883/237028000-7eca11c1-e517-400c-bf3e-84a358553533.png">


#### Release Note

```release-note
NONE
```
