### PR TITLE
Fix User Agent issue in some device

### DIFF
--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -10,7 +10,7 @@ import {
     type APIClientConfiguration,
 } from '@mattermost/react-native-network-client';
 import {nativeApplicationVersion, nativeBuildVersion} from 'expo-application';
-import {deviceName, osName, osVersion} from 'expo-device';
+import {osName, osVersion} from 'expo-device';
 import {Alert, DeviceEventEmitter} from 'react-native';
 import urlParse from 'url-parse';
 
@@ -99,7 +99,7 @@ class NetworkManager {
     };
 
     private buildConfig = async () => {
-        const userAgent = `Mattermost Mobile/${nativeApplicationVersion}+${nativeBuildVersion} (${osName}; ${osVersion}; ${deviceName})`;
+        const userAgent = `Mattermost Mobile/${nativeApplicationVersion}+${nativeBuildVersion} (${osName}; ${osVersion})`;
         const managedConfig = ManagedApp.enabled ? Emm.getManagedConfig<ManagedConfig>() : undefined;
         const headers: Record<string, string> = {
             [ClientConstants.HEADER_USER_AGENT]: userAgent,

--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -10,7 +10,7 @@ import {
     type APIClientConfiguration,
 } from '@mattermost/react-native-network-client';
 import {nativeApplicationVersion, nativeBuildVersion} from 'expo-application';
-import {osName, osVersion} from 'expo-device';
+import {modelName, osName, osVersion} from 'expo-device';
 import {Alert, DeviceEventEmitter} from 'react-native';
 import urlParse from 'url-parse';
 
@@ -99,7 +99,7 @@ class NetworkManager {
     };
 
     private buildConfig = async () => {
-        const userAgent = `Mattermost Mobile/${nativeApplicationVersion}+${nativeBuildVersion} (${osName}; ${osVersion})`;
+        const userAgent = `Mattermost Mobile/${nativeApplicationVersion}+${nativeBuildVersion} (${osName}; ${osVersion}; ${modelName})`;
         const managedConfig = ManagedApp.enabled ? Emm.getManagedConfig<ManagedConfig>() : undefined;
         const headers: Record<string, string> = {
             [ClientConstants.HEADER_USER_AGENT]: userAgent,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

The `deviceName` may contain non-ASCII characters such as CJK or other characters. Some devices may not support this behavior. It is recommended to remove `deviceName` or move it to another field to avoid such issues.

This issue was primarily observed on the Samsung A22, but it did not occur on my Xperia 1 V.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

None

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on:

Samsung A22, Android 13
Xperia 1 V, Android 13

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
