### PR TITLE
Fix multi-server icon mention badge

### DIFF
--- a/app/screens/home/channel_list/servers/index.tsx
+++ b/app/screens/home/channel_list/servers/index.tsx
@@ -166,6 +166,9 @@ const Servers = React.forwardRef<ServersRef>((_, ref) => {
             onPress={onPress}
             style={styles.icon}
             testID={'channel_list.servers.server_icon'}
+            badgeBorderColor={theme.sidebarBg}
+            badgeBackgroundColor={theme.mentionBg}
+            badgeColor={theme.mentionColor}
         />
     );
 });


### PR DESCRIPTION
#### Summary
Fixes the badge color for unread and mentions in the icon to switch servers.

https://mattermost.atlassian.net/browse/MM-56656

#### Screenshots
<img width="481" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/6757047/7e0639a8-55e3-496a-9f4d-cf624c8efac8">

<img width="355" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/6757047/791c248b-62ec-4a75-85fe-f1ccfa4d5850">


#### Release Note
```release-note
Fixed the mention badge color of multiple servers
```

@amyblais consider this for 2.13.0