### PR TITLE
feat: enhance markdown parsing to support bold text with spaces\n

### DIFF
--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -487,6 +487,23 @@ const Markdown = ({
         return <MarkdownTableRow {...args}/>;
     };
 
+    // Transform function to allow **TEXTn** Bold. n = space/spaces.
+    const transformBoldText = (text: string) => {
+        const REGEX = /\*\*(\S.*?\S?)\s*\*\*/;
+        const parts = text.split(REGEX);
+        return parts.map((part, i) => {
+            if (i % 2 === 0) {
+                return part;
+            }
+            return (
+                <Text
+                    key={text}
+                    style={style.bold}
+                >{part.trim()}</Text>
+            );
+        });
+    };
+
     const renderText = ({context, literal}: MarkdownBaseRenderer) => {
         const selectable = (managedConfig.copyAndPasteProtection !== 'true') && context.includes('table_cell');
         if (context.indexOf('image') !== -1) {
@@ -513,13 +530,15 @@ const Markdown = ({
             styles = concatStyles(styles, {backgroundColor: theme.mentionHighlightBg});
         }
 
+        const transformedText = transformBoldText(literal);
+
         return (
             <Text
                 testID='markdown_text'
                 style={styles}
                 selectable={selectable}
             >
-                {literal}
+                {transformedText}
             </Text>
         );
     };


### PR DESCRIPTION

#### Summary

> This merge request aims to trigger bold text when a user adds a space or more after the last text letter and before the last two asterisks. For example, "**TEXT **" will be displayed as "TEXT".
> I have added a TransformBoldText function that uses a regular expression to check if there is a space after the last text letter. If a space is detected, the function returns the text in bold.


#### Ticket Link

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
feat: enhance markdown parsing to support bold text with spaces\n
```
