### PR TITLE
MM-59445 + others - Add tests for channel bookmarks, systems, apps and tos files in remote/actions

### DIFF
--- a/app/actions/remote/apps.test.ts
+++ b/app/actions/remote/apps.test.ts
@@ -1,0 +1,412 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {AppCallResponseTypes} from '@constants/apps';
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+
+import {
+    handleBindingClick,
+    doAppSubmit,
+    doAppFetchForm,
+    doAppLookup,
+    postEphemeralCallResponseForPost,
+    postEphemeralCallResponseForChannel,
+    postEphemeralCallResponseForContext,
+    postEphemeralCallResponseForCommandArgs,
+} from './apps';
+
+import type PostModel from '@typings/database/models/servers/post';
+
+const serverUrl = 'baseHandler.test.com';
+
+const mockIntl = {
+    formatMessage: jest.fn((config) => {
+        return config.defaultMessage;
+    }),
+} as any;
+
+const mockBinding: AppBinding = {
+    app_id: 'app1',
+    location: 'location1',
+    label: 'Test Binding',
+    form: {
+        submit: {
+            path: '/submit/path',
+        },
+        source: {
+            path: '/source/path',
+        },
+    },
+    submit: {
+        path: '/submit/path',
+    },
+};
+
+const mockContext: AppContext = {
+    app_id: 'app1',
+    channel_id: 'channel1',
+    team_id: 'team1',
+    post_id: 'post1',
+    root_id: 'root1',
+};
+
+const mockResponse: AppCallResponse = {
+    type: AppCallResponseTypes.OK,
+    text: 'Success',
+    app_metadata: {
+        bot_user_id: 'bot1',
+        bot_username: 'testbot',
+    },
+};
+
+const mockNavigateResponse: AppCallResponse = {
+    type: AppCallResponseTypes.NAVIGATE,
+    text: 'Navigating',
+    navigate_to_url: 'https://example.com',
+};
+
+const mockPost = {
+    id: 'post1',
+    channelId: 'channel1',
+    rootId: 'root1',
+} as PostModel;
+
+const mockCommandArgs = {
+    channel_id: 'channel1',
+    root_id: 'root1',
+} as CommandArgs;
+
+const mockFormResponse: AppCallResponse = {
+    type: AppCallResponseTypes.FORM,
+    form: {
+        title: 'Test Form',
+        submit: {
+            path: '/submit/path',
+        },
+    },
+};
+
+const mockErrorResponse: AppCallResponse = {
+    type: AppCallResponseTypes.ERROR,
+    text: 'Error occurred',
+};
+
+const mockClient = {
+    executeAppCall: jest.fn(),
+} as any;
+
+jest.mock('@actions/local/post', () => {
+    const mockSendEphemeralPost = jest.fn().mockReturnValue({});
+    return {
+        sendEphemeralPost: mockSendEphemeralPost,
+    };
+});
+
+const mockSendEphemeralPost = jest.requireMock('@actions/local/post').sendEphemeralPost;
+
+const throwFunc = () => {
+    throw Error('error');
+};
+
+describe('apps', () => {
+    beforeEach(async () => {
+        NetworkManager.getClient = () => mockClient;
+        await DatabaseManager.init([serverUrl]);
+        jest.clearAllMocks();
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    describe('handleBindingClick', () => {
+        it('should handle form source binding', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockFormResponse);
+
+            const result = await handleBindingClick(serverUrl, mockBinding, mockContext, mockIntl);
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.FORM);
+            expect(mockClient.executeAppCall).toHaveBeenCalledTimes(1);
+        });
+
+        it('should handle form binding', async () => {
+            const bindingWithForm = {...mockBinding};
+            delete bindingWithForm.form?.source;
+
+            const result = await handleBindingClick(serverUrl, bindingWithForm, mockContext, mockIntl);
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.FORM);
+            expect(mockClient.executeAppCall).not.toHaveBeenCalled();
+        });
+
+        it('should handle submit binding', async () => {
+            const bindingWithSubmit = {...mockBinding};
+            delete bindingWithSubmit.form;
+
+            mockClient.executeAppCall.mockResolvedValueOnce(mockResponse);
+
+            const result = await handleBindingClick(serverUrl, bindingWithSubmit, mockContext, mockIntl);
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.OK);
+            expect(mockClient.executeAppCall).toHaveBeenCalledTimes(1);
+        });
+
+        it('should handle malformed binding', async () => {
+            const malformedBinding = {...mockBinding};
+            delete malformedBinding.form;
+            delete malformedBinding.submit;
+
+            const result = await handleBindingClick(serverUrl, malformedBinding, mockContext, mockIntl);
+
+            expect(result.error).toBeDefined();
+            expect(mockClient.executeAppCall).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('doAppSubmit', () => {
+        const mockCall = {
+            path: '/submit/path',
+            context: mockContext,
+        };
+
+        it('should handle navigation response', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockNavigateResponse);
+
+            const result = await doAppSubmit(serverUrl, mockCall, mockIntl) as any;
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.NAVIGATE);
+            expect(result.data?.navigate_to_url).toBe('https://example.com');
+        });
+
+        it('should handle invalid navigation response', async () => {
+            const invalidNavigateResponse = {
+                type: AppCallResponseTypes.NAVIGATE,
+                text: 'Invalid Navigation',
+            };
+            mockClient.executeAppCall.mockResolvedValueOnce(invalidNavigateResponse);
+
+            const result = await doAppSubmit(serverUrl, mockCall, mockIntl) as any;
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.text).toContain('no url was included');
+        });
+
+        it('should handle unknown response type', async () => {
+            const unknownResponse = {
+                type: 'UNKNOWN_TYPE',
+                text: 'Unknown',
+            };
+            mockClient.executeAppCall.mockResolvedValueOnce(unknownResponse);
+
+            const result = await doAppSubmit(serverUrl, mockCall, mockIntl) as any;
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.text).toContain('not supported');
+        });
+
+        it('should handle successful submit', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockResponse);
+
+            const result = await doAppSubmit(serverUrl, mockCall, mockIntl) as any;
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.OK);
+        });
+
+        it('should handle error response', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockErrorResponse);
+
+            const result = await doAppSubmit(serverUrl, mockCall, mockIntl) as any;
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.type).toBe(AppCallResponseTypes.ERROR);
+        });
+
+        it('should handle form response', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockFormResponse);
+
+            const result = await doAppSubmit(serverUrl, mockCall, mockIntl) as any;
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.FORM);
+        });
+
+        it('should handle network error', async () => {
+            mockClient.executeAppCall.mockRejectedValueOnce(new Error('Network error'));
+
+            const result = await doAppSubmit(serverUrl, mockCall, mockIntl) as any;
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.text).toBe('Network error');
+        });
+    });
+
+    describe('doAppLookup', () => {
+        const mockCall = {
+            path: '/lookup/path',
+            context: mockContext,
+        };
+
+        it('should handle successful lookup', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockResponse);
+
+            const result = await doAppLookup(serverUrl, mockCall, mockIntl);
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.OK);
+        });
+
+        it('should handle error response', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockErrorResponse);
+
+            const result = await doAppLookup(serverUrl, mockCall, mockIntl);
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.type).toBe(AppCallResponseTypes.ERROR);
+        });
+
+        it('should handle network error', async () => {
+            mockClient.executeAppCall.mockRejectedValueOnce(new Error('Network error'));
+
+            const result = await doAppLookup(serverUrl, mockCall, mockIntl);
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.text).toBe('Network error');
+        });
+    });
+
+    describe('doAppFetchForm', () => {
+        const mockCall = {
+            path: '/form/path',
+            context: mockContext,
+        };
+
+        it('should handle successful form fetch', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockFormResponse);
+
+            const result = await doAppFetchForm(serverUrl, mockCall, mockIntl);
+
+            expect(result.data).toBeDefined();
+            expect(result.data?.type).toBe(AppCallResponseTypes.FORM);
+        });
+
+        it('should handle error response', async () => {
+            mockClient.executeAppCall.mockResolvedValueOnce(mockErrorResponse);
+
+            const result = await doAppFetchForm(serverUrl, mockCall, mockIntl);
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.type).toBe(AppCallResponseTypes.ERROR);
+        });
+
+        it('should handle invalid form response', async () => {
+            const invalidFormResponse = {
+                type: AppCallResponseTypes.FORM,
+                form: {},
+            };
+            mockClient.executeAppCall.mockResolvedValueOnce(invalidFormResponse);
+
+            const result = await doAppFetchForm(serverUrl, mockCall, mockIntl);
+
+            expect(result.error).toBeDefined();
+        });
+
+        it('should handle thrown errors', async () => {
+            jest.spyOn(NetworkManager, 'getClient').mockImplementationOnce(throwFunc);
+            mockClient.executeAppCall.mockResolvedValueOnce(mockFormResponse);
+
+            const result = await doAppFetchForm(serverUrl, mockCall, mockIntl);
+
+            expect(result.error).toBeDefined();
+            expect(result.error?.type).toBe(AppCallResponseTypes.ERROR);
+        });
+    });
+
+    describe('ephemeral posts', () => {
+        const message = 'Test message';
+
+        beforeEach(() => {
+            mockSendEphemeralPost.mockClear();
+        });
+
+        it('should post ephemeral response for post', () => {
+            const result = postEphemeralCallResponseForPost(serverUrl, mockResponse, message, mockPost);
+            expect(result).toBeDefined();
+            expect(mockSendEphemeralPost).toHaveBeenCalledWith(
+                serverUrl,
+                message,
+                mockPost.channelId,
+                mockPost.rootId || mockPost.id,
+                mockResponse.app_metadata?.bot_user_id,
+            );
+        });
+
+        it('should post ephemeral response for channel', () => {
+            const result = postEphemeralCallResponseForChannel(serverUrl, mockResponse, message, mockPost.channelId);
+            expect(result).toBeDefined();
+            expect(mockSendEphemeralPost).toHaveBeenCalledWith(
+                serverUrl,
+                message,
+                mockPost.channelId,
+                '',
+                mockResponse.app_metadata?.bot_user_id,
+            );
+        });
+
+        it('should post ephemeral response for context', () => {
+            const result = postEphemeralCallResponseForContext(serverUrl, mockResponse, message, mockContext);
+            expect(result).toBeDefined();
+            expect(mockSendEphemeralPost).toHaveBeenCalledWith(
+                serverUrl,
+                message,
+                mockContext.channel_id,
+                mockContext.root_id || mockContext.post_id,
+                mockResponse.app_metadata?.bot_user_id,
+            );
+        });
+
+        it('should post ephemeral response for command args', () => {
+            const result = postEphemeralCallResponseForCommandArgs(serverUrl, mockResponse, message, mockCommandArgs);
+            expect(result).toBeDefined();
+            expect(mockSendEphemeralPost).toHaveBeenCalledWith(
+                serverUrl,
+                message,
+                mockCommandArgs.channel_id,
+                mockCommandArgs.root_id,
+                mockResponse.app_metadata?.bot_user_id,
+            );
+        });
+
+        it('should handle undefined bot_user_id', () => {
+            const responseWithoutBot = {...mockResponse, app_metadata: undefined};
+            const result = postEphemeralCallResponseForPost(serverUrl, responseWithoutBot, message, mockPost);
+            expect(result).toBeDefined();
+            expect(mockSendEphemeralPost).toHaveBeenCalledWith(
+                serverUrl,
+                message,
+                mockPost.channelId,
+                mockPost.rootId || mockPost.id,
+                undefined,
+            );
+        });
+    });
+
+    describe('error handling', () => {
+        it('should handle null binding', async () => {
+            const emptyBinding = {
+                app_id: 'app1',
+                location: 'location1',
+                label: 'Test Binding',
+            } as AppBinding;
+            const result = await handleBindingClick(serverUrl, emptyBinding, mockContext, mockIntl);
+            expect(result).toBeDefined();
+            expect(result.error).toBeDefined();
+            expect(result.error?.text).toBe('This binding is not properly formed. Contact the App developer.');
+        });
+    });
+});

