### PR TITLE
[MM-63481] Don't substract keyboard height in Android as it was already substracted

### DIFF
--- a/app/components/post_draft/post_draft.tsx
+++ b/app/components/post_draft/post_draft.tsx
@@ -52,6 +52,7 @@ function PostDraft({
     const [postInputTop, setPostInputTop] = useState(0);
     const [isFocused, setIsFocused] = useState(false);
     const keyboardHeight = useKeyboardHeight();
+    const kbHeight = Platform.OS === 'ios' ? keyboardHeight : 0;
     const headerHeight = useDefaultHeaderHeight();
     const serverUrl = useServerUrl();
 
@@ -61,9 +62,8 @@ function PostDraft({
         setCursorPosition(message.length);
     }, [channelId, rootId]);
 
-    const autocompletePosition = AUTOCOMPLETE_ADJUST + keyboardHeight + postInputTop;
+    const autocompletePosition = AUTOCOMPLETE_ADJUST + kbHeight + postInputTop;
     const autocompleteAvailableSpace = containerHeight - autocompletePosition - (isChannelScreen ? headerHeight : 0);
-
     const [animatedAutocompletePosition, animatedAutocompleteAvailableSpace] = useAutocompleteDefaultAnimatedValues(autocompletePosition, autocompleteAvailableSpace);
 
     if (channelIsArchived || deactivatedChannel) {

--- a/app/components/post_draft/post_draft.tsx
+++ b/app/components/post_draft/post_draft.tsx
@@ -52,7 +52,7 @@ function PostDraft({
     const [postInputTop, setPostInputTop] = useState(0);
     const [isFocused, setIsFocused] = useState(false);
     const keyboardHeight = useKeyboardHeight();
-    const kbHeight = Platform.OS === 'ios' ? keyboardHeight : 0;
+    const kbHeight = Platform.OS === 'ios' ? keyboardHeight : 0; // useKeyboardHeight is already deducting the keyboard height on Android
     const headerHeight = useDefaultHeaderHeight();
     const serverUrl = useServerUrl();
 

--- a/app/hooks/autocomplete.ts
+++ b/app/hooks/autocomplete.ts
@@ -10,11 +10,11 @@ export const useAutocompleteDefaultAnimatedValues = (position: number, available
 
     useEffect(() => {
         animatedPosition.value = position;
-    }, [position]);
+    }, [position, animatedPosition]);
 
     useEffect(() => {
         animatedAvailableSpace.value = availableSpace;
-    }, [availableSpace]);
+    }, [availableSpace, animatedAvailableSpace]);
 
     return [animatedPosition, animatedAvailableSpace];
 };


### PR DESCRIPTION
#### Summary
Seem that useKeyboardHeight is already deducting the keyboard height on Android, so by substracting it again we are leaving a very small area for the content.

#### Ticket Link
[MM-63481](https://mattermost.atlassian.net/browse/MM-63481)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: ios Simulator, Pixel 8, Xiaomi 8

#### Screenshots
| Before  | After |
| ------------- | ------------- |
| ![rn_image_picker_lib_temp_13133391-2704-4d08-802e-988ea0b4803b (1)](https://github.com/user-attachments/assets/d01d8164-fd20-4a9f-b97a-d11a1d03d975) | ![rn_image_picker_lib_temp_d0257bdd-67c9-4d09-8317-ba613c246058](https://github.com/user-attachments/assets/e7675072-0304-4f5f-ad39-5ab7ca27e0fc) |

#### Release Note

```release-note
fix autocomplete area being too small on android devices
```


[MM-63481]: https://mattermost.atlassian.net/browse/MM-63481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