### PR TITLE
[MM-62303] workflows/perf: add new workflow to be triggered by a label

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -8,6 +8,11 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     if: ${{ github.event.label.name == 'Run Performance Tests' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_ISSUE_NUMBER: ${{ github.event.pull_request.number }}
+      GITHUB_ORG: ${{ github.repository_owner }}
+      GITHUB_REPO: ${{ github.repository }}
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -15,36 +20,3 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: ci/test
         uses: ./.github/actions/test
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: test-artifcats-${{ github.run_id }}
-          path: pathToTestResults # Path to test results saved from the performance test
-  create-comment:
-    runs-on: ubuntu-22.04
-    needs: test
-    steps:
-      - name: Download test artifacts
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
-        with:
-          name: test-artifcats-${{ github.run_id }}
-          path: pathToTestResults # Download the test results
-      - name: parse-results
-        run: |
-          # Parse test results if necessary
-          # Or if the output generted by the test is in a format that can be used to create a comment
-          # we can simply remove this step and use the output from the test durectly.
-          #
-          # Echo to github output
-          # echo "COMMENT_BODY=$(cat body.txt)" >> $GITHUB_OUTPUT
-      - name: Create comment
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '${{ steps.parse-results.outputs.COMMENT_BODY }}'
-            })
-

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -15,3 +15,36 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: ci/test
         uses: ./.github/actions/test
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: test-artifcats-${{ github.run_id }}
+          path: pathToTestResults # Path to test results saved from the performance test
+  create-comment:
+    runs-on: ubuntu-22.04
+    needs: test
+    steps:
+      - name: Download test artifacts
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: test-artifcats-${{ github.run_id }}
+          path: pathToTestResults # Download the test results
+      - name: parse-results
+        run: |
+          # Parse test results if necessary
+          # Or if the output generted by the test is in a format that can be used to create a comment
+          # we can simply remove this step and use the output from the test durectly.
+          #
+          # Echo to github output
+          # echo "COMMENT_BODY=$(cat body.txt)" >> $GITHUB_OUTPUT
+      - name: Create comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '${{ steps.parse-results.outputs.COMMENT_BODY }}'
+            })
+

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,17 @@
+name: run-performance-tests
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event.label.name == 'Run Performance Tests' }}
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: ci/test
+        uses: ./.github/actions/test


### PR DESCRIPTION


#### Summary
This PR is to start a discussion around how we are going to publish performance metrics on PRs. Right now, as discussed we are triggering a workflow (right now it's only the test action). 

We have 2 alternatives moving forward;
a. Trigger another workflow (or a simple REST API request) within the mobile app to publish metrics as a comment
b. Persist result in the runner and pass the output to another workflow (which will be creating the comment

I think we were agreed on the alternative `a`, I'd prefer the other option (`b`) but it's up to whichever be the best for your tast @enahum :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62303

#### Checklist

- [ ] ~~Added or updated unit tests (required for all new features)~~
- [ ] ~~Has UI changes~~
- [ ] ~~Includes text changes and localization file updates~~
- [ ] ~~Have tested against the 5 core themes to ensure consistency between them.~~
- [ ] ~~Have run E2E tests by adding label `E2E iOS tests for PR`.~~


#### Release Note

```release-note
NONE
```
