### PR TITLE
test: more meaningful AnimatedNumber component test 

### DIFF
--- a/app/components/animated_number/index.test.tsx
+++ b/app/components/animated_number/index.test.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {fireEvent, render, waitFor} from '@testing-library/react-native';
+import React from 'react';
+
+import AnimatedNumber from '.';
+
+// jest.mock('../../../node_modules/react-native/Libraries/Text/Text', () => {
+//     const Text = jest.requireActual('../../../node_modules/react-native/Libraries/Text/Text');
+
+//     // class MockText extends React.Component {
+//     //     render() {
+//     //         return React.createElement('Text', this.props, this.props.children);
+//     //     }
+//     // }
+
+//     const MockText = jest.fn((props) => (<Text
+//         {...props}
+//         onLayout={() => ({nativeEvent: {layout: {height: 10}}})}
+//     />));
+
+//     return MockText;
+// });
+
+describe('AnimatedNumber', () => {
+    it('should render correctly', () => {
+        const {toJSON} = render(<AnimatedNumber animateToNumber={123}/>);
+        expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('should render correctly 2', () => {
+        const {toJSON, rerender, getByTestId} = render(<AnimatedNumber animateToNumber={123}/>);
+        expect(toJSON()).toMatchSnapshot();
+
+        const text = getByTestId('no-animation-number');
+
+        fireEvent(text, 'onLayout', {nativeEvent: {layout: {height: 10}}});
+
+        rerender(<AnimatedNumber
+            animateToNumber={123}
+            fontStyle={{color: 'red'}}
+                 />);
+
+        expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('should rerender the correct number', () => {
+        const {toJSON, getByTestId, rerender} = render(<AnimatedNumber animateToNumber={123}/>);
+
+        expect(toJSON()).toMatchSnapshot();
+
+        const text = getByTestId('no-animation-number');
+
+        fireEvent(text, 'onLayout', {nativeEvent: {layout: {height: 10}}});
+
+        rerender(<AnimatedNumber animateToNumber={124}/>);
+
+        rerender(<AnimatedNumber animateToNumber={125}/>);
+
+        expect(toJSON()).toMatchSnapshot();
+    });
+});
+
+describe.skip('AnimatedNumber', () => {
+    it('should render the number', () => {
+        const {getByTestId} = render(<AnimatedNumber animateToNumber={123}/>);
+
+        const text = getByTestId('no-animation-number');
+        expect(text.children).toContain('123');
+    });
+
+    it('should removed the non-animation number', async () => {
+        const {getByTestId, queryByTestId} = render(<AnimatedNumber animateToNumber={123}/>);
+
+        const text = getByTestId('no-animation-number');
+
+        expect(text.children).toContain('123');
+
+        fireEvent(text, 'onLayout', {nativeEvent: {layout: {height: 10}}});
+
+        await waitFor(() => {
+            const removedText = queryByTestId('no-animation-number');
+
+            expect(removedText).toBeNull();
+        });
+    });
+
+    it('should switch to the animated number view', async () => {
+        const {getByTestId} = render(<AnimatedNumber animateToNumber={123}/>);
+
+        const text = getByTestId('no-animation-number');
+
+        fireEvent(text, 'onLayout', {nativeEvent: {layout: {height: 10}}});
+
+        await waitFor(() => {
+            const animatedView = getByTestId('animation-number-main');
+            expect(animatedView).toBeTruthy();
+        });
+    });
+
+    it.each([123, 9982, 328])('should show the correct number', async (animateToNumber: number) => {
+        const {getByTestId} = render(<AnimatedNumber animateToNumber={animateToNumber}/>);
+
+        const text = getByTestId('no-animation-number');
+
+        fireEvent(text, 'onLayout', {nativeEvent: {layout: {height: 10}}});
+
+        animateToNumber.toString().split('').forEach(async (number, index) => {
+            const useIndex = animateToNumber.toString().length - 1 - index;
+
+            let translateY = -1;
+            await waitFor(() => {
+                const transformedView = getByTestId(`animated-number-view-${useIndex}`);
+                translateY = transformedView.props.style.transform[0].translateY;
+            });
+
+            const translateYValue = Number(number) * 10;
+
+            expect(translateY).toBe(translateYValue * -1);
+
+            const numberShowing = getByTestId(`text-${useIndex}-${number}`);
+
+            expect(numberShowing.props.children).toEqual(Number(number));
+        });
+    });
+
+    it.each([146, 144, 1, 1000000, -1])('should show the correct number that it moved to', async (animateToNumber: number) => {
+        const startingNumber = 145;
+        const {toJSON, getByTestId, rerender} = render(<AnimatedNumber animateToNumber={startingNumber}/>);
+
+        const text = getByTestId('no-animation-number');
+
+        fireEvent(text, 'onLayout', {nativeEvent: {layout: {height: 10}}});
+
+        // const animateToNumber = 456;
+
+        rerender(<AnimatedNumber animateToNumber={animateToNumber}/>);
+
+        // expect(toJSON()).toMatchSnapshot();
+
+        // await waitFor(() => {
+        animateToNumber.toString().split('').forEach(async (number, index) => {
+            const useIndex = animateToNumber.toString().length - 1 - index;
+
+            await waitFor(() => {
+                getByTestId(`animated-number-view-${useIndex}`);
+            });
+
+            // const translateY = transformedView.props.style.transform[0].translateY;
+            // const translateYValue = Number(number) * 10;
+
+            // console.log(translateY, translateYValue);
+
+            // this will always fail, because native animation will not start in test (since we're mocking it)
+            // expect(translateY).toBe(translateYValue * -1);
+
+            const numberShowing = getByTestId(`text-${useIndex}-${number}`);
+            expect(numberShowing.props.children).toEqual(Number(number));
+
+            // console.log(numberShowing.props.children);
+        });
+
+        // });
+    });
+});

--- a/app/components/animated_number/index.tsx
+++ b/app/components/animated_number/index.tsx
@@ -67,11 +67,15 @@ const AnimatedNumber = ({
     return (
         <>
             {numberHeight !== 0 && (
-                <View style={{flexDirection: 'row'}}>
+                <View
+                    style={{flexDirection: 'row'}}
+                    testID='animation-number-main'
+                >
                     {animateToNumber < 0 && (
                         <Text style={[fontStyle, {height: numberHeight}]}>{'-'}</Text>
                     )}
                     {numberStringToDigitsArray.map((n, index) => {
+                        const useIndex = numberStringToDigitsArray.length - 1 - index;
                         return (
                             <View
                                 key={`${index.toString()}`}
@@ -87,13 +91,17 @@ const AnimatedNumber = ({
                                             ],
                                         },
                                     ]}
+                                    testID={`animated-number-view-${useIndex}`}
                                 >
                                     {NUMBERS.map((number, i) => (
                                         <View
                                             style={{flexDirection: 'row'}}
                                             key={`${i.toString()}`}
                                         >
-                                            <Text style={[fontStyle, {height: numberHeight}]}>
+                                            <Text
+                                                style={[fontStyle, {height: numberHeight}]}
+                                                testID={`text-${useIndex}-${number}`}
+                                            >
                                                 {number}
                                             </Text>
                                         </View>
@@ -108,6 +116,7 @@ const AnimatedNumber = ({
             <Text
                 style={[fontStyle]}
                 onLayout={setButtonLayout}
+                testID={'no-animation-number'}
             >
                 {animateToNumberString}
             </Text>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This was presented during Developer Meeting October 30th.  The goal was to ask developers to re-consider the use of toMatchSnapshot which doesn't really give enough information what the component AnimatedNumber is doing and why it's rendering the way it did.


```
 PASS  app/components/animated_number/index.test.tsx
  AnimatedNumber, using toMatchSnapshot
    ○ skipped should render correctly
    ○ skipped should rerender the correct number
  AnimatedNumber
    ✓ should render the non-animated number (107 ms)
    ✓ should removed the non-animation number after getting the correct height (7 ms)
    ✓ should switch to the animated number view (3 ms)
    ✓ KNOWN UI BUG: should show that there will be an issue if the text height changes, due to the non-animated number view has been removed (2 ms)
    should show the correct number of animated views based on the digits
      ✓ should display 1 view(s) for 1 (2 ms)
      ✓ should display 2 view(s) for 23 (2 ms)
      ✓ should display 3 view(s) for 579 (3 ms)
      ✓ should display 4 view(s) for -123 (3 ms)
      ✓ should display 4 view(s) for 6789 (3 ms)
      ✓ should display 5 view(s) for 23456 (4 ms)
    should show the correct number
      ✓ should display the number 123 (4 ms)
      ✓ should display the number 9982 (4 ms)
      ✓ should display the number 328 (3 ms)
      ✓ should display the number 1111 (3 ms)
      ✓ should display the number 2222 (4 ms)
      ✓ should display the number 3333 (3 ms)
    should rerender the correct number that it animates to
      ✓ should display the number 146 (5 ms)
      ✓ should display the number 144 (3 ms)
      ✓ should display the number 1 (2 ms)
      ✓ should display the number 1000000 (6 ms)
      ✓ should display the number -145 (4 ms)


=============================== Coverage summary ===============================
Statements   : 100% ( 37/37 )
Branches     : 100% ( 16/16 )
Functions    : 100% ( 13/13 )
Lines        : 100% ( 35/35 )
================================================================================
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
