### PR TITLE
fix: remove from channel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.24.0",
+      "version": "2.25.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {


### PR DESCRIPTION
#### Summary
With the changes made during the load bandwidth effort, we changed the API's being called to fetch the channels and channel memberships of the user. The idea was to fetch these memberships in parallel based on the channels we got, but the endpoint returns a paginated of up to 200 members per request we were coming short as the idea was to calculate the remaining requests to be executed based on the amount of channels that we got back. The channels endpoint returns a number of channels if we do exclude the deleted channels and that does not correlate with the members we fetch, so some members can be missing, so the app here "guesses" that the user is no longer a part of the channel.

To correct this, we are now requesting the memberships in serial, iterating over the pagination until the server response with a page which memberships are less than the max per page.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62761

#### Release Note
```release-note
NONE
```
