### PR TITLE
Fix more messages indicator on read only channels

### DIFF
--- a/app/components/post_draft/read_only/index.tsx
+++ b/app/components/post_draft/read_only/index.tsx
@@ -15,6 +15,9 @@ interface ReadOnlyProps {
 }
 
 const getStyle = makeStyleSheetFromTheme((theme: Theme) => ({
+    wrapper: {
+        backgroundColor: theme.centerChannelBg,
+    },
     background: {
         backgroundColor: changeOpacity(theme.centerChannelColor, 0.04),
     },
@@ -46,26 +49,28 @@ const ReadOnlyChannnel = ({testID}: ReadOnlyProps) => {
     const theme = useTheme();
     const style = getStyle(theme);
     return (
-        <SafeAreaView
-            edges={edges}
-            style={style.background}
-        >
-            <View
-                testID={testID}
-                style={style.container}
+        <View style={style.wrapper}>
+            <SafeAreaView
+                edges={edges}
+                style={style.background}
             >
-                <CompassIcon
-                    name='glasses'
-                    style={style.icon}
-                    color={theme.centerChannelColor}
-                />
-                <FormattedText
-                    id='mobile.create_post.read_only'
-                    defaultMessage='This channel is read-only.'
-                    style={style.text}
-                />
-            </View>
-        </SafeAreaView>
+                <View
+                    testID={testID}
+                    style={style.container}
+                >
+                    <CompassIcon
+                        name='glasses'
+                        style={style.icon}
+                        color={theme.centerChannelColor}
+                    />
+                    <FormattedText
+                        id='mobile.create_post.read_only'
+                        defaultMessage='This channel is read-only.'
+                        style={style.text}
+                    />
+                </View>
+            </SafeAreaView>
+        </View>
     );
 };
 


### PR DESCRIPTION
#### Summary
When a channel is read only, the arrow indicator that there are more messages to read below was showing on top of the read only channel element (broken window) when in fact it should be hidden

#### Ticket Link
TBD

#### Checklist
- [x] Has UI changes

#### Screenshots
| Before | After |
| :-----: | :----: |
| ![image](https://github.com/user-attachments/assets/669c927c-b45b-47bf-bd39-cb99383d604b) | ![image](https://github.com/user-attachments/assets/e84adb51-db75-49e0-9af7-4c87f295ee5e) |

#### Release Note
```release-note
NONE
```