### PR TITLE
fix(MM-60645): missing bookmark emoji

### DIFF
--- a/app/components/channel_bookmarks/channel_bookmark/bookmark_icon.test.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/bookmark_icon.test.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {act, renderWithIntl} from '@test/intl-test-helper';
+
+import BookmarkIcon from './bookmark_icon';
+
+jest.mock('@context/theme', () => ({
+    useTheme: () => ({
+        centerChannelColor: '#000',
+    }),
+}));
+jest.mock('@components/emoji', () => 'Emoji');
+
+describe('components/channel_bookmarks/channel_bookmark/BookmarkIcon', () => {
+    const baseProps = {
+        emojiSize: 24,
+        iconSize: 22,
+        genericStyle: {},
+    };
+
+    it('renders default bookmark icon when no specific content provided', () => {
+        const {getByTestId} = renderWithIntl(
+            <BookmarkIcon {...baseProps}/>,
+        );
+
+        expect(getByTestId('bookmark-generic-icon')).toBeOnTheScreen();
+    });
+
+    it('renders FileIcon when file prop is provided', () => {
+        const props = {
+            ...baseProps,
+            file: {
+                id: 'file1',
+                name: 'test.pdf',
+                extension: 'pdf',
+            } as unknown as FileInfo,
+        };
+
+        const {getByTestId} = renderWithIntl(
+            <BookmarkIcon {...props}/>,
+        );
+
+        expect(getByTestId('bookmark-file-icon')).toBeOnTheScreen();
+    });
+
+    it('renders Image when imageUrl is provided', () => {
+        const props = {
+            ...baseProps,
+            imageUrl: 'https://example.com/image.jpg',
+            imageStyle: {width: 40, height: 40},
+        };
+
+        const {getByTestId} = renderWithIntl(
+            <BookmarkIcon {...props}/>,
+        );
+
+        expect(getByTestId('bookmark-image')).toBeOnTheScreen();
+    });
+
+    it('renders Emoji when emoji prop is provided', () => {
+        const props = {
+            ...baseProps,
+            emoji: 'smile',
+            emojiStyle: {fontSize: 20},
+        };
+
+        const {getByTestId} = renderWithIntl(
+            <BookmarkIcon {...props}/>,
+        );
+
+        const emojiComponent = getByTestId('bookmark-emoji');
+        expect(emojiComponent).toBeOnTheScreen();
+        expect(emojiComponent.props.emojiName).toBe('smile');
+    });
+
+    it('renders Emoji when emoji prop with `:` is provided', () => {
+        const props = {
+            ...baseProps,
+            emoji: ':computer-rage:',
+            emojiStyle: {fontSize: 20},
+        };
+
+        const {getByTestId} = renderWithIntl(
+            <BookmarkIcon {...props}/>,
+        );
+
+        const emojiComponent = getByTestId('bookmark-emoji');
+        expect(emojiComponent).toBeOnTheScreen();
+        expect(emojiComponent.props.emojiName).toBe('computer-rage');
+    });
+
+    it('falls back to default icon when image fails to load', () => {
+        const props = {
+            ...baseProps,
+            imageUrl: 'https://example.com/invalid.jpg',
+        };
+
+        const {getByTestId} = renderWithIntl(
+            <BookmarkIcon {...props}/>,
+        );
+
+        const image = getByTestId('bookmark-image');
+        const mockErrorEvent = {
+            nativeEvent: {
+                error: new Error('Image failed to load'),
+            },
+        };
+        act(() => {
+            image.props.onError(mockErrorEvent);
+        });
+
+        expect(getByTestId('bookmark-generic-icon')).toBeOnTheScreen();
+    });
+});

--- a/app/components/channel_bookmarks/channel_bookmark/bookmark_icon.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/bookmark_icon.tsx
@@ -32,6 +32,7 @@ const BookmarkIcon = ({emoji, emojiSize, emojiStyle, file, genericStyle, iconSiz
     if (file && !emoji && !hasImageError) {
         return (
             <FileIcon
+                testID='bookmark-file-icon'
                 file={file}
                 iconSize={iconSize}
                 smallImage={true}
@@ -40,6 +41,7 @@ const BookmarkIcon = ({emoji, emojiSize, emojiStyle, file, genericStyle, iconSiz
     } else if (imageUrl && !emoji && !hasImageError) {
         return (
             <Image
+                testID='bookmark-image'
                 source={{uri: imageUrl}}
                 style={imageStyle}
                 onError={handleImageError}
@@ -49,7 +51,8 @@ const BookmarkIcon = ({emoji, emojiSize, emojiStyle, file, genericStyle, iconSiz
         const sanitizedEmoji = emoji.replace(/:/g, '');
         return (
             <Emoji
-                emojiName={sanitizedEmoji!}
+                testID='bookmark-emoji'
+                emojiName={sanitizedEmoji}
                 size={emojiSize}
                 textStyle={emojiStyle}
             />
@@ -62,6 +65,7 @@ const BookmarkIcon = ({emoji, emojiSize, emojiStyle, file, genericStyle, iconSiz
             size={22}
             color={theme.centerChannelColor}
             style={genericStyle}
+            testID='bookmark-generic-icon'
         />
     );
 };

--- a/app/components/channel_bookmarks/channel_bookmark/bookmark_icon.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/bookmark_icon.tsx
@@ -46,9 +46,10 @@ const BookmarkIcon = ({emoji, emojiSize, emojiStyle, file, genericStyle, iconSiz
             />
         );
     } else if (emoji) {
+        const sanitizedEmoji = emoji.replace(/:/g, '');
         return (
             <Emoji
-                emojiName={emoji!}
+                emojiName={sanitizedEmoji!}
                 size={emojiSize}
                 textStyle={emojiStyle}
             />

--- a/app/components/files/file_icon.tsx
+++ b/app/components/files/file_icon.tsx
@@ -16,6 +16,7 @@ type FileIconProps = {
     iconColor?: string;
     iconSize?: number;
     smallImage?: boolean;
+    testID?: string;
 }
 
 const BLUE_ICON = '#338AFF';
@@ -49,7 +50,7 @@ const styles = StyleSheet.create({
 
 const FileIcon = ({
     backgroundColor, defaultImage = false, failed = false, file,
-    iconColor, iconSize = 48, smallImage = false,
+    iconColor, iconSize = 48, smallImage = false, testID = 'file-icon',
 }: FileIconProps) => {
     const theme = useTheme();
     const getFileIconNameAndColor = () => {
@@ -78,7 +79,10 @@ const FileIcon = ({
     const bgColor = backgroundColor || theme?.centerChannelBg || 'transparent';
 
     return (
-        <View style={[styles.fileIconWrapper, {backgroundColor: bgColor}]}>
+        <View
+            style={[styles.fileIconWrapper, {backgroundColor: bgColor}]}
+            testID={testID}
+        >
             <CompassIcon
                 name={iconName}
                 size={iconSize}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Emoji associated to bookmark is missing. This is due to emoji name being stored as `:computer-rage:`.  The fix is to parse out the `:` from emoji name.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes: https://mattermost.atlassian.net/browse/MM-60645

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
iPhone 16 Simulator (18.2)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
![fix-MM-60645-missing-emoji](https://github.com/user-attachments/assets/1f51b6b4-cae9-485e-8149-55d3dda93990)



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
