### PR TITLE
[MM-51088] fix: height for multiple line floating text input

### DIFF
--- a/app/components/floating_text_input_label/index.tsx
+++ b/app/components/floating_text_input_label/index.tsx
@@ -95,6 +95,7 @@ type FloatingTextInputProps = TextInputProps & {
     label: string;
     labelTextStyle?: TextStyle;
     multiline?: boolean;
+    multilineInputHeight?: number;
     onBlur?: (event: NativeSyntheticEvent<TargetedEvent>) => void;
     onFocus?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
     onLayout?: (e: LayoutChangeEvent) => void;
@@ -117,6 +118,7 @@ const FloatingTextInput = forwardRef<FloatingTextInputRef, FloatingTextInputProp
     label = '',
     labelTextStyle,
     multiline,
+    multilineInputHeight,
     onBlur,
     onFocus,
     onLayout,
@@ -199,21 +201,23 @@ const FloatingTextInput = forwardRef<FloatingTextInputRef, FloatingTextInputProp
         res.push(textInputStyle);
 
         if (multiline) {
-            res.push({height: 100, textAlignVertical: 'top'});
+            const height = multilineInputHeight || 100;
+            res.push({height, textAlignVertical: 'top'});
         }
 
         return res;
-    }, [styles, theme, shouldShowError, focused, textInputStyle, focusedLabel, multiline, editable]);
+    }, [styles, theme, shouldShowError, focused, textInputStyle, focusedLabel, multiline, multilineInputHeight, editable]);
 
     const combinedTextInputStyle = useMemo(() => {
         const res: StyleProp<TextStyle> = [styles.textInput, styles.input, textInputStyle];
 
         if (multiline) {
-            res.push({height: 80, textAlignVertical: 'top'});
+            const height = multilineInputHeight ? multilineInputHeight - 20 : 80;
+            res.push({height, textAlignVertical: 'top'});
         }
 
         return res;
-    }, [styles, theme, shouldShowError, focused, textInputStyle, focusedLabel, multiline, editable]);
+    }, [styles, theme, shouldShowError, focused, textInputStyle, focusedLabel, multiline, multilineInputHeight, editable]);
 
     const textAnimatedTextStyle = useAnimatedStyle(() => {
         const inputText = placeholder || value || props.defaultValue;

--- a/app/screens/settings/notification_auto_responder/notification_auto_responder.tsx
+++ b/app/screens/settings/notification_auto_responder/notification_auto_responder.tsx
@@ -117,6 +117,7 @@ const NotificationAutoResponder = ({currentUser, componentId}: NotificationAutoR
                     keyboardAppearance={getKeyboardAppearanceFromTheme(theme)}
                     label={intl.formatMessage(label)}
                     multiline={true}
+                    multilineInputHeight={154}
                     onChangeText={setAutoResponderMessage}
                     placeholder={intl.formatMessage(label)}
                     placeholderTextColor={changeOpacity(theme.centerChannelColor, 0.4)}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR fix the height of floating text input for automatic replies.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost/issues/25248

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> Android 12 - One UI Core 4.1

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
<img src="https://github.com/mattermost/mattermost-mobile/assets/72058456/4db8542f-4201-4126-945a-3dea3b432ade" width="300" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixes the height of automatic replies input text box.
```
