### PR TITLE
Fix search hashtag

### DIFF
--- a/app/components/markdown/hashtag/index.tsx
+++ b/app/components/markdown/hashtag/index.tsx
@@ -20,7 +20,7 @@ const Hashtag = ({hashtag, linkStyle}: HashtagProps) => {
         DeviceEventEmitter.emit(Navigation.NAVIGATE_TO_TAB, {
             screen: Screens.SEARCH,
             params: {
-                searchTerm: hashtag,
+                searchTerm: `#${hashtag}`,
             },
         });
     };


### PR DESCRIPTION
#### Summary
When tapping on a hashtag the search was not including the `#` symbol, thus the search was looking for the word instead of the hashtag

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53704

#### Release Note
```release-note
Fixed hashtag search to match the hashtag and not the word
```