### PR TITLE
revert change to allow arbitrary loads

### DIFF
--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -47,7 +47,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<false/>
+		<true/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>


### PR DESCRIPTION
#### Summary
Previously committed a change that was not intended to not allow arbitrary loads on iOS.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56725
Fixes: #7800 

#### Release Note
```release-note
Fixed http connections on iOS that was previously removed.
```