### PR TITLE
MM-59787 Add tests for preference query functions

### DIFF
--- a/app/queries/servers/preference.test.ts
+++ b/app/queries/servers/preference.test.ts
@@ -1,0 +1,361 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Preferences} from '@constants';
+import {CATEGORIES_TO_KEEP} from '@constants/preferences';
+import DatabaseManager from '@database/manager';
+
+import {
+    prepareMyPreferences,
+    queryPreferencesByCategoryAndName,
+    getThemeForCurrentTeam,
+    deletePreferences,
+    differsFromLocalNameFormat,
+    getHasCRTChanged,
+    queryDisplayNamePreferences,
+    querySavedPostsPreferences,
+    queryThemePreferences,
+    querySidebarPreferences,
+    queryEmojiPreferences,
+    queryAdvanceSettingsPreferences,
+} from './preference';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+import type {Database} from '@nozbe/watermelondb';
+
+describe('Preference Queries', () => {
+    const serverUrl = 'baseHandler.test.com';
+    let database: Database;
+    let operator: ServerDataOperator;
+
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        const serverDatabaseAndOperator = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        database = serverDatabaseAndOperator.database;
+        operator = serverDatabaseAndOperator.operator;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    describe('prepareMyPreferences', () => {
+        it('should prepare preference records', async () => {
+            const preferences = [
+                {
+                    user_id: 'user1',
+                    category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+                    name: 'name_format',
+                    value: 'username',
+                },
+                {
+                    user_id: 'user1',
+                    category: Preferences.CATEGORIES.THEME,
+                    name: 'theme',
+                    value: '{"type":"dark"}',
+                },
+            ];
+
+            const records = await prepareMyPreferences(operator, preferences);
+            expect(records.length).toBe(2);
+            expect(records[0].name).toBe('name_format');
+        });
+
+        it('should handle sync flag', async () => {
+            const preferences = [{
+                user_id: 'user1',
+                category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+                name: 'name_format',
+                value: 'username',
+            }];
+
+            const records = await prepareMyPreferences(operator, preferences, true);
+            expect(records.length).toBe(1);
+            expect(records[0].name).toBe('name_format');
+        });
+    });
+
+    describe('queryPreferencesByCategoryAndName', () => {
+        it('should query by category only', async () => {
+            await operator.handlePreferences({
+                preferences: [
+                    {
+                        user_id: 'user1',
+                        category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                        name: 'test1',
+                        value: 'value1',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                        name: 'test2',
+                        value: 'value2',
+                    },
+                ],
+                prepareRecordsOnly: false,
+            });
+
+            const prefs = await queryPreferencesByCategoryAndName(database, CATEGORIES_TO_KEEP.ADVANCED_SETTINGS).fetch();
+            expect(prefs.length).toBe(2);
+        });
+
+        it('should query by category and name', async () => {
+            await operator.handlePreferences({
+                preferences: [
+                    {
+                        user_id: 'user1',
+                        category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                        name: 'test1',
+                        value: 'value1',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                        name: 'test2',
+                        value: 'value2',
+                    },
+                ],
+                prepareRecordsOnly: false,
+            });
+
+            const prefs = await queryPreferencesByCategoryAndName(database, CATEGORIES_TO_KEEP.ADVANCED_SETTINGS, 'test1').fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].name).toBe('test1');
+        });
+
+        it('should query by category, name and value', async () => {
+            await operator.handlePreferences({
+                preferences: [
+                    {
+                        user_id: 'user1',
+                        category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                        name: 'test1',
+                        value: 'value1',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                        name: 'test1',
+                        value: 'value2',
+                    },
+                ],
+                prepareRecordsOnly: false,
+            });
+
+            const prefs = await queryPreferencesByCategoryAndName(database, CATEGORIES_TO_KEEP.ADVANCED_SETTINGS, 'test1', 'value1').fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].value).toBe('value1');
+        });
+    });
+
+    describe('getThemeForCurrentTeam', () => {
+        it('should return undefined if no theme exists', async () => {
+            const theme = await getThemeForCurrentTeam(database);
+            expect(theme).toBeUndefined();
+        });
+
+        it('should return theme for current team', async () => {
+            const teamId = 'team1';
+            const themeValue = {
+                type: 'dark',
+                sidebarBg: '#000000',
+            };
+
+            await operator.handleSystem({
+                systems: [{id: 'currentTeamId', value: teamId}],
+                prepareRecordsOnly: false,
+            });
+
+            await operator.handlePreferences({
+                preferences: [{
+                    user_id: 'user1',
+                    category: Preferences.CATEGORIES.THEME,
+                    name: teamId,
+                    value: JSON.stringify(themeValue),
+                }],
+                prepareRecordsOnly: false,
+            });
+
+            const theme = await getThemeForCurrentTeam(database);
+            expect(theme).toEqual(themeValue);
+        });
+    });
+
+    describe('deletePreferences', () => {
+        it('should delete preferences', async () => {
+            const pref1 = {
+                user_id: 'user1',
+                category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                name: 'test1',
+                value: 'value1',
+            };
+
+            await operator.handlePreferences({
+                preferences: [
+                    pref1,
+                    {
+                        user_id: 'user1',
+                        category: CATEGORIES_TO_KEEP.ADVANCED_SETTINGS,
+                        name: 'test2',
+                        value: 'value2',
+                    },
+                ],
+                prepareRecordsOnly: false,
+            });
+
+            const prefsToDelete = [pref1];
+
+            const success = await deletePreferences({database, operator}, prefsToDelete);
+            expect(success).toBe(true);
+
+            const remaining = await queryPreferencesByCategoryAndName(database, CATEGORIES_TO_KEEP.ADVANCED_SETTINGS).fetch();
+            expect(remaining.length).toBe(1);
+            expect(remaining[0].name).toBe('test2');
+        });
+
+        it('should handle empty prefs gracefully', async () => {
+            const success = await deletePreferences({database, operator}, []);
+            expect(success).toBe(true);
+        });
+    });
+
+    describe('differsFromLocalNameFormat', () => {
+        it('should detect when name format differs', async () => {
+            await operator.handlePreferences({
+                preferences: [{
+                    user_id: 'user1',
+                    category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+                    name: Preferences.NAME_NAME_FORMAT,
+                    value: 'username',
+                }],
+                prepareRecordsOnly: false,
+            });
+
+            const newPrefs = [{
+                user_id: 'user1',
+                category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+                name: Preferences.NAME_NAME_FORMAT,
+                value: 'nickname',
+            }];
+
+            const differs = await differsFromLocalNameFormat(database, newPrefs);
+            expect(differs).toBe(true);
+        });
+
+        it('should handle empty preferences', async () => {
+            const differs = await differsFromLocalNameFormat(database, []);
+            expect(differs).toBe(false);
+        });
+    });
+
+    describe('getHasCRTChanged', () => {
+        it('should detect CRT changes', async () => {
+            await operator.handlePreferences({
+                preferences: [{
+                    user_id: 'user1',
+                    category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+                    name: Preferences.COLLAPSED_REPLY_THREADS,
+                    value: 'off',
+                }],
+                prepareRecordsOnly: false,
+            });
+
+            const newPrefs = [{
+                user_id: 'user1',
+                category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+                name: Preferences.COLLAPSED_REPLY_THREADS,
+                value: 'on',
+            }];
+
+            const changed = await getHasCRTChanged(database, newPrefs);
+            expect(changed).toBe(true);
+        });
+
+        it('should handle no CRT preference', async () => {
+            const changed = await getHasCRTChanged(database, []);
+            expect(changed).toBe(false);
+        });
+    });
+
+    describe('category-specific queries', () => {
+        beforeEach(async () => {
+            await operator.handlePreferences({
+                preferences: [
+                    {
+                        user_id: 'user1',
+                        category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+                        name: 'display_test',
+                        value: 'display_value',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: Preferences.CATEGORIES.SAVED_POST,
+                        name: 'post1',
+                        value: 'saved',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: Preferences.CATEGORIES.THEME,
+                        name: 'theme1',
+                        value: '{"type":"dark"}',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: Preferences.CATEGORIES.SIDEBAR_SETTINGS,
+                        name: 'sidebar_test',
+                        value: 'sidebar_value',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: Preferences.CATEGORIES.EMOJI,
+                        name: 'emoji_test',
+                        value: 'emoji_value',
+                    },
+                    {
+                        user_id: 'user1',
+                        category: Preferences.CATEGORIES.ADVANCED_SETTINGS,
+                        name: 'advanced_test',
+                        value: 'advanced_value',
+                    },
+                ],
+                prepareRecordsOnly: false,
+            });
+        });
+
+        it('should query display name preferences', async () => {
+            const prefs = await queryDisplayNamePreferences(database).fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].category).toBe(Preferences.CATEGORIES.DISPLAY_SETTINGS);
+        });
+
+        it('should query saved posts preferences', async () => {
+            const prefs = await querySavedPostsPreferences(database).fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].category).toBe(Preferences.CATEGORIES.SAVED_POST);
+        });
+
+        it('should query theme preferences', async () => {
+            const prefs = await queryThemePreferences(database).fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].category).toBe(Preferences.CATEGORIES.THEME);
+        });
+
+        it('should query sidebar preferences', async () => {
+            const prefs = await querySidebarPreferences(database).fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].category).toBe(Preferences.CATEGORIES.SIDEBAR_SETTINGS);
+        });
+
+        it('should query emoji preferences', async () => {
+            const prefs = await queryEmojiPreferences(database, 'emoji_test').fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].category).toBe(Preferences.CATEGORIES.EMOJI);
+        });
+
+        it('should query advanced settings preferences', async () => {
+            const prefs = await queryAdvanceSettingsPreferences(database).fetch();
+            expect(prefs.length).toBe(1);
+            expect(prefs[0].category).toBe(Preferences.CATEGORIES.ADVANCED_SETTINGS);
+        });
+    });
+});


### PR DESCRIPTION
#### Summary

Add tests for preference query functions.

<img width="680" alt="Screenshot 2025-01-29 at 10 46 26" src="https://github.com/user-attachments/assets/77f534ce-97fe-4933-aa7e-b9f1c70deb84" />


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59787

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
