### PR TITLE
Improve status sync

### DIFF
--- a/app/actions/local/user.ts
+++ b/app/actions/local/user.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
-import General from '@constants/general';
 import DatabaseManager from '@database/manager';
 import {getRecentCustomStatuses} from '@queries/servers/system';
 import {getCurrentUser, getUserById} from '@queries/servers/user';
@@ -13,7 +12,7 @@ import {addRecentReaction} from './reactions';
 import type Model from '@nozbe/watermelondb/Model';
 import type UserModel from '@typings/database/models/servers/user';
 
-export async function setCurrentUserStatusOffline(serverUrl: string) {
+export async function setCurrentUserStatus(serverUrl: string, status: string) {
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const user = await getCurrentUser(database);
@@ -21,7 +20,7 @@ export async function setCurrentUserStatusOffline(serverUrl: string) {
             throw new Error(`No current user for ${serverUrl}`);
         }
 
-        user.prepareStatus(General.OFFLINE);
+        user.prepareStatus(status);
         await operator.batchRecords([user], 'setCurrentUserStatusOffline');
         return null;
     } catch (error) {

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -69,7 +69,7 @@ import {handleUserRoleUpdatedEvent, handleTeamMemberRoleUpdatedEvent, handleRole
 import {handleLicenseChangedEvent, handleConfigChangedEvent} from './system';
 import {handleLeaveTeamEvent, handleUserAddedToTeamEvent, handleUpdateTeamEvent, handleTeamArchived, handleTeamRestored} from './teams';
 import {handleThreadUpdatedEvent, handleThreadReadChangedEvent, handleThreadFollowChangedEvent} from './threads';
-import {handleUserUpdatedEvent, handleUserTypingEvent} from './users';
+import {handleUserUpdatedEvent, handleUserTypingEvent, handleStatusChangedEvent} from './users';
 
 export async function handleFirstConnect(serverUrl: string) {
     registerDeviceToken(serverUrl);
@@ -277,9 +277,8 @@ export async function handleEvent(serverUrl: string, msg: WebSocketMessage) {
             break;
 
         case WebsocketEvents.STATUS_CHANGED:
+            handleStatusChangedEvent(serverUrl, msg);
             break;
-
-        // return dispatch(handleStatusChangedEvent(msg));
         case WebsocketEvents.TYPING:
             handleUserTypingEvent(serverUrl, msg);
             break;

--- a/app/actions/websocket/users.ts
+++ b/app/actions/websocket/users.ts
@@ -4,6 +4,7 @@
 import {DeviceEventEmitter} from 'react-native';
 
 import {updateChannelsDisplayName} from '@actions/local/channel';
+import {setCurrentUserStatus} from '@actions/local/user';
 import {fetchMe, fetchUsersByIds} from '@actions/remote/user';
 import {General, Events, Preferences} from '@constants';
 import DatabaseManager from '@database/manager';
@@ -114,3 +115,8 @@ export const userTyping = async (serverUrl: string, channelId: string, rootId?: 
     const client = WebsocketManager.getClient(serverUrl);
     client?.sendUserTypingEvent(channelId, rootId);
 };
+
+export async function handleStatusChangedEvent(serverUrl: string, msg: WebSocketMessage) {
+    const newStatus = msg.data.status;
+    setCurrentUserStatus(serverUrl, newStatus);
+}

--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -8,7 +8,7 @@ import BackgroundTimer from 'react-native-background-timer';
 import {BehaviorSubject} from 'rxjs';
 import {distinctUntilChanged} from 'rxjs/operators';
 
-import {setCurrentUserStatusOffline} from '@actions/local/user';
+import {setCurrentUserStatus} from '@actions/local/user';
 import {fetchStatusByIds} from '@actions/remote/user';
 import {handleClose, handleEvent, handleFirstConnect, handleReconnect} from '@actions/websocket';
 import WebSocketClient from '@client/websocket';
@@ -173,7 +173,7 @@ class WebsocketManager {
     private onWebsocketClose = async (serverUrl: string, connectFailCount: number, lastDisconnect: number) => {
         this.getConnectedSubject(serverUrl).next('not_connected');
         if (connectFailCount <= 1) { // First fail
-            await setCurrentUserStatusOffline(serverUrl);
+            await setCurrentUserStatus(serverUrl, General.OFFLINE);
             await handleClose(serverUrl, lastDisconnect);
 
             this.stopPeriodicStatusUpdates(serverUrl);
@@ -200,6 +200,7 @@ class WebsocketManager {
 
         currentId = setInterval(getStatusForUsers, General.STATUS_INTERVAL);
         this.statusUpdatesIntervalIDs[serverUrl] = currentId;
+        getStatusForUsers();
     }
 
     private stopPeriodicStatusUpdates(serverUrl: string) {


### PR DESCRIPTION
#### Summary
We were not listening to the status change websocket event, so we were not updating correctly our own status.

We also were not getting the status of the rest of the users on load, but would wait one minute to get the statuses. If we have short sessions of less than one minute, we would never get the statuses.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-52884
Fix https://github.com/mattermost/mattermost-mobile/issues/7324
Fix https://github.com/mattermost/mattermost-mobile/issues/7022
Fix https://mattermost.atlassian.net/browse/MM-52930

#### Release Note
```release-note
Improve user status sync.
```
