### PR TITLE
Fix null reference error in notifications

### DIFF
--- a/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.kt
+++ b/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.kt
@@ -103,7 +103,7 @@ class CustomPushNotification(
 
         when (type) {
             CustomPushNotificationHelper.PUSH_TYPE_MESSAGE, CustomPushNotificationHelper.PUSH_TYPE_SESSION -> {
-                val currentActivityName = mAppLifecycleFacade.runningReactContext.currentActivity?.componentName?.className ?: ""
+                val currentActivityName = mAppLifecycleFacade.runningReactContext?.currentActivity?.componentName?.className ?: ""
                 Log.i("ReactNative", currentActivityName)
                 if (!mAppLifecycleFacade.isAppVisible() || currentActivityName != "MainActivity") {
                     var createSummary = type == CustomPushNotificationHelper.PUSH_TYPE_MESSAGE


### PR DESCRIPTION
#### Summary
While looking into the notifications acks, I noticed that notifications stopped arriving (not sure why). The logcat was complaining about `getCurrentActivity` being called on a undefined object in this line.

Not sure how to reproduce the bug, but after this change, I didn't see it happening again in the tests.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
The bug seems introduced by https://github.com/mattermost/mattermost-mobile/commit/b8c088cc70887ab054f7cd32a8fc14a186b3ee71 , so it shouldn't be in any released version.