### PR TITLE
Fix minor error on marking threads as read

### DIFF
--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -90,7 +90,7 @@ class PushNotifications {
                 if (isCRTEnabled && payload.root_id) {
                     const thread = await getThreadById(database, payload.root_id);
                     if (thread?.isFollowing) {
-                        markThreadAsRead(serverUrl, payload.team_id, payload.post_id);
+                        markThreadAsRead(serverUrl, payload.team_id, payload.root_id);
                     }
                 } else {
                     markChannelAsViewed(serverUrl, payload.channel_id);


### PR DESCRIPTION
#### Summary
By chance discovered in the logs the following error:

```
DEBUG error on markThreadAsRead Invalid or missing thread_id parameter in request URL
```

This is the only place I found where `thread_id` may be wrongly passed into the function, so I made sure it was taking the correct parameter.

#### Release Note
```release-note
Minor fix when marking threads as read
```
