### PR TITLE
Avoid unneeded group fetches

### DIFF
--- a/app/actions/remote/user.ts
+++ b/app/actions/remote/user.ts
@@ -294,14 +294,19 @@ const debouncedFetchUserOrGroupsByMentionNames = debounce(
     },
 );
 
+const notFoundMentions: {[serverUrl: string]: Set<string>} = {};
 const fetchUserOrGroupsByMentionNames = async (serverUrl: string, mentions: string[]) => {
     try {
+        if (!notFoundMentions[serverUrl]) {
+            notFoundMentions[serverUrl] = new Set();
+        }
+
         const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
 
         // Get any missing users
         const usersInDb = await queryUsersByIdsOrUsernames(database, [], mentions).fetch();
         const usersMap = new Set(usersInDb.map((u) => u.username));
-        const usernamesToFetch = mentions.filter((m) => !usersMap.has(m));
+        const usernamesToFetch = mentions.filter((m) => !usersMap.has(m) && !notFoundMentions[serverUrl].has(m));
 
         let fetchedUsers;
         if (usernamesToFetch.length) {
@@ -317,7 +322,15 @@ const fetchUserOrGroupsByMentionNames = async (serverUrl: string, mentions: stri
         const groupsToFetch = groupsToCheck.filter((g) => !groupsMap.has(g));
 
         if (groupsToFetch.length) {
-            await fetchGroupsByNames(serverUrl, groupsToFetch, false);
+            const results = await fetchGroupsByNames(serverUrl, groupsToFetch, false);
+            if (!('error' in results)) {
+                const retrievedSet = new Set(results.map((r) => r.name));
+                for (const g of groupsToFetch) {
+                    if (!retrievedSet.has(g)) {
+                        notFoundMentions[serverUrl].add(g);
+                    }
+                }
+            }
         }
         return {};
     } catch (error) {


### PR DESCRIPTION
#### Summary
Looking for other bugs, I found this potential improvement.

Everything that has a `@` prepended is considered a mention, and we try to find a user or a group with that name. So we end up making two calls to the server  if they don't exist: one to get the user with that name, and then another call to get the group with that name.

The problem is when that is no longer found due to changes in usernames or non mention words (for example, a twitter plugin that post any twitter message with the corresponding `@`). In that case, every time the post is rendered, it will try to fetch the missing mentions. So scrolling up and down a channel with many of these can create a ton of unneeded requests.

The solution is to have a "memory cache" of the usernames that we have already tried to fetch on this session. The downside is that if a group is created after it has been already used and added to the catch, it won't properly load it, but closing the app and opening again will reset the cache and will try again. Also, that scenario is very obscure.

#### Ticket Link
None

#### Release Note
```release-note
Remove unneeded requests to the server with malformed mentions.
```
