### PR TITLE
Add support for Auth Scheme customization on build time

### DIFF
--- a/app/constants/sso.ts
+++ b/app/constants/sso.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import LocalConfig from '@assets/config.json';
 import keyMirror from '@utils/key_mirror';
 
-export const REDIRECT_URL_SCHEME = 'mmauth://';
-export const REDIRECT_URL_SCHEME_DEV = 'mmauthbeta://';
+export const REDIRECT_URL_SCHEME = LocalConfig.AuthUrlScheme;
+export const REDIRECT_URL_SCHEME_DEV = LocalConfig.AuthUrlSchemeDev;
 
 const constants = keyMirror({
     SAML: null,

--- a/app/screens/sso/sso.test.tsx
+++ b/app/screens/sso/sso.test.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 
+import LocalConfig from '@assets/config.json';
 import Preferences from '@constants/preferences';
 import {renderWithIntl} from '@test/intl-test-helper';
 
@@ -16,7 +17,7 @@ jest.mock('@utils/url', () => {
 
 describe('SSO with redirect url', () => {
     const baseProps = {
-        customUrlScheme: 'mmauthbeta://',
+        customUrlScheme: LocalConfig.AuthUrlSchemeDev,
         doSSOLogin: jest.fn(),
         intl: {},
         loginError: '',

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -1,4 +1,6 @@
 {
+    "AuthUrlScheme": "mmauth://",
+    "AuthUrlSchemeDev": "mmauthbeta://",
     "DefaultServerUrl": "",
     "DefaultServerName": "",
     "TestServerUrl": "http://localhost:8065",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,6 +181,12 @@ lane :configure do
     json['ShowOnboarding'] = true
   end
 
+  # Configure the auth schemes
+  auth_scheme = ENV['APP_AUTH_SCHEME'].to_s.empty? ? 'mmauth' : ENV['APP_AUTH_SCHEME']
+  auth_scheme_dev = ENV['APP_AUTH_SCHEME_BETA'].to_s.empty? ? 'mmauthbeta' : ENV['APP_AUTH_SCHEME_BETA']
+  json["AuthUrlScheme"] = auth_scheme.end_with?('://') ? auth_scheme : "#{auth_scheme}://"
+  json["AuthUrlSchemeDev"] = auth_scheme_dev.end_with?('://') ? auth_scheme_dev : "#{auth_scheme_dev}://"
+
   # Save the config.json file
   save_json_as_file('../dist/assets/config.json', json)
 
@@ -473,7 +479,8 @@ platform :ios do
 
     # Set the deep link prefix
     app_scheme = ENV['APP_SCHEME'] || 'mattermost'
-    app_auth_scheme = ENV['BETA_BUILD'] == 'true' ? 'mmauthbeta' : 'mmauth'
+    app_auth_scheme = get_auth_scheme
+    UI.success "Update auth scheme to #{app_auth_scheme} #{ENV['BETA_BUILD']} authScheme #{ENV['APP_AUTH_SCHEME']} beta #{ENV['APP_AUTH_SCHEME_BETA']}"
     update_info_plist(
         xcodeproj: './ios/Mattermost.xcodeproj',
         plist_path: 'Mattermost/Info.plist',
@@ -748,13 +755,14 @@ platform :android do
       new_string: "scheme=\'#{app_scheme}\'"
     )
 
-    if ENV['BETA_BUILD'] != 'true'
-      find_replace_string(
-          path_to_file: "./android/app/src/main/AndroidManifest.xml",
-          old_string: 'scheme="mmauthbeta"',
-          new_string: 'scheme="mmauth"',
-      )
-    end
+    
+    app_auth_scheme = get_auth_scheme
+
+    find_replace_string(
+        path_to_file: "./android/app/src/main/AndroidManifest.xml",
+        old_string: 'scheme="mmauthbeta"',
+        new_string: "scheme=\"#{app_auth_scheme}\"",
+    )
 
     helpers_dir = './android/app/src/main/java/com/mattermost/helpers/'
     beta_dir = './android/app/src/main/java/com/mattermost/rnbeta/'
@@ -918,6 +926,14 @@ platform :android do
       sh "mv #{aab} #{new_aab_path}"
       UI.message("AAB PATH \"#{new_aab_path}\"")
     end
+  end
+end
+
+def get_auth_scheme
+  if ENV['BETA_BUILD'] == 'true'
+    ENV['APP_AUTH_SCHEME_BETA'].to_s.empty? ? 'mmauthbeta' : ENV['APP_AUTH_SCHEME_BETA']
+  else
+    ENV['APP_AUTH_SCHEME'].to_s.empty? ? 'mmauth' : ENV['APP_AUTH_SCHEME']
   end
 end
 


### PR DESCRIPTION
#### Summary
The authentication schemes were hardcoded to use `mmauthbeta` for our Beta app and `mmauth` for our release app. While the server allows this schemes to be changed in order to be used with custom mobile builds, the mobile app did not have a way to easily customize them, having to make some changes in the code before compiling.

This PR introduces a couple of environment variables to be able to change these authentication schemes on build time.

Note: This is backwards compatible so that the app builds the same way as before if no env var is set.

#### Ticket Link
N/A.

#### Release Note
```release-note
NONE
```
