### PR TITLE
Add unit tests for app/actions/local/draft

### DIFF
--- a/app/actions/local/draft.test.ts
+++ b/app/actions/local/draft.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable max-lines */
+
+import DatabaseManager from '@database/manager';
+
+import {
+    updateDraftFile,
+} from './draft';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+
+describe('updateDraftFile', () => {
+    let operator: ServerDataOperator;
+    const serverUrl = 'baseHandler.test.com';
+    const channelId = 'id1';
+    const teamId = 'tId1';
+    const team: Team = {
+        id: teamId,
+    } as Team;
+    const channel: Channel = {
+        id: channelId,
+        team_id: teamId,
+        total_msg_count: 0,
+    } as Channel;
+    const channelMember: ChannelMembership = {
+        id: 'id',
+        channel_id: channelId,
+        msg_count: 0,
+    } as ChannelMembership;
+    const fileInfo: FileInfo = {
+        id: 'fileid',
+        clientId: 'clientid',
+        localPath: 'path1',
+    } as FileInfo;
+    const draft: Draft = {
+        channel_id: channel.id,
+        message: 'test',
+        root_id: '',
+    } as Draft;
+
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('handle not found database', async () => {
+        const {error} = await updateDraftFile('foo', channelId, '', fileInfo, false);
+        expect(error).toBeTruthy();
+    });
+
+    it('handle no draft', async () => {
+        const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo, false);
+        expect(error).toBeTruthy();
+        expect(error).toBe('no draft');
+    });
+
+    it('handle no file', async () => {
+        await operator.handleTeam({teams: [team], prepareRecordsOnly: false});
+        await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
+        await operator.handleDraft({drafts: [draft], prepareRecordsOnly: false});
+
+        const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo, false);
+        expect(error).toBeTruthy();
+        expect(error).toBe('file not found');
+    });
+
+    it('update draft file', async () => {
+        await operator.handleTeam({teams: [team], prepareRecordsOnly: false});
+        await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
+        await operator.handleDraft({drafts: [{...draft, files: [{...fileInfo, localPath: 'path0'}]}], prepareRecordsOnly: false});
+
+        const {draft: draftModel, error} = await updateDraftFile(serverUrl, channelId, '', fileInfo, false);
+        expect(error).toBeUndefined();
+        expect(draftModel).toBeDefined();
+        expect(draftModel?.files?.length).toBe(1);
+        expect(draftModel?.files![0].localPath).toBe('path1');
+    });
+});

--- a/app/actions/local/draft.test.ts
+++ b/app/actions/local/draft.test.ts
@@ -210,7 +210,7 @@ describe('updateDraftMessage', () => {
     });
 
     it('update draft message, no file', async () => {
-        await operator.handleDraft({drafts: [{channel_id: channel.id, files: [fileInfo], root_id: ''}], prepareRecordsOnly: false});
+        await operator.handleDraft({drafts: [{channel_id: channel.id, files: [], root_id: ''}], prepareRecordsOnly: false});
 
         const result = await updateDraftMessage(serverUrl, channelId, '', 'newmessage', false) as {draft: DraftModel; error: unknown};
         expect(result.error).toBeUndefined();

--- a/app/actions/local/draft.test.ts
+++ b/app/actions/local/draft.test.ts
@@ -7,6 +7,7 @@ import DatabaseManager from '@database/manager';
 
 import {
     updateDraftFile,
+    removeDraftFile,
 } from './draft';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
@@ -16,19 +17,11 @@ describe('updateDraftFile', () => {
     const serverUrl = 'baseHandler.test.com';
     const channelId = 'id1';
     const teamId = 'tId1';
-    const team: Team = {
-        id: teamId,
-    } as Team;
     const channel: Channel = {
         id: channelId,
         team_id: teamId,
         total_msg_count: 0,
     } as Channel;
-    const channelMember: ChannelMembership = {
-        id: 'id',
-        channel_id: channelId,
-        msg_count: 0,
-    } as ChannelMembership;
     const fileInfo: FileInfo = {
         id: 'fileid',
         clientId: 'clientid',
@@ -61,9 +54,6 @@ describe('updateDraftFile', () => {
     });
 
     it('handle no file', async () => {
-        await operator.handleTeam({teams: [team], prepareRecordsOnly: false});
-        await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
-        await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
         await operator.handleDraft({drafts: [draft], prepareRecordsOnly: false});
 
         const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo, false);
@@ -72,9 +62,6 @@ describe('updateDraftFile', () => {
     });
 
     it('update draft file', async () => {
-        await operator.handleTeam({teams: [team], prepareRecordsOnly: false});
-        await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
-        await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
         await operator.handleDraft({drafts: [{...draft, files: [{...fileInfo, localPath: 'path0'}]}], prepareRecordsOnly: false});
 
         const {draft: draftModel, error} = await updateDraftFile(serverUrl, channelId, '', fileInfo, false);
@@ -82,5 +69,63 @@ describe('updateDraftFile', () => {
         expect(draftModel).toBeDefined();
         expect(draftModel?.files?.length).toBe(1);
         expect(draftModel?.files![0].localPath).toBe('path1');
+    });
+});
+
+describe('removeDraftFile', () => {
+    let operator: ServerDataOperator;
+    const serverUrl = 'baseHandler.test.com';
+    const channelId = 'id1';
+    const teamId = 'tId1';
+    const channel: Channel = {
+        id: channelId,
+        team_id: teamId,
+        total_msg_count: 0,
+    } as Channel;
+    const fileInfo: FileInfo = {
+        id: 'fileid',
+        clientId: 'clientid',
+        localPath: 'path1',
+    } as FileInfo;
+    const draft: Draft = {
+        channel_id: channel.id,
+        message: 'test',
+        root_id: '',
+    } as Draft;
+
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('handle not found database', async () => {
+        const {error} = await removeDraftFile('foo', channelId, '', '', false);
+        expect(error).toBeTruthy();
+    });
+
+    it('handle no draft', async () => {
+        const {error} = await removeDraftFile(serverUrl, channelId, '', 'clientid', false);
+        expect(error).toBeTruthy();
+        expect(error).toBe('no draft');
+    });
+
+    it('handle no file', async () => {
+        await operator.handleDraft({drafts: [draft], prepareRecordsOnly: false});
+
+        const {error} = await removeDraftFile(serverUrl, channelId, '', 'clientid', false);
+        expect(error).toBeTruthy();
+        expect(error).toBe('file not found');
+    });
+
+    it('update draft file', async () => {
+        await operator.handleDraft({drafts: [{...draft, files: [fileInfo]}], prepareRecordsOnly: false});
+
+        const {draft: draftModel, error} = await removeDraftFile(serverUrl, channelId, '', 'clientid', false);
+        expect(error).toBeUndefined();
+        expect(draftModel).toBeDefined();
     });
 });


### PR DESCRIPTION
#### Summary
Improving our unit test coverage of app/actions/local/draft.

Coverage for this file goes from 22.82% -> 98.91% statements.

#### Ticket Link
n/a

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note

```release-note
NONE
```
