### PR TITLE
fix: improve parallel requests calculation

### DIFF
--- a/app/client/rest/tracking.test.ts
+++ b/app/client/rest/tracking.test.ts
@@ -667,5 +667,22 @@ describe('ClientTracking', () => {
             expect(result.averageSpeedMbps).toBe(0);
             expect(result.effectiveLatency).toBe(0); // Should be 0 since data transfer time is 0/negative
         });
+
+        it('should return empty result when groupData is not found', () => {
+            // Try to categorize requests for a non-existent group
+            const result = client.categorizeRequests('Non Existent Group' as RequestGroupLabel);
+
+            // Verify empty result structure
+            expect(result.parallelGroups).toEqual([]);
+            expect(result.maxConcurrency).toBe(0);
+        });
+
+        it('should return default latency when groupData is not found', () => {
+            // Try to get average latency for a non-existent group
+            const result = client.getAverageLatency('Non Existent Group' as RequestGroupLabel);
+
+            // Should return default latency of 100ms
+            expect(result).toBe(100);
+        });
     });
 });

--- a/app/client/rest/tracking.test.ts
+++ b/app/client/rest/tracking.test.ts
@@ -438,6 +438,14 @@ describe('ClientTracking', () => {
         );
     });
 
+    it('should return true when checking allRequestsCompleted for non-existent group', () => {
+        // Try to check completion status for a non-existent group
+        const result = client.allRequestsCompleted('Non Existent Group' as RequestGroupLabel);
+
+        // Should return true since there are no pending requests
+        expect(result).toBe(true);
+    });
+
     describe('Request Categorization and Speed Calculations', () => {
         it('should create multiple parallel groups for non-overlapping requests', () => {
             client.initTrackGroup('Cold Start');

--- a/app/client/rest/tracking.test.ts
+++ b/app/client/rest/tracking.test.ts
@@ -445,6 +445,135 @@ describe('ClientTracking', () => {
         expect(result.effectiveLatency).toBe(0); // Should be 0 since data transfer time is 0/negative
     });
 
+    it('should create multiple parallel groups for non-overlapping requests', () => {
+        client.initTrackGroup('Cold Start');
+        const group = client.requestGroups.get('Cold Start')!;
+        const baseTime = Date.now();
+
+        // First parallel group (2 concurrent requests)
+        group.urls = {
+            'https://example.com/api1': {
+                count: 1,
+                metrics: {
+                    latency: 100,
+                    startTime: baseTime,
+                    endTime: baseTime + 200,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+            'https://example.com/api2': {
+                count: 1,
+                metrics: {
+                    latency: 150,
+                    startTime: baseTime + 50,
+                    endTime: baseTime + 250,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+
+            // Second parallel group (3 concurrent requests)
+            'https://example.com/api3': {
+                count: 1,
+                metrics: {
+                    latency: 120,
+                    startTime: baseTime + 300,
+                    endTime: baseTime + 500,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+            'https://example.com/api4': {
+                count: 1,
+                metrics: {
+                    latency: 180,
+                    startTime: baseTime + 320,
+                    endTime: baseTime + 520,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+            'https://example.com/api5': {
+                count: 1,
+                metrics: {
+                    latency: 160,
+                    startTime: baseTime + 340,
+                    endTime: baseTime + 540,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+        };
+
+        const result = client.categorizeRequests('Cold Start');
+
+        // Verify parallel groups
+        expect(result.parallelGroups).toHaveLength(2);
+        expect(result.maxConcurrency).toBe(3);
+
+        // First group should have 2 requests
+        expect(result.parallelGroups[0].requests).toHaveLength(2);
+        expect(result.parallelGroups[0].latency).toBe(150); // Max latency of first group
+
+        // Second group should have 3 requests
+        expect(result.parallelGroups[1].requests).toHaveLength(3);
+        expect(result.parallelGroups[1].latency).toBe(180); // Max latency of second group
+    });
+
+    it('should handle overlapping parallel groups correctly', () => {
+        client.initTrackGroup('Cold Start');
+        const group = client.requestGroups.get('Cold Start')!;
+        const baseTime = Date.now();
+
+        group.urls = {
+
+            // First request starts early and ends late
+            'https://example.com/api1': {
+                count: 1,
+                metrics: {
+                    latency: 500,
+                    startTime: baseTime,
+                    endTime: baseTime + 1000,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+
+            // These requests start during the first request
+            'https://example.com/api2': {
+                count: 1,
+                metrics: {
+                    latency: 200,
+                    startTime: baseTime + 100,
+                    endTime: baseTime + 300,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+            'https://example.com/api3': {
+                count: 1,
+                metrics: {
+                    latency: 200,
+                    startTime: baseTime + 200,
+                    endTime: baseTime + 400,
+                    size: 1000,
+                    compressedSize: 500,
+                } as ClientResponseMetrics,
+            },
+        };
+
+        const result = client.categorizeRequests('Cold Start');
+
+        // Should create a single parallel group since all requests overlap
+        expect(result.parallelGroups).toHaveLength(1);
+        expect(result.maxConcurrency).toBe(3);
+
+        // The group should contain all 3 requests
+        expect(result.parallelGroups[0].requests).toHaveLength(3);
+        expect(result.parallelGroups[0].latency).toBe(500); // Should take the max latency
+    });
+
     it('should track duplicate requests correctly and log duplicate details', async () => {
         const logDebugSpy = jest.spyOn(require('@utils/log'), 'logDebug');
         apiClientMock.get.mockResolvedValue({


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR is to improve the categorization of requests by keeping track of requests start time.  As an example:

```
Request 1:   |++++++++++------------|
Request 2:        |+++++++++++++----------------|
Request 3:                          |+++++++++---------|
Request 4:                                     |++++++-----|
Request 5:                                      |+++++----|
Request 6:                                       |+++++----|
Request 7:                                       |+++++----|
Request 8:                                        |++++-----|
Request 9:                                         |++++-----|
Request 10:                                        |++++++---|
Request 11:                                        |++++++---|
Request 12:                                         |++++++++|
Request 13:                                         |++++++++|
Request 14:                                                  |++++++++--------|
Request 15:                                                   |++++++++-------|
Request 16:                                                   |++++++++-------|
Request 17:                                                   |++++++++-------|
Request 18:                                                     |++++++++------|
Request 19:                                                     |++++++++------|
```

Request 1-2 are in 1 group, 3-13 are in another, and 14-19 are in the third one.  This allow us to get a sense of the sequential grouped requests during a session.

Note: the latency for each parallel group is based on the max latency.  So the combined latency could be high when a network request hit a bottle neck on 1 request in a group.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

```
 PASS  app/client/rest/tracking.test.ts
  ClientTracking
    ✓ should set bearer token
    ✓ should set CSRF token
    ✓ should get request headers
    ✓ should initialize and track group data (1 ms)
    ✓ should increment and decrement request count
    ✓ should handle request completion (1 ms)
    ✓ should clear completion timer
    ✓ should check if all requests are completed (1 ms)
    ✓ should send telemetry event
    ✓ should build request options (1 ms)
    ✓ should perform fetch with tracking
    ✓ should handle fetch errors (18 ms)
    ✓ should handle non-ok response with error details (1 ms)
    ✓ should handle non-ok response without error details (1 ms)
    ✓ should handle response with bearer token header
    ✓ should handle response with lowercase bearer token header (1 ms)
    ✓ should call increment and decrement the same number of times as doFetchWithTracking, and handleRequestCompletion only once (502 ms)
    ✓ should handle invalid HTTP method
    ✓ should handle server version changes without cache control (1 ms)
    ✓ should not update server version when cache control present (1 ms)
    ✓ should track duplicate requests correctly and log duplicate details (303 ms)
    ✓ should return true when checking allRequestsCompleted for non-existent group (2 ms)
    Request Categorization and Speed Calculations
      ✓ should create multiple parallel groups for non-overlapping requests (2 ms)
      ✓ should handle overlapping parallel groups correctly (2 ms)
      ✓ should handle requests with latency extending beyond group end time (1 ms)
      ✓ should handle requests with latency extending beyond group end time and separate parallel groups (9 ms)
      ✓ should calculate average speed and effective latency for multiple parallel groups (1 ms)
      ✓ should handle zero transfer time in speed calculation (1 ms)
      ✓ should return empty result when groupData is not found (1 ms)
      ✓ should return default latency when groupData is not found


=============================== Coverage summary ===============================
Statements   : 95.18% ( 158/166 )
Branches     : 86.36% ( 76/88 )
Functions    : 100% ( 31/31 )
Lines        : 94.93% ( 150/158 )
================================================================================

```

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
