### PR TITLE
Fix user autocomplete not showing users not in channel

### DIFF
--- a/app/components/autocomplete/at_mention/at_mention.tsx
+++ b/app/components/autocomplete/at_mention/at_mention.tsx
@@ -298,8 +298,14 @@ const AtMention = ({
 
         if (outOfChannel?.length) {
             const outChannelMemberIds = outOfChannel.map((e) => e.id);
+
+            // This only get us the users we have on the database.
+            // We need to append those users from which we don't have
+            // information at the end of the list.
             const outSortedMembers = await getUsersFromDMSorted(database, outChannelMemberIds);
-            sortedMembers.push(...outSortedMembers);
+            const idSet = new Set(outSortedMembers.map((v) => v.id));
+            const outRest = outOfChannel.filter((v) => !idSet.has(v.id));
+            sortedMembers.push(...outSortedMembers, ...outRest);
         }
 
         if (hasTrailingSpaces(term)) {


### PR DESCRIPTION
#### Summary
We were always getting the users from the database on user autocomplete, which may not have all the information.

We fix that by appending at the end the rest of the users received from the API.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58504


#### Release Note
```release-note
NONE
```
Issue introduced probably by https://github.com/mattermost/mattermost-mobile/pull/7506 , which (I think) never made it to production.