### PR TITLE
fix keyboard blocking input on mentions notifications settings

### DIFF
--- a/app/screens/settings/notification_mention/mention_settings.tsx
+++ b/app/screens/settings/notification_mention/mention_settings.tsx
@@ -4,6 +4,7 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {Text} from 'react-native';
+import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 
 import {updateMe} from '@actions/remote/user';
 import FloatingTextChipsInput from '@components/floating_text_chips_input';
@@ -34,6 +35,7 @@ const COMMA_KEY = ',';
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
+        flex: {flex: 1},
         input: {
             color: theme.centerChannelColor,
             paddingHorizontal: 15,
@@ -166,15 +168,8 @@ const MentionSettings = ({componentId, currentUser, isCRTEnabled}: Props) => {
 
         close();
     }, [
-        channelMentionOn,
-        firstNameMentionOn,
-        usernameMentionOn,
-        mentionKeywords,
-        notifyProps,
-        mentionProps,
-        replyNotificationType,
-        serverUrl,
-        currentUser,
+        currentUser, channelMentionOn, replyNotificationType, firstNameMentionOn,
+        usernameMentionOn, mentionKeywords, mentionProps, close, notifyProps, serverUrl,
     ]);
 
     const handleFirstNameToggle = useCallback(() => {
@@ -226,7 +221,16 @@ const MentionSettings = ({componentId, currentUser, isCRTEnabled}: Props) => {
     useAndroidHardwareBackHandler(componentId, saveMention);
 
     return (
-        <>
+        <KeyboardAwareScrollView
+            bounces={false}
+            enableAutomaticScroll={true}
+            enableOnAndroid={true}
+            keyboardShouldPersistTaps='handled'
+            keyboardDismissMode='none'
+            scrollToOverflowEnabled={true}
+            noPaddingBottomOnAndroid={true}
+            style={styles.flex}
+        >
             <SettingBlock
                 headerText={mentionHeaderText}
             >
@@ -303,7 +307,7 @@ const MentionSettings = ({componentId, currentUser, isCRTEnabled}: Props) => {
                     setReplyNotificationType={setReplyNotificationType}
                 />
             )}
-        </>
+        </KeyboardAwareScrollView>
     );
 };
 


### PR DESCRIPTION
#### Summary
Add KeyboardAwareScrollView to Settings -> Notifications -> Mentions to avoid the keyboard from blocking the text input if the input grows when there are many keywords listed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63395

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: Android & iOS

#### Release Note
```release-note
NONE
```
