### PR TITLE
fix(MM-61209): mention badge incorrect theme color

### DIFF
--- a/app/components/badge/index.tsx
+++ b/app/components/badge/index.tsx
@@ -22,7 +22,7 @@ type Props = {
 };
 
 export default function Badge({
-    borderColor,
+    borderColor: borderColorProp,
     color,
     visible = true,
     type = 'Normal',
@@ -60,9 +60,15 @@ export default function Badge({
         return null;
     }
 
-    // @ts-expect-error: backgroundColor definitely exists
-    const {backgroundColor = rest.backgroundColor || theme.mentionBg, ...restStyle} =
+    const {
+
+        // @ts-expect-error: backgroundColor & borderColor definitely exist
+        backgroundColor = rest.backgroundColor || theme.mentionBg, borderColor: styleBorderColor,
+
+        ...restStyle} =
     StyleSheet.flatten(style) || {};
+
+    const borderColor = borderColorProp || styleBorderColor || theme.mentionBg;
     const textColor = color || theme.mentionColor;
     let lineHeight = Platform.select({android: 21, ios: 16.5});
     let fontSize = 12;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Most noticeable in the quartz theme, the mention badge and unread badge is using the wrong colors. See attached. Because of this the mention badge is nearly invisible.

![IMG_4282](https://github.com/user-attachments/assets/bdb7155c-33e3-4c1d-afce-2a7d7ae6c6ad)

Fix, what it looks like on Quartz:

![quartz-fixed](https://github.com/user-attachments/assets/bff3d552-c9b0-4990-85e9-fc4a8848697c)

Fix, what it looks like on Onyx:

![onyx-fixed](https://github.com/user-attachments/assets/15b0d7a9-056a-4278-86f6-4032cf5ea957)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61209

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
