### PR TITLE
[MM-54529] Prevent Persistent Notifications Error Message for DM Channel

### DIFF
--- a/app/components/post_draft/draft_input/index.tsx
+++ b/app/components/post_draft/draft_input/index.tsx
@@ -164,7 +164,7 @@ export default function DraftInput({
 
     const handleSendMessage = useCallback(async () => {
         if (persistenNotificationsEnabled) {
-            persistentNotificationsConfirmation(serverUrl, value, mentionsList, intl, sendMessage, persistentNotificationMaxRecipients, persistentNotificationInterval);
+            persistentNotificationsConfirmation(serverUrl, value, mentionsList, intl, sendMessage, persistentNotificationMaxRecipients, persistentNotificationInterval, channelType);
         } else {
             sendMessage();
         }

--- a/app/components/post_draft/draft_input/index.tsx
+++ b/app/components/post_draft/draft_input/index.tsx
@@ -147,28 +147,28 @@ export default function DraftInput({
     const sendActionTestID = `${testID}.send_action`;
     const style = getStyleSheet(theme);
 
-    const persistenNotificationsEnabled = postPriority.persistent_notifications && postPriority.priority === PostPriorityType.URGENT;
+    const persistentNotificationsEnabled = postPriority.persistent_notifications && postPriority.priority === PostPriorityType.URGENT;
     const {noMentionsError, mentionsList} = useMemo(() => {
         let error = false;
         let mentions: string[] = [];
         if (
             channelType !== General.DM_CHANNEL &&
-            persistenNotificationsEnabled
+            persistentNotificationsEnabled
         ) {
             mentions = (value.match(MENTIONS_REGEX) || []);
             error = mentions.length === 0;
         }
 
         return {noMentionsError: error, mentionsList: mentions};
-    }, [channelType, persistenNotificationsEnabled, value]);
+    }, [channelType, persistentNotificationsEnabled, value]);
 
     const handleSendMessage = useCallback(async () => {
-        if (persistenNotificationsEnabled) {
+        if (persistentNotificationsEnabled) {
             persistentNotificationsConfirmation(serverUrl, value, mentionsList, intl, sendMessage, persistentNotificationMaxRecipients, persistentNotificationInterval, channelType);
         } else {
             sendMessage();
         }
-    }, [serverUrl, mentionsList, persistenNotificationsEnabled, persistentNotificationMaxRecipients, sendMessage, value]);
+    }, [serverUrl, mentionsList, persistentNotificationsEnabled, persistentNotificationMaxRecipients, sendMessage, value]);
 
     const sendActionDisabled = !canSend || noMentionsError;
 

--- a/app/components/post_draft/draft_input/index.tsx
+++ b/app/components/post_draft/draft_input/index.tsx
@@ -168,7 +168,7 @@ export default function DraftInput({
         } else {
             sendMessage();
         }
-    }, [serverUrl, mentionsList, persistentNotificationsEnabled, persistentNotificationMaxRecipients, sendMessage, value]);
+    }, [serverUrl, mentionsList, persistentNotificationsEnabled, persistentNotificationMaxRecipients, sendMessage, value, channelType]);
 
     const sendActionDisabled = !canSend || noMentionsError;
 

--- a/app/utils/post/index.ts
+++ b/app/utils/post/index.ts
@@ -4,7 +4,7 @@
 import {Alert, type AlertButton} from 'react-native';
 
 import {getUsersCountFromMentions} from '@actions/local/post';
-import {Post} from '@constants';
+import {General, Post} from '@constants';
 import {SPECIAL_MENTIONS_REGEX} from '@constants/autocomplete';
 import {POST_TIME_TO_FAIL} from '@constants/post';
 import {DEFAULT_LOCALE} from '@i18n';
@@ -104,7 +104,7 @@ export function hasSpecialMentions(message: string): boolean {
     return result;
 }
 
