### PR TITLE
fix entry logic to not re-fetch data for the initial team

### DIFF
--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -396,6 +396,11 @@ async function restDeferredAppEntryActions(
             const sortedTeamIds = new Set(teamsOrder?.value.split(','));
             const membershipSet = new Set(teamData.memberships.map((m) => m.team_id));
             const teamMap = new Map(teamData.teams.map((t) => [t.id, t]));
+            if (initialTeamId) {
+                sortedTeamIds.delete(initialTeamId);
+                membershipSet.delete(initialTeamId);
+                teamMap.delete(initialTeamId);
+            }
 
             let myTeams: Team[];
             if (sortedTeamIds.size) {
@@ -411,7 +416,10 @@ async function restDeferredAppEntryActions(
                 myTeams = teamData.teams.
                     sort((a, b) => a.display_name.toLocaleLowerCase().localeCompare(b.display_name.toLocaleLowerCase()));
             }
-            fetchTeamsChannelsThreadsAndUnreadPosts(serverUrl, since, myTeams, isCRTEnabled);
+
+            if (myTeams.length) {
+                fetchTeamsChannelsThreadsAndUnreadPosts(serverUrl, since, myTeams, isCRTEnabled);
+            }
         }
     });
 


### PR DESCRIPTION
#### Summary
We made some improvements to the performance of login here https://github.com/mattermost/mattermost-mobile/pull/8306 but there were two bugs that are fixed in this PR.

1. We were requesting channels, posts and others for the initial team even though we already have that data.
2. The exclusion of threads in DMs was checking for version 10.2.0 which is wrong, that PR just landed in master, so for the time being we just dedupe the models.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
