### PR TITLE
MM-54887 Fix category order being reversed after moving a channel

### DIFF
--- a/app/database/models/server/category.ts
+++ b/app/database/models/server/category.ts
@@ -120,7 +120,7 @@ export default class CategoryModel extends Model implements CategoryInterface {
     toCategoryWithChannels = async (): Promise<CategoryWithChannels> => {
         const categoryChannels = await this.categoryChannels.fetch();
         const orderedChannelIds = categoryChannels.sort((a, b) => {
-            return b.sortOrder - a.sortOrder;
+            return a.sortOrder - b.sortOrder;
         }).map((cc) => cc.channelId);
 
         return {


### PR DESCRIPTION
#### Summary
`toCategoryWithChannels` is used by code that moves channels between categories which only happens on mobile for newly created/joined channels and when favouriting/unfavouriting channels. Currently, it returns channels in reversed order, so existing channels in that category get reversed when either of those are done.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54887

#### Device Information
This PR was tested on: iOS Simulator

#### Release Note
```release-note
Fixed channel order in category being reversed after favoriting or unfavoriting a channel
```
