### PR TITLE
[MM-54704] Permanently enable timezone support in the mobile app

### DIFF
--- a/app/actions/remote/user.ts
+++ b/app/actions/remote/user.ts
@@ -14,11 +14,11 @@ import {debounce} from '@helpers/api/general';
 import NetworkManager from '@managers/network_manager';
 import {getMembersCountByChannelsId, queryChannelsByTypes} from '@queries/servers/channel';
 import {queryGroupsByNames} from '@queries/servers/group';
-import {getConfig, getCurrentUserId, setCurrentUserId} from '@queries/servers/system';
+import {getCurrentUserId, setCurrentUserId} from '@queries/servers/system';
 import {getCurrentUser, prepareUsers, queryAllUsers, queryUsersById, queryUsersByIdsOrUsernames, queryUsersByUsername} from '@queries/servers/user';
 import {getFullErrorMessage} from '@utils/errors';
 import {logDebug} from '@utils/log';
-import {getDeviceTimezone, isTimezoneEnabled} from '@utils/timezone';
+import {getDeviceTimezone} from '@utils/timezone';
 import {getUserTimezoneProps, removeUserFromList} from '@utils/user';
 
 import {fetchGroupsByNames} from './groups';
@@ -805,10 +805,9 @@ export const autoUpdateTimezone = async (serverUrl: string) => {
         return;
     }
 
-    const config = await getConfig(database);
     const currentUser = await getCurrentUser(database);
 
