### PR TITLE
Fix recent sorting difference with webapp

### DIFF
--- a/app/utils/categories.ts
+++ b/app/utils/categories.ts
@@ -180,7 +180,9 @@ const sortChannelsByName = (notifyPropsPerChannel: Record<string, Partial<Channe
 export const sortChannels = (sorting: CategorySorting, channelsWithMyChannel: ChannelWithMyChannel[], notifyPropsPerChannel: Record<string, Partial<ChannelNotifyProps>>, locale: string) => {
     if (sorting === 'recent') {
         return channelsWithMyChannel.sort((cwmA, cwmB) => {
-            return cwmB.myChannel.lastPostAt - cwmA.myChannel.lastPostAt;
+            const a = Math.max(cwmA.myChannel.lastPostAt, cwmA.channel.createAt);
+            const b = Math.max(cwmB.myChannel.lastPostAt, cwmB.channel.createAt);
+            return b - a;
         }).map((cwm) => cwm.channel);
     } else if (sorting === 'manual') {
         return channelsWithMyChannel.sort((cwmA, cwmB) => {


### PR DESCRIPTION
#### Summary
Specially for DMs with no posts opened by yourself, the "recent" order on webapp and mobile was different.

Why is that? Because mobile only considers the last post at, while webapp considers the createAt too.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-55144

#### Release Note
```release-note
Minor fix on channel order by recency
```
