### PR TITLE
Remove unneeded permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,8 +11,6 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:ignore="SelectedPhotoAccess" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:ignore="SelectedPhotoAccess" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:ignore="SelectedPhotoAccess" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
#### Summary
To comply with [this new policy](https://support.google.com/googleplay/android-developer/answer/14115180) of Google, I removed the `READ_MEDIA_VIDEO` and `READ_MEDIA_IMAGE` permissions.

These were added in https://github.com/mattermost/mattermost-mobile/pull/6667 , my guess when the `@react-native-camera-roll/camera-roll` was added.

We are not asking or checking for those particular permissions in the code, and after some testing, I didn't see anything breaking after removing the permissions, but further tests would be needed.

The reason why we don't need these is that we are using native image pickers, and not using anything extra to read the images / videos, so it should be fine.

Please let me know if I may be missing something.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-59810

#### Release Note
```release-note
Remove unneeded permissions on Android
```
