### PR TITLE
[GH-8636] Prevent Cross-fade out keyboard to fill up view

### DIFF
--- a/app/context/extra_keyboard/index.tsx
+++ b/app/context/extra_keyboard/index.tsx
@@ -109,7 +109,7 @@ export const ExtraKeyboardProvider = (({children}: {children: React.ReactElement
                 hideExtraKeyboard,
                 registerTextInputBlur,
                 registerTextInputFocus,
-                crossFadeIsEnabled
+                crossFadeIsEnabled,
             }}
         >
             {children}
@@ -160,7 +160,7 @@ export const ExtraKeyboard = () => {
 
     useEffect(() => {
         setNativeOpen(nativeHeight > 0);
-    }, [nativeHeight])
+    }, [nativeHeight]);
 
     const maxKeyboardHeight = useDerivedValue(() => {
         if (keyb.state.value === KeyboardState.OPEN) {


### PR DESCRIPTION
#### Summary
Prevent keyboard avoiding space to fill up the view due to `useAnimatedKeyboard` incorrect value.

Both state & height returned by `useAnimatedKeyboard` get corrupted after keyboard close if "Cross-fade transitions" is active - Height is approximately equal to view height ; State is put back to "OPEN".

Also, bug can occur using external keyboard ; Keyboard will open briefly before closing.

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/issues/8636

#### Device Information
This PR was tested on: 
 - iOS 18.3.1 - iPhone 11 Pro Max
 - iOS 18.1.1 - iPhone 15 (Simulator)
 - Android 15 - Medium Phone API 35 (Emulator)

#### Release Note
```release-note
Fix Cross-Fade keyboard failed to close
```
