### PR TITLE
feat(test): Mobile message drafts: Remove outdated reference to fixed issue

### DIFF
--- a/detox/e2e/test/messaging/message_draft.e2e.ts
+++ b/detox/e2e/test/messaging/message_draft.e2e.ts
@@ -146,7 +146,7 @@ describe('Messaging - Message Draft', () => {
         await ChannelScreen.back();
     });
 
-    it('MM-T4781_4 - should be able to create a message draft from reply thread -- KNOWN ISSUE: MM-50298', async () => {
+    it('MM-T4781_4 - should be able to create a message draft from reply thread', async () => {
         // # Open a channel screen, post a message, and tap on the post to open reply thread
         const message = `Message ${getRandomId()}`;
         await ChannelScreen.open(channelsCategory, testChannel.name);


### PR DESCRIPTION
Removed reference to fixed issue ` -- KNOWN ISSUE: MM-50298`.

During audit of mobile tests, found a reference in https://github.com/mattermost/mattermost-mobile/blob/main/detox/e2e/test/messaging/message_draft.e2e.ts  to a "known issue" that has since been fixed and closed: https://mattermost.atlassian.net/browse/MM-50298

```release-note
NONE
```