### PR TITLE
Allow iOS to connect to servers without SSL

### DIFF
--- a/app/utils/url/index.ts
+++ b/app/utils/url/index.ts
@@ -7,6 +7,7 @@ import urlParse from 'url-parse';
 
 import {Files} from '@constants';
 import {emptyFunction} from '@utils/general';
+import {logDebug} from '@utils/log';
 
 import {latinise} from './latinise';
 
@@ -25,8 +26,10 @@ export function sanitizeUrl(url: string, useHttp = false) {
         preUrl = urlParse('https://' + stripTrailingSlashes(url), true);
     }
 
-    if (!protocol || (preUrl.protocol === 'http:' && !useHttp)) {
+    if (preUrl.protocol === 'http:' && !useHttp) {
         protocol = 'https:';
+    } else if (!protocol) {
+        protocol = useHttp ? 'http:' : 'https:';
     }
 
     return stripTrailingSlashes(
@@ -43,12 +46,11 @@ export async function getServerUrlAfterRedirect(serverUrl: string, useHttp = fal
             url = resp.redirectUrls[resp.redirectUrls.length - 1];
         }
     } catch (error) {
-        if (useHttp) {
-            return undefined;
-        }
+        logDebug('getServerUrlAfterRedirect error', url, error);
+        return {error};
     }
 
-    return sanitizeUrl(url, useHttp);
+    return {url: sanitizeUrl(url, useHttp)};
 }
 
 export function stripTrailingSlashes(url = '') {

--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -46,8 +46,14 @@
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>Enabling access to your media library means you can attach files from your media library to your messages in $(PRODUCT_NAME).</string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {


### PR DESCRIPTION
#### Summary
It appears to have a conflict with NSAllowLocalNetworking and NSAllowsArbitraryLoads, by removing `NSAllowLocalNetworking` we are now allowing connections without SSL.

Also some changes around pinging the server to make the connection faster.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57387
Fixes: #7844 

#### Release Note
```release-note
Added back the ability to connect the iOS app to servers without SSL
```