### PR TITLE
[MM-53994] Calls: fix potential websocket client leak

### DIFF
--- a/app/products/calls/connection/websocket_client.ts
+++ b/app/products/calls/connection/websocket_client.ts
@@ -166,7 +166,7 @@ export class WebSocketClient extends EventEmitter {
 
         setTimeout(() => {
             if (!this.closed) {
-                logDebug('reconnecting');
+                logDebug(`calls: attempting ws reconnection to ${this.serverUrl + this.wsPath}`);
                 this.init(true);
             }
         }, this.reconnectRetryTime);


### PR DESCRIPTION
#### Summary

PR fixes an issue that could cause the websocket client for Calls to be leaked in some rare (but possible) event. We move the reconnect logic into its own method and solely rely on the `closed` boolean to decide whether we should reconnect or not.

Refer to [parent PR](https://github.com/mattermost/mattermost-plugin-calls/pull/492) for full context and reproduction sequence.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53994

#### Release Note

```release-note
Fixed a potential issue causing calls sessions to be stuck.
```

