### PR TITLE
DRAFT: automated QA experiments

### DIFF
--- a/scripts/mitmproxy_parsing_request_response.py
+++ b/scripts/mitmproxy_parsing_request_response.py
@@ -1,0 +1,52 @@
+from mitmproxy.net.http.http1.assemble import assemble_request, assemble_response
+from datetime import datetime
+import math
+from urllib.parse import urlsplit
+
+# Use a context manager to handle file operations
+f = open('./output.txt', 'w')
+  
+def response(flow):
+    # Convert timestamps to milliseconds
+    req_ts = math.floor(flow.request.timestamp_start * 1000)
+    req_te = math.floor(flow.request.timestamp_end * 1000)
+    resp_ts = math.floor(flow.response.timestamp_start * 1000)
+    resp_te = math.floor(flow.response.timestamp_end * 1000)
+
+    # Calculate total times
+    request_total_time = req_te - req_ts
+    response_total_time = resp_te - resp_ts
+    total_time = resp_te - req_ts
+
+    # Convert timestamps to human-readable dates
+    req_ts_human = datetime.fromtimestamp(req_ts / 1000).strftime('%Y-%m-%d %H:%M:%S.%f')
+    req_te_human = datetime.fromtimestamp(req_te / 1000).strftime('%Y-%m-%d %H:%M:%S.%f')
+    resp_ts_human = datetime.fromtimestamp(resp_ts / 1000).strftime('%Y-%m-%d %H:%M:%S.%f')
+    resp_te_human = datetime.fromtimestamp(resp_te / 1000).strftime('%Y-%m-%d %H:%M:%S.%f')
+
+    # Parse the URL to separate path and query string
+    url_parts = urlsplit(flow.request.path)
+    path = url_parts.path
+    query = url_parts.query
+
+    # Format data as a comma-separated string
+    data = (
+        f"{req_ts_human},"
+        f"{req_te_human},"
+        f"{request_total_time},"
+        f"{flow.request.method},"
+        f"{flow.request.host},"
+        f"{path},"
+        f"{query},"
+        f"{flow.response.status_code},"
+        f"{resp_ts_human},"
+        f"{resp_te_human},"
+        f"{response_total_time},"
+        f"{total_time}\n"
+    )
+
+    # need to figure out how to get the content-length header
+    # f"{flow.response.headers['Content-Length']}\n"
+
+    # Write the formatted string to the file
+    f.write(data)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
