### PR TITLE
MM-53343 - save button not grayed out when edit message is too long

### DIFF
--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -110,6 +110,8 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
 
     const onChangeTextCommon = useCallback((message: string) => {
         const tooLong = message.trim().length > maxPostSize;
+        setErrorLine(undefined);
+        setErrorExtra(undefined);
         if (tooLong) {
             const line = intl.formatMessage({id: 'mobile.message_length.message_split_left', defaultMessage: 'Message exceeds the character limit'});
             const extra = `${message.trim().length} / ${maxPostSize}`;

--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -116,7 +116,7 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
             setErrorLine(line);
             setErrorExtra(extra);
         }
-        toggleSaveButton(editingMessage !== message);
+        toggleSaveButton(editingMessage !== message && !tooLong);
     }, [intl, maxPostSize, editingMessage, toggleSaveButton]);
 
     const onAutocompleteChangeText = useCallback((message: string) => {


### PR DESCRIPTION
#### Summary
This PR fixes the Save button not grayed out and disabled when editing a message with a post that exceeds the char limit.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53343

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: pixel 6, galaxy note 20

#### Screenshots
Before:

https://github.com/mattermost/mattermost-mobile/assets/10082627/c28ce67a-ea65-4d82-b7fd-9b4c4e55ff55



After:

https://github.com/mattermost/mattermost-mobile/assets/10082627/c782ee40-8e5a-4402-8d21-4862da4c3118




#### Release Note
```release-note
NONE
```
