### PR TITLE
feat: Scroll to bottom element

### DIFF
--- a/app/components/post_list/scroll_to_end_view.tsx
+++ b/app/components/post_list/scroll_to_end_view.tsx
@@ -1,0 +1,132 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React, {useMemo, useRef} from 'react';
+import {useIntl} from 'react-intl';
+import {Platform, Pressable, Text, useWindowDimensions, View, type ViewStyle} from 'react-native';
+import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+
+import CompassIcon from '@components/compass_icon';
+import {Screens} from '@constants';
+import {useTheme} from '@context/theme';
+import {useIsTablet, useKeyboardHeight, useViewPosition} from '@hooks/device';
+import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
+
+const getStyleFromTheme = makeStyleSheetFromTheme((theme) => {
+    const commonButtonStyle: ViewStyle = {
+        height: 40,
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+    };
+    return {
+        buttonStyle: {
+            position: 'absolute',
+            alignSelf: 'center',
+            bottom: -70,
+            flexDirection: 'row',
+            elevation: 4,
+            shadowOpacity: 0.2,
+            shadowOffset: {width: 0, height: 4},
+            shadowRadius: 4,
+        },
+        scrollToEndButton: {
+            ...commonButtonStyle,
+            width: 40,
+            borderRadius: 32,
+            backgroundColor: theme.centerChannelBg,
+            borderColor: changeOpacity(theme.centerChannelColor, 0.16),
+            borderWidth: 1,
+        },
+        scrollToEndBadge: {
+            ...commonButtonStyle,
+            borderRadius: 8,
+            paddingHorizontal: 12,
+            backgroundColor: theme.buttonBg,
+        },
+        newMessagesText: {
+            color: theme.buttonColor,
+            paddingHorizontal: 8,
+            overflow: 'hidden',
+            ...typography('Body', 200, 'SemiBold'),
+        },
+    };
+});
+
+type Props = {
+    onPress: () => void;
+    isNewMessage: boolean;
+    isReply: boolean;
+    showScrollToEndBtn: boolean;
+    location: string;
+};
+
+const ScrollToEndView = ({
+    onPress,
+    isNewMessage,
+    isReply,
+    showScrollToEndBtn,
+    location,
+}: Props) => {
+    const intl = useIntl();
+    const theme = useTheme();
+    const isTablet = useIsTablet();
+    const styles = getStyleFromTheme(theme);
+
+    // On iOS we have to take account of the keyboard.
+    // We cannot use `useKeyboardOverlap` here because of the positioning of the element.
+    const guidingViewRef = useRef<View>(null);
+    const keyboardHeight = useKeyboardHeight();
+    const viewPosition = useViewPosition(guidingViewRef, []);
+    const dimensions = useWindowDimensions();
+    const bottomSpace = (dimensions.height - viewPosition);
+    const keyboardOverlap = Platform.select({ios: Math.max(0, keyboardHeight - bottomSpace), default: 0});
+
+    // Thread view on iPads has to take into account the insets
+    const insets = useSafeAreaInsets();
+    const shouldAdjustBottom = (Platform.OS === 'ios') && isTablet && (location === Screens.THREAD) && !keyboardHeight;
+    const bottomAdjustment = shouldAdjustBottom ? insets.bottom : 0;
+
+    const message = isReply ?
+        intl.formatMessage({id: 'postList.scrollToBottom.newReplies', defaultMessage: 'New replies'}) :
+        intl.formatMessage({id: 'postList.scrollToBottom.newMessages', defaultMessage: 'New messages'});
+
+    const animatedStyle = useAnimatedStyle(
+        () => ({
+            transform: [
+                {
+                    translateY: withTiming(showScrollToEndBtn ? -80 - keyboardOverlap - bottomAdjustment : 0, {duration: 300}),
+                },
+            ],
+            maxWidth: withTiming(isNewMessage ? 169 : 40, {duration: 300}),
+        }),
+        [showScrollToEndBtn, isNewMessage, keyboardOverlap, bottomAdjustment],
+    );
+
+    const scrollButtonStyles = useMemo(() => [
+        isNewMessage ? styles.scrollToEndBadge : styles.scrollToEndButton,
+    ], [isNewMessage, keyboardHeight]);
+
+    return (
+        <View ref={guidingViewRef}>
+            <Animated.View style={[animatedStyle, styles.buttonStyle]}>
+                <Pressable
+                    onPress={onPress}
+                    style={scrollButtonStyles}
+                >
+                    <CompassIcon
+                        size={18}
+                        name='arrow-down'
+                        color={isNewMessage ? theme.buttonColor : changeOpacity(theme.centerChannelColor, 0.56)}
+                    />
+                    {isNewMessage && (
+                        <Text style={styles.newMessagesText}>{message}</Text>
+                    )}
+                </Pressable>
+            </Animated.View>
+        </View>
+    );
+};
+
+export default React.memo(ScrollToEndView);


### PR DESCRIPTION
Scroll to the bottom element added in channels and threads, new messages button was also added.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
It adds new functionality to the pull request channel and thread screen of the mobile app. The problem is there is no easy way to get to the bottom of the channel when you are scrolled up in the channel's history and users are forced to scroll manually, which can be frustrating if you have scrolled up far. This problem is solved by adding a new scroll-down button when the user scrolls up to some height by reading the previous messages. The same button notifies for incoming new messages as the user scrolls.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/21269

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> Android v12 and Android v10

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
<div>
<img width="250" src="https://user-images.githubusercontent.com/72058456/195926311-dee935ed-0215-4bcb-812b-0dec31829d15.jpeg" />

<img width="250" src="https://user-images.githubusercontent.com/72058456/195926325-83d374f7-98de-43f2-b8b5-1789d30f0ab2.jpeg" />
</div>


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Added a new scroll-down button in the channel and thread screen
```
