### PR TITLE
Fix login not doing entry logic after forced logout

### DIFF
--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -147,7 +147,10 @@ class WebsocketManager {
                 if (error) {
                     client.close(false);
                 }
-                this.firstConnectionSynced[serverUrl] = true;
+                // Makes sure a client still exist, and therefore we haven't been logged out
+                if (this.clients[serverUrl]) {
+                    this.firstConnectionSynced[serverUrl] = true;
+                }
             }
         }
     };


### PR DESCRIPTION
#### Summary
Fix a race condition where when getting logged out of a server at the same time we are executing the entry logic, we may invalidate the websocket client before the entry logic returns.

In that case, the entry logic sets the `firstConnectionSynced` after the websocket has been invalidated.

In normal circumstances we want to set this even if it fails, because we are closing the websocket and letting it reconnect, which will call the reconnect logic. Nevertheless, in the case the client gets invalidated (and therefore, no longer exist) we should not set it.

I haven't been able to reproduce the error "naturally", but applying an artificial delay before returning the error shows the behaviour described by the reporter.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
