### PR TITLE
MM-55649 : Fix center of LatexInline

### DIFF
--- a/app/components/markdown/markdown_latex_inline/index.tsx
+++ b/app/components/markdown/markdown_latex_inline/index.tsx
@@ -23,12 +23,15 @@ type MathViewErrorProps = {
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         mathStyle: {
-            marginVertical: 3,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
             color: theme.centerChannelColor,
         },
         viewStyle: {
             flexDirection: 'row',
-            flexWrap: 'wrap',
+            justifyContent: 'center',
+            alignItems: 'center',
         },
         errorText: {
             color: theme.errorTextColor,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Modified style properties of latex inline.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/25561
JIRA: https://mattermost.atlassian.net/browse/MM-55649

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
- Android: 14.0, Pixel 3a
- iOS: 17.0, iPhone SE (3rd generation)
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
|iOS Before|iOS After|
|---|---|
|<img width="309" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/20448972/b3c88c3f-c3fd-477b-ac0c-b6fa853d4617">|<img width="311" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/20448972/b686ca18-a33f-471f-87b4-080ec13deb4a">|

|Android Before|Android After|
|---|---|
|<img width="295" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/20448972/df425736-122e-4a1a-8e11-8aa503c8bb22">|<img width="302" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/20448972/33e90b3e-024b-46a5-917d-95df2437eb29">|
#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
