### PR TITLE
fix: fixed image overflow in message attachments

### DIFF
--- a/app/components/post_list/post/body/content/message_attachments/attachment_image/index.tsx
+++ b/app/components/post_list/post/body/content/message_attachments/attachment_image/index.tsx
@@ -57,7 +57,7 @@ const AttachmentImage = ({imageUrl, imageMetadata, layoutWidth, location, postId
     const [error, setError] = useState(false);
     const fileId = useRef(generateId('uid')).current;
     const isTablet = useIsTablet();
-    const {height, width} = calculateDimensions(imageMetadata.height, imageMetadata.width, layoutWidth || getViewPortWidth(false, isTablet));
+    const {height, width} = calculateDimensions(imageMetadata.height, imageMetadata.width, layoutWidth || getViewPortWidth(false, isTablet, true));
     const style = getStyleSheet(theme);
 
     const onError = useCallback(() => {

--- a/app/constants/image.ts
+++ b/app/constants/image.ts
@@ -6,6 +6,7 @@ export const IMAGE_MIN_DIMENSION = 50;
 export const MAX_GIF_SIZE = 100 * 1024 * 1024;
 export const VIEWPORT_IMAGE_OFFSET = 70;
 export const VIEWPORT_IMAGE_REPLY_OFFSET = 11;
+export const VIEWPORT_IMAGE_ATTACHMENT_OFFSET = 31.5; // (2 * 12) Container Padding + (2,5 + 5) Image Padding
 export const MAX_RESOLUTION = 7680 * 4320; // 8K, ~33MPX
 
 export default {
@@ -15,4 +16,5 @@ export default {
     MAX_RESOLUTION,
     VIEWPORT_IMAGE_OFFSET,
     VIEWPORT_IMAGE_REPLY_OFFSET,
+    VIEWPORT_IMAGE_ATTACHMENT_OFFSET,
 };

--- a/app/constants/image.ts
+++ b/app/constants/image.ts
@@ -6,7 +6,7 @@ export const IMAGE_MIN_DIMENSION = 50;
 export const MAX_GIF_SIZE = 100 * 1024 * 1024;
 export const VIEWPORT_IMAGE_OFFSET = 70;
 export const VIEWPORT_IMAGE_REPLY_OFFSET = 11;
-export const VIEWPORT_IMAGE_ATTACHMENT_OFFSET = 31.5; // (2 * 12) Container Padding + (2,5 + 5) Image Padding
+export const VIEWPORT_IMAGE_ATTACHMENT_OFFSET = 31.5; // (2 * 12) MessageAttachment Padding + (2,5 + 5) AttachmentImage Padding
 export const MAX_RESOLUTION = 7680 * 4320; // 8K, ~33MPX
 
 export default {

--- a/app/utils/images/index.ts
+++ b/app/utils/images/index.ts
@@ -4,7 +4,14 @@
 import {Dimensions} from 'react-native';
 
 import {View} from '@constants';
-import {IMAGE_MAX_HEIGHT, IMAGE_MIN_DIMENSION, MAX_GIF_SIZE, VIEWPORT_IMAGE_OFFSET, VIEWPORT_IMAGE_REPLY_OFFSET} from '@constants/image';
+import {
+    IMAGE_MAX_HEIGHT,
+    IMAGE_MIN_DIMENSION,
+    MAX_GIF_SIZE,
+    VIEWPORT_IMAGE_ATTACHMENT_OFFSET,
+    VIEWPORT_IMAGE_OFFSET,
+    VIEWPORT_IMAGE_REPLY_OFFSET,
+} from '@constants/image';
 
 export const calculateDimensions = (height?: number, width?: number, viewPortWidth = 0, viewPortHeight = 0) => {
     'worklet';
@@ -47,7 +54,7 @@ export const calculateDimensions = (height?: number, width?: number, viewPortWid
     };
 };
 
-export function getViewPortWidth(isReplyPost: boolean, tabletOffset = false) {
+export function getViewPortWidth(isReplyPost: boolean, tabletOffset = false, imageAttachmentOffset = false) {
     const {width, height} = Dimensions.get('window');
     let portraitPostWidth = Math.min(width, height) - VIEWPORT_IMAGE_OFFSET;
 
@@ -57,6 +64,10 @@ export function getViewPortWidth(isReplyPost: boolean, tabletOffset = false) {
 
     if (isReplyPost) {
         portraitPostWidth -= VIEWPORT_IMAGE_REPLY_OFFSET;
+    }
+
+    if (imageAttachmentOffset) {
+        portraitPostWidth -= VIEWPORT_IMAGE_ATTACHMENT_OFFSET;
     }
 
     return portraitPostWidth;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Fixed the overflow if a message attachment is wider than the Viewport. (https://developers.mattermost.com/integrate/reference/message-attachments/#images)
This is done by modifying the `getViewPortWidth` and introducing a new `VIEWPORT_IMAGE_ATTACHMENT_OFFSET`.
The value of it is calculated with the padding of the `MessageAttachment` component (2 * 12) + the padding of the `AttachmentImage` component (2,5 + 5) => 31,5

https://github.com/mattermost/mattermost-mobile/blob/9b450cf68b60b47ebcb4ca84af9cc07293397567/app/components/post_list/post/body/content/message_attachments/message_attachment.tsx#L42

https://github.com/mattermost/mattermost-mobile/blob/9b450cf68b60b47ebcb4ca84af9cc07293397567/app/components/post_list/post/body/content/message_attachments/attachment_image/index.tsx#L26-L28

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
_None_

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
- Samsung Galaxy S22, Android 14

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

Example Attachment
```json
"attachments": [
        {
            "fallback": "test",
            "color": "#FF8000",
            "image_url": "https://raw.githubusercontent.com/mattermost/mattermost/refs/heads/master/server/tests/orientation_test_1.jpeg"
        }
    ]
```


|  Before  | After  |
|---|---|
| ![Screenshot_20241119-130413_Mattermost Beta](https://github.com/user-attachments/assets/22c2da1b-90a5-47bb-89ba-6399f6466949) | ![Screenshot_20241119-130205_Mattermost Beta](https://github.com/user-attachments/assets/df8259e1-c3a3-4faa-9c7c-d251f3cd28c7) |




#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixed image overflow when using message attachments.
```
