### PR TITLE
Only fetch bookmarks when the license allows to use them

### DIFF
--- a/app/actions/remote/channel_bookmark.test.ts
+++ b/app/actions/remote/channel_bookmark.test.ts
@@ -54,6 +54,7 @@ describe('channel bookmarks', () => {
             configsToDelete: [],
             prepareRecordsOnly: false,
         });
+        await operator.handleSystem({systems: [{id: 'License', value: {isLicensed: 'true'}}], prepareRecordsOnly: false});
         bookmarkSpy = jest.spyOn(operator, 'handleChannelBookmark');
     });
 
@@ -154,5 +155,14 @@ describe('channel bookmarks', () => {
         const result = await deleteChannelBookmark(serverUrl, channelId, bookmarkId);
         expect(result).toBeDefined();
         expect(result.bookmarks).toBeDefined();
+    });
+
+    it('should not fetch bookmarks if license is not licensed', async () => {
+        await operator.handleSystem({systems: [{id: 'License', value: {isLicensed: 'false'}}], prepareRecordsOnly: false});
+        const result = await fetchChannelBookmarks(serverUrl, channelId);
+        expect(result).toBeDefined();
+        expect(result.bookmarks).toBeDefined();
+        expect(result.bookmarks?.length).toBe(0);
+        expect(mockClient.getChannelBookmarksForChannel).not.toHaveBeenCalled();
     });
 });

--- a/app/actions/remote/channel_bookmark.ts
+++ b/app/actions/remote/channel_bookmark.ts
@@ -5,7 +5,7 @@ import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import websocketManager from '@managers/websocket_manager';
 import {getBookmarksSince, getChannelBookmarkById} from '@queries/servers/channel_bookmark';
-import {getConfigValue} from '@queries/servers/system';
+import {getConfigValue, getLicense} from '@queries/servers/system';
 import {getFullErrorMessage} from '@utils/errors';
 import {logError} from '@utils/log';
 
@@ -17,7 +17,9 @@ export async function fetchChannelBookmarks(serverUrl: string, channelId: string
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
 
         const bookmarksEnabled = (await getConfigValue(database, 'FeatureFlagChannelBookmarks')) === 'true';
-        if (!bookmarksEnabled) {
+        const license = await getLicense(database);
+
+        if (!bookmarksEnabled || license?.IsLicensed !== 'true') {
             return {bookmarks: []};
         }
 


### PR DESCRIPTION
#### Summary
On an unlicensed server, on development, we show errors because the bookmarks functionality is not available without a license.

To avoid these errors, we just check the license before fetching the bookmarks (and we do one less unneeded request).

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
