### PR TITLE
Fix iPad split screen

### DIFF
--- a/libraries/@mattermost/rnutils/ios/RNUtilsWrapper.swift
+++ b/libraries/@mattermost/rnutils/ios/RNUtilsWrapper.swift
@@ -26,22 +26,20 @@ import React
     
     func getWindowSize() -> (CGSize?, CGSize?) {
         guard let w = UIApplication.shared.delegate?.window, let window = w else { return (nil, nil) }
-        return (window.screen.bounds.size, window.frame.size)
+        return (window.screen.bounds.size, window.bounds.size)
     }
     
     func isRunningInFullScreen() -> Bool {
         guard let w = UIApplication.shared.delegate?.window, let window = w else { return false }
-        let screenSize = window.screen.bounds.size.width
-        let frameSize = window.frame.size.width
-        let shouldBeConsideredFullScreen = frameSize >= (screenSize * 0.6)
-        return shouldBeConsideredFullScreen
+        let screenWidth = window.screen.bounds.size.width
+        let windowWidth = window.bounds.size.width
+        return windowWidth >= screenWidth * (2.0 / 3.0)
     }
     
-    func isRunningInFullScreen(screen: CGSize?, frame: CGSize?) -> Bool {
-        guard let screenSize = screen?.width,
-              let frameSize = frame?.width else {return false}
-        let shouldBeConsideredFullScreen = frameSize >= (screenSize * 0.6)
-        return shouldBeConsideredFullScreen
+    func isRunningInFullScreen(screen: CGSize?, bounds: CGSize?) -> Bool {
+        guard let screenWidth = screen?.width,
+              let windowWidth = bounds?.width else {return false}
+        return windowWidth >= screenWidth * (2.0 / 3.0)
     }
     
     @objc public func captureEvents() {
@@ -53,21 +51,21 @@ import React
     
     override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == "frame" {
-            let (screen, frame) = getWindowSize()
-            guard let screen = screen, let frame = frame else {return}
-            isSplitView(screen: screen, frame: frame)
+            let (screen, bounds) = getWindowSize()
+            guard let screen = screen, let bounds = bounds else {return}
+            isSplitView(screen: screen, bounds: bounds)
             
             delegate?.sendEvent(name: "DimensionsChanged", result: [
-                "width": frame.width,
-                "height": frame.height
+                "width": bounds.width,
+                "height": bounds.height
             ])
         }
     }
     
-    @objc func isSplitView(screen: CGSize, frame: CGSize) {
+    @objc func isSplitView(screen: CGSize, bounds: CGSize) {
         if UIDevice.current.userInterfaceIdiom == .pad {
             delegate?.sendEvent(name: "SplitViewChanged", result: [
-                "isSplit": !isRunningInFullScreen(screen: screen, frame: frame),
+                "isSplit": !isRunningInFullScreen(screen: screen, bounds: bounds),
                 "isTablet": UIDevice.current.userInterfaceIdiom == .pad,
             ])
         }


### PR DESCRIPTION
#### Summary
A couple of things were fixed here, first instead of using the window frame we are using the window bounds and secondly we only consider it to be a tablet layout if the app takes at least 2/3 of the screen width.

##### bounds vs. frame
* `bounds`: Represents the window’s coordinate system and its size within its own context. The origin is typically (0,0), with width and height that represent the actual size of the window's content area.
* `frame`: Represents the window’s rectangle relative to its parent coordinate system, typically the screen’s coordinate space. If the window is rotated or scaled, the frame will change to reflect its position and orientation relative to the screen.

Using bounds is generally more reliable for checking size because:

1. **Orientation Independence**: bounds always represents the actual content size of the window, regardless of its position or rotation on the screen. When a device is rotated, the frame can change, but bounds will consistently represent the usable size.
2. **Clarity of Intent**: By using bounds, we’re explicitly focusing on the window’s internal size (i.e., the actual content area), which is more aligned with checking how much of the screen’s width the window occupies.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61317

#### Device Information
This PR was tested on: iPad

#### Release Note
```release-note
Fixed layout on iPad with split screen & stage manager
```