### PR TITLE
Fix issue with missing post headers on threads

### DIFF
--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -65,7 +65,7 @@ type ScrollIndexFailed = {
 };
 
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);
-const keyExtractor = (item: PostListItem | PostListOtherItem) => (item.type === 'post' ? item.value.id : item.value);
+const keyExtractor = (item: PostListItem | PostListOtherItem) => (item.type === 'post' ? item.value.currentPost.id : item.value);
 
 const styles = StyleSheet.create({
     flex: {
@@ -272,7 +272,8 @@ const PostList = ({
                 return (<CombinedUserActivity {...postProps}/>);
             }
             default: {
-                const post = item.value;
+                const post = item.value.currentPost;
+                const {isSaved, nextPost, previousPost} = item.value;
                 const skipSaveddHeader = (location === Screens.THREAD && post.id === rootId);
                 const postProps = {
                     appsEnabled,
@@ -281,12 +282,12 @@ const PostList = ({
                     isPostAcknowledgementEnabled,
                     highlight: highlightedId === post.id,
                     highlightPinnedOrSaved,
-                    isSaved: post.isSaved,
+                    isSaved: isSaved,
                     key: post.id,
                     location,
-                    nextPost: post.nextPost,
+                    nextPost: nextPost,
                     post,
-                    previousPost: post.previousPost,
+                    previousPost: previousPost,
                     rootId,
                     shouldRenderReplyButton,
                     skipSaveddHeader,
@@ -313,7 +314,7 @@ const PostList = ({
             if (highlightedId && orderedPosts && !scrolledToHighlighted.current) {
                 scrolledToHighlighted.current = true;
                 // eslint-disable-next-line max-nested-callbacks
-                const index = orderedPosts.findIndex((p) => p.type === 'post' && p.value.id === highlightedId);
+                const index = orderedPosts.findIndex((p) => p.type === 'post' && p.value.currentPost.id === highlightedId);
                 if (index >= 0 && listRef.current) {
                     listRef.current?.scrollToIndex({
                         animated: true,

--- a/app/screens/home/recent_mentions/recent_mentions.tsx
+++ b/app/screens/home/recent_mentions/recent_mentions.tsx
@@ -151,9 +151,9 @@ const RecentMentionsScreen = ({appsEnabled, customEmojiNames, mentions, currentT
                     <PostWithChannelInfo
                         appsEnabled={appsEnabled}
                         customEmojiNames={customEmojiNames}
-                        key={item.value.id}
+                        key={item.value.currentPost.id}
                         location={Screens.MENTIONS}
-                        post={item.value}
+                        post={item.value.currentPost}
                         testID='recent_mentions.post_list'
                     />
                 );

--- a/app/screens/home/saved_messages/saved_messages.tsx
+++ b/app/screens/home/saved_messages/saved_messages.tsx
@@ -152,9 +152,9 @@ function SavedMessages({appsEnabled, posts, currentTimezone, customEmojiNames, i
                     <PostWithChannelInfo
                         appsEnabled={appsEnabled}
                         customEmojiNames={customEmojiNames}
-                        key={item.value.id}
+                        key={item.value.currentPost.id}
                         location={Screens.SAVED_MESSAGES}
-                        post={item.value}
+                        post={item.value.currentPost}
                         testID='saved_messages.post_list'
                         skipSavedPostsHighlight={true}
                     />

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -51,9 +51,9 @@ const PostResults = ({
                     <PostWithChannelInfo
                         appsEnabled={appsEnabled}
                         customEmojiNames={customEmojiNames}
-                        key={item.value.id}
+                        key={item.value.currentPost.id}
                         location={Screens.SEARCH}
-                        post={item.value}
+                        post={item.value.currentPost}
                         testID='search_results.post_list'
                     />
                 );

--- a/app/screens/pinned_messages/pinned_messages.tsx
+++ b/app/screens/pinned_messages/pinned_messages.tsx
@@ -132,9 +132,9 @@ function SavedMessages({
                         highlightPinnedOrSaved={false}
                         isCRTEnabled={isCRTEnabled}
                         location={Screens.PINNED_MESSAGES}
-                        key={item.value.id}
+                        key={item.value.currentPost.id}
                         nextPost={undefined}
-                        post={item.value}
+                        post={item.value.currentPost}
                         previousPost={undefined}
                         showAddReaction={false}
                         shouldRenderReplyButton={false}

--- a/types/components/post_list.ts
+++ b/types/components/post_list.ts
@@ -14,7 +14,7 @@ export type ViewableItemsChangedListenerEvent = (viewableItms: ViewToken[]) => v
 export type ScrollEndIndexListener = (fn: (endIndex: number) => void) => () => void;
 export type ViewableItemsListener = (fn: (viewableItems: ViewToken[]) => void) => () => void;
 
-export type PostWithPrevAndNext = PostModel & {nextPost?: PostModel; previousPost?: PostModel; isSaved?: boolean};
+export type PostWithPrevAndNext = {currentPost: PostModel, nextPost?: PostModel; previousPost?: PostModel; isSaved?: boolean};
 
 export type PostListItem = {
     type: 'post';


### PR DESCRIPTION
#### Summary
At some times, we saw that either both the user and the "commented on someone's message" did not appear on some messages. This was due to the logic to get the previous and the next post was updating the post model adding the previous and the next post. This caused those values to be overwritten when the thread screen opens, messing up all the logic that deals with the previous post.

This ticket removes the changes to the post model to create a new object to handle this information.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-52798

#### Release Note
```release-note
Fix issue where sometimes replies seemed attributed to the wrong person or the wrong thread.
```
