### PR TITLE
MM-59741 + others - Add tests for remaining app/hooks files

### DIFF
--- a/app/hooks/apps.test.tsx
+++ b/app/hooks/apps.test.tsx
@@ -1,0 +1,162 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+import React from 'react';
+import {IntlProvider} from 'react-intl';
+
+import {handleBindingClick} from '@actions/remote/apps';
+import {handleGotoLocation} from '@actions/remote/command';
+import {AppCallResponseTypes} from '@constants/apps';
+import {showAppForm} from '@screens/navigation';
+
+import {useAppBinding} from './apps';
+
+jest.mock('@actions/remote/apps');
+jest.mock('@actions/remote/command');
+jest.mock('@screens/navigation', () => ({
+    showAppForm: jest.fn(),
+}));
+jest.mock('@context/server', () => ({
+    useServerUrl: () => 'http://localhost:8065',
+}));
+
+describe('useAppBinding', () => {
+    const context = {
+        channel_id: 'channel_id',
+        team_id: 'team_id',
+        post_id: 'post_id',
+        root_id: 'root_id',
+    };
+
+    const binding = {
+        app_id: 'app_id',
+        location: 'post_menu',
+        label: 'Test Binding',
+    };
+
+    const config = {
+        onSuccess: jest.fn(),
+        onError: jest.fn(),
+        onForm: jest.fn(),
+        onNavigate: jest.fn(),
+    };
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+        <IntlProvider
+            messages={{}}
+            locale='en'
+        >
+            {children}
+        </IntlProvider>
+    );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should handle OK response', async () => {
+        const successResponse = {
+            type: AppCallResponseTypes.OK,
+            text: 'Success message',
+        };
+
+        (handleBindingClick as jest.Mock).mockResolvedValue({
+            data: successResponse,
+        });
+
+        const {result} = renderHook(() => useAppBinding(context, config), {wrapper});
+        const callback = await result.current(binding);
+        await callback();
+
+        expect(config.onSuccess).toHaveBeenCalledWith(successResponse, 'Success message');
+        expect(config.onError).not.toHaveBeenCalled();
+        expect(config.onForm).not.toHaveBeenCalled();
+        expect(config.onNavigate).not.toHaveBeenCalled();
+    });
+
+    test('should handle error response', async () => {
+        const errorResponse = {
+            type: 'error',
+            text: 'Error message',
+        };
+
+        (handleBindingClick as jest.Mock).mockResolvedValue({
+            error: errorResponse,
+        });
+
+        const {result} = renderHook(() => useAppBinding(context, config), {wrapper});
+        const callback = await result.current(binding);
+        await callback();
+
+        expect(config.onError).toHaveBeenCalledWith(errorResponse, 'Error message');
+        expect(config.onSuccess).not.toHaveBeenCalled();
+        expect(config.onForm).not.toHaveBeenCalled();
+        expect(config.onNavigate).not.toHaveBeenCalled();
+    });
+
+    test('should handle NAVIGATE response with onNavigate config', async () => {
+        const navigateResponse = {
+            type: AppCallResponseTypes.NAVIGATE,
+            navigate_to_url: 'http://example.com',
+        };
+
+        (handleBindingClick as jest.Mock).mockResolvedValue({
+            data: navigateResponse,
+        });
+
+        const {result} = renderHook(() => useAppBinding(context, config), {wrapper});
+        const callback = await result.current(binding);
+        await callback();
+
+        expect(config.onNavigate).toHaveBeenCalledWith(navigateResponse);
+        expect(handleGotoLocation).not.toHaveBeenCalled();
+        expect(config.onSuccess).not.toHaveBeenCalled();
+        expect(config.onError).not.toHaveBeenCalled();
+    });
+
+    test('should handle FORM response with onForm config', async () => {
+        const formResponse = {
+            type: AppCallResponseTypes.FORM,
+            form: {
+                title: 'Test Form',
+                fields: [],
+            },
+        };
+
+        (handleBindingClick as jest.Mock).mockResolvedValue({
+            data: formResponse,
+        });
+
+        const {result} = renderHook(() => useAppBinding(context, config), {wrapper});
+        const callback = await result.current(binding);
+        await callback();
+
+        expect(config.onForm).toHaveBeenCalledWith(formResponse.form);
+        expect(showAppForm).not.toHaveBeenCalled();
+        expect(config.onSuccess).not.toHaveBeenCalled();
+        expect(config.onError).not.toHaveBeenCalled();
+    });
+
+    test('should handle unknown response type', async () => {
+        const unknownResponse = {
+            type: 'UNKNOWN_TYPE',
+        };
+
+        (handleBindingClick as jest.Mock).mockResolvedValue({
+            data: unknownResponse,
+        });
+
+        const {result} = renderHook(() => useAppBinding(context, config), {wrapper});
+        const callback = await result.current(binding);
+        await callback();
+
+        expect(config.onError).toHaveBeenCalledWith(
+            unknownResponse,
+            'App response type not supported. Response type: UNKNOWN_TYPE.',
+        );
+        expect(config.onSuccess).not.toHaveBeenCalled();
+        expect(config.onForm).not.toHaveBeenCalled();
+        expect(config.onNavigate).not.toHaveBeenCalled();
+    });
+});

--- a/app/hooks/autocomplete.test.ts
+++ b/app/hooks/autocomplete.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+
+import {useAutocompleteDefaultAnimatedValues} from './autocomplete';
+
+describe('useAutocompleteDefaultAnimatedValues', () => {
+    it('should initialize with provided values', () => {
+        const position = 100;
+        const availableSpace = 200;
+
+        const {result} = renderHook(() =>
+            useAutocompleteDefaultAnimatedValues(position, availableSpace),
+        );
+
+        const [animatedPosition, animatedAvailableSpace] = result.current;
+        expect(animatedPosition.value).toBe(position);
+        expect(animatedAvailableSpace.value).toBe(availableSpace);
+    });
+
+    it('should update values when props change', () => {
+        const initialPosition = 100;
+        const initialSpace = 200;
+
+        const {result, rerender} = renderHook(
+            ({position, space}) => useAutocompleteDefaultAnimatedValues(position, space),
+            {
+                initialProps: {position: initialPosition, space: initialSpace},
+            },
+        );
+
+        // Check initial values
+        const [animatedPosition, animatedAvailableSpace] = result.current;
+        expect(animatedPosition.value).toBe(initialPosition);
+        expect(animatedAvailableSpace.value).toBe(initialSpace);
+
+        // Update props
+        const newPosition = 150;
+        const newSpace = 250;
+        rerender({position: newPosition, space: newSpace});
+
+        // Check updated values
+        const [updatedPosition, updatedSpace] = result.current;
+        expect(updatedPosition.value).toBe(newPosition);
+        expect(updatedSpace.value).toBe(newSpace);
+    });
+});

