### PR TITLE
Quick fix for post input not capitalizing the start of sentences

### DIFF
--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -335,6 +335,7 @@ export default function PostInput({
             underlineColorAndroid='transparent'
             textContentType='none'
             value={value}
+            autoCapitalize='sentences'
         />
     );
 }


### PR DESCRIPTION
#### Summary
During the libraries updates, the PasteableTextInput library started to set the `autoCapitalize` prop by default to `none` instead of `sentences`.

The real fix should be done in the library, but this PR can be used as an interim solution.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60263

#### Release Note
```release-note
Fix bug where the Android Keyboard may not autocapitalize the first letter of a sentence by default when writing a post
```
