### PR TITLE
feat: Switch FormattedDate component to Intl.DateTimeFormat

### DIFF
--- a/app/components/custom_status/custom_status_expiry.tsx
+++ b/app/components/custom_status/custom_status_expiry.tsx
@@ -8,7 +8,9 @@ import {Text, type TextStyle} from 'react-native';
 import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import FormattedDate from '@components/formatted_date';
+import FormattedDate, {
+    type FormattedDateFormat,
+} from '@components/formatted_date';
 import FormattedText from '@components/formatted_text';
 import FormattedTime from '@components/formatted_time';
 import {getDisplayNamePreferenceAsBool} from '@helpers/api/preference';
@@ -32,7 +34,7 @@ type Props = {
     theme: Theme;
     time: Date | Moment;
     withinBrackets?: boolean;
-}
+};
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
@@ -43,19 +45,41 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-const CustomStatusExpiry = ({currentUser, isMilitaryTime, showPrefix, showTimeCompulsory, showToday, testID = '', textStyles = {}, theme, time, withinBrackets}: Props) => {
+const CustomStatusExpiry = ({
+    currentUser,
+    isMilitaryTime,
+    showPrefix,
+    showTimeCompulsory,
+    showToday,
+    testID = '',
+    textStyles = {},
+    theme,
+    time,
+    withinBrackets,
+}: Props) => {
     const userTimezone = getUserTimezoneProps(currentUser);
     const timezone = userTimezone.useAutomaticTimezone ? userTimezone.automaticTimezone : userTimezone.manualTimezone;
     const styles = getStyleSheet(theme);
     const currentMomentTime = getCurrentMomentForTimezone(timezone);
-    const expiryMomentTime = timezone ? moment(time).tz(timezone) : moment(time);
-    const plusSixDaysEndTime = currentMomentTime.clone().add(6, 'days').endOf('day');
-    const tomorrowEndTime = currentMomentTime.clone().add(1, 'day').endOf('day');
+    const expiryMomentTime =
+        timezone ? moment(time).tz(timezone) : moment(time);
+    const plusSixDaysEndTime = currentMomentTime.
+        clone().
+        add(6, 'days').
+        endOf('day');
+    const tomorrowEndTime = currentMomentTime.
+        clone().
+        add(1, 'day').
+        endOf('day');
     const todayEndTime = currentMomentTime.clone().endOf('day');
-    const isCurrentYear = currentMomentTime.get('y') === expiryMomentTime.get('y');
+    const isCurrentYear =
+        currentMomentTime.get('y') === expiryMomentTime.get('y');
 
     let dateComponent;
-    if ((showToday && expiryMomentTime.isBefore(todayEndTime)) || expiryMomentTime.isSame(todayEndTime)) {
+    if (
+        (showToday && expiryMomentTime.isBefore(todayEndTime)) ||
+        expiryMomentTime.isSame(todayEndTime)
+    ) {
         dateComponent = (
             <FormattedText
                 id='custom_status.expiry_time.today'
@@ -63,7 +87,10 @@ const CustomStatusExpiry = ({currentUser, isMilitaryTime, showPrefix, showTimeCo
                 style={[styles.text, textStyles]}
             />
         );
-    } else if (expiryMomentTime.isAfter(todayEndTime) && expiryMomentTime.isSameOrBefore(tomorrowEndTime)) {
+    } else if (
+        expiryMomentTime.isAfter(todayEndTime) &&
+        expiryMomentTime.isSameOrBefore(tomorrowEndTime)
+    ) {
         dateComponent = (
             <FormattedText
                 id='custom_status.expiry_time.tomorrow'
@@ -72,11 +99,11 @@ const CustomStatusExpiry = ({currentUser, isMilitaryTime, showPrefix, showTimeCo
             />
         );
     } else if (expiryMomentTime.isAfter(tomorrowEndTime)) {
-        let format = 'dddd';
+        let format: FormattedDateFormat = {weekday: 'long'};
         if (expiryMomentTime.isAfter(plusSixDaysEndTime) && isCurrentYear) {
-            format = 'MMM DD';
+            format = {month: 'short', day: 'numeric'};
         } else if (!isCurrentYear) {
-            format = 'MMM DD, YYYY';
+            format = {dateStyle: 'medium'};
         }
 
         dateComponent = (
@@ -89,7 +116,12 @@ const CustomStatusExpiry = ({currentUser, isMilitaryTime, showPrefix, showTimeCo
         );
     }
 
-    const useTime = showTimeCompulsory ?? !(expiryMomentTime.isSame(todayEndTime) || expiryMomentTime.isAfter(tomorrowEndTime));
+    const useTime =
+        showTimeCompulsory ??
+        !(
+            expiryMomentTime.isSame(todayEndTime) ||
+            expiryMomentTime.isAfter(tomorrowEndTime)
+        );
 
     return (
         <Text
@@ -113,8 +145,7 @@ const CustomStatusExpiry = ({currentUser, isMilitaryTime, showPrefix, showTimeCo
                         id='custom_status.expiry.at'
                         defaultMessage='at'
                         style={[styles.text, textStyles]}
-                    />
-                    {' '}
+                    />{' '}
                 </>
             )}
             {useTime && (
@@ -133,9 +164,15 @@ const CustomStatusExpiry = ({currentUser, isMilitaryTime, showPrefix, showTimeCo
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => ({
     currentUser: observeCurrentUser(database),
     isMilitaryTime: queryDisplayNamePreferences(database).
-        observeWithColumns(['value']).pipe(
-            switchMap(
-                (preferences) => of$(getDisplayNamePreferenceAsBool(preferences, 'use_military_time')),
+        observeWithColumns(['value']).
+        pipe(
+            switchMap((preferences) =>
+                of$(
+                    getDisplayNamePreferenceAsBool(
+                        preferences,
+                        'use_military_time',
+                    ),
+                ),
             ),
         ),
 }));

--- a/app/components/files/file_info.tsx
+++ b/app/components/files/file_info.tsx
@@ -4,7 +4,9 @@
 import React from 'react';
 import {Text, TouchableOpacity, View} from 'react-native';
 
-import FormattedDate from '@components/formatted_date';
+import FormattedDate, {
+    type FormattedDateFormat,
+} from '@components/formatted_date';
 import {useTheme} from '@context/theme';
 import {getFormattedFileSize} from '@utils/file';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
@@ -14,10 +16,15 @@ type FileInfoProps = {
     disabled?: boolean;
     file: FileInfo;
     showDate: boolean;
-    channelName?: string ;
+    channelName?: string;
     onPress: () => void;
-}
-const FORMAT = ' • MMM DD HH:MM A';
+};
+const FORMAT: FormattedDateFormat = {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+};
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
@@ -59,7 +66,13 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     };
 });
 
-const FileInfo = ({disabled, file, channelName, showDate, onPress}: FileInfoProps) => {
+const FileInfo = ({
+    disabled,
+    file,
+    channelName,
+    showDate,
+    onPress,
+}: FileInfoProps) => {
     const theme = useTheme();
     const style = getStyleSheet(theme);
 
@@ -77,7 +90,7 @@ const FileInfo = ({disabled, file, channelName, showDate, onPress}: FileInfoProp
                     {decodeURIComponent(file.name.trim())}
                 </Text>
                 <View style={style.fileDownloadContainer}>
-                    {channelName &&
+                    {channelName && (
                         <View style={style.channelWrapper}>
                             <Text
                                 style={style.channelText}
@@ -86,18 +99,21 @@ const FileInfo = ({disabled, file, channelName, showDate, onPress}: FileInfoProp
                                 {channelName}
                             </Text>
                         </View>
-                    }
+                    )}
                     <View style={style.fileStatsContainer}>
                         <Text style={style.infoText}>
                             {`${getFormattedFileSize(file.size)}`}
                         </Text>
-                        {showDate &&
-                            <FormattedDate
-                                style={style.infoText}
-                                format={FORMAT}
-                                value={file.create_at as number}
-                            />
-                        }
+                        {showDate && (
+                            <>
+                                {' • '}
+                                <FormattedDate
+                                    style={style.infoText}
+                                    format={FORMAT}
+                                    value={file.create_at as number}
+                                />
+                            </>
+                        )}
                     </View>
                 </View>
             </TouchableOpacity>

--- a/app/components/files_search/file_options/header.tsx
+++ b/app/components/files_search/file_options/header.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import React from 'react';
-import {View, Text} from 'react-native';
+import {Text, View} from 'react-native';
 
-import FormattedDate from '@components/formatted_date';
+import FormattedDate, {
+    type FormattedDateFormat,
+} from '@components/formatted_date';
 import {useTheme} from '@context/theme';
 import {getFormattedFileSize} from '@utils/file';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
@@ -11,12 +13,19 @@ import {typography} from '@utils/typography';
 
 import Icon, {ICON_SIZE} from './icon';
 
-const format = 'MMM DD YYYY HH:MM A';
+const FORMAT: FormattedDateFormat = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+};
 
 const HEADER_MARGIN = 8;
 const FILE_ICON_MARGIN = 8;
 const INFO_MARGIN = 8;
-export const HEADER_HEIGHT = HEADER_MARGIN +
+export const HEADER_HEIGHT =
+    HEADER_MARGIN +
     ICON_SIZE +
     FILE_ICON_MARGIN +
     (28 * 2) + //400 line height times two lines
@@ -55,7 +64,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
 
 type Props = {
     fileInfo: FileInfo;
-}
+};
 const Header = ({fileInfo}: Props) => {
     const theme = useTheme();
     const style = getStyleSheet(theme);
@@ -78,7 +87,7 @@ const Header = ({fileInfo}: Props) => {
                 <Text style={style.infoText}>{`${size} • `}</Text>
                 <FormattedDate
                     style={style.date}
-                    format={format}
+                    format={FORMAT}
                     value={fileInfo.create_at as number}
                 />
             </View>

--- a/app/components/formatted_date/index.tsx
+++ b/app/components/formatted_date/index.tsx
@@ -1,33 +1,37 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import moment from 'moment';
-import mtz from 'moment-timezone';
 import React from 'react';
 import {useIntl} from 'react-intl';
 import {Text, type TextProps} from 'react-native';
 
-import {getLocaleFromLanguage} from '@i18n';
+export type FormattedDateFormat = Exclude<Intl.DateTimeFormatOptions, 'timeZone'>;
 
 type FormattedDateProps = TextProps & {
-    format?: string;
+    format?: FormattedDateFormat;
     timezone?: string | UserTimezone | null;
     value: number | string | Date;
-}
+};
 
-const FormattedDate = ({format = 'MMM DD, YYYY', timezone, value, ...props}: FormattedDateProps) => {
+const FormattedDate = ({
+    format = {dateStyle: 'medium'},
+    timezone,
+    value,
+    ...props
+}: FormattedDateProps) => {
     const {locale} = useIntl();
-    moment.locale(getLocaleFromLanguage(locale).toLowerCase());
-    let formattedDate = mtz(value).format(format);
-    if (timezone) {
-        let zone: string;
-        if (typeof timezone === 'object') {
-            zone = timezone.useAutomaticTimezone ? timezone.automaticTimezone : timezone.manualTimezone;
-        } else {
-            zone = timezone;
-        }
-        formattedDate = mtz.tz(value, zone).format(format);
+
+    let timeZone: string | undefined;
+    if (timezone && typeof timezone === 'object') {
+        timeZone = timezone.useAutomaticTimezone ? timezone.automaticTimezone : timezone.manualTimezone;
+    } else {
+        timeZone = timezone ?? undefined;
     }
+
+    const formattedDate = new Intl.DateTimeFormat(locale, {
+        ...format,
+        timeZone,
+    }).format(new Date(value));
 
     return <Text {...props}>{formattedDate}</Text>;
 };

--- a/app/components/post_list/date_separator/index.tsx
+++ b/app/components/post_list/date_separator/index.tsx
@@ -4,7 +4,9 @@
 import React from 'react';
 import {type StyleProp, View, type ViewStyle} from 'react-native';
 
-import FormattedDate from '@components/formatted_date';
+import FormattedDate, {
+    type FormattedDateFormat,
+} from '@components/formatted_date';
 import FormattedText from '@components/formatted_text';
 import {useTheme} from '@context/theme';
 import {isSameYear, isToday, isYesterday} from '@utils/datetime';
@@ -60,15 +62,14 @@ const RecentDate = (props: DateSeparatorProps) => {
         );
     }
 
-    const format = isSameYear(when, new Date()) ? 'MMM DD' : 'MMM DD, YYYY';
+    const format: FormattedDateFormat = isSameYear(when, new Date()) ? {month: 'short', day: 'numeric'} : {dateStyle: 'medium'};
 
     return (
         <FormattedDate
             {...otherProps}
             format={format}
             value={date}
-        />
-    );
+        />);
 };
 
 const DateSeparator = (props: DateSeparatorProps) => {


### PR DESCRIPTION
#### Summary

Use Intl.DateTimeFormat instead of fixed momentjs format in FormattedDate component

This comes from a discussion in i18n - Localization channel in mattermost community where Ian Lui reported bad date formatting for Chinese and Japanese languages. After some digging it appeared there were more problems than that and I suggested to switch from momentjs to Intl.DateTimeFormat

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
