### PR TITLE
MM-59600 Add unit tests to utils/opengraph

### DIFF
--- a/app/utils/opengraph.test.ts
+++ b/app/utils/opengraph.test.ts
@@ -1,7 +1,17 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getDistanceBW2Points, getNearestPoint} from './opengraph';
+import {getDistanceBW2Points, getNearestPoint, fetchRaw, getFavIcon, fetchOpenGraph} from './opengraph';
+
+let mockedFetch: jest.SpyInstance;
+
+beforeEach(() => {
+    mockedFetch = jest.spyOn(global, 'fetch');
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 describe('Utility Functions', () => {
     describe('getDistanceBW2Points', () => {
@@ -59,6 +69,106 @@ describe('Utility Functions', () => {
             ] as never[];
             const nearestPoint = getNearestPoint(pivotPoint, points);
             expect(nearestPoint).toEqual({x: 2, y: 2});
+        });
+    });
+});
+
+describe('fetchRaw', () => {
+    it('should fetch raw HTML from a URL', async () => {
+        const mockResponse = {
+            ok: true,
+            text: jest.fn().mockResolvedValue('<html></html>'),
+        };
+        mockedFetch.mockResolvedValue(mockResponse as any);
+
+        const result = await fetchRaw('http://example.com');
+        expect(fetch).toHaveBeenCalledWith('http://example.com', {
+            headers: {
+                'User-Agent': 'OpenGraph',
+                'Cache-Control': 'no-cache',
+                Accept: '*/*',
+                Connection: 'keep-alive',
+            },
+        });
+        expect(result).toBe('<html></html>');
+    });
+
+    it('should return response if not ok', async () => {
+        const mockResponse = {
+            ok: false,
+        };
+        mockedFetch.mockResolvedValue(mockResponse as any);
+
+        const result = await fetchRaw('http://example.com');
+        expect(result).toBe(mockResponse);
+    });
+
+    it('should return error message on fetch failure', async () => {
+        const mockError = new Error('Network error');
+        mockedFetch.mockRejectedValue(mockError);
+
+        const result = await fetchRaw('http://example.com');
+        expect(result).toEqual({message: 'Network error'});
+    });
+});
+
+describe('getFavIcon', () => {
+    it('should return the largest favicon URL', () => {
+        const mockHtml = '<html><head><link rel="icon" href="/favicon-32x32.png" sizes="32x32"><link rel="icon" href="/favicon-16x16.png" sizes="16x16"></head></html>';
+        const result = getFavIcon('http://example.com', mockHtml);
+        expect(result).toBe('http://example.com/favicon-32x32.png');
+    });
+
+    it('should return default favicon URL if no icons found', () => {
+        const mockHtml = '<html><head></head></html>';
+        const result = getFavIcon('http://example.com', mockHtml);
+        expect(result).toBe('http://example.com/favicon.ico');
+    });
+});
+
+describe('fetchOpenGraph', () => {
+    it('should fetch OpenGraph data from a URL', async () => {
+        const mockHtml = '<html><head><title>Example</title><meta property="og:title" content="OpenGraph Title"><meta property="og:image" content="http://example.com/image.png"></head></html>';
+        const mockResponse = {
+            ok: true,
+            text: jest.fn().mockResolvedValue(mockHtml),
+        };
+        mockedFetch.mockResolvedValue(mockResponse as any);
+
+        const result = await fetchOpenGraph('http://example.com', true);
+        expect(result).toEqual({
+            link: 'http://example.com',
+            imageURL: 'http://example.com/image.png',
+            favIcon: 'http://example.com/favicon.ico',
+            title: 'OpenGraph Title',
+        });
+    });
+
+    it('should return error if fetchRaw fails', async () => {
+        const mockError = {message: 'Network error'};
+        mockedFetch.mockRejectedValue(mockError);
+
+        const result = await fetchOpenGraph('http://example.com');
+        expect(result).toEqual({
+            link: 'http://example.com',
+            error: new Error('Network error'),
+        });
+    });
+
+    it('should return default title if og:title is not found', async () => {
+        const mockHtml = '<html><head><title>Example</title></head></html>';
+        const mockResponse = {
+            ok: true,
+            text: jest.fn().mockResolvedValue(mockHtml),
+        };
+        mockedFetch.mockResolvedValue(mockResponse as any);
+
+        const result = await fetchOpenGraph('http://example.com');
+        expect(result).toEqual({
+            link: 'http://example.com',
+            imageURL: null,
+            favIcon: undefined,
+            title: 'Example',
         });
     });
 });

--- a/app/utils/opengraph.test.ts
+++ b/app/utils/opengraph.test.ts
@@ -1,7 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getDistanceBW2Points, getNearestPoint, fetchRaw, getFavIcon, fetchOpenGraph} from './opengraph';
+import {getDistanceBW2Points, getNearestPoint, fetchOpenGraph, testExports} from './opengraph';
+
+const {fetchRaw, getFavIcon} = testExports;
 
 let mockedFetch: jest.SpyInstance;
 
