### PR TITLE
Update supported ESR version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mattermost Mobile v2
 
-- **Minimum Server versions:** Current ESR version (7.8.0+)
+- **Minimum Server versions:** Current ESR version (8.1.0+)
 - **Supported iOS versions:** 12.4+
 - **Supported Android versions:** 7.0+
 

--- a/app/constants/supported_server.ts
+++ b/app/constants/supported_server.ts
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 export const MIN_REQUIRED_VERSION = '5.26.2';
-export const FULL_VERSION = '7.8.0';
-export const MAJOR_VERSION = 7;
-export const MIN_VERSION = 8;
+export const FULL_VERSION = '8.1.0';
+export const MAJOR_VERSION = 8;
+export const MIN_VERSION = 1;
 export const PATCH_VERSION = 0;
 
 export default {

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Requires Mattermost Server v7.8.0+. Older servers may not be able to connect or have unexpected behavior.
+Requires Mattermost Server v8.1.0+. Older servers may not be able to connect or have unexpected behavior.
 
 -------
 

--- a/fastlane/metadata/changelog
+++ b/fastlane/metadata/changelog
@@ -1,4 +1,4 @@
-This version is compatible with Mattermost servers v7.8.0+.
+This version is compatible with Mattermost servers v8.1.0+.
 
 Please see [changelog](https://docs.mattermost.com/administration/mobile-changelog.html) for full release notes. If you're interested in helping beta test upcoming versions before they are released, please see our [documentation](https://github.com/mattermost/mattermost-mobile#testing).
 


### PR DESCRIPTION
v7.8 ESR is going out of support on November 15th.

Ticket
https://mattermost.atlassian.net/browse/MM-54992

```release-note
Updated minimum supported version to v8.1.0.
```