### PR TITLE
Fix Save button not appearing on edit post screen

### DIFF
--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -79,14 +79,7 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
     const isTablet = useIsTablet();
 
     useEffect(() => {
-        setButtons(componentId, {
-            rightButtons: [{
-                color: theme.sidebarHeaderTextColor,
-                text: intl.formatMessage({id: 'edit_post.save', defaultMessage: 'Save'}),
-                ...RIGHT_BUTTON,
-                enabled: false,
-            }],
-        });
+        toggleSaveButton(false);
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
#### Summary
RIGHT_BUTTON constant was overriding the text. Changing the order would have fixed it, but in order to avoid code repetition, I directly used `toggleSaveButton`.

#### Ticket Link
Fix https://github.com/mattermost/mattermost-mobile/issues/7254
Fix https://mattermost.atlassian.net/browse/MM-52883

#### Release Note
```release-note
Fix save button sometimes not showing on the edit post screen
```
