### PR TITLE
Add logs for chunks in posts in channels

### DIFF
--- a/app/screens/channel/channel_post_list/index.ts
+++ b/app/screens/channel/channel_post_list/index.ts
@@ -18,6 +18,7 @@ import {observeIsCRTEnabled} from '@queries/servers/thread';
 import ChannelPostList from './channel_post_list';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
+import { logDebug } from '@app/utils/log';
 
 const enhanced = withObservables(['channelId'], ({database, channelId}: {channelId: string} & WithDatabaseArgs) => {
     const isCRTEnabledObserver = observeIsCRTEnabled(database);
@@ -36,6 +37,7 @@ const enhanced = withObservables(['channelId'], ({database, channelId}: {channel
                 }
 
                 const {earliest, latest} = postsInChannel[0];
+                logDebug('using as posts in channels', {earliest, latest, now: Date.now()});
                 return queryPostsBetween(database, earliest, latest, Q.desc, '', channelId, isCRTEnabled ? '' : undefined).observe();
             }),
         ),

--- a/app/screens/channel/channel_post_list/index.ts
+++ b/app/screens/channel/channel_post_list/index.ts
@@ -14,11 +14,11 @@ import {observeMyChannel} from '@queries/servers/channel';
 import {queryPostsBetween, queryPostsInChannel} from '@queries/servers/post';
 import {queryAdvanceSettingsPreferences} from '@queries/servers/preference';
 import {observeIsCRTEnabled} from '@queries/servers/thread';
+import {logDebug} from '@utils/log';
 
 import ChannelPostList from './channel_post_list';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
-import { logDebug } from '@app/utils/log';
 
 const enhanced = withObservables(['channelId'], ({database, channelId}: {channelId: string} & WithDatabaseArgs) => {
     const isCRTEnabledObserver = observeIsCRTEnabled(database);


### PR DESCRIPTION
#### Summary
Add logs to get the chunk used for posts in channels. This will help us see what may be the issue with empty channels and why the current strategies to recover from it are still not working.

#### Ticket Link
None

#### Release Note
```release-note
Improve logs around empty channels issue
```
