### PR TITLE
Surround text on file info for searches

### DIFF
--- a/app/components/files/file_info.tsx
+++ b/app/components/files/file_info.tsx
@@ -98,7 +98,9 @@ const FileInfo = ({disabled, file, channelName, showDate, onPress}: FileInfoProp
                         </Text>
                         {showDate && file.create_at != null && (
                             <>
-                                {' • '}
+                                <Text style={style.infoText}>
+                                    {' • '}
+                                </Text>
                                 <FormattedDate
                                     style={style.infoText}
                                     format={FORMAT}


### PR DESCRIPTION
#### Summary
Text on React Native must be surrounded by a Text tag.

This particular text was breaking searches (and any other place where file infos where showing a date)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62057

#### Release Note
Catched before release
```release-note
NONE
```