@@ -123,6 +125,24 @@ describe('getFavIcon', () => {
         const mockHtml = '<html><head></head></html>';
         const result = getFavIcon('http://example.com', mockHtml);
         expect(result).toBe('http://example.com/favicon.ico');
+    });
+
+    it('should handle shortcut icon rel attribute', () => {
+        const mockHtml = '<html><head><link rel="shortcut icon" href="/favicon.png"></head></html>';
+        const result = getFavIcon('http://example.com', mockHtml);
+        expect(result).toBe('http://example.com/favicon.png');
+    });
+
+    it('should handle absolute URLs in href', () => {
+        const mockHtml = '<html><head><link rel="icon" href="https://cdn.example.com/favicon.png"></head></html>';
+        const result = getFavIcon('http://example.com', mockHtml);
+        expect(result).toBe('https://cdn.example.com/favicon.png');
+    });
+
+    it('should handle icons without sizes attribute', () => {
+        const mockHtml = '<html><head><link rel="icon" href="/favicon.png"><link rel="icon" href="/favicon-32x32.png" sizes="32x32"></head></html>';
+        const result = getFavIcon('http://example.com', mockHtml);
+        expect(result).toBe('http://example.com/favicon-32x32.png');
     });
 });
 

--- a/app/utils/opengraph.ts
+++ b/app/utils/opengraph.ts
@@ -70,7 +70,7 @@ export function getNearestPoint(pivotPoint: {height: number; width: number}, poi
     return nearestPoint as BestImage;
 }
 
-export const fetchRaw = async (url: string) => {
+const fetchRaw = async (url: string) => {
     try {
         const res = await fetch(url, {
             headers: {
@@ -91,7 +91,7 @@ export const fetchRaw = async (url: string) => {
     }
 };
 
-export const getFavIcon = (url: string, html: string) => {
+const getFavIcon = (url: string, html: string) => {
     const getSize = (el: LinkRelIcon) => {
         return (el.sizes && el.sizes[0] && parseInt(el.sizes[0], 10)) || 0;
     };
@@ -187,4 +187,9 @@ export const fetchOpenGraph = async (url: string, includeFavIcon = false): Promi
             error,
         };
     }
+};
+
+export const testExports = {
+    fetchRaw,
+    getFavIcon,
 };

--- a/app/utils/opengraph.ts
+++ b/app/utils/opengraph.ts
@@ -70,7 +70,7 @@ export function getNearestPoint(pivotPoint: {height: number; width: number}, poi
     return nearestPoint as BestImage;
 }
 
-const fetchRaw = async (url: string) => {
+export const fetchRaw = async (url: string) => {
     try {
         const res = await fetch(url, {
             headers: {
@@ -91,7 +91,7 @@ const fetchRaw = async (url: string) => {
     }
 };
 
-const getFavIcon = (url: string, html: string) => {
+export const getFavIcon = (url: string, html: string) => {
     const getSize = (el: LinkRelIcon) => {
         return (el.sizes && el.sizes[0] && parseInt(el.sizes[0], 10)) || 0;
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Increase test coverage of utils/opengraph to 98.5%.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59600

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
```
 PASS  app/utils/opengraph.test.ts
  Utility Functions
    getDistanceBW2Points
      ✓ calculates the distance correctly (1 ms)
      ✓ calculates the distance correctly with custom attributes
    getNearestPoint
      ✓ finds the nearest point correctly
      ✓ returns an empty object if points array is empty (1 ms)
      ✓ finds the nearest point with custom attributes
      ✓ updates nearest point based on distance comparison
  fetchRaw
    ✓ should fetch raw HTML from a URL (1 ms)
    ✓ should return response if not ok
    ✓ should return error message on fetch failure
  getFavIcon
    ✓ should return the largest favicon URL (5 ms)
    ✓ should return default favicon URL if no icons found
    ✓ should handle shortcut icon rel attribute
    ✓ should handle absolute URLs in href
    ✓ should handle icons without sizes attribute (1 ms)
  fetchOpenGraph
    ✓ should fetch OpenGraph data from a URL (1 ms)
    ✓ should return error if fetchRaw fails
    ✓ should return default title if og:title is not found


=============================== Coverage summary ===============================
Statements   : 100% ( 68/68 )
Branches     : 90.24% ( 37/41 )
Functions    : 100% ( 10/10 )
Lines        : 100% ( 67/67 )
================================================================================
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
