### PR TITLE
Fix can not reconnect websocket after turn off then turn on wifi. Thi…

### DIFF
--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -229,6 +229,7 @@ export default class WebSocketClient {
         });
 
         this.conn!.onError((evt: any) => {
+            this.conn = undefined;
             if (evt.url === this.url) {
                 this.hasReliablyReconnect = false;
                 if (this.connectFailCount <= 1) {

--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -15,6 +15,7 @@ const MAX_WEBSOCKET_FAILS = 7;
 const WEBSOCKET_TIMEOUT = toMilliseconds({seconds: 30});
 const MIN_WEBSOCKET_RETRY_TIME = toMilliseconds({seconds: 3});
 const MAX_WEBSOCKET_RETRY_TIME = toMilliseconds({minutes: 5});
+const ERROR_UNKNOWN_HOST = 'UnknownHostException';
 
 export default class WebSocketClient {
     private conn?: WebSocketClientInterface;
@@ -229,7 +230,10 @@ export default class WebSocketClient {
         });
 
         this.conn!.onError((evt: any) => {
-            this.conn = undefined;
+            if (evt?.message?.error?.includes(ERROR_UNKNOWN_HOST)) {
+                this.conn = undefined;
+            }
+
             if (evt.url === this.url) {
                 this.hasReliablyReconnect = false;
                 if (this.connectFailCount <= 1) {


### PR DESCRIPTION
#### Summary
On some Samsung devices, when turning off and then turning on Wi-Fi (or when Wi-Fi is not stable), it cannot auto-reconnect.

#### Ticket Link
none

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
Android - Samsung galaxy s10 plus - Android 12

#### Screenshots
**Before fix:**
- 4G on => 4G off => 4G on: ✅ 
- 4G on => 4G off => Wifi on: ✅ 
- Wifi on => Wifi off => Wifi on: ❌ 
- Wifi on => Wifi off => 4G on: ❌

https://github.com/mattermost/mattermost-mobile/assets/28721870/270e9398-7999-49fe-be57-87e8a542d6ec


**After fix:**
- 4G on => 4G off => 4G on: ✅ 
- 4G on => 4G off => Wifi on: ✅ 
- Wifi on => Wifi off => Wifi on: ✅ 
- Wifi on => Wifi off => 4G on: ✅ 

https://github.com/mattermost/mattermost-mobile/assets/28721870/224cf957-40d4-487f-946b-02a04fa4a67e


#### Release Note
```release-note
Fix cannot auto-reconnect websocket after when turning off and then turning on Wi-Fi (or when Wi-Fi is not stable) on some Samsung device
```