### PR TITLE
Automated cherry pick of #8523

### DIFF
--- a/app/components/channel_item/__snapshots__/channel_item.test.tsx.snap
+++ b/app/components/channel_item/__snapshots__/channel_item.test.tsx.snap
@@ -93,10 +93,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,
@@ -218,10 +214,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,
@@ -260,10 +252,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,
@@ -374,10 +362,6 @@ exports[`components/channel_list/categories/body/channel_item should match snaps
             },
             {
               "color": "#ffffff",
-              "fontFamily": "OpenSans",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
             },
             false,
             null,

--- a/app/components/channel_item/channel_item.tsx
+++ b/app/components/channel_item/channel_item.tsx
@@ -52,7 +52,6 @@ export const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
     text: {
         color: theme.sidebarText,
-        ...typography('Body', 200),
     },
     highlight: {
         color: theme.sidebarUnreadText,

--- a/app/components/threads_button/__snapshots__/threads_button.test.tsx.snap
+++ b/app/components/threads_button/__snapshots__/threads_button.test.tsx.snap
@@ -80,10 +80,6 @@ exports[`Thread item in the channel list Threads Component should match snapshot
           },
           {
             "color": "#ffffff",
-            "fontFamily": "OpenSans",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
           },
           false,
           false,
@@ -179,10 +175,6 @@ exports[`Thread item in the channel list Threads Component should match snapshot
           },
           {
             "color": "#ffffff",
-            "fontFamily": "OpenSans",
-            "fontSize": 16,
-            "fontWeight": "400",
-            "lineHeight": 24,
           },
           false,
           false,


### PR DESCRIPTION
Cherry pick of #8523 on release-2.25.

/cc  @Rajat-Dabade

```release-note
NONE
```