### PR TITLE
Add some performance improvements

### DIFF
--- a/app/actions/local/user.ts
+++ b/app/actions/local/user.ts
@@ -20,11 +20,14 @@ export async function setCurrentUserStatus(serverUrl: string, status: string) {
             throw new Error(`No current user for ${serverUrl}`);
         }
 
-        user.prepareStatus(status);
-        await operator.batchRecords([user], 'setCurrentUserStatusOffline');
+        if (user.status !== status) {
+            user.prepareStatus(status);
+            await operator.batchRecords([user], 'setCurrentUserStatus');
+        }
+
         return null;
     } catch (error) {
-        logError('Failed setCurrentUserStatusOffline', error);
+        logError('Failed setCurrentUserStatus', error);
         return {error};
     }
 }

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -378,7 +378,10 @@ export async function fetchPosts(serverUrl: string, channelId: string, page = 0,
                     models.push(...threadModels);
                 }
             }
-            await operator.batchRecords(models, 'fetchPosts');
+
+            if (models.length) {
+                await operator.batchRecords(models, 'fetchPosts');
+            }
         }
         return result;
     } catch (error) {

--- a/app/actions/remote/user.ts
+++ b/app/actions/remote/user.ts
@@ -344,12 +344,19 @@ export async function fetchStatusByIds(serverUrl: string, userIds: string[], fet
                 return result;
             }, {});
 
+            const usersToBatch = [];
             for (const user of users) {
-                const status = userStatuses[user.id];
-                user.prepareStatus(status?.status || General.OFFLINE);
+                const receivedStatus = userStatuses[user.id];
+                const statusToSet = receivedStatus?.status || General.OFFLINE;
+                if (statusToSet !== user.status) {
+                    user.prepareStatus(statusToSet);
+                    usersToBatch.push(user);
+                }
             }
 
-            await operator.batchRecords(users, 'fetchStatusByIds');
+            if (usersToBatch.length) {
+                await operator.batchRecords(usersToBatch, 'fetchStatusByIds');
+            }
         }
 
         return {statuses};

--- a/app/database/operator/server_data_operator/comparators/files.ts
+++ b/app/database/operator/server_data_operator/comparators/files.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type FileModel from '@typings/database/models/servers/file';
+
+export const shouldUpdateFileRecord = (e: FileModel, n: FileInfo): boolean => {
+    return Boolean(
+        (n.post_id !== e.postId) ||
+        (n.name !== e.name) ||
+        (n.extension !== e.extension) ||
+        (n.size !== e.size) ||
+        ((n.mime_type || '') !== e.mimeType) ||
+        (n.width && n.width !== e.width) ||
+        (n.height && n.height !== e.height) ||
+        (n.mini_preview && n.mini_preview !== e.imageThumbnail) ||
+        (n.localPath && n.localPath !== e.localPath),
+    );
+};

--- a/app/database/operator/server_data_operator/comparators/thread.ts
+++ b/app/database/operator/server_data_operator/comparators/thread.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type ThreadModel from '@typings/database/models/servers/thread';
+
+export const shouldUpdateThreadRecord = (e: ThreadModel, n: ThreadWithLastFetchedAt): boolean => {
+    return (
+        ((n.last_reply_at != null) && n.last_reply_at !== e.lastReplyAt) ||
+        ((n.lastFetchedAt || 0) > e.lastFetchedAt) ||
+        ((n.last_viewed_at != null) && e.lastViewedAt !== n.last_viewed_at) ||
+        (e.replyCount !== n.reply_count) ||
+        ((n.is_following != null) && e.isFollowing !== n.is_following) ||
+        ((n.unread_replies != null) && e.unreadReplies !== n.unread_replies) ||
+        ((n.unread_mentions != null) && e.unreadMentions !== n.unread_mentions)
+    );
+};

--- a/app/database/operator/server_data_operator/comparators/user.ts
+++ b/app/database/operator/server_data_operator/comparators/user.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type UserModel from '@typings/database/models/servers/user';
+
+export function shouldUpdateUserRecord(e: UserModel, n: UserProfile) {
+    return Boolean(n.update_at > e.updateAt || (n.status && n.status !== e.status));
+}

--- a/app/database/operator/server_data_operator/handlers/post.ts
+++ b/app/database/operator/server_data_operator/handlers/post.ts
@@ -6,6 +6,7 @@ import {Q} from '@nozbe/watermelondb';
 import {ActionType} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import {buildDraftKey} from '@database/operator/server_data_operator/comparators';
