### PR TITLE
[MM-56555] Patch commonmark to resolve unmentioned username

### DIFF
--- a/patches/commonmark+0.30.1-2.patch
+++ b/patches/commonmark+0.30.1-2.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/commonmark/dist/commonmark.js b/node_modules/commonmark/dist/commonmark.js
+index 376b127..502360f 100644
+--- a/node_modules/commonmark/dist/commonmark.js
++++ b/node_modules/commonmark/dist/commonmark.js
+@@ -13579,7 +13579,7 @@
+     };
+ 
+     // Attempt to parse an at mention
+-    var reAtMention = /^@([a-z][a-z0-9._-]*)/i;
++    var reAtMention = /^@([a-z0-9._-]+)/i;
+     var parseAtMention = function(block) {
+         if (this.brackets) {
+             // Don't perform autolinking while inside an explicit link
+diff --git a/node_modules/commonmark/lib/inlines.js b/node_modules/commonmark/lib/inlines.js
+index fdf7a7e..7940a11 100644
+--- a/node_modules/commonmark/lib/inlines.js
++++ b/node_modules/commonmark/lib/inlines.js
+@@ -946,7 +946,7 @@ var parseUrl = function(block) {
+ }
+ 
+ // Attempt to parse an at mention
+-var reAtMention = /^@([a-z][a-z0-9._-]*)/i;
++var reAtMention = /^@([a-z0-9._-]+)/i;
+ var parseAtMention = function(block) {
+     if (this.brackets) {
+         // Don't perform autolinking while inside an explicit link


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
When a username that starts with number or period, underscore, dash is mentioned, the fullname doesn't appear. Only @username is displayed.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-mobile/issues/7755
JIRA: https://mattermost.atlassian.net/browse/MM-56555

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
- Device Name: iPhone 11
- OS Version: iOS 17.0

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

|Before|After|
|---|---|
|<img width="351" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/20448972/cfec7e2d-fa6f-48da-8cca-75fe3d157ec1">|<img width="352" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/20448972/d37e752e-7c07-401c-8b74-1470d30aaec7">|
#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```

ref : [commonmark repo PR](https://github.com/mattermost/commonmark.js/pull/18)
