### PR TITLE
Fix the Universal Android build download URL for releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -329,7 +329,7 @@ lane :github do
     android = [
       "    * [Mattermost arm64-v8a](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-arm64-v8a.apk)",
       "    * [Mattermost armeabi-v7a](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-armeabi-v7a.apk)",
-      "    * [Mattermost Universal](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-universal.apk)",
+      "    * [Mattermost Universal](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost.apk)",
       "    * [Mattermost x86](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-x86.apk)",
       "    * [Mattermost x86_64](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-x86_64.apk)",
     ]


### PR DESCRIPTION
#### Summary

The filename in the URL should be `Mattermost.apk`, not `Mattermost-universal.apk`. For instance:
- I have fixed the URL manually for the 2.17.1 release: https://github.com/mattermost/mattermost-mobile/releases/tag/v2.17.1
- The 2.17.0 release contains the old URL instead, which doesn't work: https://github.com/mattermost/mattermost-mobile/releases/tag/v2.17.0

For reference: the change likely happened between [the 1.41.1 release](https://github.com/mattermost/mattermost-mobile/releases/tag/v1.41.1) and [the 1.42.0 release](https://github.com/mattermost/mattermost-mobile/releases/tag/v1.42.0) in 2021, although I couldn't find the exact change that caused the filename to change in the first place.


#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6866

#### Release Note

```release-note
NONE
```
