### PR TITLE
Properly unset the active channel in the server

### DIFF
--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -667,6 +667,17 @@ export async function markChannelAsRead(serverUrl: string, channelId: string, up
     }
 }
 
+export async function unsetActiveChannelOnServer(serverUrl: string) {
+    try {
+        const client = NetworkManager.getClient(serverUrl);
+        await client.viewMyChannel('');
+        return {};
+    } catch (error) {
+        logDebug('error on markChannelAsRead', getFullErrorMessage(error));
+        return {error};
+    }
+}
+
 export async function switchToChannelByName(serverUrl: string, channelName: string, teamName: string, errorHandler: (intl: IntlShape) => void, intl: IntlShape) {
     const onError = (joinedTeam: boolean, teamId?: string) => {
         errorHandler(intl);


### PR DESCRIPTION
#### Summary
When we mark a channel as read on the server, the "active channel" gets set. This handles how we receive push notifications.

This PR makes sure we unset the active channel when we exit from the channel screen, or we send the app to the background.

I also piggybacked a fix for channels in other servers being read when they should not.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-57000

#### Release Note
```release-note
Improve status management to avoid missing notifications
Fix issue where channels from other servers may get read on startup
```
