### PR TITLE
T271: Prevent access to Android components if they do not need external comms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,14 +1,20 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission-sdk-23 android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:ignore="SelectedPhotoAccess" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:ignore="SelectedPhotoAccess" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:ignore="SelectedPhotoAccess" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
@@ -34,6 +40,8 @@
     <application
       android:name=".MainApplication"
       android:allowBackup="false"
+      android:dataExtractionRules="@xml/data_extraction_rules"
+      android:fullBackupContent="false"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
@@ -49,7 +57,6 @@
                    android:resource="@xml/app_restrictions" />
       <activity
         android:name=".MainActivity"
-        android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:windowSoftInputMode="adjustResize"
         android:launchMode="singleTask"
@@ -84,14 +91,12 @@
         android:name="com.reactnativenavigation.controllers.NavigationActivity"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:resizeableActivity="true"
-        android:exported="true"
+        android:exported="false"
       />
       <activity
         android:name="com.mattermost.share.ShareActivity"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:windowSoftInputMode="adjustResize"
-        android:label="@string/app_name"
-        android:screenOrientation="portrait"
         android:theme="@style/AppTheme"
         android:taskAffinity="com.mattermost.share"
         android:exported="true"
@@ -109,7 +114,7 @@
         <service
                 android:name="com.voximplant.foregroundservice.VIForegroundService"
                 android:foregroundServiceType="microphone"
-                android:exported="true"
+                android:exported="false"
         />
     </application>
 </manifest>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref"/>
+        <exclude domain="file" path="./databases"/>
+    </cloud-backup>
+    <!--
+    <device-transfer>
+        <include .../>
+        <exclude .../>
+    </device-transfer>
+    -->
+</data-extraction-rules>

--- a/patches/react-native-exception-handler+2.10.10.patch
+++ b/patches/react-native-exception-handler+2.10.10.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-exception-handler/android/src/main/AndroidManifest.xml b/node_modules/react-native-exception-handler/android/src/main/AndroidManifest.xml
+index 58dfc7b..47c9954 100644
+--- a/node_modules/react-native-exception-handler/android/src/main/AndroidManifest.xml
++++ b/node_modules/react-native-exception-handler/android/src/main/AndroidManifest.xml
+@@ -3,7 +3,7 @@
+     package="com.masteratul.exceptionhandler">
+ 
+     <application>
+-        <activity android:name=".DefaultErrorScreen">
++        <activity android:name=".DefaultErrorScreen" android:exported="false">
+         </activity>
+     </application>
+ 

--- a/patches/react-native-notifications+5.1.0.patch
+++ b/patches/react-native-notifications+5.1.0.patch
@@ -16,10 +16,10 @@ index 30bb01c..bba788d 100644
                  events "PASSED", "SKIPPED", "FAILED", "standardOut", "standardError"
              }
 diff --git a/node_modules/react-native-notifications/lib/android/app/src/main/AndroidManifest.xml b/node_modules/react-native-notifications/lib/android/app/src/main/AndroidManifest.xml
-index 24cd226..4bfacba 100644
+index 24cd226..3aa1728 100644
 --- a/node_modules/react-native-notifications/lib/android/app/src/main/AndroidManifest.xml
 +++ b/node_modules/react-native-notifications/lib/android/app/src/main/AndroidManifest.xml
-@@ -3,6 +3,7 @@
+@@ -3,19 +3,19 @@
      xmlns:android="http://schemas.android.com/apk/res/android"
      package="com.wix.reactnativenotifications">
  
@@ -27,7 +27,22 @@ index 24cd226..4bfacba 100644
      <application>
  
          <!--
-@@ -23,6 +24,9 @@
+          A proxy-service that gives the library an opportunity to do some work before launching/resuming the actual application task.
+          -->
+-        <service android:name=".core.ProxyService"/>
++        <service android:name=".core.ProxyService" android:exported="false"/>
+ 
+         <service
+             android:name=".fcm.FcmInstanceIdListenerService"
+-            android:exported="true">
++            android:exported="false">
+             <intent-filter>
+                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
+-                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
+             </intent-filter>
+         </service>
+ 
+@@ -23,6 +23,9 @@
              android:name=".fcm.FcmInstanceIdRefreshHandlerService"
              android:exported="false"
              android:permission="android.permission.BIND_JOB_SERVICE" />


### PR DESCRIPTION
#### Summary
This PR patches a couple of dependencies to set the activities and services with the flag of exported=false

Also address in this PR, corrections to our own Manifest file to apply exported=false and other improvements, specially around backups.

#### Release Note
```release-note
NONE
```
