### PR TITLE
Bump package-lock.json version to 2.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.25.0",
+      "version": "2.26.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {


### PR DESCRIPTION
#### Summary
When we bump versions, all the needed files get their version updated but the package lock. This should be automated, but in the meanwhile we do it manually.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
