### PR TITLE
Fix reply from permalink

### DIFF
--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -94,14 +94,7 @@ export const switchToThread = async (serverUrl: string, rootId: string, isFromNo
             }
         }
 
-        if (currentTeamId === teamId) {
-            const models = await prepareCommonSystemValues(operator, {
-                currentChannelId: channel.id,
-            });
-            if (models.length) {
-                await operator.batchRecords(models, 'switchToThread');
-            }
-        } else {
+        if (currentTeamId !== teamId) {
             const modelPromises: Array<Promise<Model[]>> = [];
             modelPromises.push(addTeamToTeamHistory(operator, teamId, true));
             const commonValues: PrepareCommonSystemValuesArgs = {


### PR DESCRIPTION
#### Summary
When opening the reply screen from a permalink, keep the current channel unless the team changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54969

#### Release Note
```release-note
Fixed remain in current channel when replying a post from the permalink view
```