### PR TITLE
MM-58137 Fix crash by importing the correct Animated component

### DIFF
--- a/app/components/post_list/post/body/content/image_preview/image_preview.tsx
+++ b/app/components/post_list/post/body/content/image_preview/image_preview.tsx
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {Animated, StyleSheet, TouchableWithoutFeedback, View} from 'react-native';
+import {StyleSheet, TouchableWithoutFeedback, View} from 'react-native';
+import Animated from 'react-native-reanimated';
 
 import {getRedirectLocation} from '@actions/remote/general';
 import FileIcon from '@components/files/file_icon';


### PR DESCRIPTION
#### Summary
The ImagePreview component for some reason (code from 2Y) ago was using the wrong Animated component, now replaced with the one provided by the reanimated library.

This was causing the library to access a property directly that causes the crash as it should only be accessible in the UI Thread (native side)

This crash is only happening after updating the Reanimated library with all the other deps done for 2.16, so this PR needs to be cherry picked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58137

#### Release Note
```release-note
NONE
```
