### PR TITLE
Fix bad use of updatelocaluser on fetchChannelMember

### DIFF
--- a/app/client/rest/channels.ts
+++ b/app/client/rest/channels.ts
@@ -43,7 +43,7 @@ export interface ClientChannelsMix {
     searchArchivedChannels: (teamId: string, term: string) => Promise<Channel[]>;
     searchAllChannels: (term: string, teamIds: string[], archivedOnly?: boolean) => Promise<Channel[]>;
     updateChannelMemberSchemeRoles: (channelId: string, userId: string, isSchemeUser: boolean, isSchemeAdmin: boolean) => Promise<any>;
-    getMemberInChannel: (channelId: string, userId: string) => Promise<any>;
+    getMemberInChannel: (channelId: string, userId: string) => Promise<ChannelMembership>;
 }
 
 const ClientChannels = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {


### PR DESCRIPTION
#### Summary
We were calling `getMemberInChannel` and using it as a user, instead of as a user membership. This can create several issues, specially when dealing with the current user, since several fields could be overwritten when they shouldn't (notify props and roles).

This fixes the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-52965

#### Release Note
```release-note
Fix rare issue when changing the role of the current user in a channel.
```
