### PR TITLE
fix: (MM-59956) Android crash when sharing

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <!-- Request legacy Bluetooth permissions on older devices. -->
     <uses-permission android:name="android.permission.BLUETOOTH"
@@ -116,5 +117,15 @@
                 android:foregroundServiceType="microphone"
                 android:exported="false"
         />
+
+      <!-- Android 14 requires the correct Foreground Service (FGS) type for RNShare -->
+      <service
+          android:name="androidx.work.impl.foreground.SystemForegroundService"
+          android:foregroundServiceType="dataSync"
+          android:exported="false"
+          android:stopWithTask="false"
+          tools:node="merge"
+      />
+
     </application>
 </manifest>

--- a/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/ShareWorker.kt
+++ b/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/ShareWorker.kt
@@ -1,5 +1,6 @@
 package com.mattermost.rnshare
 
+import android.content.pm.ServiceInfo
 import android.content.Context
 import android.util.Base64
 import android.util.Log
@@ -198,7 +199,7 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
                 .setSmallIcon(applicationContext.resources.getIdentifier("ic_notification", "mipmap", applicationContext.packageName))
                 .setOngoing(true)
                 .build()
-        return ForegroundInfo(1, notification)
+        return ForegroundInfo(1, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
 
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
On Android devices, when sharing photos (from camera or internal storage), or files, or screenshots, the app will more likely crash.  This is because the app is now being built using target SDK version of 34 (Android 14).  Recent changes on [Android 14](https://developer.android.com/about/versions/14/changes/fgs-types-required)

> Caution: If your app doesn't fulfill all of the runtime requirements for starting a foreground service, the system throws a [SecurityException](https://developer.android.com/reference/java/lang/SecurityException) after you call startForeground() for that service. This prevents the foreground service from starting, might cause a running foreground service to be removed from the foreground process state, and might cause your app to crash.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-59956

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

* Google Pixel 6, Android 14

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->


https://github.com/user-attachments/assets/f0d3b2dc-f572-4fb5-bd43-dc4e177763f2



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
