### PR TITLE
Fixed UI button Mark all as read in Thread disappear when the font size is large

### DIFF
--- a/app/screens/global_threads/threads_list/header/index.tsx
+++ b/app/screens/global_threads/threads_list/header/index.tsx
@@ -35,6 +35,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flexDirection: 'row',
             paddingLeft: 12,
             marginVertical: 12,
+            flex: 1,
+            overflow: 'hidden',
         },
         menuItemContainer: {
             paddingVertical: 8,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
I found a special case when users increase their device font sizes (old people may do this). This leads to the disappearance of the button Mark all as read in Thread, especially for android devices. This button is an important feature, so it should not be hidden even though the text is long. Hence I create a minor fix for it for this case. In normal case, it's doesn't change anything.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> ios and android.

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
Before fix, the button icon mark all as read disappears:
![Screen Shot 2023-08-04 at 18 32 10](https://github.com/mattermost/mattermost-mobile/assets/39702132/dc816daf-922b-4ae5-99ff-6e0723c8ee4e)

After fix, the button is still available in any case:
![Screen Shot 2023-08-04 at 18 34 20](https://github.com/mattermost/mattermost-mobile/assets/39702132/1db4dcdd-7dd7-449c-be82-37fe0ea0c93e)
![Screen Shot 2023-08-04 at 18 35 02](https://github.com/mattermost/mattermost-mobile/assets/39702132/943e0253-481c-4021-be18-a3f5f815835a)
![Screen Shot 2023-08-04 at 18 47 15](https://github.com/mattermost/mattermost-mobile/assets/39702132/22f7ed88-e439-4017-9b41-e9c8e9d419a8)


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixed UI button Mark all as read in Thread disappear when the font size is large
```
