### PR TITLE
Graciously handle load measure when there is no mark

### DIFF
--- a/app/managers/performance_metrics_manager/index.ts
+++ b/app/managers/performance_metrics_manager/index.ts
@@ -4,11 +4,16 @@
 import {AppState, type AppStateStatus} from 'react-native';
 import performance from 'react-native-performance';
 
+import {logWarning} from '@utils/log';
+
 import Batcher from './performance_metrics_batcher';
 
 type Target = 'HOME' | 'CHANNEL' | 'THREAD' | undefined;
 type MetricName = 'mobile_channel_switch' |
     'mobile_team_switch';
+
+const RETRY_TIME = 100;
+const MAX_RETRIES = 3;
 
 class PerformanceMetricsManager {
     private target: Target;
@@ -43,18 +48,29 @@ class PerformanceMetricsManager {
         this.target = target;
     }
 
-    public finishLoad(location: Target, serverUrl: string) {
+    public finishLoad(location: Target, serverUrl: string, retries = 0) {
         if (this.target !== location || this.hasRegisteredLoad) {
             return;
         }
 
-        const measure = performance.measure('mobile_load', 'nativeLaunchStart');
-        this.ensureBatcher(serverUrl).addToBatch({
-            metric: 'mobile_load',
-            value: measure.duration,
-            timestamp: Date.now(),
-        });
-        performance.clearMeasures('mobile_load');
+        try {
+            const measure = performance.measure('mobile_load', 'nativeLaunchStart');
+            this.ensureBatcher(serverUrl).addToBatch({
+                metric: 'mobile_load',
+                value: measure.duration,
+                timestamp: Date.now(),
+            });
+            performance.clearMeasures('mobile_load');
+        } catch {
+            // There seems to be a race condition where in some scenarios, the mobile load
+            // mark does not exist. We add this to avoid crashes related to this.
+            if (retries < MAX_RETRIES) {
+                setTimeout(() => this.finishLoad(location, serverUrl, retries + 1), RETRY_TIME);
+                return;
+            }
+            logWarning('We could not retrieve the mobile load metric');
+        }
+
         this.hasRegisteredLoad = true;
     }
 
@@ -81,5 +97,11 @@ class PerformanceMetricsManager {
         performance.clearMeasures(measureName);
     }
 }
+
+export const testExports = {
+    PerformanceMetricsManager,
+    RETRY_TIME,
+    MAX_RETRIES,
+};
 
 export default new PerformanceMetricsManager();

--- a/app/managers/performance_metrics_manager/index.ts
+++ b/app/managers/performance_metrics_manager/index.ts
@@ -48,7 +48,11 @@ class PerformanceMetricsManager {
         this.target = target;
     }
 
-    public finishLoad(location: Target, serverUrl: string, retries = 0) {
+    public finishLoad(location: Target, serverUrl: string) {
+        this.finishLoadWithRetries(location, serverUrl, 0);
+    }
+
+    private finishLoadWithRetries(location: Target, serverUrl: string, retries: number) {
         if (this.target !== location || this.hasRegisteredLoad) {
             return;
         }
@@ -65,7 +69,7 @@ class PerformanceMetricsManager {
             // There seems to be a race condition where in some scenarios, the mobile load
             // mark does not exist. We add this to avoid crashes related to this.
             if (retries < MAX_RETRIES) {
-                setTimeout(() => this.finishLoad(location, serverUrl, retries + 1), RETRY_TIME);
+                setTimeout(() => this.finishLoadWithRetries(location, serverUrl, retries + 1), RETRY_TIME);
                 return;
             }
             logWarning('We could not retrieve the mobile load metric');

--- a/app/managers/performance_metrics_manager/performance_metrics_batcher.ts
+++ b/app/managers/performance_metrics_manager/performance_metrics_batcher.ts
@@ -100,4 +100,8 @@ class Batcher {
     }
 }
 
+export const testExports = {
+    MAX_BATCH_SIZE,
+    INTERVAL_TIME,
+};
 export default Batcher;


### PR DESCRIPTION
#### Summary
Specially on iOS, we seem to have a race condition with the load measures. I added a retry (in case the masure is not yet on the JS side) and a warning if even after the retries is not there.

Right now the retry will delay the measure up to 300ms. Given we are in the realm of several seconds for mobile load, I don't think this will skew too much the metrics.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59280

#### Release Note
```release-note
NONE
```
