### PR TITLE
Android: Use network APIClient reactContext if already set

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/Network.java
+++ b/android/app/src/main/java/com/mattermost/helpers/Network.java
@@ -21,7 +21,7 @@ public class Network {
     private static final Promise emptyPromise = new ResolvePromise();
 
     public static void init(Context context) {
-        final ReactApplicationContext reactContext = new ReactApplicationContext(context);
+        final ReactApplicationContext reactContext = (APIClientModule.context == null) ? new ReactApplicationContext(context) : APIClientModule.context;
         clientModule = new APIClientModule(reactContext);
         createClientOptions();
     }


### PR DESCRIPTION
#### Summary
The Network class used for Notifications gets initialized when a new push notification comes in or when the app opens an intent, this causes the react context to be overridden in the APIClientModule of the network library with a context that has not initialized react, this PR makes sure that the instance of the module does not replaces the react context if it was already set by the running app.

#### Release Note
```release-note
Fixed progress indicator when uploading files on Android
```