### PR TITLE
Fix issue when opening a avatar image from a thread

### DIFF
--- a/app/screens/gallery/footer/index.ts
+++ b/app/screens/gallery/footer/index.ts
@@ -48,8 +48,8 @@ const enhanced = withObservables(['item'], ({database, item}: FooterProps) => {
     const enablePostUsernameOverride = observeConfigBooleanValue(database, 'EnablePostUsernameOverride');
     const enablePostIconOverride = observeConfigBooleanValue(database, 'EnablePostIconOverride');
     const enablePublicLink = observeConfigBooleanValue(database, 'EnablePublicLink');
-    const channelName = channel.pipe(switchMap((c: ChannelModel) => of$(c.displayName)));
-    const isDirectChannel = channel.pipe(switchMap((c: ChannelModel) => of$(c.type === General.DM_CHANNEL)));
+    const channelName = channel.pipe(switchMap((c: ChannelModel) => of$(c?.displayName || '')));
+    const isDirectChannel = channel.pipe(switchMap((c: ChannelModel) => of$(c?.type === General.DM_CHANNEL)));
 
     return {
         author,

--- a/app/screens/gallery/footer/index.ts
+++ b/app/screens/gallery/footer/index.ts
@@ -14,7 +14,6 @@ import {observeTeammateNameDisplay, observeUser} from '@queries/servers/user';
 import Footer from './footer';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
-import type ChannelModel from '@typings/database/models/servers/channel';
 import type {GalleryItemType} from '@typings/screens/gallery';
 
 type FooterProps = WithDatabaseArgs & {
@@ -48,8 +47,8 @@ const enhanced = withObservables(['item'], ({database, item}: FooterProps) => {
     const enablePostUsernameOverride = observeConfigBooleanValue(database, 'EnablePostUsernameOverride');
     const enablePostIconOverride = observeConfigBooleanValue(database, 'EnablePostIconOverride');
     const enablePublicLink = observeConfigBooleanValue(database, 'EnablePublicLink');
-    const channelName = channel.pipe(switchMap((c: ChannelModel) => of$(c?.displayName || '')));
-    const isDirectChannel = channel.pipe(switchMap((c: ChannelModel) => of$(c?.type === General.DM_CHANNEL)));
+    const channelName = channel.pipe(switchMap((c) => of$(c?.displayName || '')));
+    const isDirectChannel = channel.pipe(switchMap((c) => of$(c?.type === General.DM_CHANNEL)));
 
     return {
         author,


### PR DESCRIPTION
#### Summary
The gallery tries to get the display name of a channel to show in the gallery. But avatars may not be tied to any channel.

When navigating from the threads screen, there is no current channel, so when the gallery footer tried to get the channel, it was crashing.

We solve it by handling the case where the channel is undefined.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-56755
Fix https://github.com/mattermost/mattermost-mobile/issues/7811

#### Release Note
```release-note
Fix issue where opening a user avatar may cause a crash
```
