### PR TITLE
Upgrade React Native Network Client to 1.3.5

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -377,7 +377,7 @@ PODS:
     - React-Core
   - react-native-netinfo (9.3.10):
     - React-Core
-  - react-native-network-client (1.3.4):
+  - react-native-network-client (1.3.5):
     - Alamofire (~> 5.6.4)
     - React-Core
     - Starscream (~> 4.0.4)
@@ -952,7 +952,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: 77f552291e993f3fdcdf48cc3c280ef7f11789c8
   react-native-in-app-review: db8bb167a5f238e7ceca5c242d6b36ce8c4404a4
   react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
-  react-native-network-client: 35acc439782ee71000497961f624d085f5a7abbb
+  react-native-network-client: a403aae9b09f83c6454edfcec9b927fa7f9f07fb
   react-native-notifications: 504143d59f9628c3b0c22fd0ccf34b65b9182d01
   react-native-paste-input: 3392800944a47c00dddbff23c31c281482209679
   react-native-safe-area-context: b8979f5eda6ed5903d4dbc885be3846ea3daa753

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mattermost/calls": "github:mattermost/calls-common#v0.14.0",
         "@mattermost/compass-icons": "0.1.36",
         "@mattermost/react-native-emm": "1.3.5",
-        "@mattermost/react-native-network-client": "1.3.4",
+        "@mattermost/react-native-network-client": "1.3.5",
         "@mattermost/react-native-paste-input": "0.6.2",
         "@mattermost/react-native-turbo-log": "0.2.3",
         "@msgpack/msgpack": "2.8.0",
@@ -3483,12 +3483,12 @@
       }
     },
     "node_modules/@mattermost/react-native-network-client": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.4.tgz",
-      "integrity": "sha512-5sAxtULA8nsIG55c8UCB0KugCVypA8b8XrgdZQG92yCk4I8jUpYSL8AryjYY3jgSvFDQjvMdN4Rce9WAqWpLjg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.5.tgz",
+      "integrity": "sha512-uDAcunFFx4vdfTZ9HznyoDpPF7nP6eIOiTrkP8w6myw0Ns85TnsYcsHfr6zTNDWO7gLovIUayTok0XdyJXpzqw==",
       "dependencies": {
         "validator": "13.9.0",
-        "zod": "3.20.6"
+        "zod": "3.21.4"
       },
       "peerDependencies": {
         "react": "*",
@@ -21758,9 +21758,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.20.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
-      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -24101,12 +24101,12 @@
       "requires": {}
     },
     "@mattermost/react-native-network-client": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.4.tgz",
-      "integrity": "sha512-5sAxtULA8nsIG55c8UCB0KugCVypA8b8XrgdZQG92yCk4I8jUpYSL8AryjYY3jgSvFDQjvMdN4Rce9WAqWpLjg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.3.5.tgz",
+      "integrity": "sha512-uDAcunFFx4vdfTZ9HznyoDpPF7nP6eIOiTrkP8w6myw0Ns85TnsYcsHfr6zTNDWO7gLovIUayTok0XdyJXpzqw==",
       "requires": {
         "validator": "13.9.0",
-        "zod": "3.20.6"
+        "zod": "3.21.4"
       }
     },
     "@mattermost/react-native-paste-input": {
@@ -37843,9 +37843,9 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zod": {
-      "version": "3.20.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
-      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     },
     "zwitch": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@mattermost/calls": "github:mattermost/calls-common#v0.14.0",
     "@mattermost/compass-icons": "0.1.36",
     "@mattermost/react-native-emm": "1.3.5",
-    "@mattermost/react-native-network-client": "1.3.4",
+    "@mattermost/react-native-network-client": "1.3.5",
     "@mattermost/react-native-paste-input": "0.6.2",
     "@mattermost/react-native-turbo-log": "0.2.3",
     "@msgpack/msgpack": "2.8.0",


### PR DESCRIPTION
#### Summary
Upgrade React Native Network Client to 1.3.5

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-53445
May fix https://mattermost.atlassian.net/browse/MM-49968

#### Release Note
```release-note
Fix timeouts when uploading files
Improve behavior on multirequest environments (like HTTP1.1)
```
