### PR TITLE
[MM-62925] introduce websocket client-side ping

### DIFF
--- a/app/client/websocket/index.test.ts
+++ b/app/client/websocket/index.test.ts
@@ -4,9 +4,9 @@
 import {WebSocketReadyState, getOrCreateWebSocketClient} from '@mattermost/react-native-network-client';
 
 import {WebsocketEvents} from '@constants';
-import {enableFakeTimers, disableFakeTimers, advanceTimers} from '@test/timer_helpers';
 import DatabaseManager from '@database/manager';
 import {getConfigValue} from '@queries/servers/system';
+import {enableFakeTimers, disableFakeTimers, advanceTimers} from '@test/timer_helpers';
 import {hasReliableWebsocket} from '@utils/config';
 import {logDebug, logInfo, logError, logWarning} from '@utils/log';
 
@@ -43,7 +43,6 @@ jest.mock('@utils/config', () => ({
 
 const mockedHasReliableWebsocket = jest.mocked(hasReliableWebsocket);
 const mockedGetOrCreateWebSocketClient = jest.mocked(getOrCreateWebSocketClient);
-
 
 describe('WebSocketClient', () => {
     const serverUrl = 'https://example.com';

--- a/app/client/websocket/index.test.ts
+++ b/app/client/websocket/index.test.ts
@@ -165,6 +165,29 @@ describe('WebSocketClient', () => {
         expect(closeCallback).toHaveBeenCalled();
     });
 
+    it('should handle WebSocket close event - reconnect', async () => {
+        enableFakeTimers();
+
+        const closeCallback = jest.fn();
+        client.setCloseCallback(closeCallback);
+
+        const connectingCallback = jest.fn();
+        client.setConnectingCallback(connectingCallback);
+
+        await client.initialize();
+
+        expect(connectingCallback).toHaveBeenCalledTimes(1);
+        expect(closeCallback).toHaveBeenCalledTimes(0);
+
+        mockConn.close();
+
+        await advanceTimers(6000);
+
+        expect(connectingCallback).toHaveBeenCalledTimes(2);
+        expect(closeCallback).toHaveBeenCalledTimes(1);
+        expect(mockConn.readyState).toBe(WebSocketReadyState.OPEN);
+    });
+
     it('should handle WebSocket close event - tls handshake error', async () => {
         await client.initialize();
         const message = {code: 1015, reason: 'tls handshake error'};

--- a/app/client/websocket/index.test.ts
+++ b/app/client/websocket/index.test.ts
@@ -4,6 +4,7 @@
 import {WebSocketReadyState, getOrCreateWebSocketClient} from '@mattermost/react-native-network-client';
 
 import {WebsocketEvents} from '@constants';
+import {enableFakeTimers, disableFakeTimers, advanceTimers} from '@test/timer_helpers';
 import DatabaseManager from '@database/manager';
 import {getConfigValue} from '@queries/servers/system';
 import {hasReliableWebsocket} from '@utils/config';
@@ -43,22 +44,6 @@ jest.mock('@utils/config', () => ({
 const mockedHasReliableWebsocket = jest.mocked(hasReliableWebsocket);
 const mockedGetOrCreateWebSocketClient = jest.mocked(getOrCreateWebSocketClient);
 
-// Helper functions to handle Jest timer issues with async code
-// These are needed because Jest's fake timers don't play well with Promise-based code.
-// The combination of fake timers for time advancement + real timers for nextTick
-// allows us to properly test async timing behavior.
-const enableFakeTimers = () => {
-    jest.useFakeTimers({doNotFake: ['nextTick']});
-};
-
-const disableFakeTimers = () => {
-    jest.useRealTimers();
-};
-
-const advanceTimers = async (ms: number) => {
-    jest.advanceTimersByTime(ms);
-    await new Promise(process.nextTick);
-};
 
 describe('WebSocketClient', () => {
     const serverUrl = 'https://example.com';

--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -15,6 +15,7 @@ const MAX_WEBSOCKET_FAILS = 7;
 const WEBSOCKET_TIMEOUT = toMilliseconds({seconds: 30});
 const MIN_WEBSOCKET_RETRY_TIME = toMilliseconds({seconds: 3});
 const MAX_WEBSOCKET_RETRY_TIME = toMilliseconds({minutes: 5});
+const PING_INTERVAL = toMilliseconds({seconds: 30});
 const DEFAULT_OPTIONS = {
     forceConnection: true,
 };
@@ -29,6 +30,9 @@ export default class WebSocketClient {
     private url = '';
     private serverUrl: string;
     private connectFailCount = 0;
+
+    private pingInterval: NodeJS.Timeout | undefined;
+    private waitingForPong: boolean = false;
 
     // The first time we connect to a server (on init or login)
     // we do the sync out of the websocket lifecycle.
@@ -138,6 +142,7 @@ export default class WebSocketClient {
                 // the websocket will call onClose then onError then initialize again with readyState CLOSED, we need to open it again
                 if (this.conn.readyState === WebSocketReadyState.CLOSED) {
                     clearTimeout(this.connectionTimeout);
+                    clearInterval(this.pingInterval);
                     this.conn.open();
                 }
                 return;
@@ -149,6 +154,7 @@ export default class WebSocketClient {
 
         this.conn!.onOpen(() => {
             clearTimeout(this.connectionTimeout);
+            clearInterval(this.pingInterval);
 
             // No need to reset sequence number here.
             if (!reliableWebSockets) {
@@ -177,11 +183,30 @@ export default class WebSocketClient {
                 }
             }
 
+            this.waitingForPong = false;
+            this.pingInterval = setInterval(
+                () => {
+                    if (!this.waitingForPong) {
+                        this.waitingForPong = true;
+                        this.ping();
+                        return;
+                    }
+
+                    // We are not calling this.close() because we need to auto-restart.
+                    this.responseSequence = 1;
+                    clearInterval(this.pingInterval);
+                    this.conn?.close();
+                },
+                PING_INTERVAL,
+            );
+
             this.connectFailCount = 0;
         });
 
         this.conn!.onClose((ev) => {
             clearTimeout(this.connectionTimeout);
+            clearInterval(this.pingInterval);
+
             this.conn = undefined;
             this.responseSequence = 1;
 
@@ -252,6 +277,9 @@ export default class WebSocketClient {
             if (msg.seq_reply) {
                 if (msg.error) {
                     logWarning(msg);
+                }
+                if (msg.data?.text === WebsocketEvents.PONG) {
+                    this.waitingForPong = false;
                 }
             } else if (this.eventCallback) {
                 if (reliableWebSockets) {
@@ -339,13 +367,26 @@ export default class WebSocketClient {
         this.connectFailCount = 0;
         this.responseSequence = 1;
         clearTimeout(this.connectionTimeout);
+        clearInterval(this.pingInterval);
         this.conn?.close();
     }
 
     public invalidate() {
         clearTimeout(this.connectionTimeout);
+        clearInterval(this.pingInterval);
         this.conn?.invalidate();
         this.conn = undefined;
+    }
+
+    private ping() {
+        const msg = {
+            action: WebsocketEvents.PING,
+            seq: this.responseSequence++,
+        };
+
+        if (this.conn && this.conn.readyState === WebSocketReadyState.OPEN) {
+            this.conn.send(JSON.stringify(msg));
+        }
     }
 
     private sendMessage(action: string, data: any) {

--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -398,9 +398,6 @@ export default class WebSocketClient {
 
         if (this.conn && this.conn.readyState === WebSocketReadyState.OPEN) {
             this.conn.send(JSON.stringify(msg));
-        } else if (!this.conn || this.conn.readyState === WebSocketReadyState.CLOSED) {
-            this.conn = undefined;
-            this.initialize(this.token);
         }
     }
 

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -40,6 +40,8 @@ const WebsocketEvents = {
     PREFERENCES_DELETED: 'preferences_deleted',
     EPHEMERAL_MESSAGE: 'ephemeral_message',
     STATUS_CHANGED: 'status_change',
+    PING: 'ping',
+    PONG: 'pong',
     HELLO: 'hello',
     WEBRTC: 'webrtc',
     REACTION_ADDED: 'reaction_added',

--- a/test/timer_helpers.ts
+++ b/test/timer_helpers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 // Helper functions to handle Jest timer issues with async code
 // These are needed because Jest's fake timers don't play well with Promise-based code.
 // The combination of fake timers for time advancement + real timers for nextTick

--- a/test/timer_helpers.ts
+++ b/test/timer_helpers.ts
@@ -1,0 +1,17 @@
+// Helper functions to handle Jest timer issues with async code
+// These are needed because Jest's fake timers don't play well with Promise-based code.
+// The combination of fake timers for time advancement + real timers for nextTick
+// allows us to properly test async timing behavior.
+
+export const enableFakeTimers = () => {
+    jest.useFakeTimers({doNotFake: ['nextTick']});
+};
+
+export const disableFakeTimers = () => {
+    jest.useRealTimers();
+};
+
+export const advanceTimers = async (ms: number) => {
+    jest.advanceTimersByTime(ms);
+    await new Promise(process.nextTick);
+};


### PR DESCRIPTION
#### Summary
This PR introduces new functionality on the client side to send PING messages over the websocket. If the server doesn't respond within `PING_INTERVAL` (currently 30 seconds), the connection is closed and re-created. This will allow us to find broken connections more quickly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62925

This is related to a similar change in the webapp client: https://github.com/mattermost/mattermost/pull/30293

#### Testing

This change can be manually verified using a `mitmproxy` that intermittently drops websocket messages. This script will drop every other `PONG` message from the server, starting with the first:

```python
import time
from mitmproxy import ctx

class WebSocketDropper:
    def __init__(self):
        self.drop_pong = True

    def websocket_message(self, flow):
        if not "pong" in flow.websocket.messages[-1].content.decode('utf-8'):
            return
        
        if self.drop_pong:
            ctx.log.info("Dropping server PONG response")
            flow.websocket.messages[-1].drop()
            self.drop_pong = False
        else:
            self.drop_pong = True

addons = [WebSocketDropper()]

```

This proxy can be run with:

```sh
mitmproxy --set verbosity=3 -s PATH_TO_MITMPROXY_PYTHON_SCRIPT --listen-port 8080 --mode reverse:http://localhost:8065
```

That will start delivering requests on `localhost:8080` to a local mattermost instance on the default port.

Additionally to get around some CORS checks, the local instance needs to have its base URL set to `http://LOCAL_HOST_IP:8080` in the system console. The mobile app should connect to `http://LOCAL_HOST_IP:8080`.

With everything up and running, you'll see:
- After 30 seconds, the client sends a `PING`, but the server `PONG` message is dropped
- After another 30 seconds, the websocket will be closed and re-opened (since the `PONG` was never received).
- After another 30 seconds, the client will successfully complete a `PING`/`PONG` interaction with the server
- Repeat

#### Checklist
- [X] Added or updated unit tests (required for all new features)
- [X] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Release Note
```release-note
Added a client-side ping to the websocket to detect broken connections more quickly.
```