### PR TITLE
Fix keyboard overlap with recent search items in the search tab

### DIFF
--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -4,7 +4,7 @@
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
-import {FlatList, type LayoutChangeEvent, Platform, StyleSheet, type ViewStyle} from 'react-native';
+import {FlatList, type LayoutChangeEvent, Platform, StyleSheet, type ViewStyle, KeyboardAvoidingView} from 'react-native';
 import HWKeyboardEvent from 'react-native-hw-keyboard-event';
 import Animated, {useAnimatedStyle, useDerivedValue, withTiming} from 'react-native-reanimated';
 import {type Edge, SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -363,10 +363,14 @@ const SearchScreen = ({teamId, teams}: Props) => {
                 onLayout={onLayout}
                 testID='search_messages.screen'
             >
-                <Animated.View style={animated}>
-                    <Animated.View style={headerTopStyle}>
-                        <RoundedHeaderContext/>
-                        {lastSearchedValue && !loading &&
+                <KeyboardAvoidingView
+                    style={styles.flex}
+                    behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                >
+                    <Animated.View style={animated}>
+                        <Animated.View style={headerTopStyle}>
+                            <RoundedHeaderContext/>
+                            {lastSearchedValue && !loading &&
                             <Header
                                 teamId={searchTeamId}
                                 setTeamId={handleResultsTeamChange}
@@ -378,9 +382,9 @@ const SearchScreen = ({teamId, teams}: Props) => {
                                 selectedFilter={filter}
                                 teams={teams}
                             />
-                        }
-                    </Animated.View>
-                    {!showResults &&
+                            }
+                        </Animated.View>
+                        {!showResults &&
                         <AnimatedFlatList
                             onLayout={onFlatLayout}
                             data={dummyData}
@@ -397,8 +401,8 @@ const SearchScreen = ({teamId, teams}: Props) => {
                             ref={scrollRef}
                             renderItem={renderInitialOrLoadingItem}
                         />
-                    }
-                    {showResults && !loading &&
+                        }
+                        {showResults && !loading &&
                         <Results
                             loading={resultsLoading}
                             selectedTab={selectedTab}
@@ -409,8 +413,9 @@ const SearchScreen = ({teamId, teams}: Props) => {
                             scrollPaddingTop={lockValue.value}
                             fileChannelIds={fileChannelIds}
                         />
-                    }
-                </Animated.View>
+                        }
+                    </Animated.View>
+                </KeyboardAvoidingView>
             </SafeAreaView>
             {searchIsFocused &&
             <Autocomplete

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -365,7 +365,7 @@ const SearchScreen = ({teamId, teams}: Props) => {
             >
                 <KeyboardAvoidingView
                     style={styles.flex}
-                    behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                    behavior={Platform.OS === 'ios' ? 'padding' : undefined}
                 >
                     <Animated.View style={animated}>
                         <Animated.View style={headerTopStyle}>


### PR DESCRIPTION
#### Summary
In the latest build, when I open the keyboard to input text on the tab search, it overlaps the content of the recent search item. This PR adds KeyboardAvoidingView to fix this issue.

#### Ticket Link
None

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Iphone 13 Simulator (iOS 16.1)
- Samsung S10 plus (Android 12)

#### Screenshots
Before fix:

https://github.com/mattermost/mattermost-mobile/assets/28721870/ee4da287-381d-4cb2-9062-f509d5d2a451


https://github.com/mattermost/mattermost-mobile/assets/28721870/e518c8b3-abeb-49f1-88b1-c05bf24a966f



After fix:

https://github.com/mattermost/mattermost-mobile/assets/28721870/af3f9d55-c724-4313-ab88-9f79e439c4cd


https://github.com/mattermost/mattermost-mobile/assets/28721870/9f3429f0-8398-4805-b22c-ab2955f1f22f


#### Release Note
```release-note
Fix keyboard overlap with recent search items in the search tab
```