### PR TITLE
MacOS-latest-xlarge for m1 github runners

### DIFF
--- a/.github/actions/prepare-mobile-build/action.yaml
+++ b/.github/actions/prepare-mobile-build/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # v1.144.0
       with:
-        ruby-version: "2.7.8"
+        ruby-version: "2.7.7"
 
     - name: ci/setup-fastlane-dependencies
       shell: bash

--- a/.github/actions/prepare-mobile-build/action.yaml
+++ b/.github/actions/prepare-mobile-build/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # v1.144.0
       with:
-        ruby-version: "2.7.7"
+        ruby-version: "2.7.8"
 
     - name: ci/setup-fastlane-dependencies
       shell: bash

--- a/.github/actions/prepare-mobile-build/action.yaml
+++ b/.github/actions/prepare-mobile-build/action.yaml
@@ -7,6 +7,8 @@ runs:
     - uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # v1.144.0
       with:
         ruby-version: "2.7.7"
+        bundler-cache: true
+        cache-version: 1
 
     - name: ci/setup-fastlane-dependencies
       shell: bash

--- a/.github/actions/prepare-mobile-build/action.yaml
+++ b/.github/actions/prepare-mobile-build/action.yaml
@@ -7,8 +7,6 @@ runs:
     - uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # v1.144.0
       with:
         ruby-version: "2.7.7"
-        bundler-cache: true
-        cache-version: 1
 
     - name: ci/setup-fastlane-dependencies
       shell: bash

--- a/.github/workflows/build-ios-beta.yml
+++ b/.github/workflows/build-ios-beta.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-ios-simulator:
-    runs-on: macos-12
+    runs-on: macos-12-large
     if: ${{ !contains(github.ref_name, 'beta-ios') }}
     needs:
       - test
@@ -50,7 +50,7 @@ jobs:
           path: Mattermost-simulator-x86_64.app.zip
 
   build-and-deploy-ios-beta:
-    runs-on: macos-12
+    runs-on: macos-12-large
     if: ${{ !contains(github.ref_name, 'beta-sim') }}
     needs:
       - test

--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-and-deploy-ios-release:
-    runs-on: macos-12
+    runs-on: macos-12-large
     if: ${{ !contains(github.ref_name, 'release-sim') }}
     needs:
       - test
@@ -71,7 +71,7 @@ jobs:
           path: "*.ipa"
 
   build-ios-simulator:
-    runs-on: macos-12
+    runs-on: macos-12-large
     if: ${{ !contains(github.ref_name , 'release-ios') }}
     needs:
       - test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-ios-pr:
-    runs-on: macos-13-xlarge
+    runs-on: macos-12-large
     if: ${{ github.event.label.name == 'Build Apps for PR' || github.event.label.name == 'Build App for iOS' }}
     # needs:
     #   - test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-ios-pr:
-    runs-on: macos-12-large
+    runs-on: macos-13-xlarge
     if: ${{ github.event.label.name == 'Build Apps for PR' || github.event.label.name == 'Build App for iOS' }}
     needs:
       - test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,8 +24,8 @@ jobs:
   build-ios-pr:
     runs-on: macos-12-large
     if: ${{ github.event.label.name == 'Build Apps for PR' || github.event.label.name == 'Build App for iOS' }}
-    # needs:
-    #   - test
+    needs:
+      - test
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-ios-pr:
-    runs-on: macos-12
+    runs-on: macos-latest-xlarge
     if: ${{ github.event.label.name == 'Build Apps for PR' || github.event.label.name == 'Build App for iOS' }}
     needs:
       - test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-ios-pr:
-    runs-on: macos-latest-xlarge
+    runs-on: macos-13-xlarge
     if: ${{ github.event.label.name == 'Build Apps for PR' || github.event.label.name == 'Build App for iOS' }}
     # needs:
     #   - test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,8 +24,8 @@ jobs:
   build-ios-pr:
     runs-on: macos-latest-xlarge
     if: ${{ github.event.label.name == 'Build Apps for PR' || github.event.label.name == 'Build App for iOS' }}
-    needs:
-      - test
+    # needs:
+    #   - test
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-ios-pr:
-    runs-on: macos-13-xlarge
+    runs-on: macos-12-large
     if: ${{ github.event.label.name == 'Build Apps for PR' || github.event.label.name == 'Build App for iOS' }}
     needs:
       - test

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: ./.github/actions/test
 
   build-ios-unsigned:
-    runs-on: macos-12
+    runs-on: macos-12-large
     needs:
       - test
     steps:


### PR DESCRIPTION
- Saves almost 10 minutes in all iOS build jobs.

before:
<img width="802" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/15979783/a3bb9745-4501-48e5-b630-0426eb0ed51b">


after:
<img width="803" alt="image" src="https://github.com/mattermost/mattermost-mobile/assets/15979783/d6f1165a-d4bd-4809-8168-cbf4324559d1">


```release-note
NONE
```