### PR TITLE
Handling 2 API for scheduled post (createPost and deleteScheduledPost)

### DIFF
--- a/app/actions/local/scheduled_post.test.ts
+++ b/app/actions/local/scheduled_post.test.ts
@@ -4,7 +4,7 @@
 import {ActionType} from '@constants';
 import DatabaseManager from '@database/manager';
 
-import {handleScheduledPosts} from './scheduled_post';
+import {handleScheduledPosts, handleUpdateScheduledPostErrorCode} from './scheduled_post';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 
@@ -116,5 +116,39 @@ describe('handleScheduledPosts', () => {
     it('handleScheduledPosts - should return undefined if no scheduled post', async () => {
         const {models} = await handleScheduledPosts(serverUrl, ActionType.SCHEDULED_POSTS.CREATE_OR_UPDATED_SCHEDULED_POST, []);
         expect(models).toBeUndefined();
+    });
+});
+
+describe('handleUpdateScheduledPostErrorCode', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should update scheduled post error code successfully', async () => {
+        await handleScheduledPosts(
+            serverUrl,
+            ActionType.SCHEDULED_POSTS.CREATE_OR_UPDATED_SCHEDULED_POST,
+            scheduledPosts,
+            false,
+        );
+
+        const scheduledPostId = scheduledPosts[0].id;
+        const errorCode = 'channel_not_found';
+
+        const result = await handleUpdateScheduledPostErrorCode(serverUrl, scheduledPostId, errorCode);
+
+        expect(result).toBeDefined();
+        expect(result.models).toBeDefined();
+    });
+
+    it('should handle errors when updating scheduled post error code', async () => {
+        const scheduledPostId = 'post123';
+        const errorCode = 'channel_not_found';
+
+        const invalidServerUrl = 'foo';
+        const result = await handleUpdateScheduledPostErrorCode(invalidServerUrl, scheduledPostId, errorCode);
+
+        expect(result.error).toBeDefined();
+        expect(result.error.message).toBe('foo database not found');
     });
 });

