### PR TITLE
Fix husky by adding npm prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "pod-install": "react-native setup-ios-permissions && cd ios && pod install",
     "pod-install-m1": "react-native setup-ios-permissions && cd ios && arch -x86_64 pod install",
     "postinstall": "patch-package && ./scripts/postinstall.sh",
+    "prepare": "husky install",
     "preinstall": "./scripts/preinstall.sh && npx solidarity",
     "start": "react-native start",
     "test": "jest --forceExit --runInBand",


### PR DESCRIPTION
#### Summary
https://typicode.github.io/husky/getting-started.html#install
https://blog.typicode.com/husky-git-hooks-autoinstall/
husky doesn't get autoinstalldc anymore so it seems like we need to specify `husky install` explicitly. 
#### Release Note
husky fix
