### PR TITLE
Fix cannot scroll acknowledgement bottom sheet of user list when there are many users

### DIFF
--- a/app/components/post_list/post/body/acknowledgements/users_list/users_list.tsx
+++ b/app/components/post_list/post/body/acknowledgements/users_list/users_list.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useRef} from 'react';
-import {FlatList} from 'react-native-gesture-handler';
+import {BottomSheetFlatList} from '@gorhom/bottom-sheet';
+import React, {useCallback} from 'react';
 
 import UserListItem from './user_list_item';
 
@@ -18,8 +18,6 @@ type Props = {
 };
 
 const UsersList = ({channelId, location, users, userAcknowledgements, timezone}: Props) => {
-    const listRef = useRef<FlatList>(null);
-
     const renderItem = useCallback(({item}: ListRenderItemInfo<UserModel>) => (
         <UserListItem
             channelId={channelId}
@@ -31,9 +29,8 @@ const UsersList = ({channelId, location, users, userAcknowledgements, timezone}:
     ), [channelId, location, timezone]);
 
     return (
-        <FlatList
+        <BottomSheetFlatList
             data={users}
-            ref={listRef}
             renderItem={renderItem}
             overScrollMode={'always'}
         />

--- a/app/components/post_list/post/body/acknowledgements/users_list/users_list.tsx
+++ b/app/components/post_list/post/body/acknowledgements/users_list/users_list.tsx
@@ -2,7 +2,10 @@
 // See LICENSE.txt for license information.
 
 import {BottomSheetFlatList} from '@gorhom/bottom-sheet';
-import React, {useCallback} from 'react';
+import React, {useCallback, useRef} from 'react';
+import {FlatList} from 'react-native-gesture-handler';
+
+import {useIsTablet} from '@hooks/device';
 
 import UserListItem from './user_list_item';
 
@@ -18,6 +21,9 @@ type Props = {
 };
 
 const UsersList = ({channelId, location, users, userAcknowledgements, timezone}: Props) => {
+    const isTablet = useIsTablet();
+    const listRef = useRef<FlatList>(null);
+
     const renderItem = useCallback(({item}: ListRenderItemInfo<UserModel>) => (
         <UserListItem
             channelId={channelId}
@@ -27,6 +33,17 @@ const UsersList = ({channelId, location, users, userAcknowledgements, timezone}:
             timezone={timezone}
         />
     ), [channelId, location, timezone]);
+
+    if (isTablet) {
+        return (
+            <FlatList
+                data={users}
+                ref={listRef}
+                renderItem={renderItem}
+                overScrollMode={'always'}
+            />
+        );
+    }
 
     return (
         <BottomSheetFlatList

--- a/app/screens/bottom_sheet/index.tsx
+++ b/app/screens/bottom_sheet/index.tsx
@@ -191,10 +191,10 @@ const BottomSheet = ({
 
     if (isTablet) {
         return (
-            <GestureHandlerRootView style={styles.container}>
+            <>
                 <View style={styles.separator}/>
                 {renderContainerContent()}
-            </GestureHandlerRootView>
+            </>
         );
     }
 

--- a/app/screens/bottom_sheet/index.tsx
+++ b/app/screens/bottom_sheet/index.tsx
@@ -4,7 +4,6 @@
 import BottomSheetM, {BottomSheetBackdrop, type BottomSheetBackdropProps, type BottomSheetFooterProps} from '@gorhom/bottom-sheet';
 import React, {type ReactNode, useCallback, useEffect, useMemo, useRef} from 'react';
 import {DeviceEventEmitter, type Handle, InteractionManager, Keyboard, type StyleProp, View, type ViewStyle} from 'react-native';
-import {GestureHandlerRootView} from 'react-native-gesture-handler';
 
 import {Events} from '@constants';
 import {useTheme} from '@context/theme';
@@ -39,7 +38,6 @@ const PADDING_TOP_TABLET = 8;
 
 export const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
-        container: {flex: 1},
         bottomSheet: {
             backgroundColor: theme.centerChannelBg,
             borderTopStartRadius: 24,
@@ -199,27 +197,25 @@ const BottomSheet = ({
     }
 
     return (
-        <GestureHandlerRootView style={styles.container}>
-            <BottomSheetM
-                ref={sheetRef}
-                index={initialSnapIndex}
-                snapPoints={snapPoints}
-                animateOnMount={true}
-                backdropComponent={renderBackdrop}
-                onAnimate={handleAnimationStart}
-                onChange={handleChange}
-                animationConfigs={animatedConfig}
-                handleComponent={Indicator}
-                style={styles.bottomSheet}
-                backgroundStyle={bottomSheetBackgroundStyle}
-                footerComponent={footerComponent}
-                keyboardBehavior='extend'
-                keyboardBlurBehavior='restore'
-                onClose={close}
-            >
-                {renderContainerContent()}
-            </BottomSheetM>
-        </GestureHandlerRootView>
+        <BottomSheetM
+            ref={sheetRef}
+            index={initialSnapIndex}
+            snapPoints={snapPoints}
+            animateOnMount={true}
+            backdropComponent={renderBackdrop}
+            onAnimate={handleAnimationStart}
+            onChange={handleChange}
+            animationConfigs={animatedConfig}
+            handleComponent={Indicator}
+            style={styles.bottomSheet}
+            backgroundStyle={bottomSheetBackgroundStyle}
+            footerComponent={footerComponent}
+            keyboardBehavior='extend'
+            keyboardBlurBehavior='restore'
+            onClose={close}
+        >
+            {renderContainerContent()}
+        </BottomSheetM>
     );
 };
 

--- a/app/screens/bottom_sheet/index.tsx
+++ b/app/screens/bottom_sheet/index.tsx
@@ -191,10 +191,10 @@ const BottomSheet = ({
 
     if (isTablet) {
         return (
-            <>
+            <GestureHandlerRootView style={styles.container}>
                 <View style={styles.separator}/>
                 {renderContainerContent()}
-            </>
+            </GestureHandlerRootView>
         );
     }
 

--- a/app/screens/index.tsx
+++ b/app/screens/index.tsx
@@ -69,7 +69,7 @@ Navigation.setLazyComponentRegistrator((screenName) => {
         case Screens.BOTTOM_SHEET:
             screen = withServerDatabase(require('@screens/bottom_sheet').default);
             Navigation.registerComponent(Screens.BOTTOM_SHEET, () =>
-                withSafeAreaInsets(withManagedConfig(screen)),
+                withGestures(withSafeAreaInsets(withManagedConfig(screen)), undefined),
             );
             return;
         case Screens.BROWSE_CHANNELS:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
When there are many users in the acknowledgement list, we cannot scroll the list to the bottom.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
None.
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> ios

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
Before fix, we cannot scroll the user list. We must grab it outside the list to expand it first:

https://github.com/mattermost/mattermost-mobile/assets/39702132/395b3a2b-b946-4dc6-a75a-629e854866fe

After fix, we can expand and scroll the whole list (similar to facebook's bottom sheet reaction)

https://github.com/mattermost/mattermost-mobile/assets/39702132/c630c49b-b63f-438d-b409-f296faed9390



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fix cannot scroll acknowledgement bottom sheet of user list when there are many users
```
