### PR TITLE
Fix sidebar teams order

### DIFF
--- a/app/components/team_sidebar/team_list/index.ts
+++ b/app/components/team_sidebar/team_list/index.ts
@@ -14,6 +14,7 @@ import {queryJoinedTeams, queryMyTeams} from '@queries/servers/team';
 import TeamList from './team_list';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
+import type MyTeamModel from '@typings/database/models/servers/my_team';
 
 const withTeams = withObservables([], ({database}: WithDatabaseArgs) => {
     const myTeams = queryMyTeams(database).observe();
@@ -33,22 +34,18 @@ const withTeams = withObservables([], ({database}: WithDatabaseArgs) => {
                     map((t) => t.id);
             }
 
-            const indexes: {[x: string]: number} = {};
-            const originalIndexes: {[x: string]: number} = {};
-            ids.forEach((v, i) => {
-                indexes[v] = i;
-            });
+            const teamMap = ts.reduce<{[x: string]: MyTeamModel}>((result, team) => {
+                result[team.id] = team;
+                return result;
+            }, {});
 
-            ts.forEach((t, i) => {
-                originalIndexes[t.id] = i;
-            });
-
-            return ts.sort((a, b) => {
-                if ((indexes[a.id] != null) || (indexes[b.id] != null)) {
-                    return (indexes[a.id] ?? tids.length) - (indexes[b.id] ?? tids.length);
+            return ids.reduce<MyTeamModel[]>((result, id) => {
+                const t = teamMap[id];
+                if (t) {
+                    result.push(t);
                 }
-                return (originalIndexes[a.id] - originalIndexes[b.id]);
-            });
+                return result;
+            }, []);
         }),
     );
     return {


### PR DESCRIPTION
#### Summary
The code to sort the teams based on the order established by the preferences wasn't working, the preferences are already sorted and if no preferences set we sort by the display name of the team.

Noticed this issue since we started to add more teams on Hub.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60723

#### Release Note
```release-note
Fixed sort of teams in the Team Sidebar by following the user preferences if set.
```