### PR TITLE
MM-54117 - Calls: Support wiredHeadsets; generalize panel_item

### DIFF
--- a/app/components/channel_actions/copy_channel_link_option/copy_channel_link_option.tsx
+++ b/app/components/channel_actions/copy_channel_link_option/copy_channel_link_option.tsx
@@ -35,7 +35,7 @@ const CopyChannelLinkOption = ({channelName, teamName, showAsLabel, testID}: Pro
             <SlideUpPanelItem
                 onPress={onCopyLink}
                 text={intl.formatMessage({id: 'channel_info.copy_link', defaultMessage: 'Copy Link'})}
-                icon='link-variant'
+                leftIcon='link-variant'
                 testID={testID}
             />
         );

--- a/app/components/channel_actions/info_box/index.tsx
+++ b/app/components/channel_actions/info_box/index.tsx
@@ -45,7 +45,7 @@ const InfoBox = ({channelId, containerStyle, showAsLabel = false, testID}: Props
     if (showAsLabel) {
         return (
             <SlideUpPanelItem
-                icon='information-outline'
+                leftIcon='information-outline'
                 onPress={onViewInfo}
                 testID={testID}
                 text={intl.formatMessage({id: 'channel_header.info', defaultMessage: 'View info'})}

--- a/app/components/channel_actions/leave_channel_label/leave_channel_label.tsx
+++ b/app/components/channel_actions/leave_channel_label/leave_channel_label.tsx
@@ -174,7 +174,7 @@ const LeaveChannelLabel = ({canLeave, channelId, displayName, isOptionItem, type
     return (
         <SlideUpPanelItem
             destructive={true}
-            icon={icon}
+            leftIcon={icon}
             onPress={onLeave}
             text={leaveText}
             testID={testID}

--- a/app/components/markdown/at_mention/at_mention.tsx
+++ b/app/components/markdown/at_mention/at_mention.tsx
@@ -167,7 +167,7 @@ const AtMention = ({
                         style={style.bottomSheet}
                     >
                         <SlideUpPanelItem
-                            icon='content-copy'
+                            leftIcon='content-copy'
                             onPress={() => {
                                 dismissBottomSheet();
                                 let username = mentionName;
@@ -182,7 +182,7 @@ const AtMention = ({
                         />
                         <SlideUpPanelItem
                             destructive={true}
-                            icon='cancel'
+                            leftIcon='cancel'
                             onPress={() => {
                                 dismissBottomSheet();
                             }}

--- a/app/components/markdown/markdown_code_block/index.tsx
+++ b/app/components/markdown/markdown_code_block/index.tsx
@@ -123,7 +123,7 @@ const MarkdownCodeBlock = ({language = '', content, textStyle}: MarkdownCodeBloc
                         style={style.bottomSheet}
                     >
                         <SlideUpPanelItem
-                            icon='content-copy'
+                            leftIcon='content-copy'
                             onPress={() => {
                                 dismissBottomSheet();
                                 Clipboard.setString(content);
@@ -133,7 +133,7 @@ const MarkdownCodeBlock = ({language = '', content, textStyle}: MarkdownCodeBloc
                         />
                         <SlideUpPanelItem
                             destructive={true}
-                            icon='cancel'
+                            leftIcon='cancel'
                             onPress={() => {
                                 dismissBottomSheet();
                             }}

--- a/app/components/markdown/markdown_image/index.tsx
+++ b/app/components/markdown/markdown_image/index.tsx
@@ -157,7 +157,7 @@ const MarkdownImage = ({
                         style={style.bottomSheet}
                     >
                         <SlideUpPanelItem
-                            icon='content-copy'
+                            leftIcon='content-copy'
                             onPress={() => {
                                 dismissBottomSheet();
                                 Clipboard.setString(linkDestination || source);
@@ -167,7 +167,7 @@ const MarkdownImage = ({
                         />
                         <SlideUpPanelItem
                             destructive={true}
-                            icon='cancel'
+                            leftIcon='cancel'
                             onPress={() => {
                                 dismissBottomSheet();
                             }}

--- a/app/components/markdown/markdown_latex_block/index.tsx
+++ b/app/components/markdown/markdown_latex_block/index.tsx
@@ -139,7 +139,7 @@ const LatexCodeBlock = ({content, theme}: Props) => {
                         style={styles.bottomSheet}
                     >
                         <SlideUpPanelItem
-                            icon='content-copy'
+                            leftIcon='content-copy'
                             onPress={() => {
                                 dismissBottomSheet();
                                 Clipboard.setString(content);
@@ -149,7 +149,7 @@ const LatexCodeBlock = ({content, theme}: Props) => {
                         />
                         <SlideUpPanelItem
                             destructive={true}
-                            icon='cancel'
+                            leftIcon='cancel'
                             onPress={dismissBottomSheet}
                             testID='at_mention.bottom_sheet.cancel'
                             text={intl.formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'})}

--- a/app/components/markdown/markdown_link/markdown_link.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.tsx
@@ -116,7 +116,7 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                         style={style.bottomSheet}
                     >
                         <SlideUpPanelItem
-                            icon='content-copy'
+                            leftIcon='content-copy'
                             onPress={() => {
                                 dismissBottomSheet();
                                 Clipboard.setString(href);
@@ -126,7 +126,7 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                         />
                         <SlideUpPanelItem
                             destructive={true}
-                            icon='cancel'
+                            leftIcon='cancel'
                             onPress={() => {
                                 dismissBottomSheet();
                             }}

--- a/app/components/post_draft/quick_actions/camera_quick_action/camera_type.tsx
+++ b/app/components/post_draft/quick_actions/camera_quick_action/camera_type.tsx
@@ -66,13 +66,13 @@ const CameraType = ({onPress}: Props) => {
             />
             }
             <SlideUpPanelItem
-                icon='camera-outline'
+                leftIcon='camera-outline'
                 onPress={onPhoto}
                 testID='camera_type.photo'
                 text={intl.formatMessage({id: 'camera_type.photo.option', defaultMessage: 'Capture Photo'})}
             />
             <SlideUpPanelItem
-                icon='video-outline'
+                leftIcon='video-outline'
                 onPress={onVideo}
                 testID='camera_type.video'
                 text={intl.formatMessage({id: 'camera_type.video.option', defaultMessage: 'Record Video'})}

--- a/app/components/post_list/post/body/failed/index.tsx
+++ b/app/components/post_list/post/body/failed/index.tsx
@@ -44,7 +44,7 @@ const Failed = ({post, theme}: FailedProps) => {
                     style={styles.bottomSheet}
                 >
                     <SlideUpPanelItem
-                        icon='send-outline'
+                        leftIcon='send-outline'
                         onPress={() => {
                             dismissBottomSheet();
                             retryFailedPost(serverUrl, post);
@@ -54,7 +54,7 @@ const Failed = ({post, theme}: FailedProps) => {
                     />
                     <SlideUpPanelItem
                         destructive={true}
-                        icon='close-circle-outline'
+                        leftIcon='close-circle-outline'
                         onPress={() => {
                             dismissBottomSheet();
                             removePost(serverUrl, post);

--- a/app/components/slide_up_panel_item/index.tsx
+++ b/app/components/slide_up_panel_item/index.tsx
@@ -14,10 +14,12 @@ import {isValidUrl} from '@utils/url';
 
 type SlideUpPanelProps = {
     destructive?: boolean;
-    icon?: string | Source;
-    rightIcon?: boolean;
-    imageStyles?: StyleProp<ImageStyle>;
-    iconStyles?: StyleProp<TextStyle>;
+    leftIcon?: string | Source;
+    leftImageStyles?: StyleProp<ImageStyle>;
+    leftIconStyles?: StyleProp<TextStyle>;
+    rightIcon?: string | Source;
+    rightImageStyles?: StyleProp<ImageStyle>;
+    rightIconStyles?: StyleProp<TextStyle>;
     onPress: () => void;
     textStyles?: TextStyle;
     testID?: string;
@@ -65,13 +67,55 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-const SlideUpPanelItem = ({destructive, icon, imageStyles, onPress, testID, text, textStyles, iconStyles, rightIcon = false}: SlideUpPanelProps) => {
+const SlideUpPanelItem = ({
+    destructive = false,
+    leftIcon,
+    leftImageStyles,
+    leftIconStyles,
+    rightIcon,
+    rightImageStyles,
+    rightIconStyles,
+    onPress,
+    testID,
+    text,
+    textStyles,
+}: SlideUpPanelProps) => {
     const theme = useTheme();
+    const style = getStyleSheet(theme);
+
+    const {image: leftImage, iconStyle: leftIconStyle} = useImageAndStyle(leftIcon, leftImageStyles, leftIconStyles, destructive);
+    const {image: rightImage, iconStyle: rightIconStyle} = useImageAndStyle(rightIcon, rightImageStyles, rightIconStyles, destructive);
+
     const handleOnPress = useCallback(preventDoubleTap(onPress, 500), []);
+
+    return (
+        <TouchableHighlight
+            onPress={handleOnPress}
+            style={style.container}
+            testID={testID}
+            underlayColor={changeOpacity(theme.buttonBg, 0.08)}
+        >
+            <View style={style.row}>
+                {Boolean(leftImage) &&
+                    <View style={leftIconStyle}>{leftImage}</View>
+                }
+                <View style={style.textContainer}>
+                    <Text style={[style.text, destructive && style.destructive, textStyles]}>{text}</Text>
+                </View>
+                {Boolean(rightImage) &&
+                    <View style={rightIconStyle}>{rightImage}</View>
+                }
+            </View>
+        </TouchableHighlight>
+    );
+};
+
+const useImageAndStyle = (icon: string | Source | undefined, imageStyles: StyleProp<ImageStyle>, iconStyles: StyleProp<TextStyle>, destructive: boolean) => {
+    const theme = useTheme();
     const style = getStyleSheet(theme);
 
     let image;
-    let iconStyle: StyleProp<ViewStyle> = [style.iconContainer];
+    let iconStyle: Array<StyleProp<ViewStyle>> = [style.iconContainer];
     if (icon) {
         if (typeof icon === 'object') {
             if (icon.uri && isValidUrl(icon.uri)) {
@@ -101,26 +145,7 @@ const SlideUpPanelItem = ({destructive, icon, imageStyles, onPress, testID, text
         }
     }
 
-    return (
-        <TouchableHighlight
-            onPress={handleOnPress}
-            style={style.container}
-            testID={testID}
-            underlayColor={changeOpacity(theme.buttonBg, 0.08)}
-        >
-            <View style={style.row}>
-                {Boolean(image) && !rightIcon &&
-                    <View style={iconStyle}>{image}</View>
-                }
-                <View style={style.textContainer}>
-                    <Text style={[style.text, destructive && style.destructive, textStyles]}>{text}</Text>
-                </View>
-                {Boolean(image) && rightIcon &&
-                    <View style={iconStyle}>{image}</View>
-                }
-            </View>
-        </TouchableHighlight>
-    );
+    return {image, iconStyle};
 };
 
 export default SlideUpPanelItem;

--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -477,7 +477,7 @@ const CallScreen = ({
                     {
                         showStartRecording &&
                         <SlideUpPanelItem
-                            icon={'record-circle-outline'}
+                            leftIcon={'record-circle-outline'}
                             onPress={startRecording}
                             text={recordOptionTitle}
                         />
@@ -485,14 +485,14 @@ const CallScreen = ({
                     {
                         showStopRecording &&
                         <SlideUpPanelItem
-                            icon={'record-square-outline'}
+                            leftIcon={'record-square-outline'}
                             onPress={stopRecording}
                             text={stopRecordingOptionTitle}
                             textStyles={style.denimDND}
                         />
                     }
                     <SlideUpPanelItem
-                        icon='message-text-outline'
+                        leftIcon='message-text-outline'
                         onPress={switchToThread}
                         text={callThreadOptionTitle}
                     />
@@ -764,7 +764,6 @@ const CallScreen = ({
                                 iconStyle={[
                                     style.buttonIcon,
                                     isLandscape && style.buttonIconLandscape,
-                                    style.speakerphoneIcon,
                                     currentCall.speakerphoneOn && style.buttonOn,
                                 ]}
                                 buttonTextStyle={style.buttonText}

--- a/app/screens/browse_channels/dropdown_slideup.tsx
+++ b/app/screens/browse_channels/dropdown_slideup.tsx
@@ -42,11 +42,6 @@ export default function DropdownSlideup({
     const style = getStyleFromTheme(theme);
     const isTablet = useIsTablet();
 
-    const commonProps = {
-        rightIcon: true,
-        iconStyles: style.checkIcon,
-    };
-
     const handlePublicPress = useCallback(() => {
         dismissBottomSheet();
         onPress(PUBLIC);
@@ -73,16 +68,16 @@ export default function DropdownSlideup({
                 onPress={handlePublicPress}
                 testID='browse_channels.dropdown_slideup_item.public_channels'
                 text={intl.formatMessage({id: 'browse_channels.publicChannels', defaultMessage: 'Public Channels'})}
-                icon={selected === PUBLIC ? 'check' : undefined}
-                {...commonProps}
+                rightIcon={selected === PUBLIC ? 'check' : undefined}
+                rightIconStyles={style.checkIcon}
             />
             {canShowArchivedChannels && (
                 <SlideUpPanelItem
                     onPress={handleArchivedPress}
                     testID='browse_channels.dropdown_slideup_item.archived_channels'
                     text={intl.formatMessage({id: 'browse_channels.archivedChannels', defaultMessage: 'Archived Channels'})}
-                    icon={selected === ARCHIVED ? 'check' : undefined}
-                    {...commonProps}
+                    rightIcon={selected === ARCHIVED ? 'check' : undefined}
+                    rightIconStyles={style.checkIcon}
                 />
             )}
             {sharedChannelsEnabled && (
@@ -90,8 +85,8 @@ export default function DropdownSlideup({
                     onPress={handleSharedPress}
                     testID='browse_channels.dropdown_slideup_item.shared_channels'
                     text={intl.formatMessage({id: 'browse_channels.sharedChannels', defaultMessage: 'Shared Channels'})}
-                    icon={selected === SHARED ? 'check' : undefined}
-                    {...commonProps}
+                    rightIcon={selected === SHARED ? 'check' : undefined}
+                    rightIconStyles={style.checkIcon}
                 />
             )}
         </BottomSheetContent>

--- a/app/screens/edit_profile/components/panel_item.tsx
+++ b/app/screens/edit_profile/components/panel_item.tsx
@@ -71,7 +71,7 @@ const PanelItem = ({pickerAction, pictureUtils, onRemoveProfileImage}: PanelItem
 
     return (
         <SlideUpPanelItem
-            icon={item.icon}
+            leftIcon={item.icon}
             onPress={item.onPress}
             testID={item.testID}
             text={intl.formatMessage(item.text)}

--- a/app/screens/home/account/components/options/user_presence/index.tsx
+++ b/app/screens/home/account/components/options/user_presence/index.tsx
@@ -78,8 +78,8 @@ const UserStatus = ({currentUser}: Props) => {
                         </View>
                     )}
                     <SlideUpPanelItem
-                        icon='check-circle'
-                        iconStyles={{color: theme.onlineIndicator}}
+                        leftIcon='check-circle'
+                        leftIconStyles={{color: theme.onlineIndicator}}
                         onPress={() => setUserStatus(ONLINE)}
                         testID='user_status.online.option'
                         text={intl.formatMessage({
@@ -89,8 +89,8 @@ const UserStatus = ({currentUser}: Props) => {
                         textStyles={styles.label}
                     />
                     <SlideUpPanelItem
-                        icon='clock'
-                        iconStyles={{color: theme.awayIndicator}}
+                        leftIcon='clock'
+                        leftIconStyles={{color: theme.awayIndicator}}
                         onPress={() => setUserStatus(AWAY)}
                         testID='user_status.away.option'
                         text={intl.formatMessage({
@@ -100,8 +100,8 @@ const UserStatus = ({currentUser}: Props) => {
                         textStyles={styles.label}
                     />
                     <SlideUpPanelItem
-                        icon='minus-circle'
-                        iconStyles={{color: theme.dndIndicator}}
+                        leftIcon='minus-circle'
+                        leftIconStyles={{color: theme.dndIndicator}}
                         onPress={() => setUserStatus(DND)}
                         testID='user_status.dnd.option'
                         text={intl.formatMessage({
@@ -111,8 +111,8 @@ const UserStatus = ({currentUser}: Props) => {
                         textStyles={styles.label}
                     />
                     <SlideUpPanelItem
-                        icon='circle-outline'
-                        iconStyles={{color: changeOpacity('#B8B8B8', 0.64)}}
+                        leftIcon='circle-outline'
+                        leftIconStyles={{color: changeOpacity('#B8B8B8', 0.64)}}
                         onPress={() => setUserStatus(OFFLINE)}
                         testID='user_status.offline.option'
                         text={intl.formatMessage({

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -435,6 +435,7 @@
   "mobile.calls_ended_at": "Ended at",
   "mobile.calls_error_message": "Error: {error}",
   "mobile.calls_error_title": "Error",
+  "mobile.calls_headset": "Headset",
   "mobile.calls_host": "host",
   "mobile.calls_host_rec": "You are recording this meeting. Consider letting everyone know that this meeting is being recorded.",
   "mobile.calls_host_rec_error": "Please try to record again. You can also contact your system admin for troubleshooting help.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@formatjs/intl-relativetimeformat": "11.2.4",
         "@gorhom/bottom-sheet": "4.4.7",
         "@mattermost/calls": "github:mattermost/calls-common#v0.17.0",
-        "@mattermost/compass-icons": "0.1.37",
+        "@mattermost/compass-icons": "0.1.38",
         "@mattermost/react-native-emm": "1.3.5",
         "@mattermost/react-native-network-client": "1.4.1",
         "@mattermost/react-native-paste-input": "0.6.4",
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/@mattermost/compass-icons": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.37.tgz",
-      "integrity": "sha512-4me1W0hj1nu8A1gpdQA6cij/hyb2P7uIYMJQ+xrNvn5ImTRfQ67LEdyNOa/LY+oT1NO2ui6kKOs8oLUehIaneg=="
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.38.tgz",
+      "integrity": "sha512-JfLQJtvxD++7lw+jiLWs55+SOhF8wPQgfTCOEi/uyl9bRxfY736a9fPzRcRJwF80se7lPMxvAx8itwvTz0o7CQ=="
     },
     "node_modules/@mattermost/react-native-emm": {
       "version": "1.3.5",
@@ -25415,9 +25415,9 @@
       }
     },
     "@mattermost/compass-icons": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.37.tgz",
-      "integrity": "sha512-4me1W0hj1nu8A1gpdQA6cij/hyb2P7uIYMJQ+xrNvn5ImTRfQ67LEdyNOa/LY+oT1NO2ui6kKOs8oLUehIaneg=="
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.38.tgz",
+      "integrity": "sha512-JfLQJtvxD++7lw+jiLWs55+SOhF8wPQgfTCOEi/uyl9bRxfY736a9fPzRcRJwF80se7lPMxvAx8itwvTz0o7CQ=="
     },
     "@mattermost/react-native-emm": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@formatjs/intl-relativetimeformat": "11.2.4",
     "@gorhom/bottom-sheet": "4.4.7",
     "@mattermost/calls": "github:mattermost/calls-common#v0.17.0",
-    "@mattermost/compass-icons": "0.1.37",
+    "@mattermost/compass-icons": "0.1.38",
     "@mattermost/react-native-emm": "1.3.5",
     "@mattermost/react-native-network-client": "1.4.1",
     "@mattermost/react-native-paste-input": "0.6.4",


### PR DESCRIPTION
#### Summary
- Some users reported a problem with support for wired headsets, so this PR adds them as a supported output option.
- The support differs in Android vs iOS:
  - In Android, wired headset will override the earpiece, so remove that option when it's plugged in.
  - In iOS it's a bit more complicated. The wired headset will override the earpiece too, but bluetooth will take over from both if it's plugged in. Since we don't have a way to detect if bluetooth is active (in native coed we _can_ check if it's available as an output, but not if it's currently active), we will continue to use the speakerphone button as a toggle -- if the speakerphone toggle is active, speakerphone overrides whatever you have. If speakerphone is not toggled, then bluetooth, or wired headset, or earpiece will be active (depending on what is active on your phone).
- @matthewbirtch added a new headset icon for this PR, thank you.
- Added a checkmark to the bottom sheet's options. 
  - This required generalizing the panel_item to take a left and a right icon.

|headset active|the new bottom sheet|
|--|--|
| ![Screenshot_20230912-161057](https://github.com/mattermost/mattermost-mobile/assets/1490756/359f2a9c-0633-4108-aeac-5ca59f47acbe) | ![Screenshot_20230912-161047](https://github.com/mattermost/mattermost-mobile/assets/1490756/557ff592-ad75-419d-9059-7ded04180b13) |


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-54117

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- Android: 13, Galaxy Tab s7+
- iOS: 16.5.1, iPhone 14

#### Release Note
```release-note
Calls: Added wired headset support as an option in the Android build. iOS supports wired headset as the non-speakerphone output.
```