### PR TITLE
MM-59684 Add tests for client/websocket

### DIFF
--- a/app/client/websocket/index.test.ts
+++ b/app/client/websocket/index.test.ts
@@ -1,0 +1,267 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {WebSocketReadyState} from '@mattermost/react-native-network-client';
+
+import {WebsocketEvents} from '@constants';
+import DatabaseManager from '@database/manager';
+import {getConfigValue} from '@queries/servers/system';
+import {hasReliableWebsocket} from '@utils/config';
+import {logDebug, logInfo, logError, logWarning} from '@utils/log';
+
+import WebSocketClient from './index';
+
+const getOrCreateWebSocketClient = require('@mattermost/react-native-network-client').getOrCreateWebSocketClient;
+
+jest.mock('@mattermost/react-native-network-client', () => ({
+    WebSocketReadyState: {
+        OPEN: 1,
+        CLOSED: 3,
+    },
+    getOrCreateWebSocketClient: jest.fn(),
+}));
+
+jest.mock('@queries/servers/system', () => ({
+    getConfigValue: jest.fn(),
+}));
+
+const mockedGetConfigValue = getConfigValue as jest.MockedFunction<typeof getConfigValue>;
+
+jest.mock('@database/manager', () => ({
+    serverDatabases: {},
+}));
+
+jest.mock('@utils/log', () => ({
+    logInfo: jest.fn(),
+    logWarning: jest.fn(),
+    logError: jest.fn(),
+    logDebug: jest.fn(),
+}));
+
+jest.mock('@utils/config', () => ({
+    hasReliableWebsocket: jest.fn(),
+}));
+
+const mockedHasReliableWebsocket = hasReliableWebsocket as jest.MockedFunction<typeof hasReliableWebsocket>;
+
+describe('WebSocketClient', () => {
+    let client: WebSocketClient;
+    const serverUrl = 'https://example.com';
+    const token = 'test-token';
+
+    const mockConn = {
+        onOpen: jest.fn(),
+        onClose: jest.fn(),
+        onError: jest.fn(),
+        onMessage: jest.fn(),
+        open: jest.fn(),
+        close: jest.fn(),
+        invalidate: jest.fn(),
+        send: jest.fn(),
+        readyState: WebSocketReadyState.OPEN,
+    };
+    const mockClient = {client: mockConn};
+    getOrCreateWebSocketClient.mockResolvedValue(mockClient);
+    mockedHasReliableWebsocket.mockReturnValue(false);
+
+    beforeEach(() => {
+        client = new WebSocketClient(serverUrl, token);
+    });
+
+    it('should initialize the WebSocketClient', async () => {
+        DatabaseManager.serverDatabases[serverUrl] = {database: {} as any, operator: {} as any};
+        mockedGetConfigValue.mockResolvedValueOnce('wss://example.com');
+        mockedGetConfigValue.mockResolvedValueOnce('5.0.0');
+        mockedGetConfigValue.mockResolvedValueOnce('true');
+
+        await client.initialize();
+
+        expect(logInfo).toHaveBeenCalledWith('websocket connecting to wss://example.com/api/v4/websocket');
+    });
+
+    it('should handle WebSocket open event - skip sync', async () => {
+        const firstConnectCallback = jest.fn();
+        client.setFirstConnectCallback(firstConnectCallback);
+
+        await client.initialize({}, true);
+
+        mockConn.onOpen.mock.calls[0][0]();
+
+        expect(logInfo).toHaveBeenCalledWith('websocket connected to', 'wss://example.com/api/v4/websocket');
+        expect(firstConnectCallback).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket open event - dont skip sync', async () => {
+        const reconnectCallback = jest.fn();
+        client.setReconnectCallback(reconnectCallback);
+
+        await client.initialize();
+
+        mockConn.onOpen.mock.calls[0][0]();
+
+        expect(logInfo).toHaveBeenCalledWith('websocket re-established connection to', 'wss://example.com/api/v4/websocket');
+        expect(reconnectCallback).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket open event - dont skip sync, reliable ws', async () => {
+        mockedHasReliableWebsocket.mockReturnValueOnce(true);
+        const reliableReconnectCallback = jest.fn();
+        client.setReliableReconnectCallback(reliableReconnectCallback);
+        const missedEventsCallback = jest.fn();
+        client.setMissedEventsCallback(missedEventsCallback);
+        client.setEventCallback(jest.fn());
+
+        await client.initialize();
+
+        // Set seq to non-zero
+        const message = {seq: 0, event: 'test_event'};
+        mockConn.onMessage.mock.calls[0][0]({message});
+
+        mockConn.onOpen.mock.calls[0][0]();
+
+        expect(logInfo).toHaveBeenCalledWith('websocket re-established connection to', 'wss://example.com/api/v4/websocket?connection_id=&sequence_number=0');
+        expect(reliableReconnectCallback).toHaveBeenCalled();
+        expect(missedEventsCallback).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket close event', async () => {
+        const closeCallback = jest.fn();
+        client.setCloseCallback(closeCallback);
+
+        await client.initialize();
+
+        mockConn.onClose.mock.calls[0][0]({});
+
+        expect(logInfo).toHaveBeenCalledWith('websocket closed', 'wss://example.com/api/v4/websocket');
+        expect(closeCallback).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket close event - tls handshake error', async () => {
+        await client.initialize();
+        const message = {code: 1015, reason: 'tls handshake error'};
+
+        mockConn.onClose.mock.calls[0][0]({message});
+
+        expect(logDebug).toHaveBeenCalledWith('websocket did not connect', 'wss://example.com/api/v4/websocket', message.reason);
+    });
+
+    it('should handle WebSocket error event', async () => {
+        const errorCallback = jest.fn();
+        client.setErrorCallback(errorCallback);
+
+        await client.initialize();
+
+        mockConn.onError.mock.calls[0][0]({url: 'wss://example.com/api/v4/websocket'});
+
+        expect(logError).toHaveBeenCalledWith('websocket error', 'wss://example.com/api/v4/websocket');
+        expect(errorCallback).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket message event', async () => {
+        const eventCallback = jest.fn();
+        client.setEventCallback(eventCallback);
+
+        await client.initialize();
+
+        const message = {seq: 0, event: 'test_event'};
+        mockConn.onMessage.mock.calls[0][0]({message});
+
+        expect(client.getServerSequence()).toBe(1);
+        expect(eventCallback).toHaveBeenCalledWith(message);
+    });
+
+    it('should handle WebSocket message event - seq_reply', async () => {
+        const eventCallback = jest.fn();
+        client.setEventCallback(eventCallback);
+
+        await client.initialize();
+
+        mockConn.onMessage.mock.calls[0][0]({message: {seq_reply: 1}});
+        expect(logWarning).not.toHaveBeenCalled();
+        expect(client.getServerSequence()).toBe(0); // does not increment
+
+        const message = {seq_reply: 1, error: 'an error'};
+        mockConn.onMessage.mock.calls[0][0]({message});
+
+        expect(logWarning).toHaveBeenCalledWith(message);
+        expect(client.getServerSequence()).toBe(0); // does not increment
+    });
+
+    it('should handle WebSocket message event - reliable ws', async () => {
+        mockedHasReliableWebsocket.mockReturnValueOnce(true);
+
+        const eventCallback = jest.fn();
+        client.setEventCallback(eventCallback);
+
+        await client.initialize();
+
+        const message = {seq: 0, event: WebsocketEvents.HELLO, data: {connection_id: 'test-connection-id'}};
+        mockConn.onMessage.mock.calls[0][0]({message});
+
+        expect(client.getServerSequence()).toBe(1);
+        expect(client.getConnectionId()).toBe('test-connection-id');
+
+        expect(eventCallback).toHaveBeenCalledWith(message);
+    });
+
+    it('should handle WebSocket message event - reliable ws, missed event', async () => {
+        mockedHasReliableWebsocket.mockReturnValueOnce(true);
+
+        const eventCallback = jest.fn();
+        client.setEventCallback(eventCallback);
+
+        await client.initialize();
+
+        const message = {seq: 1, event: 'test_event'};
+        mockConn.onMessage.mock.calls[0][0]({message});
+
+        expect(logInfo).toHaveBeenCalledWith('wss://example.com/api/v4/websocket?connection_id=&sequence_number=0', 'missed websocket event, act_seq=1 exp_seq=0');
+        expect(client.getConnectionId()).toBe('');
+        expect(client.getServerSequence()).toBe(0); // does not increment
+        expect(eventCallback).not.toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket message event - missed event', async () => {
+        const eventCallback = jest.fn();
+        client.setEventCallback(eventCallback);
+        const reconnectCallback = jest.fn();
+        client.setReconnectCallback(reconnectCallback);
+
+        await client.initialize();
+
+        const message = {seq: 1, event: 'test_event'};
+        mockConn.onMessage.mock.calls[0][0]({message});
+
+        expect(reconnectCallback).toHaveBeenCalled();
+        expect(client.getServerSequence()).toBe(2);
+        expect(eventCallback).toHaveBeenCalledWith(message);
+    });
+
+    it('should send a user typing event', async () => {
+        await client.initialize();
+
+        client.sendUserTypingEvent('channel1', 'parent1');
+
+        expect(mockConn.send).toHaveBeenCalledWith(JSON.stringify({
+            action: 'user_typing',
+            seq: 1,
+            data: {
+                channel_id: 'channel1',
+                parent_id: 'parent1',
+            },
+        }));
+    });
+
+    it('should fail to send user typing event', async () => {
+        client.close();
+        client.sendUserTypingEvent('channel1', 'parent1');
+
+        expect(mockConn.send).not.toHaveBeenCalled();
+    });
+
+    it('should check if the WebSocket is connected', async () => {
+        await client.initialize();
+
+        expect(client.isConnected()).toBe(true);
+    });
+});

--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -377,4 +377,8 @@ export default class WebSocketClient {
     public getConnectionId(): string {
         return this.connectionId;
     }
+
+    public getServerSequence(): number {
+        return this.serverSequence;
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Increase test coverage of client/websocket to 84.9%.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59684

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
