### PR TITLE
MM-53924 - Android should use category to allow replies

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
+++ b/android/app/src/main/java/com/mattermost/helpers/CustomPushNotificationHelper.java
@@ -52,6 +52,7 @@ public class CustomPushNotificationHelper {
     public static final String PUSH_TYPE_MESSAGE = "message";
     public static final String PUSH_TYPE_CLEAR = "clear";
     public static final String PUSH_TYPE_SESSION = "session";
+    public static final String CATEGORY_CAN_REPLY = "CAN_REPLY";
 
     private static NotificationChannel mHighImportanceChannel;
     private static NotificationChannel mMinImportanceChannel;
@@ -132,8 +133,9 @@ public class CustomPushNotificationHelper {
     private static void addNotificationReplyAction(Context context, NotificationCompat.Builder notification, Bundle bundle, int notificationId) {
         String postId = bundle.getString("post_id");
         String serverUrl = bundle.getString("server_url");
+        boolean canReply = bundle.containsKey("category") && bundle.getString("category").equals(CATEGORY_CAN_REPLY);
 
-        if (android.text.TextUtils.isEmpty(postId) || serverUrl == null) {
+        if (android.text.TextUtils.isEmpty(postId) || serverUrl == null || !canReply) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
- Android should not add reply functionality to messages that are not marked `can_reply`.
- This will allow Android to match how iOS handles the `category` field.
- Sister to: https://github.com/mattermost/mattermost-push-proxy/pull/106

#### Ticket Link
- This is ultimately because Calls wants to remove the "Okay" etc. auto reply options when we send a new call notification. https://mattermost.atlassian.net/browse/MM-53924

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- iOS: 16.5.1, iPhone 14

#### Release Note

```release-note
NONE
```

