### PR TITLE
Add logs when notification device tokens is registered or fails to do so

### DIFF
--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -12,6 +12,7 @@ import {
     Notifications,
     type NotificationTextInput,
     type Registered,
+    type RegistrationError,
 } from 'react-native-notifications';
 import {requestNotifications} from 'react-native-permissions';
 
@@ -45,6 +46,8 @@ class PushNotifications {
             Notifications.events().registerRemoteNotificationsRegistered(this.onRemoteNotificationsRegistered),
             Notifications.events().registerNotificationReceivedBackground(this.onNotificationReceivedBackground),
             Notifications.events().registerNotificationReceivedForeground(this.onNotificationReceivedForeground),
+            Notifications.events().registerRemoteNotificationsRegistrationFailed(this.NotificationsRegistrationFailed),
+            Notifications.events().registerRemoteNotificationsRegistrationDenied(this.onRemoteNotificationsRegistrationDenied),
         ];
 
         if (register) {
@@ -276,12 +279,22 @@ class PushNotifications {
                 prefix = Device.PUSH_NOTIFY_ANDROID_REACT_NATIVE;
             }
 
-            storeDeviceToken(`${prefix}-v2:${deviceToken}`);
+            const token = `${prefix}-v2:${deviceToken}`;
+            storeDeviceToken(token);
+            logDebug('Notification token registered', token);
 
             // Store the device token in the default database
             this.requestNotificationReplyPermissions();
         }
         return null;
+    };
+
+    onRemoteNotificationsRegistrationDenied = () => {
+        logDebug('Notification registration denied');
+    };
+
+    NotificationsRegistrationFailed = (event: RegistrationError) => {
+        logDebug('Notification registration failed', event);
     };
 
     removeChannelNotifications = async (serverUrl: string, channelId: string) => {


### PR DESCRIPTION
#### Summary
Adding some logs for the notification device token registration flow, this way we can inspect the device logs to determine if the token was registered or not, in case of no, then why

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
