### PR TITLE
Fix handlePreferences warning

### DIFF
--- a/app/database/operator/server_data_operator/handlers/user.ts
+++ b/app/database/operator/server_data_operator/handlers/user.ts
@@ -37,13 +37,15 @@ const UserHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
      */
     handlePreferences = async ({preferences, prepareRecordsOnly = true, sync = false}: HandlePreferencesArgs): Promise<PreferenceModel[]> => {
         const records: PreferenceModel[] = [];
-        const filtered = filterPreferences(preferences);
-        if (!filtered?.length) {
+
+        if (!preferences?.length) {
             logWarning(
                 'An empty or undefined "preferences" array has been passed to the handlePreferences method',
             );
             return records;
         }
+
+        const filtered = filterPreferences(preferences);
 
         // WE NEED TO SYNC THE PREFS FROM WHAT WE GOT AND WHAT WE HAVE
         const deleteValues: PreferenceModel[] = [];

--- a/app/helpers/api/preference.ts
+++ b/app/helpers/api/preference.ts
@@ -53,8 +53,8 @@ export function getSidebarPreferenceAsBool(preferences: Preference[], name: stri
     return getPreferenceAsBool(preferences, Preferences.CATEGORIES.SIDEBAR_SETTINGS, name, defaultValue);
 }
 
-export function filterPreferences(preferences?: PreferenceType[]) {
-    if (!preferences?.length) {
+export function filterPreferences(preferences: PreferenceType[]) {
+    if (!preferences.length) {
         return preferences;
     }
 


### PR DESCRIPTION
#### Summary
This warning is logged frequently in my development environment, and it's a bit noisy. I also noticed that the warning message isn't accurate, so I changed it to only log that warning when the input array is actually empty.

#### Device Information
This PR was tested on: iOS Simulator (various)

#### Release Note
```release-note
NONE
```
