### PR TITLE
Add handling of posts with unsafe links.

### DIFF
--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -73,6 +73,7 @@ type MarkdownProps = {
     theme: Theme;
     value?: string;
     onLinkLongPress?: (url?: string) => void;
+    isUnsafeLinksPost?: boolean;
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
@@ -135,7 +136,7 @@ const Markdown = ({
     enableInlineLatex, enableLatex, maxNodes,
     imagesMetadata, isEdited, isReplyPost, isSearchResult, layoutHeight, layoutWidth,
     location, mentionKeys, highlightKeys, minimumHashtagLength = 3, onPostPress, postId, searchPatterns,
-    textStyles = {}, theme, value = '', baseParagraphStyle, onLinkLongPress,
+    textStyles = {}, theme, value = '', baseParagraphStyle, onLinkLongPress, isUnsafeLinksPost,
 }: MarkdownProps) => {
     const style = getStyleSheet(theme);
     const managedConfig = useManagedConfig<ManagedConfig>();
@@ -352,7 +353,7 @@ const Markdown = ({
     };
 
     const renderImage = ({linkDestination, context, src, size}: MarkdownImageRenderer) => {
-        if (!imagesMetadata) {
+        if (!imagesMetadata || isUnsafeLinksPost) {
             return null;
         }
 
@@ -403,6 +404,9 @@ const Markdown = ({
     };
 
     const renderLink = ({children, href}: {children: ReactElement; href: string}) => {
+        if (isUnsafeLinksPost) {
+            return renderText({context: [], literal: href});
+        }
         return (
             <MarkdownLink
                 href={href}

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -188,7 +188,7 @@ const Markdown = ({
     };
 
     const renderChannelLink = ({context, channelName}: MarkdownChannelMentionRenderer) => {
-        if (disableChannelLink) {
+        if (disableChannelLink || isUnsafeLinksPost) {
             return renderText({context, literal: `~${channelName}`});
         }
 
@@ -223,7 +223,7 @@ const Markdown = ({
         // These sometimes include a trailing newline
         const content = props.literal.replace(/\n$/, '');
 
-        if (enableLatex && props.language === 'latex') {
+        if (enableLatex && !isUnsafeLinksPost && props.language === 'latex') {
             return (
                 <MarkdownLatexCodeBlock
                     content={content}
@@ -287,7 +287,7 @@ const Markdown = ({
     };
 
     const renderHashtag = ({context, hashtag}: {context: string[]; hashtag: string}) => {
-        if (disableHashtags) {
+        if (disableHashtags || isUnsafeLinksPost) {
             return renderText({context, literal: `#${hashtag}`});
         }
 
@@ -388,7 +388,7 @@ const Markdown = ({
     };
 
     const renderLatexInline = ({context, latexCode}: MarkdownLatexRenderer) => {
-        if (!enableInlineLatex) {
+        if (!enableInlineLatex || isUnsafeLinksPost) {
             return renderText({context, literal: `$${latexCode}$`});
         }
 

--- a/app/components/post_list/post/body/message/message.tsx
+++ b/app/components/post_list/post/body/message/message.tsx
@@ -100,6 +100,7 @@ const Message = ({currentUser, isHighlightWithoutNotificationLicensed, highlight
                             highlightKeys={isHighlightWithoutNotificationLicensed ? (currentUser?.highlightKeys ?? EMPTY_HIGHLIGHT_KEYS) : EMPTY_HIGHLIGHT_KEYS}
                             searchPatterns={searchPatterns}
                             theme={theme}
+                            isUnsafeLinksPost={post.props.unsafe_links && post.props.unsafe_links !== ''}
                         />
                     </View>
                 </ScrollView>


### PR DESCRIPTION
#### Summary
Unsafe links can potentially be generated by LLMs in the Mattermost AI plugin. For example a prompt injection could occour that tells the AI to create a malicious link that contains private data in the query paramenter: `http://badserver.com/all/my?private=data`

This adds the ability to restrict posts that have this unsafe property by adding an unsafe links post prop and passing a rendering option. This option prevents posts from rendering links and it prevents markdown images from being rendered.

Webapp PR: https://github.com/mattermost/mattermost/pull/26129


#### Release Note

```release-note
NONE
```
