### PR TITLE
MM-59444 Add tests for actions/remote/command

### DIFF
--- a/app/actions/remote/command.test.ts
+++ b/app/actions/remote/command.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable max-lines */
+
+import {doAppSubmit} from '@actions/remote/apps';
+import {AppCommandParser} from '@components/autocomplete/slash_suggestion/app_command_parser/app_command_parser';
+import {AppCallResponseTypes} from '@constants/apps';
+import DatabaseManager from '@database/manager';
+import AppsManager from '@managers/apps_manager';
+import IntegrationsManager from '@managers/integrations_manager';
+import NetworkManager from '@managers/network_manager';
+import {logDebug} from '@utils/log';
+
+import {executeCommand, executeAppCommand} from './command';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+import type {IntlShape} from 'react-intl';
+
+jest.mock('@actions/remote/apps');
+jest.mock('@components/autocomplete/slash_suggestion/app_command_parser/app_command_parser');
+jest.mock('@constants/apps');
+jest.mock('@database/manager');
+jest.mock('@managers/apps_manager');
+jest.mock('@managers/integrations_manager');
+jest.mock('@managers/network_manager');
+jest.mock('@utils/log');
+
+const serverUrl = 'baseHandler.test.com';
+let operator: ServerDataOperator;
+const intl: IntlShape = {
+    formatMessage: jest.fn(({defaultMessage}) => defaultMessage),
+} as any;
+const channelId = 'channel_id';
+const teamId = 'team_id';
+const rootId = 'root_id';
+const message = '/test command';
+const args = {
+    channel_id: channelId,
+    team_id: teamId,
+    root_id: rootId,
+    parent_id: rootId,
+};
+
+const channel: Channel = {
+    id: channelId,
+    display_name: 'channelname',
+    team_id: teamId,
+    total_msg_count: 0,
+    group_constrained: true,
+} as Channel;
+
+const mockClient = {
+    executeCommand: jest.fn(() => ({trigger_id: 'trigger_id'})),
+};
+
+beforeAll(() => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    NetworkManager.getClient = () => mockClient;
+});
+
+beforeEach(async () => {
+    jest.clearAllMocks();
+    await DatabaseManager.init([serverUrl]);
+    operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+});
+
+afterEach(async () => {
+    await DatabaseManager.destroyServerDatabase(serverUrl);
+});
+
+describe('executeCommand', () => {
+    it('handle not found database', async () => {
+        const result = await executeCommand('invalid_url', intl, message, channelId, rootId);
+        expect(result).toEqual({error: 'invalid_url database not found'});
+    });
+
+    it('handle apps enabled', async () => {
+        jest.spyOn(AppsManager, 'isAppsEnabled').mockResolvedValue(true);
+        const parser = {
+            isAppCommand: jest.fn().mockReturnValue(true),
+            composeCommandSubmitCall: jest.fn().mockResolvedValue({creq: {}, errorMessage: null}),
+        };
+        (AppCommandParser as jest.Mock).mockReturnValue(parser);
+        (doAppSubmit as jest.Mock).mockResolvedValue({data: {type: AppCallResponseTypes.OK, text: 'Success'}});
+
+        const result = await executeCommand(serverUrl, intl, message, channelId, rootId);
+
+        expect(AppsManager.isAppsEnabled).toHaveBeenCalledWith(serverUrl);
+        expect(parser.isAppCommand).toHaveBeenCalledWith(message);
+        expect(result).toEqual(await executeAppCommand(serverUrl, intl, parser as any, message, args));
+    });
+
+    it('handle apps enabled but not an app command', async () => {
+        jest.spyOn(AppsManager, 'isAppsEnabled').mockResolvedValue(true);
+        const parser = {
+            isAppCommand: jest.fn().mockReturnValue(false),
+        };
+        (AppCommandParser as jest.Mock).mockImplementation(() => parser);
+
+        const result = await executeCommand(serverUrl, intl, message, channelId, rootId);
+
+        expect(AppsManager.isAppsEnabled).toHaveBeenCalledWith(serverUrl);
+        expect(parser.isAppCommand).toHaveBeenCalledWith(message);
+        expect(mockClient.executeCommand).toHaveBeenCalled();
+        expect(result).toEqual({data: {trigger_id: 'trigger_id'}});
+    });
+
+    it('handle apps disabled', async () => {
+        jest.spyOn(AppsManager, 'isAppsEnabled').mockResolvedValue(false);
+
+        const result = await executeCommand(serverUrl, intl, message, channelId, rootId);
+
+        expect(AppsManager.isAppsEnabled).toHaveBeenCalledWith(serverUrl);
+        expect(mockClient.executeCommand).toHaveBeenCalled();
+        expect(result).toEqual({data: {trigger_id: 'trigger_id'}});
+    });
+
+    it('handle command execution with successful response', async () => {
+        await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
+
+        jest.spyOn(AppsManager, 'isAppsEnabled').mockResolvedValue(false);
+        const mockSetTriggerId = jest.fn();
+        jest.spyOn(IntegrationsManager, 'getManager').mockReturnValue({
+            setTriggerId: mockSetTriggerId,
+        } as any);
+
+        const result = await executeCommand(serverUrl, intl, message, channelId, rootId);
+
+        expect(mockClient.executeCommand).toHaveBeenCalledWith(message, args);
+        expect(mockSetTriggerId).toHaveBeenCalledWith('trigger_id');
+        expect(result).toEqual({data: {trigger_id: 'trigger_id'}});
+    });
+
+    it('handle command execution with error response', async () => {
+        await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
+
+        jest.spyOn(AppsManager, 'isAppsEnabled').mockResolvedValue(false);
+        const error = new Error('Test error');
+        mockClient.executeCommand.mockRejectedValue(error as never);
+
+        const result = await executeCommand(serverUrl, intl, message, channelId, rootId);
+
+        expect(mockClient.executeCommand).toHaveBeenCalledWith(message, args);
+        expect(logDebug).toHaveBeenCalledWith('error on executeCommand', error.message);
+        expect(result).toEqual({error});
+    });
+});

