### PR TITLE
[MM-53249] Allow server to hide or customize the Forgot Password link

### DIFF
--- a/app/screens/login/form.tsx
+++ b/app/screens/login/form.tsx
@@ -8,6 +8,7 @@ import {Keyboard, TextInput, TouchableOpacity, View} from 'react-native';
 import Button from 'react-native-button';
 
 import {login} from '@actions/remote/session';
+import {tryOpenURL} from '@app/utils/url';
 import CompassIcon from '@components/compass_icon';
 import FloatingTextInput from '@components/floating_text_input_label';
 import FormattedText from '@components/formatted_text';
@@ -206,6 +207,11 @@ const LoginForm = ({config, extra, serverDisplayName, launchError, launchType, l
     }, [error]);
 
     const onPressForgotPassword = useCallback(() => {
+        if (config.ForgotPasswordLink) {
+            tryOpenURL(config.ForgotPasswordLink);
+            return;
+        }
+
         const passProps = {
             theme,
             serverUrl,
@@ -334,7 +340,7 @@ const LoginForm = ({config, extra, serverDisplayName, launchError, launchType, l
                 endAdornment={endAdornment}
             />
 
-            {(emailEnabled || usernameEnabled) && (
+            {(emailEnabled || usernameEnabled) && config.PasswordEnableForgotLink === 'true' && (
                 <Button
                     onPress={onPressForgotPassword}
                     containerStyle={[styles.forgotPasswordBtn, error ? styles.forgotPasswordError : undefined]}

--- a/app/screens/login/form.tsx
+++ b/app/screens/login/form.tsx
@@ -8,7 +8,6 @@ import {Keyboard, TextInput, TouchableOpacity, View} from 'react-native';
 import Button from 'react-native-button';
 
 import {login} from '@actions/remote/session';
-import {tryOpenURL} from '@utils/url';
 import CompassIcon from '@components/compass_icon';
 import FloatingTextInput from '@components/floating_text_input_label';
 import FormattedText from '@components/formatted_text';
@@ -20,6 +19,7 @@ import {buttonBackgroundStyle, buttonTextStyle} from '@utils/buttonStyles';
 import {getFullErrorMessage, isErrorWithMessage, isServerError} from '@utils/errors';
 import {preventDoubleTap} from '@utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {tryOpenURL} from '@utils/url';
 
 import type {LaunchProps} from '@typings/launch';
 

--- a/app/screens/login/form.tsx
+++ b/app/screens/login/form.tsx
@@ -8,7 +8,7 @@ import {Keyboard, TextInput, TouchableOpacity, View} from 'react-native';
 import Button from 'react-native-button';
 
 import {login} from '@actions/remote/session';
-import {tryOpenURL} from '@app/utils/url';
+import {tryOpenURL} from '@utils/url';
 import CompassIcon from '@components/compass_icon';
 import FloatingTextInput from '@components/floating_text_input_label';
 import FormattedText from '@components/formatted_text';

--- a/app/screens/login/form.tsx
+++ b/app/screens/login/form.tsx
@@ -340,7 +340,7 @@ const LoginForm = ({config, extra, serverDisplayName, launchError, launchType, l
                 endAdornment={endAdornment}
             />
 
-            {(emailEnabled || usernameEnabled) && config.PasswordEnableForgotLink === 'true' && (
+            {(emailEnabled || usernameEnabled) && config.PasswordEnableForgotLink !== 'false' && (
                 <Button
                     onPress={onPressForgotPassword}
                     containerStyle={[styles.forgotPasswordBtn, error ? styles.forgotPasswordError : undefined]}

--- a/types/api/config.d.ts
+++ b/types/api/config.d.ts
@@ -121,6 +121,7 @@ interface ClientConfig {
     FeatureFlagCollapsedThreads?: string;
     FeatureFlagGraphQL?: string;
     FeatureFlagPostPriority?: string;
+    ForgotPasswordLink?: string;
     GfycatApiKey: string;
     GfycatApiSecret: string;
     GoogleDeveloperKey: string;
@@ -146,6 +147,7 @@ interface ClientConfig {
     MinimumHashtagLength: string;
     OpenIdButtonColor: string;
     OpenIdButtonText: string;
+    PasswordEnableForgotLink: string;
     PasswordMinimumLength: string;
     PasswordRequireLowercase: string;
     PasswordRequireNumber: string;


### PR DESCRIPTION
#### Summary
Mobile app changes for allowing servers to customize the Forgot Password link.

Related server/web app PR: https://github.com/mattermost/mattermost/pull/23831

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53249

```release-note
NONE
```
