### PR TITLE
MM-55010  - Calls: more messages bar adjustments

### DIFF
--- a/app/components/post_list/more_messages/more_messages.tsx
+++ b/app/components/post_list/more_messages/more_messages.tsx
@@ -7,17 +7,11 @@ import Animated, {interpolate, useAnimatedStyle, useSharedValue, withSpring} fro
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {resetMessageCount} from '@actions/local/channel';
-import {useCallsState, useChannelsWithCalls, useCurrentCall, useGlobalCallsState, useIncomingCalls} from '@calls/state';
+import {useCallsAdjustment} from '@app/products/calls/hooks';
 import CompassIcon from '@components/compass_icon';
 import FormattedText from '@components/formatted_text';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {Events} from '@constants';
-import {
-    CALL_ERROR_BAR_HEIGHT,
-    CALL_NOTIFICATION_BAR_HEIGHT,
-    CURRENT_CALL_BAR_HEIGHT,
-    JOIN_CALL_BAR_HEIGHT,
-} from '@constants/view';
 import {useServerUrl} from '@context/server';
 import useDidUpdate from '@hooks/did_update';
 import EphemeralStore from '@store/ephemeral_store';
@@ -129,28 +123,7 @@ const MoreMessages = ({
     const underlayColor = useMemo(() => `hsl(${hexToHue(theme.buttonBg)}, 50%, 38%)`, [theme]);
     const styles = getStyleSheet(theme);
     const top = useSharedValue(0);
-
-    // Calls state
-    const incomingCalls = useIncomingCalls().incomingCalls;
-    const channelsWithCalls = useChannelsWithCalls(serverUrl);
-    const callsState = useCallsState(serverUrl);
-    const globalCallsState = useGlobalCallsState();
-    const currentCall = useCurrentCall();
-    const dismissed = Boolean(callsState.calls[channelId]?.dismissed[callsState.myUserId]);
-    const inCurrentCall = currentCall?.id === channelId;
-    const joinCallBannerVisible = Boolean(channelsWithCalls[channelId]) && !dismissed && !inCurrentCall;
-
-    // Do we have calls banners?
-    const currentCallBarVisible = Boolean(currentCall);
-    const micPermissionsError = !globalCallsState.micPermissionsGranted && (currentCall && !currentCall.micPermissionsErrorDismissed);
-    const callQualityAlert = Boolean(currentCall?.callQualityAlert);
-    const incomingCallsShowing = incomingCalls.filter((ic) => ic.channelID !== channelId);
-    const callsIncomingAdjustment = (incomingCallsShowing.length * CALL_NOTIFICATION_BAR_HEIGHT) + (incomingCallsShowing.length * 8);
-    const callsAdjustment = (currentCallBarVisible ? CURRENT_CALL_BAR_HEIGHT + 8 : 0) +
-        (micPermissionsError ? CALL_ERROR_BAR_HEIGHT + 8 : 0) +
-        (callQualityAlert ? CALL_ERROR_BAR_HEIGHT + 8 : 0) +
-        (joinCallBannerVisible ? JOIN_CALL_BAR_HEIGHT + 8 : 0) +
-        callsIncomingAdjustment;
+    const callsAdjustment = useCallsAdjustment(serverUrl, channelId);
 
     // The final top:
     const adjustedTop = insets.top + callsAdjustment;

--- a/app/components/post_list/more_messages/more_messages.tsx
+++ b/app/components/post_list/more_messages/more_messages.tsx
@@ -96,7 +96,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             flexDirection: 'row',
         },
         textContainer: {
-            paddingLeft: 4,
+            marginLeft: 8,
         },
         text: {
             color: theme.buttonColor,

--- a/app/components/post_list/more_messages/more_messages.tsx
+++ b/app/components/post_list/more_messages/more_messages.tsx
@@ -144,7 +144,8 @@ const MoreMessages = ({
     const currentCallBarVisible = Boolean(currentCall);
     const micPermissionsError = !globalCallsState.micPermissionsGranted && (currentCall && !currentCall.micPermissionsErrorDismissed);
     const callQualityAlert = Boolean(currentCall?.callQualityAlert);
-    const callsIncomingAdjustment = (incomingCalls.length * CALL_NOTIFICATION_BAR_HEIGHT) + (incomingCalls.length * 8);
+    const incomingCallsShowing = incomingCalls.filter((ic) => ic.channelID !== channelId);
+    const callsIncomingAdjustment = (incomingCallsShowing.length * CALL_NOTIFICATION_BAR_HEIGHT) + (incomingCallsShowing.length * 8);
     const callsAdjustment = (currentCallBarVisible ? CURRENT_CALL_BAR_HEIGHT + 8 : 0) +
         (micPermissionsError ? CALL_ERROR_BAR_HEIGHT + 8 : 0) +
         (callQualityAlert ? CALL_ERROR_BAR_HEIGHT + 8 : 0) +

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -52,7 +52,6 @@ type Props = {
     header?: ReactElement;
     testID: string;
     currentCallBarVisible?: boolean;
-    joinCallBannerVisible?: boolean;
     savedPostIds: Set<string>;
 }
 
@@ -111,8 +110,6 @@ const PostList = ({
     showMoreMessages,
     showNewMessageLine = true,
     testID,
-    currentCallBarVisible,
-    joinCallBannerVisible,
     savedPostIds,
 }: Props) => {
     const listRef = useRef<FlatList<string | PostModel>>(null);
@@ -377,8 +374,6 @@ const PostList = ({
                 scrollToIndex={scrollToIndex}
                 theme={theme}
                 testID={`${testID}.more_messages_button`}
-                currentCallBarVisible={Boolean(currentCallBarVisible)}
-                joinCallBannerVisible={Boolean(joinCallBannerVisible)}
             />
             }
         </>

--- a/app/products/calls/components/floating_call_container.tsx
+++ b/app/products/calls/components/floating_call_container.tsx
@@ -8,11 +8,9 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import CurrentCallBar from '@calls/components/current_call_bar';
 import {IncomingCallsContainer} from '@calls/components/incoming_calls_container';
 import JoinCallBanner from '@calls/components/join_call_banner';
-import {DEFAULT_HEADER_HEIGHT} from '@constants/view';
+import {DEFAULT_HEADER_HEIGHT, TABLET_HEADER_HEIGHT} from '@constants/view';
 import {useServerUrl} from '@context/server';
 import {useIsTablet} from '@hooks/device';
-
-const topBarHeight = DEFAULT_HEADER_HEIGHT;
 
 const style = StyleSheet.create({
     wrapper: {
@@ -36,9 +34,10 @@ const FloatingCallContainer = ({channelId, showJoinCallBanner, showIncomingCalls
     const insets = useSafeAreaInsets();
     const isTablet = useIsTablet();
 
-    const topBarIsIncludedAlready = Boolean(isTablet || threadScreen);
+    const topBarForTablet = (isTablet && !threadScreen) ? TABLET_HEADER_HEIGHT : 0;
+    const topBarChannel = (!isTablet && !threadScreen) ? DEFAULT_HEADER_HEIGHT : 0;
     const wrapperTop = {
-        top: insets.top + (topBarIsIncludedAlready ? 0 : topBarHeight),
+        top: insets.top + topBarForTablet + topBarChannel,
     };
 
     return (

--- a/app/products/calls/hooks.ts
+++ b/app/products/calls/hooks.ts
@@ -8,8 +8,9 @@ import {useIntl} from 'react-intl';
 import {Alert, Platform} from 'react-native';
 import Permissions from 'react-native-permissions';
 
+import {CALL_ERROR_BAR_HEIGHT, CALL_NOTIFICATION_BAR_HEIGHT, CURRENT_CALL_BAR_HEIGHT, JOIN_CALL_BAR_HEIGHT} from '@app/constants/view';
 import {initializeVoiceTrack} from '@calls/actions/calls';
-import {setMicPermissionsGranted} from '@calls/state';
+import {setMicPermissionsGranted, useCallsState, useChannelsWithCalls, useCurrentCall, useGlobalCallsState, useIncomingCalls} from '@calls/state';
 import {errorAlert} from '@calls/utils';
 import {useServerUrl} from '@context/server';
 import {useAppState} from '@hooks/device';
@@ -107,4 +108,28 @@ export const usePermissionsChecker = (micPermissionsGranted: boolean) => {
             asyncFn();
         }
     }, [appState]);
+};
+
+export const useCallsAdjustment = (serverUrl: string, channelId: string) => {
+    const incomingCalls = useIncomingCalls().incomingCalls;
+    const channelsWithCalls = useChannelsWithCalls(serverUrl);
+    const callsState = useCallsState(serverUrl);
+    const globalCallsState = useGlobalCallsState();
+    const currentCall = useCurrentCall();
+    const dismissed = Boolean(callsState.calls[channelId]?.dismissed[callsState.myUserId]);
+    const inCurrentCall = currentCall?.id === channelId;
+    const joinCallBannerVisible = Boolean(channelsWithCalls[channelId]) && !dismissed && !inCurrentCall;
+
+    // Do we have calls banners?
+    const currentCallBarVisible = Boolean(currentCall);
+    const micPermissionsError = !globalCallsState.micPermissionsGranted && (currentCall && !currentCall.micPermissionsErrorDismissed);
+    const callQualityAlert = Boolean(currentCall?.callQualityAlert);
+    const incomingCallsShowing = incomingCalls.filter((ic) => ic.channelID !== channelId);
+    const callsIncomingAdjustment = (incomingCallsShowing.length * CALL_NOTIFICATION_BAR_HEIGHT) + (incomingCallsShowing.length * 8);
+    const callsAdjustment = (currentCallBarVisible ? CURRENT_CALL_BAR_HEIGHT + 8 : 0) +
+        (micPermissionsError ? CALL_ERROR_BAR_HEIGHT + 8 : 0) +
+        (callQualityAlert ? CALL_ERROR_BAR_HEIGHT + 8 : 0) +
+        (joinCallBannerVisible ? JOIN_CALL_BAR_HEIGHT + 8 : 0) +
+        callsIncomingAdjustment;
+    return callsAdjustment;
 };

--- a/app/screens/channel/channel.tsx
+++ b/app/screens/channel/channel.tsx
@@ -131,8 +131,6 @@ const Channel = ({
                         <ChannelPostList
                             channelId={channelId}
                             nativeID={channelId}
-                            currentCallBarVisible={isInACall}
-                            joinCallBannerVisible={showJoinCallBanner}
                         />
                     </View>
                     <PostDraft

--- a/app/screens/channel/channel_post_list/channel_post_list.tsx
+++ b/app/screens/channel/channel_post_list/channel_post_list.tsx
@@ -29,8 +29,6 @@ type Props = {
     nativeID: string;
     posts: PostModel[];
     shouldShowJoinLeaveMessages: boolean;
-    currentCallBarVisible: boolean;
-    joinCallBannerVisible: boolean;
 }
 
 const edges: Edge[] = ['bottom'];
@@ -42,7 +40,6 @@ const styles = StyleSheet.create({
 const ChannelPostList = ({
     channelId, contentContainerStyle, isCRTEnabled,
     lastViewedAt, nativeID, posts, shouldShowJoinLeaveMessages,
-    currentCallBarVisible, joinCallBannerVisible,
 }: Props) => {
     const appState = useAppState();
     const isTablet = useIsTablet();
@@ -110,8 +107,6 @@ const ChannelPostList = ({
             shouldShowJoinLeaveMessages={shouldShowJoinLeaveMessages}
             showMoreMessages={true}
             testID='channel.post_list'
-            currentCallBarVisible={currentCallBarVisible}
-            joinCallBannerVisible={joinCallBannerVisible}
         />
     );
 


### PR DESCRIPTION
#### Summary
- Implements new design for more_messages bar (https://www.figma.com/file/WVbRdxA4aRFdw410j2DxxU/MM-51513-Ringing-in-DMs%2C-GMs-(Mobile)?type=design&node-id=1378-95706&mode=design&t=CoxDrNZEd8wk9Y0B-0)
- Tried to clarify how spacing is calculated
- Refactored to remove some of the props.
- More messages bar now correctly handles all the variations of calls banners.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-55010

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- Android: 13, Galaxy Tab s7+
- iOS: 16.5.1, iPhone 14

#### Screenshots

# iOS

| channel screen by itself | thread screen by itself |
|--|--|
| ![IMG_1338](https://github.com/mattermost/mattermost-mobile/assets/1490756/f68d84e4-e5be-4a02-a4cd-16e0ac43a498) | ![IMG_1339](https://github.com/mattermost/mattermost-mobile/assets/1490756/45c1bdfa-cb71-488b-87d6-fe25d5178879) |






| channel screen calls banners | thread screen calls banners |
|--|--|
| ![IMG_1340](https://github.com/mattermost/mattermost-mobile/assets/1490756/64d88956-3868-4527-942b-0e406b5c7cd4) | ![IMG_1341](https://github.com/mattermost/mattermost-mobile/assets/1490756/44b44be9-24be-48b7-aaa5-c0f754f2acf8) |



# Android phone

| channel screen by itself | thread screen by itself |
|--|--|
| ![Screenshot_20231019-153124](https://github.com/mattermost/mattermost-mobile/assets/1490756/dffe63f8-f4e5-4405-b997-7abc9bd3f498) | ![Screenshot_20231019-153108](https://github.com/mattermost/mattermost-mobile/assets/1490756/0fd9938b-7094-4e55-8e7a-55e3c1e89b1d) | 


| channel screen calls banners | thread screen calls banners |
|--|--|
| ![Screenshot_20231019-161742](https://github.com/mattermost/mattermost-mobile/assets/1490756/fd445393-44e3-48a0-bf51-c82caa5f6241) | ![Screenshot_20231019-161802](https://github.com/mattermost/mattermost-mobile/assets/1490756/7617abd4-c3a6-4f63-8f13-1eea9a4ffadd) |




# Android tablet

| channel screen by itself | thread screen by itself |
|--|--|
| ![Screenshot_20231019_150546_Mattermost Beta](https://github.com/mattermost/mattermost-mobile/assets/1490756/fb582753-ba0f-4a52-bb6c-5c355ff3613b) | ![Screenshot_20231019_160043_Mattermost Beta](https://github.com/mattermost/mattermost-mobile/assets/1490756/14eddc32-5539-4613-8313-ef49a61dfdf2) |



| channel screen calls banners | thread screen calls banners |
|--|--|
| ![Screenshot_20231019_163044_Mattermost Beta](https://github.com/mattermost/mattermost-mobile/assets/1490756/8aa715da-22cc-4d36-aaca-935ca6b25f01) | ![Screenshot_20231019_162612_Mattermost Beta](https://github.com/mattermost/mattermost-mobile/assets/1490756/a283e72c-c3cd-4e56-8fec-8085acbe5a29) |





#### Release Note
```release-note
Calls: fixed more messages bar; small redesign for consistency with calls banners.
```

