### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mattermost Mobile v2
 
-- **Minimum Server versions:** Current ESR version (8.1.0+)
+- **Minimum Server versions:** Current ESR version (9.5.0+)
 - **Supported iOS versions:** 12.4+
 - **Supported Android versions:** 7.0+
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Requires Mattermost Server v8.1.0+. Older servers may not be able to connect or have unexpected behavior.
+Requires Mattermost Server v9.5.0+. Older servers may not be able to connect or have unexpected behavior.
 
 -------
 

--- a/fastlane/metadata/changelog
+++ b/fastlane/metadata/changelog
@@ -1,4 +1,4 @@
-This version is compatible with Mattermost servers v8.1.0+.
+This version is compatible with Mattermost servers v9.5.0+.
 
 Please see [changelog](https://docs.mattermost.com/administration/mobile-changelog.html) for full release notes. If you're interested in helping beta test upcoming versions before they are released, please see our [documentation](https://github.com/mattermost/mattermost-mobile#testing).
 


### PR DESCRIPTION
v8.1 ESR is going out of support mid-May, and v9.5+ will become the new minimum supported ESR version.