### PR TITLE
[MM-58074] Calls: Fix crashing app when starting/joining call

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
     <!-- Request legacy Bluetooth permissions on older devices. -->
     <uses-permission android:name="android.permission.BLUETOOTH"
@@ -105,6 +106,10 @@
       </activity>
 
         <!-- For Calls microphone to work in the background -->
-        <service android:name="com.voximplant.foregroundservice.VIForegroundService"/>
+        <service
+                android:name="com.voximplant.foregroundservice.VIForegroundService"
+                android:foregroundServiceType="microphone"
+                android:exported="true"
+        />
     </application>
 </manifest>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -80,7 +80,7 @@ PODS:
   - HMSegmentedControl (1.5.6)
   - jail-monkey (2.8.0):
     - React-Core
-  - JitsiWebRTC (118.0.0)
+  - JitsiWebRTC (111.0.2)
   - libevent (2.1.12)
   - libwebp (1.3.2):
     - libwebp/demux (= 1.3.2)
@@ -1017,8 +1017,8 @@ PODS:
     - react-native-video/Video (= 5.2.1)
   - react-native-video/Video (5.2.1):
     - React-Core
-  - react-native-webrtc (118.0.3):
-    - JitsiWebRTC (~> 118.0.0)
+  - react-native-webrtc (111.0.6):
+    - JitsiWebRTC (~> 111.0.0)
     - React-Core
   - react-native-webview (13.8.4):
     - glog
@@ -1641,7 +1641,7 @@ SPEC CHECKSUMS:
   hermes-engine: 9cecf9953a681df7556b8cc9c74905de8f3293c0
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   jail-monkey: a71b35d482a70ecba844a90f002994012cf12a5d
-  JitsiWebRTC: 3a41671ef65a51d7204323814b055a2690b921c7
+  JitsiWebRTC: 80f62908fcf2a1160e0d14b584323fb6e6be630b
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   mattermost-react-native-turbo-log: 8e3a92c8e8ad68282977b679586f5708f2aa5f97
@@ -1683,7 +1683,7 @@ SPEC CHECKSUMS:
   react-native-paste-input: d2136a8269eb8ad57d81407ee2b8a646f738a694
   react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
-  react-native-webrtc: 6fc32f3d556aa60aa2334eeaf6cadcdab2432809
+  react-native-webrtc: 255a1172fd31525b952b36aef7b8e9a41de325e5
   react-native-webview: 9395e82c917d81407deb9b1fe53158dd6c8880ff
   React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
   React-NativeModulesApple: cd26e56d56350e123da0c1e3e4c76cb58a05e1ee

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "react-native-vector-icons": "10.0.3",
         "react-native-video": "5.2.1",
         "react-native-walkthrough-tooltip": "1.6.0",
-        "react-native-webrtc": "118.0.3",
+        "react-native-webrtc": "111.0.6",
         "react-native-webview": "13.8.4",
         "react-syntax-highlighter": "15.5.0",
         "semver": "7.6.0",
@@ -17478,9 +17478,9 @@
       }
     },
     "node_modules/react-native-webrtc": {
-      "version": "118.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-118.0.3.tgz",
-      "integrity": "sha512-qw+aa4rxGJTvltmYwwHonx4Qcgk/tcoojONu/6y5nsXGctkUqo886EIBb29Jv4ssHnudDzvkxyG/xVKK2vJc7Q==",
+      "version": "111.0.6",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-111.0.6.tgz",
+      "integrity": "sha512-uxaczOCsSOe3Olzg4w9PJpK1T+Kv45aerNlcehWClvTZ3NqSebarPuKKnrd1uuFK5bb8TVvWvq5h5qZMa2pNUw==",
       "dependencies": {
         "base64-js": "1.5.1",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-native-vector-icons": "10.0.3",
     "react-native-video": "5.2.1",
     "react-native-walkthrough-tooltip": "1.6.0",
-    "react-native-webrtc": "118.0.3",
+    "react-native-webrtc": "111.0.6",
     "react-native-webview": "13.8.4",
     "react-syntax-highlighter": "15.5.0",
     "semver": "7.6.0",

--- a/patches/@voximplant+react-native-foreground-service+3.0.2.patch
+++ b/patches/@voximplant+react-native-foreground-service+3.0.2.patch
@@ -19,3 +19,20 @@ index 7f9022f..b3e920a 100644
          versionCode 1
          versionName "1.0"
      }
+diff --git a/node_modules/@voximplant/react-native-foreground-service/android/src/main/java/com/voximplant/foregroundservice/VIForegroundServiceModule.java b/node_modules/@voximplant/react-native-foreground-service/android/src/main/java/com/voximplant/foregroundservice/VIForegroundServiceModule.java
+index afc578c..c8c32e3 100644
+--- a/node_modules/@voximplant/react-native-foreground-service/android/src/main/java/com/voximplant/foregroundservice/VIForegroundServiceModule.java
++++ b/node_modules/@voximplant/react-native-foreground-service/android/src/main/java/com/voximplant/foregroundservice/VIForegroundServiceModule.java
+@@ -110,7 +110,11 @@ public class VIForegroundServiceModule extends ReactContextBaseJavaModule {
+ 
+         IntentFilter filter = new IntentFilter();
+         filter.addAction(FOREGROUND_SERVICE_BUTTON_PRESSED);
+-        getReactApplicationContext().registerReceiver(foregroundReceiver, filter);
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
++            getReactApplicationContext().registerReceiver(foregroundReceiver, filter, Context.RECEIVER_EXPORTED);
++        } else {
++            getReactApplicationContext().registerReceiver(foregroundReceiver, filter);
++        }
+ 
+         if (componentName != null) {
+             promise.resolve(null);


### PR DESCRIPTION
#### Summary
- The recent bump to Android 34 (#7863) broke calls, this fixes it. Android 34 requires more specific permissions and some new code for foreground services (we're using that to make the call continue while the app is in the background).
- Totally understandable and unanticipated consequence of updating things. But it highlights a problem we have with mobile -- no calls e2e test infra. Until we get that, I wonder if we could request manual testing from @DHaussermann or myself on any react-native or Android SDK bumps like that, to make sure Calls doesn't break?
- Related, I reverted the `react-native-webrtc` upgrade from that PR as well -- we don't want to upgrade that without thorough testing. It's a fast-moving package and often breaks things. If possible, could XYZ update that when needed? (bc of the manual testing required)
- cc @larkox for visibility, you can review if you'd like. 
- Thanks everyone!

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-58074

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- Android: 13, Galaxy Tab s7+
- iOS: 16.5.1, iPhone 14

#### Release Note

```release-note
NONE
```