--- a/app/hooks/channel_switch.test.ts
+++ b/app/hooks/channel_switch.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+import {DeviceEventEmitter} from 'react-native';
+
+import {Events} from '@constants';
+
+import {useChannelSwitch} from './channel_switch';
+
+describe('useChannelSwitch', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it('should initialize with loading false', () => {
+        const {result} = renderHook(() => useChannelSwitch());
+        expect(result.current).toBe(false);
+    });
+
+    it('should set loading true when switching starts', () => {
+        const {result} = renderHook(() => useChannelSwitch());
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.CHANNEL_SWITCH, true);
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('should set loading false when switching ends', () => {
+        const {result} = renderHook(() => useChannelSwitch());
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.CHANNEL_SWITCH, true);
+        });
+        expect(result.current).toBe(true);
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.CHANNEL_SWITCH, false);
+            jest.runAllTimers();
+        });
+        expect(result.current).toBe(false);
+    });
+
+    it('should cleanup event listener on unmount', () => {
+        const removeMock = jest.fn();
+        jest.spyOn(DeviceEventEmitter, 'addListener').mockReturnValue({
+            remove: removeMock,
+        } as any);
+
+        const {unmount} = renderHook(() => useChannelSwitch());
+        unmount();
+
+        expect(removeMock).toHaveBeenCalled();
+    });
+});

--- a/app/hooks/device.test.tsx
+++ b/app/hooks/device.test.tsx
@@ -1,0 +1,318 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+import React from 'react';
+import {AppState, Keyboard} from 'react-native';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
+
+import {DeviceContext} from '@context/device';
+
+import {
+    useAppState,
+    useWindowDimensions,
+    useIsTablet,
+    useKeyboardHeightWithDuration,
+    useKeyboardHeight,
+    useSplitView,
+    useViewPosition,
+    useKeyboardOverlap,
+    useAvoidKeyboard,
+    testSetUtilsEmitter,
+} from './device';
+
+jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+    OS: 'ios',
+    select: jest.fn((obj) => obj.ios),
+}));
+
+const mockEmitter = {
+    addListener: jest.fn((eventType, callback) => {
+        if (eventType === 'DimensionsChanged') {
+            callback({height: 800, width: 600});
+        }
+        return {remove: jest.fn()};
+    }),
+} as any;
+
+jest.mock('react-native', () => {
+    const ReactNative = jest.requireActual('react-native');
+    return {
+        AppState: {
+            currentState: 'active',
+            addEventListener: jest.fn(() => ({
+                remove: jest.fn(),
+            })),
+        },
+        Keyboard: {
+            addListener: jest.fn((event, callback) => {
+                if (callback) {
+                    callback({endCoordinates: {height: 300}, duration: 250});
+                }
+                return {remove: jest.fn()};
+            }),
+        },
+        NativeEventEmitter: jest.fn(() => mockEmitter),
+        Platform: {
+            OS: 'ios',
+            select: jest.fn((obj) => obj.ios),
+        },
+        View: ReactNative.View,
+    };
+});
+
+jest.mock('@mattermost/rnutils', () => ({
+    getWindowDimensions: jest.fn(() => ({height: 800, width: 600})),
+    isRunningInSplitView: jest.fn(() => false),
+    default: {
+        getWindowDimensions: jest.fn(() => ({height: 800, width: 600})),
+        isRunningInSplitView: jest.fn(() => false),
+    },
+}));
+
+describe('device hooks', () => {
+    describe('useAppState', () => {
+        it('should return current app state', () => {
+            const {result} = renderHook(() => useAppState());
+            expect(result.current).toBe(AppState.currentState);
+        });
+
+        it('should update when app state changes', () => {
+            const {result} = renderHook(() => useAppState());
+
+            act(() => {
+                const listener = (AppState.addEventListener as jest.Mock).mock.calls[0][1];
+                listener('background');
+            });
+
+            expect(result.current).toBe('background');
+        });
+    });
+
+    describe('useWindowDimensions', () => {
+        testSetUtilsEmitter(mockEmitter);
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should return initial dimensions', () => {
+            const {result} = renderHook(() => useWindowDimensions());
+            expect(result.current).toEqual({height: 800, width: 600});
+        });
+
+        it('should update dimensions on change', () => {
+            const {result} = renderHook(() => useWindowDimensions());
+
+            act(() => {
+                mockEmitter.addListener.mock.calls[0][1]({height: 1000, width: 800});
+            });
+
+            expect(result.current).toEqual({height: 1000, width: 800});
+        });
+    });
+
+    describe('useSplitView', () => {
+        const wrapper: React.FC<{children: React.ReactNode; isSplit?: boolean}> = ({children, isSplit = false}) => (
+            <DeviceContext.Provider value={{isTablet: false, isSplit}}>
+                {children}
+            </DeviceContext.Provider>
+        );
+
+        it('should return split view state', () => {
+            const {result} = renderHook(() => useSplitView(), {
+                wrapper: ({children}) => wrapper({children, isSplit: true}),
+            });
+            expect(result.current).toBe(true);
+        });
+    });
+
+    describe('useIsTablet', () => {
+        const wrapper: React.FC<{children: React.ReactNode; isTablet?: boolean; isSplit?: boolean}> = ({children, isTablet = false, isSplit = false}) => (
+            <DeviceContext.Provider value={{isTablet, isSplit}}>
+                {children}
+            </DeviceContext.Provider>
+        );
+
+        it('should return true for tablet when not split', () => {
+            const {result} = renderHook(() => useIsTablet(), {
+                wrapper: ({children}) => wrapper({children, isTablet: true, isSplit: false}),
+            });
+            expect(result.current).toBe(true);
+        });
+
+        it('should return false for tablet when split', () => {
+            const {result} = renderHook(() => useIsTablet(), {
+                wrapper: ({children}) => wrapper({children, isTablet: true, isSplit: true}),
+            });
+            expect(result.current).toBe(false);
+        });
+    });
+
+    describe('useKeyboardHeightWithDuration', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        const wrapper = ({children}: any) => (
+            <SafeAreaProvider>
+                {children}
+            </SafeAreaProvider>
+        );
+
+        it('should handle keyboard show event', () => {
+            const {result} = renderHook(() => useKeyboardHeightWithDuration(), {wrapper});
+
+            act(() => {
+                const showCallback = (Keyboard.addListener as jest.Mock).mock.calls[0][1];
+                showCallback({endCoordinates: {height: 300}, duration: 250});
+            });
+
+            expect(result.current).toEqual({height: 300, duration: 250});
+        });
+
+        it('should handle keyboard hide event', () => {
+            const {result} = renderHook(() => useKeyboardHeightWithDuration(), {wrapper});
+
+            act(() => {
+                const hideCallback = (Keyboard.addListener as jest.Mock).mock.calls[1][1];
+                hideCallback({duration: 200});
+            });
+
+            expect(result.current).toEqual({height: 0, duration: 200});
+        });
+    });
+
+    describe('useKeyboardHeight', () => {
+        it('should return only height from useKeyboardHeightWithDuration', () => {
+            const {result} = renderHook(() => useKeyboardHeight());
+
+            act(() => {
+                const showCallback = (Keyboard.addListener as jest.Mock).mock.calls[0][1];
+                showCallback({endCoordinates: {height: 300}, duration: 250});
+            });
+
+            act(() => {
+                const showCallback = (Keyboard.addListener as jest.Mock).mock.calls[0][1];
+                showCallback({endCoordinates: {height: 300}, duration: 250});
+            });
+
+            expect(result.current).toBe(300);
+        });
+    });
+
+    describe('useViewPosition', () => {
+        const mockRef = {
+            current: {
+                measureInWindow: jest.fn((callback) => {
+                    callback(0, 100, 0, 0);
+                }),
+            },
+        } as any;
+
+        const wrapper = ({children, isTablet = false}: any) => (
+            <DeviceContext.Provider value={{isTablet, isSplit: false}}>
+                {children}
+            </DeviceContext.Provider>
+        );
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should measure position for tablet', () => {
+            const {result} = renderHook(() => useViewPosition(mockRef), {
+                wrapper: ({children}) => wrapper({children, isTablet: true}),
+            });
+
+            expect(result.current).toBe(100);
+            expect(mockRef.current.measureInWindow).toHaveBeenCalled();
+        });
+
+        it('should not measure position for non-tablet', () => {
+            const {result} = renderHook(() => useViewPosition(mockRef), {
+                wrapper: ({children}) => wrapper({children, isTablet: false}),
+            });
+
+            expect(result.current).toBe(0);
+            expect(mockRef.current.measureInWindow).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('useKeyboardOverlap', () => {
+        const mockRef = {
+            current: {
+                measureInWindow: jest.fn((callback) => callback(0, 100)),
+            },
+        } as any;
+
+        const wrapper = ({children, isTablet = false}: any) => (
+            <SafeAreaProvider
+                initialMetrics={{
+                    frame: {x: 0, y: 0, width: 0, height: 0},
+                    insets: {top: 0, left: 0, right: 0, bottom: 20},
+                }}
+            >
+                <DeviceContext.Provider value={{isTablet, isSplit: false}}>
+                    {children}
+                </DeviceContext.Provider>
+            </SafeAreaProvider>
+        );
+
+        it('should calculate overlap for tablet', () => {
+            const {result} = renderHook(() => useKeyboardOverlap(mockRef, 400), {
+                wrapper: ({children}) => wrapper({children, isTablet: true}),
+            });
+
+            expect(result.current).toBe(0);
+        });
+
+        it('should use inset bottom for phone', () => {
+            const {result} = renderHook(() => useKeyboardOverlap(mockRef, 400), {
+                wrapper: ({children}) => wrapper({children, isTablet: false}),
+            });
+
+            act(() => {
+                const showCallback = (Keyboard.addListener as jest.Mock).mock.calls[0][1];
+                showCallback({endCoordinates: {height: 300}, duration: 250});
+            });
+
+            expect(result.current).toBe(300);
+        });
+    });
+
+    describe('useAvoidKeyboard', () => {
+        const mockScrollToPosition = jest.fn();
+        const mockRef = {
+            current: {
+                scrollToPosition: mockScrollToPosition,
+            },
+        } as any;
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should scroll when keyboard height changes', () => {
+            renderHook(() => useAvoidKeyboard(mockRef));
+
+            act(() => {
+                const showCallback = (Keyboard.addListener as jest.Mock).mock.calls[0][1];
+                showCallback({endCoordinates: {height: 300}, duration: 250});
+            });
+
+            expect(mockScrollToPosition).toHaveBeenCalledWith(0, 100);
+        });
+
+        it('should not scroll when calculated offset is less than 80', () => {
+            renderHook(() => useAvoidKeyboard(mockRef, 5));
+
+            act(() => {
+                const showCallback = (Keyboard.addListener as jest.Mock).mock.calls[0][1];
+                showCallback({endCoordinates: {height: 300}, duration: 250});
+            });
+
+            expect(mockScrollToPosition).toHaveBeenCalledWith(0, 0);
+        });
+    });
+});

