### PR TITLE
fix: saving test report

### DIFF
--- a/detox/save_report.js
+++ b/detox/save_report.js
@@ -139,9 +139,12 @@ const saveReport = async () => {
 
     // Create or use an existing test cycle
     let testCycle = {};
-    if (ZEPHYR_ENABLE === true) {
+    if (ZEPHYR_ENABLE === 'true') {
         const {start, end} = summary.stats;
         testCycle = ZEPHYR_CYCLE_KEY ? {key: ZEPHYR_CYCLE_KEY} : await createTestCycle(start, end);
+        if (!testCycle?.key) {
+            console.log('Failed to create test cycle');
+        }
     }
 
     // Send test report to "QA: Mobile Test Automation Report" channel via webhook


### PR DESCRIPTION
#### Summary
Reverted previous change to `ZEPHYR_ENABLE` for it requires a string

#### Ticket Link
none

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
NONE
```
