### PR TITLE
use useAndroidHardwareBackHnd on Files and Members

### DIFF
--- a/app/screens/channel_files/channel_files.tsx
+++ b/app/screens/channel_files/channel_files.tsx
@@ -7,23 +7,27 @@ import {Platform, StyleSheet, View} from 'react-native';
 import {type Edge, SafeAreaView} from 'react-native-safe-area-context';
 
 import {searchFiles} from '@actions/remote/search';
+import useAndroidHardwareBackHandler from '@app/hooks/android_back_handler';
 import FileResults from '@components/files_search/file_results';
 import Loading from '@components/loading';
 import Search from '@components/search';
 import {General} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
+import {popTopScreen} from '@screens/navigation';
 import {type FileFilter, FileFilters, filterFileExtensions} from '@utils/file';
 import {changeOpacity, getKeyboardAppearanceFromTheme} from '@utils/theme';
 
 import Header from './header';
 
 import type ChannelModel from '@typings/database/models/servers/channel';
+import type {AvailableScreens} from '@typings/screens/navigation';
 
 const TEST_ID = 'channel_files';
 
 type Props = {
     channel: ChannelModel;
+    componentId: AvailableScreens;
     canDownloadFiles: boolean;
     publicLinkEnabled: boolean;
 }
@@ -69,6 +73,7 @@ const emptyFileResults: FileInfo[] = [];
 
 function ChannelFiles({
     channel,
+    componentId,
     canDownloadFiles,
     publicLinkEnabled,
 }: Props) {
@@ -82,6 +87,14 @@ function ChannelFiles({
     const lastSearchRequest = useRef<number>();
 
     const [fileInfos, setFileInfos] = useState<FileInfo[]>(emptyFileResults);
+
+    const close = () => {
+        if (componentId) {
+            popTopScreen(componentId);
+        }
+    };
+
+    useAndroidHardwareBackHandler(componentId, close);
 
     const handleSearch = useCallback(async (searchTerm: string, ftr: FileFilter) => {
         const t = Date.now();

--- a/app/screens/channel_files/channel_files.tsx
+++ b/app/screens/channel_files/channel_files.tsx
@@ -7,13 +7,13 @@ import {Platform, StyleSheet, View} from 'react-native';
 import {type Edge, SafeAreaView} from 'react-native-safe-area-context';
 
 import {searchFiles} from '@actions/remote/search';
-import useAndroidHardwareBackHandler from '@app/hooks/android_back_handler';
 import FileResults from '@components/files_search/file_results';
 import Loading from '@components/loading';
 import Search from '@components/search';
 import {General} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
+import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
 import {popTopScreen} from '@screens/navigation';
 import {type FileFilter, FileFilters, filterFileExtensions} from '@utils/file';
 import {changeOpacity, getKeyboardAppearanceFromTheme} from '@utils/theme';
@@ -88,11 +88,9 @@ function ChannelFiles({
 
     const [fileInfos, setFileInfos] = useState<FileInfo[]>(emptyFileResults);
 
-    const close = () => {
-        if (componentId) {
-            popTopScreen(componentId);
-        }
-    };
+    const close = useCallback(() => {
+        popTopScreen(componentId);
+    }, [componentId]);
 
     useAndroidHardwareBackHandler(componentId, close);
 

--- a/app/screens/manage_channel_members/manage_channel_members.tsx
+++ b/app/screens/manage_channel_members/manage_channel_members.tsx
@@ -8,6 +8,7 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {fetchChannelMemberships} from '@actions/remote/channel';
 import {fetchUsersByIds, searchProfiles} from '@actions/remote/user';
+import useAndroidHardwareBackHandler from '@app/hooks/android_back_handler';
 import {PER_PAGE_DEFAULT} from '@client/rest/constants';
 import Search from '@components/search';
 import UserList from '@components/user_list';
@@ -15,7 +16,7 @@ import {Events, General, Screens} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import useNavButtonPressed from '@hooks/navigation_button_pressed';
-import {openAsBottomSheet, setButtons} from '@screens/navigation';
+import {openAsBottomSheet, popTopScreen, setButtons} from '@screens/navigation';
 import NavigationStore from '@store/navigation_store';
 import {showRemoveChannelUserSnackbar} from '@utils/snack_bar';
 import {changeOpacity, getKeyboardAppearanceFromTheme} from '@utils/theme';
@@ -97,6 +98,14 @@ export default function ManageChannelMembers({
         setTerm('');
         setSearchResults(EMPTY);
     }, []);
+
+    const close = () => {
+        if (componentId) {
+            popTopScreen(componentId);
+        }
+    };
+
+    useAndroidHardwareBackHandler(componentId, close);
 
     const handleSelectProfile = useCallback(async (profile: UserProfile) => {
         if (profile.id === currentUserId && isManageMode) {

--- a/app/screens/manage_channel_members/manage_channel_members.tsx
+++ b/app/screens/manage_channel_members/manage_channel_members.tsx
@@ -8,13 +8,13 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {fetchChannelMemberships} from '@actions/remote/channel';
 import {fetchUsersByIds, searchProfiles} from '@actions/remote/user';
-import useAndroidHardwareBackHandler from '@app/hooks/android_back_handler';
 import {PER_PAGE_DEFAULT} from '@client/rest/constants';
 import Search from '@components/search';
 import UserList from '@components/user_list';
 import {Events, General, Screens} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
+import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
 import useNavButtonPressed from '@hooks/navigation_button_pressed';
 import {openAsBottomSheet, popTopScreen, setButtons} from '@screens/navigation';
 import NavigationStore from '@store/navigation_store';
@@ -99,11 +99,9 @@ export default function ManageChannelMembers({
         setSearchResults(EMPTY);
     }, []);
 
-    const close = () => {
-        if (componentId) {
-            popTopScreen(componentId);
-        }
-    };
+    const close = useCallback(() => {
+        popTopScreen(componentId);
+    }, [componentId]);
 
     useAndroidHardwareBackHandler(componentId, close);
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

there is an issue on Android, when we press the hardware back button in the Members and Files UI of a channel, the App goes to background instead of redirecting to the channel information.

Pinned messages UI works fine
please take a look to the screenshots, (GIF images, please open individually to completely watch them)


Files UI => app goes to background
![Files_UI](https://github.com/mattermost/mattermost-mobile/assets/5940718/b6cb8323-5593-4a7e-8158-e38f5d74e8cf)



Members UI => app goes to background
![Members_UI](https://github.com/mattermost/mattermost-mobile/assets/5940718/a1092bae-c01b-4ba9-8ffa-00be5dd91ee0)



Pinned UI => app goes to channel info (OK)
![Pinned_UI](https://github.com/mattermost/mattermost-mobile/assets/5940718/f161ddc5-e4ce-46e7-9e4d-0bd53b1c3198)


<!--
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
