### PR TITLE
MM-53849 - hide channels from archived teams during channels search

### DIFF
--- a/app/screens/find_channels/filtered_list/index.ts
+++ b/app/screens/find_channels/filtered_list/index.ts
@@ -37,14 +37,15 @@ const enhanced = withObservables(['term'], ({database, term}: EnhanceProps) => {
         switchMap((matchStart) => {
             return retrieveChannels(database, matchStart.flat(), true);
         }),
-        switchMap((myChannels) => removeChannelsFromArchivedTeams(myChannels, teamIds)),
+        combineLatestWith(teamIds),
+        switchMap(([myChannels, tmIds]) => of$(removeChannelsFromArchivedTeams(myChannels, tmIds))),
     );
 
     const channelsMatch = joinedChannelsMatch.pipe(
         combineLatestWith(directChannelsMatch),
         switchMap((matched) => retrieveChannels(database, matched.flat(), true)),
-        switchMap((myChannels) => removeChannelsFromArchivedTeams(myChannels, teamIds)),
-
+        combineLatestWith(teamIds),
+        switchMap(([myChannels, tmIds]) => of$(removeChannelsFromArchivedTeams(myChannels, tmIds))),
     );
 
     const archivedChannels = observeArchiveChannelsByTerm(database, term, MAX_RESULTS).pipe(

--- a/app/screens/find_channels/filtered_list/index.ts
+++ b/app/screens/find_channels/filtered_list/index.ts
@@ -12,7 +12,7 @@ import {observeConfigValue, observeCurrentTeamId} from '@queries/servers/system'
 import {queryJoinedTeams} from '@queries/servers/team';
 import {observeIsCRTEnabled} from '@queries/servers/thread';
 import {observeTeammateNameDisplay} from '@queries/servers/user';
-import {retrieveChannels} from '@screens/find_channels/utils';
+import {removeChannelsFromArchivedTeams, retrieveChannels} from '@screens/find_channels/utils';
 
 import FilteredList, {MAX_RESULTS} from './filtered_list';
 
@@ -37,11 +37,14 @@ const enhanced = withObservables(['term'], ({database, term}: EnhanceProps) => {
         switchMap((matchStart) => {
             return retrieveChannels(database, matchStart.flat(), true);
         }),
+        switchMap((myChannels) => removeChannelsFromArchivedTeams(myChannels, teamIds)),
     );
 
     const channelsMatch = joinedChannelsMatch.pipe(
         combineLatestWith(directChannelsMatch),
         switchMap((matched) => retrieveChannels(database, matched.flat(), true)),
+        switchMap((myChannels) => removeChannelsFromArchivedTeams(myChannels, teamIds)),
+
     );
 
     const archivedChannels = observeArchiveChannelsByTerm(database, term, MAX_RESULTS).pipe(

--- a/app/screens/find_channels/unfiltered_list/index.ts
+++ b/app/screens/find_channels/unfiltered_list/index.ts
@@ -3,12 +3,12 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {of as of$} from 'rxjs';
+import {Observable, of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {queryMyRecentChannels} from '@queries/servers/channel';
 import {queryJoinedTeams} from '@queries/servers/team';
-import {retrieveChannels} from '@screens/find_channels/utils';
+import {removeChannelsFromArchivedTeams, retrieveChannels} from '@screens/find_channels/utils';
 
 import UnfilteredList from './unfiltered_list';
 
@@ -18,10 +18,15 @@ const MAX_CHANNELS = 20;
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const teamsCount = queryJoinedTeams(database).observeCount();
+    const teamIds: Observable<Set<string>> = queryJoinedTeams(database).observe().pipe(
+        // eslint-disable-next-line max-nested-callbacks
+        switchMap((teams) => of$(new Set(teams.map((t) => t.id)))),
+    );
 
     const recentChannels = queryMyRecentChannels(database, MAX_CHANNELS).
         observeWithColumns(['last_viewed_at']).pipe(
             switchMap((myChannels) => retrieveChannels(database, myChannels, true)),
+            switchMap((myChannels) => removeChannelsFromArchivedTeams(myChannels, teamIds)),
         );
 
     return {

--- a/app/screens/find_channels/utils.ts
+++ b/app/screens/find_channels/utils.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Database, Q} from '@nozbe/watermelondb';
-import {of as of$} from 'rxjs';
+import {Observable, of as of$, switchMap} from 'rxjs';
 
 import {MM_TABLES} from '@constants/database';
 
@@ -24,4 +24,19 @@ export const retrieveChannels = (database: Database, myChannels: MyChannelModel[
     }
 
     return of$([]);
+};
+
+export const removeChannelsFromArchivedTeams = (recentChannels: ChannelModel[], teamIds: Observable<Set<string>>) => {
+    return teamIds.pipe(
+        // eslint-disable-next-line max-nested-callbacks
+        switchMap((teamIdsSet) =>
+            // eslint-disable-next-line max-nested-callbacks
+            of$(recentChannels.filter((channel) => {
+                if (!channel.teamId) {
+                    return true;
+                }
+                return teamIdsSet.has(channel.teamId);
+            })),
+        ),
+    );
 };

--- a/app/screens/find_channels/utils.ts
+++ b/app/screens/find_channels/utils.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Database, Q} from '@nozbe/watermelondb';
-import {Observable, of as of$, switchMap} from 'rxjs';
+import {of as of$} from 'rxjs';
 
 import {MM_TABLES} from '@constants/database';
 
@@ -26,17 +26,11 @@ export const retrieveChannels = (database: Database, myChannels: MyChannelModel[
     return of$([]);
 };
 
-export const removeChannelsFromArchivedTeams = (recentChannels: ChannelModel[], teamIds: Observable<Set<string>>) => {
-    return teamIds.pipe(
-        // eslint-disable-next-line max-nested-callbacks
-        switchMap((teamIdsSet) =>
-            // eslint-disable-next-line max-nested-callbacks
-            of$(recentChannels.filter((channel) => {
-                if (!channel.teamId) {
-                    return true;
-                }
-                return teamIdsSet.has(channel.teamId);
-            })),
-        ),
-    );
+export const removeChannelsFromArchivedTeams = (recentChannels: ChannelModel[], teamIds: Set<string>) => {
+    return recentChannels.filter((channel) => {
+        if (!channel.teamId) {
+            return true;
+        }
+        return teamIds.has(channel.teamId);
+    });
 };


### PR DESCRIPTION
#### Summary
This PR filters the channels from archived teams during the channels search (cmd + k).

Root cause:
Even when the Websocket event works correctly at the moment of the team deletion by receiving the team deletedEvent and removing the team and associated channels from the channels search, once the app have been reloaded the subsequent searches of unfiltered recent channels and filtered channels do include the channels from archived teams. (see video below)

https://github.com/mattermost/mattermost-mobile/assets/10082627/0bb254d4-b245-4fd4-948d-5a4fb9c8d976


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53849

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: pixel 6, iphone 14 (emulators)

#### Screenshots
Before:

https://github.com/mattermost/mattermost-mobile/assets/10082627/bce8742c-5b5a-4b4a-a4ba-e16ad0c2e766




After:

https://github.com/mattermost/mattermost-mobile/assets/10082627/7f1ab8d7-c37e-4b6b-8ed8-90adff05ece1




#### Release Note
```release-note
NONE
```
