### PR TITLE
Fix erratic behavior of pull to refresh on threads

### DIFF
--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -156,6 +156,9 @@ const PostList = ({
     }, []);
 
     const onRefresh = useCallback(async () => {
+        if (disablePullToRefresh) {
+            return;
+        }
         setRefreshing(true);
         if (location === Screens.CHANNEL && channelId) {
             await fetchPosts(serverUrl, channelId);
@@ -170,7 +173,7 @@ const PostList = ({
             await fetchPostThread(serverUrl, rootId, options);
         }
         setRefreshing(false);
-    }, [channelId, location, posts, rootId]);
+    }, [channelId, location, posts, rootId, disablePullToRefresh]);
 
     const onScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
         const {y} = event.nativeEvent.contentOffset;
@@ -357,7 +360,7 @@ const PostList = ({
                 testID={`${testID}.flat_list`}
                 inverted={true}
                 refreshing={refreshing}
-                onRefresh={disablePullToRefresh ? undefined : onRefresh}
+                onRefresh={onRefresh}
             />
             {location !== Screens.PERMALINK &&
             <ScrollToEndView


### PR DESCRIPTION
#### Summary
Only on threads, we were seeing a weird behavior of the pull to refresh functionality.

It will blur the images, and sometimes won't go back to its original state.

The main difference was we were passing the `disablePullToRefresh` prop to the post list. This prop decided whether to pass or not the `onRefresh` function. This seems to cause the whole list to re-render when changing form `undefined` to a proper function.

Moving the logic of `disablePullToRefresh` inside the `onRefresh` makes it so the flat list always has a `onRefresh` function, and does not re-render the complete list.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-57063

#### Release Note
```release-note
Fix erratic behavior when pull up to refresh on a thread
```
