### PR TITLE
fix: use polyfill-force to improve startup time

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,13 +41,13 @@ setFontFamily();
 
 if (global.HermesInternal) {
     // Polyfills required to use Intl with Hermes engine
-    require('@formatjs/intl-getcanonicallocales/polyfill');
-    require('@formatjs/intl-locale/polyfill');
-    require('@formatjs/intl-pluralrules/polyfill');
-    require('@formatjs/intl-numberformat/polyfill');
-    require('@formatjs/intl-datetimeformat/polyfill');
+    require('@formatjs/intl-getcanonicallocales/polyfill-force');
+    require('@formatjs/intl-locale/polyfill-force');
+    require('@formatjs/intl-pluralrules/polyfill-force');
+    require('@formatjs/intl-numberformat/polyfill-force');
+    require('@formatjs/intl-datetimeformat/polyfill-force');
     require('@formatjs/intl-datetimeformat/add-golden-tz');
-    require('@formatjs/intl-listformat/polyfill');
+    require('@formatjs/intl-listformat/polyfill-force');
 }
 
 if (Platform.OS === 'android') {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Improved startup performance by using polyfill-force on all @formatjs polyfills. `require('@formatjs/*/polyfill')` calls `shouldPolyfill()` method which in some instances could take over 2000ms.

When using Samsung Galaxy S9, it was observed that the startup time even after initial install was taking over 7s to move from splash screen to server screen.  Added a bunch of logInfo() between ./index.ts => ./app/screen/server/index.tsx and discovered that the biggest execution time was during polyfill-ing.  At first, created a dynamic loading as example can be found here: https://formatjs.io/docs/polyfills/intl-pluralrules/

```
import {shouldPolyfill} from '@formatjs/intl-pluralrules/should-polyfill'
async function polyfill(locale: string) {
  const unsupportedLocale = shouldPolyfill(locale)
  // This locale is supported
  if (!unsupportedLocale) {
    return
  }
  // Load the polyfill 1st BEFORE loading data
  await import('@formatjs/intl-pluralrules/polyfill-force')
  await import(`@formatjs/intl-pluralrules/locale-data/${unsupportedLocale}`)
}
```

but then discovered the shouldPolyfill() method was the culprit of the slowdown.  Localization on unsupported language would default to `en`, so polyfill-ing can ignore shouldPolyfill() call by requiring /polyfill-force instead.

Android tests were performed using real devices and `release` build.

| | |Galaxy S9| |Pixel 6| | Galaxy S22|
|---|---:|---:|---:|---:|---:|---:|
| |normal|force|normal|force|normal|force|
|getcanonical|20|14|3|5|6|6|
|locale|0|0|0|0|1|0|
|pluralrules|656|1|333|0|426|0|
|numberformat|1614|1|15|1|13|0|
|dateformat|1554|183|908|94|1394|91|
|listformat|1679|1|810|0|975|0|
|TOTAL|5523|200|2069|100|2815|97|

iOS tests were performed using real device tests and `release` build:

| | |iPhone X| |iPhone 13 Pro|
|---|---:|---:|---:|---:|
| |normal|force|normal|force|
|getcanonical|0|6|1|5|
|locale|1|0|0|0|
|pluralrules|292|0|360|0|
|numberformat|710|1|888|1|
|dateformat|790|102|988|117|
|listformat|702|0|882|0|
|TOTAL|2495|109|3119|123|

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
Google Pixel 6, Android 14
Samsung Galaxy S22, Android 12
Samsung Galaxy S9, Android 11(?)
iPhone X, iOS 16.7.2
iPhone 13 Pro, iOS 17.4.1

#### Screenshots

iOS after (1s)

https://github.com/mattermost/mattermost-mobile/assets/5550094/c7fa317b-d390-4080-840e-a52d9f5813b6



iOS before (4s)


https://github.com/mattermost/mattermost-mobile/assets/5550094/18be99e6-329a-4a09-847d-e1114e95df04



<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