--- a/app/actions/remote/command.test.ts
+++ b/app/actions/remote/command.test.ts
@@ -3,19 +3,24 @@
 
 /* eslint-disable max-lines */
 
-import {doAppSubmit} from '@actions/remote/apps';
+import {createIntl} from 'react-intl';
+
+import {doAppSubmit, postEphemeralCallResponseForCommandArgs} from '@actions/remote/apps';
 import {AppCommandParser} from '@components/autocomplete/slash_suggestion/app_command_parser/app_command_parser';
 import {AppCallResponseTypes} from '@constants/apps';
 import DatabaseManager from '@database/manager';
 import AppsManager from '@managers/apps_manager';
 import IntegrationsManager from '@managers/integrations_manager';
 import NetworkManager from '@managers/network_manager';
+import {showAppForm} from '@screens/navigation';
 import {logDebug} from '@utils/log';
 
-import {executeCommand, executeAppCommand} from './command';
+import {
+    executeCommand,
+    executeAppCommand,
+} from './command';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
-import type {IntlShape} from 'react-intl';
 
 jest.mock('@actions/remote/apps');
 jest.mock('@components/autocomplete/slash_suggestion/app_command_parser/app_command_parser');
@@ -26,11 +31,22 @@ jest.mock('@managers/integrations_manager');
 jest.mock('@managers/network_manager');
 jest.mock('@utils/log');
 
+jest.mock('@screens/navigation', () => {
+    const original = jest.requireActual('@screens/navigation');
+    return {
+        ...original,
+        showAppForm: jest.fn(),
+    };
+});
+
 const serverUrl = 'baseHandler.test.com';
 let operator: ServerDataOperator;
-const intl: IntlShape = {
-    formatMessage: jest.fn(({defaultMessage}) => defaultMessage),
-} as any;
+
+const intl = createIntl({
+    locale: 'en',
+    messages: {},
+});
+
 const channelId = 'channel_id';
 const teamId = 'team_id';
 const rootId = 'root_id';
