### PR TITLE
MM-54223 - Remove unused getOpenGraphMetadata

### DIFF
--- a/app/client/rest/general.ts
+++ b/app/client/rest/general.ts
@@ -14,7 +14,6 @@ type PoliciesResponse<T> = {
 }
 
 export interface ClientGeneralMix {
-    getOpenGraphMetadata: (url: string) => Promise<any>;
     ping: (deviceId?: string, timeoutInterval?: number) => Promise<any>;
     logClientError: (message: string, level?: string) => Promise<any>;
     getClientConfigOld: () => Promise<ClientConfig>;
@@ -28,13 +27,6 @@ export interface ClientGeneralMix {
 }
 
 const ClientGeneral = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
-    getOpenGraphMetadata = async (url: string) => {
-        return this.doFetch(
-            `${this.urlVersion}/opengraph`,
-            {method: 'post', body: {url}},
-        );
-    };
-
     ping = async (deviceId?: string, timeoutInterval?: number) => {
         let url = `${this.urlVersion}/system/ping?time=${Date.now()}`;
         if (deviceId) {


### PR DESCRIPTION
### Summary
- https://github.com/mattermost/mattermost/pull/24177 removed the `/opengraph` endpoint
- And the `getOpenGraphMetadata` was unused, so removing it.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-54223

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Release Note
```release-note
NONE
```
