### PR TITLE
MM-53927 - fix channel names not shown during search

### DIFF
--- a/app/screens/find_channels/filtered_list/filtered_list.tsx
+++ b/app/screens/find_channels/filtered_list/filtered_list.tsx
@@ -219,7 +219,7 @@ const FilteredList = ({
                 />
             );
         }
-        if ('teamId' in item) {
+        if ('teamId' in item || 'team_id' in item) {
             return (
                 <ChannelItem
                     channel={item}


### PR DESCRIPTION
#### Summary
There was a problem at the moment of styling  the name of the open channels where the user was not member of during the channels searching using the find channels modal (cmd + k).

This PR makes sure that the filtered list component styles correctly the ChannelItem component by verifying it is actually an Open channel and does contain a teamId.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53927

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: Pixel 6, Iphone 14 (emulators), Note 20

#### Screenshots
Before:

https://github.com/mattermost/mattermost-mobile/assets/10082627/3c8be86a-3884-41f8-b2e6-39a9a88f09d4



After:

https://github.com/mattermost/mattermost-mobile/assets/10082627/d291db7b-eb13-4d73-9fe0-bb80b6a99d54



#### Release Note
```release-note
NONE
```
