### PR TITLE
MM-60425 Making clickable images work inside Markdown

### DIFF
--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -352,16 +352,18 @@ const Markdown = ({
         return rendered;
     };
 
-    const renderImage = ({linkDestination, context, src, size}: MarkdownImageRenderer) => {
+    const renderImage = ({linkDestination, context, src, size, isInsideLink = false}: MarkdownImageRenderer) => {
         if (!imagesMetadata || isUnsafeLinksPost) {
             return null;
         }
+
+        const isImageDisabled = (disableGallery ?? Boolean(!location)) || isInsideLink;
 
         if (context.indexOf('table') !== -1) {
             // We have enough problems rendering images as is, so just render a link inside of a table
             return (
                 <MarkdownTableImage
-                    disabled={disableGallery ?? Boolean(!location)}
+                    disabled={isImageDisabled}
                     imagesMetadata={imagesMetadata}
                     location={location}
                     postId={postId!}
@@ -372,7 +374,7 @@ const Markdown = ({
 
         return (
             <MarkdownImage
-                disabled={disableGallery ?? Boolean(!location)}
+                disabled={isImageDisabled}
                 errorTextStyle={[computeTextStyle(textStyles, baseTextStyle, context), textStyles.error]}
                 layoutHeight={layoutHeight}
                 layoutWidth={layoutWidth}
@@ -403,16 +405,24 @@ const Markdown = ({
         );
     };
 
-    const renderLink = ({children, href}: {children: ReactElement; href: string}) => {
+    const renderLink = ({children, href}: {children: any; href: string}) => {
         if (isUnsafeLinksPost) {
             return renderText({context: [], literal: href});
         }
+
+        const childrenWithLinkFlag = React.Children.map(children, (child) => {
+            if (React.isValidElement(child)) {
+                return React.cloneElement(child as ReactElement<any>, {isInsideLink: true});
+            }
+            return child;
+        });
+
         return (
             <MarkdownLink
                 href={href}
                 onLinkLongPress={onLinkLongPress}
             >
-                {children}
+                {childrenWithLinkFlag}
             </MarkdownLink>
         );
     };

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -352,10 +352,12 @@ const Markdown = ({
         return rendered;
     };
 
-    const renderImage = ({linkDestination, context, src, size, isInsideLink = false}: MarkdownImageRenderer) => {
+    const renderImage = ({linkDestination, context, src, size}: MarkdownImageRenderer) => {
         if (!imagesMetadata || isUnsafeLinksPost) {
             return null;
         }
+
+        const isInsideLink = context.indexOf('link') !== -1;
 
         const isImageDisabled = (disableGallery ?? Boolean(!location)) || isInsideLink;
 
@@ -405,24 +407,17 @@ const Markdown = ({
         );
     };
 
-    const renderLink = ({children, href}: {children: any; href: string}) => {
+    const renderLink = ({children, href}: {children: ReactElement; href: string}) => {
         if (isUnsafeLinksPost) {
             return renderText({context: [], literal: href});
         }
-
-        const childrenWithLinkFlag = React.Children.map(children, (child) => {
-            if (React.isValidElement(child)) {
-                return React.cloneElement(child as ReactElement<any>, {isInsideLink: true});
-            }
-            return child;
-        });
 
         return (
             <MarkdownLink
                 href={href}
                 onLinkLongPress={onLinkLongPress}
             >
-                {childrenWithLinkFlag}
+                {children}
             </MarkdownLink>
         );
     };

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -359,13 +359,13 @@ const Markdown = ({
 
         const isInsideLink = context.indexOf('link') !== -1;
 
-        const isImageDisabled = (disableGallery ?? Boolean(!location)) || isInsideLink;
+        const disableInteraction = (disableGallery ?? Boolean(!location)) || isInsideLink;
 
         if (context.indexOf('table') !== -1) {
             // We have enough problems rendering images as is, so just render a link inside of a table
             return (
                 <MarkdownTableImage
-                    disabled={isImageDisabled}
+                    disabled={disableInteraction}
                     imagesMetadata={imagesMetadata}
                     location={location}
                     postId={postId!}
@@ -376,7 +376,7 @@ const Markdown = ({
 
         return (
             <MarkdownImage
-                disabled={isImageDisabled}
+                disabled={disableInteraction}
                 errorTextStyle={[computeTextStyle(textStyles, baseTextStyle, context), textStyles.error]}
                 layoutHeight={layoutHeight}
                 layoutWidth={layoutWidth}

--- a/types/global/markdown.ts
+++ b/types/global/markdown.ts
@@ -54,6 +54,7 @@ export type MarkdownImageRenderer = {
         width?: number;
         height?: number;
     };
+    isInsideLink?: boolean;
 }
 
 export type MarkdownLatexRenderer = MarkdownBaseRenderer & {

--- a/types/global/markdown.ts
+++ b/types/global/markdown.ts
@@ -54,7 +54,6 @@ export type MarkdownImageRenderer = {
         width?: number;
         height?: number;
     };
-    isInsideLink?: boolean;
 }
 
 export type MarkdownLatexRenderer = MarkdownBaseRenderer & {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

The following ticket reported that images that were wrapped into a link inside Markdown were not triggering the link itself, but just opened the image.

Previous behavior:

https://github.com/user-attachments/assets/6260c2d1-c831-40d3-9835-ac602ca8c70b

I changed the behavior, now if an image is inside a link in Markdown, the user will be able to navigate to the link:

https://github.com/user-attachments/assets/c69ed639-3f00-49ab-b586-7fcdd9dbffb1

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-60425

https://github.com/mattermost/mattermost-mobile/issues/8208

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [X] Includes text changes and localization file updates
- [X] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on:
- iOS Simulator 17.2
- Android Simulator API 33

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

It doesn't have any UI changes

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Images inside Links within Markdown are now clickable for link navigation.
```
