### PR TITLE
MM-62726 fix the active label color for channel and thread

### DIFF
--- a/app/components/channel_item/__snapshots__/channel_item.test.tsx.snap
+++ b/app/components/channel_item/__snapshots__/channel_item.test.tsx.snap
@@ -93,10 +93,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,
@@ -218,10 +214,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,
@@ -260,10 +252,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,
@@ -374,10 +362,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,

--- a/app/components/channel_item/channel_item.tsx
+++ b/app/components/channel_item/channel_item.tsx
@@ -52,7 +52,6 @@ export const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
     text: {
         color: theme.sidebarText,
-        ...typography('Body', 200),
     },
     highlight: {
         color: theme.sidebarUnreadText,

--- a/app/components/threads_button/__snapshots__/threads_button.test.tsx.snap
+++ b/app/components/threads_button/__snapshots__/threads_button.test.tsx.snap
@@ -80,10 +80,6 @@ exports[`Thread item in the channel list Threads Component should match snapshot
           },
           {
             "color": "#ffffff",
-            "fontFamily": "OpenSans",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
           },
           false,
           false,
@@ -179,10 +175,6 @@ exports[`Thread item in the channel list Threads Component should match snapshot
           },
           {
             "color": "#ffffff",
-            "fontFamily": "OpenSans",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
           },
           false,
           false,


### PR DESCRIPTION
#### Summary
Fixed the active label colour for channels and threads that have been unread. This is a regression from draft PR: https://github.com/mattermost/mattermost-mobile/pull/8280

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62726

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: IOS 17.5

#### Screenshot
![Screenshot 2025-01-28 at 12 22 07 AM](https://github.com/user-attachments/assets/46d28712-5446-42a7-a00e-3bcc4d5df6c1)

#### Release Note
```release-note
NONE
```