@@ -145,5 +161,81 @@ describe('executeCommand', () => {
         expect(mockClient.executeCommand).toHaveBeenCalledWith(message, args);
         expect(logDebug).toHaveBeenCalledWith('error on executeCommand', error.message);
         expect(result).toEqual({error});
+    });
+});
+
+describe('executeAppCommand', () => {
+    const msg = 'test message';
+
+    it('should handle a successful command execution with OK response', async () => {
+        const parser = {
+            composeCommandSubmitCall: jest.fn().mockResolvedValue({creq: {}, errorMessage: null}),
+        };
+        (AppCommandParser as jest.Mock).mockReturnValue(parser);
+        (doAppSubmit as jest.Mock).mockResolvedValue({data: {type: AppCallResponseTypes.OK, text: 'Success'}});
+
+        const result = await executeAppCommand(serverUrl, intl, parser as any, msg, args);
+
+        expect(parser.composeCommandSubmitCall).toHaveBeenCalledWith(msg);
+        expect(doAppSubmit).toHaveBeenCalledWith(serverUrl, {}, intl);
+        expect(postEphemeralCallResponseForCommandArgs).toHaveBeenCalledWith(serverUrl, {type: AppCallResponseTypes.OK, text: 'Success'}, 'Success', args);
+        expect(result).toEqual({data: {}});
+    });
+
+    it('should handle an error response', async () => {
+        const parser = {
+            composeCommandSubmitCall: jest.fn().mockResolvedValue({creq: {}, errorMessage: null}),
+        };
+        (AppCommandParser as jest.Mock).mockReturnValue(parser);
+        (doAppSubmit as jest.Mock).mockResolvedValue({error: {text: 'Error occurred'}});
+
+        const result = await executeAppCommand(serverUrl, intl, parser as any, msg, args);
+
+        expect(parser.composeCommandSubmitCall).toHaveBeenCalledWith(msg);
+        expect(doAppSubmit).toHaveBeenCalledWith(serverUrl, {}, intl);
+        expect(result).toEqual({error: {message: 'Error occurred'}});
+    });
+
+    it('should handle a form response', async () => {
+        const parser = {
+            composeCommandSubmitCall: jest.fn().mockResolvedValue({creq: {context: {}}, errorMessage: null}),
+        };
+        (AppCommandParser as jest.Mock).mockReturnValue(parser);
+        (doAppSubmit as jest.Mock).mockResolvedValue({data: {type: AppCallResponseTypes.FORM, form: {title: 'Form Title'}}});
+
+        const result = await executeAppCommand(serverUrl, intl, parser as any, msg, args);
+
+        expect(parser.composeCommandSubmitCall).toHaveBeenCalledWith(msg);
+        expect(doAppSubmit).toHaveBeenCalledWith(serverUrl, {context: {}}, intl);
+        expect(showAppForm).toHaveBeenCalledWith({title: 'Form Title'}, {});
+        expect(result).toEqual({data: {}});
+    });
+
+    it('should handle a navigate response', async () => {
+        const parser = {
+            composeCommandSubmitCall: jest.fn().mockResolvedValue({creq: {}, errorMessage: null}),
+        };
+        (AppCommandParser as jest.Mock).mockReturnValue(parser);
+        (doAppSubmit as jest.Mock).mockResolvedValue({data: {type: AppCallResponseTypes.NAVIGATE, navigate_to_url: 'https://navigate.com'}});
+
+        const result = await executeAppCommand(serverUrl, intl, parser as any, msg, args);
+
+        expect(parser.composeCommandSubmitCall).toHaveBeenCalledWith(msg);
+        expect(doAppSubmit).toHaveBeenCalledWith(serverUrl, {}, intl);
+        expect(result).toEqual({data: {}});
+    });
+
+    it('should handle an unknown response type', async () => {
+        const parser = {
+            composeCommandSubmitCall: jest.fn().mockResolvedValue({creq: {}, errorMessage: null}),
+        };
+        (AppCommandParser as jest.Mock).mockReturnValue(parser);
+        (doAppSubmit as jest.Mock).mockResolvedValue({data: {type: 'UNKNOWN'}});
+
+        const result = await executeAppCommand(serverUrl, intl, parser as any, msg, args);
+
+        expect(parser.composeCommandSubmitCall).toHaveBeenCalledWith(msg);
+        expect(doAppSubmit).toHaveBeenCalledWith(serverUrl, {}, intl);
+        expect(result).toEqual({error: {message: 'App response type not supported. Response type: UNKNOWN.'}});
     });
 });

--- a/app/actions/remote/command.ts
+++ b/app/actions/remote/command.ts
@@ -82,7 +82,7 @@ export const executeCommand = async (serverUrl: string, intl: IntlShape, message
     return {data};
 };
 
-const executeAppCommand = async (serverUrl: string, intl: IntlShape, parser: AppCommandParser, msg: string, args: CommandArgs) => {
+export const executeAppCommand = async (serverUrl: string, intl: IntlShape, parser: AppCommandParser, msg: string, args: CommandArgs) => {
     const {creq, errorMessage} = await parser.composeCommandSubmitCall(msg);
     const createErrorMessage = (errMessage: string) => {
         return {error: {message: errMessage}};


### PR DESCRIPTION
#### Summary

Add unit tests for actions/remote/command. Coverage increases from x% to 95.06%.

This was my first time using GitHub Copilot Chat to help write tests. As a result it took me longer than usual to write these but they are more thorough than some of the other tests I've written.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59444

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
