### PR TITLE
Remove location strings from info.plist

### DIFF
--- a/ios/Mattermost/Info.plist
+++ b/ios/Mattermost/Info.plist
@@ -65,10 +65,6 @@
 	<string>Allowing access to your camera enables you to take photos or videos and attach them to messages.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Enabling access to your Face ID means we can restrict unauthorized users from accessing $(PRODUCT_NAME) on your device.</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Enabling access to your location data means we can add location metadata to pictures and videos you share in $(PRODUCT_NAME).</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Enabling access to your location data means we can add location metadata to pictures and videos you share in $(PRODUCT_NAME).</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Enabling access to your device's microphones means you can capture audio for calls or videos to share in $(PRODUCT_NAME).</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
#### Summary
Remove strings related to location permissions since we don't use location permissions.

#### Release Note
```release-note
NONE
```
