### PR TITLE
[MM-62898] Reset filter when changing team

### DIFF
--- a/app/screens/home/search/search.test.tsx
+++ b/app/screens/home/search/search.test.tsx
@@ -6,9 +6,9 @@ import React from 'react';
 
 import {addSearchToTeamSearchHistory} from '@actions/local/team';
 import {searchPosts, searchFiles} from '@actions/remote/search';
+import {bottomSheet} from '@screens/navigation';
 import {renderWithEverything} from '@test/intl-test-helper';
 import TestHelper from '@test/test_helper';
-import {bottomSheet} from '@screens/navigation';
 
 import SearchScreen from './search';
 
@@ -76,8 +76,10 @@ describe('SearchScreen', () => {
             {database},
         );
         expect(getByTestId('search_messages.screen')).toBeTruthy();
+
         // The page title
-        expect(getByText("Search")).toBeTruthy();
+        expect(getByText('Search')).toBeTruthy();
+
         // The search input with the expected placeholder
         expect(getByPlaceholderText('Search messages & files')).toBeTruthy();
     });

--- a/app/screens/home/search/search.test.tsx
+++ b/app/screens/home/search/search.test.tsx
@@ -1,0 +1,159 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fireEvent, waitFor} from '@testing-library/react-native';
+import React from 'react';
+
+import {addSearchToTeamSearchHistory} from '@actions/local/team';
+import {searchPosts, searchFiles} from '@actions/remote/search';
+import {renderWithEverything} from '@test/intl-test-helper';
+import TestHelper from '@test/test_helper';
+
+import SearchScreen from './search';
+
+import type {TeamModel} from '@database/models/server';
+import type {Database} from '@nozbe/watermelondb';
+
+// Some subcomponents require react-native-camera-roll, which is not available in the test environment
+jest.mock('@react-native-camera-roll/camera-roll', () => ({}));
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+        getState: () => ({
+            index: 0,
+            routes: [{params: {searchTerm: ''}}],
+        }),
+    }),
+    useIsFocused: () => true,
+}));
+
+jest.mock('@actions/local/post', () => ({
+    getPosts: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@actions/local/team', () => ({
+    addSearchToTeamSearchHistory: jest.fn(),
+}));
+
+jest.mock('@actions/remote/search', () => ({
+    searchPosts: jest.fn().mockResolvedValue({order: [], matches: {}}),
+    searchFiles: jest.fn().mockResolvedValue({files: [], channels: []}),
+}));
+
+jest.mock('@mattermost/hardware-keyboard', () => ({
+    useHardwareKeyboardEvents: jest.fn(),
+}));
+
+jest.mock('@screens/navigation', () => ({
+    bottomSheet: jest.fn(),
+}));
+
+describe('SearchScreen', () => {
+    const baseProps = {
+        teamId: 'team1',
+        teams: [
+            {id: 'team1', displayName: 'Team 1'},
+            {id: 'team2', displayName: 'Team 2'},
+        ] as TeamModel[],
+        crossTeamSearchEnabled: true,
+    };
+
+    let database: Database;
+    beforeAll(async () => {
+        const server = await TestHelper.setupServerDatabase();
+        database = server.database;
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders search screen correctly', () => {
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+        expect(getByTestId('search_messages.screen')).toBeTruthy();
+    });
+
+    it('handles search input changes', () => {
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+
+        const searchInput = getByTestId('navigation.header.search_bar.search.input');
+        fireEvent.changeText(searchInput, 'test search');
+        expect(searchInput.props.value).toBe('test search');
+    });
+
+    it('performs search when submitting', async () => {
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+
+        const searchInput = getByTestId('navigation.header.search_bar.search.input');
+        fireEvent.changeText(searchInput, 'test search');
+        fireEvent(searchInput, 'submitEditing');
+
+        await waitFor(() => {
+            expect(searchPosts).toHaveBeenCalledWith(
+                expect.any(String),
+                'team1',
+                expect.objectContaining({
+                    terms: 'test search',
+                }),
+            );
+            expect(searchFiles).toHaveBeenCalled();
+        });
+    });
+
+    it('handles team changes', async () => {
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+
+        const teamPicker = getByTestId('team_picker.button');
+        fireEvent.press(teamPicker);
+
+        expect(teamPicker).toBeTruthy();
+        expect(require('@screens/navigation').bottomSheet).toHaveBeenCalled();
+    });
+
+    it('clears search when clear button is pressed', async () => {
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+
+        const searchInput = getByTestId('navigation.header.search_bar.search.input');
+        fireEvent.changeText(searchInput, 'test search');
+
+        const clearButton = getByTestId('navigation.header.search_bar.search.clear.button');
+        fireEvent.press(clearButton);
+
+        expect(searchInput.props.value).toBe('');
+    });
+
+    it('adds search to team history when searching in a specific team', async () => {
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+
+        const searchInput = getByTestId('navigation.header.search_bar.search.input');
+        fireEvent.changeText(searchInput, 'test search');
+        fireEvent(searchInput, 'submitEditing');
+
+        await waitFor(() => {
+            expect(addSearchToTeamSearchHistory).toHaveBeenCalledWith(
+                expect.any(String),
+                'team1',
+                'test search',
+            );
+        });
+    });
+});

