### PR TITLE
fix bookmarks sort order when WS does not bump update_at

### DIFF
--- a/app/database/operator/server_data_operator/handlers/channel.ts
+++ b/app/database/operator/server_data_operator/handlers/channel.ts
@@ -392,7 +392,7 @@ const ChannelHandler = <TBase extends Constructor<ServerDataOperatorBase>>(super
                 return res;
             }
 
-            if (e.updateAt !== b.update_at) {
+            if (e.updateAt !== b.update_at || e.sortOrder !== b.sort_order) {
                 res.createOrUpdateRaws.push(b);
                 if (b.file) {
                     files.push(b.file);

--- a/app/queries/servers/channel_bookmark.ts
+++ b/app/queries/servers/channel_bookmark.ts
@@ -113,5 +113,5 @@ export const getBookmarksSince = async (database: Database, channelId: string) =
 };
 
 export const observeBookmarks = (database: Database, channelId: string) => {
-    return queryBookmarks(database, channelId).observeWithColumns(['file_id']);
+    return queryBookmarks(database, channelId).observeWithColumns(['update_at', 'sort_order']);
 };


### PR DESCRIPTION
#### Summary
When sorting the channel bookmarks on the webapp, the WS event was not changing the update_at property of the objects

We are now also updating the local records if the `sort_order` has changed to fix the sorting updates while the server does not have the changes included in https://github.com/mattermost/mattermost/pull/28807

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60644

#### Server PR
https://github.com/mattermost/mattermost/pull/28807

#### Release Note
```release-note
Fixed the sort order of channel bookmarks when sorted on a different client
```