--- a/app/actions/remote/channel_bookmark.test.ts
+++ b/app/actions/remote/channel_bookmark.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+
+import {fetchChannelBookmarks, createChannelBookmark, editChannelBookmark, deleteChannelBookmark} from './channel_bookmark';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+
+const serverUrl = 'baseHandler.test.com';
+let operator: ServerDataOperator;
+
+const channelId = 'channel1';
+const bookmarkId = 'bookmark1';
+
+const bookmark1: ChannelBookmark = {
+    id: bookmarkId,
+    channel_id: channelId,
+    create_at: 123,
+    update_at: 123,
+    delete_at: 0,
+    owner_id: 'user1',
+    display_name: 'Test Bookmark',
+    link_url: 'http://test.com',
+    emoji: ':test:',
+    sort_order: 0,
+    type: 'link',
+};
+
+const mockClient = {
+    getChannelBookmarksForChannel: jest.fn(() => [bookmark1]),
+    createChannelBookmark: jest.fn(() => bookmark1),
+    updateChannelBookmark: jest.fn(() => ({updated: bookmark1})),
+    deleteChannelBookmark: jest.fn(() => ({deleted: bookmark1})),
+};
+
+beforeAll(() => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    NetworkManager.getClient = () => mockClient;
+});
+
+describe('channel bookmarks', () => {
+    let bookmarkSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+        await operator.handleConfigs({
+            configs: [
+                {id: 'FeatureFlagChannelBookmarks', value: 'true'},
+            ],
+            configsToDelete: [],
+            prepareRecordsOnly: false,
+        });
+        bookmarkSpy = jest.spyOn(operator, 'handleChannelBookmark');
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('fetchChannelBookmarks - handle not found database', async () => {
+        const result = await fetchChannelBookmarks('invalid', channelId) as {error: unknown};
+        expect(result).toBeDefined();
+        expect(result.error).toBeDefined();
+    });
+
+    it('fetchChannelBookmarks - base case', async () => {
+        const result = await fetchChannelBookmarks(serverUrl, channelId);
+        expect(result).toBeDefined();
+        expect(result.bookmarks).toBeDefined();
+        expect(result.bookmarks?.length).toBe(1);
+        expect(result.bookmarks?.[0].id).toBe(bookmark1.id);
+        expect(bookmarkSpy).toHaveBeenCalled();
+    });
+
+    it('fetchChannelBookmarks - fetch only', async () => {
+        const result = await fetchChannelBookmarks(serverUrl, channelId, true);
+        expect(result).toBeDefined();
+        expect(result.bookmarks).toBeDefined();
+        expect(result.bookmarks?.length).toBe(1);
+        expect(result.bookmarks?.[0].id).toBe(bookmark1.id);
+        expect(bookmarkSpy).not.toHaveBeenCalled();
+    });
+
+    it('fetchChannelBookmarks - feature flag disabled', async () => {
+        await operator.handleConfigs({
+            configs: [
+                {id: 'FeatureFlagChannelBookmarks', value: 'false'},
+            ],
+            configsToDelete: [],
+            prepareRecordsOnly: false,
+        });
+        const result = await fetchChannelBookmarks(serverUrl, channelId);
+        expect(result).toBeDefined();
+        expect(result.bookmarks).toBeDefined();
+        expect(result.bookmarks?.length).toBe(0);
+    });
+
+    it('createChannelBookmark - handle not found database', async () => {
+        const result = await createChannelBookmark('invalid', channelId, bookmark1) as {error: unknown};
+        expect(result).toBeDefined();
+        expect(result.error).toBeDefined();
+    });
+
+    it('createChannelBookmark - base case', async () => {
+        const result = await createChannelBookmark(serverUrl, channelId, bookmark1);
+        expect(result).toBeDefined();
+        expect(result.bookmark).toBeDefined();
+        expect(result.bookmark?.id).toBe(bookmark1.id);
+        expect(bookmarkSpy).toHaveBeenCalled();
+    });
+
+    it('createChannelBookmark - fetch only', async () => {
+        const result = await createChannelBookmark(serverUrl, channelId, bookmark1, true);
+        expect(result).toBeDefined();
+        expect(result.bookmark).toBeDefined();
+        expect(result.bookmark?.id).toBe(bookmark1.id);
+        expect(bookmarkSpy).not.toHaveBeenCalled();
+    });
+
+    it('editChannelBookmark - handle not found database', async () => {
+        const result = await editChannelBookmark('invalid', bookmark1) as {error: unknown};
+        expect(result).toBeDefined();
+        expect(result.error).toBeDefined();
+    });
+
+    it('editChannelBookmark - base case', async () => {
+        const result = await editChannelBookmark(serverUrl, bookmark1);
+        expect(result).toBeDefined();
+        expect(result.bookmarks).toBeDefined();
+        expect(result.bookmarks?.updated.id).toBe(bookmark1.id);
+        expect(bookmarkSpy).toHaveBeenCalled();
+    });
+
+    it('editChannelBookmark - fetch only', async () => {
+        const result = await editChannelBookmark(serverUrl, bookmark1, true);
+        expect(result).toBeDefined();
+        expect(result.bookmarks).toBeDefined();
+        expect(result.bookmarks?.updated.id).toBe(bookmark1.id);
+        expect(bookmarkSpy).not.toHaveBeenCalled();
+    });
+
+    it('deleteChannelBookmark - handle not found database', async () => {
+        const result = await deleteChannelBookmark('invalid', channelId, bookmarkId) as {error: unknown};
+        expect(result).toBeDefined();
+        expect(result.error).toBeDefined();
+    });
+
+    it('deleteChannelBookmark - base case', async () => {
+        await operator.handleChannelBookmark({bookmarks: [bookmark1], prepareRecordsOnly: false});
+        const result = await deleteChannelBookmark(serverUrl, channelId, bookmarkId);
+        expect(result).toBeDefined();
+        expect(result.bookmarks).toBeDefined();
+    });
+});

