### PR TITLE
Fix fetching unreads from archived channels, fetching groups on unlicensed servers and logs

### DIFF
--- a/app/actions/remote/groups.ts
+++ b/app/actions/remote/groups.ts
@@ -17,7 +17,7 @@ export const fetchGroupsForAutocomplete = async (serverUrl: string, query: strin
     try {
         const {operator, database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const license = await getLicense(database);
-        if (!license || !license.IsLicensed) {
+        if (!license || license.IsLicensed !== 'true') {
             return [];
         }
 
@@ -40,7 +40,7 @@ export const fetchGroupsByNames = async (serverUrl: string, names: string[], fet
     try {
         const {operator, database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const license = await getLicense(database);
-        if (!license || !license.IsLicensed) {
+        if (!license || license.IsLicensed !== 'true') {
             return [];
         }
 
@@ -70,7 +70,7 @@ export const fetchGroupsForChannel = async (serverUrl: string, channelId: string
     try {
         const {operator, database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const license = await getLicense(database);
-        if (!license || !license.IsLicensed) {
+        if (!license || license.IsLicensed !== 'true') {
             return {groups: [], groupChannels: []};
         }
 
@@ -102,7 +102,7 @@ export const fetchGroupsForTeam = async (serverUrl: string, teamId: string, fetc
     try {
         const {operator, database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const license = await getLicense(database);
-        if (!license || !license.IsLicensed) {
+        if (!license || license.IsLicensed !== 'true') {
             return {groups: [], groupTeams: []};
         }
 
@@ -133,7 +133,7 @@ export const fetchGroupsForMember = async (serverUrl: string, userId: string, fe
     try {
         const {operator, database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const license = await getLicense(database);
-        if (!license || !license.IsLicensed) {
+        if (!license || license.IsLicensed !== 'true') {
             return {groups: [], groupMemberships: []};
         }
 

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -339,7 +339,7 @@ export const fetchPostsForUnreadChannels = async (serverUrl: string, channels: C
     const promises = [];
     for (const member of memberships) {
         const channel = channels.find((c) => c.id === member.channel_id);
-        if (channel && (channel.total_msg_count - member.msg_count) > 0 && channel.id !== excludeChannelId) {
+        if (channel && !channel.delete_at && (channel.total_msg_count - member.msg_count) > 0 && channel.id !== excludeChannelId) {
             promises.push(fetchPostsForChannel(serverUrl, channel.id));
         }
     }

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -28,7 +28,8 @@ export function isErrorWithDetails(obj: unknown): obj is {details: Error} {
     return (
         typeof obj === 'object' &&
         obj !== null &&
-        'details' in obj
+        'details' in obj &&
+        typeof obj.details !== 'undefined'
     );
 }
 


### PR DESCRIPTION
#### Summary
Fixed some errors that were polluting the logs:
- Fetching unreads from archived channels when not allowed to see archived channels
- Fetching groups on unlicensed servers (there was a bug on https://github.com/mattermost/mattermost-mobile/pull/7369 )
- Logs showing `Unknown error` at the end of every error

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-53214
Fix https://mattermost.atlassian.net/browse/MM-50052

#### Release Note
```release-note
Remove unneeded fetch posts for unread archived channels that were appearing in the logs.
Remove unneeded group calls that were appearing in the logs.
Improve logging.
```
