### PR TITLE
Remove Post Priority Feature Flag

### DIFF
--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -244,7 +244,7 @@ export const getIsPostAcknowledgementsEnabled = async (database: Database) => {
 };
 
 export const observeIsPostPriorityEnabled = (database: Database) => {
-     return observeConfigBooleanValue(database, 'PostPriority');
+    return observeConfigBooleanValue(database, 'PostPriority');
 };
 
 export const observeIsPostAcknowledgementsEnabled = (database: Database) => {

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -234,9 +234,8 @@ export const observeSavedPostsByIds = (database: Database, postIds: string[]) =>
 };
 
 export const getIsPostPriorityEnabled = async (database: Database) => {
-    const featureFlag = await getConfigValue(database, 'FeatureFlagPostPriority');
     const cfg = await getConfigValue(database, 'PostPriority');
-    return featureFlag === 'true' && cfg === 'true';
+    return cfg === 'true';
 };
 
 export const getIsPostAcknowledgementsEnabled = async (database: Database) => {
@@ -245,13 +244,7 @@ export const getIsPostAcknowledgementsEnabled = async (database: Database) => {
 };
 
 export const observeIsPostPriorityEnabled = (database: Database) => {
-    const featureFlag = observeConfigBooleanValue(database, 'FeatureFlagPostPriority');
-    const cfg = observeConfigBooleanValue(database, 'PostPriority');
-    return featureFlag.pipe(
-        combineLatestWith(cfg),
-        switchMap(([ff, c]) => of$(ff && c)),
-        distinctUntilChanged(),
-    );
+     return observeConfigBooleanValue(database, 'PostPriority');
 };
 
 export const observeIsPostAcknowledgementsEnabled = (database: Database) => {


### PR DESCRIPTION
#### Summary

Remove the Post Priority feature flag. This is no longer needed as it has been enabled for a while and it now relies on the ServiceSettings.PostPriority config setting

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48931

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Related PR
https://github.com/mattermost/mattermost/pull/23735

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
None
```