--- a/app/actions/remote/systems.test.ts
+++ b/app/actions/remote/systems.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+
+import {fetchDataRetentionPolicy, fetchConfigAndLicense} from './systems';
+
+const serverUrl = 'baseHandler.test.com';
+
+const globalPolicy = {
+    message_deletion_enabled: true,
+    file_deletion_enabled: true,
+    message_retention_cutoff: 30,
+    file_retention_cutoff: 30,
+};
+
+const teamPolicy = {
+    team_id: 'team1',
+    post_duration: 30,
+};
+
+const channelPolicy = {
+    channel_id: 'channel1',
+    post_duration: 30,
+};
+
+const config = {
+    DiagnosticsEnabled: 'true',
+    EnableDeveloper: 'true',
+} as ClientConfig;
+
+const license = {
+    IsLicensed: 'true',
+    DataRetention: 'true',
+} as ClientLicense;
+
+const mockClient = {
+    getGlobalDataRetentionPolicy: jest.fn(() => globalPolicy),
+    getTeamDataRetentionPolicies: jest.fn(() => ({policies: [teamPolicy], total_count: 1})),
+    getChannelDataRetentionPolicies: jest.fn(() => ({policies: [channelPolicy], total_count: 1})),
+    getClientConfigOld: jest.fn(() => config),
+    getClientLicenseOld: jest.fn(() => license),
+};
+
+jest.mock('@managers/network_manager', () => ({
+    getClient: () => mockClient,
+}));
+
+beforeAll(() => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    NetworkManager.getClient = () => mockClient;
+});
+
+describe('systems', () => {
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('fetchDataRetentionPolicy - handle not found database', async () => {
+        const result = await fetchDataRetentionPolicy('foo') as {error: unknown};
+        expect(result).toBeDefined();
+        expect(result.error).toBeDefined();
+    });
+
+    it('fetchDataRetentionPolicy - base case', async () => {
+        const result = await fetchDataRetentionPolicy(serverUrl);
+        expect(result).toBeDefined();
+        expect(result.globalPolicy).toBeDefined();
+        expect(result.teamPolicies).toBeDefined();
+        expect(result.channelPolicies).toBeDefined();
+        expect(result.globalPolicy).toEqual(globalPolicy);
+        expect(result.teamPolicies).toEqual([teamPolicy]);
+        expect(result.channelPolicies).toEqual([channelPolicy]);
+    });
+
+    it('fetchDataRetentionPolicy - fetch only', async () => {
+        const result = await fetchDataRetentionPolicy(serverUrl, true);
+        expect(result).toBeDefined();
+        expect(result.globalPolicy).toBeDefined();
+        expect(result.teamPolicies).toBeDefined();
+        expect(result.channelPolicies).toBeDefined();
+        expect(result.globalPolicy).toEqual(globalPolicy);
+        expect(result.teamPolicies).toEqual([teamPolicy]);
+        expect(result.channelPolicies).toEqual([channelPolicy]);
+    });
+
+    it('fetchDataRetentionPolicy - error case', async () => {
+        mockClient.getGlobalDataRetentionPolicy.mockImplementationOnce(() => {
+            throw new Error('error');
+        });
+        const result = await fetchDataRetentionPolicy(serverUrl);
+        expect(result).toBeDefined();
+        expect(result.error).toBeDefined();
+    });
+
+    it('fetchConfigAndLicense - base case', async () => {
+        const result = await fetchConfigAndLicense(serverUrl);
+        expect(result).toBeDefined();
+        expect(result.config).toBeDefined();
+        expect(result.license).toBeDefined();
+        expect(result.config).toEqual(config);
+        expect(result.license).toEqual(license);
+    });
+
+    it('fetchConfigAndLicense - fetch only', async () => {
+        const result = await fetchConfigAndLicense(serverUrl, true);
+        expect(result).toBeDefined();
+        expect(result.config).toBeDefined();
+        expect(result.license).toBeDefined();
+        expect(result.config).toEqual(config);
+        expect(result.license).toEqual(license);
+    });
+
+    it('fetchConfigAndLicense - error case', async () => {
+        mockClient.getClientConfigOld.mockImplementationOnce(() => {
+            throw new Error('error');
+        });
+        const result = await fetchConfigAndLicense(serverUrl);
+        expect(result).toBeDefined();
+        expect(result.error).toBeDefined();
+    });
+});

