### PR TITLE
Avoid race condition setting the badge number when the app is in the background

### DIFF
--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -30,7 +30,7 @@ class NotificationService: UNNotificationServiceExtension {
               self?.sendMessageIntent()
             })
           } else {
-            bestAttemptContent.badge = Gekidou.Database.default.getTotalMentions() as NSNumber
+            bestAttemptContent.badge = nil
             os_log(OSLogType.default, "Mattermost Notifications: app in use, no data processed. Will call sendMessageIntent")
             self?.sendMessageIntent()
           }


### PR DESCRIPTION
#### Summary
While testing I noticed that, specially when the app was in the background, the notification badge was not being updated.

After some testing, I think the root cause is a race condition. The notification badge is set on the native side looking at the values in the database. But the database is not updated until the information is processed in the JS side. So more often than not, the information in the database is not yet ready. This is a bigger issue if the database returns 0 mentions, since 0 has a bigger meaning in this context.

We solve this by updating the badge on the frontend when we are in the background, and assigning nil in the native side, so the badge stays the same.

(Documentation reference: https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/badge )

I also did some refactoring around the home component so we don't have to create so many functions on every render. We could consider move these also to a different file.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55131
Fix #7630 

#### Release Note
```release-note
(iOS) Fix badge number not being correct sometimes
```
