### PR TITLE
Improve copy text response time

### DIFF
--- a/app/screens/post_options/options/copy_text_option.tsx
+++ b/app/screens/post_options/options/copy_text_option.tsx
@@ -19,8 +19,8 @@ type Props = {
 }
 const CopyTextOption = ({bottomSheetId, postMessage, sourceScreen}: Props) => {
     const handleCopyText = useCallback(async () => {
-        await dismissBottomSheet(bottomSheetId);
         Clipboard.setString(postMessage);
+        await dismissBottomSheet(bottomSheetId);
         showSnackBar({barType: SNACK_BAR_TYPE.MESSAGE_COPIED, sourceScreen});
     }, [postMessage]);
 


### PR DESCRIPTION
#### Summary
Copy Text was waiting for the bottom sheet to disappear before putting the text into the clipboard. Now we put it as soon as we hit the button.

#### Ticket Link
Fix https://github.com/mattermost/mattermost-mobile/issues/7287
Fix https://mattermost.atlassian.net/browse/MM-52218

#### Release Note
```release-note
Improve reaction time for Copy Text option
```