--- a/app/actions/remote/terms_of_service.test.ts
+++ b/app/actions/remote/terms_of_service.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+import {getCurrentUser} from '@queries/servers/user';
+
+import {fetchTermsOfService, updateTermsOfServiceStatus} from './terms_of_service';
+
+const serverUrl = 'terms-of-service.test.com';
+
+const mockTerms: TermsOfService = {
+    create_at: 1234567890,
+    id: 'terms123',
+    text: 'Test Terms of Service',
+    user_id: 'user123',
+};
+
+const mockClient = {
+    getTermsOfService: jest.fn(),
+    updateMyTermsOfServiceStatus: jest.fn(),
+} as any;
+
+jest.mock('@queries/servers/user');
+
+describe('terms_of_service', () => {
+    beforeEach(async () => {
+        NetworkManager.getClient = () => mockClient;
+        await DatabaseManager.init([serverUrl]);
+        jest.clearAllMocks();
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    describe('fetchTermsOfService', () => {
+        it('should fetch terms of service successfully', async () => {
+            mockClient.getTermsOfService.mockResolvedValueOnce(mockTerms);
+
+            const result = await fetchTermsOfService(serverUrl);
+
+            expect(result.terms).toBeDefined();
+            expect(result.terms).toEqual(mockTerms);
+            expect(mockClient.getTermsOfService).toHaveBeenCalledTimes(1);
+        });
+
+        it('should handle fetch error', async () => {
+            const error = new Error('Network error');
+            mockClient.getTermsOfService.mockRejectedValueOnce(error);
+
+            const result = await fetchTermsOfService(serverUrl);
+
+            expect(result.error).toBeDefined();
+            expect(result.terms).toBeUndefined();
+            expect(mockClient.getTermsOfService).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('updateTermsOfServiceStatus', () => {
+        const mockGetCurrentUser = jest.mocked(getCurrentUser);
+        const mockUser = {
+            id: 'user123',
+            prepareUpdate: jest.fn((fn) => fn({})),
+        };
+
+        it('should update terms of service status successfully', async () => {
+            mockGetCurrentUser.mockResolvedValue(mockUser);
+            const termsId = 'terms123';
+            const accepted = true;
+            const mockResponse = {status: 'ok'};
+            mockClient.updateMyTermsOfServiceStatus.mockResolvedValueOnce(mockResponse);
+
+            const result = await updateTermsOfServiceStatus(serverUrl, termsId, accepted);
+
+            expect(result.resp).toEqual(mockResponse);
+            expect(mockClient.updateMyTermsOfServiceStatus).toHaveBeenCalledWith(termsId, accepted);
+            expect(mockUser.prepareUpdate).toHaveBeenCalled();
+        });
+
+        it('should handle update error', async () => {
+            const error = new Error('Network error');
+            mockClient.updateMyTermsOfServiceStatus.mockRejectedValueOnce(error);
+
+            const result = await updateTermsOfServiceStatus(serverUrl, 'terms123', true);
+
+            expect(result.error).toBeDefined();
+            expect(result.resp).toBeUndefined();
+            expect(mockClient.updateMyTermsOfServiceStatus).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/app/actions/remote/terms_of_service.test.ts
+++ b/app/actions/remote/terms_of_service.test.ts
@@ -62,7 +62,7 @@ describe('terms_of_service', () => {
         const mockUser = {
             id: 'user123',
             prepareUpdate: jest.fn((fn) => fn({})),
-        };
+        } as any;
 
         it('should update terms of service status successfully', async () => {
             mockGetCurrentUser.mockResolvedValue(mockUser);


### PR DESCRIPTION
#### Summary

Add tests for channel bookmarks, systems, apps and tos files in remote/actions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59445
https://mattermost.atlassian.net/browse/MM-59435
https://mattermost.atlassian.net/browse/MM-59443

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
