### PR TITLE
Make app init more idempotent

### DIFF
--- a/app/init/app.ts
+++ b/app/init/app.ts
@@ -19,10 +19,6 @@ import NavigationStore from '@store/navigation_store';
 // or on the Share Extension, for example.
 let baseAppInitialized = false;
 
-// Controls whether the app initialization (websockets, screen listeners, etc...) is done, mainly
-// on app launch
-let mainAppInitialized = false;
-
 let serverCredentials: ServerCredential[];
 
 // Fallback Polyfill for Promise.allSettle
@@ -55,25 +51,19 @@ export async function initialize() {
 }
 
 export async function start() {
-    if (baseAppInitialized) {
-        // Clean relevant information on ephemeral stores
-        NavigationStore.reset();
-        EphemeralStore.setCurrentThreadId('');
-        EphemeralStore.setProcessingNotification('');
-    }
+    // Clean relevant information on ephemeral stores
+    NavigationStore.reset();
+    EphemeralStore.setCurrentThreadId('');
+    EphemeralStore.setProcessingNotification('');
 
     await initialize();
 
-    if (!mainAppInitialized) {
-        mainAppInitialized = true;
+    PushNotifications.init(serverCredentials.length > 0);
 
-        PushNotifications.init(serverCredentials.length > 0);
+    registerNavigationListeners();
+    registerScreens();
 
-        registerNavigationListeners();
-        registerScreens();
-
-        await WebsocketManager.init(serverCredentials);
-    }
+    await WebsocketManager.init(serverCredentials);
 
     initialLaunch();
 }

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -39,14 +39,13 @@ class PushNotifications {
     subscriptions?: EmitterSubscription[];
 
     init(register: boolean) {
-        if (!this.subscriptions) {
-            this.subscriptions = [
-                Notifications.events().registerNotificationOpened(this.onNotificationOpened),
-                Notifications.events().registerRemoteNotificationsRegistered(this.onRemoteNotificationsRegistered),
-                Notifications.events().registerNotificationReceivedBackground(this.onNotificationReceivedBackground),
-                Notifications.events().registerNotificationReceivedForeground(this.onNotificationReceivedForeground),
-            ];
-        }
+        this.subscriptions?.forEach((v) => v.remove());
+        this.subscriptions = [
+            Notifications.events().registerNotificationOpened(this.onNotificationOpened),
+            Notifications.events().registerRemoteNotificationsRegistered(this.onRemoteNotificationsRegistered),
+            Notifications.events().registerNotificationReceivedBackground(this.onNotificationReceivedBackground),
+            Notifications.events().registerNotificationReceivedForeground(this.onNotificationReceivedForeground),
+        ];
 
         if (register) {
             this.registerIfNeeded();

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {AppState, DeviceEventEmitter, Platform} from 'react-native';
+import {AppState, DeviceEventEmitter, Platform, type EmitterSubscription} from 'react-native';
 import {
     Notification,
     NotificationAction,
@@ -36,12 +36,17 @@ import {convertToNotificationData} from '@utils/notification';
 
 class PushNotifications {
     configured = false;
+    subscriptions?: EmitterSubscription[];
 
     init(register: boolean) {
-        Notifications.events().registerNotificationOpened(this.onNotificationOpened);
-        Notifications.events().registerRemoteNotificationsRegistered(this.onRemoteNotificationsRegistered);
-        Notifications.events().registerNotificationReceivedBackground(this.onNotificationReceivedBackground);
-        Notifications.events().registerNotificationReceivedForeground(this.onNotificationReceivedForeground);
+        if (!this.subscriptions) {
+            this.subscriptions = [
+                Notifications.events().registerNotificationOpened(this.onNotificationOpened),
+                Notifications.events().registerRemoteNotificationsRegistered(this.onRemoteNotificationsRegistered),
+                Notifications.events().registerNotificationReceivedBackground(this.onNotificationReceivedBackground),
+                Notifications.events().registerNotificationReceivedForeground(this.onNotificationReceivedForeground),
+            ];
+        }
 
         if (register) {
             this.registerIfNeeded();

--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -70,6 +70,10 @@ class WebsocketManager {
     };
 
     public createClient = (serverUrl: string, bearerToken: string, storedLastDisconnect = 0) => {
+        if (this.clients[serverUrl]) {
+            this.invalidateClient(serverUrl);
+        }
+
         const client = new WebSocketClient(serverUrl, bearerToken, storedLastDisconnect);
 
         client.setFirstConnectCallback(() => this.onFirstConnect(serverUrl));

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -36,13 +36,12 @@ export const allOrientations: LayoutOrientation[] = ['sensor', 'sensorLandscape'
 export const portraitOrientation: LayoutOrientation[] = ['portrait'];
 
 export function registerNavigationListeners() {
-    if (!subscriptions) {
-        subscriptions = [
-            Navigation.events().registerScreenPoppedListener(onPoppedListener),
-            Navigation.events().registerCommandListener(onCommandListener),
-            Navigation.events().registerComponentWillAppearListener(onScreenWillAppear),
-        ];
-    }
+    subscriptions?.forEach((v) => v.remove());
+    subscriptions = [
+        Navigation.events().registerScreenPoppedListener(onPoppedListener),
+        Navigation.events().registerCommandListener(onCommandListener),
+        Navigation.events().registerComponentWillAppearListener(onScreenWillAppear),
+    ];
 }
 
 function onCommandListener(name: string, params: any) {

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -4,8 +4,8 @@
 /* eslint-disable max-lines */
 
 import merge from 'deepmerge';
-import {Appearance, DeviceEventEmitter, NativeModules, StatusBar, Platform, Alert} from 'react-native';
-import {type ComponentWillAppearEvent, type ImageResource, type LayoutOrientation, Navigation, type Options, OptionsModalPresentationStyle, type OptionsTopBarButton, type ScreenPoppedEvent} from 'react-native-navigation';
+import {Appearance, DeviceEventEmitter, NativeModules, StatusBar, Platform, Alert, type EmitterSubscription} from 'react-native';
+import {type ComponentWillAppearEvent, type ImageResource, type LayoutOrientation, Navigation, type Options, OptionsModalPresentationStyle, type OptionsTopBarButton, type ScreenPoppedEvent, type EventSubscription} from 'react-native-navigation';
 import tinyColor from 'tinycolor2';
 
 import CompassIcon from '@components/compass_icon';
@@ -30,14 +30,19 @@ const alpha = {
     to: 1,
     duration: 150,
 };
+let subscriptions: Array<EmitterSubscription | EventSubscription> | undefined;
 
 export const allOrientations: LayoutOrientation[] = ['sensor', 'sensorLandscape', 'sensorPortrait', 'landscape', 'portrait'];
 export const portraitOrientation: LayoutOrientation[] = ['portrait'];
 
 export function registerNavigationListeners() {
-    Navigation.events().registerScreenPoppedListener(onPoppedListener);
-    Navigation.events().registerCommandListener(onCommandListener);
-    Navigation.events().registerComponentWillAppearListener(onScreenWillAppear);
+    if (!subscriptions) {
+        subscriptions = [
+            Navigation.events().registerScreenPoppedListener(onPoppedListener),
+            Navigation.events().registerCommandListener(onCommandListener),
+            Navigation.events().registerComponentWillAppearListener(onScreenWillAppear),
+        ];
+    }
 }
 
 function onCommandListener(name: string, params: any) {


### PR DESCRIPTION
#### Summary
Sometimes we receive a `inviariant violation: "Home" was not registered` error on load. The only reason for this to happen is that `registerScreens` has not been called, which shouldn't happen. The only reason I could fathom is that something in the navigation library died, but the `mainAppInitialized` variable was still set to true.

To address that (and other possible mishaps) I tried to make the start function more idempotent by:
- Storing and removing previous listeners every time we call `PushNotifications.init` or `registerNavigationListeners`
- Invalidating any websocket connection when creating a new one

`registerScreens` seems idempotent in all the tests I have made, so no changes there were needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55522

#### Release Note
```release-note
Fix "Invariant Violation: "Home" has not been registered" error when opening the app
```
