### PR TITLE
CLD-7296 Fix watchman installation after dependency changes

### DIFF
--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -17,6 +17,7 @@ runs:
         #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
         #echo "### Installing watchman"
         #brew install $(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/w/watchman.rb
+        sudo chown -R $(id -u) /usr/local
         brew install --overwrite watchman
         echo "::endgroup::"
 

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -12,8 +12,7 @@ runs:
         echo "::group::install-os-deps"
         echo "### Running brew update"
         brew update
-        brew uninstall azure-cli python@3.11
-        brew upgrade
+        brew uninstall $(brew list)
         #echo "### Checking out specific homebrew/core tap version"
         #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
         echo "### Installing watchman"

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -10,7 +10,6 @@ runs:
       shell: bash
       run: |
         echo "::group::install-os-deps"
-        sudo dseditgroup -o edit -a $(id -n -u) -t user wheel
         brew install --overwrite python@3.12
         brew install watchman
         echo "::endgroup::"

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -12,7 +12,7 @@ runs:
         echo "::group::install-os-deps"
         echo "### Running brew update"
         brew update
-        brew uninstall $(brew list)
+        brew link --overwrite python@3.12
         #echo "### Checking out specific homebrew/core tap version"
         #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
         echo "### Installing watchman"

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -10,10 +10,12 @@ runs:
       shell: bash
       run: |
         echo "::group::install-os-deps"
+        echo "### Running brew update"
         brew update
-        HOMEBREW_PREFIX=$(brew config | grep HOMEBREW_PREFIX | awk '{ print $2; }')
-        git -c "${HOMEBREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core/" checkout c0c26c4e33875733cb694a075ba3e408400ee398
-        brew install watchman
+        echo "### Checking out specific homebrew/core tap version"
+        git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
+        echo "### Installing watchman"
+        brew install $(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/w/watchman.rb
         echo "::endgroup::"
 
     - name: ci/prepare-mobile-build

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -12,7 +12,7 @@ runs:
         echo "::group::install-os-deps"
         echo "### Running brew update"
         brew update
-        brew uninstall python@3.11
+        brew uninstall azure-cli python@3.11
         brew upgrade
         #echo "### Checking out specific homebrew/core tap version"
         #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -10,14 +10,14 @@ runs:
       shell: bash
       run: |
         echo "::group::install-os-deps"
-        echo "### Running brew update"
-        brew update
-        brew link --overwrite python@3.12
+        #echo "### Running brew update"
+        #brew update
+        #brew link --overwrite python@3.12
         #echo "### Checking out specific homebrew/core tap version"
         #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
-        echo "### Installing watchman"
+        #echo "### Installing watchman"
         #brew install $(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/w/watchman.rb
-        brew install watchman
+        brew install --overwrite watchman
         echo "::endgroup::"
 
     - name: ci/prepare-mobile-build

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -12,6 +12,7 @@ runs:
         echo "::group::install-os-deps"
         echo "### Running brew update"
         brew update
+        brew uninstall python@3.11
         brew upgrade
         #echo "### Checking out specific homebrew/core tap version"
         #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -10,7 +10,10 @@ runs:
       shell: bash
       run: |
         echo "::group::install-os-deps"
-        brew install watchman@2024.01.15.00
+        brew update
+        HOMEBREW_PREFIX=$(brew config | grep HOMEBREW_PREFIX | awk '{ print $2; }')
+        git -c "${HOMEBREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core/" checkout c0c26c4e33875733cb694a075ba3e408400ee398
+        brew install watchman
         echo "::endgroup::"
 
     - name: ci/prepare-mobile-build

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -17,7 +17,10 @@ runs:
         #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
         #echo "### Installing watchman"
         #brew install $(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/w/watchman.rb
-        sudo chown -R $(id -u) /usr/local
+        set -x
+        ls -la /usr/local/bin/2to3
+        sudo chown -v -R $(id -u) /usr/local
+        ls -la /usr/local/bin/2to3
         brew install --overwrite watchman
         echo "::endgroup::"
 

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -5,15 +5,13 @@ runs:
   using: composite
   steps:
     - name: ci/install-os-deps
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: "1"
       shell: bash
       run: |
         echo "::group::install-os-deps"
-        set -x
-        sudo dseditgroup -o edit -a $(id -n -u) -t user wheel
-        brew install --overwrite python@3.12 || true
+        brew install python@3.12
         brew install watchman
-        which watchman
-        exit 1
         echo "::endgroup::"
 
     - name: ci/prepare-mobile-build

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -10,7 +10,8 @@ runs:
         echo "::group::install-os-deps"
         set -x
         sudo dseditgroup -o edit -a $(id -n -u) -t user wheel
-        brew install --overwrite watchman || true
+        brew install --overwrite python@3.12 || true
+        brew install watchman
         which watchman
         exit 1
         echo "::endgroup::"

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -12,10 +12,12 @@ runs:
         echo "::group::install-os-deps"
         echo "### Running brew update"
         brew update
-        echo "### Checking out specific homebrew/core tap version"
-        git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
+        brew upgrade
+        #echo "### Checking out specific homebrew/core tap version"
+        #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
         echo "### Installing watchman"
-        brew install $(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/w/watchman.rb
+        #brew install $(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/w/watchman.rb
+        brew install watchman
         echo "::endgroup::"
 
     - name: ci/prepare-mobile-build

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -5,23 +5,14 @@ runs:
   using: composite
   steps:
     - name: ci/install-os-deps
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: "1"
       shell: bash
       run: |
         echo "::group::install-os-deps"
-        #echo "### Running brew update"
-        #brew update
-        #brew link --overwrite python@3.12
-        #echo "### Checking out specific homebrew/core tap version"
-        #git -C $(brew --repository)/Library/Taps/homebrew/homebrew-core/ checkout c0c26c4e33875733cb694a075ba3e408400ee398
-        #echo "### Installing watchman"
-        #brew install $(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/w/watchman.rb
         set -x
-        ls -la /usr/local/bin/2to3
-        sudo chown -v -R $(id -u) /usr/local
-        ls -la /usr/local/bin/2to3
-        brew install --overwrite watchman
+        sudo dseditgroup -o edit -a $(id -n -u) -t user wheel
+        brew install --overwrite watchman || true
+        which watchman
+        exit 1
         echo "::endgroup::"
 
     - name: ci/prepare-mobile-build

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -10,7 +10,8 @@ runs:
       shell: bash
       run: |
         echo "::group::install-os-deps"
-        brew install python@3.12
+        sudo dseditgroup -o edit -a $(id -n -u) -t user wheel
+        brew install --overwrite python@3.12
         brew install watchman
         echo "::endgroup::"
 

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -10,7 +10,7 @@ runs:
       shell: bash
       run: |
         echo "::group::install-os-deps"
-        brew install watchman
+        brew install watchman@2024.01.15.00
         echo "::endgroup::"
 
     - name: ci/prepare-mobile-build


### PR DESCRIPTION
#### Summary

This PR solves an incompatibility between the [latest watchman formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/w/watchman.rb) and the current MacOS runners.

Analysis of the root cause: the `brew install watchman` command seems to try to install both python 3.11 (required by e.g. `azure-cli`) and python 3.12 (required by the latest `watchman`, already present in the system but outdated), and these two formulae versions compete for the corresponding python symlinks under `/usr/local/bin`, which causes the installation to fail. As a workaround, we pre-install the latest `python@3.12` before installing watchman, for this to be handled cleanly.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7296

#### Release Note
```release-note
NONE
```
