### PR TITLE
chore(deps-dev): skip to explicitly install Bundler 2.5

### DIFF
--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -11,11 +11,6 @@ function cocoapods() {
 }
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  if !(gem list bundler -i --version 2.5.11) > /dev/null 2>&1; then
-    echo "Installing Bundler"
-    gem install bundler --version 2.5.11  || exit 1
-  fi
-
   if !(gem list cocoapods -i --version 1.16.1) > /dev/null 2>&1; then
     cocoapods
   fi


### PR DESCRIPTION
#### Summary

Since Ruby 2.6, released in 2018, Bundler has been included in the Ruby standard library. So, we don't need to install Bundler explicitly. The latest minor version can be used with the latest Ruby version.

#### Ticket Link

n/a

#### Checklist

- [n/a] Added or updated unit tests (required for all new features)
- [n/a] Has UI changes
- [n/a] Includes text changes and localization file updates
- [n/a] Have tested against the 5 core themes to ensure consistency between them.
- [n/a] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information

n/a

#### Screenshots

n/a

#### Release Note

```release-note
NONE
```