### PR TITLE
Fix: Show admin on channel members

### DIFF
--- a/app/components/user_list/index.tsx
+++ b/app/components/user_list/index.tsx
@@ -67,12 +67,12 @@ export function createProfilesSections(intl: IntlShape, profiles: UserProfile[],
         return [];
     }
 
-    const sections = new Map<string, UserProfile[]>();
+    const sections = new Map<string, UserProfileWithChannelAdmin[]>();
 
     if (members?.length) {
         // when channel members are provided, build the sections by admins and members
         const membersDictionary = new Map<string, ChannelMembership>();
-        const membersSections = new Map<string, UserProfile[]>();
+        const membersSections = new Map<string, UserProfileWithChannelAdmin[]>();
         const {formatMessage} = intl;
         members.forEach((m) => membersDictionary.set(m.user_id, m));
         profiles.forEach((p) => {
@@ -80,7 +80,7 @@ export function createProfilesSections(intl: IntlShape, profiles: UserProfile[],
             if (member) {
                 const sectionKey = sectionRoleKeyExtractor(member.scheme_admin!).id;
                 const section = membersSections.get(sectionKey) || [];
-                section.push(p);
+                section.push({...p, scheme_admin: member.scheme_admin});
                 membersSections.set(sectionKey, section);
             }
         });
@@ -337,7 +337,7 @@ export default function UserList({
     };
 
     if (term) {
-        return renderFlatList(data as UserProfile[]);
+        return renderFlatList(data as UserProfileWithChannelAdmin[]);
     }
-    return renderSectionList(data as Array<SectionListData<UserProfile>>);
+    return renderSectionList(data as Array<SectionListData<UserProfileWithChannelAdmin>>);
 }

--- a/app/components/user_list/index.tsx
+++ b/app/components/user_list/index.tsx
@@ -111,6 +111,28 @@ export function createProfilesSections(intl: IntlShape, profiles: UserProfile[],
     return results;
 }
 
+function createProfiles(profiles: UserProfile[], members?: ChannelMembership[]): UserProfileWithChannelAdmin[] {
+    if (!profiles.length) {
+        return [];
+    }
+
+    const profileMap = new Map<string, UserProfileWithChannelAdmin>();
+    profiles.forEach((profile) => {
+        profileMap.set(profile.id, profile);
+    });
+
+    if (members?.length) {
+        members.forEach((m) => {
+            const profileFound = profileMap.get(m.user_id);
+            if (profileFound) {
+                profileFound.scheme_admin = m.scheme_admin;
+            }
+        });
+    }
+
+    return Array.from(profileMap.values());
+}
+
 const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
     return {
         list: {
@@ -195,7 +217,7 @@ export default function UserList({
         }
 
         if (term) {
-            return profiles;
+            return createProfiles(profiles, channelMembers);
         }
 
         return createProfilesSections(intl, profiles, channelMembers);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes the label that shows Admin/Member when the managing members are on the Members screen of a channel.

The label was showing just `Member` for all users and now is differentiating between Admin and Member users.

#### Ticket Link

[Reported Issue](https://github.com/mattermost/mattermost/issues/23864)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Has UI changes
- [X] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

- iOS Simulator, iOS 16.4
- Android Emulator, Nexus 5 API 31

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

# iOS - With Sections
<img width="360" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/eb343c0f-0f87-4a52-8b0c-a9f4b7e90529">

# iOS - With Search
<img width="361" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/9a359a3e-cf30-45f1-8753-86c7e297661a">

# Android - With Sections
<img width="407" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/db77d3b4-0785-4a0d-ada2-f82f3c0a7147">

# Android - With Search
<img width="412" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/2154092/8f054ca3-9d13-431d-992b-f50de219c5f5">

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Shows correctly the Member/Admin label on a UserRow inside the Members Screen when managing users
```
