### PR TITLE
Fix image attachment overlap

### DIFF
--- a/app/components/files/image_file.tsx
+++ b/app/components/files/image_file.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo, useState} from 'react';
-import {type StyleProp, StyleSheet, useWindowDimensions, View, type ViewStyle} from 'react-native';
+import {StyleSheet, useWindowDimensions, View} from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 
 import {buildFilePreviewUrl, buildFileThumbnailUrl} from '@actions/remote/file';
@@ -59,15 +59,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     imagePreview: {
         ...StyleSheet.absoluteFillObject,
     },
-    smallImageBorder: {
-        borderRadius: 5,
-    },
-    smallImageOverlay: {
-        justifyContent: 'center',
-        alignItems: 'center',
-        borderRadius: 4,
-        position: 'absolute',
-    },
     singleSmallImageWrapper: {
         height: SMALL_IMAGE_MAX_HEIGHT,
         width: SMALL_IMAGE_MAX_WIDTH,
@@ -117,56 +108,9 @@ const ImageFile = ({
         return props;
     };
 
-    const imageDimensions = getImageDimensions();
-    if (imageDimensions && (imageDimensions.height <= SMALL_IMAGE_MAX_HEIGHT || imageDimensions.width <= SMALL_IMAGE_MAX_WIDTH)) {
-        let wrapperStyle: StyleProp<ViewStyle> = style.fileImageWrapper;
-        if (isSingleImage) {
-            wrapperStyle = style.singleSmallImageWrapper;
-
-            if (file.width > SMALL_IMAGE_MAX_WIDTH) {
-                wrapperStyle = [wrapperStyle, {width: '100%'}];
-            }
-        }
-
-        image = (
-            <ProgressiveImage
-                id={file.id!}
-                forwardRef={forwardRef}
-                style={{height: file.height, width: file.width}}
-                tintDefaultSource={!file.localPath && !failed}
-                onError={handleError}
-                resizeMode={'contain'}
-                {...imageProps()}
-            />
-        );
-
-        if (failed) {
-            image = (
-                <FileIcon
-                    failed={failed}
-                    file={file}
-                    backgroundColor={backgroundColor}
-                />
-            );
-        }
-
-        return (
-            <View
-                style={[
-                    wrapperStyle,
-                    style.smallImageBorder,
-                    {
-                        borderColor: changeOpacity(theme.centerChannelColor, 0.4),
-                        backgroundColor: changeOpacity(theme.centerChannelColor, 0.08),
-                    },
-                ]}
-            >
-                {!isSingleImage && <View style={style.boxPlaceholder}/>}
-                <View style={style.smallImageOverlay}>
-                    {image}
-                </View>
-            </View>
-        );
+    let imageDimensions = getImageDimensions();
+    if (isSingleImage && (!imageDimensions || (imageDimensions?.height === 0 && imageDimensions?.width === 0))) {
+        imageDimensions = style.singleSmallImageWrapper;
     }
 
     image = (

--- a/app/components/progressive_image/index.tsx
+++ b/app/components/progressive_image/index.tsx
@@ -7,6 +7,7 @@ import FastImage, {type ResizeMode} from 'react-native-fast-image';
 import Animated, {interpolate, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming} from 'react-native-reanimated';
 
 import {useTheme} from '@context/theme';
+import {emptyFunction} from '@utils/general';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
 import Thumbnail from './thumbnail';
@@ -24,6 +25,7 @@ type Props = ProgressiveImageProps & {
     imageStyle?: StyleProp<ImageStyle>;
     isBackgroundImage?: boolean;
     onError: () => void;
+    onSucess?: () => void;
     resizeMode?: ResizeMode;
     style?: StyleProp<ViewStyle>;
     tintDefaultSource?: boolean;
@@ -45,7 +47,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
 
 const ProgressiveImage = ({
     children, defaultSource, forwardRef, id, imageStyle, imageUri, inViewPort, isBackgroundImage,
-    onError, resizeMode = 'contain', style = {}, thumbnailUri, tintDefaultSource,
+    onError, onSucess, resizeMode = 'contain', style = {}, thumbnailUri, tintDefaultSource,
 }: Props) => {
     const [showHighResImage, setShowHighResImage] = useState(false);
     const theme = useTheme();
@@ -62,6 +64,7 @@ const ProgressiveImage = ({
 
     const onLoadImageEnd = () => {
         intensity.value = withTiming(100, {duration: 300});
+        onSucess?.();
     };
 
     const animatedOpacity = useAnimatedStyle(() => ({
@@ -153,8 +156,9 @@ const ProgressiveImage = ({
         <Animated.View
             style={[styles.defaultImageContainer, style, containerStyle]}
         >
+            {Boolean(thumbnailUri) &&
             <Thumbnail
-                onError={onError}
+                onError={emptyFunction}
                 opacity={defaultOpacity}
                 source={{uri: thumbnailUri}}
                 style={[
@@ -163,6 +167,7 @@ const ProgressiveImage = ({
                 ]}
                 tintColor={thumbnailUri ? undefined : theme.centerChannelColor}
             />
+            }
             {image}
         </Animated.View>
     );

--- a/app/components/progressive_image/index.tsx
+++ b/app/components/progressive_image/index.tsx
@@ -25,7 +25,6 @@ type Props = ProgressiveImageProps & {
     imageStyle?: StyleProp<ImageStyle>;
     isBackgroundImage?: boolean;
     onError: () => void;
-    onSucess?: () => void;
     resizeMode?: ResizeMode;
     style?: StyleProp<ViewStyle>;
     tintDefaultSource?: boolean;
@@ -47,7 +46,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
 
 const ProgressiveImage = ({
     children, defaultSource, forwardRef, id, imageStyle, imageUri, inViewPort, isBackgroundImage,
-    onError, onSucess, resizeMode = 'contain', style = {}, thumbnailUri, tintDefaultSource,
+    onError, resizeMode = 'contain', style = {}, thumbnailUri, tintDefaultSource,
 }: Props) => {
     const [showHighResImage, setShowHighResImage] = useState(false);
     const theme = useTheme();
@@ -64,7 +63,6 @@ const ProgressiveImage = ({
 
     const onLoadImageEnd = () => {
         intensity.value = withTiming(100, {duration: 300});
-        onSucess?.();
     };
 
     const animatedOpacity = useAnimatedStyle(() => ({


### PR DESCRIPTION
#### Summary
The footer of some messages was overlapping with the image attachment when the image was smaller than 48 pixels in height or width

Tests: Create posts in CRT and none CRT mode with single and multiple images that exceed and lower than the minimum size 48x48 and the posts with the images should display correctly.

Perhaps a channel with multiple posts with combination of images ex:
* Single image with height lower than 48
* Single image with width lower than 48
* Single image with dimensions higher than 48x48
* Repeat by attaching multiple images from 2 with a maximum of 10 images (a max of 6 should be enough)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53243

#### Release Note
```release-note
Fixed the overlap between image attachments and the post footer in CRT
```
