### PR TITLE
[MM-60291] Fix rendering of live captions

### DIFF
--- a/app/products/calls/components/captions.tsx
+++ b/app/products/calls/components/captions.tsx
@@ -21,11 +21,15 @@ const styles = StyleSheet.create({
     captionContainer: {
         display: 'flex',
         height: 400,
-        bottom: -352, // 48-400, to place the bottoms at the same place
+        bottom: 400 - 48, // to place the bottoms at the same place
         gap: 8,
         alignItems: 'center',
         flexDirection: 'column-reverse',
         overflow: 'hidden',
+
+        // needed so that events (e.g., long press on participants)
+        // still work when the captions overlay is rendered on top
+        pointerEvents: 'none',
     },
     caption: {
         paddingTop: 1,

--- a/app/products/calls/connection/websocket_event_handlers.ts
+++ b/app/products/calls/connection/websocket_event_handlers.ts
@@ -250,5 +250,13 @@ export const handleCallState = (serverUrl: string, msg: WebSocketMessage<CallSta
     const call = createCallAndAddToIds(msg.data.channel_id, callState);
 
     setCallForChannel(serverUrl, msg.data.channel_id, call);
+
+    if (callState.recording) {
+        setRecordingState(serverUrl, msg.data.channel_id, callState.recording);
+    }
+
+    if (callState.live_captions) {
+        setCaptioningState(serverUrl, msg.data.channel_id, callState.live_captions);
+    }
 };
 


### PR DESCRIPTION
#### Summary

It took a while to track this down but it looks like https://github.com/mattermost/mattermost-mobile/pull/8011 caused a regression in the way the style of the live captions container for calls behaved. The bottom-based positioning changed in a way that caused the container not to show at all. I am not sure if this was a change on our side or simply due to updating some stuff.

Since we are here, I am also fixing a related issue with the calls jobs state not getting synched as expected.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60291

#### Release Note

```release-note
Fixed a regression that prevented live captions for calls to show
```
