### PR TITLE
CLD-6883 Fix build script failure

### DIFF
--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,5 +4,5 @@
 
 gem 'fastlane-plugin-android_change_package_identifier'
 gem 'fastlane-plugin-android_change_string_app_name'
-gem 'fastlane-plugin-find_replace_string'
+gem 'fastlane-plugin-find_replace_string', git: "https://github.com/jonathanneilritchie/fastlane-plugin-find_replace_string"
 gem 'fastlane-plugin-versioning_android'


### PR DESCRIPTION
#### Summary

This works around the recent yanking of the `find_replace_string` ruby plugin from RubyGems, as reported here: https://github.com/jonathanneilritchie/fastlane-plugin-find_replace_string/issues/3#issue-2060246328

After verifying this this works, we also need to backport this to all active release branches,

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6883

#### Release Note
```release-note
NONE
```
