### PR TITLE
Better handle threads sync

### DIFF
--- a/app/actions/remote/thread.ts
+++ b/app/actions/remote/thread.ts
@@ -259,7 +259,7 @@ export const fetchThreads = async (
             threadsData.push(...threads);
 
             if (threads.length === perPage && (pages == null || currentPage < pages!)) {
-                const newOptions: FetchThreadsOptions = {perPage, deleted, unread};
+                const newOptions: FetchThreadsOptions = {perPage, deleted, unread, since};
                 if (fetchDirection === Direction.Down) {
                     const last = threads[threads.length - 1];
                     newOptions.before = last.id;
@@ -385,7 +385,7 @@ export const syncTeamThreads = async (
                 // We are fetching the threads for the first time. We get "latest" and "earliest" values.
                 // At this point we may receive threads without replies, so we also check the post.create_at timestamp.
                 const {earliestThread, latestThread} = getThreadsListEdges(latestThreads.threads);
-                syncDataUpdate.latest = latestThread.last_reply_at || latestThread.post.create_at;
+                syncDataUpdate.latest = Math.max(latestThread.last_viewed_at || latestThread.last_reply_at || latestThread.post.create_at);
                 syncDataUpdate.earliest = earliestThread.last_reply_at || earliestThread.post.create_at;
 
                 threads.push(...latestThreads.threads);
@@ -409,8 +409,8 @@ export const syncTeamThreads = async (
                     serverUrl,
                     teamId,
                     {deleted: true, since: refresh ? undefined : syncData.latest + 1, excludeDirect},
+                    Direction.Down,
                     undefined,
-                    1,
                     groupLabel,
                 ),
             ]);
@@ -421,7 +421,7 @@ export const syncTeamThreads = async (
             if (allNewThreads.threads?.length) {
                 // As we are syncing, we get all new threads and we will update the "latest" value.
                 const {latestThread} = getThreadsListEdges(allNewThreads.threads);
-                const latestDate = latestThread.last_reply_at || latestThread.post.create_at;
+                const latestDate = Math.max(latestThread.last_reply_at, latestThread.last_viewed_at, latestThread.post.create_at);
                 syncDataUpdate.latest = Math.max(syncData.latest, latestDate);
 
                 threads.push(...allNewThreads.threads);

--- a/app/actions/remote/thread.ts
+++ b/app/actions/remote/thread.ts
@@ -385,7 +385,7 @@ export const syncTeamThreads = async (
                 // We are fetching the threads for the first time. We get "latest" and "earliest" values.
                 // At this point we may receive threads without replies, so we also check the post.create_at timestamp.
                 const {earliestThread, latestThread} = getThreadsListEdges(latestThreads.threads);
-                syncDataUpdate.latest = Math.max(latestThread.last_viewed_at || latestThread.last_reply_at || latestThread.post.create_at);
+                syncDataUpdate.latest = Math.max(latestThread.last_viewed_at, latestThread.last_reply_at, latestThread.post.create_at);
                 syncDataUpdate.earliest = earliestThread.last_reply_at || earliestThread.post.create_at;
 
                 threads.push(...latestThreads.threads);

--- a/app/utils/thread/index.ts
+++ b/app/utils/thread/index.ts
@@ -35,8 +35,8 @@ export function processIsCRTEnabled(preferences: PreferenceModel[]|PreferenceTyp
 export const getThreadsListEdges = (threads: Thread[]) => {
     // Sort a clone of 'threads' array by last_reply_at
     const sortedThreads = [...threads].sort((a, b) => {
-        const aDate = a.last_reply_at || a.post.create_at;
-        const bDate = b.last_reply_at || b.post.create_at;
+        const aDate = Math.max(a.last_reply_at, a.last_viewed_at, a.post.create_at);
+        const bDate = Math.max(b.last_reply_at, b.last_viewed_at, b.post.create_at);
         return aDate - bDate;
     });
 


### PR DESCRIPTION
#### Summary
This improve the handling of threads, to fix an issue where read threads were not marked as such.

The fixes are the following:
- Set the correct direction so the pagination is done as it should
- Remove the limit of pages, since we want to get all the changes since the last time we synced.
- Take into account the `last_viewed_at` for calculations on "which one is the latest thread I have".

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-63211

#### Release Note
```release-note
Fix some threads not getting marked as read when read from a different device.
```
