### PR TITLE
Remove keychain cache to avoid token invalidation problems

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MattermostManagedModule.java
@@ -221,11 +221,6 @@ public class MattermostManagedModule extends ReactContextBaseJavaModule {
         }
     }
 
-    @ReactMethod
-    public void invalidateKeychainCache(String serverUrl) {
-        // Not using cache
-    }
-
     private static class SaveDataTask extends GuardedResultAsyncTask<Object> {
         private final WeakReference<Context> weakContext;
         private final String fromFile;

--- a/app/managers/session_manager.ts
+++ b/app/managers/session_manager.ts
@@ -22,7 +22,6 @@ import {getThemeFromState} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {deleteFileCache, deleteFileCacheByDir} from '@utils/file';
 import {isMainActivity} from '@utils/helpers';
-import {invalidateKeychainCache} from '@utils/mattermost_managed';
 import {addNewServer} from '@utils/server';
 
 import type {LaunchType} from '@typings/launch';
@@ -116,7 +115,6 @@ class SessionManager {
     private terminateSession = async (serverUrl: string, removeServer: boolean) => {
         cancelSessionNotification(serverUrl);
         await removeServerCredentials(serverUrl);
-        invalidateKeychainCache(serverUrl);
         PushNotifications.removeServerNotifications(serverUrl);
 
         NetworkManager.invalidateClient(serverUrl);

--- a/app/utils/mattermost_managed.ts
+++ b/app/utils/mattermost_managed.ts
@@ -64,7 +64,3 @@ export const deleteEntititesFile = (callback?: (success: boolean) => void) => {
         callback(true);
     }
 };
-
-export const invalidateKeychainCache = (serverUrl: string) => {
-    MattermostManaged.invalidateKeychainCache(serverUrl);
-};

--- a/ios/Gekidou/Sources/Gekidou/Keychain.swift
+++ b/ios/Gekidou/Sources/Gekidou/Keychain.swift
@@ -48,7 +48,6 @@ extension KeychainError: LocalizedError {
 
 public class Keychain: NSObject {
     @objc public static let `default` = Keychain()
-    private var tokenCache = Dictionary<String, String>()
     
     public func getClientIdentityAndCertificate(for host: String) throws -> (SecIdentity, SecCertificate)? {
         let query = try buildIdentityQuery(for: host)
@@ -81,10 +80,6 @@ public class Keychain: NSObject {
     }
     
     public func getToken(for serverUrl: String) throws -> String? {
-        if let cache = tokenCache[serverUrl] {
-            return cache
-        }
-
         var attributes = try buildTokenAttributes(for: serverUrl)
         attributes[kSecMatchLimit] = kSecMatchLimitOne
         attributes[kSecReturnData] = kCFBooleanTrue
@@ -94,15 +89,10 @@ public class Keychain: NSObject {
         let data = result as? Data
         if status == errSecSuccess && data != nil {
             let token = String(data: data!, encoding: .utf8)
-            tokenCache[serverUrl] = token
             return token
         }
         
         return nil
-    }
-
-    public func invalidateToken(for serverUrl: String) {
-        tokenCache.removeValue(forKey: serverUrl)
     }
     
     private func buildIdentityQuery(for host: String) throws -> [CFString: Any] {

--- a/ios/GekidouWrapper.swift
+++ b/ios/GekidouWrapper.swift
@@ -42,8 +42,4 @@ import Gekidou
     
     return nil
   }
-
-  @objc func invalidateToken(for url: String) {
-    Keychain.default.invalidateToken(for: url)
-  }
 }

--- a/ios/Mattermost/MattermostManaged.m
+++ b/ios/Mattermost/MattermostManaged.m
@@ -153,11 +153,6 @@ RCT_EXPORT_METHOD(removeListeners:(double)count) {
   // Keep: Required for RN built in Event Emitter Calls.
 }
 
-RCT_EXPORT_METHOD(invalidateKeychainCache:(NSString *) serverUrl)
-{
-  [[GekidouWrapper default] invalidateTokenFor:serverUrl];
-}
-
 RCT_EXPORT_METHOD(createThumbnail:(NSDictionary *)config findEventsWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   NSMutableDictionary *newConfig = [config mutableCopy];


### PR DESCRIPTION
#### Summary
Remove keychain cache, since it was not being properly invalidated in all instances of the notification service.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-52991

#### Release Note
```release-note
Fix notifications showing a session expired message when it shouldn't.
```
