### PR TITLE
Remove end user message for unsupported servers

### DIFF
--- a/app/utils/server/index.ts
+++ b/app/utils/server/index.ts
@@ -21,9 +21,8 @@ export function isSupportedServer(currentVersion: string) {
 
 export function unsupportedServer(serverDisplayName: string, isSystemAdmin: boolean, intl: IntlShape, onPress?: () => void) {
     if (isSystemAdmin) {
-        return unsupportedServerAdminAlert(serverDisplayName, intl, onPress);
+        unsupportedServerAdminAlert(serverDisplayName, intl, onPress);
     }
-    return unsupportedServerAlert(serverDisplayName, intl, onPress);
 }
 
 export function semverFromServerVersion(value: string) {
@@ -240,26 +239,6 @@ function unsupportedServerAdminAlert(serverDisplayName: string, intl: IntlShape,
         },
     };
     const buttons: AlertButton[] = [cancel, learnMore];
-    const options = {cancelable: false};
-
-    Alert.alert(title, message, buttons, options);
-}
-
-function unsupportedServerAlert(serverDisplayName: string, intl: IntlShape, onPress?: () => void) {
-    const title = intl.formatMessage({id: 'unsupported_server.title', defaultMessage: 'Unsupported server version'});
-
-    const message = intl.formatMessage({
-        id: 'unsupported_server.message',
-        defaultMessage: 'Your server, {serverDisplayName}, is running an unsupported server version. You may experience compatibility issues that cause crashes or severe bugs breaking core functionality of the app. Please contact your System Administrator to upgrade your Mattermost server.',
-    }, {serverDisplayName});
-
-    const okButton: AlertButton = {
-        text: intl.formatMessage({id: 'mobile.server_upgrade.button', defaultMessage: 'OK'}),
-        style: 'default',
-        onPress,
-    };
-
-    const buttons: AlertButton[] = [okButton];
     const options = {cancelable: false};
 
     Alert.alert(title, message, buttons, options);

--- a/app/utils/server/server.test.ts
+++ b/app/utils/server/server.test.ts
@@ -16,9 +16,9 @@ describe('Unsupported Server Alert', () => {
         expect(alert?.mock?.calls?.[0]?.[2]?.length).toBe(2);
     });
 
-    it('should show the alert for team admin / user', () => {
+    it('should not show the alert for team admin / user', () => {
         const alert = jest.spyOn(Alert, 'alert');
         unsupportedServer('Default Server', false, intl);
-        expect(alert?.mock?.calls?.[0]?.[2]?.length).toBe(1);
+        expect(alert).not.toHaveBeenCalled();
     });
 });

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1162,8 +1162,6 @@
   "unreads.empty.paragraph": "Turn off the unread filter to show all your channels.",
   "unreads.empty.show_all": "Show all",
   "unreads.empty.title": "No more unreads",
-  "unsupported_server.message": "Your server, {serverDisplayName}, is running an unsupported server version. You may experience compatibility issues that cause crashes or severe bugs breaking core functionality of the app. Please contact your System Administrator to upgrade your Mattermost server.",
-  "unsupported_server.title": "Unsupported server version",
   "user_profile.custom_status": "Custom Status",
   "user_settings.notifications.test_notification.body": "Not receiving notifications? Start by sending a test notification to all your devices to check if they’re working as expected. If issues persist, explore ways to solve them with troubleshooting steps.",
   "user_settings.notifications.test_notification.go_to_docs": "Troubleshooting docs",


### PR DESCRIPTION
#### Summary
Remove end user message for unsupported servers. We keep the admin message.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-59408

#### Release Note
```release-note
End users won't receive messages about being on unsupported servers
```
