### PR TITLE
Update string on notification error

### DIFF
--- a/app/utils/notification/index.ts
+++ b/app/utils/notification/index.ts
@@ -72,7 +72,7 @@ export const notificationError = (intl: IntlShape, type: 'Team' | 'Channel' | 'C
         case 'Connection':
             message = intl.formatMessage({
                 id: 'notification.no_connection',
-                defaultMessage: 'The server is unreachable and we were not able to retrieve the notification channel / team.',
+                defaultMessage: 'The server is unreachable and it was not possible to retrieve the specific message information for the notification.',
             });
             break;
     }

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -765,7 +765,7 @@
   "notification_settings.threads_start": "Threads that I start",
   "notification_settings.threads_start_participate": "Threads that I start or participate in",
   "notification.message_not_found": "Message not found",
-  "notification.no_connection": "The server is unreachable and we were not able to retrieve the notification channel / team.",
+  "notification.no_connection": "The server is unreachable and it was not possible to retrieve the specific message information for the notification.",
   "notification.no_post": "The message has not been found.",
   "notification.not_channel_member": "This message belongs to a channel where you are not a member.",
   "notification.not_team_member": "This message belongs to a team where you are not a member.",


### PR DESCRIPTION
#### Summary
Update string based on https://mattermost.atlassian.net/browse/MM-51219

I kept "unreachable" because I think it details better the state of the server, instead of "unavailable". But that may be because I am not a native speaker, so I am open to suggestions.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-51219

#### Release Note
```release-note
Minor string improvement.
```
