### PR TITLE
Enforce names for singleton imports

### DIFF
--- a/app/database/manager/__mocks__/index.ts
+++ b/app/database/manager/__mocks__/index.ts
@@ -37,7 +37,7 @@ if (__DEV__) {
     logger.silence();
 }
 
-class DatabaseManager {
+class DatabaseManagerSingleton {
     public appDatabase?: AppDatabase;
     public serverDatabases: ServerDatabases = {};
     private readonly appModels: Models;
@@ -399,4 +399,5 @@ class DatabaseManager {
     };
 }
 
-export default new DatabaseManager();
+const DatabaseManager = new DatabaseManagerSingleton();
+export default DatabaseManager;

--- a/app/database/manager/index.ts
+++ b/app/database/manager/index.ts
@@ -34,7 +34,7 @@ import type {AppDatabase, CreateServerDatabaseArgs, RegisterServerDatabaseArgs, 
 const {SERVERS} = MM_TABLES.APP;
 const APP_DATABASE = 'app';
 
-class DatabaseManager {
+class DatabaseManagerSingleton {
     public appDatabase?: AppDatabase;
     public serverDatabases: ServerDatabases = {};
     private readonly appModels: Models;
@@ -554,4 +554,5 @@ if (!__DEV__) {
     logger.silence();
 }
 
-export default new DatabaseManager();
+const DatabaseManager = new DatabaseManagerSingleton();
+export default DatabaseManager;

--- a/app/init/managed_app.ts
+++ b/app/init/managed_app.ts
@@ -13,7 +13,7 @@ import {getIOSAppGroupDetails} from '@utils/mattermost_managed';
 
 const PROMPT_IN_APP_PIN_CODE_AFTER = toMilliseconds({minutes: 5});
 
-class ManagedApp {
+class ManagedAppSingleton {
     backgroundSince = 0;
     enabled = false;
     inAppPinCode = false;
@@ -199,4 +199,5 @@ class ManagedApp {
     };
 }
 
-export default new ManagedApp();
+const ManagedApp = new ManagedAppSingleton();
+export default ManagedApp;

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -35,7 +35,7 @@ import {isMainActivity, isTablet} from '@utils/helpers';
 import {logDebug, logInfo} from '@utils/log';
 import {convertToNotificationData} from '@utils/notification';
 
-class PushNotifications {
+class PushNotificationsSingleton {
     configured = false;
     subscriptions?: EmitterSubscription[];
 
@@ -333,4 +333,5 @@ class PushNotifications {
     };
 }
 
-export default new PushNotifications();
+const PushNotifications = new PushNotificationsSingleton();
+export default PushNotifications;

--- a/app/managers/apps_manager.test.ts
+++ b/app/managers/apps_manager.test.ts
@@ -9,7 +9,7 @@ import {getChannelById} from '@queries/servers/channel';
 import {getConfig} from '@queries/servers/system';
 import {logDebug} from '@utils/log';
 
-import {AppsManager as AppsManagerClass} from './apps_manager';
+import {AppsManagerSingleton as AppsManagerClass} from './apps_manager';
 
 import type ChannelModel from '@typings/database/models/servers/channel';
 

--- a/app/managers/apps_manager.ts
+++ b/app/managers/apps_manager.ts
@@ -17,7 +17,7 @@ const emptyBindings: AppBinding[] = [];
 
 const normalizeBindings = (bindings: AppBinding[]) => bindings.reduce<AppBinding[]>((acc, v) => (v.bindings ? acc.concat(v.bindings) : acc), []);
 
-export class AppsManager {
+export class AppsManagerSingleton {
     private enabled: {[serverUrl: string]: BehaviorSubject<boolean>} = {};
 
     private bindings: {[serverUrl: string]: BehaviorSubject<AppBinding[]>} = {};
@@ -209,4 +209,5 @@ export class AppsManager {
     };
 }
 
-export default new AppsManager();
+const AppsManager = new AppsManagerSingleton();
+export default AppsManager;

--- a/app/managers/draft_upload_manager/index.test.ts
+++ b/app/managers/draft_upload_manager/index.test.ts
@@ -14,7 +14,7 @@ import {exportedForTesting} from '.';
 import type ServerDataOperator from '@database/operator/server_data_operator';
 import type {ClientResponse, ProgressPromise} from '@mattermost/react-native-network-client';
 
-const {DraftUploadManager} = exportedForTesting;
+const {DraftUploadManagerSingleton} = exportedForTesting;
 
 const url = 'baseHandler.test.com';
 const mockClient = TestHelper.createClient();
@@ -79,7 +79,7 @@ describe('draft upload manager', () => {
     });
 
     it('File is uploaded and stored', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const fileClientId = 'clientId';
@@ -103,7 +103,7 @@ describe('draft upload manager', () => {
     });
 
     it('Progress is not stored on progress, but stored on fail', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const fileClientId = 'clientId';
@@ -158,7 +158,7 @@ describe('draft upload manager', () => {
         const spyNow = jest.spyOn(Date, 'now');
         spyNow.mockImplementation(() => now);
         AppState.currentState = 'active';
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
 
         const progressFunc: {[fileUrl: string] : ((fractionCompleted: number, bytesRead?: number | null | undefined) => void)} = {};
         const cancel = jest.fn();
@@ -255,7 +255,7 @@ describe('draft upload manager', () => {
     });
 
     it('Error on complete: Received wrong response code', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const fileClientId = 'clientId';
@@ -280,7 +280,7 @@ describe('draft upload manager', () => {
     });
 
     it('Error on complete: Received no data', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const clientId = 'clientId';
@@ -304,7 +304,7 @@ describe('draft upload manager', () => {
     });
 
     it('Error on complete: Received no file info', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const clientId = 'clientId';
@@ -328,7 +328,7 @@ describe('draft upload manager', () => {
     });
 
     it('Progress handler', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const clientId = 'clientId';
@@ -369,7 +369,7 @@ describe('draft upload manager', () => {
     });
 
     it('Error handler: normal error', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const clientId = 'clientId';
@@ -405,7 +405,7 @@ describe('draft upload manager', () => {
     });
 
     it('Error handler: complete error', async () => {
-        const manager = new DraftUploadManager();
+        const manager = new DraftUploadManagerSingleton();
         const uploadMocks = mockUpload();
 
         const clientId = 'clientId';

--- a/app/managers/draft_upload_manager/index.ts
+++ b/app/managers/draft_upload_manager/index.ts
@@ -23,7 +23,7 @@ type FileHandler = {
     };
 }
 
-class DraftUploadManager {
+class DraftUploadManagerSingleton {
     private handlers: FileHandler = {};
     private previousAppState: AppStateStatus;
 
@@ -186,8 +186,9 @@ class DraftUploadManager {
     };
 }
 
-export default new DraftUploadManager();
+const DraftUploadManager = new DraftUploadManagerSingleton();
+export default DraftUploadManager;
 
 export const exportedForTesting = {
-    DraftUploadManager,
+    DraftUploadManagerSingleton,
 };

--- a/app/managers/global_event_handler.ts
+++ b/app/managers/global_event_handler.ts
@@ -23,7 +23,7 @@ type LinkingCallbackArg = {url: string};
 
 const splitViewEmitter = new NativeEventEmitter(RNUtils);
 
-class GlobalEventHandler {
+class GlobalEventHandlerSingleton {
     JavascriptAndNativeErrorHandler: jsAndNativeErrorHandler | undefined;
 
     constructor() {
@@ -112,4 +112,5 @@ class GlobalEventHandler {
     };
 }
 
-export default new GlobalEventHandler();
+const GlobalEventHandler = new GlobalEventHandlerSingleton();
+export default GlobalEventHandler;

--- a/app/managers/integrations_manager.ts
+++ b/app/managers/integrations_manager.ts
@@ -61,7 +61,7 @@ class ServerIntegrationsManager {
     }
 }
 
-class IntegrationsManager {
+class IntegrationsManagerSingleton {
     private serverManagers: {[serverUrl: string]: ServerIntegrationsManager | undefined} = {};
     public getManager(serverUrl: string): ServerIntegrationsManager {
         if (!this.serverManagers[serverUrl]) {
@@ -72,4 +72,5 @@ class IntegrationsManager {
     }
 }
 
-export default new IntegrationsManager();
+const IntegrationsManager = new IntegrationsManagerSingleton();
+export default IntegrationsManager;

--- a/app/managers/network_manager.ts
+++ b/app/managers/network_manager.ts
@@ -47,7 +47,7 @@ const messages = defineMessages({
     },
 });
 
-class NetworkManager {
+class NetworkManagerSingleton {
     private clients: Record<string, Client> = {};
 
     private intl = getIntlShape();
@@ -174,4 +174,5 @@ class NetworkManager {
     };
 }
 
-export default new NetworkManager();
+const NetworkManager = new NetworkManagerSingleton();
+export default NetworkManager;

--- a/app/managers/performance_metrics_manager/index.test.ts
+++ b/app/managers/performance_metrics_manager/index.test.ts
@@ -17,7 +17,7 @@ import {getBaseReportRequest} from './test_utils';
 
 import {testExports} from '.';
 
-const PerformanceMetricsManagerClass = testExports.PerformanceMetricsManager;
+const PerformanceMetricsManagerClass = testExports.PerformanceMetricsManagerSingleton;
 const {
     RETRY_TIME,
     MAX_RETRIES,

--- a/app/managers/performance_metrics_manager/index.ts
+++ b/app/managers/performance_metrics_manager/index.ts
@@ -20,7 +20,7 @@ type MetricName = 'mobile_channel_switch' |
 const RETRY_TIME = 100;
 const MAX_RETRIES = 3;
 
-class PerformanceMetricsManager {
+class PerformanceMetricsManagerSingleton {
     private target: Target;
     private batchers: {[serverUrl: string]: Batcher} = {};
     private lastAppStateIsActive = AppState.currentState === 'active';
@@ -136,9 +136,10 @@ class PerformanceMetricsManager {
 }
 
 export const testExports = {
-    PerformanceMetricsManager,
+    PerformanceMetricsManagerSingleton,
     RETRY_TIME,
     MAX_RETRIES,
 };
 
-export default new PerformanceMetricsManager();
+const PerformanceMetricsManager = new PerformanceMetricsManagerSingleton();
+export default PerformanceMetricsManager;

--- a/app/managers/session_manager.test.ts
+++ b/app/managers/session_manager.test.ts
@@ -15,7 +15,7 @@ import WebsocketManager from '@managers/websocket_manager';
 import {deleteFileCache, deleteFileCacheByDir} from '@utils/file';
 import {isMainActivity} from '@utils/helpers';
 
-import {SessionManager as SessionManagerClass} from './session_manager';
+import {SessionManagerSingleton as SessionManagerClass} from './session_manager';
 
 jest.mock('@react-native-cookies/cookies', () => ({
     get: jest.fn(),

--- a/app/managers/session_manager.ts
+++ b/app/managers/session_manager.ts
@@ -31,7 +31,7 @@ type LogoutCallbackArg = {
     removeServer: boolean;
 }
 
-export class SessionManager {
+export class SessionManagerSingleton {
     private previousAppState: AppStateStatus;
     private scheduling = false;
     private terminatingSessionUrl = new Set<string>();
@@ -207,4 +207,5 @@ export class SessionManager {
     };
 }
 
-export default new SessionManager();
+const SessionManager = new SessionManagerSingleton();
+export default SessionManager;

--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -23,7 +23,7 @@ import {logError} from '@utils/log';
 const WAIT_TO_CLOSE = toMilliseconds({seconds: 15});
 const WAIT_UNTIL_NEXT = toMilliseconds({seconds: 5});
 
-class WebsocketManager {
+class WebsocketManagerSingleton {
     private connectedSubjects: {[serverUrl: string]: BehaviorSubject<WebsocketConnectedState>} = {};
 
     private clients: Record<string, WebSocketClient> = {};
@@ -292,4 +292,5 @@ class WebsocketManager {
     };
 }
 
-export default new WebsocketManager();
+const WebsocketManager = new WebsocketManagerSingleton();
+export default WebsocketManager;

--- a/app/store/ephemeral_store.ts
+++ b/app/store/ephemeral_store.ts
@@ -9,7 +9,7 @@ import {toMilliseconds} from '@utils/datetime';
 
 const TIME_TO_CLEAR_WEBSOCKET_ACTIONS = toMilliseconds({seconds: 30});
 
-class EphemeralStore {
+class EphemeralStoreSingleton {
     theme: Theme | undefined;
     creatingChannel = false;
     creatingDMorGMTeammates: string[] = [];
@@ -281,4 +281,5 @@ class EphemeralStore {
     };
 }
 
-export default new EphemeralStore();
+const EphemeralStore = new EphemeralStoreSingleton();
+export default EphemeralStore;

--- a/app/store/navigation_store.ts
+++ b/app/store/navigation_store.ts
@@ -5,7 +5,7 @@ import {BehaviorSubject} from 'rxjs';
 
 import type {AvailableScreens} from '@typings/screens/navigation';
 
-class NavigationStore {
+class NavigationStoreSingleton {
     private screensInStack: AvailableScreens[] = [];
     private modalsInStack: AvailableScreens[] = [];
     private visibleTab = 'Home';
@@ -144,4 +144,5 @@ class NavigationStore {
     };
 }
 
-export default new NavigationStore();
+const NavigationStore = new NavigationStoreSingleton();
+export default NavigationStore;

--- a/app/utils/error_handling.ts
+++ b/app/utils/error_handling.ts
@@ -15,7 +15,7 @@ import {
 
 import {logWarning} from './log';
 
-class JavascriptAndNativeErrorHandler {
+class JavascriptAndNativeErrorHandlerSingleton {
     initializeErrorHandling = () => {
         initializeSentry();
         setJSExceptionHandler(this.errorHandler, false);
@@ -61,4 +61,5 @@ class JavascriptAndNativeErrorHandler {
     };
 }
 
-export default new JavascriptAndNativeErrorHandler();
+const JavascriptAndNativeErrorHandler = new JavascriptAndNativeErrorHandlerSingleton();
+export default JavascriptAndNativeErrorHandler;

--- a/test/test_helper.ts
+++ b/test/test_helper.ts
@@ -21,7 +21,7 @@ import type {APIClientInterface} from '@mattermost/react-native-network-client';
 
 const DEFAULT_LOCALE = 'en';
 
-class TestHelper {
+class TestHelperSingleton {
     basicClient: Client | null;
     basicUser: UserProfile | null;
     basicTeam: Team | null;
@@ -733,4 +733,5 @@ class TestHelper {
     tick = () => new Promise((r) => setImmediate(r));
 }
 
-export default new TestHelper();
+const TestHelper = new TestHelperSingleton();
+export default TestHelper;


### PR DESCRIPTION
#### Summary
The singletons we use, when we try to import them, the IDE automatically set the file name, instead of the name of the class (e.g. `test_helper` vs. `TestHelper`.

This is due to the variable returned in the default not having a name. This is solved by changing the name of the class, and storing the new object in a constant before exporting it.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
