### PR TITLE
[MM-48225] Reduce Padding/Margins from Files Tab and moving the Search Results to the FlatList

### DIFF
--- a/app/components/files/file.tsx
+++ b/app/components/files/file.tsx
@@ -44,7 +44,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             flex: 1,
             flexDirection: 'row',
             alignItems: 'center',
-            marginTop: 10,
             borderWidth: 1,
             borderColor: changeOpacity(theme.centerChannelColor, 0.24),
             borderRadius: 4,

--- a/app/components/files/files.tsx
+++ b/app/components/files/files.tsx
@@ -76,7 +76,7 @@ const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, l
 
     const renderItems = (items: FileInfo[], moreImagesCount = 0, includeGutter = false) => {
         let nonVisibleImagesCount: number;
-        let container: StyleProp<ViewStyle> = items.length > 1 ? styles.container : styles.marginTop;
+        let container: StyleProp<ViewStyle> = items.length > 1 ? styles.container : undefined;
         const containerWithGutter = [container, styles.gutter];
 
         return items.map((file, idx) => {
@@ -89,7 +89,7 @@ const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, l
             }
             return (
                 <View
-                    style={container}
+                    style={[container, styles.marginTop]}
                     key={file.id}
                 >
                     <File

--- a/app/components/files/files.tsx
+++ b/app/components/files/files.tsx
@@ -43,6 +43,9 @@ const styles = StyleSheet.create({
     failed: {
         opacity: 0.5,
     },
+    marginTop: {
+        marginTop: 10,
+    },
 });
 
 const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, location, postId, publicLinkEnabled}: FilesProps) => {
@@ -73,7 +76,7 @@ const Files = ({canDownloadFiles, failed, filesInfo, isReplyPost, layoutWidth, l
 
     const renderItems = (items: FileInfo[], moreImagesCount = 0, includeGutter = false) => {
         let nonVisibleImagesCount: number;
-        let container: StyleProp<ViewStyle> = items.length > 1 ? styles.container : undefined;
+        let container: StyleProp<ViewStyle> = items.length > 1 ? styles.container : styles.marginTop;
         const containerWithGutter = [container, styles.gutter];
 
         return items.map((file, idx) => {

--- a/app/components/files_search/file_results.tsx
+++ b/app/components/files_search/file_results.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo, useState} from 'react';
+import {useIntl} from 'react-intl';
 import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, Text} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
@@ -62,6 +63,7 @@ const FileResults = ({
     isFilterEnabled,
 }: Props) => {
     const theme = useTheme();
+    const intl = useIntl();
     const styles = getStyles(theme);
     const insets = useSafeAreaInsets();
     const isTablet = useIsTablet();
@@ -154,7 +156,13 @@ const FileResults = ({
             <FlatList
                 ListHeaderComponent={
                     <Text style={styles.resultsNumber}>
-                        {`${orderedFileInfos.length} search results`}
+                        {intl.formatMessage(
+                            {
+                                id: 'mobile.search.results',
+                                defaultMessage: '{results} search results',
+                            },
+                            {results: orderedFileInfos.length},
+                        )}
                     </Text>
                 }
                 ListEmptyComponent={noResults}

--- a/app/components/files_search/file_results.tsx
+++ b/app/components/files_search/file_results.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo, useState} from 'react';
-import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle} from 'react-native';
+import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, Text} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import NoResults from '@components/files_search/no_results';
@@ -20,6 +20,8 @@ import {
 import {openGalleryAtIndex} from '@utils/gallery';
 import {TabTypes} from '@utils/search';
 import {preventDoubleTap} from '@utils/tap';
+import {makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
 
 import {showMobileOptionsBottomSheet} from './file_options/mobile_options';
 import Toasts from './file_options/toasts';
@@ -27,6 +29,14 @@ import FileResult from './file_result';
 
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type {GalleryAction} from '@typings/screens/gallery';
+
+const getStyles = makeStyleSheetFromTheme((theme: Theme) => ({
+    resultsNumber: {
+        ...typography('Heading', 300),
+        padding: 20,
+        color: theme.centerChannelColor,
+    },
+}));
 
 type Props = {
     canDownloadFiles: boolean;
@@ -52,6 +62,7 @@ const FileResults = ({
     isFilterEnabled,
 }: Props) => {
     const theme = useTheme();
+    const styles = getStyles(theme);
     const insets = useSafeAreaInsets();
     const isTablet = useIsTablet();
 
@@ -141,6 +152,11 @@ const FileResults = ({
     return (
         <>
             <FlatList
+                ListHeaderComponent={
+                    <Text style={styles.resultsNumber}>
+                        {`${orderedFileInfos.length} search results`}
+                    </Text>
+                }
                 ListEmptyComponent={noResults}
                 contentContainerStyle={containerStyle}
                 data={orderedFileInfos}

--- a/app/components/files_search/file_results.tsx
+++ b/app/components/files_search/file_results.tsx
@@ -2,11 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo, useState} from 'react';
-import {useIntl} from 'react-intl';
-import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, Text} from 'react-native';
+import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import NoResults from '@components/files_search/no_results';
+import FormattedText from '@components/formatted_text';
 import NoResultsWithTerm from '@components/no_results_with_term';
 import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
@@ -63,7 +63,6 @@ const FileResults = ({
     isFilterEnabled,
 }: Props) => {
     const theme = useTheme();
-    const intl = useIntl();
     const styles = getStyles(theme);
     const insets = useSafeAreaInsets();
     const isTablet = useIsTablet();
@@ -155,15 +154,12 @@ const FileResults = ({
         <>
             <FlatList
                 ListHeaderComponent={
-                    <Text style={styles.resultsNumber}>
-                        {intl.formatMessage(
-                            {
-                                id: 'mobile.search.results',
-                                defaultMessage: '{results} search results',
-                            },
-                            {results: orderedFileInfos.length},
-                        )}
-                    </Text>
+                    <FormattedText
+                        style={styles.resultsNumber}
+                        id='mobile.search.results'
+                        defaultMessage='{count} search {count, plural, one {result} other {results}}'
+                        values={{count: orderedFileInfos.length}}
+                    />
                 }
                 ListEmptyComponent={noResults}
                 contentContainerStyle={containerStyle}

--- a/app/components/files_search/file_results.tsx
+++ b/app/components/files_search/file_results.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo, useState} from 'react';
-import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle} from 'react-native';
+import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import NoResults from '@components/files_search/no_results';
@@ -37,6 +37,9 @@ const getStyles = makeStyleSheetFromTheme((theme: Theme) => ({
         padding: 20,
         color: theme.centerChannelColor,
     },
+    separator: {
+        height: 10,
+    },
 }));
 
 type Props = {
@@ -70,7 +73,7 @@ const FileResults = ({
     const [action, setAction] = useState<GalleryAction>('none');
     const [lastViewedFileInfo, setLastViewedFileInfo] = useState<FileInfo | undefined>(undefined);
 
-    const containerStyle = useMemo(() => ([paddingTop, {top: fileInfos.length ? 8 : 0, flexGrow: 1}]), [fileInfos, paddingTop]);
+    const containerStyle = useMemo(() => ([paddingTop, {flexGrow: 1}]), [paddingTop]);
     const numOptions = getNumberFileMenuOptions(canDownloadFiles, publicLinkEnabled);
 
     const {images: imageAttachments, nonImages: nonImageAttachments} = useImageAttachments(fileInfos, publicLinkEnabled);
@@ -161,6 +164,7 @@ const FileResults = ({
                         values={{count: orderedFileInfos.length}}
                     />
                 }
+                ItemSeparatorComponent={() => <View style={styles.separator}/>}
                 ListEmptyComponent={noResults}
                 contentContainerStyle={containerStyle}
                 data={orderedFileInfos}

--- a/app/components/files_search/file_results.tsx
+++ b/app/components/files_search/file_results.tsx
@@ -37,9 +37,6 @@ const getStyles = makeStyleSheetFromTheme((theme: Theme) => ({
         padding: 20,
         color: theme.centerChannelColor,
     },
-    separator: {
-        height: 10,
-    },
 }));
 
 type Props = {
@@ -54,6 +51,9 @@ type Props = {
 }
 
 const galleryIdentifier = 'search-files-location';
+
+const separatorStyle = {height: 10};
+const Separator = () => <View style={separatorStyle}/>;
 
 const FileResults = ({
     canDownloadFiles,
@@ -164,7 +164,7 @@ const FileResults = ({
                         values={{count: orderedFileInfos.length}}
                     />
                 }
-                ItemSeparatorComponent={() => <View style={styles.separator}/>}
+                ItemSeparatorComponent={Separator}
                 ListEmptyComponent={noResults}
                 contentContainerStyle={containerStyle}
                 data={orderedFileInfos}

--- a/app/screens/home/search/results/header.tsx
+++ b/app/screens/home/search/results/header.tsx
@@ -122,7 +122,7 @@ const Header = ({
         });
     }, [onFilterChanged, selectedFilter]);
 
-    const filterStyle = useMemo(() => ({marginRight: teams.length > 1 ? 0 : 10}), [teams.length > 1]);
+    const filterStyle = useMemo(() => ({marginRight: teams.length > 1 ? 0 : 8}), [teams.length > 1]);
 
     return (
         <View style={styles.container}>
@@ -138,31 +138,34 @@ const Header = ({
                     text={`${filesText} (${numberFiles})`}
                 />
                 <View style={styles.iconsContainer}>
-                    {showFilterIcon &&
-                    <View style={filterStyle}>
-                        <CompassIcon
-                            name={'filter-variant'}
-                            size={24}
-                            color={changeOpacity(theme.centerChannelColor, 0.56)}
-                            onPress={handleFilterPress}
+                    {showFilterIcon && (
+                        <View style={filterStyle}>
+                            <CompassIcon
+                                name={'filter-variant'}
+                                size={24}
+                                color={changeOpacity(
+                                    theme.centerChannelColor,
+                                    0.56,
+                                )}
+                                onPress={handleFilterPress}
+                            />
+                            <Badge
+                                style={styles.badge}
+                                visible={hasFilters}
+                                testID={'search.filters.badge'}
+                                value={-1}
+                            />
+                        </View>
+                    )}
+                    {teams.length > 1 && (
+                        <TeamPickerIcon
+                            size={32}
+                            divider={true}
+                            setTeamId={setTeamId}
+                            teamId={teamId}
+                            teams={teams}
                         />
-                        <Badge
-                            style={styles.badge}
-                            visible={hasFilters}
-                            testID={'search.filters.badge'}
-                            value={-1}
-                        />
-                    </View>
-                    }
-                    {teams.length > 1 &&
-                    <TeamPickerIcon
-                        size={32}
-                        divider={true}
-                        setTeamId={setTeamId}
-                        teamId={teamId}
-                        teams={teams}
-                    />
-                    }
+                    )}
                 </View>
             </View>
         </View>
@@ -170,4 +173,3 @@ const Header = ({
 };
 
 export default Header;
-

--- a/app/screens/home/search/results/header.tsx
+++ b/app/screens/home/search/results/header.tsx
@@ -27,8 +27,6 @@ type Props = {
     onFilterChanged: (filter: FileFilter) => void;
     selectedTab: TabType;
     selectedFilter: FileFilter;
-    numberMessages: number;
-    numberFiles: number;
     setTeamId: (id: string) => void;
     teamId: string;
     teams: TeamModel[];
@@ -65,8 +63,6 @@ const Header = ({
     setTeamId,
     onTabSelect,
     onFilterChanged,
-    numberMessages,
-    numberFiles,
     selectedTab,
     selectedFilter,
     teams,
@@ -130,12 +126,12 @@ const Header = ({
                 <SelectButton
                     selected={selectedTab === TabTypes.MESSAGES}
                     onPress={handleMessagesPress}
-                    text={`${messagesText} (${numberMessages})`}
+                    text={messagesText}
                 />
                 <SelectButton
                     selected={selectedTab === TabTypes.FILES}
                     onPress={handleFilesPress}
-                    text={`${filesText} (${numberFiles})`}
+                    text={filesText}
                 />
                 <View style={styles.iconsContainer}>
                     {showFilterIcon && (

--- a/app/screens/home/search/results/header_button.tsx
+++ b/app/screens/home/search/results/header_button.tsx
@@ -16,7 +16,7 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
             borderRadius: 4,
         },
         text: {
-            paddingHorizontal: 16,
+            paddingHorizontal: 12,
             paddingVertical: 8,
             ...typography('Body', 200, 'SemiBold'),
         },

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo} from 'react';
-import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, Text} from 'react-native';
+import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle} from 'react-native';
 
 import FormattedText from '@components/formatted_text';
 import NoResultsWithTerm from '@components/no_results_with_term';
@@ -103,14 +103,12 @@ const PostResults = ({
     return (
         <FlatList
             ListHeaderComponent={
-                <Text style={styles.resultsNumber}>
-                    <FormattedText
-                        style={styles.resultsNumber}
-                        id='mobile.search.results'
-                        defaultMessage='{count} search {count, plural, one {result} other {results}}'
-                        values={{count: posts.length}}
-                    />
-                </Text>
+                <FormattedText
+                    style={styles.resultsNumber}
+                    id='mobile.search.results'
+                    defaultMessage='{count} search {count, plural, one {result} other {results}}'
+                    values={{count: posts.length}}
+                />
             }
             ListEmptyComponent={noResults}
             contentContainerStyle={[paddingTop, containerStyle]}

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo} from 'react';
+import {useIntl} from 'react-intl';
 import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, Text} from 'react-native';
 
 import NoResultsWithTerm from '@components/no_results_with_term';
@@ -49,6 +50,7 @@ const PostResults = ({
     searchValue,
 }: Props) => {
     const theme = useTheme();
+    const intl = useIntl();
     const styles = getStyles(theme);
     const orderedPosts = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [posts]);
     const containerStyle = useMemo(() => ({top: posts.length ? 4 : 8, flexGrow: 1}), [posts]);
@@ -103,7 +105,13 @@ const PostResults = ({
         <FlatList
             ListHeaderComponent={
                 <Text style={styles.resultsNumber}>
-                    {`${posts.length} search results`}
+                    {intl.formatMessage(
+                        {
+                            id: 'mobile.search.results',
+                            defaultMessage: '{results} search results',
+                        },
+                        {results: posts.length},
+                    )}
                 </Text>
             }
             ListEmptyComponent={noResults}

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -2,19 +2,30 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo} from 'react';
-import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle} from 'react-native';
+import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, Text} from 'react-native';
 
 import NoResultsWithTerm from '@components/no_results_with_term';
 import DateSeparator from '@components/post_list/date_separator';
 import PostWithChannelInfo from '@components/post_with_channel_info';
 import {Screens} from '@constants';
+import {useTheme} from '@context/theme';
 import {convertSearchTermToRegex, parseSearchTerms} from '@utils/markdown';
 import {getDateForDateLine, selectOrderedPosts} from '@utils/post_list';
 import {TabTypes} from '@utils/search';
+import {makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
 
 import type {PostListItem, PostListOtherItem} from '@typings/components/post_list';
 import type PostModel from '@typings/database/models/servers/post';
 import type {SearchPattern} from '@typings/global/markdown';
+
+const getStyles = makeStyleSheetFromTheme((theme: Theme) => ({
+    resultsNumber: {
+        ...typography('Heading', 300),
+        padding: 20,
+        color: theme.centerChannelColor,
+    },
+}));
 
 type Props = {
     appsEnabled: boolean;
@@ -37,6 +48,8 @@ const PostResults = ({
     paddingTop,
     searchValue,
 }: Props) => {
+    const theme = useTheme();
+    const styles = getStyles(theme);
     const orderedPosts = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [posts]);
     const containerStyle = useMemo(() => ({top: posts.length ? 4 : 8, flexGrow: 1}), [posts]);
 
@@ -88,6 +101,11 @@ const PostResults = ({
 
     return (
         <FlatList
+            ListHeaderComponent={
+                <Text style={styles.resultsNumber}>
+                    {`${posts.length} search results`}
+                </Text>
+            }
             ListEmptyComponent={noResults}
             contentContainerStyle={[paddingTop, containerStyle]}
             data={orderedPosts}

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -52,7 +52,7 @@ const PostResults = ({
     const theme = useTheme();
     const styles = getStyles(theme);
     const orderedPosts = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [posts]);
-    const containerStyle = useMemo(() => ({top: posts.length ? 4 : 8, flexGrow: 1}), [posts]);
+    const containerStyle = useMemo(() => ([paddingTop, {flexGrow: 1}]), [paddingTop]);
 
     const renderItem = useCallback(({item}: ListRenderItemInfo<PostListItem | PostListOtherItem>) => {
         switch (item.type) {
@@ -111,7 +111,7 @@ const PostResults = ({
                 />
             }
             ListEmptyComponent={noResults}
-            contentContainerStyle={[paddingTop, containerStyle]}
+            contentContainerStyle={containerStyle}
             data={orderedPosts}
             indicatorStyle='black'
             initialNumToRender={5}
@@ -126,7 +126,6 @@ const PostResults = ({
             scrollEventThrottle={16}
             scrollToOverflowEnabled={true}
             showsVerticalScrollIndicator={true}
-            style={containerStyle}
             testID='search_results.post_list.flat_list'
         />
     );

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useMemo} from 'react';
-import {useIntl} from 'react-intl';
 import {FlatList, type ListRenderItemInfo, type StyleProp, type ViewStyle, Text} from 'react-native';
 
+import FormattedText from '@components/formatted_text';
 import NoResultsWithTerm from '@components/no_results_with_term';
 import DateSeparator from '@components/post_list/date_separator';
 import PostWithChannelInfo from '@components/post_with_channel_info';
@@ -50,7 +50,6 @@ const PostResults = ({
     searchValue,
 }: Props) => {
     const theme = useTheme();
-    const intl = useIntl();
     const styles = getStyles(theme);
     const orderedPosts = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [posts]);
     const containerStyle = useMemo(() => ({top: posts.length ? 4 : 8, flexGrow: 1}), [posts]);
@@ -105,13 +104,12 @@ const PostResults = ({
         <FlatList
             ListHeaderComponent={
                 <Text style={styles.resultsNumber}>
-                    {intl.formatMessage(
-                        {
-                            id: 'mobile.search.results',
-                            defaultMessage: '{results} search results',
-                        },
-                        {results: posts.length},
-                    )}
+                    <FormattedText
+                        style={styles.resultsNumber}
+                        id='mobile.search.results'
+                        defaultMessage='{count} search {count, plural, one {result} other {results}}'
+                        values={{count: posts.length}}
+                    />
                 </Text>
             }
             ListEmptyComponent={noResults}

--- a/app/screens/home/search/results/results.tsx
+++ b/app/screens/home/search/results/results.tsx
@@ -100,7 +100,7 @@ const Results = ({
             }
             {!loading &&
             <Animated.View style={[styles.container, transform]}>
-                <View style={styles.result} >
+                <View style={styles.result}>
                     <PostResults
                         appsEnabled={appsEnabled}
                         currentTimezone={currentTimezone}
@@ -112,7 +112,7 @@ const Results = ({
                         searchValue={searchValue}
                     />
                 </View>
-                <View style={styles.result} >
+                <View style={styles.result}>
                     <FileResults
                         canDownloadFiles={canDownloadFiles}
                         fileChannels={fileChannels}

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -372,9 +372,7 @@ const SearchScreen = ({teamId, teams}: Props) => {
                                 setTeamId={handleResultsTeamChange}
                                 onTabSelect={setSelectedTab}
                                 onFilterChanged={handleFilterChange}
-                                numberMessages={posts.length}
                                 selectedTab={selectedTab}
-                                numberFiles={fileInfos.length}
                                 selectedFilter={filter}
                                 teams={teams}
                             />

--- a/app/screens/home/search/team_picker_icon.tsx
+++ b/app/screens/home/search/team_picker_icon.tsx
@@ -28,7 +28,7 @@ const NO_TEAMS_HEIGHT = 392;
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         teamContainer: {
-            paddingLeft: 12,
+            paddingLeft: 8,
             flexDirection: 'row',
             alignItems: 'center',
         },

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -681,7 +681,7 @@
   "mobile.search.show_less": "Show less",
   "mobile.search.show_more": "Show more",
   "mobile.search.team.select": "Select a team to search",
-  "mobile.search.results": "{results} search results",
+  "mobile.search.results": "{count} search {count, plural, one {result} other {results}}",
   "mobile.server_identifier.exists": "You are already connected to this server.",
   "mobile.server_link.error.text": "The link could not be found on this server.",
   "mobile.server_link.error.title": "Link Error",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -681,6 +681,7 @@
   "mobile.search.show_less": "Show less",
   "mobile.search.show_more": "Show more",
   "mobile.search.team.select": "Select a team to search",
+  "mobile.search.results": "{results} search results",
   "mobile.server_identifier.exists": "You are already connected to this server.",
   "mobile.server_link.error.text": "The link could not be found on this server.",
   "mobile.server_link.error.title": "Link Error",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

This pull request reduces the padding/margins to make space for the Messages/Files tab on the Search Page. Without reducing these spaces the Team Icon was getting above the sort icon you can see it in the following screenshots.

It moves as well the number of results in the files/messages tabs to the FlatList result

Feel free to let me know if I need to update more things.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[Github Issue](https://github.com/mattermost/mattermost/issues/23725)
[Jira Issue](https://mattermost.atlassian.net/browse/MM-48225)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Has UI changes

#### Device Information
This PR was tested on:
- iPhone SE (3rd Generation) - iOS 16.4
- Nexus S - API 25

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
# iOS

## Light Theme

<img width="392" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/a3fc19de-9d58-43ea-a9bf-a19f95d6c560">

<img width="397" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/0806b3eb-b323-4bab-bf04-310929c3ff70">

## Onyx Theme

<img width="392" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/c0d7db39-7228-4b75-91b3-73f9cebbad14">

<img width="405" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/55adec86-c7e6-49d1-9c07-36fcc1c9a602">

# Android

## Light Theme

<img width="421" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/3c3007c7-c47f-4176-8909-d70bcf6fe60e">


<img width="416" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/d6c4bb75-349b-4454-8ec8-332750297091">

## Onyx Theme

<img width="423" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/2418ebd2-47e6-44bc-bc1b-6f4db9496428">


<img width="421" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/bbe830df-ee24-4c16-99c4-0a8411f8840c">

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Reduces the padding/margins on the Files Tab in the Search Page
```
