### PR TITLE
Fix foldable device LHS size when changing modes

### DIFF
--- a/app/screens/home/channel_list/categories_list/index.tsx
+++ b/app/screens/home/channel_list/categories_list/index.tsx
@@ -46,7 +46,7 @@ const CategoriesList = ({hasChannels, iconPad, isCRTEnabled, moreThanOneTeam}: C
         if (isTablet) {
             tabletWidth.value = getTabletWidth(moreThanOneTeam);
         }
-    }, [isTablet && moreThanOneTeam]);
+    }, [isTablet, moreThanOneTeam]);
 
     const tabletStyle = useAnimatedStyle(() => {
         if (!isTablet) {


### PR DESCRIPTION
#### Summary
When the server has no teams, foldable devices that started the app folded, got into a weird state when unfolding them. This was due to the value `tabletWidth` not being set, since the effect was checking the && of the two conditions, instead of each condition separately.

This only happens when there are no teams because `moreThanOneTeam` is false, so changes in `isTablet` are not listened by the effect.

#### Release Note
```release-note
Fix issue with foldable devices where sometimes it wasn't possible to navigate to Home in the unfolded view
```
