### PR TITLE
MM-60534 -fix rate my app broken styles

### DIFF
--- a/app/components/button/index.tsx
+++ b/app/components/button/index.tsx
@@ -14,6 +14,7 @@ type ConditionalProps = | {iconName: string; iconSize: number} | {iconName?: nev
 type Props = ConditionalProps & {
     theme: Theme;
     backgroundStyle?: StyleProp<ViewStyle>;
+    buttonContainerStyle?: StyleProp<ViewStyle>;
     textStyle?: StyleProp<TextStyle>;
     size?: ButtonSize;
     emphasis?: ButtonEmphasis;
@@ -25,7 +26,7 @@ type Props = ConditionalProps & {
     iconComponent?: ReactNode;
     disabled?: boolean;
     hitSlop?: Insets;
-}
+};
 
 const styles = StyleSheet.create({
     container: {flexDirection: 'row'},
@@ -35,6 +36,7 @@ const styles = StyleSheet.create({
 const Button = ({
     theme,
     backgroundStyle,
+    buttonContainerStyle,
     textStyle,
     size,
     emphasis,
@@ -59,7 +61,7 @@ const Button = ({
         textStyle,
     ], [theme, textStyle, size, emphasis, buttonType]);
 
-    const containerStyle = useMemo(
+    const textContainerStyle = useMemo(
         () =>
             (iconSize ? [
                 styles.container,
@@ -68,11 +70,11 @@ const Button = ({
         [iconSize],
     );
 
-    let buttonContainerStyle = StyleSheet.flatten(bgStyle);
+    let buttonStyle = StyleSheet.flatten(bgStyle);
     if (disabled) {
-        buttonContainerStyle = {
-            ...buttonContainerStyle,
-            backgroundColor: changeOpacity(buttonContainerStyle.backgroundColor! as string, 0.4),
+        buttonStyle = {
+            ...buttonStyle,
+            backgroundColor: changeOpacity(buttonStyle.backgroundColor! as string, 0.4),
         };
     }
 
@@ -93,13 +95,14 @@ const Button = ({
 
     return (
         <ElementButton
-            buttonStyle={buttonContainerStyle}
+            buttonStyle={buttonStyle}
+            containerStyle={buttonContainerStyle}
             onPress={onPress}
             testID={testID}
             disabled={disabled}
             hitSlop={hitSlop}
         >
-            <View style={containerStyle}>
+            <View style={textContainerStyle}>
                 {icon}
                 <Text
                     style={txtStyle}

--- a/app/screens/review_app/index.tsx
+++ b/app/screens/review_app/index.tsx
@@ -63,11 +63,11 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         flexDirection: 'row',
         width: '100%',
     },
-    leftButtonWrapper: {
+    leftButton: {
         flex: 1,
         marginRight: 5,
     },
-    rightButtonWrapper: {
+    rightButton: {
         flex: 1,
         marginLeft: 5,
     },
@@ -198,23 +198,21 @@ const ReviewApp = ({
                                 {intl.formatMessage({id: 'rate.subtitle', defaultMessage: 'Let us know what you think.'})}
                             </Text>
                             <View style={styles.buttonsWrapper}>
-                                <View style={styles.leftButtonWrapper}>
-                                    <Button
-                                        theme={theme}
-                                        size={'lg'}
-                                        emphasis={'tertiary'}
-                                        onPress={onPressNeedsWork}
-                                        text={intl.formatMessage({id: 'rate.button.needs_work', defaultMessage: 'Needs work'})}
-                                    />
-                                </View>
-                                <View style={styles.rightButtonWrapper}>
-                                    <Button
-                                        theme={theme}
-                                        size={'lg'}
-                                        onPress={onPressYes}
-                                        text={intl.formatMessage({id: 'rate.button.yes', defaultMessage: 'Love it!'})}
-                                    />
-                                </View>
+                                <Button
+                                    theme={theme}
+                                    size={'lg'}
+                                    emphasis={'tertiary'}
+                                    onPress={onPressNeedsWork}
+                                    text={intl.formatMessage({id: 'rate.button.needs_work', defaultMessage: 'Needs work'})}
+                                    buttonContainerStyle={styles.leftButton}
+                                />
+                                <Button
+                                    theme={theme}
+                                    size={'lg'}
+                                    onPress={onPressYes}
+                                    text={intl.formatMessage({id: 'rate.button.yes', defaultMessage: 'Love it!'})}
+                                    buttonContainerStyle={styles.rightButton}
+                                />
                             </View>
                             {hasAskedBefore && (
                                 <TouchableWithoutFeedback

--- a/app/screens/review_app/index.tsx
+++ b/app/screens/review_app/index.tsx
@@ -63,6 +63,14 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         flexDirection: 'row',
         width: '100%',
     },
+    leftButtonWrapper: {
+        flex: 1,
+        marginRight: 5,
+    },
+    rightButtonWrapper: {
+        flex: 1,
+        marginLeft: 5,
+    },
     close: {
         justifyContent: 'center',
         height: 44,
@@ -82,14 +90,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         color: changeOpacity(theme.centerChannelColor, 0.72),
         marginBottom: 24,
         textAlign: 'center',
-    },
-    leftButton: {
-        flex: 1,
-        marginRight: 5,
-    },
-    rightButton: {
-        flex: 1,
-        marginLeft: 5,
     },
     dontAsk: {
         ...typography('Body', 75, 'SemiBold'),
@@ -198,21 +198,23 @@ const ReviewApp = ({
                                 {intl.formatMessage({id: 'rate.subtitle', defaultMessage: 'Let us know what you think.'})}
                             </Text>
                             <View style={styles.buttonsWrapper}>
-                                <Button
-                                    theme={theme}
-                                    size={'lg'}
-                                    emphasis={'tertiary'}
-                                    onPress={onPressNeedsWork}
-                                    text={intl.formatMessage({id: 'rate.button.needs_work', defaultMessage: 'Needs work'})}
-                                    backgroundStyle={styles.leftButton}
-                                />
-                                <Button
-                                    theme={theme}
-                                    size={'lg'}
-                                    onPress={onPressYes}
-                                    text={intl.formatMessage({id: 'rate.button.yes', defaultMessage: 'Love it!'})}
-                                    backgroundStyle={styles.rightButton}
-                                />
+                                <View style={styles.leftButtonWrapper}>
+                                    <Button
+                                        theme={theme}
+                                        size={'lg'}
+                                        emphasis={'tertiary'}
+                                        onPress={onPressNeedsWork}
+                                        text={intl.formatMessage({id: 'rate.button.needs_work', defaultMessage: 'Needs work'})}
+                                    />
+                                </View>
+                                <View style={styles.rightButtonWrapper}>
+                                    <Button
+                                        theme={theme}
+                                        size={'lg'}
+                                        onPress={onPressYes}
+                                        text={intl.formatMessage({id: 'rate.button.yes', defaultMessage: 'Love it!'})}
+                                    />
+                                </View>
                             </View>
                             {hasAskedBefore && (
                                 <TouchableWithoutFeedback


### PR DESCRIPTION
#### Summary
Fix "rate my app" broken styles 🤦 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60534

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: android and ios emulator

#### Screenshots
Before:
<img width="445" alt="Screenshot 2024-09-26 at 23 23 39" src="https://github.com/user-attachments/assets/990bd292-61ac-4da9-b539-b556a06c9a3a">


After:
Android:
<img width="563" alt="Screenshot 2024-09-26 at 22 49 37" src="https://github.com/user-attachments/assets/1e817ead-d48a-4561-93dd-85cc80121aa6">
<img width="562" alt="Screenshot 2024-09-26 at 22 50 20" src="https://github.com/user-attachments/assets/97e021e2-e1e3-4294-859d-863c4adf6505">

ios:
<img width="456" alt="Screenshot 2024-09-26 at 23 04 33" src="https://github.com/user-attachments/assets/0270c0df-3feb-4454-9d01-0c9e27d77d3e">


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
