### PR TITLE
Check file id instead of metadata for file removal

### DIFF
--- a/app/database/operator/server_data_operator/handlers/post.ts
+++ b/app/database/operator/server_data_operator/handlers/post.ts
@@ -157,6 +157,7 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
         const postsReactions: ReactionsPerPost[] = [];
         const pendingPostsToDelete: Post[] = [];
         const postsInThread: Record<string, Post[]> = {};
+        const receivedFilesSet = new Set<string>();
 
         // Let's process the post data
         for (const post of posts) {
@@ -201,6 +202,8 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
 
                 post.metadata = data;
             }
+
+            post.file_ids?.forEach((fileId) => receivedFilesSet.add(fileId));
         }
 
         // Get unique posts in case they are duplicated
@@ -261,7 +264,6 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
         }
 
         const allFiles = await database.get<FileModel>(MM_TABLES.SERVER.FILE).query(Q.where('post_id', Q.oneOf(uniquePosts.map((p) => p.id)))).fetch();
-        const receivedFilesSet = new Set(files.map((f) => f.id));
         allFiles.forEach((f) => {
             if (!receivedFilesSet.has(f.id)) {
                 batch.push(f.prepareDestroyPermanently());


### PR DESCRIPTION
#### Summary
On https://github.com/mattermost/mattermost-mobile/pull/8468 , with the addition to edit file attachments on web, we added logic to remove the file attachments when the server said certain post no longer had one.

This surfaced an issue where the server is not sending the post metadata in all the relevant events. In particular, we pinpointed that the "Thread Updated" websocket event is not sending any metadata. The lack of metadata leads the code to think the files has been removed, and therefore removes from the local database.

To handle this in a backwards compatible manner, we check the `file_ids` field, instead of relying on the metadata. Nevertheless, we should consider fixing in the server the fact that we are not sending the metadata in all posts.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-62727

#### Release Note
```release-note
NONE
```
