### PR TITLE
Fix server list bottom sheet on tablet

### DIFF
--- a/app/screens/home/channel_list/servers/index.tsx
+++ b/app/screens/home/channel_list/servers/index.tsx
@@ -135,7 +135,7 @@ const Servers = React.forwardRef<ServersRef>((_, ref) => {
             bottomSheet({
                 closeButtonId,
                 renderContent,
-                footerComponent: AddServerButton,
+                footerComponent: isTablet ? undefined : AddServerButton,
                 snapPoints,
                 theme,
                 title: intl.formatMessage({id: 'your.servers', defaultMessage: 'Your servers'}),


### PR DESCRIPTION
#### Summary
The Add Server footer was being added and causing an error trying to access a hook outside of the gorhom provider for the bottom sheet as on Tablet it opens as a Modal.

Note: The Add Server button was being added twice as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59527

#### Release Note
```release-note
Fixed the server list modal displayed on Tablets
```
