### PR TITLE
Fix typo: use correct base branch in PR creation

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -87,7 +87,7 @@ if [ -n "${CREATE_PR}" ]; then
   PR_TITLE="Bump app ${BUMP_BUILD_NUMBER:+build}${BUMP_VERSION_NUMBER:+${BUMP_BUILD_NUMBER:+ and }version} number"
   gh pr create \
     --repo mattermost/mattermost-mobile \
-    --base main \
+    --base "${BRANCH_TO_BUILD}" \
     --head "${GIT_LOCAL_BRANCH}" \
     --reviewer "${PR_REVIEWERS}" \
     --title "$PR_TITLE" \


### PR DESCRIPTION
#### Summary

The version bump script works, but contains a typo at PR creation time: it should try to merge the new branch against `BRANCH_TO_BUILD`, but instead always creates the PR against `main`. E.g.: https://github.com/mattermost/mattermost-mobile/pull/7719

This PR fixes that, so that we're able to fully control which branch to bump the build/version numbers for.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6707

#### Release Note

```release-note
NONE
```