### PR TITLE
MM-52949 - Calls: Blank screen after ending a call and exiting its thread

### DIFF
--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -557,6 +557,13 @@ const CallScreen = ({
             // ignore the error because the call screen has likely already been popped async
             Navigation.pop(componentId).catch(() => null);
         }
+
+        // // If we end a call and return from the Thread screen, the "visible screen" is still the thread.
+        if (NavigationStore.getVisibleScreen() === Screens.THREAD) {
+            popTopScreen();
+            popTopScreen(componentId);
+        }
+
         return null;
     }
 


### PR DESCRIPTION
#### Summary
- Fixing a small bug where ending a call while in the thread view would leave the user on an empty call screen.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-52949

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 15.7, iPhone 7 plus

#### Release Note
```release-note
Calls: Fix for blank screen after ending a call and exiting its thread
```
