### PR TITLE
Hide deactivated users in iOS

### DIFF
--- a/app/components/user_item/user_item.tsx
+++ b/app/components/user_item/user_item.tsx
@@ -121,6 +121,10 @@ const UserItem = ({
     const shared = user ? isShared(user) : false;
     const deactivated = user ? isDeactivated(user) : false;
 
+    if (deactivated) {
+        return null;
+    }
+
     const isCurrentUser = currentUserId === user?.id;
     const customStatus = getUserCustomStatus(user);
     const customStatusExpired = isCustomStatusExpired(user);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Do now show deactivated users in iOS Mobile
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/issues/8074
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Device Information
This PR was tested on: iPhone 15 Pro <!-- Device name(s), OS version(s) -->

#### Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-07-15 at 12 36 39](https://github.com/user-attachments/assets/a054ca87-2ee3-4318-bdc4-1a70bd71416b)

<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
NONE
```
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.


```
