### PR TITLE
Fix all references to mention color on "login" screens

### DIFF
--- a/app/screens/forgot_password/index.tsx
+++ b/app/screens/forgot_password/index.tsx
@@ -54,7 +54,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         marginTop: 20,
     },
     header: {
-        color: theme.mentionColor,
+        color: theme.centerChannelColor,
         marginBottom: 12,
         ...typography('Heading', 1000, 'SemiBold'),
     },
@@ -84,7 +84,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         textAlign: 'center',
     },
     successTitle: {
-        color: theme.mentionColor,
+        color: theme.centerChannelColor,
         marginBottom: 12,
         ...typography('Heading', 1000),
     },

--- a/app/screens/login/index.tsx
+++ b/app/screens/login/index.tsx
@@ -57,7 +57,7 @@ const getStyles = makeStyleSheetFromTheme((theme: Theme) => ({
         flex: 1,
     },
     header: {
-        color: theme.mentionColor,
+        color: theme.centerChannelColor,
         marginBottom: 12,
         ...typography('Heading', 1000, 'SemiBold'),
     },

--- a/app/screens/mfa/index.tsx
+++ b/app/screens/mfa/index.tsx
@@ -61,7 +61,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         marginTop: 20,
     },
     header: {
-        color: theme.mentionColor,
+        color: theme.centerChannelColor,
         marginBottom: 12,
         ...typography('Heading', 1000, 'SemiBold'),
     },

--- a/app/screens/sso/sso_with_redirect_url.tsx
+++ b/app/screens/sso/sso_with_redirect_url.tsx
@@ -51,7 +51,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             ...typography('Body', 100, 'Regular'),
         },
         infoTitle: {
-            color: theme.mentionColor,
+            color: theme.centerChannelColor,
             marginBottom: 4,
             ...typography('Heading', 700),
         },


### PR DESCRIPTION
#### Summary
At some point, the title on the server screen changed from `mentionColor` to `centerChannelColor`. This was done for the server screen, but not for other "login" screens. This fixed for all other screens (Forgot password + forgot password success, login, sso login and mfa).

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-49940

#### Release Note
```release-note
Fix theming in log in screen
```
