### PR TITLE
MM-54277 - Calls: Add incoming banners to channel_list screen

### DIFF
--- a/app/products/calls/components/floating_call_container.tsx
+++ b/app/products/calls/components/floating_call_container.tsx
@@ -22,14 +22,22 @@ const style = StyleSheet.create({
 });
 
 type Props = {
-    channelId: string;
-    showJoinCallBanner: boolean;
-    showIncomingCalls: boolean;
-    isInACall: boolean;
+    channelId?: string;
+    showJoinCallBanner?: boolean;
+    showIncomingCalls?: boolean;
+    isInACall?: boolean;
     threadScreen?: boolean;
+    channelsScreen?: boolean;
 }
 
-const FloatingCallContainer = ({channelId, showJoinCallBanner, showIncomingCalls, isInACall, threadScreen}: Props) => {
+const FloatingCallContainer = ({
+    channelId,
+    showJoinCallBanner,
+    showIncomingCalls,
+    isInACall,
+    threadScreen,
+    channelsScreen,
+}: Props) => {
     const serverUrl = useServerUrl();
     const insets = useSafeAreaInsets();
     const isTablet = useIsTablet();
@@ -39,10 +47,13 @@ const FloatingCallContainer = ({channelId, showJoinCallBanner, showIncomingCalls
     const wrapperTop = {
         top: insets.top + topBarForTablet + topBarChannel,
     };
+    const wrapperBottom = {
+        bottom: 8,
+    };
 
     return (
-        <View style={[style.wrapper, wrapperTop]}>
-            {showJoinCallBanner &&
+        <View style={[style.wrapper, channelsScreen ? wrapperBottom : wrapperTop]}>
+            {showJoinCallBanner && channelId &&
                 <JoinCallBanner
                     serverUrl={serverUrl}
                     channelId={channelId}

--- a/app/products/calls/components/incoming_calls_container.tsx
+++ b/app/products/calls/components/incoming_calls_container.tsx
@@ -15,7 +15,7 @@ const style = StyleSheet.create({
 });
 
 type Props = {
-    channelId: string;
+    channelId?: string;
 }
 
 export const IncomingCallsContainer = ({

--- a/app/screens/home/channel_list/channel_list.tsx
+++ b/app/screens/home/channel_list/channel_list.tsx
@@ -10,6 +10,7 @@ import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
 import {type Edge, SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {refetchCurrentUser} from '@actions/remote/user';
+import FloatingCallContainer from '@calls/components/floating_call_container';
 import AnnouncementBanner from '@components/announcement_banner';
 import ConnectionBanner from '@components/connection_banner';
 import TeamSidebar from '@components/team_sidebar';
@@ -40,6 +41,7 @@ type ChannelProps = {
     coldStart?: boolean;
     currentUserId?: string;
     hasCurrentUser: boolean;
+    showIncomingCalls: boolean;
 };
 
 const edges: Edge[] = ['bottom', 'left', 'right'];
@@ -196,6 +198,12 @@ const ChannelListScreen = (props: ChannelProps) => {
                         />
                         {isTablet &&
                             <AdditionalTabletView/>
+                        }
+                        {props.showIncomingCalls && !isTablet &&
+                            <FloatingCallContainer
+                                showIncomingCalls={props.showIncomingCalls}
+                                channelsScreen={true}
+                            />
                         }
                     </Animated.View>
                 </View>

--- a/app/screens/home/channel_list/index.ts
+++ b/app/screens/home/channel_list/index.ts
@@ -6,6 +6,7 @@ import withObservables from '@nozbe/with-observables';
 import {of as of$} from 'rxjs';
 import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
+import {observeIncomingCalls} from '@calls/state';
 import {queryAllMyChannelsForTeam} from '@queries/servers/channel';
 import {observeCurrentTeamId, observeCurrentUserId, observeLicense} from '@queries/servers/system';
 import {queryMyTeams} from '@queries/servers/team';
@@ -23,6 +24,11 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     );
 
     const teamsCount = queryMyTeams(database).observeCount(false);
+
+    const showIncomingCalls = observeIncomingCalls().pipe(
+        switchMap((ics) => of$(ics.incomingCalls.length > 0)),
+        distinctUntilChanged(),
+    );
 
     return {
         isCRTEnabled: observeIsCRTEnabled(database),
@@ -46,6 +52,7 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
             switchMap((u) => of$(Boolean(u))),
             distinctUntilChanged(),
         ),
+        showIncomingCalls,
     };
 });
 

--- a/app/screens/thread/index.tsx
+++ b/app/screens/thread/index.tsx
@@ -3,9 +3,9 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import withObservables from '@nozbe/with-observables';
-import {distinctUntilChanged, switchMap, combineLatest, of as of$} from 'rxjs';
+import {distinctUntilChanged, switchMap, of as of$} from 'rxjs';
 
-import {observeCallsState, observeChannelsWithCalls, observeCurrentCall, observeIncomingCalls} from '@calls/state';
+import {observeCallStateInChannel} from '@calls/observers';
 import {withServerUrl} from '@context/server';
 import {observePost} from '@queries/servers/post';
 import {observeIsCRTEnabled} from '@queries/servers/thread';
@@ -28,41 +28,10 @@ const enhanced = withObservables(['rootId'], ({database, serverUrl, rootId}: Enh
         switchMap((r) => of$(r?.channelId || '')),
         distinctUntilChanged(),
     );
-    const isCallInCurrentChannel = combineLatest([channelId, observeChannelsWithCalls(serverUrl)]).pipe(
-        switchMap(([id, calls]) => of$(Boolean(calls[id]))),
-        distinctUntilChanged(),
-    );
-    const currentCall = observeCurrentCall();
-    const ccChannelId = currentCall.pipe(
-        switchMap((call) => of$(call?.channelId)),
-        distinctUntilChanged(),
-    );
-    const isInACall = currentCall.pipe(
-        switchMap((call) => of$(Boolean(call?.connected))),
-        distinctUntilChanged(),
-    );
-    const dismissed = combineLatest([channelId, observeCallsState(serverUrl)]).pipe(
-        switchMap(([id, state]) => of$(Boolean(state.calls[id]?.dismissed[state.myUserId]))),
-        distinctUntilChanged(),
-    );
-    const isInCurrentChannelCall = combineLatest([channelId, ccChannelId]).pipe(
-        switchMap(([id, ccId]) => of$(id === ccId)),
-        distinctUntilChanged(),
-    );
-    const showJoinCallBanner = combineLatest([isCallInCurrentChannel, dismissed, isInCurrentChannelCall]).pipe(
-        switchMap(([isCall, dism, inCurrCall]) => of$(Boolean(isCall && !dism && !inCurrCall))),
-        distinctUntilChanged(),
-    );
-    const showIncomingCalls = observeIncomingCalls().pipe(
-        switchMap((ics) => of$(ics.incomingCalls.length > 0)),
-        distinctUntilChanged(),
-    );
 
     return {
         isCRTEnabled: observeIsCRTEnabled(database),
-        showJoinCallBanner,
-        isInACall,
-        showIncomingCalls,
+        ...observeCallStateInChannel(serverUrl, database, channelId),
         rootId: of$(rId),
         rootPost,
     };


### PR DESCRIPTION
#### Summary
- Adding the incoming calls banners to the channel list screen
- Took this opportunity to do some refactoring and cleanup.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-54277
- Figma: https://www.figma.com/file/WVbRdxA4aRFdw410j2DxxU/MM-51513-Ringing-in-DMs%2C-GMs-(Mobile)?type=design&node-id=1429-18525&mode=design&t=VuGgjjADk1BaJEVV-0

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- Android: 13, Galaxy Tab s7+
- iOS: 16.5.1, iPhone 14

#### Screenshots

| iOS | Android |
|--|--|
| ![IMG_63F1D1662281-1](https://github.com/mattermost/mattermost-mobile/assets/1490756/c5d64d04-05ec-493f-8f56-12c6247cacf4) | ![Screenshot_20231120-183802](https://github.com/mattermost/mattermost-mobile/assets/1490756/8b77647a-2238-4cb0-be41-cf484a4f1126) | 

Tablet:

| vertical mobile mode | tablet horizontal state | horizontal mobile state |
|--|--|--|
| ![Screenshot_20231120_183428_Mattermost Beta](https://github.com/mattermost/mattermost-mobile/assets/1490756/7a7b18d3-2e14-4dd5-8fc5-cc934dc1d94e) | ![Screenshot_20231120_183539_Mattermost Beta](https://github.com/mattermost/mattermost-mobile/assets/1490756/d459a428-d712-474c-b49c-700a2a1cb6d0) | ![Screenshot_20231120_183411_Mattermost Beta](https://github.com/mattermost/mattermost-mobile/assets/1490756/e14765b2-67ad-4b18-a74b-1de8bd9d2854) |

The `horizontal mobile state` happens when you go from vertical to horizontal, and then its stuck that way if you go back and forth (you can't get back to `tablet horizontal state`). I don't think this is a Calls-related issue, should I file a ticket  @enahum?

#### Release Note

```release-note
Calls: Incoming call notifications now appear on the channel list screen.
```
