### PR TITLE
fix open code block when keyboard is opened

### DIFF
--- a/app/components/markdown/markdown_code_block/index.tsx
+++ b/app/components/markdown/markdown_code_block/index.tsx
@@ -213,7 +213,10 @@ const MarkdownCodeBlock = ({language = '', content, textStyle}: MarkdownCodeBloc
                 onLongPress={handleLongPress}
                 testID='markdown_code_block'
             >
-                <View style={style.container}>
+                <View
+                    style={style.container}
+                    pointerEvents='none'
+                >
                     <View>
                         <View style={style.code}>
                             <SyntaxHighlighter


### PR DESCRIPTION
#### Summary
Allow the codeblock on a post to transition to the code block screen when tapping on it while the keyboard is opened.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53346

```release-note
NONE
```
