### PR TITLE
Fix ios cache

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
@@ -221,6 +221,11 @@ public class MattermostManagedModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void invalidateKeychainCache(String serverUrl) {
+        // Not using cache
+    }
+
     private static class SaveDataTask extends GuardedResultAsyncTask<Object> {
         private final WeakReference<Context> weakContext;
         private final String fromFile;

--- a/app/managers/session_manager.ts
+++ b/app/managers/session_manager.ts
@@ -7,6 +7,7 @@ import FastImage from 'react-native-fast-image';
 
 import {storeOnboardingViewedValue} from '@actions/app/global';
 import {cancelSessionNotification, logout, scheduleSessionNotification} from '@actions/remote/session';
+import {invalidateKeychainCache} from '@app/utils/mattermost_managed';
 import {Events, Launch} from '@constants';
 import DatabaseManager from '@database/manager';
 import {resetMomentLocale} from '@i18n';
@@ -115,6 +116,7 @@ class SessionManager {
     private terminateSession = async (serverUrl: string, removeServer: boolean) => {
         cancelSessionNotification(serverUrl);
         await removeServerCredentials(serverUrl);
+        invalidateKeychainCache(serverUrl);
         PushNotifications.removeServerNotifications(serverUrl);
 
         NetworkManager.invalidateClient(serverUrl);

--- a/app/managers/session_manager.ts
+++ b/app/managers/session_manager.ts
@@ -7,7 +7,6 @@ import FastImage from 'react-native-fast-image';
 
 import {storeOnboardingViewedValue} from '@actions/app/global';
 import {cancelSessionNotification, logout, scheduleSessionNotification} from '@actions/remote/session';
-import {invalidateKeychainCache} from '@app/utils/mattermost_managed';
 import {Events, Launch} from '@constants';
 import DatabaseManager from '@database/manager';
 import {resetMomentLocale} from '@i18n';
@@ -23,6 +22,7 @@ import {getThemeFromState} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {deleteFileCache, deleteFileCacheByDir} from '@utils/file';
 import {isMainActivity} from '@utils/helpers';
+import {invalidateKeychainCache} from '@utils/mattermost_managed';
 import {addNewServer} from '@utils/server';
 
 import type {LaunchType} from '@typings/launch';

--- a/app/utils/mattermost_managed.ts
+++ b/app/utils/mattermost_managed.ts
@@ -64,3 +64,7 @@ export const deleteEntititesFile = (callback?: (success: boolean) => void) => {
         callback(true);
     }
 };
+
+export const invalidateKeychainCache = (serverUrl: string) => {
+    MattermostManaged.invalidateKeychainCache(serverUrl);
+};

--- a/ios/Gekidou/Sources/Gekidou/Keychain.swift
+++ b/ios/Gekidou/Sources/Gekidou/Keychain.swift
@@ -100,6 +100,10 @@ public class Keychain: NSObject {
         
         return nil
     }
+
+    public func invalidateToken(for serverUrl: String) {
+        tokenCache.removeValue(forKey: serverUrl)
+    }
     
     private func buildIdentityQuery(for host: String) throws -> [CFString: Any] {
         guard let hostData = host.data(using: .utf8) else {

--- a/ios/GekidouWrapper.swift
+++ b/ios/GekidouWrapper.swift
@@ -42,4 +42,8 @@ import Gekidou
     
     return nil
   }
+
+  @objc func invalidateToken(for url: String) {
+    Keychain.default.invalidateToken(for: url)
+  }
 }

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -153,6 +153,10 @@ RCT_EXPORT_METHOD(removeListeners:(double)count) {
   // Keep: Required for RN built in Event Emitter Calls.
 }
 
+RCT_EXPORT_METHOD(invalidateKeychainCache:(NSString *) serverUrl)
+{
+  [[GekidouWrapper default] invalidateTokenFor:serverUrl]
+}
 
 RCT_EXPORT_METHOD(createThumbnail:(NSDictionary *)config findEventsWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -155,7 +155,7 @@ RCT_EXPORT_METHOD(removeListeners:(double)count) {
 
 RCT_EXPORT_METHOD(invalidateKeychainCache:(NSString *) serverUrl)
 {
-  [[GekidouWrapper default] invalidateTokenFor:serverUrl]
+  [[GekidouWrapper default] invalidateTokenFor:serverUrl];
 }
 
 RCT_EXPORT_METHOD(createThumbnail:(NSDictionary *)config findEventsWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
#### Summary
We were caching the token to not access too often the Keychain on iOS, but that cache was not getting invalidated on logout.

This was creating problems with Push Notifications where a wrong token was used to get the notification message, resulting in the message showing "session expired".

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-52991

#### QA Steps
- Log in
- Close the app
- Receive a notification: It shows the message alright
- Log out
- Log back in
- Close the app
- Receive a notification

Expected:
The notification shows alright

Before the fix:
The notfication shows as if the message was "session expired"

#### Release Note
```release-note
Fix case where notifications would show "Session expired" instead of the message.
```
