### PR TITLE
[MM-57460] - Calls: Host controls, add mute all to participant list

### DIFF
--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -642,6 +642,17 @@ export const hostMuteSession = async (serverUrl: string, callId: string, session
     }
 };
 
+export const hostMuteAll = async (serverUrl: string, callId: string) => {
+    try {
+        const client = NetworkManager.getClient(serverUrl);
+        return client.hostMuteAll(callId);
+    } catch (error) {
+        logDebug('error on hostMuteAll', getFullErrorMessage(error));
+        await forceLogoutIfNecessary(serverUrl, error);
+        return error;
+    }
+};
+
 export const hostStopScreenshare = async (serverUrl: string, callId: string, sessionId: string) => {
     try {
         const client = NetworkManager.getClient(serverUrl);

--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -642,12 +642,12 @@ export const hostMuteSession = async (serverUrl: string, callId: string, session
     }
 };
 
-export const hostMuteAll = async (serverUrl: string, callId: string) => {
+export const hostMuteOthers = async (serverUrl: string, callId: string) => {
     try {
         const client = NetworkManager.getClient(serverUrl);
-        return client.hostMuteAll(callId);
+        return client.hostMuteOthers(callId);
     } catch (error) {
-        logDebug('error on hostMuteAll', getFullErrorMessage(error));
+        logDebug('error on hostMuteOthers', getFullErrorMessage(error));
         await forceLogoutIfNecessary(serverUrl, error);
         return error;
     }

--- a/app/products/calls/client/rest.ts
+++ b/app/products/calls/client/rest.ts
@@ -19,6 +19,7 @@ export interface ClientCallsMix {
     dismissCall: (channelId: string) => Promise<ApiResp>;
     hostMake: (callId: string, newHostId: string) => Promise<ApiResp>;
     hostMute: (callId: string, sessionId: string) => Promise<ApiResp>;
+    hostMuteAll: (callId: string) => Promise<ApiResp>;
     hostScreenOff: (callId: string, sessionId: string) => Promise<ApiResp>;
     hostLowerHand: (callId: string, sessionId: string) => Promise<ApiResp>;
     hostRemove: (callId: string, sessionId: string) => Promise<ApiResp>;
@@ -128,6 +129,13 @@ const ClientCalls = (superclass: any) => class extends superclass {
                 method: 'post',
                 body: {session_id: sessionId},
             },
+        );
+    };
+
+    hostMuteAll = async (callId: string) => {
+        return this.doFetch(
+            `${this.getCallsRoute()}/calls/${callId}/host/mute-all`,
+            {method: 'post'},
         );
     };
 

--- a/app/products/calls/client/rest.ts
+++ b/app/products/calls/client/rest.ts
@@ -19,7 +19,7 @@ export interface ClientCallsMix {
     dismissCall: (channelId: string) => Promise<ApiResp>;
     hostMake: (callId: string, newHostId: string) => Promise<ApiResp>;
     hostMute: (callId: string, sessionId: string) => Promise<ApiResp>;
-    hostMuteAll: (callId: string) => Promise<ApiResp>;
+    hostMuteOthers: (callId: string) => Promise<ApiResp>;
     hostScreenOff: (callId: string, sessionId: string) => Promise<ApiResp>;
     hostLowerHand: (callId: string, sessionId: string) => Promise<ApiResp>;
     hostRemove: (callId: string, sessionId: string) => Promise<ApiResp>;
@@ -132,9 +132,9 @@ const ClientCalls = (superclass: any) => class extends superclass {
         );
     };
 
-    hostMuteAll = async (callId: string) => {
+    hostMuteOthers = async (callId: string) => {
         return this.doFetch(
-            `${this.getCallsRoute()}/calls/${callId}/host/mute-all`,
+            `${this.getCallsRoute()}/calls/${callId}/host/mute-others`,
             {method: 'post'},
         );
     };

--- a/app/products/calls/screens/participants_list/index.ts
+++ b/app/products/calls/screens/participants_list/index.ts
@@ -21,12 +21,16 @@ const enhanced = withObservables([], () => {
     const callChannelId = observeCurrentCall().pipe(
         switchMap((call) => of$(call?.channelId)),
     );
+    const callUserId = observeCurrentCall().pipe(
+        switchMap((call) => of$(call?.myUserId)),
+    );
 
     return {
         sessionsDict: observeCurrentSessionsDict(),
         teammateNameDisplay,
         callServerUrl,
         callChannelId,
+        callUserId,
     };
 });
 

--- a/app/products/calls/screens/participants_list/index.ts
+++ b/app/products/calls/screens/participants_list/index.ts
@@ -7,6 +7,7 @@ import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
 import {observeCallDatabase, observeCurrentSessionsDict} from '@calls/observers';
 import {ParticipantsList} from '@calls/screens/participants_list/participants_list';
+import {observeCurrentCall} from '@calls/state';
 import {observeTeammateNameDisplay} from '@queries/servers/user';
 
 const enhanced = withObservables([], () => {
@@ -14,10 +15,22 @@ const enhanced = withObservables([], () => {
         switchMap((db) => (db ? observeTeammateNameDisplay(db) : of$(''))),
         distinctUntilChanged(),
     );
+    const callServerUrl = observeCurrentCall().pipe(
+        switchMap((call) => of$(call?.serverUrl)),
+    );
+    const isHost = observeCurrentCall().pipe(
+        switchMap((call) => of$(Boolean(call?.hostId === call?.myUserId))),
+    );
+    const callChannelId = observeCurrentCall().pipe(
+        switchMap((call) => of$(call?.channelId)),
+    );
 
     return {
         sessionsDict: observeCurrentSessionsDict(),
         teammateNameDisplay,
+        callServerUrl,
+        isHost,
+        callChannelId,
     };
 });
 

--- a/app/products/calls/screens/participants_list/index.ts
+++ b/app/products/calls/screens/participants_list/index.ts
@@ -18,9 +18,6 @@ const enhanced = withObservables([], () => {
     const callServerUrl = observeCurrentCall().pipe(
         switchMap((call) => of$(call?.serverUrl)),
     );
-    const isHost = observeCurrentCall().pipe(
-        switchMap((call) => of$(Boolean(call?.hostId === call?.myUserId))),
-    );
     const callChannelId = observeCurrentCall().pipe(
         switchMap((call) => of$(call?.channelId)),
     );
@@ -29,7 +26,6 @@ const enhanced = withObservables([], () => {
         sessionsDict: observeCurrentSessionsDict(),
         teammateNameDisplay,
         callServerUrl,
-        isHost,
         callChannelId,
     };
 });

--- a/app/products/calls/screens/participants_list/participants_list.tsx
+++ b/app/products/calls/screens/participants_list/participants_list.tsx
@@ -9,7 +9,7 @@ import {FlatList} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {hostMuteAll} from '@calls/actions/calls';
-import {useHostMenus} from '@calls/hooks';
+import {useHostControlsAvailable, useHostMenus} from '@calls/hooks';
 import {Participant} from '@calls/screens/participants_list/participant';
 import Pill from '@calls/screens/participants_list/pill';
 import {sortSessions} from '@calls/utils';
@@ -34,7 +34,6 @@ type Props = {
     sessionsDict: Dictionary<CallSession>;
     teammateNameDisplay: string;
     callServerUrl?: string;
-    isHost: boolean;
     callChannelId?: string;
 }
 
@@ -67,10 +66,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-export const ParticipantsList = ({closeButtonId, sessionsDict, teammateNameDisplay, callServerUrl, isHost, callChannelId}: Props) => {
+export const ParticipantsList = ({closeButtonId, sessionsDict, teammateNameDisplay, callServerUrl, callChannelId}: Props) => {
     const intl = useIntl();
     const theme = useTheme();
     const {onPress} = useHostMenus();
+    const hostControlsAvailable = useHostControlsAvailable();
     const {bottom} = useSafeAreaInsets();
     const {height} = useWindowDimensions();
     const isTablet = useIsTablet();
@@ -112,7 +112,7 @@ export const ParticipantsList = ({closeButtonId, sessionsDict, teammateNameDispl
                         defaultMessage={'Participants'}
                     />
                     <Pill text={sessions.length}/>
-                    {isHost && unMuted &&
+                    {hostControlsAvailable && unMuted &&
                         <TouchableOpacity
                             style={styles.muteButton}
                             onPress={muteAllPress}

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -486,7 +486,7 @@
   "mobile.calls_mic_error": "To participate, open Settings to grant Mattermost access to your microphone.",
   "mobile.calls_more": "More",
   "mobile.calls_mute": "Mute",
-  "mobile.calls_mute_all": "Mute all",
+  "mobile.calls_mute_others": "Mute others",
   "mobile.calls_mute_participant": "Mute participant",
   "mobile.calls_name_is_talking_postfix": "is talking...",
   "mobile.calls_name_started_call": "{name} started a call",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -486,6 +486,7 @@
   "mobile.calls_mic_error": "To participate, open Settings to grant Mattermost access to your microphone.",
   "mobile.calls_more": "More",
   "mobile.calls_mute": "Mute",
+  "mobile.calls_mute_all": "Mute all",
   "mobile.calls_mute_participant": "Mute participant",
   "mobile.calls_name_is_talking_postfix": "is talking...",
   "mobile.calls_name_started_call": "{name} started a call",


### PR DESCRIPTION
#### Summary
- Add the mute all command in the participant list for hosts
- Designs: https://www.figma.com/file/8C0ojMc778Zx3a0nm66Edw/MM-56584-Host-Controls?node-id=1270%3A54648&mode=dev

<img src="https://github.com/mattermost/mattermost-mobile/assets/1490756/28e813b9-246f-49e1-b0c2-e0e9c3d3d5e8" width="200">

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-57470

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
- Android: 13, Pixel 6
- Android: 13, Galaxy Tab s7+
- iOS: 16.5.1, iPhone 14

#### Release Note
```release-note
Calls: Host controls, mute all option added to participants list
```
