### PR TITLE
Attachment list in view info for DMs and GMs mobile

### DIFF
--- a/app/actions/remote/search.ts
+++ b/app/actions/remote/search.ts
@@ -18,8 +18,8 @@ import {getUserTimezone} from '@utils/user';
 import {fetchPostAuthors, fetchMissingChannelsFromPosts} from './post';
 import {forceLogoutIfNecessary} from './session';
 
-import type {ChannelModel} from '@app/database/models/server';
 import type Model from '@nozbe/watermelondb/Model';
+import type ChannelModel from '@typings/database/models/servers/channel';
 import type PostModel from '@typings/database/models/servers/post';
 
 export async function fetchRecentMentions(serverUrl: string): Promise<PostSearchRequest> {

--- a/app/screens/channel_files/channel_files.tsx
+++ b/app/screens/channel_files/channel_files.tsx
@@ -7,14 +7,12 @@ import {Platform, StyleSheet, View} from 'react-native';
 import {type Edge, SafeAreaView} from 'react-native-safe-area-context';
 
 import {searchFiles} from '@actions/remote/search';
-import {getCurrentTeamId} from '@app/queries/servers/system';
 import FileResults from '@components/files_search/file_results';
 import Loading from '@components/loading';
 import Search from '@components/search';
 import {General} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
-import DatabaseManager from '@database/manager';
 import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
 import {popTopScreen} from '@screens/navigation';
 import {type FileFilter, FileFilters, filterFileExtensions} from '@utils/file';
@@ -100,18 +98,7 @@ function ChannelFiles({
         const t = Date.now();
         lastSearchRequest.current = t;
         const searchParams = getSearchParams(channel.id, searchTerm, ftr);
-        let files: FileInfo[] | undefined = [];
-        if (channel.teamId) {
-            const searchedFiles = await searchFiles(serverUrl, channel.teamId, searchParams);
-            files = searchedFiles.files;
-        } else {
-            // teamId can be empty for GMs and DMs, as do not store teamId for GMs and DMs in the database
-            // so we need to fetch the current teamId from the systems table
-            const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-            const teamId = await getCurrentTeamId(database);
-            const searchedFiles = await searchFiles(serverUrl, teamId, searchParams);
-            files = searchedFiles.files;
-        }
+        const {files} = await searchFiles(serverUrl, channel.teamId, searchParams, channel);
         if (lastSearchRequest.current !== t) {
             return;
         }


### PR DESCRIPTION
#### Summary
The attachment list API was failing due to an incorrect API call. The API call to fetch files should include teamId, which was missing. This PR resolves the issue by retrieving the teamId for DMs and GMs (since teamId is not stored for DMs and GMs inside the `channels` table, it needs to be fetched from the systems table) and then making the API call to fetch files with the correct teamId.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54528


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

```release-note
NONE
```
