### PR TITLE
Fix typo in UIRequiredDeviceCapabilities for iOS

### DIFF
--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -109,7 +109,7 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv64</string>
+		<string>arm64</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
 	<false/>


### PR DESCRIPTION
#### Summary

This PR changed the UIRequiredDeviceCapabilities value for iOS: https://github.com/mattermost/mattermost-mobile/pull/8011
However, after it was merged, Apple refused to accept the weekly beta build:  https://github.com/mattermost/mattermost-mobile/actions/runs/9646645994/job/26603731918#step:5:9750

Looking up some docs it seems the correct value expected by UIRequiredDeviceCapabilities is `arm64`: https://developer.apple.com/documentation/bundleresources/information_property_list/uirequireddevicecapabilities/

After this PR is merged, i'll trigger a new beta build for iOS cc @amyblais 


#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7948

#### Release Note
```release-note
NONE
```
