### PR TITLE
[Draft] Update mobile ESR in-product notice

### DIFF
--- a/app/constants/supported_server.ts
+++ b/app/constants/supported_server.ts
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 export const MIN_REQUIRED_VERSION = '5.26.2';
-export const FULL_VERSION = '8.1.0';
-export const MAJOR_VERSION = 8;
-export const MIN_VERSION = 1;
+export const FULL_VERSION = '9.5.0';
+export const MAJOR_VERSION = 9;
+export const MIN_VERSION = 5;
 export const PATCH_VERSION = 0;
 
 export default {


### PR DESCRIPTION
v8.1 ESR has gone out of support on May 15th, and v9.5.0 is the new minimum required ESR version.

```release-note
Updated minimum supported version to v9.5.0.
```