--- a/app/hooks/device.ts
+++ b/app/hooks/device.ts
@@ -10,7 +10,11 @@ import {DeviceContext} from '@context/device';
 
 import type {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 
-const utilsEmitter = new NativeEventEmitter(RNUtils);
+let utilsEmitter = new NativeEventEmitter(RNUtils);
+
+export function testSetUtilsEmitter(emitter: NativeEventEmitter) {
+    utilsEmitter = emitter;
+}
 
 export function useSplitView() {
     const {isSplit} = React.useContext(DeviceContext);

--- a/app/hooks/did_update.test.tsx
+++ b/app/hooks/did_update.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+
+import useDidUpdate from './did_update';
+
+describe('useDidUpdate', () => {
+    test('should not call callback on mount', () => {
+        const callback = jest.fn();
+        renderHook(() => useDidUpdate(callback));
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    test('should call callback when dependencies change', () => {
+        const callback = jest.fn();
+        const {rerender} = renderHook(({dep}) => useDidUpdate(callback, [dep]), {
+            initialProps: {dep: 1},
+        });
+
+        expect(callback).not.toHaveBeenCalled();
+
+        act(() => {
+            rerender({dep: 2});
+        });
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test('should maintain mounted state across re-renders with same deps', () => {
+        const callback = jest.fn();
+        const {rerender} = renderHook(({dep}) => useDidUpdate(callback, [dep]), {
+            initialProps: {dep: 1},
+        });
+
+        expect(callback).not.toHaveBeenCalled();
+
+        // Re-render with same dependency
+        act(() => {
+            rerender({dep: 1});
+        });
+
+        expect(callback).not.toHaveBeenCalled();
+
+        // Change dependency
+        act(() => {
+            rerender({dep: 2});
+        });
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/hooks/fetching_thread.test.ts
+++ b/app/hooks/fetching_thread.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+
+import {subject} from '@store/fetching_thread_store';
+
+import {useFetchingThreadState} from './fetching_thread';
+
+describe('useFetchingThreadState', () => {
+    const rootId = 'test-root-id';
+
+    afterEach(() => {
+        // Clear all subjects after each test
+        subject.next({});
+    });
+
+    it('should initialize with false', () => {
+        const {result} = renderHook(() => useFetchingThreadState(rootId));
+        expect(result.current).toBe(false);
+    });
+
+    it('should update when subject emits new state', () => {
+        const {result} = renderHook(() => useFetchingThreadState(rootId));
+
+        act(() => {
+            subject.next({[rootId]: true});
+        });
+        expect(result.current).toBe(true);
+
+        act(() => {
+            subject.next({[rootId]: false});
+        });
+        expect(result.current).toBe(false);
+    });
+
+    it('should not update for different rootId', () => {
+        const {result} = renderHook(() => useFetchingThreadState(rootId));
+
+        act(() => {
+            subject.next({'different-root-id': true});
+        });
+        expect(result.current).toBe(false);
+    });
+
+    it('should handle empty subject updates', () => {
+        const {result} = renderHook(() => useFetchingThreadState(rootId));
+
+        act(() => {
+            subject.next({[rootId]: true});
+        });
+        expect(result.current).toBe(true);
+
+        act(() => {
+            subject.next({});
+        });
+        expect(result.current).toBe(false);
+    });
+});

--- a/app/hooks/freeze.test.ts
+++ b/app/hooks/freeze.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+import {DeviceEventEmitter} from 'react-native';
+
+import {Events} from '@constants';
+
+import useFreeze from './freeze';
+
+describe('useFreeze hook', () => {
+    it('should initialize with default values', () => {
+        const {result} = renderHook(() => useFreeze());
+
+        expect(result.current.freeze).toBe(false);
+        expect(result.current.backgroundColor).toBe('#000');
+    });
+
+    it('should update freeze state when event is emitted', () => {
+        const {result} = renderHook(() => useFreeze());
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.FREEZE_SCREEN, true);
+        });
+
+        expect(result.current.freeze).toBe(true);
+        expect(result.current.backgroundColor).toBe('#000');
+    });
+
+    it('should update backgroundColor when provided with event', () => {
+        const {result} = renderHook(() => useFreeze());
+        const testColor = '#fff';
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.FREEZE_SCREEN, true, testColor);
+        });
+
+        expect(result.current.freeze).toBe(true);
+        expect(result.current.backgroundColor).toBe(testColor);
+    });
+
+    it('should cleanup event listener on unmount', () => {
+        const removeMock = jest.fn();
+        jest.spyOn(DeviceEventEmitter, 'addListener').mockReturnValue({
+            remove: removeMock,
+        } as any);
+
+        const {unmount} = renderHook(() => useFreeze());
+
+        unmount();
+
+        expect(removeMock).toHaveBeenCalled();
+    });
+});

--- a/app/hooks/handle_send_message.test.tsx
+++ b/app/hooks/handle_send_message.test.tsx
@@ -1,0 +1,380 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+import React from 'react';
+import {IntlProvider} from 'react-intl';
+import {DeviceEventEmitter} from 'react-native';
+
+import {getChannelTimezones} from '@actions/remote/channel';
+import {executeCommand, handleGotoLocation} from '@actions/remote/command';
+import {createPost} from '@actions/remote/post';
+import {handleCallsSlashCommand} from '@calls/actions';
+import {Events, Screens} from '@constants';
+import {useServerUrl} from '@context/server';
+import * as DraftUtils from '@utils/draft';
+
+import {useHandleSendMessage} from './handle_send_message';
+
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
+
+jest.mock('@actions/remote/post');
+jest.mock('@actions/remote/channel', () => ({
+    getChannelTimezones: jest.fn().mockResolvedValue({channelTimezones: []}),
+}));
+jest.mock('@actions/remote/command');
+jest.mock('@actions/remote/reactions');
+jest.mock('@actions/remote/user');
+jest.mock('@calls/actions');
+jest.mock('@context/server', () => ({
+    useServerUrl: jest.fn().mockReturnValue('https://server.com'),
+}));
+
+describe('useHandleSendMessage', () => {
+    const defaultProps = {
+        value: 'test message',
+        channelId: 'channel-id',
+        rootId: '',
+        maxMessageLength: 4000,
+        files: [],
+        customEmojis: [],
+        enableConfirmNotificationsToChannel: true,
+        useChannelMentions: true,
+        membersCount: 3,
+        userIsOutOfOffice: false,
+        currentUserId: 'current-user',
+        channelType: 'O',
+        postPriority: {},
+        clearDraft: jest.fn(),
+    } as any;
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+        <IntlProvider
+            messages={{}}
+            locale='en'
+        >
+            {children}
+        </IntlProvider>
+    );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.mocked(getChannelTimezones).mockResolvedValue({channelTimezones: []});
+        jest.mocked(useServerUrl).mockReturnValue('https://server.com');
+        jest.spyOn(DeviceEventEmitter, 'emit');
+    });
+
+    it('should handle basic message send', async () => {
+        const {result} = renderHook(() => useHandleSendMessage(defaultProps), {wrapper});
+
+        expect(result.current.canSend).toBe(true);
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(createPost).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                channel_id: 'channel-id',
+                message: 'test message',
+                user_id: 'current-user',
+            }),
+            [],
+        );
+        expect(defaultProps.clearDraft).toHaveBeenCalled();
+        expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.POST_LIST_SCROLL_TO_BOTTOM, Screens.CHANNEL);
+    });
+
+    it('should not allow sending when message exceeds length', () => {
+        const props = {
+            ...defaultProps,
+            value: 'a'.repeat(4001),
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+        expect(result.current.canSend).toBe(false);
+    });
+
+    it('should handle message with priority', async () => {
+        const props = {
+            ...defaultProps,
+            postPriority: {
+                priority: 'urgent',
+                requested_ack: true,
+            },
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(createPost).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                metadata: {
+                    priority: {
+                        priority: 'urgent',
+                        requested_ack: true,
+                    },
+                },
+            }),
+            [],
+        );
+    });
+
+    it('should emit thread event when sending reply', async () => {
+        const props = {
+            ...defaultProps,
+            rootId: 'root-post-id',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.POST_LIST_SCROLL_TO_BOTTOM, Screens.THREAD);
+    });
+
+    it('should not allow sending while already sending', async () => {
+        const {result} = renderHook(() => useHandleSendMessage(defaultProps), {wrapper});
+
+        // Trigger first send
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        // Try to send again immediately
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(createPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not allow sending with uploading files', () => {
+        const props = {
+            ...defaultProps,
+            files: [{clientId: 'file1', loading: true, failed: false}],
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+        expect(result.current.canSend).toBe(false);
+    });
+
+    it('should handle failed file attachments', async () => {
+        jest.spyOn(DraftUtils, 'alertAttachmentFail').mockImplementation((intl, accept) => {
+            accept();
+        });
+
+        const props = {
+            ...defaultProps,
+            files: [{clientId: 'file1', failed: true}],
+            value: 'test with failed attachment',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(DraftUtils.alertAttachmentFail).toHaveBeenCalled();
+        expect(createPost).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                message: 'test with failed attachment',
+            }),
+            [], // Empty files array
+        );
+    });
+
+    it('should handle reaction messages', async () => {
+        const props = {
+            ...defaultProps,
+            value: '+:smile:',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(createPost).not.toHaveBeenCalled();
+    });
+
+    it('should handle slash commands', async () => {
+        const mockExecuteCommand = jest.mocked(executeCommand);
+        mockExecuteCommand.mockResolvedValueOnce({data: {}, error: null});
+
+        const props = {
+            ...defaultProps,
+            value: '/away',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(executeCommand).toHaveBeenCalledWith(
+            'https://server.com',
+            expect.anything(),
+            '/away',
+            'channel-id',
+            '',
+        );
+        expect(defaultProps.clearDraft).toHaveBeenCalled();
+    });
+
+    it('should handle slash command errors', async () => {
+        const mockExecuteCommand = jest.mocked(executeCommand);
+        mockExecuteCommand.mockResolvedValueOnce({data: undefined, error: new Error('Command failed')});
+        jest.spyOn(DraftUtils, 'alertSlashCommandFailed');
+
+        const props = {
+            ...defaultProps,
+            value: '/invalid-command',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(executeCommand).toHaveBeenCalled();
+        expect(DraftUtils.alertSlashCommandFailed).toHaveBeenCalledWith(
+            expect.anything(),
+            'Command failed',
+        );
+        expect(defaultProps.clearDraft).not.toHaveBeenCalled();
+    });
+
+    it('should handle call command', async () => {
+        const mockHandleCallsSlashCommand = jest.mocked(handleCallsSlashCommand);
+        mockHandleCallsSlashCommand.mockResolvedValueOnce({handled: true});
+
+        const props = {
+            ...defaultProps,
+            value: '/call start',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(handleCallsSlashCommand).toHaveBeenCalledWith(
+            '/call start',
+            'https://server.com',
+            'channel-id',
+            'O',
+            '',
+            'current-user',
+            expect.anything(),
+        );
+        expect(defaultProps.clearDraft).toHaveBeenCalled();
+    });
+
+    it('should handle call command error', async () => {
+        const mockHandleCallsSlashCommand = jest.mocked(handleCallsSlashCommand);
+        mockHandleCallsSlashCommand.mockResolvedValueOnce({handled: false, error: 'Call error'});
+
+        const props = {
+            ...defaultProps,
+            value: '/call invalid',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(handleCallsSlashCommand).toHaveBeenCalled();
+        expect(DraftUtils.alertSlashCommandFailed).toHaveBeenCalledWith(
+            expect.anything(),
+            'Call error',
+        );
+    });
+
+    it('should handle status command for out-of-office user', async () => {
+        jest.spyOn(DraftUtils, 'getStatusFromSlashCommand').mockReturnValue('online');
+        const mockConfirmOutOfOffice = jest.fn();
+        jest.spyOn(require('@utils/user'), 'confirmOutOfOfficeDisabled').mockImplementation(mockConfirmOutOfOffice);
+
+        const props = {
+            ...defaultProps,
+            value: '/online',
+            userIsOutOfOffice: true,
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(mockConfirmOutOfOffice).toHaveBeenCalledWith(
+            expect.anything(),
+            'online',
+            expect.any(Function),
+        );
+        expect(executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should handle goto location from command', async () => {
+        const mockExecuteCommand = jest.mocked(executeCommand);
+        mockExecuteCommand.mockResolvedValueOnce({
+            data: {goto_location: 'http://example.com'},
+            error: null,
+        });
+
+        const props = {
+            ...defaultProps,
+            value: '/goto command',
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(handleGotoLocation).toHaveBeenCalledWith(
+            'https://server.com',
+            expect.anything(),
+            'http://example.com',
+        );
+    });
+
+    it('should handle channel-wide mentions confirmation', async () => {
+        jest.spyOn(DraftUtils, 'textContainsAtAllAtChannel').mockReturnValue(true);
+        jest.spyOn(DraftUtils, 'alertChannelWideMention');
+
+        const props = {
+            ...defaultProps,
+            value: '@channel message',
+            membersCount: 25,
+            enableConfirmNotificationsToChannel: true,
+            useChannelMentions: true,
+        };
+
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            result.current.handleSendMessage();
+        });
+
+        expect(DraftUtils.alertChannelWideMention).toHaveBeenCalled();
+        expect(createPost).not.toHaveBeenCalled();
+    });
+});

--- a/app/hooks/handle_send_message.test.tsx
+++ b/app/hooks/handle_send_message.test.tsx
@@ -12,6 +12,7 @@ import {createPost} from '@actions/remote/post';
 import {handleCallsSlashCommand} from '@calls/actions';
 import {Events, Screens} from '@constants';
 import {useServerUrl} from '@context/server';
+import DraftUploadManager from '@managers/draft_upload_manager';
 import * as DraftUtils from '@utils/draft';
 
 import {useHandleSendMessage} from './handle_send_message';
@@ -161,6 +162,8 @@ describe('useHandleSendMessage', () => {
             ...defaultProps,
             files: [{clientId: 'file1', loading: true, failed: false}],
         };
+
+        jest.spyOn(DraftUploadManager, 'isUploading').mockReturnValueOnce(true);
 
         const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
         expect(result.current.canSend).toBe(false);

--- a/app/hooks/handle_send_message.ts
+++ b/app/hooks/handle_send_message.ts
@@ -73,8 +73,8 @@ export const useHandleSendMessage = ({
         }
 
         if (files.length) {
-            const hasUploadingFiles = files.some((file) => file.loading || DraftUploadManager.isUploading(file.clientId!));
-            return !hasUploadingFiles;
+            const loadingComplete = !files.some((file) => DraftUploadManager.isUploading(file.clientId!));
+            return loadingComplete;
         }
 
         return messageLength > 0;

--- a/app/hooks/handle_send_message.ts
+++ b/app/hooks/handle_send_message.ts
@@ -73,8 +73,8 @@ export const useHandleSendMessage = ({
         }
 
         if (files.length) {
-            const loadingComplete = !files.some((file) => DraftUploadManager.isUploading(file.clientId!));
-            return loadingComplete;
+            const hasUploadingFiles = files.some((file) => file.loading || DraftUploadManager.isUploading(file.clientId!));
+            return !hasUploadingFiles;
         }
 
         return messageLength > 0;

--- a/app/hooks/header.test.tsx
+++ b/app/hooks/header.test.tsx
@@ -1,0 +1,209 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+import {act} from '@testing-library/react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+
+import ViewConstants from '@constants/view';
+import {useIsTablet} from '@hooks/device';
+
+import {useDefaultHeaderHeight, useLargeHeaderHeight, useHeaderHeight, useCollapsibleHeader} from './header';
+
+jest.mock('react-native-reanimated', () => {
+    const sharedValues = new Map();
+
+    return {
+        ...jest.requireActual('react-native-reanimated/mock'),
+        useAnimatedRef: jest.fn(() => ({
+            current: {
+                scrollTo: jest.fn(),
+            },
+        })),
+        useSharedValue: jest.fn((initial) => {
+            const key = Math.random();
+            const sv = {
+                value: initial,
+                _key: key,
+            };
+            sharedValues.set(key, sv);
+            return sv;
+        }),
+        useAnimatedScrollHandler: jest.fn((handlers) => (event: any) => {
+            if (handlers.onScroll) {
+                handlers.onScroll(event);
+            }
+        }),
+        scrollTo: jest.fn(),
+    };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: jest.fn(),
+}));
+
+jest.mock('@hooks/device', () => ({
+    useIsTablet: jest.fn(),
+}));
+
+describe('Header Hooks', () => {
+    beforeEach(() => {
+        (useSafeAreaInsets as jest.Mock).mockReturnValue({top: 20});
+        (useIsTablet as jest.Mock).mockReturnValue(false);
+    });
+
+    describe('useDefaultHeaderHeight', () => {
+        it('should return correct height for mobile', () => {
+            const {result} = renderHook(() => useDefaultHeaderHeight());
+            expect(result.current).toBe(ViewConstants.DEFAULT_HEADER_HEIGHT + 20);
+        });
+
+        it('should return correct height for tablet', () => {
+            (useIsTablet as jest.Mock).mockReturnValue(true);
+            const {result} = renderHook(() => useDefaultHeaderHeight());
+            expect(result.current).toBe(ViewConstants.TABLET_HEADER_HEIGHT + 20);
+        });
+    });
+
+    describe('useLargeHeaderHeight', () => {
+        it('should return correct large header height', () => {
+            const {result} = renderHook(() => useLargeHeaderHeight());
+            const expectedHeight = ViewConstants.DEFAULT_HEADER_HEIGHT +
+                                 ViewConstants.LARGE_HEADER_TITLE_HEIGHT +
+                                 ViewConstants.SUBTITLE_HEIGHT + 20;
+            expect(result.current).toBe(expectedHeight);
+        });
+    });
+
+    describe('useHeaderHeight', () => {
+        it('should return correct height values', () => {
+            const {result} = renderHook(() => useHeaderHeight());
+            const defaultHeight = ViewConstants.DEFAULT_HEADER_HEIGHT + 20;
+            const largeHeight = defaultHeight +
+                              ViewConstants.LARGE_HEADER_TITLE_HEIGHT +
+                              ViewConstants.SUBTITLE_HEIGHT;
+
+            expect(result.current).toEqual({
+                defaultHeight,
+                largeHeight,
+                headerOffset: largeHeight - defaultHeight,
+            });
+        });
+    });
+
+    describe('useCollapsibleHeader', () => {
+        const mockScrollTo = jest.fn();
+        const mockScrollToOffset = jest.fn();
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should initialize with correct values', () => {
+            const onSnap = jest.fn();
+            const {result} = renderHook(() => useCollapsibleHeader(true, onSnap));
+
+            expect(result.current.defaultHeight).toBeDefined();
+            expect(result.current.largeHeight).toBeDefined();
+            expect(result.current.scrollPaddingTop).toBeDefined();
+            expect(result.current.scrollRef).toBeDefined();
+            expect(result.current.scrollValue).toBeDefined();
+            expect(result.current.onScroll).toBeDefined();
+            expect(result.current.hideHeader).toBeDefined();
+            expect(result.current.lockValue).toBe(0);
+            expect(result.current.scrollEnabled.value).toBe(true);
+        });
+
+        it('should handle header lock and unlock', () => {
+            const {result} = renderHook(() => useCollapsibleHeader(true));
+
+            act(() => {
+                result.current.hideHeader(true);
+            });
+            expect(result.current.lockValue).toBe(result.current.defaultHeight);
+            act(() => {
+                result.current.scrollEnabled.value = false;
+            });
+            expect(result.current.scrollEnabled.value).toBe(false);
+
+            act(() => {
+                result.current.unlock();
+            });
+            expect(result.current.lockValue).toBe(0);
+            expect(result.current.scrollEnabled.value).toBe(true);
+        });
+
+        it('should handle auto-scroll correctly', () => {
+            const {result} = renderHook(() => useCollapsibleHeader(true));
+
+            act(() => {
+                result.current.setAutoScroll(true);
+            });
+
+            expect(result.current.scrollValue.value).toBe(0);
+        });
+
+        it('should calculate correct scroll padding for large and normal headers', () => {
+            const {result: largeTitleResult} = renderHook(() => useCollapsibleHeader(true));
+            const {result: normalTitleResult} = renderHook(() => useCollapsibleHeader(false));
+
+            expect(largeTitleResult.current.scrollPaddingTop).toBe(largeTitleResult.current.largeHeight);
+            expect(normalTitleResult.current.scrollPaddingTop).toBe(normalTitleResult.current.defaultHeight);
+        });
+
+        it('should handle hideHeader with scrollTo', () => {
+            const {result} = renderHook(() => useCollapsibleHeader(true));
+
+            // @ts-expect-error override for test mock
+            result.current.scrollRef.current = {
+                scrollTo: mockScrollTo,
+            } as any;
+
+            act(() => {
+                result.current.hideHeader();
+            });
+
+            expect(mockScrollTo).toHaveBeenCalledWith({
+                y: result.current.headerOffset,
+                animated: true,
+            });
+        });
+
+        it('should handle hideHeader with scrollToOffset', () => {
+            const {result} = renderHook(() => useCollapsibleHeader(true));
+
+            // @ts-expect-error override for test mock
+            result.current.scrollRef.current = {
+                scrollToOffset: mockScrollToOffset,
+            } as any;
+
+            act(() => {
+                result.current.hideHeader();
+            });
+
+            expect(mockScrollToOffset).toHaveBeenCalledWith({
+                offset: result.current.headerOffset,
+                animated: true,
+            });
+        });
+
+        it('should handle snap callback', () => {
+            const onSnap = jest.fn();
+            const {result} = renderHook(() => useCollapsibleHeader(true, onSnap));
+
+            act(() => {
+                const mockScrollEvent = {
+                    contentOffset: {y: 10},
+                    contentSize: {height: 1000},
+                    layoutMeasurement: {height: 100},
+                };
+
+                // Simulate scroll event
+                result.current.scrollValue.value = mockScrollEvent.contentOffset.y;
+                result.current.onScroll(mockScrollEvent as any);
+            });
+
+            expect(result.current.scrollValue.value).toBe(10);
+        });
+    });
+});

--- a/app/hooks/input.test.ts
+++ b/app/hooks/input.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+import {Platform} from 'react-native';
+
+import {useInputPropagation} from './input';
+
+describe('useInputPropagation', () => {
+    const originalPlatform = Platform.OS;
+
+    afterEach(() => {
+        Platform.OS = originalPlatform;
+    });
+
+    describe('on Android', () => {
+        beforeEach(() => {
+            Platform.OS = 'android';
+        });
+
+        it('should always process events', () => {
+            const {result} = renderHook(() => useInputPropagation());
+            const [waitToPropagate, shouldProcessEvent] = result.current;
+
+            act(() => {
+                waitToPropagate('test');
+            });
+
+            expect(shouldProcessEvent('test')).toBe(true);
+            expect(shouldProcessEvent('different')).toBe(true);
+        });
+    });
+
+    describe('on iOS', () => {
+        beforeEach(() => {
+            Platform.OS = 'ios';
+        });
+
+        it('should process event when no value is waiting', () => {
+            const {result} = renderHook(() => useInputPropagation());
+            const [, shouldProcessEvent] = result.current;
+
+            expect(shouldProcessEvent('test')).toBe(true);
+        });
+
+        it('should not process event when waiting for specific value', () => {
+            const {result} = renderHook(() => useInputPropagation());
+            const [waitToPropagate, shouldProcessEvent] = result.current;
+
+            act(() => {
+                waitToPropagate('expected');
+            });
+
+            expect(shouldProcessEvent('different')).toBe(false);
+        });
+
+        it('should clear waiting value after matching', () => {
+            const {result} = renderHook(() => useInputPropagation());
+            const [waitToPropagate, shouldProcessEvent] = result.current;
+
+            act(() => {
+                waitToPropagate('test');
+            });
+
+            expect(shouldProcessEvent('test')).toBe(false);
+            expect(shouldProcessEvent('test')).toBe(true);
+        });
+    });
+});

--- a/app/hooks/navigate_back.test.ts
+++ b/app/hooks/navigate_back.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+import {Navigation} from 'react-native-navigation';
+
+import useBackNavigation from './navigate_back';
+
+jest.mock('react-native-navigation', () => ({
+    Navigation: {
+        events: jest.fn().mockReturnValue({
+            registerNavigationButtonPressedListener: jest.fn(),
+        }),
+    },
+}));
+
+describe('hooks/useBackNavigation', () => {
+    let mockRemove: jest.Mock;
+    let mockRegisterListener: jest.Mock;
+
+    beforeEach(() => {
+        mockRemove = jest.fn();
+        mockRegisterListener = jest.fn().mockReturnValue({remove: mockRemove});
+        (Navigation.events as jest.Mock)().registerNavigationButtonPressedListener = mockRegisterListener;
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should register navigation button listener on mount', () => {
+        renderHook(() => useBackNavigation(jest.fn()));
+        expect(mockRegisterListener).toHaveBeenCalled();
+    });
+
+    it('should remove listener on unmount', () => {
+        const {unmount} = renderHook(() => useBackNavigation(jest.fn()));
+        unmount();
+        expect(mockRemove).toHaveBeenCalled();
+    });
+
+    it('should call callback when back button is pressed', () => {
+        const callback = jest.fn();
+        renderHook(() => useBackNavigation(callback));
+
+        const listener = mockRegisterListener.mock.calls[0][0];
+        listener({buttonId: 'RNN.back'});
+
+        expect(callback).toHaveBeenCalled();
+    });
+
+    it('should not call callback when different button is pressed', () => {
+        const callback = jest.fn();
+        renderHook(() => useBackNavigation(callback));
+
+        const listener = mockRegisterListener.mock.calls[0][0];
+        listener({buttonId: 'other.button'});
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should update listener when callback changes', () => {
+        const initialCallback = jest.fn();
+        const {rerender} = renderHook(({cb}) => useBackNavigation(cb), {
+            initialProps: {cb: initialCallback},
+        });
+
+        expect(mockRegisterListener).toHaveBeenCalledTimes(1);
+
+        const newCallback = jest.fn();
+        rerender({cb: newCallback});
+
+        expect(mockRemove).toHaveBeenCalled();
+        expect(mockRegisterListener).toHaveBeenCalledTimes(2);
+    });
+});

--- a/app/hooks/navigation_button_pressed.test.ts
+++ b/app/hooks/navigation_button_pressed.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+import {Navigation} from 'react-native-navigation';
+
+import useNavButtonPressed from './navigation_button_pressed';
+
+jest.mock('react-native-navigation', () => ({
+    Navigation: {
+        events: jest.fn().mockReturnValue({
+            registerComponentListener: jest.fn(),
+        }),
+    },
+}));
+
+describe('hooks/useNavButtonPressed', () => {
+    const componentId = 'test-component-id';
+    const buttonId = 'test-button-id';
+    let callback: jest.Mock;
+    let unsubscribeMock: jest.Mock;
+
+    beforeEach(() => {
+        callback = jest.fn();
+        unsubscribeMock = jest.fn();
+        (Navigation.events().registerComponentListener as jest.Mock).mockReturnValue({
+            remove: unsubscribeMock,
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should register navigation button listener', () => {
+        renderHook(() => useNavButtonPressed(buttonId, componentId, callback));
+
+        expect(Navigation.events().registerComponentListener).toHaveBeenCalledWith(
+            expect.any(Object),
+            componentId,
+        );
+    });
+
+    it('should call callback when matching button is pressed', () => {
+        renderHook(() => useNavButtonPressed(buttonId, componentId, callback));
+
+        const listener = (Navigation.events().registerComponentListener as jest.Mock).mock.calls[0][0];
+        listener.navigationButtonPressed({buttonId});
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call callback when different button is pressed', () => {
+        renderHook(() => useNavButtonPressed(buttonId, componentId, callback));
+
+        const listener = (Navigation.events().registerComponentListener as jest.Mock).mock.calls[0][0];
+        listener.navigationButtonPressed({buttonId: 'different-button'});
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should unsubscribe listener on unmount', () => {
+        const {unmount} = renderHook(() => useNavButtonPressed(buttonId, componentId, callback));
+
+        unmount();
+
+        expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-register listener when deps change', () => {
+        const {rerender} = renderHook(
+            ({dep}) => useNavButtonPressed(buttonId, componentId, callback, [dep]),
+            {initialProps: {dep: 1}},
+        );
+
+        rerender({dep: 2});
+
+        expect(Navigation.events().registerComponentListener).toHaveBeenCalledTimes(2);
+        expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/hooks/persistent_notification_props.test.ts
+++ b/app/hooks/persistent_notification_props.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+
+import {General} from '@constants';
+import {PostPriorityType} from '@constants/post';
+
+import {usePersistentNotificationProps} from './persistent_notification_props';
+
+describe('usePersistentNotificationProps', () => {
+    const baseProps = {
+        value: '',
+        channelType: 'O' as ChannelType,
+        postPriority: {
+            priority: PostPriorityType.URGENT,
+            persistent_notifications: true,
+        },
+    };
+
+    it('should initialize with default values', () => {
+        const {result} = renderHook(() => usePersistentNotificationProps(baseProps));
+
+        expect(result.current.persistentNotificationsEnabled).toBe(true);
+        expect(result.current.noMentionsError).toBe(true);
+        expect(result.current.mentionsList).toEqual([]);
+    });
+
+    it('should detect mentions in message', () => {
+        const props = {
+            ...baseProps,
+            value: 'Hello @user1 and @user2',
+        };
+
+        const {result} = renderHook(() => usePersistentNotificationProps(props));
+
+        expect(result.current.persistentNotificationsEnabled).toBe(true);
+        expect(result.current.noMentionsError).toBe(false);
+        expect(result.current.mentionsList).toEqual(['@user1', '@user2']);
+    });
+
+    it('should disable persistent notifications for DM channels', () => {
+        const props = {
+            ...baseProps,
+            channelType: General.DM_CHANNEL as ChannelType,
+            value: 'Hello @user1',
+        };
+
+        const {result} = renderHook(() => usePersistentNotificationProps(props));
+
+        expect(result.current.persistentNotificationsEnabled).toBe(true);
+        expect(result.current.noMentionsError).toBe(false);
+        expect(result.current.mentionsList).toEqual([]);
+    });
+
+    it('should disable when priority is not urgent', () => {
+        const props = {
+            ...baseProps,
+            postPriority: {
+                priority: PostPriorityType.IMPORTANT,
+                persistent_notifications: true,
+            },
+        };
+
+        const {result} = renderHook(() => usePersistentNotificationProps(props));
+
+        expect(result.current.persistentNotificationsEnabled).toBe(false);
+        expect(result.current.noMentionsError).toBe(false);
+        expect(result.current.mentionsList).toEqual([]);
+    });
+});

--- a/app/hooks/show_more.test.ts
+++ b/app/hooks/show_more.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+import {withTiming} from 'react-native-reanimated';
+
+import {useShowMoreAnimatedStyle} from './show_more';
+
+jest.mock('react-native-reanimated', () => ({
+    useAnimatedStyle: (callback: () => any) => callback(),
+    withTiming: jest.fn((value) => value),
+}));
+
+describe('useShowMoreAnimatedStyle', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns maxHeight when height is undefined', () => {
+        const maxHeight = 100;
+        const {result} = renderHook(() =>
+            useShowMoreAnimatedStyle(undefined, maxHeight, false),
+        );
+
+        expect(result.current).toEqual({
+            maxHeight,
+        });
+    });
+
+    it('animates to maxHeight when not open', () => {
+        const height = 200;
+        const maxHeight = 100;
+        const {result} = renderHook(() =>
+            useShowMoreAnimatedStyle(height, maxHeight, false),
+        );
+
+        expect(result.current).toEqual({
+            maxHeight,
+        });
+        expect(withTiming).toHaveBeenCalledWith(maxHeight, {duration: 300});
+    });
+
+    it('animates to full height when open', () => {
+        const height = 200;
+        const maxHeight = 100;
+        const {result} = renderHook(() =>
+            useShowMoreAnimatedStyle(height, maxHeight, true),
+        );
+
+        expect(result.current).toEqual({
+            maxHeight: height,
+        });
+        expect(withTiming).toHaveBeenCalledWith(height, {duration: 300});
+    });
+});

--- a/app/hooks/team_switch.test.ts
+++ b/app/hooks/team_switch.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {act, renderHook} from '@testing-library/react-hooks';
+import {DeviceEventEmitter} from 'react-native';
+
+import {Events} from '@constants';
+
+import {useTeamSwitch} from './team_switch';
+
+jest.useFakeTimers();
+
+describe('useTeamSwitch', () => {
+    it('should initialize with loading false', () => {
+        const {result} = renderHook(() => useTeamSwitch());
+        expect(result.current).toBe(false);
+    });
+
+    it('should set loading true when switching starts', () => {
+        const {result} = renderHook(() => useTeamSwitch());
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.TEAM_SWITCH, true);
+        });
+        expect(result.current).toBe(true);
+    });
+
+    it('should set loading false when switching ends', () => {
+        const {result} = renderHook(() => useTeamSwitch());
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.TEAM_SWITCH, true);
+        });
+        expect(result.current).toBe(true);
+
+        act(() => {
+            DeviceEventEmitter.emit(Events.TEAM_SWITCH, false);
+            jest.runAllTimers();
+        });
+        expect(result.current).toBe(false);
+    });
+
+    it('should cleanup event listener on unmount', () => {
+        const removeMock = jest.fn();
+        jest.spyOn(DeviceEventEmitter, 'addListener').mockImplementation(() => ({
+            remove: removeMock,
+        } as any));
+
+        const {unmount} = renderHook(() => useTeamSwitch());
+        unmount();
+
+        expect(removeMock).toHaveBeenCalled();
+    });
+});

--- a/app/hooks/teams_loading.test.ts
+++ b/app/hooks/teams_loading.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook, act} from '@testing-library/react-hooks';
+import {BehaviorSubject} from 'rxjs';
+
+import {getLoadingTeamChannelsSubject} from '@store/team_load_store';
+
+import {useTeamsLoading} from './teams_loading';
+
+jest.mock('@store/team_load_store', () => ({
+    getLoadingTeamChannelsSubject: jest.fn(),
+}));
+
+describe('useTeamsLoading', () => {
+    const mockSubject = new BehaviorSubject(0);
+    const serverUrl = 'https://example.com';
+
+    beforeEach(() => {
+        (getLoadingTeamChannelsSubject as jest.Mock).mockReturnValue(mockSubject);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        mockSubject.next(0);
+    });
+
+    it('should initialize with loading false', () => {
+        const {result} = renderHook(() => useTeamsLoading(serverUrl));
+        expect(result.current).toBe(false);
+    });
+
+    it('should update loading state when subject emits non-zero value', () => {
+        const {result} = renderHook(() => useTeamsLoading(serverUrl));
+
+        act(() => {
+            mockSubject.next(1);
+        });
+        expect(result.current).toBe(true);
+
+        act(() => {
+            mockSubject.next(0);
+        });
+        expect(result.current).toBe(false);
+    });
+
+    it('should unsubscribe on unmount', () => {
+        const unsubscribeSpy = jest.fn();
+        const subscription = {unsubscribe: unsubscribeSpy};
+        jest.spyOn(mockSubject, 'pipe').mockReturnValue({
+            subscribe: () => subscription,
+        } as any);
+
+        const {unmount} = renderHook(() => useTeamsLoading(serverUrl));
+        unmount();
+
+        expect(unsubscribeSpy).toHaveBeenCalled();
+    });
+});

--- a/app/hooks/why_did_you_update.test.ts
+++ b/app/hooks/why_did_you_update.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHook} from '@testing-library/react-hooks';
+
+import {useWhyDidYouUpdate} from './why_did_you_update';
+
+describe('hooks/useWhyDidYouUpdate', () => {
+    beforeEach(() => {
+        // Mock console.log since that's what we use to output changes
+        global.console.log = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should not log on initial render', () => {
+        const props = {test: 'value'};
+        renderHook(() => useWhyDidYouUpdate('TestComponent', props));
+
+        expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it('should log when props change', () => {
+        const initialProps = {test: 'initial'};
+        const {rerender} = renderHook(
+            (props) => useWhyDidYouUpdate('TestComponent', props),
+            {initialProps},
+        );
+
+        // Update props
+        const newProps = {test: 'updated'};
+        rerender(newProps);
+
+        expect(console.log).toHaveBeenCalledWith(
+            '[why-did-you-update]',
+            'TestComponent',
+            {
+                test: {
+                    from: 'initial',
+                    to: 'updated',
+                },
+            },
+        );
+    });
+
+    it('should not log when props remain the same', () => {
+        const props = {test: 'value'} as any;
+        const {rerender} = renderHook(
+            (_props) => useWhyDidYouUpdate('TestComponent', _props),
+            {initialProps: props},
+        );
+
+        // Rerender with same props
+        rerender(props);
+
+        expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple prop changes', () => {
+        const initialProps = {prop1: 'initial1', prop2: 'initial2'};
+        const {rerender} = renderHook(
+            (props) => useWhyDidYouUpdate('TestComponent', props),
+            {initialProps},
+        );
+
+        // Update multiple props
+        const newProps = {prop1: 'updated1', prop2: 'updated2'};
+        rerender(newProps);
+
+        expect(console.log).toHaveBeenCalledWith(
+            '[why-did-you-update]',
+            'TestComponent',
+            {
+                prop1: {
+                    from: 'initial1',
+                    to: 'updated1',
+                },
+                prop2: {
+                    from: 'initial2',
+                    to: 'updated2',
+                },
+            },
+        );
+    });
+});


### PR DESCRIPTION
#### Summary

Add tests for remaining app/hooks files.

<img width="1206" alt="Screenshot 2025-01-23 at 11 46 33" src="https://github.com/user-attachments/assets/e94ebdc2-e028-4a37-a831-413332bf3098" />


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59741
https://mattermost.atlassian.net/browse/MM-59742
https://mattermost.atlassian.net/browse/MM-59743
https://mattermost.atlassian.net/browse/MM-59744
https://mattermost.atlassian.net/browse/MM-59745
https://mattermost.atlassian.net/browse/MM-59747
https://mattermost.atlassian.net/browse/MM-59749
https://mattermost.atlassian.net/browse/MM-59751
https://mattermost.atlassian.net/browse/MM-59752
https://mattermost.atlassian.net/browse/MM-59755
https://mattermost.atlassian.net/browse/MM-59756
https://mattermost.atlassian.net/browse/MM-59757
https://mattermost.atlassian.net/browse/MM-59758
https://mattermost.atlassian.net/browse/MM-59759
https://mattermost.atlassian.net/browse/MM-59760

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