--- a/app/screens/home/search/search.test.tsx
+++ b/app/screens/home/search/search.test.tsx
@@ -8,6 +8,7 @@ import {addSearchToTeamSearchHistory} from '@actions/local/team';
 import {searchPosts, searchFiles} from '@actions/remote/search';
 import {renderWithEverything} from '@test/intl-test-helper';
 import TestHelper from '@test/test_helper';
+import {bottomSheet} from '@screens/navigation';
 
 import SearchScreen from './search';
 
@@ -70,11 +71,15 @@ describe('SearchScreen', () => {
     });
 
     it('renders search screen correctly', () => {
-        const {getByTestId} = renderWithEverything(
+        const {getByTestId, getByText, getByPlaceholderText} = renderWithEverything(
             <SearchScreen {...baseProps}/>,
             {database},
         );
         expect(getByTestId('search_messages.screen')).toBeTruthy();
+        // The page title
+        expect(getByText("Search")).toBeTruthy();
+        // The search input with the expected placeholder
+        expect(getByPlaceholderText('Search messages & files')).toBeTruthy();
     });
 
     it('handles search input changes', () => {
@@ -102,11 +107,13 @@ describe('SearchScreen', () => {
             expect(searchPosts).toHaveBeenCalledWith(
                 expect.any(String),
                 'team1',
-                expect.objectContaining({
-                    terms: 'test search',
-                }),
+                expect.objectContaining({terms: 'test search'}),
             );
-            expect(searchFiles).toHaveBeenCalled();
+            expect(searchFiles).toHaveBeenCalledWith(
+                expect.any(String),
+                'team1',
+                expect.objectContaining({terms: 'test search'}),
+            );
         });
     });
 
@@ -120,7 +127,7 @@ describe('SearchScreen', () => {
         fireEvent.press(teamPicker);
 
         expect(teamPicker).toBeTruthy();
-        expect(require('@screens/navigation').bottomSheet).toHaveBeenCalled();
+        expect(bottomSheet).toHaveBeenCalled();
     });
 
     it('clears search when clear button is pressed', async () => {

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -241,10 +241,27 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
         setResultsLoading(false);
     }, [lastSearchedValue, searchTeamId, serverUrl]);
 
-    const handleResultsTeamChange = useCallback((newTeamId: string) => {
-        setSearchTeamId(newTeamId);
-        handleSearch(newTeamId, lastSearchedValue);
-    }, [lastSearchedValue, handleSearch]);
+    const removeChannelAndUserFiltersFromString = (str: string) => {
+        return str.replace(/(?:from|channel|in):\s?[^\s\n]+/gi, '').trim();
+    };
+
+    const updateSearchTeamId = useCallback(
+        (newTeamId: string) => {
+            setSearchTeamId(newTeamId);
+            setSearchValue(removeChannelAndUserFiltersFromString(searchValue));
+        },
+        [searchValue],
+    );
+
+    const handleResultsTeamChange = useCallback(
+        (newTeamId: string) => {
+            setSearchTeamId(newTeamId);
+            const cleanedSearchValue = removeChannelAndUserFiltersFromString(lastSearchedValue);
+            setSearchValue(cleanedSearchValue);
+            handleSearch(newTeamId, cleanedSearchValue);
+        },
+        [lastSearchedValue, handleSearch],
+    );
 
     const initialContainerStyle: AnimatedStyle<ViewStyle> = useMemo(() => {
         return {
@@ -268,7 +285,7 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
                 setRecentValue={handleRecentSearch}
                 searchRef={searchRef}
                 setSearchValue={handleModifierTextChange}
-                setTeamId={setSearchTeamId}
+                setTeamId={updateSearchTeamId}
                 teamId={searchTeamId}
                 teams={teams}
             />

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -81,6 +81,8 @@ const getSearchParams = (terms: string, filterValue?: FileFilter) => {
 
 const searchScreenIndex = 1;
 
+const CHANNEL_AND_USER_FILTERS_REGEX = /(?:from|channel|in):\s?[^\s\n]+/gi;
+
 const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
     const nav = useNavigation();
     const isFocused = useIsFocused();
@@ -242,26 +244,20 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
     }, [lastSearchedValue, searchTeamId, serverUrl]);
 
     const removeChannelAndUserFiltersFromString = (str: string) => {
-        return str.replace(/(?:from|channel|in):\s?[^\s\n]+/gi, '').trim();
+        return str.replace(CHANNEL_AND_USER_FILTERS_REGEX, '').trim();
     };
 
-    const updateSearchTeamId = useCallback(
-        (newTeamId: string) => {
-            setSearchTeamId(newTeamId);
-            setSearchValue(removeChannelAndUserFiltersFromString(searchValue));
-        },
-        [searchValue],
-    );
+    const updateSearchTeamId = useCallback((newTeamId: string) => {
+        setSearchTeamId(newTeamId);
+        setSearchValue(removeChannelAndUserFiltersFromString(searchValue));
+    }, [searchValue]);
 
-    const handleResultsTeamChange = useCallback(
-        (newTeamId: string) => {
-            setSearchTeamId(newTeamId);
-            const cleanedSearchValue = removeChannelAndUserFiltersFromString(lastSearchedValue);
-            setSearchValue(cleanedSearchValue);
-            handleSearch(newTeamId, cleanedSearchValue);
-        },
-        [lastSearchedValue, handleSearch],
-    );
+    const handleResultsTeamChange = useCallback((newTeamId: string) => {
+        setSearchTeamId(newTeamId);
+        const cleanedSearchValue = removeChannelAndUserFiltersFromString(lastSearchedValue);
+        setSearchValue(cleanedSearchValue);
+        handleSearch(newTeamId, cleanedSearchValue);
+    }, [lastSearchedValue, handleSearch]);
 
     const initialContainerStyle: AnimatedStyle<ViewStyle> = useMemo(() => {
         return {

--- a/ios/Gekidou/Package.resolved
+++ b/ios/Gekidou/Package.resolved
@@ -2,93 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/Kitura/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "cec97c24b111351e70e448972a7d3fe68a756d6d",
-          "version": "2.0.2"
-        }
-      },
-      {
-        "package": "CryptorECC",
-        "repositoryURL": "https://github.com/Kitura/BlueECC.git",
-        "state": {
-          "branch": null,
-          "revision": "1485268a54f8135435a825a855e733f026fa6cc8",
-          "version": "1.2.201"
-        }
-      },
-      {
-        "package": "CryptorRSA",
-        "repositoryURL": "https://github.com/Kitura/BlueRSA.git",
-        "state": {
-          "branch": null,
-          "revision": "4c9464b4a21dd558a9b1f4a4ed603bb67dcbc773",
-          "version": "1.0.202"
-        }
-      },
-      {
-        "package": "KituraContracts",
-        "repositoryURL": "https://github.com/Kitura/KituraContracts.git",
-        "state": {
-          "branch": null,
-          "revision": "8a4778c3aa7833e9e1af884e8819d436c237cd70",
-          "version": "1.2.201"
-        }
-      },
-      {
-        "package": "LoggerAPI",
-        "repositoryURL": "https://github.com/Kitura/LoggerAPI.git",
-        "state": {
-          "branch": null,
-          "revision": "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
-          "version": "1.9.200"
-        }
-      },
-      {
-        "package": "OpenGraph",
-        "repositoryURL": "https://github.com/satoshi-takano/OpenGraph.git",
-        "state": {
-          "branch": null,
-          "revision": "382972f1963580eeabafd88ad012e66576b4d213",
-          "version": "1.4.1"
-        }
-      },
-      {
-        "package": "Sentry",
-        "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
-        "state": {
-          "branch": null,
-          "revision": "56bfb7e723c76614be4c0861ee820ccbaed14c6d",
-          "version": "8.41.0"
-        }
-      },
-      {
         "package": "SQLite.swift",
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "a95fc6df17d108bd99210db5e8a9bac90fe984b8",
-          "version": "0.15.3"
-        }
-      },
-      {
-        "package": "SwiftJWT",
-        "repositoryURL": "https://github.com/Kitura/Swift-JWT.git",
-        "state": {
-          "branch": null,
-          "revision": "47c6384b6923e9bb1f214d2ba4bd52af39440588",
-          "version": "3.6.201"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "9cb486020ebf03bfa5b5df985387a14a98744537",
-          "version": "1.6.1"
+          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
+          "version": "0.13.0"
         }
       }
     ]

--- a/ios/Gekidou/Package.resolved
+++ b/ios/Gekidou/Package.resolved
@@ -2,12 +2,93 @@
   "object": {
     "pins": [
       {
+        "package": "Cryptor",
+        "repositoryURL": "https://github.com/Kitura/BlueCryptor.git",
+        "state": {
+          "branch": null,
+          "revision": "cec97c24b111351e70e448972a7d3fe68a756d6d",
+          "version": "2.0.2"
+        }
+      },
+      {
+        "package": "CryptorECC",
+        "repositoryURL": "https://github.com/Kitura/BlueECC.git",
+        "state": {
+          "branch": null,
+          "revision": "1485268a54f8135435a825a855e733f026fa6cc8",
+          "version": "1.2.201"
+        }
+      },
+      {
+        "package": "CryptorRSA",
+        "repositoryURL": "https://github.com/Kitura/BlueRSA.git",
+        "state": {
+          "branch": null,
+          "revision": "4c9464b4a21dd558a9b1f4a4ed603bb67dcbc773",
+          "version": "1.0.202"
+        }
+      },
+      {
+        "package": "KituraContracts",
+        "repositoryURL": "https://github.com/Kitura/KituraContracts.git",
+        "state": {
+          "branch": null,
+          "revision": "8a4778c3aa7833e9e1af884e8819d436c237cd70",
+          "version": "1.2.201"
+        }
+      },
+      {
+        "package": "LoggerAPI",
+        "repositoryURL": "https://github.com/Kitura/LoggerAPI.git",
+        "state": {
+          "branch": null,
+          "revision": "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
+          "version": "1.9.200"
+        }
+      },
+      {
+        "package": "OpenGraph",
+        "repositoryURL": "https://github.com/satoshi-takano/OpenGraph.git",
+        "state": {
+          "branch": null,
+          "revision": "382972f1963580eeabafd88ad012e66576b4d213",
+          "version": "1.4.1"
+        }
+      },
+      {
+        "package": "Sentry",
+        "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
+        "state": {
+          "branch": null,
+          "revision": "56bfb7e723c76614be4c0861ee820ccbaed14c6d",
+          "version": "8.41.0"
+        }
+      },
+      {
         "package": "SQLite.swift",
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
-          "version": "0.13.0"
+          "revision": "a95fc6df17d108bd99210db5e8a9bac90fe984b8",
+          "version": "0.15.3"
+        }
+      },
+      {
+        "package": "SwiftJWT",
+        "repositoryURL": "https://github.com/Kitura/Swift-JWT.git",
+        "state": {
+          "branch": null,
+          "revision": "47c6384b6923e9bb1f214d2ba4bd52af39440588",
+          "version": "3.6.201"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "9cb486020ebf03bfa5b5df985387a14a98744537",
+          "version": "1.6.1"
         }
       }
     ]


### PR DESCRIPTION
#### Summary
To replicate the webapp behavior, changing team must reset from from:/in: filters.

I added a test for the search page, thanks to Aider, but I couldn't figure out how to test specifically what I changed, because it depends on `bottomsheet` and I couldn't make it work (i had to mock them).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62898

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [x] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: ios and android simulator

#### Screenshots
Playthrough:
- select a modifier `from: [user]`.
- type "error" or any text that'll provide a result
- confirm the search worked to get to the result page.
- change team
- notice the filter has been removed.

https://github.com/user-attachments/assets/175e6186-9eac-46da-95b4-6ba28d4fe019

#### Release Note
```release-note
NONE
```
