### PR TITLE
Avoid registering wrong performance load logs

### DIFF
--- a/app/actions/remote/entry/login.ts
+++ b/app/actions/remote/entry/login.ts
@@ -4,6 +4,7 @@
 import {fetchConfigAndLicense} from '@actions/remote/systems';
 import DatabaseManager from '@database/manager';
 import {getServerCredentials} from '@init/credentials';
+import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import WebsocketManager from '@managers/websocket_manager';
 
 type AfterLoginArgs = {
@@ -15,6 +16,11 @@ export async function loginEntry({serverUrl}: AfterLoginArgs): Promise<{error?: 
     if (!operator) {
         return {error: `${serverUrl} database not found`};
     }
+
+    // There are cases where the target may be reset and a performance metric
+    // be added after login. This would be done with a wrong value, so we make
+    // sure we don't do this by skipping the load metric here.
+    PerformanceMetricsManager.skipLoadMetric();
 
     try {
         const clData = await fetchConfigAndLicense(serverUrl, false);

--- a/app/managers/performance_metrics_manager/index.ts
+++ b/app/managers/performance_metrics_manager/index.ts
@@ -48,6 +48,10 @@ class PerformanceMetricsManager {
         this.target = target;
     }
 
+    public skipLoadMetric() {
+        this.hasRegisteredLoad = true;
+    }
+
     public finishLoad(location: Target, serverUrl: string) {
         this.finishLoadWithRetries(location, serverUrl, 0);
     }

--- a/share_extension/index.tsx
+++ b/share_extension/index.tsx
@@ -11,6 +11,7 @@ import {Appearance, BackHandler} from 'react-native';
 import {getDefaultThemeByAppearance} from '@context/theme';
 import {DEFAULT_LOCALE, getTranslations} from '@i18n';
 import {initialize} from '@init/app';
+import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {extractStartLink, isValidUrl} from '@utils/url';
 
 import ChannelsScreen from './screens/channels';
@@ -62,6 +63,13 @@ const ShareExtension = () => {
     const files = useMemo(() => {
         return data?.filter((i) => !i.isString) || [];
     }, [data]);
+
+    useEffect(() => {
+        // Since the share functionality inits the app, the init mark gets set
+        // at this point. Therefore, any check on load times after this is done
+        // over the wrong value.
+        PerformanceMetricsManager.skipLoadMetric();
+    }, []);
 
     useEffect(() => {
         initialize().finally(async () => {


### PR DESCRIPTION
#### Summary
On the performance metrics we have seen that specially on Android, we are seeing a lot of load events over 30 seconds. This is out of the ordinary. I found two instances where this might happen:
- On initial login, after we already have logged in, if we close the app by hitting the back button and open it again, the target will be set and the performance metric will be generated. Nevertheless, the "init time" will be still set to the time we opened the app before login.
- When we open the share menu, the app opens. If we then open the app, the load logic will send a performance metric based on the init time when the share menu was opened.

I solved this by making sure we skip the load metric on those two scenarios.

#### Ticket Link
NONE

#### Release Note
```release-note
Improve load time performance metrics
```
