### PR TITLE
Move away from curl and jq for the version bump script

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -87,7 +87,7 @@ if [ -n "${CREATE_PR}" ]; then
   log "Creating PR"
   PR_TITLE="Bump app ${BUMP_BUILD_NUMBER:+build}${BUMP_VERSION_NUMBER:+${BUMP_BUILD_NUMBER:+ and }version} number"
   # We won't specify the milestone when opening the PR if either we're not bumping the version number, or if the milestone is not found
-  MILESTONE_FOUND=$(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/mattermost/mattermost-mobile/milestones | jq -r ".[] | .title | select(. == \"v${VERSION_NUMBER:-}\")")
+  MILESTONE_FOUND=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" --jq '.[] | .title' /repos/mattermost/mattermost-mobile/milestones | grep -E "^v${VERSION_NUMBER}$")
   #shellcheck disable=SC2046
   gh pr create \
     --repo mattermost/mattermost-mobile \


### PR DESCRIPTION
#### Summary

Fix for a better error message when the PR creation fails, on a version bump script ruin

#### Release Note
```release-note
NONE
```
