### PR TITLE
Update sentry to fix error with the Privacy files

### DIFF
--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -1194,8 +1194,8 @@
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			packageReferences = (
-				7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph.git" */,
-				27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */,
+				7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph" */,
+				27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
@@ -2373,15 +2373,15 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */ = {
+		27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
-				branch = 8.15.2;
-				kind = branch;
+				kind = exactVersion;
+				version = 8.21.0;
 			};
 		};
-		7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph.git" */ = {
+		7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/satoshi-takano/OpenGraph.git";
 			requirement = {
@@ -2394,12 +2394,12 @@
 /* Begin XCSwiftPackageProductDependency section */
 		27C667A229523ECA00E590D5 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		27C667A429523F0A00E590D5 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = 27C667A129523ECA00E590D5 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		49AE370026D4455D00EF4E52 /* Gekidou */ = {
@@ -2416,7 +2416,7 @@
 		};
 		7FD4822B2864D73300A5B18B /* OpenGraph */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph.git" */;
+			package = 7FD4822A2864D73300A5B18B /* XCRemoteSwiftPackageReference "OpenGraph" */;
 			productName = OpenGraph;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ios/Mattermost.xcodeproj/project.pbxproj
+++ b/ios/Mattermost.xcodeproj/project.pbxproj
@@ -1420,7 +1420,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Mattermost/Pods-Mattermost-resources.sh",
-				"${PODS_ROOT}/CocoaLumberjack/Sources/CocoaLumberjack/PrivacyInfo.xcprivacy",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CocoaLumberjack/CocoaLumberjackPrivacy.bundle",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
@@ -1442,7 +1442,7 @@
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Zocial.ttf",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
-				"${PODS_ROOT}/Sentry/Sources/Resources/PrivacyInfo.xcprivacy",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Sentry/Sentry.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -1468,7 +1468,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Zocial.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PrivacyInfo.xcprivacy",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Sentry.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2262,8 +2262,8 @@
 					"$(inherited)",
 					"-Wl",
 					"-ld_classic",
-					" ",
-					"-Wl -ld_classic ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -2321,8 +2321,8 @@
 					"$(inherited)",
 					"-Wl",
 					"-ld_classic",
-					" ",
-					"-Wl -ld_classic ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/ios/Mattermost.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Mattermost.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,24 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "OpenGraph",
-        "repositoryURL": "https://github.com/satoshi-takano/OpenGraph.git",
-        "state": {
-          "branch": null,
-          "revision": "382972f1963580eeabafd88ad012e66576b4d213",
-          "version": "1.4.1"
-        }
-      },
-      {
-        "package": "Sentry",
-        "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
-        "state": {
-          "branch": "8.15.2",
-          "revision": "c60f232c96264c3bea75bc0b81e6126b2f7475ee",
-          "version": null
-        }
-      },
-      {
         "package": "SQLite.swift",
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {

--- a/ios/Mattermost.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Mattermost.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "OpenGraph",
+        "repositoryURL": "https://github.com/satoshi-takano/OpenGraph.git",
+        "state": {
+          "branch": null,
+          "revision": "382972f1963580eeabafd88ad012e66576b4d213",
+          "version": "1.4.1"
+        }
+      },
+      {
+        "package": "Sentry",
+        "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
+        "state": {
+          "branch": null,
+          "revision": "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
+          "version": "8.21.0"
+        }
+      },
+      {
         "package": "SQLite.swift",
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - BVLinearGradient (2.8.3):
     - React-Core
   - CocoaAsyncSocket (7.6.5)
-  - CocoaLumberjack (3.8.4):
-    - CocoaLumberjack/Core (= 3.8.4)
-  - CocoaLumberjack/Core (3.8.4)
+  - CocoaLumberjack (3.8.5):
+    - CocoaLumberjack/Core (= 3.8.5)
+  - CocoaLumberjack/Core (3.8.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.7)
   - FBReactNativeSpec (0.72.7):
@@ -634,9 +634,11 @@ PODS:
   - RNScreens (3.27.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - RNSentry (5.14.0):
+  - RNSentry (5.20.0):
+    - hermes-engine
     - React-Core
-    - Sentry/HybridSDK (= 8.15.2)
+    - React-hermes
+    - Sentry/HybridSDK (= 8.21.0)
   - RNShare (10.0.1):
     - React-Core
   - RNSVG (14.0.0):
@@ -644,15 +646,15 @@ PODS:
   - RNVectorIcons (10.0.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - SDWebImage (5.18.11):
-    - SDWebImage/Core (= 5.18.11)
-  - SDWebImage/Core (5.18.11)
+  - SDWebImage (5.18.12):
+    - SDWebImage/Core (= 5.18.12)
+  - SDWebImage/Core (5.18.12)
   - SDWebImageWebPCoder (0.13.0):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
-  - Sentry/HybridSDK (8.15.2):
-    - SentryPrivate (= 8.15.2)
-  - SentryPrivate (8.15.2)
+  - Sentry/HybridSDK (8.21.0):
+    - SentryPrivate (= 8.21.0)
+  - SentryPrivate (8.21.0)
   - simdjson (3.1.0-wmelon1)
   - SocketRocket (0.6.1)
   - Starscream (4.0.4)
@@ -985,7 +987,7 @@ SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  CocoaLumberjack: df59726690390bb8aaaa585938564ba1c8dbbb44
+  CocoaLumberjack: 6a459bc897d6d80bd1b8c78482ec7ad05dffc3f0
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5fbbff1d7734827299274638deb8ba3024f6c597
   FBReactNativeSpec: 638095fe8a01506634d77b260ef8a322019ac671
@@ -1074,14 +1076,14 @@ SPEC CHECKSUMS:
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
   RNReanimated: ab2e96c6d5591c3dfbb38a464f54c8d17fb34a87
   RNScreens: 3c2d122f5e08c192e254c510b212306da97d2581
-  RNSentry: e12330e6fc1b2fc2347babdd8aba346d1211ef75
+  RNSentry: 5381e9284aec59a546e4a7d40e33ad0839b99c1e
   RNShare: bed7c4fbe615f3d977f22feb0902af9a790c1660
   RNSVG: 255767813dac22db1ec2062c8b7e7b856d4e5ae6
   RNVectorIcons: 23b6e11af4aaf104d169b1b0afa7e5cf96c676ce
-  SDWebImage: a3ba0b8faac7228c3c8eadd1a55c9c9fe5e16457
+  SDWebImage: 2d6d229046fea284d62e36bfb8ebe8287dfc5b10
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
-  Sentry: 6f5742b4c47c17c9adcf265f6f328cf4a0ed1923
-  SentryPrivate: b2f7996f37781080f04a946eb4e377ff63c64195
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   simdjson: e6bfae9ce4bcdc80452d388d593816f1ca2106f3
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Starscream: e7497aedb1c2e27d2a672d40286fd1b34f20f2e4

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@react-navigation/bottom-tabs": "6.5.11",
         "@react-navigation/native": "6.1.9",
         "@react-navigation/stack": "6.3.20",
-        "@sentry/react-native": "5.14.0",
+        "@sentry/react-native": "5.20.0",
         "@stream-io/flat-list-mvcp": "0.10.3",
         "@tsconfig/react-native": "3.0.2",
         "@voximplant/react-native-foreground-service": "3.0.2",
@@ -5543,38 +5543,67 @@
         "react-native-screens": ">= 3.0.0"
       }
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.81.1.tgz",
-      "integrity": "sha512-E5xm27xrLXL10knH2EWDQsQYh5nb4SxxZzJ3sJwDGG9XGKzBdlp20UUhKqx00wixooVX9uCj3e4Jg8SvNB1hKg==",
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.100.1.tgz",
+      "integrity": "sha512-yqcRVnjf+qS+tC4NxOKLJOaSJ+csHmh/dHUzvCTkf5rLsplwXYRnny2r0tqGTQ4tuXMxwgSMKPYwicg81P+xuw==",
       "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.100.1.tgz",
+      "integrity": "sha512-TnqxqJGhbFhhYRhTG2WLFer+lVieV7mNGeIxFBiw1L4kuj8KGl+C0sknssKyZSRVJFSahhHIosHJGRMkkD//7g==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
+      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.81.1.tgz",
-      "integrity": "sha512-DNtS7bZEnFPKVoGazKs5wHoWC0FwsOFOOMNeDvEfouUqKKbjO7+RDHbr7H6Bo83zX4qmZWRBf8V+3n3YPIiJFw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.100.1.tgz",
+      "integrity": "sha512-IxHQ08ixf0bmaWpe4yt1J4UUsOpg02fxax9z3tOQYXw5MSzz5pDXn8M8DFUVJB3wWuyXhHXTub9yD3VIP9fnoA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/replay": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry-internal/feedback": "7.100.1",
+        "@sentry-internal/replay-canvas": "7.100.1",
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.21.3.tgz",
-      "integrity": "sha512-gv8SNaMVNggiE/+6fPxEj8+y5uj9PqAQ8QS277aZ/HSXFgoidnNecE4QGHh4n+AkT0qCSQ/byxZsojVXkwkC7g==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.30.0.tgz",
+      "integrity": "sha512-GTO5e98vy2QwEYQvhE/ZtGUiVrUu4XungLioJbazm+ZOen8cyac8YOapZfozN5mtxjWOWMOwhOqoTeCU3Q8YKQ==",
       "hasInstallScript": true,
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
@@ -5588,41 +5617,158 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.30.0",
+        "@sentry/cli-linux-arm": "2.30.0",
+        "@sentry/cli-linux-arm64": "2.30.0",
+        "@sentry/cli-linux-i686": "2.30.0",
+        "@sentry/cli-linux-x64": "2.30.0",
+        "@sentry/cli-win32-i686": "2.30.0",
+        "@sentry/cli-win32-x64": "2.30.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.30.0.tgz",
+      "integrity": "sha512-JVesQ9PznbHBOOOwuej2X8/onfXdmAEjBH6fTyWxBl6K8mB4KmBX/aHunXWMBX+VR9X32XZghIqj7acwaFUMPA==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.30.0.tgz",
+      "integrity": "sha512-MDB3iS31WKg4krCcLo520yxbUERPeA2DCtk9Qs9vSDbQl6Er64dteHllOdx1SDOyX/7GKcxrQEQ6SMmbnOo6wg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.30.0.tgz",
+      "integrity": "sha512-JNXPkkMubKoZVlcFIoClSmTb9C/I6Bz08DuAZm2jnjRaaOMiCBxI/l50H3dmfVZ6apjEguG9JkjFdb0kqKB90w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.30.0.tgz",
+      "integrity": "sha512-WhVVziFQw/fO0Cc53pY8goPAzJtIs6ORTR89fVbKwa3ZDNkX++mEOECbP7RkmD87kuRxyKzN543RPV971PcAHw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.30.0.tgz",
+      "integrity": "sha512-QkiVDeSfspotZ0Au5Yauv2DAm/BC1fL9BwPek/WwddM18I2HqnDp6l4TA4bQeEY++o0KEuNF53cPahpepltPjw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.30.0.tgz",
+      "integrity": "sha512-xLY9B1EEGuNYPKpK6M9PMmcu2PzofdvRtbraTcU6Ck2zALS5oXB9kmWc4dDKucZ/uu9JB0m+Lo4ebaNlca45qQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.30.0.tgz",
+      "integrity": "sha512-CiXuxnpJI0zho0XE5PVqIS9CwjDEYoMnHQRIr4Jj9OzlGTJ2iSSU6Zp3Ykd7lgo2iK4P6MfxIBm30gFQPnSvVA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.81.1.tgz",
-      "integrity": "sha512-tU37yAmckOGCw/moWKSwekSCWWJP15O6luIq+u7wal22hE88F3Vc5Avo8SeF3upnPR+4ejaOFH+BJTr6bgrs6Q==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
+      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
       "dependencies": {
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.81.1.tgz",
-      "integrity": "sha512-25cvsI3HKiRLJBZGFC8ntuy7/yB8M1w8YLTjr3tIqydYmjFUX7f18w0iuWEtd204d8OQSPBJDapbGMdfkE5x6w==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.100.1.tgz",
+      "integrity": "sha512-zdt7f1k+5JE5FAunzBZUEFbvK5YP/LekLMeogTonaRObB07J6fJ9FD4mtNk7pV0utrTDwR+n942qmp+LbWauWA==",
       "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.81.1.tgz",
-      "integrity": "sha512-DN5ONn0/LX5HHVPf1EBGHFssIZaZmLgkqUIeMqCNYBpB4DiOrJANnGwTcWKDPphqhdPxjnPv9AGRLaU0PdvvZQ==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.100.1.tgz",
+      "integrity": "sha512-RUyZHcsN3Plc8G4hJN3BCMdbwS8ljUY3E3iLjzucA4HroBsGk5AMc6n7Pp/QqFIRgxrPjKEgA52Wgy5Nq6dSvw==",
       "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -5630,13 +5776,14 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.81.1.tgz",
-      "integrity": "sha512-kk0plP/mf8KgVLOiImIpp1liYysmh3Un8uXcVAToomSuHZPGanelFAdP0XhY+0HlWU9KIfxTjhMte1iSwQ8pYw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.100.1.tgz",
+      "integrity": "sha512-EdrBtrXVLK2LSx4Rvz/nQP7HZUZQmr+t3GHV8436RAhF6vs5mntACVMBoQJRWiUvtZ1iRo3rIsIdah7DLiFPgQ==",
       "dependencies": {
-        "@sentry/browser": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1",
+        "@sentry/browser": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -5647,52 +5794,61 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.14.0.tgz",
-      "integrity": "sha512-QpG3OWQ5eWwFOE5sNtsOkbFaqCBJB7z9W92CxnD08WUwIPtt+5YcHs4aBi3bVqQAhwmC0VMwxCqCAgxt6VNf5Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.20.0.tgz",
+      "integrity": "sha512-1jWqQFRvQeFgYrEXfvr0TTG/kXIGV2KgtkNqlInTTuXFXo6qInFhuu4Ak4zNuitFlfr6Soh2ASlJrpkBKf2pAg==",
       "dependencies": {
-        "@sentry/browser": "7.81.1",
-        "@sentry/cli": "2.21.3",
-        "@sentry/core": "7.81.1",
-        "@sentry/hub": "7.81.1",
-        "@sentry/integrations": "7.81.1",
-        "@sentry/react": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/browser": "7.100.1",
+        "@sentry/cli": "2.30.0",
+        "@sentry/core": "7.100.1",
+        "@sentry/hub": "7.100.1",
+        "@sentry/integrations": "7.100.1",
+        "@sentry/react": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
       },
       "peerDependencies": {
+        "expo": ">=49.0.0",
         "react": ">=17.0.0",
         "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.81.1.tgz",
-      "integrity": "sha512-4ueT0C4bYjngN/9p0fEYH10dTMLovHyk9HxJ6zSTgePvGVexhg+cSEHXisoBDwHeRZVnbIvsVM0NA7rmEDXJJw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
+      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.81.1.tgz",
-      "integrity": "sha512-dvJvGyctiaPMIQqa46k56Re5IODWMDxiHJ1UjBs/WYDLrmWFPGrEbyJ8w8CYLhYA+7qqrCyIZmHbWSTRIxstHw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
+      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.81.1.tgz",
-      "integrity": "sha512-gq+MDXIirHKxNZ+c9/lVvCXd6y2zaZANujwlFggRH2u9SRiPaIXVilLpvMm4uJqmqBMEcY81ArujExtHvkbCqg==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
+      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
       "dependencies": {
-        "@sentry/types": "7.81.1"
+        "@sentry/types": "7.100.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@react-navigation/bottom-tabs": "6.5.11",
     "@react-navigation/native": "6.1.9",
     "@react-navigation/stack": "6.3.20",
-    "@sentry/react-native": "5.14.0",
+    "@sentry/react-native": "5.20.0",
     "@stream-io/flat-list-mvcp": "0.10.3",
     "@tsconfig/react-native": "3.0.2",
     "@voximplant/react-native-foreground-service": "3.0.2",

--- a/patches/@sentry+utils+7.100.1.patch
+++ b/patches/@sentry+utils+7.100.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@sentry/utils/cjs/object.js b/node_modules/@sentry/utils/cjs/object.js
-index eb89fb8..0716abb 100644
+index a6151b5..67dcf57 100644
 --- a/node_modules/@sentry/utils/cjs/object.js
 +++ b/node_modules/@sentry/utils/cjs/object.js
-@@ -198,7 +198,11 @@ function dropUndefinedKeys(inputValue) {
+@@ -203,7 +203,11 @@ function dropUndefinedKeys(inputValue) {
    return _dropUndefinedKeys(inputValue, memoizationMap);
  }
  
@@ -12,10 +12,10 @@ index eb89fb8..0716abb 100644
 +    return inputValue;
 +  }
 +
-   if (is.isPlainObject(inputValue)) {
+   if (isPojo(inputValue)) {
      // If this node has already been visited due to a circular reference, return the object it was mapped to in the new object
      const memoVal = memoizationMap.get(inputValue);
-@@ -212,7 +216,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
+@@ -217,7 +221,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
  
      for (const key of Object.keys(inputValue)) {
        if (typeof inputValue[key] !== 'undefined') {
@@ -24,7 +24,7 @@ index eb89fb8..0716abb 100644
        }
      }
  
-@@ -231,7 +235,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
+@@ -236,7 +240,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
      memoizationMap.set(inputValue, returnValue);
  
      inputValue.forEach((item) => {
@@ -34,10 +34,10 @@ index eb89fb8..0716abb 100644
  
      return returnValue ;
 diff --git a/node_modules/@sentry/utils/esm/object.js b/node_modules/@sentry/utils/esm/object.js
-index 0f5c411..1a8b5c9 100644
+index c63c177..3e43a58 100644
 --- a/node_modules/@sentry/utils/esm/object.js
 +++ b/node_modules/@sentry/utils/esm/object.js
-@@ -196,7 +196,11 @@ function dropUndefinedKeys(inputValue) {
+@@ -201,7 +201,11 @@ function dropUndefinedKeys(inputValue) {
    return _dropUndefinedKeys(inputValue, memoizationMap);
  }
  
@@ -47,10 +47,10 @@ index 0f5c411..1a8b5c9 100644
 +    return inputValue;
 +  }
 +
-   if (isPlainObject(inputValue)) {
+   if (isPojo(inputValue)) {
      // If this node has already been visited due to a circular reference, return the object it was mapped to in the new object
      const memoVal = memoizationMap.get(inputValue);
-@@ -210,7 +214,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
+@@ -215,7 +219,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
  
      for (const key of Object.keys(inputValue)) {
        if (typeof inputValue[key] !== 'undefined') {
@@ -59,7 +59,7 @@ index 0f5c411..1a8b5c9 100644
        }
      }
  
-@@ -229,7 +233,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
+@@ -234,7 +238,7 @@ function _dropUndefinedKeys(inputValue, memoizationMap) {
      memoizationMap.set(inputValue, returnValue);
  
      inputValue.forEach((item) => {


### PR DESCRIPTION
#### Summary
On https://github.com/mattermost/mattermost-mobile/pull/7891 I added the privacy files, but I made the big mistake of not running the app after setting this up. The result is that the `sentry` package was also declaring this privacy file and making conflicts with our own.

This was solved on later versions of sentry, so I updated the dependency to the latest, as https://github.com/mattermost/mattermost-mobile/pull/7863 was going to do either way.

The idea to push this PR separately is because right now it is not possible to create a build because of this failure.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