-export async function persistentNotificationsConfirmation(serverUrl: string, value: string, mentionsList: string[], intl: IntlShape, sendMessage: () => void, persistentNotificationMaxRecipients: number, persistentNotificationInterval: number) {
+export async function persistentNotificationsConfirmation(serverUrl: string, value: string, mentionsList: string[], intl: IntlShape, sendMessage: () => void, persistentNotificationMaxRecipients: number, persistentNotificationInterval: number, channelType: ChannelType) {
     let title = '';
     let description = '';
     let buttons: AlertButton[] = [{
@@ -136,7 +136,7 @@ export async function persistentNotificationsConfirmation(serverUrl: string, val
                 max: persistentNotificationMaxRecipients,
                 count: mentionsList.length,
             });
-        } else if (usersCount === 0) {
+        } else if (usersCount === 0 && channelType !== General.DM_CHANNEL) {
             title = intl.formatMessage({
                 id: 'persistent_notifications.error.no_mentions.title',
                 defaultMessage: 'Recipients must be @mentioned',
@@ -152,7 +152,7 @@ export async function persistentNotificationsConfirmation(serverUrl: string, val
             });
             description = intl.formatMessage({
                 id: 'persistent_notifications.confirm.description',
-                defaultMessage: '@mentioned recipients will be notified every {interval, plural, one {minute} other {{interval} minutes}} until they’ve acknowledged or replied to the message.',
+                defaultMessage: `${ 'R' ? channelType === General.DM_CHANNEL : '@mentioned r' }ecipients will be notified every {interval, plural, one {minute} other {{interval} minutes}} until they’ve acknowledged or replied to the message.`,
             }, {
                 interval: persistentNotificationInterval,
             });

--- a/app/utils/post/index.ts
+++ b/app/utils/post/index.ts
@@ -152,7 +152,7 @@ export async function persistentNotificationsConfirmation(serverUrl: string, val
             });
             description = intl.formatMessage({
                 id: 'persistent_notifications.confirm.description',
-                defaultMessage: `${ 'R' ? channelType === General.DM_CHANNEL : '@mentioned r' }ecipients will be notified every {interval, plural, one {minute} other {{interval} minutes}} until they’ve acknowledged or replied to the message.`,
+                defaultMessage: '@mentioned recipients will be notified every {interval, plural, one {minute} other {{interval} minutes}} until they’ve acknowledged or replied to the message.',
             }, {
                 interval: persistentNotificationInterval,
             });

--- a/app/utils/post/index.ts
+++ b/app/utils/post/index.ts
@@ -104,7 +104,7 @@ export function hasSpecialMentions(message: string): boolean {
     return result;
 }
 
-export async function persistentNotificationsConfirmation(serverUrl: string, value: string, mentionsList: string[], intl: IntlShape, sendMessage: () => void, persistentNotificationMaxRecipients: number, persistentNotificationInterval: number, channelType: ChannelType) {
+export async function persistentNotificationsConfirmation(serverUrl: string, value: string, mentionsList: string[], intl: IntlShape, sendMessage: () => void, persistentNotificationMaxRecipients: number, persistentNotificationInterval: number, channelType?: ChannelType) {
     let title = '';
     let description = '';
     let buttons: AlertButton[] = [{


### PR DESCRIPTION
#### Summary
Added condition so 'Recipients must be @mentioned' no longer appears for messages sent in DM channel when **Apply**ing **Send persistent notifications** was chosen by selecting the **Message Priority**<img src="https://docs.mattermost.com/_images/Priority-Message-Icon.svg" width=20/> on [Enterprise and Professional plans](https://docs.mattermost.com/collaborate/message-priority.html)  like below:
   <img src="https://github.com/mattermost/mattermost-mobile/assets/26387877/a949a8e5-40e9-4e83-a442-34bca2dca8dd" width=350>

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-mobile/issues/25116
Jira https://mattermost.atlassian.net/browse/MM-54529

#### Checklist
- [x] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: Android emulator

before | after
-|-
<img width="97" alt="Screenshot 2023-11-21 at 5 34 58 AM" src="https://github.com/mattermost/mattermost-mobile/assets/26387877/7b731268-2e95-4bc4-9597-d39ac37b171f">|<img width="100" alt="Screenshot 2023-11-21 at 5 35 37 AM" src="https://github.com/mattermost/mattermost-mobile/assets/26387877/2be6464b-7045-4936-9ac3-beda96e7b0b0">


#### Release Note
```release-note
Added channelType param to persistentNotificationsConfirmation.
```
