### PR TITLE
Improves get roles by names requests to batch them following the new endpoint limit

### DIFF
--- a/app/constants/general.ts
+++ b/app/constants/general.ts
@@ -32,6 +32,7 @@ export default {
     MAX_USERS_IN_GM: 7,
     MIN_USERS_IN_GM: 3,
     MAX_GROUP_CHANNELS_FOR_PROFILES: 50,
+    MAX_GET_ROLES_BY_NAMES: 100,
     DEFAULT_AUTOLINKED_URL_SCHEMES: ['http', 'https', 'ftp', 'mailto', 'tel', 'mattermost'],
     PROFILE_CHUNK_SIZE: 100,
     SEARCH_TIMEOUT_MILLISECONDS: 500,


### PR DESCRIPTION
#### Summary
After adding a limit to the get roles by names endpoint, this PR updates the client's logic to batch the roles requests honoring the threshold.

Related to https://github.com/mattermost/mattermost/pull/25215

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55094

#### Release Note
```release-note
NONE
```
