### PR TITLE
Fixed fastlane script for the case of Match and iOS API key usage

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -535,7 +535,7 @@ platform :ios do
 
     # Sync the provisioning profiles using match
     if ENV['SYNC_PROVISIONING_PROFILES'] == 'true'
-      if !ENV['MATCH_PASSWORD'].nil? && !ENV['MATCH_PASSWORD'].empty?
+      if !ENV['FASTLANE_PASSWORD'].nil? && !ENV['FASTLANE_PASSWORD'].empty?
         match(type: ENV['MATCH_TYPE'] || 'adhoc')
       end
       if !ENV['IOS_API_KEY_ID'].nil? && !ENV['IOS_API_KEY_ID'].empty?


### PR DESCRIPTION
#### Summary
There is an issue in build scripts, which doesn't allow to use Match and iOS API key. `MATCH_PASSWORD` is used to decrypt certificates from Match repo, not for authentification. And it is needed for both cases of auth types: plain with login and password OR using API key, so it should be set in both cases and cannot be used as a condition to choose auth type.
The correct way would be to use `FASTLANE_PASSWORD`, which is set only for plain type auth.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: macOS 13.2.1, fastlane 2.212.2

#### Release Note
```release-note
NONE
```
