### PR TITLE
Ignore local deps in notice-file-generator config

### DIFF
--- a/build/notice-file/config.yaml
+++ b/build/notice-file/config.yaml
@@ -8,7 +8,12 @@ reviewers:
   - "enahum"
 search:
   - "package.json"
-dependencies: []
-devDependencies: []
+additionalDependencies: []
+includeDevDependencies: false
+ignoreDependencies:
+- "@mattermost/hardware-keyboard"
+- "@mattermost/rnshare"
+- "@mattermost/rnutils"
+- "@mattermost/keyboard-tracker"
 
 ...


### PR DESCRIPTION
#### Summary

A recent PR migrated some functionality to local modules referenced in `package.json`: https://github.com/mattermost/mattermost-mobile/pull/8011

The code is local to the repository, and thus doesn't need to be reported in the `NOTICE.txt` file. The new notice-file-generator config file format supports the `ignoreDependencies` field to do just that.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7943

#### Release Note

```release-note
NONE
```
