### PR TITLE
Fix: Edit post scroll for max characters

### DIFF
--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -200,8 +200,9 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
     const overlap = useKeyboardOverlap(mainView, containerHeight);
     const autocompletePosition = overlap + AUTOCOMPLETE_SEPARATION;
     const autocompleteAvailableSpace = containerHeight - autocompletePosition;
+    const errorHeight = (errorLine || errorExtra) ? 44 : 0;
 
-    const inputHeight = containerHeight - overlap;
+    const inputHeight = containerHeight - overlap - errorHeight;
 
     const [animatedAutocompletePosition, animatedAutocompleteAvailableSpace] = useAutocompleteDefaultAnimatedValues(autocompletePosition, autocompleteAvailableSpace);
 


### PR DESCRIPTION
#### Summary
Once the error message has appeared at the top of the screen, you are now able to scroll down to the end of the post to edit/remove characters.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-56679
Fixes https://github.com/mattermost/mattermost/issues/26112

#### Device Information
This PR was tested on:
- Google Pixel 9, Android 15

#### Release Note
```release-note
NONE
```