--- a/app/actions/local/scheduled_post.test.ts
+++ b/app/actions/local/scheduled_post.test.ts
@@ -139,6 +139,7 @@ describe('handleUpdateScheduledPostErrorCode', () => {
 
         expect(result).toBeDefined();
         expect(result.models).toBeDefined();
+        expect(result.models![0].errorCode).toBe(errorCode);
     });
 
     it('should handle errors when updating scheduled post error code', async () => {

--- a/app/actions/local/scheduled_post.ts
+++ b/app/actions/local/scheduled_post.ts
@@ -5,6 +5,8 @@ import DatabaseManager from '@database/manager';
 import ScheduledPostModel from '@typings/database/models/servers/scheduled_post';
 import {logError} from '@utils/log';
 
+import type {ScheduledPostErrorCode} from '@utils/scheduled_post';
+
 export async function handleScheduledPosts(serverUrl: string, actionType: string, scheduledPosts: ScheduledPost[], prepareRecordsOnly = false): Promise<{models?: ScheduledPostModel[]; error?: any}> {
     if (!scheduledPosts.length) {
         return {models: undefined};
@@ -16,6 +18,17 @@ export async function handleScheduledPosts(serverUrl: string, actionType: string
         return {models};
     } catch (error) {
         logError('handleScheduledPosts cannot handle scheduled post websocket event', error);
+        return {error};
+    }
+}
+
+export async function handleUpdateScheduledPostErrorCode(serverUrl: string, scheduledPostId: string, errorCode: ScheduledPostErrorCode, prepareRecordsOnly = false): Promise<{models?: ScheduledPostModel; error?: any}> {
+    try {
+        const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const models = await operator.handleUpdateScheduledPostErrorCode({scheduledPostId, errorCode, prepareRecordsOnly});
+        return {models};
+    } catch (error) {
+        logError('handleUpdateScheduledPostErrorCode cannot update scheduled post error code', error);
         return {error};
     }
 }

--- a/app/actions/local/scheduled_post.ts
+++ b/app/actions/local/scheduled_post.ts
@@ -22,10 +22,10 @@ export async function handleScheduledPosts(serverUrl: string, actionType: string
     }
 }
 
-export async function handleUpdateScheduledPostErrorCode(serverUrl: string, scheduledPostId: string, errorCode: ScheduledPostErrorCode, prepareRecordsOnly = false): Promise<{models?: ScheduledPostModel; error?: any}> {
+export async function handleUpdateScheduledPostErrorCode(serverUrl: string, scheduledPostId: string, errorCode: ScheduledPostErrorCode, prepareRecordsOnly = false): Promise<{models?: ScheduledPostModel[]; error?: any}> {
     try {
         const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const models = await operator.handleUpdateScheduledPostErrorCode({scheduledPostId, errorCode, prepareRecordsOnly});
+        const models = [await operator.handleUpdateScheduledPostErrorCode({scheduledPostId, errorCode, prepareRecordsOnly})];
         return {models};
     } catch (error) {
         logError('handleUpdateScheduledPostErrorCode cannot update scheduled post error code', error);

--- a/app/components/draft_scheduled_post/draft_scheduled_post.tsx
+++ b/app/components/draft_scheduled_post/draft_scheduled_post.tsx
@@ -12,9 +12,8 @@ import Header from '@components/post_draft/draft_input/header';
 import {Screens} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
-import {useIsTablet} from '@hooks/device';
 import {DRAFT_OPTIONS_BUTTON} from '@screens/draft_scheduled_post_options';
-import {DRAFT_TYPE_SCHEDULED, type DraftType} from '@screens/global_drafts/constants';
+import {DRAFT_TYPE_DRAFT, DRAFT_TYPE_SCHEDULED, type DraftType} from '@screens/global_drafts/constants';
 import {openAsBottomSheet} from '@screens/navigation';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
@@ -77,13 +76,17 @@ const DraftAndScheduledPost: React.FC<Props> = ({
     const intl = useIntl();
     const theme = useTheme();
     const style = getStyleSheet(theme);
-    const isTablet = useIsTablet();
     const serverUrl = useServerUrl();
     const showPostPriority = Boolean(isPostPriorityEnabled && post.metadata?.priority && post.metadata?.priority?.priority);
 
     const onLongPress = useCallback(() => {
         Keyboard.dismiss();
-        const title = isTablet ? intl.formatMessage({id: 'draft.options.title', defaultMessage: 'Draft Options'}) : 'Draft Options';
+        let title;
+        if (draftType === DRAFT_TYPE_DRAFT) {
+            title = intl.formatMessage({id: 'draft.options.title', defaultMessage: 'Draft Options'});
+        } else {
+            title = intl.formatMessage({id: 'scheduled_post.options.title', defaultMessage: 'Message actions'});
+        }
         openAsBottomSheet({
             closeButtonId: DRAFT_OPTIONS_BUTTON,
             screen: Screens.DRAFT_SCHEDULED_POST_OPTIONS,
@@ -91,7 +94,7 @@ const DraftAndScheduledPost: React.FC<Props> = ({
             title,
             props: {channel, rootId: post.rootId, draftType, draft: post, draftReceiverUserName: postReceiverUser?.username},
         });
-    }, [isTablet, intl, draftType, theme, channel, post, postReceiverUser?.username]);
+    }, [intl, draftType, theme, channel, post, postReceiverUser?.username]);
 
     const onPress = useCallback(() => {
         if (post.rootId) {

--- a/app/database/operator/server_data_operator/handlers/post.test.ts
+++ b/app/database/operator/server_data_operator/handlers/post.test.ts
@@ -11,6 +11,7 @@ import {buildDraftKey} from '@database/operator/server_data_operator/comparators
 import {transformDraftRecord, transformPostsInChannelRecord} from '@database/operator/server_data_operator/transformers/post';
 import {createPostsChain} from '@database/operator/utils/post';
 import * as ScheduledPostQueries from '@queries/servers/scheduled_post';
+import {logWarning} from '@utils/log';
 
 import {shouldUpdateScheduledPostRecord} from '../comparators/scheduled_post';
 
@@ -23,6 +24,10 @@ import type ScheduledPostModel from '@typings/database/models/servers/scheduled_
 Q.sortBy = jest.fn().mockImplementation((field) => {
     return Q.where(field, Q.gte(0));
 });
+
+jest.mock('@utils/log', () => ({
+    logWarning: jest.fn(),
+}));
 describe('*** Operator: Post Handlers tests ***', () => {
     let operator: ServerDataOperator;
     let database: Database;
@@ -691,7 +696,6 @@ describe('*** Operator: Post Handlers tests ***', () => {
 
     it('HandleUpdateScheduledPostErrorCode: should return null when post is not found', async () => {
         const errorCode = 'ERROR_CODE_TEST';
-        const logWarningSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
         jest.spyOn(database, 'get').mockReturnValue({
             find: jest.fn().mockReturnValue(null),
@@ -704,7 +708,7 @@ describe('*** Operator: Post Handlers tests ***', () => {
         });
 
         expect(result).toBeNull();
-        expect(logWarningSpy).toHaveBeenCalled();
+        expect(logWarning).toHaveBeenCalled();
     });
 
     it('=> HandlePosts: should not remove files if file ids are present but metadata is missing', async () => {

--- a/app/database/operator/server_data_operator/handlers/post.test.ts
+++ b/app/database/operator/server_data_operator/handlers/post.test.ts
@@ -657,6 +657,56 @@ describe('*** Operator: Post Handlers tests ***', () => {
         expect(spyOnBatchRecords).toHaveBeenCalledWith(scheduledPosts, 'handleScheduledPosts');
     });
 
+    it('HandleUpdateScheduledPostErrorCode: should update error code for a scheduled post', async () => {
+        // First create a scheduled post
+        await operator.handleScheduledPosts({
+            actionType: ActionType.SCHEDULED_POSTS.CREATE_OR_UPDATED_SCHEDULED_POST,
+            scheduledPosts: [scheduledPosts[0]],
+            prepareRecordsOnly: false,
+        });
+
+        const errorCode = 'ERROR_CODE_TEST';
+        const spyOnBatchRecords = jest.spyOn(operator, 'batchRecords');
+
+        // Update the error code
+        const updatedPost = await operator.handleUpdateScheduledPostErrorCode({
+            scheduledPostId: scheduledPosts[0].id,
+            errorCode,
+            prepareRecordsOnly: false,
+        });
+
+        expect(updatedPost).toBeTruthy();
+        expect(updatedPost?.id).toBe(scheduledPosts[0].id);
+        expect(updatedPost?.errorCode).toBe(errorCode);
+        expect(spyOnBatchRecords).toHaveBeenCalledWith([updatedPost], 'handleScheduledPostErrorCode');
+
+        // Verify the post was updated in the database
+        const scheduledPost = await operator.database.get('ScheduledPost').query(
+            Q.where('id', scheduledPosts[0].id),
+        ).fetch() as ScheduledPostModel[];
+
+        expect(scheduledPost.length).toBe(1);
+        expect(scheduledPost[0].errorCode).toBe(errorCode);
+    });
+
+    it('HandleUpdateScheduledPostErrorCode: should return null when post is not found', async () => {
+        const errorCode = 'ERROR_CODE_TEST';
+        const logWarningSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        jest.spyOn(database, 'get').mockReturnValue({
+            find: jest.fn().mockReturnValue(null),
+        } as any);
+
+        const result = await operator.handleUpdateScheduledPostErrorCode({
+            scheduledPostId: 'non_existent_id',
+            errorCode,
+            prepareRecordsOnly: false,
+        });
+
+        expect(result).toBeNull();
+        expect(logWarningSpy).toHaveBeenCalled();
+    });
+
     it('=> HandlePosts: should not remove files if file ids are present but metadata is missing', async () => {
         const postWithMetadata = posts[0];
         const uploadedFiles = postWithMetadata.metadata.files!;

--- a/app/database/operator/server_data_operator/handlers/post.ts
+++ b/app/database/operator/server_data_operator/handlers/post.ts
@@ -167,7 +167,7 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
         return batch;
     };
 
-    handleUpdateScheduledPostErrorCode = async ({scheduledPostId, errorCode, prepareRecordsOnly}: HandleScheduledPostErrorCodeArgs): Promise<ScheduledPostModel | null> => {
+    handleUpdateScheduledPostErrorCode = async ({scheduledPostId, errorCode, prepareRecordsOnly}: HandleScheduledPostErrorCodeArgs) => {
         const database: Database = this.database;
         const scheduledPost = await database.get<ScheduledPostModel>(SCHEDULED_POST).find(scheduledPostId);
 
@@ -180,7 +180,7 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
 
         const updatedScheduledPost = scheduledPost.prepareUpdate((record) => {
             record.errorCode = errorCode;
-            record.updateAt = scheduledPost.updateAt; // We don't want to update the updateAt field
+            record.updateAt = scheduledPost.updateAt; // We don't want to update the updateAt field as prepareUpdate will do it is not set
         });
 
         if (!prepareRecordsOnly) {

--- a/app/database/operator/server_data_operator/transformers/post.ts
+++ b/app/database/operator/server_data_operator/transformers/post.ts
@@ -179,7 +179,7 @@ export const transformSchedulePostsRecord = ({action, database, value}: Transfor
         scheduledPost.createAt = raw.create_at;
         scheduledPost.scheduledAt = raw.scheduled_at;
         scheduledPost.processedAt = raw.processed_at ?? 0;
-        scheduledPost.errorCode = raw.error_code ?? '';
+        scheduledPost.errorCode = raw.error_code || scheduledPost.errorCode;
     };
 
     return prepareBaseRecord({

--- a/app/queries/servers/scheduled_post.ts
+++ b/app/queries/servers/scheduled_post.ts
@@ -24,7 +24,7 @@ export const queryScheduledPostsForTeam = (database: Database, teamId: string, i
 };
 
 export const observeScheduledPostsForTeam = (database: Database, teamId: string, includeDirectChannelPosts?: boolean) => {
-    return queryScheduledPostsForTeam(database, teamId, includeDirectChannelPosts).observeWithColumns(['update_at']);
+    return queryScheduledPostsForTeam(database, teamId, includeDirectChannelPosts).observeWithColumns(['update_at', 'error_code']);
 };
 
 export const observeScheduledPostCount = (database: Database, teamId: string, includeDirectChannelPosts?: boolean) => {

--- a/app/screens/draft_scheduled_post_options/send_draft.test.tsx
+++ b/app/screens/draft_scheduled_post_options/send_draft.test.tsx
@@ -3,12 +3,22 @@
 
 import React from 'react';
 
+import {handleUpdateScheduledPostErrorCode} from '@actions/local/scheduled_post';
+import {createPost} from '@actions/remote/post';
+import {deleteScheduledPost} from '@actions/remote/scheduled_post';
 import {General, Screens} from '@constants';
 import {DRAFT_TYPE_DRAFT, DRAFT_TYPE_SCHEDULED} from '@screens/global_drafts/constants';
 import {dismissBottomSheet} from '@screens/navigation';
-import {fireEvent, renderWithIntlAndTheme} from '@test/intl-test-helper';
+import {act, fireEvent, renderWithEverything, renderWithIntlAndTheme} from '@test/intl-test-helper';
+import TestHelper from '@test/test_helper';
+import {sendMessageWithAlert} from '@utils/post';
+import {showSnackBar} from '@utils/snack_bar';
 
 import SendDraft from './send_draft';
+
+import type {Database} from '@nozbe/watermelondb';
+
+const SERVER_URL = 'https://www.baseUrl.com';
 
 jest.mock('@screens/navigation', () => ({
     dismissBottomSheet: jest.fn(),
@@ -26,7 +36,33 @@ jest.mock('@context/server', () => ({
     useServerUrl: jest.fn(() => 'https://server.com'),
 }));
 
+jest.mock('@utils/snack_bar', () => ({
+    showSnackBar: jest.fn(),
+}));
+
+jest.mock('@utils/post', () => ({
+    sendMessageWithAlert: jest.fn(),
+    persistentNotificationsConfirmation: jest.fn(),
+}));
+
+jest.mock('@actions/remote/post', () => ({
+    deleteScheduledPost: jest.fn(),
+    createPost: jest.fn(),
+}));
+
+jest.mock('@actions/local/scheduled_post', () => ({
+    handleUpdateScheduledPostErrorCode: jest.fn(),
+}));
+
 describe('Send Draft', () => {
+    let database: Database;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        const server = await TestHelper.setupServerDatabase(SERVER_URL);
+        database = server.database;
+    });
+
     it('should render the component', () => {
         const props = {
             channelId: 'channel_id',
@@ -112,5 +148,82 @@ describe('Send Draft', () => {
         );
         const {getByText} = wrapper;
         expect(getByText('Send')).toBeTruthy();
+    });
+
+    test('should handle deleteScheduledPost failure and call handleUpdateScheduledPostErrorCode', async () => {
+        let capturedHandler: Function;
+        const mockError = new Error('Failed to delete scheduled post');
+        jest.mocked(deleteScheduledPost).mockResolvedValue({error: mockError});
+        jest.mocked(sendMessageWithAlert).mockImplementation((params) => {
+            capturedHandler = params.sendMessageHandler;
+            return Promise.resolve();
+        });
+        jest.mocked(createPost).mockResolvedValueOnce({
+            data: true,
+        });
+
+        const baseProps: Parameters<typeof SendDraft>[0] = {
+            channelId: 'channel-id',
+            rootId: 'root-id',
+            channelType: 'O',
+            currentUserId: 'user-id',
+            channelName: 'channel-name',
+            channelDisplayName: 'Channel Display Name',
+            enableConfirmNotificationsToChannel: true,
+            maxMessageLength: 4000,
+            membersCount: 3,
+            useChannelMentions: true,
+            userIsOutOfOffice: false,
+            customEmojis: [],
+            value: 'test message',
+            files: [],
+            postPriority: {
+                persistent_notifications: false,
+                priority: '',
+            },
+            persistentNotificationInterval: 0,
+            persistentNotificationMaxRecipients: 0,
+            draftType: 'scheduled',
+            postId: 'post-id',
+        };
+
+        const {getByTestId} = renderWithEverything(<SendDraft {...baseProps}/>, {database});
+
+        // Trigger the send action
+        await act(async () => {
+            fireEvent.press(getByTestId('send_draft_button'));
+        });
+
+        // Verify dismissBottomSheet was called
+        expect(dismissBottomSheet).toHaveBeenCalled();
+
+        expect(sendMessageWithAlert).toHaveBeenCalledWith(expect.objectContaining({
+            sendMessageHandler: expect.any(Function),
+        }));
+
+        // Now execute the captured handler to simulate user confirming the send
+        await act(async () => {
+            await capturedHandler();
+        });
+
+        // Verify deleteScheduledPost was called with correct params
+        expect(deleteScheduledPost).toHaveBeenCalledWith(
+            'https://server.com',
+            'post-id',
+        );
+
+        // Verify handleUpdateScheduledPostErrorCode was called with correct params
+        expect(handleUpdateScheduledPostErrorCode).toHaveBeenCalledWith(
+            'https://server.com',
+            'post-id',
+            'post_send_success_delete_failed',
+        );
+
+        // Verify showSnackBar was called with error message
+        expect(showSnackBar).toHaveBeenCalledWith({
+            barType: 'DELETE_SCHEDULED_POST_ERROR',
+            customMessage: 'Failed to delete scheduled post',
+            type: 'error',
+        });
     });
 });

--- a/app/screens/draft_scheduled_post_options/send_draft.test.tsx
+++ b/app/screens/draft_scheduled_post_options/send_draft.test.tsx
@@ -147,11 +147,9 @@ describe('Send Draft', () => {
     });
 
     test('should handle deleteScheduledPost failure and call handleUpdateScheduledPostErrorCode', async () => {
-        let capturedHandler: Function;
         const mockError = new Error('Failed to delete scheduled post');
         jest.mocked(deleteScheduledPost).mockResolvedValue({error: mockError});
-        jest.mocked(sendMessageWithAlert).mockImplementation((params) => {
-            capturedHandler = params.sendMessageHandler;
+        jest.mocked(sendMessageWithAlert).mockImplementation(() => {
             return Promise.resolve();
         });
         jest.mocked(createPost).mockResolvedValueOnce({
@@ -199,7 +197,7 @@ describe('Send Draft', () => {
 
         // Now execute the captured handler to simulate user confirming the send
         await act(async () => {
-            await capturedHandler();
+            jest.mocked(sendMessageWithAlert).mock.calls[0][0].sendMessageHandler();
         });
 
         // Verify deleteScheduledPost was called with correct params

--- a/app/screens/draft_scheduled_post_options/send_draft.test.tsx
+++ b/app/screens/draft_scheduled_post_options/send_draft.test.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {Alert} from 'react-native';
 
 import {handleUpdateScheduledPostErrorCode} from '@actions/local/scheduled_post';
 import {createPost} from '@actions/remote/post';
@@ -12,7 +13,6 @@ import {dismissBottomSheet} from '@screens/navigation';
 import {act, fireEvent, renderWithEverything, renderWithIntlAndTheme} from '@test/intl-test-helper';
 import TestHelper from '@test/test_helper';
 import {sendMessageWithAlert} from '@utils/post';
-import {showSnackBar} from '@utils/snack_bar';
 
 import SendDraft from './send_draft';
 
@@ -34,10 +34,6 @@ jest.mock('@actions/remote/scheduled_post', () => ({
 
 jest.mock('@context/server', () => ({
     useServerUrl: jest.fn(() => 'https://server.com'),
-}));
-
-jest.mock('@utils/snack_bar', () => ({
-    showSnackBar: jest.fn(),
 }));
 
 jest.mock('@utils/post', () => ({
@@ -219,11 +215,15 @@ describe('Send Draft', () => {
             'post_send_success_delete_failed',
         );
 
-        // Verify showSnackBar was called with error message
-        expect(showSnackBar).toHaveBeenCalledWith({
-            barType: 'DELETE_SCHEDULED_POST_ERROR',
-            customMessage: 'Failed to delete scheduled post',
-            type: 'error',
-        });
+        // Verify Alert was called with error message
+        expect(Alert.alert).toHaveBeenCalledWith(
+            'Delete fails',
+            'Post has been create successfully but failed to delete. Please delete the scheduled post manually from the scheduled post list.',
+            [{
+                style: 'cancel',
+                text: 'Cancel',
+            }],
+            {cancelable: false},
+        );
     });
 });

--- a/app/screens/draft_scheduled_post_options/send_draft.tsx
+++ b/app/screens/draft_scheduled_post_options/send_draft.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {useIntl} from 'react-intl';
 
 import {removeDraft} from '@actions/local/draft';
+import {handleUpdateScheduledPostErrorCode} from '@actions/local/scheduled_post';
 import {deleteScheduledPost} from '@actions/remote/scheduled_post';
 import CompassIcon from '@components/compass_icon';
 import FormattedText from '@components/formatted_text';
@@ -104,6 +105,11 @@ const SendDraft: React.FC<Props> = ({
         if (postId) {
             const res = await deleteScheduledPost(serverUrl, postId);
             if (res?.error) {
+                try {
+                    await handleUpdateScheduledPostErrorCode(serverUrl, postId, 'post_send_success_delete_failed');
+                } catch {
+                    // do nothing
+                }
                 showSnackBar({
                     barType: SNACK_BAR_TYPE.DELETE_SCHEDULED_POST_ERROR,
                     customMessage: getErrorMessage(res.error),

--- a/app/screens/draft_scheduled_post_options/send_draft.tsx
+++ b/app/screens/draft_scheduled_post_options/send_draft.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import {useIntl} from 'react-intl';
+import {Alert} from 'react-native';
 
 import {removeDraft} from '@actions/local/draft';
 import {handleUpdateScheduledPostErrorCode} from '@actions/local/scheduled_post';
@@ -12,16 +13,13 @@ import FormattedText from '@components/formatted_text';
 import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {General} from '@constants';
 import {ICON_SIZE} from '@constants/post_draft';
-import {MESSAGE_TYPE, SNACK_BAR_TYPE} from '@constants/snack_bar';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useHandleSendMessage} from '@hooks/handle_send_message';
 import {usePersistentNotificationProps} from '@hooks/persistent_notification_props';
 import {DRAFT_TYPE_DRAFT, type DraftType} from '@screens/global_drafts/constants';
 import {dismissBottomSheet} from '@screens/navigation';
-import {getErrorMessage} from '@utils/errors';
 import {persistentNotificationsConfirmation, sendMessageWithAlert} from '@utils/post';
-import {showSnackBar} from '@utils/snack_bar';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 
@@ -110,11 +108,18 @@ const SendDraft: React.FC<Props> = ({
                 } catch {
                     // do nothing
                 }
-                showSnackBar({
-                    barType: SNACK_BAR_TYPE.DELETE_SCHEDULED_POST_ERROR,
-                    customMessage: getErrorMessage(res.error),
-                    type: MESSAGE_TYPE.ERROR,
-                });
+                Alert.alert(
+                    intl.formatMessage({id: 'scheduled_post.delete_fails', defaultMessage: 'Delete fails'}),
+                    intl.formatMessage({
+                        id: 'scheduled_post.delete_fails.message',
+                        defaultMessage: 'Post has been create successfully but failed to delete. Please delete the scheduled post manually from the scheduled post list.',
+                    }),
+                    [{
+                        text: intl.formatMessage({id: 'mobile.post.cancel', defaultMessage: 'Cancel'}),
+                        style: 'cancel',
+                    },
+                    ], {cancelable: false},
+                );
             }
         }
     };

--- a/app/screens/global_drafts/components/tabbed_contents/tabbed_contents.tsx
+++ b/app/screens/global_drafts/components/tabbed_contents/tabbed_contents.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {type ReactNode, useState, useMemo} from 'react';
+import React, {type ReactNode, useState, useMemo, useCallback} from 'react';
 import {Freeze} from 'react-freeze';
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, View, type LayoutChangeEvent} from 'react-native';
 import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
 
-import {useWindowDimensions} from '@hooks/device';
+import {useIsTablet} from '@hooks/device';
 import {DRAFT_SCREEN_TAB_DRAFTS, DRAFT_SCREEN_TAB_SCHEDULED_POSTS, type DraftScreenTab} from '@screens/global_drafts';
 import {DraftTabsHeader} from '@screens/global_drafts/components/tabbed_contents/draftTabsHeader';
 
@@ -20,7 +20,7 @@ type Props = {
     scheduledPosts: ReactNode;
 }
 
-const getStyleSheet = (width: number) => {
+const getStyleSheet = (width: number, isTablet: boolean) => {
     return StyleSheet.create({
         tabContainer: {
             height: '100%',
@@ -28,34 +28,41 @@ const getStyleSheet = (width: number) => {
         tabContentContainer: {
             flex: 1,
             flexDirection: 'row',
-            width: width * 2,
         },
         tabContent: {
             width,
         },
         hiddenTabContent: {
-            opacity: 0,
+            opacity: isTablet ? 1 : 0,
+            display: isTablet ? 'none' : 'flex',
         },
     });
 };
 
 export default function TabbedContents({draftsCount, scheduledPostCount, initialTab, drafts, scheduledPosts}: Props) {
     const [selectedTab, setSelectedTab] = useState(initialTab);
+    const [width, setWidth] = useState(0);
+    const isTablet = useIsTablet();
 
-    const {width} = useWindowDimensions();
-    const styles = useMemo(() => getStyleSheet(width), [width]);
+    const onLayout = useCallback((e: LayoutChangeEvent) => {
+        setWidth(e.nativeEvent.layout.width);
+    }, []);
+    const styles = useMemo(() => getStyleSheet(width, isTablet), [isTablet, width]);
 
     const transform = useAnimatedStyle(() => {
         const translateX = selectedTab === DRAFT_SCREEN_TAB_DRAFTS ? 0 : -width;
         return {
             transform: [
-                {translateX: withTiming(translateX, {duration})},
+                {translateX: withTiming(isTablet ? 0 : translateX, {duration})},
             ],
         };
     }, [selectedTab, width]);
 
     return (
-        <View style={styles.tabContainer}>
+        <View
+            style={styles.tabContainer}
+            onLayout={onLayout}
+        >
             <DraftTabsHeader
                 draftsCount={draftsCount}
                 scheduledPostCount={scheduledPostCount}

--- a/app/utils/scheduled_post/index.ts
+++ b/app/utils/scheduled_post/index.ts
@@ -70,7 +70,7 @@ export function deleteScheduledPostConfirmation({
 export const hasScheduledPostError = (scheduledPosts: ScheduledPostModel[]) =>
     scheduledPosts.some((post) => post.errorCode !== '');
 
-export type ScheduledPostErrorCode = 'unknown' | 'channel_archived' | 'channel_not_found' | 'user_missing' | 'user_deleted' | 'no_channel_permission' | 'no_channel_member' | 'thread_deleted' | 'unable_to_send' | 'invalid_post';
+export type ScheduledPostErrorCode = 'unknown' | 'channel_archived' | 'channel_not_found' | 'user_missing' | 'user_deleted' | 'no_channel_permission' | 'no_channel_member' | 'thread_deleted' | 'unable_to_send' | 'invalid_post' | 'post_send_success_delete_failed';
 
 const errorCodeToErrorMessage = defineMessages<ScheduledPostErrorCode>({
     unknown: {
@@ -112,6 +112,10 @@ const errorCodeToErrorMessage = defineMessages<ScheduledPostErrorCode>({
     invalid_post: {
         id: 'scheduled_post.error_code.invalid_post',
         defaultMessage: 'Invalid Post',
+    },
+    post_send_success_delete_failed: {
+        id: 'scheduled_post.error_code.post_send_success_delete_failed',
+        defaultMessage: 'Post already Sent, Delete Manually',
     },
 });
 

--- a/app/utils/scheduled_post/scheduled_post.test.ts
+++ b/app/utils/scheduled_post/scheduled_post.test.ts
@@ -282,6 +282,7 @@ describe('getErrorStringFromCode', () => {
             'thread_deleted',
             'unable_to_send',
             'invalid_post',
+            'post_send_success_delete_failed',
         ];
 
         const expectedMessages = [
@@ -294,6 +295,7 @@ describe('getErrorStringFromCode', () => {
             'Thread Deleted',
             'Unable to Send',
             'Invalid Post',
+            'Post already Sent, Delete Manually',
         ];
 
         testCases.forEach((errorCode, index) => {

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1009,6 +1009,8 @@
   "scheduled_post.channel_indicator.multiple": "{count} scheduled messages in channel.",
   "scheduled_post.channel_indicator.single": "Message scheduled for {dateTime}.",
   "scheduled_post.channel_indicator.thread.multiple": "{count} scheduled messages in thread.",
+  "scheduled_post.delete_fails": "Delete fails",
+  "scheduled_post.delete_fails.message": "Post has been create successfully but failed to delete. Please delete the scheduled post manually from the scheduled post list.",
   "scheduled_post.empty.subtitle": "Schedule drafts to send messages at a later time. Any scheduled drafts will show up here and can be modified after being scheduled.",
   "scheduled_post.empty.title": "No scheduled drafts at the moment",
   "scheduled_post.error_code.channel_archived": "Channel Archived",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1016,6 +1016,7 @@
   "scheduled_post.error_code.invalid_post": "Invalid Post",
   "scheduled_post.error_code.no_channel_member": "Not In Channel",
   "scheduled_post.error_code.no_channel_permission": "Missing Permission",
+  "scheduled_post.error_code.post_send_success_delete_failed": "Post already Sent, Delete Manually",
   "scheduled_post.error_code.thread_deleted": "Thread Deleted",
   "scheduled_post.error_code.unable_to_send": "Unable to Send",
   "scheduled_post.error_code.unknown_error": "Unknown Error",

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1031,6 +1031,7 @@
   "scheduled_post.options.delete.confirmation": "Are you sure you want to delete this scheduled post?",
   "scheduled_post.options.delete.title": "Delete",
   "scheduled_post.options.send.title": "Send",
+  "scheduled_post.options.title": "Message actions",
   "scheduled_post.picker.custom": "Custom Time",
   "scheduled_post.picker.monday": "Monday at {9amTime}",
   "scheduled_post.picker.next_monday": "Next Monday at {9amTime}",

--- a/types/database/database.ts
+++ b/types/database/database.ts
@@ -300,6 +300,11 @@ export type HandleScheduledPostsArgs = PrepareOnly & {
   includeDirectChannelPosts?: boolean;
 };
 
+export type HandleScheduledPostErrorCodeArgs = PrepareOnly & {
+  scheduledPostId: string;
+  errorCode: string;
+};
+
 export type LoginArgs = {
   config: Partial<ClientConfig>;
   ldapOnly?: boolean;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR handles two API calls when sending a scheduled post: first, creating the post, and then deleting the scheduled post. The issue arises when the post is successfully created, but the scheduled post deletion fails. To address this, we now update the local database with an error code and notify the user via an alert, prompting them to manually delete the scheduled post, since the message has already been sent to the appropriate channel or thread.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
