### PR TITLE
Add unit tests for app/actions/local/category

### DIFF
--- a/app/actions/local/category.test.ts
+++ b/app/actions/local/category.test.ts
@@ -185,9 +185,6 @@ describe('addChannelToDefaultCategory', () => {
 
     let operator: ServerDataOperator;
 
-    beforeEach(async () => {
-    });
-
     it('base case', async () => {
         await DatabaseManager.init([serverUrl]);
         operator = DatabaseManager.serverDatabases[serverUrl]!.operator;

--- a/app/actions/local/category.test.ts
+++ b/app/actions/local/category.test.ts
@@ -99,7 +99,7 @@ describe('category crud', () => {
 
     let operator: ServerDataOperator;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         await DatabaseManager.init([serverUrl]);
         operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
         await operator.handleTeam({teams: [team], prepareRecordsOnly: false});

--- a/app/actions/local/category.test.ts
+++ b/app/actions/local/category.test.ts
@@ -1,9 +1,17 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {DMS_CATEGORY} from '@app/constants/categories';
+import {setCurrentUserId} from '@app/queries/servers/system';
 import DatabaseManager from '@database/manager';
 
-import {handleConvertedGMCategories} from './category';
+import {
+    deleteCategory,
+    handleConvertedGMCategories,
+    storeCategories,
+    toggleCollapseCategory,
+    addChannelToDefaultCategory,
+} from './category';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 
@@ -18,12 +26,9 @@ describe('handleConvertedGMCategories', () => {
 
     let operator: ServerDataOperator;
 
-    beforeEach(async () => {
+    it('base case', async () => {
         await DatabaseManager.init([serverUrl]);
         operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
-    });
-
-    it('base case', async () => {
         await operator.handleTeam({teams: [team], prepareRecordsOnly: false});
 
         const defaultCategory: Category = {
@@ -65,5 +70,173 @@ describe('handleConvertedGMCategories', () => {
         expect(error).toBeUndefined();
         expect(models).toBeDefined();
         expect(models!.length).toBe(3); // two for removing channel for a custom and a DM category, and one for adding it to default channels category
+    });
+
+    it('error - no channel category', async () => {
+        await DatabaseManager.init([serverUrl]);
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+
+        const {models, error} = await handleConvertedGMCategories(serverUrl, channelId, teamId1, true);
+        expect(error).toBeDefined();
+        expect(error).toBe('Failed to find default category when handling category of converted GM');
+        expect(models).toBeUndefined();
+    });
+
+    it('error - database not prepared', async () => {
+        const {error} = await handleConvertedGMCategories(serverUrl, channelId, teamId1, true);
+        expect(error).toBeDefined();
+    });
+});
+
+describe('category crud', () => {
+    const serverUrl = 'baseHandler.test.com';
+    const teamId1 = 'team_id_1';
+    const channelId1 = 'channel_id_1';
+    const channelId2 = 'channel_id_2';
+    const team: Team = {
+        id: teamId1,
+    } as Team;
+
+    let operator: ServerDataOperator;
+
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+        await operator.handleTeam({teams: [team], prepareRecordsOnly: false});
+    });
+
+    it('deleteCategory', async () => {
+        const defaultCategory: Category = {
+            id: 'default_category_id',
+            team_id: teamId1,
+            type: 'channels',
+        } as Category;
+
+        await operator.handleCategories({categories: [defaultCategory], prepareRecordsOnly: false});
+
+        const {category, error} = await deleteCategory(serverUrl, defaultCategory.id);
+        expect(error).toBeUndefined();
+        expect(category).toBeDefined();
+        expect(category?.id).toBe(defaultCategory.id);
+
+        const {category: nullCategory, error: error2} = await deleteCategory(serverUrl, 'junk');
+        expect(nullCategory).toBeUndefined();
+        expect(error2).toBeUndefined();
+    });
+
+    it('storeCategories', async () => {
+        const defaultCategory: CategoryWithChannels = {
+            id: 'default_category_id',
+            team_id: teamId1,
+            type: 'channels',
+            channel_ids: [channelId1, channelId2],
+        } as CategoryWithChannels;
+
+        const {models: prepModels, error: prepError} = await storeCategories(serverUrl, [defaultCategory], false, true); // only prepare
+        expect(prepError).toBeUndefined();
+        expect(prepModels).toBeDefined();
+        expect(prepModels!.length).toBe(3); // one for the category and two for the channels added to the category
+
+        const {models, error} = await storeCategories(serverUrl, [defaultCategory], false, false);
+        expect(error).toBeUndefined();
+        expect(models).toBeDefined();
+        expect(models!.length).toBe(3);
+    });
+
+    it('toggleCollapseCategory', async () => {
+        const defaultCategory: Category = {
+            id: 'default_category_id',
+            team_id: teamId1,
+            type: 'channels',
+            collapsed: false,
+        } as Category;
+
+        await operator.handleCategories({categories: [defaultCategory], prepareRecordsOnly: false});
+
+        const {category: categoryResult1, error: error1} = await toggleCollapseCategory(serverUrl, defaultCategory.id);
+        expect(error1).toBeUndefined();
+        expect(categoryResult1).toBeDefined();
+        expect(categoryResult1?.collapsed).toBe(!defaultCategory.collapsed);
+
+        const {category: categoryResult2, error: error2} = await toggleCollapseCategory(serverUrl, defaultCategory.id);
+        expect(error2).toBeUndefined();
+        expect(categoryResult2).toBeDefined();
+        expect(categoryResult2?.collapsed).toBe(defaultCategory.collapsed);
+    });
+});
+
+describe('addChannelToDefaultCategory', () => {
+    const serverUrl = 'baseHandler.test.com';
+    const channelId = 'channel_id_1';
+    const teamId1 = 'team_id_1';
+    const team: Team = {
+        id: teamId1,
+    } as Team;
+    const channel: Channel = {
+        id: channelId,
+        team_id: teamId1,
+        type: 'O',
+    } as Channel;
+    const dmChannel: Channel = {
+        id: channelId,
+        team_id: '',
+        type: 'D',
+    } as Channel;
+
+    let operator: ServerDataOperator;
+
+    beforeEach(async () => {
+    });
+
+    it('base case', async () => {
+        await DatabaseManager.init([serverUrl]);
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+        await operator.handleTeam({teams: [team], prepareRecordsOnly: false});
+        setCurrentUserId(operator, 'userid');
+
+        const myTeams: MyTeam[] = [{
+            id: team.id,
+            roles: 'team_user',
+        }];
+
+        await operator.handleMyTeam({myTeams, prepareRecordsOnly: false});
+
+        const defaultCategory: Category = {
+            id: 'default_category_id',
+            team_id: teamId1,
+            type: 'channels',
+        } as Category;
+
+        const dmCategory: Category = {
+            id: 'dm_category_id',
+            team_id: teamId1,
+            type: DMS_CATEGORY,
+        } as Category;
+
+        await operator.handleCategories({categories: [defaultCategory, dmCategory], prepareRecordsOnly: false});
+
+        const {models, error} = await addChannelToDefaultCategory(serverUrl, channel);
+        expect(error).toBeUndefined();
+        expect(models).toBeDefined();
+        expect(models!.length).toBe(1); // one for the channel
+
+        const {models: dmModels, error: dmError} = await addChannelToDefaultCategory(serverUrl, dmChannel);
+        expect(dmError).toBeUndefined();
+        expect(dmModels).toBeDefined();
+        expect(dmModels!.length).toBe(1); // one for the dm channel
+    });
+
+    it('error - no current user', async () => {
+        await DatabaseManager.init([serverUrl]);
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+        const {models, error} = await addChannelToDefaultCategory(serverUrl, channel);
+        expect(error).toBeDefined();
+        expect(error).toBe('no current user id');
+        expect(models).toBeUndefined();
+    });
+
+    it('error - database not prepared', async () => {
+        const {error} = await addChannelToDefaultCategory(serverUrl, channel);
+        expect(error).toBeDefined();
     });
 });


### PR DESCRIPTION
### Summary

Improving our unit test coverage of app/actions/local/category.

Coverage for this file goes from 30.33% -> 85.39% statements.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
