### PR TITLE
Update calls-common

### DIFF
--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -27,7 +27,7 @@ import {WebSocketClient, wsReconnectionTimeoutErr} from './websocket_client';
 import type {EmojiData} from '@mattermost/calls/lib/types';
 
 const peerConnectTimeout = 5000;
-const rtcMonitorInterval = 4000;
+const rtcMonitorInterval = 10000;
 
 const InCallManagerEmitter = new NativeEventEmitter(NativeModules.InCallManager);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@formatjs/intl-numberformat": "8.10.3",
         "@formatjs/intl-pluralrules": "5.2.14",
         "@gorhom/bottom-sheet": "4.6.4",
-        "@mattermost/calls": "github:mattermost/calls-common#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
+        "@mattermost/calls": "github:mattermost/calls-common#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
         "@mattermost/compass-icons": "0.1.45",
         "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
         "@mattermost/keyboard-tracker": "file:./libraries/@mattermost/keyboard-tracker",
@@ -5850,8 +5850,8 @@
     "node_modules/@mattermost/calls": {
       "name": "@mattermost/calls-common",
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
-      "integrity": "sha512-jze9YO7n9c8AgaE2FOMzj8g2ieqczNfCzah7W6TeQtC0Ufhe3jcGG99DNtrB3tHeiBsp/ZlrvBXCVpA/oQR6YA==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
+      "integrity": "sha512-aZIYwtgRVj8tdWJUPtAr4TPNa6tNM3lnRkC74CkSsFCpwZ1miwov0B4TLYG4Srj1rTgUqUwG3gQz4o5JHJ2fuQ==",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",
         "fflate": "^0.8.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-numberformat": "8.10.3",
     "@formatjs/intl-pluralrules": "5.2.14",
     "@gorhom/bottom-sheet": "4.6.4",
-    "@mattermost/calls": "github:mattermost/calls-common#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
+    "@mattermost/calls": "github:mattermost/calls-common#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
     "@mattermost/compass-icons": "0.1.45",
     "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
     "@mattermost/keyboard-tracker": "file:./libraries/@mattermost/keyboard-tracker",


### PR DESCRIPTION
#### Summary

Updating `calls-common` to latest and the `rtcMonitorInterval` value to match the plugin's side. Increasing the interval helps to lower the variance on gathered stats.

#### Release Note

```release-note
NONE
```
