### PR TITLE
MM-56513 Do not display deactivated users to add channel members

### DIFF
--- a/app/screens/channel_add_members/channel_add_members.tsx
+++ b/app/screens/channel_add_members/channel_add_members.tsx
@@ -201,7 +201,7 @@ export default function ChannelAddMembers({
 
         const result = await fetchProfilesNotInChannel(serverUrl, channel.teamId, channel.id, channel.isGroupConstrained, page, General.PROFILE_CHUNK_SIZE);
         if (result.users?.length) {
-            return result.users;
+            return result.users.filter((u) => !u.delete_at);
         }
 
         return [];
@@ -213,7 +213,7 @@ export default function ChannelAddMembers({
         }
 
         const lowerCasedTerm = searchTerm.toLowerCase();
-        const results = await searchProfiles(serverUrl, lowerCasedTerm, {team_id: channel.teamId, not_in_channel_id: channel.id, allow_inactive: true});
+        const results = await searchProfiles(serverUrl, lowerCasedTerm, {team_id: channel.teamId, not_in_channel_id: channel.id, allow_inactive: false});
 
         if (results.data) {
             return results.data;


### PR DESCRIPTION
#### Summary
removes from the list of users to be added as a channel member those users who have been deactivated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56513
PR to restrict it from the server https://github.com/mattermost/mattermost/pull/25954 (current apps used with the server that has this patch, would just show an alert message with an error)

#### Release Note
```release-note
NONE
```
