### PR TITLE
Remove check for android command on solidarity

### DIFF
--- a/.solidarity
+++ b/.solidarity
@@ -24,10 +24,6 @@
         "binary": "emulator"
       },
       {
-        "rule": "cli",
-        "binary": "android"
-      },
-      {
         "rule": "env",
         "variable": "ANDROID_HOME",
         "error": "The ANDROID_HOME environment variable must be set to your local SDK.  Refer to getting started docs for help."


### PR DESCRIPTION
#### Summary
The `android` executable doesn't get created during Android Studio install, but the first time we run `npm run android` it gets created. So oftentimes, solidarity fail this check on the first run. We remove the need of the `android` executable, since we expect if the user has already the emulator and the environment variable, they will also have all the needed things to execute the app.

#### Release Note
```release-note
NONE
```
