### PR TITLE
Fix posts not showing on permalink view

### DIFF
--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -9,11 +9,9 @@ import {addPostAcknowledgement, removePost, removePostAcknowledgement, storePost
 import {addRecentReaction} from '@actions/local/reactions';
 import {createThreadFromNewPost} from '@actions/local/thread';
 import {ActionType, General, Post, ServerErrors} from '@constants';
-import {MM_TABLES} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import {filterPostsInOrderedArray} from '@helpers/api/post';
 import {getNeededAtMentionedUsernames} from '@helpers/api/user';
-import {extractRecordsForTable} from '@helpers/database';
 import NetworkManager from '@managers/network_manager';
 import {getMyChannel, prepareMissingChannelsForAllTeams, queryAllMyChannel} from '@queries/servers/channel';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
@@ -600,7 +598,7 @@ export async function fetchPostThread(serverUrl: string, postId: string, options
             await operator.batchRecords(models, 'fetchPostThread');
         }
         setFetchingThreadState(postId, false);
-        return {posts: extractRecordsForTable<PostModel>(posts, MM_TABLES.SERVER.POST)};
+        return {posts: result.posts};
     } catch (error) {
         logDebug('error on fetchPostThread', getFullErrorMessage(error));
         forceLogoutIfNecessary(serverUrl, error);
@@ -668,7 +666,7 @@ export async function fetchPostsAround(serverUrl: string, channelId: string, pos
             await operator.batchRecords(models, 'fetchPostsAround');
         }
 
-        return {posts: extractRecordsForTable<PostModel>(posts, MM_TABLES.SERVER.POST)};
+        return {posts: data.posts};
     } catch (error) {
         logDebug('error on fetchPostsAround', getFullErrorMessage(error));
         forceLogoutIfNecessary(serverUrl, error);

--- a/app/helpers/database/index.ts
+++ b/app/helpers/database/index.ts
@@ -5,7 +5,6 @@ import xRegExp from 'xregexp';
 
 import {General} from '@constants';
 
-import type Model from '@nozbe/watermelondb/Model';
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type MyChannelModel from '@typings/database/models/servers/my_channel';
 
@@ -25,11 +24,6 @@ type NotifyProps = {
     Record<string, ChannelModel>,
     NotifyProps,
 ]
-
-export const extractRecordsForTable = <T>(records: Model[], tableName: string): T[] => {
-    // @ts-expect-error constructor.table not exposed in type definition
-    return records.filter((r) => r.constructor.table === tableName) as T[];
-};
 
 export function extractChannelDisplayName(raw: Pick<Channel, 'type' | 'display_name' | 'fake'>, record?: ChannelModel) {
     let displayName = '';

--- a/app/screens/permalink/permalink.tsx
+++ b/app/screens/permalink/permalink.tsx
@@ -6,6 +6,7 @@ import {Alert, Text, TouchableOpacity, View} from 'react-native';
 import Animated from 'react-native-reanimated';
 import {type Edge, SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
+import {getPosts} from '@actions/local/post';
 import {fetchChannelById, joinChannel, switchToChannelById} from '@actions/remote/channel';
 import {fetchPostById, fetchPostsAround, fetchPostThread} from '@actions/remote/post';
 import {addCurrentUserToTeam, fetchTeamByName, removeCurrentUserFromTeam} from '@actions/remote/team';
@@ -122,6 +123,10 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 
 const POSTS_LIMIT = 5;
 
+const idExtractor = (item: Post) => {
+    return item.id;
+};
+
 function Permalink({
     channel,
     rootId,
@@ -163,7 +168,9 @@ function Permalink({
                     setError({unreachable: true});
                 }
                 if (data.posts) {
-                    setPosts(loadThreadPosts ? processThreadPosts(data.posts, postId) : data.posts);
+                    const ids = data.posts.map(idExtractor);
+                    const postsModels = await getPosts(serverUrl, ids, 'desc');
+                    setPosts(loadThreadPosts ? processThreadPosts(postsModels, postId) : postsModels);
                 }
                 setLoading(false);
                 return;


### PR DESCRIPTION
#### Summary
On #7481 we introduced a bug where permalinks no longer show the messages.

This is because we were using on a few fetch functions a non-expected pattern. Instead of returning the raw client provided objects as many other remote functions, we were returning the models. And to do so, we were filtering the models that were on the Post table on the list of models passed to write to the database.

With #7481 we no longer store all posts, but only those that are different. So if there is no new post in the list retrieved from the server, we won't show any post.

To simplify this, we made it so the fetch functions work as expected (returning the raw client objects), and just let the caller deal with fetching the models from the database.

This only affected the permalink, and the paging of the `thread_post_list` component (which only was looking at the size, and that is the reason it shows no changes).

I finally went with getting the posts by ids instead by between times because I expect the number of ids not being huge (maximum the page size) and to simplify the code (since if we were looking at a thread, we would also have another condition on the root id).

#### Ticket Link
None

#### Related ticket
https://github.com/mattermost/mattermost-mobile/pull/7481
#### Release Note
No release note needed since this is fixing a regression from a change in this release.
```release-note
NONE
```
