### PR TITLE
Fix attachments being removed when replying to a thread

### DIFF
--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -192,7 +192,13 @@ export async function createThreadFromNewPost(serverUrl: string, post: Post, pre
 }
 
 // On receiving threads, Along with the "threads" & "thread participants", extract and save "posts" & "users"
-export async function processReceivedThreads(serverUrl: string, threads: Thread[], teamId: string, prepareRecordsOnly = false) {
+export async function processReceivedThreads(
+    serverUrl: string,
+    threads: Thread[],
+    teamId: string,
+    isThreadUpdatedEvent = false,
+    prepareRecordsOnly = false,
+) {
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const currentUserId = await getCurrentUserId(database);
@@ -218,6 +224,7 @@ export async function processReceivedThreads(serverUrl: string, threads: Thread[
             order: [],
             posts,
             prepareRecordsOnly: true,
+            isThreadUpdatedEvent,
         });
 
         const threadModels = await operator.handleThreads({

--- a/app/actions/remote/thread.ts
+++ b/app/actions/remote/thread.ts
@@ -436,7 +436,7 @@ export const syncTeamThreads = async (
         const models: Model[] = [];
 
         if (threads.length) {
-            const {error, models: threadModels = []} = await processReceivedThreads(serverUrl, threads, teamId, true);
+            const {error, models: threadModels = []} = await processReceivedThreads(serverUrl, threads, teamId, false, true);
             if (error) {
                 return {error};
             }
@@ -494,7 +494,7 @@ export const loadEarlierThreads = async (serverUrl: string, teamId: string, last
         const threads = fetchedThreads.threads || [];
 
         if (threads?.length) {
-            const {error, models: threadModels = []} = await processReceivedThreads(serverUrl, threads, teamId, true);
+            const {error, models: threadModels = []} = await processReceivedThreads(serverUrl, threads, teamId, false, true);
             if (error) {
                 return {error};
             }

--- a/app/actions/websocket/threads.ts
+++ b/app/actions/websocket/threads.ts
@@ -19,7 +19,7 @@ export async function handleThreadUpdatedEvent(serverUrl: string, msg: WebSocket
 
         // Mark it as following
         thread.is_following = true;
-        processReceivedThreads(serverUrl, [thread], teamId);
+        processReceivedThreads(serverUrl, [thread], teamId, true);
     } catch (error) {
         // Do nothing
     }

--- a/types/database/database.ts
+++ b/types/database/database.ts
@@ -88,6 +88,11 @@ export type HandlePostsArgs = {
   previousPostId?: string;
   posts?: Post[];
   prepareRecordsOnly?: boolean;
+
+  // For backwards compatibility, we need to check whether the posts
+  // are coming from a thread updated event, since those events do not
+  // include metadata, which will lead to remove all files from the post.
+  isThreadUpdatedEvent?: boolean;
 };
 
 export type HandleThreadsArgs = {


### PR DESCRIPTION
#### Summary
On https://github.com/mattermost/mattermost-mobile/pull/8468 , with the addition to edit file attachments on web, we added logic to remove the file attachments when the server said certain post no longer had one.

This surfaced an issue where the server is not sending the post metadata in all the relevant events. In particular, we pinpointed that the "Thread Updated" websocket event is not sending any metadata. The lack of metadata leads the code to think the files has been removed, and therefore removes from the local database.

The current fix is a "dirty patch" to make sure we are backwards compatible while preserving the file removal functionality. A couple of follow up PRs should be done, to fix the issue in the server, and add yet another check to listen to the new flag only on servers where the metadata may be empty.

#### Ticket Link
Short term fix for: https://mattermost.atlassian.net/browse/MM-62727

#### Release Note
```release-note
NONE
```
