### PR TITLE
fix: (MM-59973) emoji count 0 update

### DIFF
--- a/app/components/animated_number/index.tsx
+++ b/app/components/animated_number/index.tsx
@@ -61,7 +61,7 @@ const AnimatedNumber = ({
         const previousNumberArray = Array.from(previousNumberString, Number);
 
         return animateToNumberArray.map((_, index) => {
-            const useDigit = previousNumberArray[index] === animateToNumberArray[index] ? 0 : previousNumberArray[index];
+            const useDigit = previousNumberArray[index] === animateToNumberArray[index] ? animateToNumberArray[index] : previousNumberArray[index];
 
             return new Animated.Value(-1 * (numberHeight * useDigit));
         });

--- a/app/components/animated_number/index.tsx
+++ b/app/components/animated_number/index.tsx
@@ -42,9 +42,9 @@ const AnimatedNumber = ({
             '0',
         );
 
-        if (previousNumberString.length > animateToNumberString.length) {
+        if (_previousNumberString.length > animateToNumberString.length) {
             _previousNumberString = _previousNumberString.slice(
-                previousNumberString.length - animateToNumberString.length,
+                _previousNumberString.length - animateToNumberString.length,
             );
         }
 

--- a/app/components/animated_number/index.tsx
+++ b/app/components/animated_number/index.tsx
@@ -37,15 +37,13 @@ const AnimatedNumber = ({
         // comparing previousNumber and animateToNumber gets trickier when the number of digits changes and the length differs.
         // By padding the previousNumber with 0s, or slicing the previousNumber to match the length of animateToNumber
         // we can compare them digit by digit
-        let _previousNumberString = String(Math.abs(previousNumber)).padStart(
+        const _previousNumberString = String(Math.abs(previousNumber)).padStart(
             animateToNumberString.length,
             '0',
         );
 
         if (_previousNumberString.length > animateToNumberString.length) {
-            _previousNumberString = _previousNumberString.slice(
-                _previousNumberString.length - animateToNumberString.length,
-            );
+            _previousNumberString.slice(_previousNumberString.length - animateToNumberString.length);
         }
 
         return _previousNumberString;

--- a/app/components/animated_number/index.tsx
+++ b/app/components/animated_number/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {Animated, Easing, type LayoutChangeEvent, type StyleProp, Text, type TextStyle, View} from 'react-native';
 
 interface Props {
@@ -24,44 +24,70 @@ const usePrevious = (value: number) => {
 
 const AnimatedNumber = ({
     animateToNumber,
-    animationDuration,
+    animationDuration = 1400,
     fontStyle,
     easing = 1.2,
 }: Props) => {
-    const prevNumber = usePrevious(animateToNumber);
+    const previousNumber = usePrevious(animateToNumber);
+    const [numberHeight, setNumberHeight] = useState(0);
+
     const animateToNumberString = String(Math.abs(animateToNumber));
-    const prevNumberString = String(Math.abs(prevNumber));
 
-    const [numberHeight, setNumberHeight] = React.useState(0);
-    const animations = useMemo(() => {
-        const numberStringToDigitsArray = Array.from(animateToNumberString, Number);
-        const prevNumberersArr = Array.from(prevNumberString, Number);
+    const previousNumberString = useMemo(() => {
+        // comparing previousNumber and animateToNumber gets trickier when the number of digits changes and the length differs.
+        // By padding the previousNumber with 0s, or slicing the previousNumber to match the length of animateToNumber
+        // we can compare them digit by digit
+        let _previousNumberString = String(Math.abs(previousNumber)).padStart(
+            animateToNumberString.length,
+            '0',
+        );
 
-        if (numberHeight === 0) {
-            return numberStringToDigitsArray.map(() => new Animated.Value(0));
+        if (previousNumberString.length > animateToNumberString.length) {
+            _previousNumberString = _previousNumberString.slice(
+                previousNumberString.length - animateToNumberString.length,
+            );
         }
 
-        return numberStringToDigitsArray.map((digit, index) => {
-            const previousDigit = prevNumberersArr[index] ?? 0;
+        return _previousNumberString;
+    }, [animateToNumberString, previousNumber]);
 
-            if (previousDigit === digit && prevNumberersArr.length === numberStringToDigitsArray.length) {
-                // skipping any animation by just returning the current "position"
-                return new Animated.Value(-1 * (numberHeight * digit));
-            }
+    const animations = useMemo(() => {
+        const animateToNumberArray = Array.from(animateToNumberString, Number);
 
-            const prevHeight = -1 * (numberHeight * previousDigit);
-            const animation = new Animated.Value(prevHeight);
+        if (!numberHeight) {
+            return animateToNumberArray.map(() => new Animated.Value(0));
+        }
 
+        const previousNumberArray = Array.from(previousNumberString, Number);
+
+        return animateToNumberArray.map((_, index) => {
+            const useDigit = previousNumberArray[index] === animateToNumberArray[index] ? 0 : previousNumberArray[index];
+
+            return new Animated.Value(-1 * (numberHeight * useDigit));
+        });
+    }, [animateToNumberString, numberHeight, previousNumberString]);
+
+    useEffect(() => {
+        if (!numberHeight) {
+            return;
+        }
+
+        const animateToNumberArray = Array.from(animateToNumberString, Number);
+        animations.forEach((animation, index) => {
             Animated.timing(animation, {
-                toValue: -1 * (numberHeight * digit),
-                duration: animationDuration || 1400,
+                toValue: -1 * (numberHeight * animateToNumberArray[index]),
+                duration: animationDuration,
                 useNativeDriver: true,
                 easing: Easing.elastic(easing),
             }).start();
-
-            return animation;
         });
-    }, [animateToNumberString, prevNumberString, numberHeight, animationDuration, easing]);
+    }, [
+        animateToNumberString,
+        animationDuration,
+        animations,
+        easing,
+        numberHeight,
+    ]);
 
     const setButtonLayout = useCallback((e: LayoutChangeEvent) => {
         setNumberHeight(e.nativeEvent.layout.height);
@@ -76,7 +102,7 @@ const AnimatedNumber = ({
                     )}
                     {Array.from(animateToNumberString, Number).map((_, index) => (
                         <View
-                            key={`${index.toString()}`}
+                            key={`${animateToNumberString.length - index}`}
                             style={{height: numberHeight, overflow: 'hidden'}}
                         >
                             <Animated.View
@@ -90,7 +116,7 @@ const AnimatedNumber = ({
                             >
                                 {NUMBERS.map((number, i) => (
                                     <View
-                                        key={`${i.toString()}`}
+                                        key={`${NUMBERS.length - i}`}
                                         style={{flexDirection: 'row'}}
                                     >
                                         <Text style={[fontStyle, {height: numberHeight}]}>


### PR DESCRIPTION
* tried to include everything into useMemo was an anti-pattern
* moved back to useMemo + useEffect
* previousNumber and animateToNumber comparison has some flaw when dealing with difference length between the two

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
