### PR TITLE
Pin and bump nokogiri

### DIFF
--- a/fastlane/Gemfile
+++ b/fastlane/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "fastlane"
-gem "nokogiri"
+gem "nokogiri", '~> 1.16.8'
 gem "dotenv"
 
 plugins_path = File.join(File.dirname(__FILE__), '.', 'Pluginfile')

--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -174,11 +174,11 @@ GEM
     nanaimo (0.4.0)
     naturally (2.2.1)
     nkf (0.2.0)
-    nokogiri (1.16.7-arm64-darwin)
+    nokogiri (1.16.8-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-darwin)
+    nokogiri (1.16.8-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.16.8-x86_64-linux)
       racc (~> 1.4)
     optparse (0.6.0)
     os (1.1.4)
@@ -244,7 +244,7 @@ DEPENDENCIES
   fastlane-plugin-android_change_string_app_name
   fastlane-plugin-find_replace_string!
   fastlane-plugin-versioning_android
-  nokogiri
+  nokogiri (~> 1.16.8)
 
 BUNDLED WITH
    2.5.11


### PR DESCRIPTION
#### Summary

- Pin version of nokogiri (and bump from `1.16.7` to `1.16.8`)

#### Ticket Link

NA

#### Checklist

NA

#### Device Information

NA

#### Screenshots

NA

#### Release Note

```release-note
NONE
```
