### PR TITLE
fix update image on account screen when updating profile image

### DIFF
--- a/app/components/profile_picture/image.tsx
+++ b/app/components/profile_picture/image.tsx
@@ -13,6 +13,7 @@ import {ACCOUNT_OUTLINE_IMAGE} from '@constants/profile';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {getLastPictureUpdate} from '@utils/user';
 
 import type UserModel from '@typings/database/models/servers/user';
 
@@ -42,6 +43,7 @@ const Image = ({author, forwardRef, iconSize, size, source, url}: Props) => {
     serverUrl = url || serverUrl;
 
     const style = getStyleSheet(theme);
+    const lastPictureUpdateAt = author ? getLastPictureUpdate(author) : 0;
     const fIStyle = useMemo(() => ({
         borderRadius: size / 2,
         backgroundColor: theme.centerChannelBg,
@@ -56,7 +58,7 @@ const Image = ({author, forwardRef, iconSize, size, source, url}: Props) => {
 
         const pictureUrl = buildProfileImageUrlFromUser(serverUrl, author);
         return source ?? {uri: buildAbsoluteUrl(serverUrl, pictureUrl)};
-    }, [author, serverUrl, source]);
+    }, [author, serverUrl, source, lastPictureUpdateAt]);
 
     if (typeof source === 'string') {
         return (

--- a/app/screens/edit_profile/components/edit_profile_picture.tsx
+++ b/app/screens/edit_profile/components/edit_profile_picture.tsx
@@ -82,7 +82,7 @@ const EditProfilePicture = ({user, onUpdateProfilePicture}: ChangeProfilePicture
             let prefix = '';
             if (pictureUrl.includes('/api/')) {
                 prefix = serverUrl;
-            } else if (Platform.OS === 'android' && !pictureUrl.startsWith('content://') && !pictureUrl.startsWith('http://') && !pictureUrl.startsWith('https://')) {
+            } else if (Platform.OS === 'android' && !pictureUrl.startsWith('content://') && !pictureUrl.startsWith('http://') && !pictureUrl.startsWith('https://') && !pictureUrl.startsWith('file://')) {
                 prefix = 'file://';
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {


### PR DESCRIPTION
#### Summary
For some reason the `author` changes was not being picked up by the useMemo, now we are getting the last time the user updated the picture as part of the dependencies of the memo in order to trigger it and update the url of the profile picture.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58501

#### Release Note
```release-note
NONE
```
