### PR TITLE
prevent overlap of clear button, fix font, reduce space on recent statuses

### DIFF
--- a/app/screens/custom_status/components/custom_status_input.tsx
+++ b/app/screens/custom_status/components/custom_status_input.tsx
@@ -34,7 +34,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             alignSelf: 'stretch',
             color: theme.centerChannelColor,
             flex: 1,
-            fontSize: 17,
             paddingHorizontal: 16,
             textAlignVertical: 'center',
             height: '100%',

--- a/app/screens/custom_status/components/custom_status_input.tsx
+++ b/app/screens/custom_status/components/custom_status_input.tsx
@@ -8,6 +8,7 @@ import {TextInput, View} from 'react-native';
 import ClearButton from '@components/custom_status/clear_button';
 import {CUSTOM_STATUS_TEXT_CHARACTER_LIMIT} from '@constants/custom_status';
 import {changeOpacity, getKeyboardAppearanceFromTheme, makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
 
 import CustomStatusEmoji from './custom_status_emoji';
 
@@ -29,11 +30,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             marginRight: 16,
             marginLeft: 52,
         },
-        clearButton: {
-            position: 'absolute',
-            top: 3,
-            right: 14,
-        },
         input: {
             alignSelf: 'stretch',
             color: theme.centerChannelColor,
@@ -42,11 +38,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             paddingHorizontal: 16,
             textAlignVertical: 'center',
             height: '100%',
+            ...typography('Body', 200, 'Regular'),
         },
         inputContainer: {
             justifyContent: 'center',
             alignItems: 'center',
-            height: 48,
+            height: 80,
             backgroundColor: theme.centerChannelBg,
             flexDirection: 'row',
         },
@@ -83,11 +80,11 @@ const CustomStatusInput = ({emoji, isStatusSet, onChangeText, onClearHandle, onO
                     style={style.input}
                     secureTextEntry={false}
                     underlineColorAndroid='transparent'
+                    multiline={true}
                     value={text}
                 />
                 {isStatusSet ? (
                     <View
-                        style={style.clearButton}
                         testID='custom_status.status.input.clear.button'
                     >
                         <ClearButton

--- a/app/screens/custom_status/components/custom_status_suggestion/custom_status_suggestion.tsx
+++ b/app/screens/custom_status/components/custom_status_suggestion/custom_status_suggestion.tsx
@@ -11,6 +11,7 @@ import Emoji from '@components/emoji';
 import {CST} from '@constants/custom_status';
 import {preventDoubleTap} from '@utils/tap';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
 
 type Props = {
     duration?: CustomStatusDuration;
@@ -43,7 +44,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             paddingTop: 14,
             paddingBottom: 14,
             justifyContent: 'center',
-            width: '70%',
+            width: '93%',
             flex: 1,
         },
         divider: {
@@ -57,6 +58,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         customStatusText: {
             color: theme.centerChannelColor,
+            ...typography('Body', 200, 'Regular'),
         },
     };
 });

--- a/app/screens/custom_status/custom_status.tsx
+++ b/app/screens/custom_status/custom_status.tsx
@@ -128,7 +128,7 @@ function reducer(state: NewStatusType, action: {
             return state;
         }
         case 'text':
-            return {...state, text: action.value};
+            return {...state, text: action.value?.replace('\n', '')};
         case 'emoji':
             return {...state, emoji: action.value};
         case 'duration':
@@ -192,8 +192,7 @@ const CustomStatus = ({
     }, []);
 
     const handleTextChange = useCallback((value: string) => {
-        const noLines = value.replace('\n', '');
-        dispatchStatus({type: 'text', value: noLines});
+        dispatchStatus({type: 'text', value});
     }, []);
 
     const handleEmojiClick = useCallback((value: string) => {

--- a/app/screens/custom_status/custom_status.tsx
+++ b/app/screens/custom_status/custom_status.tsx
@@ -128,7 +128,7 @@ function reducer(state: NewStatusType, action: {
             return state;
         }
         case 'text':
-            return {...state, text: action.value?.replace('\n', '')};
+            return {...state, text: action.value?.replace('\n', ' ')};
         case 'emoji':
             return {...state, emoji: action.value};
         case 'duration':

--- a/app/screens/custom_status/custom_status.tsx
+++ b/app/screens/custom_status/custom_status.tsx
@@ -192,7 +192,8 @@ const CustomStatus = ({
     }, []);
 
     const handleTextChange = useCallback((value: string) => {
-        dispatchStatus({type: 'text', value});
+        const noLines = value.replace('\n', '');
+        dispatchStatus({type: 'text', value: noLines});
     }, []);
 
     const handleEmojiClick = useCallback((value: string) => {


### PR DESCRIPTION
#### Summary
- clear button on long statuses was being drawn on top of the text
- not using same font as rest of the app
- recent status were having huge space between text and clear button

#### Ticket Link
[MM-61129](https://mattermost.atlassian.net/browse/MM-61129)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [x] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: android and ios simulators

#### Screenshots

![CleanShot 2024-11-08 at 12 11 22@2x](https://github.com/user-attachments/assets/346aa4ae-b588-4c04-a91f-5ed33eee2dd1)


#### Release Note
```release-note
fix UI for editing custom status
```


[MM-61129]: https://mattermost.atlassian.net/browse/MM-61129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