### PR TITLE
Fix server options text by in Quartz theme

### DIFF
--- a/app/screens/home/channel_list/servers/servers_list/server_item/options/option.tsx
+++ b/app/screens/home/channel_list/servers/servers_list/server_item/options/option.tsx
@@ -33,7 +33,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         width: OPTION_SIZE,
     },
     text: {
-        color: theme.sidebarText,
+        color: theme.buttonColor,
         ...typography('Body', 75, 'SemiBold'),
     },
 }));


### PR DESCRIPTION
#### Summary
We were using the wrong text color from the theme. This was not a problem in most of the themes, because it was coincident with the color of the icon, but on Quartz theme they are different.

Now the theme color used for the text and the icon are the same.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-56657

#### Release Note
```release-note
Fix server option text on Quartz theme
```
