### PR TITLE
Fix notification impeding the input in the rest of the app

### DIFF
--- a/app/screens/in_app_notification/index.tsx
+++ b/app/screens/in_app_notification/index.tsx
@@ -62,6 +62,9 @@ const styles = StyleSheet.create({
     touchable: {
         flexDirection: 'row',
     },
+    gestureHandler: {
+        flex: 0,
+    },
 });
 
 const InAppNotification = ({componentId, serverName, serverUrl, notification}: InAppNotificationProps) => {
@@ -148,7 +151,7 @@ const InAppNotification = ({componentId, serverName, serverUrl, notification}: I
     const database = DatabaseManager.serverDatabases[serverUrl]?.database;
 
     return (
-        <GestureHandlerRootView>
+        <GestureHandlerRootView style={styles.gestureHandler}>
             <GestureDetector gesture={gesture}>
                 <Animated.View
                     style={[styles.container, isTablet ? styles.tablet : undefined, animatedStyle]}


### PR DESCRIPTION
#### Summary
On react native gesture handler v2.16.0 they changed the default flex for GestureHandlerRootView from 0 to 1.

This caused the gesture handler to fit the whole screen, catching the input even if the overlay was set not to catch taps in the background.

Passing the new flex solves the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-32183

#### Release Note
```release-note
NONE
```
Issue introduced in https://github.com/mattermost/mattermost-mobile/pull/7863 which is not yet in the release branch.
