### PR TITLE
Do not use extra keyboard on Android

### DIFF
--- a/app/components/post_draft/post_draft.tsx
+++ b/app/components/post_draft/post_draft.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useEffect, useState} from 'react';
+import {Platform} from 'react-native';
 
 import Autocomplete from '@components/autocomplete';
 import {ExtraKeyboard} from '@context/extra_keyboard';
@@ -122,7 +123,7 @@ function PostDraft({
         <>
             {draftHandler}
             {autoComplete}
-            <ExtraKeyboard/>
+            {Platform.OS !== 'android' && <ExtraKeyboard/>}
         </>
     );
 }


### PR DESCRIPTION
#### Summary
This PR removes (for now) the use of ExtraKeyboard on Android.

The reason for this is that:
1. We are not really using that area for other components at the moment.
2. React Native does not report keyboardDidShow and KeyboardDidHide on Android 10 and below if the `windowSoftInputMode` is set as `adjustNothing`
3. [useAnimatedKeyboard](https://docs.swmansion.com/react-native-reanimated/docs/device/useAnimatedKeyboard) modifies the Android screen and had an issue where it did not update the values in certain scenarios like when switching from one channel to another keeping the same screen (ex: tap on a channel link) while the keyboard was opened.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62855

#### Release Note
```release-note
Fixes a blank space between the content an the keyboard on Android
```