### PR TITLE
List member filter deactivated users

### DIFF
--- a/app/screens/manage_channel_members/manage_channel_members.tsx
+++ b/app/screens/manage_channel_members/manage_channel_members.tsx
@@ -217,9 +217,9 @@ export default function ManageChannelMembers({
     const data = useMemo(() => {
         const isSearch = Boolean(searchedTerm);
         if (isSearch) {
-            return filterProfilesMatchingTerm(searchResults.length ? searchResults : sortedProfiles, searchedTerm);
+            return filterDeactivatedProfiles(filterProfilesMatchingTerm(searchResults.length ? searchResults : sortedProfiles, searchedTerm));
         }
-        return profiles;
+        return filterDeactivatedProfiles(profiles);
     }, [searchResults, profiles, searchedTerm, sortedProfiles]);
 
     useEffect(() => {
@@ -243,7 +243,7 @@ export default function ManageChannelMembers({
                 hasMoreProfiles.current = true;
             }
             if (users.length) {
-                setProfiles(filterDeactivatedProfiles(users));
+                setProfiles(users);
                 setChannelMembers(members);
             }
             setLoading(false);

--- a/app/screens/manage_channel_members/manage_channel_members.tsx
+++ b/app/screens/manage_channel_members/manage_channel_members.tsx
@@ -216,10 +216,8 @@ export default function ManageChannelMembers({
 
     const data = useMemo(() => {
         const isSearch = Boolean(searchedTerm);
-        if (isSearch) {
-            return filterDeactivatedProfiles(filterProfilesMatchingTerm(searchResults.length ? searchResults : sortedProfiles, searchedTerm));
-        }
-        return filterDeactivatedProfiles(profiles);
+        const newProfiles = isSearch ? filterProfilesMatchingTerm(searchResults.length ? searchResults : sortedProfiles, searchedTerm) : profiles;
+        return filterDeactivatedProfiles(newProfiles);
     }, [searchResults, profiles, searchedTerm, sortedProfiles]);
 
     useEffect(() => {

--- a/app/screens/manage_channel_members/manage_channel_members.tsx
+++ b/app/screens/manage_channel_members/manage_channel_members.tsx
@@ -20,7 +20,7 @@ import {openAsBottomSheet, popTopScreen, setButtons} from '@screens/navigation';
 import NavigationStore from '@store/navigation_store';
 import {showRemoveChannelUserSnackbar} from '@utils/snack_bar';
 import {changeOpacity, getKeyboardAppearanceFromTheme} from '@utils/theme';
-import {displayUsername, filterProfilesMatchingTerm} from '@utils/user';
+import {displayUsername, filterDeactivatedProfiles, filterProfilesMatchingTerm} from '@utils/user';
 
 import type {AvailableScreens} from '@typings/screens/navigation';
 
@@ -243,7 +243,7 @@ export default function ManageChannelMembers({
                 hasMoreProfiles.current = true;
             }
             if (users.length) {
-                setProfiles(users);
+                setProfiles(filterDeactivatedProfiles(users));
                 setChannelMembers(members);
             }
             setLoading(false);

--- a/app/utils/user/index.ts
+++ b/app/utils/user/index.ts
@@ -320,6 +320,10 @@ export function filterProfilesMatchingTerm(users: UserProfile[], term: string): 
     });
 }
 
+export const filterDeactivatedProfiles = (users: UserProfile[]) => {
+    return users.filter((u) => isDeactivated(u) === false);
+};
+
 export function getNotificationProps(user?: UserModel) {
     if (user && user.notifyProps) {
         return user.notifyProps;


### PR DESCRIPTION
#### Summary
Remove deactivated users from the channel member lists. It's handled by default on the webapp but isn't the case on mobile.

#### Device Information
Macbook Air M2, Sonoma 14.3

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Filtered deactivated users from channel member list 
```