-    if (!currentUser || !config || !isTimezoneEnabled(config)) {
+    if (!currentUser) {
         return;
     }
 

--- a/app/components/post_draft/send_handler/index.ts
+++ b/app/components/post_draft/send_handler/index.ts
@@ -54,7 +54,6 @@ const enhanced = withObservables([], (ownProps: WithDatabaseArgs & OwnProps) => 
     );
 
     const enableConfirmNotificationsToChannel = observeConfigBooleanValue(database, 'EnableConfirmNotificationsToChannel');
-    const isTimezoneEnabled = observeConfigBooleanValue(database, 'ExperimentalTimezone');
     const maxMessageLength = observeConfigIntValue(database, 'MaxPostSize', MAX_MESSAGE_LENGTH_FALLBACK);
     const persistentNotificationInterval = observeConfigIntValue(database, 'PersistentNotificationInterval');
     const persistentNotificationMaxRecipients = observeConfigIntValue(database, 'PersistentNotificationMaxRecipients');
@@ -81,7 +80,6 @@ const enhanced = withObservables([], (ownProps: WithDatabaseArgs & OwnProps) => 
         channelType,
         currentUserId,
         enableConfirmNotificationsToChannel,
-        isTimezoneEnabled,
         maxMessageLength,
         membersCount,
         userIsOutOfOffice,

--- a/app/components/post_draft/send_handler/send_handler.tsx
+++ b/app/components/post_draft/send_handler/send_handler.tsx
@@ -39,7 +39,6 @@ type Props = {
     currentUserId: string;
     cursorPosition: number;
     enableConfirmNotificationsToChannel?: boolean;
-    isTimezoneEnabled: boolean;
     maxMessageLength: number;
     membersCount?: number;
     useChannelMentions: boolean;
@@ -73,7 +72,6 @@ export default function SendHandler({
     currentUserId,
     enableConfirmNotificationsToChannel,
     files,
-    isTimezoneEnabled,
     maxMessageLength,
     membersCount = 0,
     cursorPosition,
@@ -156,13 +154,13 @@ export default function SendHandler({
     }, [files, currentUserId, channelId, rootId, value, clearDraft, postPriority]);
 
     const showSendToAllOrChannelOrHereAlert = useCallback((calculatedMembersCount: number, atHere: boolean) => {
-        const notifyAllMessage = DraftUtils.buildChannelWideMentionMessage(intl, calculatedMembersCount, Boolean(isTimezoneEnabled), channelTimezoneCount, atHere);
+        const notifyAllMessage = DraftUtils.buildChannelWideMentionMessage(intl, calculatedMembersCount, channelTimezoneCount, atHere);
         const cancel = () => {
             setSendingMessage(false);
         };
 
         DraftUtils.alertChannelWideMention(intl, notifyAllMessage, doSubmitMessage, cancel);
-    }, [intl, isTimezoneEnabled, channelTimezoneCount, doSubmitMessage]);
+    }, [intl, channelTimezoneCount, doSubmitMessage]);
 
     const sendCommand = useCallback(async () => {
         if (value.trim().startsWith('/call')) {

--- a/app/components/post_list/index.ts
+++ b/app/components/post_list/index.ts
@@ -22,7 +22,6 @@ const enhancedWithoutPosts = withObservables([], ({database}: WithDatabaseArgs) 
     const currentUser = observeCurrentUser(database);
     return {
         appsEnabled: observeConfigBooleanValue(database, 'FeatureFlagAppsEnabled'),
-        isTimezoneEnabled: observeConfigBooleanValue(database, 'ExperimentalTimezone'),
         currentTimezone: currentUser.pipe((switchMap((user) => of$(getTimezone(user?.timezone || null))))),
         currentUserId: currentUser.pipe((switchMap((user) => of$(user?.id)))),
         currentUsername: currentUser.pipe((switchMap((user) => of$(user?.username)))),

--- a/app/components/post_list/post/header/header.tsx
+++ b/app/components/post_list/post/header/header.tsx
@@ -34,7 +34,6 @@ type HeaderProps = {
     isMilitaryTime: boolean;
     isPendingOrFailed: boolean;
     isSystemPost: boolean;
-    isTimezoneEnabled: boolean;
     isWebHook: boolean;
     location: string;
     post: PostModel;
@@ -74,7 +73,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
 const Header = (props: HeaderProps) => {
     const {
         author, commentCount = 0, currentUser, enablePostUsernameOverride, isAutoResponse, isCRTEnabled, isCustomStatusEnabled,
-        isEphemeral, isMilitaryTime, isPendingOrFailed, isSystemPost, isTimezoneEnabled, isWebHook,
+        isEphemeral, isMilitaryTime, isPendingOrFailed, isSystemPost, isWebHook,
         location, post, rootPostAuthor, showPostPriority, shouldRenderReplyButton, teammateNameDisplay, hideGuestTags,
     } = props;
     const theme = useTheme();
@@ -116,7 +115,7 @@ const Header = (props: HeaderProps) => {
                     />
                     }
                     <FormattedTime
-                        timezone={isTimezoneEnabled ? getUserTimezone(currentUser) : ''}
+                        timezone={getUserTimezone(currentUser)}
                         isMilitaryTime={isMilitaryTime}
                         value={post.createAt}
                         style={style.time}

--- a/app/components/post_list/post/header/index.ts
+++ b/app/components/post_list/post/header/index.ts
@@ -28,7 +28,6 @@ const withHeaderProps = withObservables(
             observeWithColumns(['value']);
         const author = observePostAuthor(database, post);
         const enablePostUsernameOverride = observeConfigBooleanValue(database, 'EnablePostUsernameOverride');
-        const isTimezoneEnabled = observeConfigBooleanValue(database, 'ExperimentalTimezone');
         const isMilitaryTime = preferences.pipe(map((prefs) => getDisplayNamePreferenceAsBool(prefs, 'use_military_time')));
         const teammateNameDisplay = observeTeammateNameDisplay(database);
         const commentCount = queryPostReplies(database, post.rootId || post.id).observeCount();
@@ -47,7 +46,6 @@ const withHeaderProps = withObservables(
             enablePostUsernameOverride,
             isCustomStatusEnabled,
             isMilitaryTime,
-            isTimezoneEnabled,
             rootPostAuthor,
             teammateNameDisplay,
             hideGuestTags: observeConfigBooleanValue(database, 'HideGuestTags'),

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -36,7 +36,6 @@ type Props = {
     highlightPinnedOrSaved?: boolean;
     isCRTEnabled?: boolean;
     isPostAcknowledgementEnabled?: boolean;
-    isTimezoneEnabled: boolean;
     lastViewedAt: number;
     location: string;
     nativeID: string;
@@ -89,7 +88,6 @@ const PostList = ({
     highlightPinnedOrSaved = true,
     isCRTEnabled,
     isPostAcknowledgementEnabled,
-    isTimezoneEnabled,
     lastViewedAt,
     location,
     nativeID,
@@ -111,8 +109,8 @@ const PostList = ({
     const theme = useTheme();
     const serverUrl = useServerUrl();
     const orderedPosts = useMemo(() => {
-        return preparePostList(posts, lastViewedAt, showNewMessageLine, currentUserId, currentUsername, shouldShowJoinLeaveMessages, isTimezoneEnabled, currentTimezone, location === Screens.THREAD, savedPostIds);
-    }, [posts, lastViewedAt, showNewMessageLine, currentTimezone, currentUsername, shouldShowJoinLeaveMessages, isTimezoneEnabled, location, savedPostIds]);
+        return preparePostList(posts, lastViewedAt, showNewMessageLine, currentUserId, currentUsername, shouldShowJoinLeaveMessages, currentTimezone, location === Screens.THREAD, savedPostIds);
+    }, [posts, lastViewedAt, showNewMessageLine, currentTimezone, currentUsername, shouldShowJoinLeaveMessages, location, savedPostIds]);
 
     const initialIndex = useMemo(() => {
         return orderedPosts.findIndex((i) => i.type === 'start-of-new-messages');
@@ -223,7 +221,7 @@ const PostList = ({
                     <DateSeparator
                         key={item.value}
                         date={getDateForDateLine(item.value)}
-                        timezone={isTimezoneEnabled ? currentTimezone : null}
+                        timezone={currentTimezone}
                     />
                 );
             case 'thread-overview':
@@ -274,7 +272,7 @@ const PostList = ({
                 return (<Post {...postProps}/>);
             }
         }
-    }, [appsEnabled, currentTimezone, customEmojiNames, highlightPinnedOrSaved, isCRTEnabled, isPostAcknowledgementEnabled, isTimezoneEnabled, shouldRenderReplyButton, theme]);
+    }, [appsEnabled, currentTimezone, customEmojiNames, highlightPinnedOrSaved, isCRTEnabled, isPostAcknowledgementEnabled, shouldRenderReplyButton, theme]);
 
     const scrollToIndex = useCallback((index: number, animated = true, applyOffset = true) => {
         listRef.current?.scrollToIndex({

--- a/app/components/system_header/index.tsx
+++ b/app/components/system_header/index.tsx
@@ -10,7 +10,6 @@ import FormattedText from '@components/formatted_text';
 import FormattedTime from '@components/formatted_time';
 import {getDisplayNamePreferenceAsBool} from '@helpers/api/preference';
 import {queryDisplayNamePreferences} from '@queries/servers/preference';
-import {observeConfigBooleanValue} from '@queries/servers/system';
 import {observeCurrentUser} from '@queries/servers/user';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -22,7 +21,6 @@ import type UserModel from '@typings/database/models/servers/user';
 type Props = {
     createAt: number | string | Date;
     isMilitaryTime: boolean;
-    isTimezoneEnabled: boolean;
     theme: Theme;
     user?: UserModel;
 }
@@ -52,9 +50,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-const SystemHeader = ({isMilitaryTime, isTimezoneEnabled, createAt, theme, user}: Props) => {
+const SystemHeader = ({isMilitaryTime, createAt, theme, user}: Props) => {
     const styles = getStyleSheet(theme);
-    const userTimezone = isTimezoneEnabled ? getUserTimezone(user) : '';
+    const userTimezone = getUserTimezone(user);
 
     return (
         <View style={styles.header}>
@@ -80,7 +78,6 @@ const SystemHeader = ({isMilitaryTime, isTimezoneEnabled, createAt, theme, user}
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const preferences = queryDisplayNamePreferences(database, 'use_military_time').
         observeWithColumns(['value']);
-    const isTimezoneEnabled = observeConfigBooleanValue(database, 'ExperimentalTimezone');
     const isMilitaryTime = preferences.pipe(
         map((prefs) => getDisplayNamePreferenceAsBool(prefs, 'use_military_time')),
     );
@@ -88,7 +85,6 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
 
     return {
         isMilitaryTime,
-        isTimezoneEnabled,
         user,
     };
 });

--- a/app/screens/home/recent_mentions/index.ts
+++ b/app/screens/home/recent_mentions/index.ts
@@ -35,7 +35,6 @@ const enhance = withObservables([], ({database}: WithDatabaseArgs) => {
         customEmojiNames: queryAllCustomEmojis(database).observe().pipe(
             switchMap((customEmojis) => of$(mapCustomEmojiNames(customEmojis))),
         ),
-        isTimezoneEnabled: observeConfigBooleanValue(database, 'ExperimentalTimezone'),
     };
 });
 

--- a/app/screens/home/recent_mentions/recent_mentions.tsx
+++ b/app/screens/home/recent_mentions/recent_mentions.tsx
@@ -31,7 +31,6 @@ type Props = {
     appsEnabled: boolean;
     customEmojiNames: string[];
     currentTimezone: string | null;
-    isTimezoneEnabled: boolean;
     mentions: PostModel[];
 }
 
@@ -49,7 +48,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const RecentMentionsScreen = ({appsEnabled, customEmojiNames, mentions, currentTimezone, isTimezoneEnabled}: Props) => {
+const RecentMentionsScreen = ({appsEnabled, customEmojiNames, mentions, currentTimezone}: Props) => {
     const theme = useTheme();
     const route = useRoute();
     const isFocused = useIsFocused();
@@ -87,7 +86,7 @@ const RecentMentionsScreen = ({appsEnabled, customEmojiNames, mentions, currentT
 
     const {scrollPaddingTop, scrollRef, scrollValue, onScroll, headerHeight} = useCollapsibleHeader<FlatList<string>>(true, onSnap);
     const paddingTop = useMemo(() => ({paddingTop: scrollPaddingTop, flexGrow: 1}), [scrollPaddingTop]);
-    const posts = useMemo(() => selectOrderedPosts(mentions, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [mentions]);
+    const posts = useMemo(() => selectOrderedPosts(mentions, 0, false, '', '', false, currentTimezone, false).reverse(), [mentions]);
 
     const animated = useAnimatedStyle(() => {
         return {
@@ -143,7 +142,7 @@ const RecentMentionsScreen = ({appsEnabled, customEmojiNames, mentions, currentT
                     <DateSeparator
                         key={item.value}
                         date={getDateForDateLine(item.value)}
-                        timezone={isTimezoneEnabled ? currentTimezone : null}
+                        timezone={currentTimezone}
                     />
                 );
             case 'post':

--- a/app/screens/home/saved_messages/index.ts
+++ b/app/screens/home/saved_messages/index.ts
@@ -9,7 +9,6 @@ import {switchMap} from 'rxjs/operators';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
 import {queryPostsById} from '@queries/servers/post';
 import {querySavedPostsPreferences} from '@queries/servers/preference';
-import {observeConfigBooleanValue} from '@queries/servers/system';
 import {observeCurrentUser} from '@queries/servers/user';
 import {mapCustomEmojiNames} from '@utils/emoji/helpers';
 import {getTimezone} from '@utils/user';
@@ -42,7 +41,6 @@ const enhance = withObservables([], ({database}: WithDatabaseArgs) => {
         customEmojiNames: queryAllCustomEmojis(database).observe().pipe(
             switchMap((customEmojis) => of$(mapCustomEmojiNames(customEmojis))),
         ),
-        isTimezoneEnabled: observeConfigBooleanValue(database, 'ExperimentalTimezone'),
     };
 });
 

--- a/app/screens/home/saved_messages/saved_messages.tsx
+++ b/app/screens/home/saved_messages/saved_messages.tsx
@@ -29,7 +29,6 @@ type Props = {
     appsEnabled: boolean;
     currentTimezone: string | null;
     customEmojiNames: string[];
-    isTimezoneEnabled: boolean;
     posts: PostModel[];
 }
 
@@ -50,7 +49,7 @@ const styles = StyleSheet.create({
     },
 });
 
-function SavedMessages({appsEnabled, posts, currentTimezone, customEmojiNames, isTimezoneEnabled}: Props) {
+function SavedMessages({appsEnabled, posts, currentTimezone, customEmojiNames}: Props) {
     const intl = useIntl();
     const [loading, setLoading] = useState(!posts.length);
     const [refreshing, setRefreshing] = useState(false);
@@ -88,7 +87,7 @@ function SavedMessages({appsEnabled, posts, currentTimezone, customEmojiNames, i
 
     const {scrollPaddingTop, scrollRef, scrollValue, onScroll, headerHeight} = useCollapsibleHeader<FlatList<string>>(true, onSnap);
     const paddingTop = useMemo(() => ({paddingTop: scrollPaddingTop, flexGrow: 1}), [scrollPaddingTop]);
-    const data = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [posts]);
+    const data = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, currentTimezone, false).reverse(), [posts]);
 
     const animated = useAnimatedStyle(() => {
         return {
@@ -144,7 +143,7 @@ function SavedMessages({appsEnabled, posts, currentTimezone, customEmojiNames, i
                     <DateSeparator
                         key={item.value}
                         date={getDateForDateLine(item.value)}
-                        timezone={isTimezoneEnabled ? currentTimezone : null}
+                        timezone={currentTimezone}
                     />
                 );
             case 'post':
@@ -162,7 +161,7 @@ function SavedMessages({appsEnabled, posts, currentTimezone, customEmojiNames, i
             default:
                 return null;
         }
-    }, [appsEnabled, currentTimezone, customEmojiNames, isTimezoneEnabled, theme]);
+    }, [appsEnabled, currentTimezone, customEmojiNames, theme]);
 
     return (
         <>

--- a/app/screens/home/search/results/index.tsx
+++ b/app/screens/home/search/results/index.tsx
@@ -31,7 +31,6 @@ const enhance = withObservables(['fileChannelIds'], ({database, fileChannelIds}:
         customEmojiNames: queryAllCustomEmojis(database).observe().pipe(
             switchMap((customEmojis) => of$(mapCustomEmojiNames(customEmojis))),
         ),
-        isTimezoneEnabled: observeConfigBooleanValue(database, 'ExperimentalTimezone'),
         fileChannels,
         canDownloadFiles: observeCanDownloadFiles(database),
         publicLinkEnabled: observeConfigBooleanValue(database, 'EnablePublicLink'),

--- a/app/screens/home/search/results/post_results.tsx
+++ b/app/screens/home/search/results/post_results.tsx
@@ -32,7 +32,6 @@ type Props = {
     appsEnabled: boolean;
     customEmojiNames: string[];
     currentTimezone: string;
-    isTimezoneEnabled: boolean;
     posts: PostModel[];
     matches?: SearchMatches;
     paddingTop: StyleProp<ViewStyle>;
@@ -43,7 +42,6 @@ const PostResults = ({
     appsEnabled,
     currentTimezone,
     customEmojiNames,
-    isTimezoneEnabled,
     posts,
     matches,
     paddingTop,
@@ -51,7 +49,7 @@ const PostResults = ({
 }: Props) => {
     const theme = useTheme();
     const styles = getStyles(theme);
-    const orderedPosts = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [posts]);
+    const orderedPosts = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, currentTimezone, false).reverse(), [posts]);
     const containerStyle = useMemo(() => ([paddingTop, {flexGrow: 1}]), [paddingTop]);
 
     const renderItem = useCallback(({item}: ListRenderItemInfo<PostListItem | PostListOtherItem>) => {
@@ -61,7 +59,7 @@ const PostResults = ({
                     <DateSeparator
                         key={item.value}
                         date={getDateForDateLine(item.value)}
-                        timezone={isTimezoneEnabled ? currentTimezone : null}
+                        timezone={currentTimezone}
                     />
                 );
             case 'post': {

--- a/app/screens/home/search/results/results.tsx
+++ b/app/screens/home/search/results/results.tsx
@@ -43,7 +43,6 @@ type Props = {
     customEmojiNames: string[];
     fileChannels: ChannelModel[];
     fileInfos: FileInfo[];
-    isTimezoneEnabled: boolean;
     loading: boolean;
     posts: PostModel[];
     matches?: SearchMatches;
@@ -60,7 +59,6 @@ const Results = ({
     customEmojiNames,
     fileChannels,
     fileInfos,
-    isTimezoneEnabled,
     loading,
     posts,
     matches,
@@ -105,7 +103,6 @@ const Results = ({
                         appsEnabled={appsEnabled}
                         currentTimezone={currentTimezone}
                         customEmojiNames={customEmojiNames}
-                        isTimezoneEnabled={isTimezoneEnabled}
                         posts={posts}
                         matches={matches}
                         paddingTop={paddingTop}

--- a/app/screens/pinned_messages/index.ts
+++ b/app/screens/pinned_messages/index.ts
@@ -32,7 +32,6 @@ const enhance = withObservables(['channelId'], ({channelId, database}: Props) =>
             switchMap((customEmojis) => of$(mapCustomEmojiNames(customEmojis))),
         ),
         isCRTEnabled: observeIsCRTEnabled(database),
-        isTimezoneEnabled: observeConfigBooleanValue(database, 'ExperimentalTimezone'),
         posts,
     };
 });

--- a/app/screens/pinned_messages/pinned_messages.tsx
+++ b/app/screens/pinned_messages/pinned_messages.tsx
@@ -29,7 +29,6 @@ type Props = {
     currentTimezone: string | null;
     customEmojiNames: string[];
     isCRTEnabled: boolean;
-    isTimezoneEnabled: boolean;
     posts: PostModel[];
 }
 
@@ -56,7 +55,6 @@ function SavedMessages({
     currentTimezone,
     customEmojiNames,
     isCRTEnabled,
-    isTimezoneEnabled,
     posts,
 }: Props) {
     const [loading, setLoading] = useState(!posts.length);
@@ -64,7 +62,7 @@ function SavedMessages({
     const theme = useTheme();
     const serverUrl = useServerUrl();
 
-    const data = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, isTimezoneEnabled, currentTimezone, false).reverse(), [posts]);
+    const data = useMemo(() => selectOrderedPosts(posts, 0, false, '', '', false, currentTimezone, false).reverse(), [posts]);
 
     const close = useCallback(() => {
         if (componentId) {
@@ -121,7 +119,7 @@ function SavedMessages({
                     <DateSeparator
                         key={item.value}
                         date={getDateForDateLine(item.value)}
-                        timezone={isTimezoneEnabled ? currentTimezone : null}
+                        timezone={currentTimezone}
                     />
                 );
             case 'post':
@@ -146,7 +144,7 @@ function SavedMessages({
             default:
                 return null;
         }
-    }, [appsEnabled, currentTimezone, customEmojiNames, isTimezoneEnabled, theme]);
+    }, [appsEnabled, currentTimezone, customEmojiNames, theme]);
 
     return (
         <SafeAreaView

--- a/app/screens/settings/display/display.tsx
+++ b/app/screens/settings/display/display.tsx
@@ -58,10 +58,9 @@ type DisplayProps = {
     isCRTEnabled: boolean;
     isCRTSwitchEnabled: boolean;
     isThemeSwitchingEnabled: boolean;
-    isTimezoneEnabled: boolean;
 }
 
-const Display = ({componentId, currentUser, hasMilitaryTimeFormat, isCRTEnabled, isCRTSwitchEnabled, isThemeSwitchingEnabled, isTimezoneEnabled}: DisplayProps) => {
+const Display = ({componentId, currentUser, hasMilitaryTimeFormat, isCRTEnabled, isCRTSwitchEnabled, isThemeSwitchingEnabled}: DisplayProps) => {
     const intl = useIntl();
     const theme = useTheme();
     const timezone = useMemo(() => getUserTimezoneProps(currentUser), [currentUser?.timezone]);
@@ -112,14 +111,12 @@ const Display = ({componentId, currentUser, hasMilitaryTimeFormat, isCRTEnabled,
                 info={intl.formatMessage(hasMilitaryTimeFormat ? TIME_FORMAT[1] : TIME_FORMAT[0])}
                 testID='display_settings.clock_display.option'
             />
-            {isTimezoneEnabled && (
-                <SettingItem
-                    optionName='timezone'
-                    onPress={goToTimezoneSettings}
-                    info={intl.formatMessage(timezone.useAutomaticTimezone ? TIMEZONE_FORMAT[0] : TIMEZONE_FORMAT[1])}
-                    testID='display_settings.timezone.option'
-                />
-            )}
+            <SettingItem
+                optionName='timezone'
+                onPress={goToTimezoneSettings}
+                info={intl.formatMessage(timezone.useAutomaticTimezone ? TIMEZONE_FORMAT[0] : TIMEZONE_FORMAT[1])}
+                testID='display_settings.timezone.option'
+            />
             {isCRTSwitchEnabled && (
                 <SettingItem
                     optionName='crt'

--- a/app/screens/settings/display/index.tsx
+++ b/app/screens/settings/display/index.tsx
@@ -17,8 +17,6 @@ import DisplaySettings from './display';
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const isTimezoneEnabled = observeConfigBooleanValue(database, 'ExperimentalTimezone');
-
     const allowsThemeSwitching = observeConfigBooleanValue(database, 'EnableThemeSelection');
     const allowedThemeKeys = observeAllowedThemesKeys(database);
 
@@ -29,7 +27,6 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     );
 
     return {
-        isTimezoneEnabled,
         isThemeSwitchingEnabled,
         isCRTEnabled: observeIsCRTEnabled(database),
         isCRTSwitchEnabled: observeCRTUserPreferenceDisplay(database),

--- a/app/utils/draft/index.ts
+++ b/app/utils/draft/index.ts
@@ -76,9 +76,9 @@ export const textContainsAtHere = (text: string) => {
     return (/(?:\B|\b_+)@(here)(?!(\.|-|_)*[^\W_])/i).test(textWithoutCode);
 };
 
-export function buildChannelWideMentionMessage(intl: IntlShape, membersCount: number, isTimezoneEnabled: boolean, channelTimezoneCount: number, atHere: boolean) {
+export function buildChannelWideMentionMessage(intl: IntlShape, membersCount: number, channelTimezoneCount: number, atHere: boolean) {
     let notifyAllMessage = '';
-    if (isTimezoneEnabled && channelTimezoneCount) {
+    if (channelTimezoneCount) {
         const msgID = atHere ? t('mobile.post_textbox.entire_channel_here.message.with_timezones') : t('mobile.post_textbox.entire_channel.message.with_timezones');
         const atHereMsg = 'By using @here you are about to send notifications up to {totalMembers, number} {totalMembers, plural, one {person} other {people}} in {timezones, number} {timezones, plural, one {timezone} other {timezones}}. Are you sure you want to do this?';
         const atAllOrChannelMsg = 'By using @all or @channel you are about to send notifications to {totalMembers, number} {totalMembers, plural, one {person} other {people}} in {timezones, number} {timezones, plural, one {timezone} other {timezones}}. Are you sure you want to do this?';

--- a/app/utils/post_list/index.ts
+++ b/app/utils/post_list/index.ts
@@ -171,18 +171,18 @@ function isJoinLeavePostForUsername(post: PostModel, currentUsername: string): b
 
 export function selectOrderedPostsWithPrevAndNext(
     posts: PostModel[], lastViewedAt: number, indicateNewMessages: boolean, currentUserId: string, currentUsername: string, showJoinLeave: boolean,
-    timezoneEnabled: boolean, currentTimezone: string | null, isThreadScreen = false, savedPostIds = new Set<string>(),
+    currentTimezone: string | null, isThreadScreen = false, savedPostIds = new Set<string>(),
 ): PostList {
     return selectOrderedPosts(
         posts, lastViewedAt, indicateNewMessages,
         currentUserId, currentUsername, showJoinLeave,
-        timezoneEnabled, currentTimezone, isThreadScreen, savedPostIds, true,
+        currentTimezone, isThreadScreen, savedPostIds, true,
     );
 }
 
 export function selectOrderedPosts(
     posts: PostModel[], lastViewedAt: number, indicateNewMessages: boolean, currentUserId: string, currentUsername: string, showJoinLeave: boolean,
-    timezoneEnabled: boolean, currentTimezone: string | null, isThreadScreen = false, savedPostIds = new Set<string>(), includePrevNext = false) {
+    currentTimezone: string | null, isThreadScreen = false, savedPostIds = new Set<string>(), includePrevNext = false) {
     if (posts.length === 0) {
         return [];
     }
@@ -216,14 +216,12 @@ export function selectOrderedPosts(
 
         // Push on a date header if the last post was on a different day than the current one
         const postDate = new Date(post.currentPost.createAt);
-        if (timezoneEnabled) {
-            const currentOffset = toMilliseconds({minutes: postDate.getTimezoneOffset()});
-            if (currentTimezone) {
-                const zone = moment.tz.zone(currentTimezone);
-                if (zone) {
-                    const timezoneOffset = toMilliseconds({minutes: zone.utcOffset(post.currentPost.createAt)});
-                    postDate.setTime(post.currentPost.createAt + (currentOffset - timezoneOffset));
-                }
+        const currentOffset = toMilliseconds({minutes: postDate.getTimezoneOffset()});
+        if (currentTimezone) {
+            const zone = moment.tz.zone(currentTimezone);
+            if (zone) {
+                const timezoneOffset = toMilliseconds({minutes: zone.utcOffset(post.currentPost.createAt)});
+                postDate.setTime(post.currentPost.createAt + (currentOffset - timezoneOffset));
             }
         }
 
@@ -363,8 +361,8 @@ export function getPostIdsForCombinedUserActivityPost(item: string) {
 
 export function preparePostList(
     posts: PostModel[], lastViewedAt: number, indicateNewMessages: boolean, currentUserId: string, currentUsername: string, showJoinLeave: boolean,
-    timezoneEnabled: boolean, currentTimezone: string | null, isThreadScreen = false, savedPostIds = new Set<string>()) {
-    const orderedPosts = selectOrderedPostsWithPrevAndNext(posts, lastViewedAt, indicateNewMessages, currentUserId, currentUsername, showJoinLeave, timezoneEnabled, currentTimezone, isThreadScreen, savedPostIds);
+    currentTimezone: string | null, isThreadScreen = false, savedPostIds = new Set<string>()) {
+    const orderedPosts = selectOrderedPostsWithPrevAndNext(posts, lastViewedAt, indicateNewMessages, currentUserId, currentUsername, showJoinLeave, currentTimezone, isThreadScreen, savedPostIds);
     return combineUserActivityPosts(orderedPosts);
 }
 

--- a/app/utils/timezone.ts
+++ b/app/utils/timezone.ts
@@ -3,10 +3,6 @@
 
 import {getTimeZone} from 'react-native-localize';
 
-export const isTimezoneEnabled = (config: Partial<ClientConfig>) => {
-    return config?.ExperimentalTimezone === 'true';
-};
-
 export function getDeviceTimezone() {
     return getTimeZone();
 }

--- a/types/api/config.d.ts
+++ b/types/api/config.d.ts
@@ -113,7 +113,6 @@ interface ClientConfig {
     ExperimentalNormalizeMarkdownLinks: string;
     ExperimentalPrimaryTeam: string;
     ExperimentalSharedChannels: string;
-    ExperimentalTimezone: string;
     ExperimentalTownSquareIsReadOnly: string;
     ExperimentalViewArchivedChannels: string;
     ExtendSessionLengthWithActivity: string;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Removed usages of `ExperimentalTimezone` and `isTimeZoneEnabled` to permanently enable timezone support in the mobile app

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost/issues/24665

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
NA

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
