### PR TITLE
test for helpers/api/general

### DIFF
--- a/app/helpers/api/general.test.ts
+++ b/app/helpers/api/general.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {debounce} from './general';
+
+describe('helpers/api/general', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+    describe('debounce', () => {
+        test('should debounce function calls', () => {
+            const func = jest.fn();
+            const debouncedFunc = debounce(func, 100);
+
+            // Call debounced function multiple times
+            debouncedFunc();
+            debouncedFunc();
+            debouncedFunc();
+
+            // Function should not have been called yet
+            expect(func).not.toHaveBeenCalled();
+
+            // Fast forward time
+            jest.runAllTimers();
+
+            // Function should have been called once
+            expect(func).toHaveBeenCalledTimes(1);
+        });
+
+        test('should execute callback after debounced function', () => {
+            const func = jest.fn();
+            const callback = jest.fn();
+            const debouncedFunc = debounce(func, 100, false, callback);
+
+            debouncedFunc();
+
+            // Neither function should have been called yet
+            expect(func).not.toHaveBeenCalled();
+            expect(callback).not.toHaveBeenCalled();
+
+            // Fast forward time
+            jest.runAllTimers();
+
+            // Both functions should have been called once
+            expect(func).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        test('should execute immediately when immediate flag is true', () => {
+            const func = jest.fn();
+            const callback = jest.fn();
+            const debouncedFunc = debounce(func, 100, true, callback);
+
+            debouncedFunc();
+
+            // Both functions should be called immediately
+            expect(func).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledTimes(1);
+
+            // Call it again immediately
+            debouncedFunc();
+
+            // Should not call again immediately
+            expect(func).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledTimes(1);
+
+            // Fast forward time
+            jest.runAllTimers();
+
+            // Counts should remain the same
+            expect(func).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        test('should pass arguments to the debounced function', () => {
+            const func = jest.fn();
+            const debouncedFunc = debounce(func, 100);
+            const args = ['arg1', 'arg2'];
+
+            debouncedFunc(...args);
+            jest.runAllTimers();
+
+            expect(func).toHaveBeenCalledWith(...args);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
