### PR TITLE
MM-52888 Always load users mentioned in message attachments

### DIFF
--- a/app/helpers/api/user.ts
+++ b/app/helpers/api/user.ts
@@ -7,9 +7,13 @@ import {MENTIONS_REGEX} from '@constants/autocomplete';
 export const getNeededAtMentionedUsernames = (usernames: Set<string>, posts: Post[], excludeUsername?: string) => {
     const usernamesToLoad = new Set<string>();
 
-    posts.forEach((p) => {
+    const findNeededUsernames = (text?: string) => {
+        if (!text || !text.includes('@')) {
+            return;
+        }
+
         let match;
-        while ((match = MENTIONS_REGEX.exec(p.message)) !== null) {
+        while ((match = MENTIONS_REGEX.exec(text)) !== null) {
             const lowercaseMatch = match[1].toLowerCase();
 
             if (General.SPECIAL_MENTIONS.has(lowercaseMatch)) {
@@ -26,7 +30,19 @@ export const getNeededAtMentionedUsernames = (usernames: Set<string>, posts: Pos
 
             usernamesToLoad.add(lowercaseMatch);
         }
-    });
+    };
+
+    for (const post of posts) {
+        // These correspond to the fields searched by getMentionsEnabledFields on the server
+        findNeededUsernames(post.message);
+
+        if (post.props?.attachments) {
+            for (const attachment of post.props.attachments) {
+                findNeededUsernames(attachment.pretext);
+                findNeededUsernames(attachment.text);
+            }
+        }
+    }
 
     return usernamesToLoad;
 };


### PR DESCRIPTION
#### Summary
We render at mentions in message attachments and the `pretext`/`text` fields are capable of mentioning users, but we don't currently load users that are mentioned there.

Full disclaimer, I wasn't able to test this locally since my dev environment is broken, but these changes match the ones made in https://github.com/mattermost/mattermost-server/pull/23460

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52888

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/23460

#### Device Information
This PR was tested on: **I wasn't able to test this since my dev environment broke again**

#### Release Note
```release-note
Ensured users mentioned in message attachments are loaded by the app
```
