### PR TITLE
Automated cherry pick of #8681

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1410,7 +1410,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-emm (1.6.0):
+  - react-native-emm (1.6.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2550,7 +2550,7 @@ SPEC CHECKSUMS:
   react-native-cameraroll: 5f180ef5e9b52b6c3c3a2645fa33a921d1e37a6c
   react-native-cookies: d648ab7025833b977c0b19e142503034f5f29411
   react-native-document-picker: 530879d9e89b490f0954bcc4ab697c5b5e35d659
-  react-native-emm: 710fa6ce569cf04084224fa61a038e6143ea7fe0
+  react-native-emm: afc895b726861262e1b7fecaccb1339492c0bbdc
   react-native-image-picker: 130fad649d07e4eec8faaed361d3bba570e1e5ff
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-network-client: fdbd7f5f4c2818d6b90b4dcf9613d0a54ab41303

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mattermost/calls": "github:mattermost/calls-common#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
         "@mattermost/compass-icons": "0.1.48",
         "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
-        "@mattermost/react-native-emm": "1.6.0",
+        "@mattermost/react-native-emm": "1.6.1",
         "@mattermost/react-native-network-client": "1.8.2",
         "@mattermost/react-native-paste-input": "0.8.1",
         "@mattermost/react-native-turbo-log": "0.6.0",
@@ -4638,9 +4638,9 @@
       "link": true
     },
     "node_modules/@mattermost/react-native-emm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-emm/-/react-native-emm-1.6.0.tgz",
-      "integrity": "sha512-e8Ka0Zd6LZsbVWIiGeASiydV0WTQqc+2LNl8t/Zm22i0M7zhVgf4QIciXE/XjVJk1tfxJ5fhRM4LCp8q87HgTw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-emm/-/react-native-emm-1.6.1.tgz",
+      "integrity": "sha512-xFRCuByoC/uhMuUB5wy3U4ipUUexZpS2s51uNAe2moyhqU0PVY/mT0PjiaVNY1erYzJWz8gRiUz/9Hx5eganew==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@mattermost/calls": "github:mattermost/calls-common#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
     "@mattermost/compass-icons": "0.1.48",
     "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
-    "@mattermost/react-native-emm": "1.6.0",
+    "@mattermost/react-native-emm": "1.6.1",
     "@mattermost/react-native-network-client": "1.8.2",
     "@mattermost/react-native-paste-input": "0.8.1",
     "@mattermost/react-native-turbo-log": "0.6.0",


### PR DESCRIPTION
Cherry pick of #8681 on release-2.27.

/cc  @enahum

```release-note
NONE
```