### PR TITLE
[MM-52675] Use message_source in copy text action (#26674)

### DIFF
--- a/app/screens/post_options/post_options.tsx
+++ b/app/screens/post_options/post_options.tsx
@@ -140,7 +140,7 @@ const PostOptions = ({
                 {Boolean(canCopyText && post.message) &&
                 <CopyTextOption
                     bottomSheetId={Screens.POST_OPTIONS}
-                    postMessage={post.message}
+                    postMessage={post.messageSource || post.message}
                     sourceScreen={sourceScreen}
                 />}
                 {canPin &&


### PR DESCRIPTION
Fixes https://github.com/mattermost/mattermost/issues/26674
Fixes Jira https://mattermost.atlassian.net/browse/MM-52675

```release-note
When clicking on the "Copy Text" list item in a channel post dot menu (accessed by clicking the three dots) for a post that includes embedded images using markdown, the clipboard now receives the markdown as was entered into the original post instead of one that includes a proxy link.
```