### PR TITLE
Handle Mark Multiple Channels as Read

### DIFF
--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -18,6 +18,7 @@ import {deleteChannelMembership, getChannelById, prepareMyChannelsForTeam, getCu
 import {getConfig, getCurrentChannelId} from '@queries/servers/system';
 import {getCurrentUser, getTeammateNameDisplay, getUserById} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
+import MyChannelModel from '@typings/database/models/servers/my_channel';
 import {logDebug} from '@utils/log';
 
 import type {Model} from '@nozbe/watermelondb';
@@ -116,6 +117,38 @@ export async function handleChannelViewedEvent(serverUrl: string, msg: any) {
 
         if (activeServerUrl !== serverUrl || (currentChannelId !== channelId && !EphemeralStore.isSwitchingToChannel(channelId))) {
             await markChannelAsViewed(serverUrl, channelId);
+        }
+    } catch {
+        // do nothing
+    }
+}
+
+export async function handleMultipleChannelsViewedEvent(serverUrl: string, msg: any) {
+    try {
+        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+
+        const {channel_times: channelTimes} = msg.data;
+
+        const activeServerUrl = await DatabaseManager.getActiveServerUrl();
+        const currentChannelId = await getCurrentChannelId(database);
+
+        const promises: Array<ReturnType<typeof markChannelAsViewed>> = [];
+        for (const id of Object.keys(channelTimes)) {
+            if (activeServerUrl === serverUrl && (currentChannelId === id || EphemeralStore.isSwitchingToChannel(id))) {
+                continue;
+            }
+            promises.push(markChannelAsViewed(serverUrl, id, false, true));
+        }
+
+        const members = (await Promise.all(promises)).reduce<MyChannelModel[]>((acum, v) => {
+            if (v.member) {
+                acum.push(v.member);
+            }
+            return acum;
+        }, []);
+
+        if (members.length) {
+            operator.batchRecords(members, 'handleMultipleCahnnelViewedEvent');
         }
     } catch {
         // do nothing

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -57,6 +57,7 @@ import {handleChannelConvertedEvent, handleChannelCreatedEvent,
     handleChannelUnarchiveEvent,
     handleChannelUpdatedEvent,
     handleChannelViewedEvent,
+    handleMultipleChannelsViewedEvent,
     handleDirectAddedEvent,
     handleUserAddedToChannelEvent,
     handleUserRemovedFromChannelEvent} from './channel';
@@ -249,6 +250,10 @@ export async function handleEvent(serverUrl: string, msg: WebSocketMessage) {
 
         case WebsocketEvents.CHANNEL_VIEWED:
             handleChannelViewedEvent(serverUrl, msg);
+            break;
+
+        case WebsocketEvents.MULTIPLE_CHANNELS_VIEWED:
+            handleMultipleChannelsViewedEvent(serverUrl, msg);
             break;
 
         case WebsocketEvents.CHANNEL_MEMBER_UPDATED:

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -20,6 +20,7 @@ const WebsocketEvents = {
     CHANNEL_UNARCHIVED: 'channel_restored',
     CHANNEL_UPDATED: 'channel_updated',
     CHANNEL_VIEWED: 'channel_viewed',
+    MULTIPLE_CHANNELS_VIEWED: 'multiple_channels_viewed',
     CHANNEL_MEMBER_UPDATED: 'channel_member_updated',
     CHANNEL_SCHEME_UPDATED: 'channel_scheme_updated',
     DIRECT_ADDED: 'direct_added',


### PR DESCRIPTION
#### Summary
Added the Mark Multiple Channels as Read websocket event.

This change is needed for https://github.com/mattermost/mattermost/pull/24003

#### Ticket Link
NONE

#### Release Note
```release-note
None
```
