### PR TITLE
feat(test): Mobile reply: Remove outdated note about fixed issue

### DIFF
--- a/detox/e2e/test/messaging/message_reply.e2e.ts
+++ b/detox/e2e/test/messaging/message_reply.e2e.ts
@@ -107,7 +107,7 @@ describe('Messaging - Message Reply', () => {
         await ChannelScreen.back();
     });
 
-    it('MM-T4785_3 - should not have reply option available on reply thread post options -- KNOWN ISSUE: MM-50206', async () => {
+    it('MM-T4785_3 - should not have reply option available on reply thread post options', async () => {
         // # Open a channel screen, post a message, and tap on the post
         const message = `Message ${getRandomId()}`;
         await ChannelScreen.open(channelsCategory, testChannel.name);


### PR DESCRIPTION
Removed outdated note ` -- KNOWN ISSUE: MM-50206`

During audit of mobile tests, found a reference in https://github.com/mattermost/mattermost-mobile/blob/main/detox/e2e/test/messaging/message_reply.e2e.ts to a "known issue" that has since been fixed and closed: https://mattermost.atlassian.net/browse/MM-50206.

```release-note-none
NONE
```