+import {shouldUpdateFileRecord} from '@database/operator/server_data_operator/comparators/files';
 import {
     transformDraftRecord,
     transformFileRecord,
@@ -234,6 +235,7 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
             deleteRawValues: pendingPostsToDelete,
             tableName,
             fieldName: 'id',
+            shouldUpdate: (e: PostModel, n: Post) => n.update_at > e.updateAt,
         }));
 
         const preparedPosts = (await this.prepareRecords({
@@ -309,6 +311,7 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
             tableName: FILE,
             fieldName: 'id',
             deleteRawValues: [],
+            shouldUpdate: shouldUpdateFileRecord,
         }));
 
         const postFiles = await this.prepareRecords({

--- a/app/database/operator/server_data_operator/handlers/thread.test.ts
+++ b/app/database/operator/server_data_operator/handlers/thread.test.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import DatabaseManager from '@database/manager';
+import {shouldUpdateThreadRecord} from '@database/operator/server_data_operator/comparators/thread';
 import {transformThreadRecord, transformThreadParticipantRecord, transformThreadInTeamRecord, transformTeamThreadsSyncRecord} from '@database/operator/server_data_operator/transformers/thread';
 
 import type ServerDataOperator from '..';
@@ -59,6 +60,7 @@ describe('*** Operator: Thread Handlers tests ***', () => {
             createOrUpdateRawValues: threads,
             tableName: 'Thread',
             prepareRecordsOnly: true,
+            shouldUpdate: shouldUpdateThreadRecord,
         }, 'handleThreads(NEVER)');
 
         // Should handle participants

--- a/app/database/operator/server_data_operator/handlers/thread.ts
+++ b/app/database/operator/server_data_operator/handlers/thread.ts
@@ -4,6 +4,7 @@
 import {Q} from '@nozbe/watermelondb';
 
 import {MM_TABLES} from '@constants/database';
+import {shouldUpdateThreadRecord} from '@database/operator/server_data_operator/comparators/thread';
 import {
     transformThreadRecord,
     transformThreadParticipantRecord,
@@ -110,6 +111,7 @@ const ThreadHandler = <TBase extends Constructor<ServerDataOperatorBase>>(superc
             prepareRecordsOnly: true,
             createOrUpdateRawValues: createOrUpdateThreads,
             tableName: THREAD,
+            shouldUpdate: shouldUpdateThreadRecord,
         }, 'handleThreads(NEVER)');
 
         // Add the models to be batched here

--- a/app/database/operator/server_data_operator/handlers/user.test.ts
+++ b/app/database/operator/server_data_operator/handlers/user.test.ts
@@ -3,6 +3,7 @@
 
 import DatabaseManager from '@database/manager';
 import {buildPreferenceKey} from '@database/operator/server_data_operator/comparators';
+import {shouldUpdateUserRecord} from '@database/operator/server_data_operator/comparators/user';
 import {
     transformPreferenceRecord,
     transformUserRecord,
@@ -102,6 +103,7 @@ describe('*** Operator: User Handlers tests ***', () => {
             tableName: 'User',
             prepareRecordsOnly: false,
             transformer: transformUserRecord,
+            shouldUpdate: shouldUpdateUserRecord,
         }, 'handleUsers');
     });
 

--- a/app/database/operator/server_data_operator/handlers/user.ts
+++ b/app/database/operator/server_data_operator/handlers/user.ts
@@ -3,6 +3,7 @@
 
 import {MM_TABLES} from '@constants/database';
 import {buildPreferenceKey} from '@database/operator/server_data_operator/comparators';
+import {shouldUpdateUserRecord} from '@database/operator/server_data_operator/comparators/user';
 import {
     transformPreferenceRecord,
     transformUserRecord,
@@ -126,7 +127,7 @@ const UserHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
             createOrUpdateRawValues,
             tableName: USER,
             prepareRecordsOnly,
-            shouldUpdate: (e: UserModel, n: UserProfile) => Boolean(n.update_at > e.updateAt || (n.status && n.status !== e.status)),
+            shouldUpdate: shouldUpdateUserRecord,
         }, 'handleUsers');
     };
 };

--- a/app/database/operator/server_data_operator/handlers/user.ts
+++ b/app/database/operator/server_data_operator/handlers/user.ts
@@ -126,6 +126,7 @@ const UserHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
             createOrUpdateRawValues,
             tableName: USER,
             prepareRecordsOnly,
+            shouldUpdate: (e: UserModel, n: UserProfile) => Boolean(n.update_at > e.updateAt || (n.status && n.status !== e.status)),
         }, 'handleUsers');
     };
 };

--- a/types/database/database.ts
+++ b/types/database/database.ts
@@ -155,6 +155,7 @@ export type ProcessRecordsArgs = {
   tableName: string;
   fieldName: string;
   buildKeyRecordBy?: (obj: Record<string, any>) => string;
+  shouldUpdate?: (existing: Record<string, any>, newRaw: Record<string, any>) => boolean;
 };
 
 export type HandleRecordsArgs<T extends Model> = {
@@ -165,6 +166,7 @@ export type HandleRecordsArgs<T extends Model> = {
   deleteRawValues?: RawValue[];
   tableName: string;
   prepareRecordsOnly: boolean;
+  shouldUpdate?: (existingRecord: T, newRaw: RawValue) => boolean;
 };
 
 export type RangeOfValueArgs = {


### PR DESCRIPTION
#### Summary
Trying to figure out the issue where the app gets hanged when opening the post options, I found that some database batches were taking more than expected. The most troublesome was the periodic status fetch, that was getting the status of all the users in the channel, and no matter the new status, updating and re-rendering all users in the channel (avatars, status, etc...). I also made some similar improvements for when we get the posts for a channel. If we already have all the posts, now we almost don't update any field in the database, improving the batching time.

#### Ticket Link
None

#### Release Note
```release-note
Some performance improvements.
```
