### PR TITLE
Fix user autocomplete not always showing on search screen

### DIFF
--- a/app/components/autocomplete/at_mention/at_mention.tsx
+++ b/app/components/autocomplete/at_mention/at_mention.tsx
@@ -278,7 +278,7 @@ const AtMention = ({
             const filteredUsers = filterResults(fallbackUsers, term);
             setFilteredLocalUsers(filteredUsers.length ? filteredUsers : emptyUserlList);
         } else if (receivedUsers) {
-            sortRecievedUsers(sUrl, term, receivedUsers?.users, receivedUsers?.out_of_channel);
+            await sortRecievedUsers(sUrl, term, receivedUsers?.users, receivedUsers?.out_of_channel);
         }
 
         setLoading(false);


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost-mobile/pull/7506 we changed the behavior of the user autocomplete. Among other things, we made an async call where there was no async call, and we were not waiting for it, causing the `loading` state setting back to false before setting the users. This let the autocomplete think there are no results to show.

Awaiting that line solves the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-58493

#### Release Note
```release-note
NONE
```
I think the offending PR has not yet being released. If it has been released, then the release note should show:
Fix issue where the user autocomplete doesn't show in the search screen on some circumstances
