### PR TITLE
Add license checks to several groups calls

### DIFF
--- a/app/client/rest/groups.ts
+++ b/app/client/rest/groups.ts
@@ -8,24 +8,13 @@ import {PER_PAGE_DEFAULT} from './constants';
 import type ClientBase from './base';
 
 export interface ClientGroupsMix {
-    getGroup: (id: string) => Promise<Group>;
     getGroups: (params: {query?: string; filterAllowReference?: boolean; page?: number; perPage?: number; since?: number; includeMemberCount?: boolean}) => Promise<Group[]>;
     getAllGroupsAssociatedToChannel: (channelId: string, filterAllowReference?: boolean) => Promise<{groups: Group[]; total_group_count: number}>;
     getAllGroupsAssociatedToMembership: (userId: string, filterAllowReference?: boolean) => Promise<Group[]>;
     getAllGroupsAssociatedToTeam: (teamId: string, filterAllowReference?: boolean) => Promise<{groups: Group[]; total_group_count: number}>;
-    getAllChannelsAssociatedToGroup: (groupId: string, filterAllowReference?: boolean) => Promise<{groupChannels: GroupChannel[]}>;
-    getAllMembershipsAssociatedToGroup: (groupId: string, filterAllowReference?: boolean) => Promise<{groupMemberships: UserProfile[]; total_member_count: number}>;
-    getAllTeamsAssociatedToGroup: (groupId: string, filterAllowReference?: boolean) => Promise<{groupTeams: GroupTeam[]}>;
 }
 
 const ClientGroups = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
-    getGroup = async (id: string) => {
-        return this.doFetch(
-            `${this.urlVersion}/groups/${id}`,
-            {method: 'get'},
-        );
-    };
-
     getGroups = async ({query = '', filterAllowReference = true, page = 0, perPage = PER_PAGE_DEFAULT, since = 0, includeMemberCount = false}) => {
         return this.doFetch(
             `${this.urlVersion}/groups${buildQueryString({
@@ -61,27 +50,6 @@ const ClientGroups = <TBase extends Constructor<ClientBase>>(superclass: TBase) 
     getAllGroupsAssociatedToMembership = async (userId: string, filterAllowReference = false) => {
         return this.doFetch(
             `${this.urlVersion}/users/${userId}/groups${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference})}`,
-            {method: 'get'},
-        );
-    };
-
-    getAllTeamsAssociatedToGroup = async (groupId: string, filterAllowReference = false) => {
-        return this.doFetch(
-            `${this.urlVersion}/groups/${groupId}/teams${buildQueryString({filter_allow_reference: filterAllowReference})}`,
-            {method: 'get'},
-        );
-    };
-
-    getAllChannelsAssociatedToGroup = async (groupId: string, filterAllowReference = false) => {
-        return this.doFetch(
-            `${this.urlVersion}/groups/${groupId}/channels${buildQueryString({filter_allow_reference: filterAllowReference})}`,
-            {method: 'get'},
-        );
-    };
-
-    getAllMembershipsAssociatedToGroup = async (groupId: string, filterAllowReference = false) => {
-        return this.doFetch(
-            `${this.urlVersion}/groups/${groupId}/members${buildQueryString({filter_allow_reference: filterAllowReference})}`,
             {method: 'get'},
         );
     };


### PR DESCRIPTION
#### Summary
We were asking for groups without having the license, which resulted in errors both in the server and the client. These errors were innocuous but were dirtying the logs. This remove these unneeded calls.

I also removed several client calls that were not being used to reduce the code. They can be added again in the future if needed.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-50052

#### Release Note
```release-note
Remove unneeded group calls that were appearing in the logs.
```
