### PR TITLE
Fix flaky client/rest/general/ping test

### DIFF
--- a/app/client/rest/general.test.ts
+++ b/app/client/rest/general.test.ts
@@ -22,12 +22,12 @@ describe('ClientGeneral', () => {
         const deviceId = 'device1';
         const timeoutInterval = 1000;
         const groupLabel = 'DeepLink';
-        const expectedUrl = `${client.urlVersion}/system/ping?time=${Date.now()}&device_id=${deviceId}`;
+        const expectedUrl = `${client.urlVersion}/system/ping`;
         const expectedOptions = {method: 'get', timeoutInterval, groupLabel};
 
         await client.ping(deviceId, timeoutInterval, groupLabel);
 
-        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions, false);
+        expect(client.doFetch).toHaveBeenCalledWith(expect.stringContaining(expectedUrl), expectedOptions, false);
     });
 
     test('logClientError', async () => {


### PR DESCRIPTION
#### Summary

There was a race between the expected URL `Date.now()` and the one in the ping function. Unfortunately this makes the test a little worse but it's not a critical test so it's probably fine.

#### Ticket Link
n/a

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
