### PR TITLE
[MM-63431] Calls 1-1 video support (MVP)

### DIFF
--- a/app/actions/websocket/event.test.ts
+++ b/app/actions/websocket/event.test.ts
@@ -372,6 +372,18 @@ describe('handleWebSocketEvent', () => {
         expect(calls.handleCallUserVoiceOff).toHaveBeenCalledWith(msg);
     });
 
+    it('should handle CALLS_USER_VIDEO_ON event', async () => {
+        msg.event = WebsocketEvents.CALLS_USER_VIDEO_ON;
+        await handleWebSocketEvent(serverUrl, msg);
+        expect(calls.handleCallUserVideoOn).toHaveBeenCalledWith(serverUrl, msg);
+    });
+
+    it('should handle CALLS_USER_VIDEO_OFF event', async () => {
+        msg.event = WebsocketEvents.CALLS_USER_VIDEO_OFF;
+        await handleWebSocketEvent(serverUrl, msg);
+        expect(calls.handleCallUserVideoOff).toHaveBeenCalledWith(serverUrl, msg);
+    });
+
     it('should handle CALLS_CALL_START event', async () => {
         msg.event = WebsocketEvents.CALLS_CALL_START;
         await handleWebSocketEvent(serverUrl, msg);

--- a/app/actions/websocket/event.ts
+++ b/app/actions/websocket/event.ts
@@ -200,6 +200,12 @@ export async function handleWebSocketEvent(serverUrl: string, msg: WebSocketMess
         case WebsocketEvents.CALLS_USER_UNMUTED:
             calls.handleCallUserUnmuted(serverUrl, msg);
             break;
+        case WebsocketEvents.CALLS_USER_VIDEO_ON:
+            calls.handleCallUserVideoOn(serverUrl, msg);
+            break;
+        case WebsocketEvents.CALLS_USER_VIDEO_OFF:
+            calls.handleCallUserVideoOff(serverUrl, msg);
+            break;
         case WebsocketEvents.CALLS_USER_VOICE_ON:
             calls.handleCallUserVoiceOn(msg);
             break;

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -83,6 +83,8 @@ const WebsocketEvents = {
     CALLS_USER_RAISE_HAND: `custom_${Calls.PluginId}_user_raise_hand`,
     CALLS_USER_UNRAISE_HAND: `custom_${Calls.PluginId}_user_unraise_hand`,
     CALLS_USER_REACTED: `custom_${Calls.PluginId}_user_reacted`,
+    CALLS_USER_VIDEO_ON: `custom_${Calls.PluginId}_user_video_on`,
+    CALLS_USER_VIDEO_OFF: `custom_${Calls.PluginId}_user_video_off`,
 
     // DEPRECATED in favour of CALLS_JOB_STATE (since v2.15.0)
     CALLS_RECORDING_STATE: `custom_${Calls.PluginId}_call_recording_state`,

--- a/app/products/calls/actions/calls.test.ts
+++ b/app/products/calls/actions/calls.test.ts
@@ -88,6 +88,9 @@ jest.mock('@calls/connection/connection', () => ({
         unmute: jest.fn(),
         waitForPeerConnection: jest.fn(() => Promise.resolve()),
         initializeVoiceTrack: jest.fn(),
+        initializeVideoTrack: jest.fn(),
+        startVideo: jest.fn(),
+        stopVideo: jest.fn(),
         sendReaction: jest.fn(),
     })),
 }));
@@ -260,7 +263,7 @@ describe('Actions.Calls', () => {
 
         let response: { data?: string };
         await act(async () => {
-            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }));
@@ -282,7 +285,7 @@ describe('Actions.Calls', () => {
         // Test error case
         newConnection.mockRejectedValueOnce(forceLogoutError);
         await act(async () => {
-            await expect(CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+            await expect(CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }))).resolves.toStrictEqual({error: forceLogoutError});
@@ -297,7 +300,7 @@ describe('Actions.Calls', () => {
         newConnection.mockResolvedValueOnce(connection);
 
         await act(async () => {
-            const res = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+            const res = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }));
@@ -316,7 +319,7 @@ describe('Actions.Calls', () => {
 
         let response: { data?: string };
         await act(async () => {
-            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }));
@@ -353,7 +356,7 @@ describe('Actions.Calls', () => {
 
         let response: { data?: string };
         await act(async () => {
-            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }));
@@ -386,7 +389,7 @@ describe('Actions.Calls', () => {
 
         let response: { data?: string };
         await act(async () => {
-            response = await CallsActions.joinCall('server1', 'channel-id', 'mysUserId', true, createIntl({
+            response = await CallsActions.joinCall('server1', 'channel-id', 'mysUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }));
@@ -1215,7 +1218,7 @@ describe('Actions.Calls', () => {
         addFakeCall('server1', 'channel-id');
 
         await act(async () => {
-            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }));
@@ -1226,12 +1229,60 @@ describe('Actions.Calls', () => {
         expect(getConnectionForTesting()?.initializeVoiceTrack).toHaveBeenCalled();
     });
 
+    it('startMyVideo', async () => {
+        renderHook(() => useCurrentCall());
+        addFakeCall('server1', 'channel-id');
+
+        await act(async () => {
+            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
+                locale: 'en',
+                messages: {},
+            }));
+            newCurrentCall('server1', 'channel-id', 'myUserId');
+        });
+
+        CallsActions.startMyVideo();
+        expect(getConnectionForTesting()?.startVideo).toHaveBeenCalled();
+    });
+
+    it('stopMyVideo', async () => {
+        renderHook(() => useCurrentCall());
+        addFakeCall('server1', 'channel-id');
+
+        await act(async () => {
+            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
+                locale: 'en',
+                messages: {},
+            }));
+            newCurrentCall('server1', 'channel-id', 'myUserId');
+        });
+
+        CallsActions.stopMyVideo();
+        expect(getConnectionForTesting()?.stopVideo).toHaveBeenCalled();
+    });
+
+    it('initializeVideoTrack', async () => {
+        renderHook(() => useCurrentCall());
+        addFakeCall('server1', 'channel-id');
+
+        await act(async () => {
+            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
+                locale: 'en',
+                messages: {},
+            }));
+            newCurrentCall('server1', 'channel-id', 'myUserId');
+        });
+
+        CallsActions.initializeVideoTrack();
+        expect(getConnectionForTesting()?.initializeVideoTrack).toHaveBeenCalledWith(false);
+    });
+
     it('sendReaction', async () => {
         renderHook(() => useCurrentCall());
         addFakeCall('server1', 'channel-id');
 
         await act(async () => {
-            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, createIntl({
                 locale: 'en',
                 messages: {},
             }));
@@ -1259,7 +1310,7 @@ describe('Actions.Calls', () => {
         intl.formatMessage = jest.fn();
 
         await act(async () => {
-            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, intl);
+            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, intl);
 
             // manually call newCurrentConnection because newConnection is mocked
             newCurrentCall('server1', 'channel-id', 'myUserId');
@@ -1302,7 +1353,7 @@ describe('Actions.Calls', () => {
         intl.formatMessage = jest.fn();
 
         await act(async () => {
-            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, intl);
+            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, intl);
 
             // manually call newCurrentConnection because newConnection is mocked
             newCurrentCall('server1', 'channel-id', 'myUserId');
@@ -1345,7 +1396,7 @@ describe('Actions.Calls', () => {
         intl.formatMessage = jest.fn();
 
         await act(async () => {
-            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, intl);
+            response = await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, true, intl);
 
             // manually call newCurrentConnection because newConnection is mocked
             newCurrentCall('server1', 'channel-id', 'myUserId');

--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -27,6 +27,8 @@ import {
     setConfig,
     setPluginEnabled,
     setScreenShareURL,
+    setLocalVideoURL,
+    setRemoteVideoURL,
     setSpeakerPhone,
 } from '@calls/state';
 import {type AudioDevice, type Call, type CallSession, type CallsConnection, EndCallReturn} from '@calls/types/calls';
@@ -155,6 +157,7 @@ const convertOldCallToNew = (call: CallState): CallState => {
                 user_id: cur,
                 unmuted: call.states && call.states[curIdx] ? call.states[curIdx].unmuted : false,
                 raised_hand: call.states && call.states[curIdx] ? call.states[curIdx].raised_hand : 0,
+                video: call.states && call.states[curIdx] ? call.states[curIdx].video : false,
             });
             return accum;
         }, [] as SessionState[]),
@@ -175,6 +178,7 @@ export const createCallAndAddToIds = (channelId: string, call: CallState, ids?: 
                 sessionId: cur.session_id,
                 raisedHand: cur.raised_hand || 0,
                 muted: !cur.unmuted,
+                video: cur.video,
             };
             return accum;
         }, {} as Dictionary<CallSession>),
@@ -240,6 +244,7 @@ export const joinCall = async (
     channelId: string,
     userId: string,
     hasMicPermission: boolean,
+    hasCameraPermission: boolean,
     intl: IntlShape,
     title?: string,
     rootId?: string,
@@ -265,7 +270,7 @@ export const joinCall = async (
                 logDebug('calls: error on close', getFullErrorMessage(err));
                 showErrorAlertOnClose(err, intl);
             }
-        }, setScreenShareURL, hasMicPermission, title, rootId);
+        }, setScreenShareURL, setLocalVideoURL, setRemoteVideoURL, hasMicPermission, hasCameraPermission, title, rootId);
     } catch (error) {
         await forceLogoutIfNecessary(serverUrl, error);
         return {error};
@@ -342,9 +347,27 @@ export const unmuteMyself = () => {
     }
 };
 
+export const startMyVideo = () => {
+    if (connection) {
+        connection.startVideo();
+    }
+};
+
+export const stopMyVideo = () => {
+    if (connection) {
+        connection.stopVideo();
+    }
+};
+
 export const initializeVoiceTrack = () => {
     if (connection) {
         connection.initializeVoiceTrack();
+    }
+};
+
+export const initializeVideoTrack = () => {
+    if (connection) {
+        connection.initializeVideoTrack(false);
     }
 };
 

--- a/app/products/calls/actions/index.ts
+++ b/app/products/calls/actions/index.ts
@@ -24,6 +24,7 @@ export {
     hostRemove,
     setPreferredAudioRoute,
     initializeVoiceTrack,
+    initializeVideoTrack,
     sendReaction,
     endCall,
     loadCallForChannel,
@@ -31,6 +32,8 @@ export {
     checkIsCallsPluginEnabled,
     canEndCall,
     getEndCallMessage,
+    startMyVideo,
+    stopMyVideo,
 } from './calls';
 
-export {hasMicrophonePermission} from './permissions';
+export {hasMicrophonePermission, hasCameraPermission} from './permissions';

--- a/app/products/calls/actions/permissions.test.ts
+++ b/app/products/calls/actions/permissions.test.ts
@@ -4,17 +4,19 @@
 import {Platform} from 'react-native';
 import Permissions from 'react-native-permissions';
 
-import {hasBluetoothPermission, hasMicrophonePermission} from './permissions';
+import {hasBluetoothPermission, hasCameraPermission, hasMicrophonePermission} from './permissions';
 
 jest.mock('react-native-permissions', () => ({
     PERMISSIONS: {
         IOS: {
             BLUETOOTH: 'ios.bluetooth',
             MICROPHONE: 'ios.microphone',
+            CAMERA: 'ios.camera',
         },
         ANDROID: {
             BLUETOOTH_CONNECT: 'android.bluetooth_connect',
             RECORD_AUDIO: 'android.record_audio',
+            CAMERA: 'android.camera',
         },
     },
     RESULTS: {
@@ -88,6 +90,35 @@ describe('Permissions', () => {
             jest.mocked(Permissions.check).mockResolvedValue(Permissions.RESULTS.GRANTED);
             await hasMicrophonePermission();
             expect(Permissions.check).toHaveBeenCalledWith(Permissions.PERMISSIONS.ANDROID.RECORD_AUDIO);
+        });
+    });
+
+    describe('hasCameraPermission', () => {
+        it('should return true when permission is granted', async () => {
+            jest.mocked(Permissions.check).mockResolvedValue(Permissions.RESULTS.GRANTED);
+            const result = await hasCameraPermission();
+            expect(result).toBe(true);
+        });
+
+        it('should request permission when denied', async () => {
+            jest.mocked(Permissions.check).mockResolvedValue(Permissions.RESULTS.DENIED);
+            jest.mocked(Permissions.request).mockResolvedValue(Permissions.RESULTS.GRANTED);
+            const result = await hasCameraPermission();
+            expect(result).toBe(true);
+            expect(Permissions.request).toHaveBeenCalled();
+        });
+
+        it('should return false when blocked', async () => {
+            jest.mocked(Permissions.check).mockResolvedValue(Permissions.RESULTS.BLOCKED);
+            const result = await hasCameraPermission();
+            expect(result).toBe(false);
+        });
+
+        it('should handle Android permissions', async () => {
+            Platform.select = jest.fn((options: Record<string, unknown>) => options.default);
+            jest.mocked(Permissions.check).mockResolvedValue(Permissions.RESULTS.GRANTED);
+            await hasCameraPermission();
+            expect(Permissions.check).toHaveBeenCalledWith(Permissions.PERMISSIONS.ANDROID.CAMERA);
         });
     });
 });

--- a/app/products/calls/actions/permissions.ts
+++ b/app/products/calls/actions/permissions.ts
@@ -46,3 +46,24 @@ export const hasMicrophonePermission = async () => {
     }
 };
 
+export const hasCameraPermission = async () => {
+    const camera = Platform.select({
+        ios: Permissions.PERMISSIONS.IOS.CAMERA,
+        default: Permissions.PERMISSIONS.ANDROID.CAMERA,
+    });
+
+    const hasCamera = await Permissions.check(camera);
+
+    switch (hasCamera) {
+        case Permissions.RESULTS.DENIED:
+        case Permissions.RESULTS.UNAVAILABLE: {
+            const permissionRequest = await Permissions.request(camera);
+            return permissionRequest === Permissions.RESULTS.GRANTED;
+        }
+        case Permissions.RESULTS.BLOCKED:
+            return false;
+        default:
+            return true;
+    }
+};
+

--- a/app/products/calls/alerts.test.ts
+++ b/app/products/calls/alerts.test.ts
@@ -26,6 +26,7 @@ jest.mock('@calls/actions', () => ({
     leaveCall: jest.fn(),
     joinCall: jest.fn().mockResolvedValue({}),
     hasMicrophonePermission: jest.fn().mockResolvedValue(true),
+    hasCameraPermission: jest.fn().mockResolvedValue(true),
     unmuteMyself: jest.fn(),
     dismissIncomingCall: jest.fn(),
     removeIncomingCall: jest.fn(),
@@ -39,6 +40,7 @@ jest.mock('@calls/state', () => ({
     getCurrentCall: jest.fn(),
     getCallsConfig: jest.fn(),
     setMicPermissionsGranted: jest.fn(),
+    setCameraPermissionsGranted: jest.fn(),
 }));
 jest.mock('@calls/actions/calls');
 jest.mock('@screens/navigation', () => ({
@@ -371,7 +373,7 @@ describe('alerts', () => {
         });
 
         it('joins new call when not in a call', async () => {
-            const {getCallsState, getChannelsWithCalls, getCurrentCall, getCallsConfig, setMicPermissionsGranted} = require('@calls/state');
+            const {getCallsState, getChannelsWithCalls, getCurrentCall, getCallsConfig, setMicPermissionsGranted, setCameraPermissionsGranted} = require('@calls/state');
             getCallsState.mockReturnValue({
                 enabled: {
                     'join-channel': true,
@@ -381,6 +383,7 @@ describe('alerts', () => {
             getCurrentCall.mockReturnValue(null);
             getCallsConfig.mockReturnValue({});
             setMicPermissionsGranted.mockReturnValue(true);
+            setCameraPermissionsGranted.mockReturnValue(true);
 
             const mockAlert = jest.spyOn(Alert, 'alert');
             const result = await leaveAndJoinWithAlert(intl as any, 'server1', 'join-channel');
@@ -389,7 +392,7 @@ describe('alerts', () => {
         });
 
         it('shows leave and join confirmation when in a call', async () => {
-            const {getCallsState, getChannelsWithCalls, getCurrentCall, getCallsConfig, setMicPermissionsGranted} = require('@calls/state');
+            const {getCallsState, getChannelsWithCalls, getCurrentCall, getCallsConfig, setMicPermissionsGranted, setCameraPermissionsGranted} = require('@calls/state');
             getCallsState.mockReturnValue({
                 enabled: {
                     'join-channel': true,
@@ -405,6 +408,7 @@ describe('alerts', () => {
             });
             getCallsConfig.mockReturnValue({});
             setMicPermissionsGranted.mockReturnValue(true);
+            setCameraPermissionsGranted.mockReturnValue(true);
 
             const mockAlert = jest.spyOn(Alert, 'alert').mockImplementationOnce(async (title, message, buttons) => {
                 // Simulate cancel
@@ -412,8 +416,6 @@ describe('alerts', () => {
             });
 
             expect(await leaveAndJoinWithAlert(intl as any, 'server1', 'join-channel')).toBe(false);
-
-            console.log('rar');
 
             expect(mockAlert).toHaveBeenCalledWith(
                 'Are you sure you want to switch to a different call?',

--- a/app/products/calls/components/current_call_bar/current_call_bar.tsx
+++ b/app/products/calls/components/current_call_bar/current_call_bar.tsx
@@ -34,6 +34,7 @@ type Props = {
     sessionsDict: Dictionary<CallSession>;
     teammateNameDisplay: string;
     micPermissionsGranted: boolean;
+    cameraPermissionsGranted: boolean;
     threadScreen?: boolean;
     otherParticipants: boolean;
     isAdmin: boolean;
@@ -142,6 +143,7 @@ const CurrentCallBar = ({
     sessionsDict,
     teammateNameDisplay,
     micPermissionsGranted,
+    cameraPermissionsGranted,
     threadScreen,
     otherParticipants,
     isAdmin,
@@ -149,12 +151,12 @@ const CurrentCallBar = ({
 }: Props) => {
     const theme = useTheme();
     const serverUrl = useServerUrl();
-    const {EnableTranscriptions} = useCallsConfig(serverUrl);
+    const {EnableTranscriptions, EnableVideo} = useCallsConfig(serverUrl);
     const callsTheme = useMemo(() => makeCallsTheme(theme), [theme]);
     const style = getStyleSheet(callsTheme);
     const intl = useIntl();
     const {formatMessage} = intl;
-    usePermissionsChecker(micPermissionsGranted);
+    usePermissionsChecker(micPermissionsGranted, !EnableVideo || cameraPermissionsGranted);
 
     const goToCallScreen = useCallback(async () => {
         const options: Options = {

--- a/app/products/calls/components/current_call_bar/index.ts
+++ b/app/products/calls/components/current_call_bar/index.ts
@@ -39,6 +39,10 @@ const enhanced = withObservables([], () => {
         switchMap((gs) => of$(gs.micPermissionsGranted)),
         distinctUntilChanged(),
     );
+    const cameraPermissionsGranted = observeGlobalCallsState().pipe(
+        switchMap((gs) => of$(gs.cameraPermissionsGranted)),
+        distinctUntilChanged(),
+    );
 
     return {
         displayName,
@@ -46,6 +50,7 @@ const enhanced = withObservables([], () => {
         sessionsDict: observeCurrentSessionsDict(),
         teammateNameDisplay,
         micPermissionsGranted,
+        cameraPermissionsGranted,
         ...observeEndCallDetails(),
     };
 });

--- a/app/products/calls/connection/websocket_event_handlers.test.ts
+++ b/app/products/calls/connection/websocket_event_handlers.test.ts
@@ -21,6 +21,7 @@ import {
     setChannelEnabled,
     setHost,
     setRaisedHand,
+    setUserVideo,
     setRecordingState,
     setUserMuted,
     setUserVoiceOn,
@@ -58,6 +59,8 @@ import {
     handleHostMute,
     handleHostRemoved,
     handleUserDismissedNotification,
+    handleCallUserVideoOff,
+    handleCallUserVideoOn,
 } from './websocket_event_handlers';
 
 import type {
@@ -77,6 +80,7 @@ import type {
     UserReactionData,
     UserScreenOnOffData,
     UserVoiceOnOffData,
+    UserVideoOnOffData,
 } from '@mattermost/calls/lib/types';
 
 jest.mock('@actions/remote/user');
@@ -218,6 +222,24 @@ describe('websocket event handlers', () => {
                 data: {session_id: sessionId},
             } as WebSocketMessage<UserVoiceOnOffData>);
             expect(setUserVoiceOn).toHaveBeenCalledWith(channelId, sessionId, false);
+        });
+    });
+
+    describe('handleCallUserVideoOn/Off', () => {
+        it('should handle video on', () => {
+            handleCallUserVideoOn(serverUrl, {
+                broadcast: {channel_id: channelId},
+                data: {session_id: sessionId},
+            } as WebSocketMessage<UserVideoOnOffData>);
+            expect(setUserVideo).toHaveBeenCalledWith(serverUrl, channelId, sessionId, true);
+        });
+
+        it('should handle video off', () => {
+            handleCallUserVideoOff(serverUrl, {
+                broadcast: {channel_id: channelId},
+                data: {session_id: sessionId},
+            } as WebSocketMessage<UserVideoOnOffData>);
+            expect(setUserVideo).toHaveBeenCalledWith(serverUrl, channelId, sessionId, false);
         });
     });
 

--- a/app/products/calls/connection/websocket_event_handlers.ts
+++ b/app/products/calls/connection/websocket_event_handlers.ts
@@ -24,6 +24,7 @@ import {
     setRecordingState,
     setUserMuted,
     setUserVoiceOn,
+    setUserVideo,
     userJoinedCall,
     userLeftCall,
     userReacted,
@@ -54,6 +55,7 @@ import type {
     UserReactionData,
     UserScreenOnOffData,
     UserVoiceOnOffData,
+    UserVideoOnOffData,
 } from '@mattermost/calls/lib/types';
 
 // DEPRECATED in favour of user_joined (since v0.21.0)
@@ -108,6 +110,14 @@ export const handleCallUserVoiceOn = (msg: WebSocketMessage<UserVoiceOnOffData>)
 export const handleCallUserVoiceOff = (msg: WebSocketMessage<UserVoiceOnOffData>) => {
     // pre v0.21.0, sessionID == userID
     setUserVoiceOn(msg.broadcast.channel_id, msg.data.session_id || msg.data.userID, false);
+};
+
+export const handleCallUserVideoOn = (serverUrl: string, msg: WebSocketMessage<UserVideoOnOffData>) => {
+    setUserVideo(serverUrl, msg.broadcast.channel_id, msg.data.session_id, true);
+};
+
+export const handleCallUserVideoOff = (serverUrl: string, msg: WebSocketMessage<UserVideoOnOffData>) => {
+    setUserVideo(serverUrl, msg.broadcast.channel_id, msg.data.session_id, false);
 };
 
 export const handleCallStarted = (serverUrl: string, msg: WebSocketMessage<CallStartData>) => {

--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -21,7 +21,7 @@ import {
 import {Navigation} from 'react-native-navigation';
 import {RTCView} from 'react-native-webrtc';
 
-import {muteMyself, unmuteMyself} from '@calls/actions';
+import {muteMyself, unmuteMyself, startMyVideo, stopMyVideo} from '@calls/actions';
 import {leaveCallConfirmation, startCallRecording, stopCallRecording} from '@calls/actions/calls';
 import {
     recordingAlert,
@@ -89,9 +89,11 @@ export type Props = {
     currentCall: CurrentCall | null;
     sessionsDict: Dictionary<CallSession>;
     micPermissionsGranted: boolean;
+    cameraPermissionsGranted: boolean;
     teammateNameDisplay: string;
     fromThreadScreen?: boolean;
     displayName?: string;
+    isDM: boolean;
     isOwnDirectMessage: boolean;
     otherParticipants: boolean;
     isAdmin: boolean;
@@ -320,9 +322,11 @@ const CallScreen = ({
     currentCall,
     sessionsDict,
     micPermissionsGranted,
+    cameraPermissionsGranted,
     teammateNameDisplay,
     fromThreadScreen,
     displayName,
+    isDM,
     isOwnDirectMessage,
     otherParticipants,
     isAdmin,
@@ -333,8 +337,8 @@ const CallScreen = ({
     const {width, height} = useWindowDimensions();
     const isTablet = useIsTablet();
     const serverUrl = useServerUrl();
-    const {EnableRecordings, EnableTranscriptions} = useCallsConfig(serverUrl);
-    usePermissionsChecker(micPermissionsGranted);
+    const {EnableRecordings, EnableTranscriptions, EnableVideo} = useCallsConfig(serverUrl);
+    usePermissionsChecker(micPermissionsGranted, !EnableVideo || cameraPermissionsGranted);
     const incomingCalls = useIncomingCalls();
     const {hostControlsAvailable, onPress, openUserProfile} = useHostMenus();
 
@@ -369,6 +373,10 @@ const CallScreen = ({
     });
     const showCCTitle = intl.formatMessage({id: 'mobile.calls_show_cc', defaultMessage: 'Show live captions'});
     const hideCCTitle = intl.formatMessage({id: 'mobile.calls_hide_cc', defaultMessage: 'Hide live captions'});
+
+    // TODO: remove this when implementing UX (MM-63547)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const enableVideo = EnableVideo && isDM;
 
     useEffect(() => {
         mergeNavigationOptions('Call', {
@@ -405,6 +413,16 @@ const CallScreen = ({
             muteMyself();
         }
     }, [mySession?.muted]);
+
+    // TODO: remove this when implementing UX (MM-63547)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const startStopVideoHandler = useCallback(() => {
+        if (mySession?.video) {
+            stopMyVideo();
+        } else {
+            startMyVideo();
+        }
+    }, [mySession?.video]);
 
     const toggleReactions = useCallback(() => {
         setShowReactions((prev) => !prev);
@@ -809,6 +827,7 @@ const CallScreen = ({
                                 {mySession.muted ? UnmuteText : MuteText}
                             </Pressable>
                         }
+
                         <View style={[style.otherButtons, isLandscape && style.otherButtonsLandscape]}>
                             <Pressable
                                 testID='leave'

--- a/app/products/calls/screens/call_screen/index.ts
+++ b/app/products/calls/screens/call_screen/index.ts
@@ -20,6 +20,10 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
         switchMap((gs) => of$(gs.micPermissionsGranted)),
         distinctUntilChanged(),
     );
+    const cameraPermissionsGranted = observeGlobalCallsState().pipe(
+        switchMap((gs) => of$(gs.cameraPermissionsGranted)),
+        distinctUntilChanged(),
+    );
     const teammateNameDisplay = observeCallDatabase().pipe(
         switchMap((db) => (db ? observeTeammateNameDisplay(db) : of$(''))),
         distinctUntilChanged(),
@@ -46,12 +50,16 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     );
     const displayName = channel.pipe(switchMap((c) => of$(c?.displayName)));
 
+    const isDM = channel.pipe(switchMap((c) => of$(c?.type === General.DM_CHANNEL)));
+
     return {
         currentCall,
         sessionsDict: observeCurrentSessionsDict(),
         micPermissionsGranted,
+        cameraPermissionsGranted,
         teammateNameDisplay,
         displayName,
+        isDM,
         isOwnDirectMessage,
         ...observeEndCallDetails(),
     };

--- a/app/products/calls/state/actions.test.ts
+++ b/app/products/calls/state/actions.test.ts
@@ -24,6 +24,8 @@ import {
     setJoiningChannelId,
     setMicPermissionsErrorDismissed,
     setMicPermissionsGranted,
+    setCameraPermissionsGranted,
+    setCameraPermissionsErrorDismissed,
     setRecordingState,
     useCallsConfig,
     useCallsState,
@@ -46,9 +48,12 @@ import {
     setPluginEnabled,
     setRaisedHand,
     setScreenShareURL,
+    setLocalVideoURL,
+    setRemoteVideoURL,
     setSpeakerPhone,
     setUserMuted,
     setUserVoiceOn,
+    setUserVideo,
     userJoinedCall,
     userLeftCall,
     callsOnAppStateChange,
@@ -114,8 +119,8 @@ jest.mock('react-native-navigation', () => ({
 const call1: Call = {
     id: 'call1',
     sessions: {
-        session1: {sessionId: 'session1', userId: 'user-1', muted: false, raisedHand: 0},
-        session2: {sessionId: 'session2', userId: 'user-2', muted: true, raisedHand: 0},
+        session1: {sessionId: 'session1', userId: 'user-1', muted: false, video: false, raisedHand: 0},
+        session2: {sessionId: 'session2', userId: 'user-2', muted: true, video: false, raisedHand: 0},
     },
     channelId: 'channel-1',
     startTime: 123,
@@ -128,8 +133,8 @@ const call1: Call = {
 const call2: Call = {
     id: 'call2',
     sessions: {
-        session3: {sessionId: 'session3', userId: 'user-3', muted: false, raisedHand: 0},
-        session4: {sessionId: 'session4', userId: 'user-4', muted: true, raisedHand: 0},
+        session3: {sessionId: 'session3', userId: 'user-3', muted: false, video: false, raisedHand: 0},
+        session4: {sessionId: 'session4', userId: 'user-4', muted: true, video: false, raisedHand: 0},
     },
     channelId: 'channel-2',
     startTime: 123,
@@ -142,8 +147,8 @@ const call2: Call = {
 const call3: Call = {
     id: 'call3',
     sessions: {
-        session5: {sessionId: 'session5', userId: 'user-5', muted: false, raisedHand: 0},
-        session6: {sessionId: 'session6', userId: 'user-6', muted: true, raisedHand: 0},
+        session5: {sessionId: 'session5', userId: 'user-5', muted: false, video: false, raisedHand: 0},
+        session6: {sessionId: 'session6', userId: 'user-6', muted: true, video: false, raisedHand: 0},
     },
     channelId: 'channel-3',
     startTime: 123,
@@ -156,7 +161,7 @@ const call3: Call = {
 const callDM: Call = {
     id: 'callDM',
     sessions: {
-        session5: {sessionId: 'session5', userId: 'user-5', muted: false, raisedHand: 0},
+        session5: {sessionId: 'session5', userId: 'user-5', muted: false, video: false, raisedHand: 0},
     },
     channelId: 'channel-private',
     startTime: 123,
@@ -291,9 +296,9 @@ describe('useCallsState', () => {
             'channel-1': {
                 id: 'call1',
                 sessions: {
-                    session1: {sessionId: 'session1', userId: 'user-1', muted: false, raisedHand: 0},
-                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, raisedHand: 0},
-                    session3: {sessionId: 'session3', userId: 'user-3', muted: true, raisedHand: 0},
+                    session1: {sessionId: 'session1', userId: 'user-1', muted: false, video: false, raisedHand: 0},
+                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, video: false, raisedHand: 0},
+                    session3: {sessionId: 'session3', userId: 'user-3', muted: true, video: false, raisedHand: 0},
                 },
                 channelId: 'channel-1',
                 startTime: 123,
@@ -353,7 +358,7 @@ describe('useCallsState', () => {
             'channel-1': {
                 id: 'call1',
                 sessions: {
-                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, raisedHand: 0},
+                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, video: false, raisedHand: 0},
                 },
                 channelId: 'channel-1',
                 startTime: 123,
@@ -419,7 +424,7 @@ describe('useCallsState', () => {
             'channel-1': {
                 id: 'call1',
                 sessions: {
-                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, raisedHand: 0},
+                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, video: false, raisedHand: 0},
                 },
                 channelId: 'channel-1',
                 startTime: 123,
@@ -564,6 +569,52 @@ describe('useCallsState', () => {
         assert.deepEqual(result.current[0], initialCallsState);
     });
 
+    it('setUserVideo', () => {
+        const initialCallsState = {
+            ...DefaultCallsState,
+            calls: {'channel-1': call1, 'channel-2': call2},
+        };
+        const initialChannelsWithCallsState = {'channel-1': true, 'channel-2': true};
+        const initialCurrentCallState: CurrentCall = {
+            ...DefaultCurrentCall,
+            connected: true,
+            serverUrl: 'server1',
+            myUserId: 'myUserId',
+            ...call1,
+        };
+
+        // setup
+        const {result} = renderHook(() => {
+            return [useCallsState('server1'), useChannelsWithCalls('server1'), useCurrentCall()];
+        });
+        act(() => {
+            setCallsState('server1', initialCallsState);
+            setChannelsWithCalls('server1', initialChannelsWithCallsState);
+            setCurrentCall(initialCurrentCallState);
+        });
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], initialChannelsWithCallsState);
+        assert.deepEqual(result.current[2], initialCurrentCallState);
+
+        // test
+        act(() => setUserVideo('server1', 'channel-1', 'session1', true));
+        assert.deepEqual((result.current[0] as CallsState).calls['channel-1'].sessions.session1.video, true);
+        assert.deepEqual((result.current[2] as CurrentCall | null)?.sessions.session1.video, true);
+        act(() => {
+            setUserVideo('server1', 'channel-1', 'session1', false);
+            setUserVideo('server1', 'channel-1', 'session2', true);
+        });
+        assert.deepEqual((result.current[0] as CallsState).calls['channel-1'].sessions.session1.video, false);
+        assert.deepEqual((result.current[0] as CallsState).calls['channel-1'].sessions.session2.video, true);
+        assert.deepEqual((result.current[2] as CurrentCall | null)?.sessions.session1.video, false);
+        assert.deepEqual((result.current[2] as CurrentCall | null)?.sessions.session2.video, true);
+        act(() => {
+            setUserVideo('server1', 'invalid-channel', 'session1', true);
+            setUserVideo('server1', 'channel-1', 'session2', false);
+        });
+        assert.deepEqual(result.current[0], initialCallsState);
+    });
+
     it('setCallScreenOn/Off', () => {
         const initialCallsState = {
             ...DefaultCallsState,
@@ -618,8 +669,8 @@ describe('useCallsState', () => {
             'channel-1': {
                 id: 'call1',
                 sessions: {
-                    session1: {sessionId: 'session1', userId: 'user-1', muted: false, raisedHand: 0},
-                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, raisedHand: 345},
+                    session1: {sessionId: 'session1', userId: 'user-1', muted: false, video: false, raisedHand: 0},
+                    session2: {sessionId: 'session2', userId: 'user-2', muted: true, video: false, raisedHand: 345},
                 },
                 channelId: 'channel-1',
                 startTime: 123,
@@ -678,7 +729,7 @@ describe('useCallsState', () => {
             ...call1,
             sessions: {
                 ...call1.sessions,
-                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, raisedHand: 0},
+                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, video: false, raisedHand: 0},
             },
         };
         const expectedCallsState = {
@@ -794,6 +845,68 @@ describe('useCallsState', () => {
         assert.deepEqual(result.current[1], null);
     });
 
+    it('setLocalVideoURL', () => {
+        const initialCallsState = {
+            ...DefaultCallsState,
+            myUserId: 'myUserId',
+            calls: {'channel-1': call1, 'channel-2': call2},
+        };
+
+        // setup
+        const {result} = renderHook(() => {
+            return [useCallsState('server1'), useCurrentCall()];
+        });
+        act(() => setCallsState('server1', initialCallsState));
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], null);
+
+        // test joining a call and setting local video url:
+        act(() => newCurrentCall('server1', 'channel-1', 'myUserId'));
+        act(() => userJoinedCall('server1', 'channel-1', 'myUserId', 'mySessionId'));
+        assert.deepEqual((result.current[1] as CurrentCall | null)?.localVideoURL, '');
+        act(() => setLocalVideoURL('localVideoUrl'));
+        assert.deepEqual((result.current[1] as CurrentCall | null)?.localVideoURL, 'localVideoUrl');
+
+        act(() => {
+            myselfLeftCall();
+            userLeftCall('server1', 'channel-1', 'mySessionId');
+            setLocalVideoURL('test');
+        });
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], null);
+    });
+
+    it('setRemoteVideoURL', () => {
+        const initialCallsState = {
+            ...DefaultCallsState,
+            myUserId: 'myUserId',
+            calls: {'channel-1': call1, 'channel-2': call2},
+        };
+
+        // setup
+        const {result} = renderHook(() => {
+            return [useCallsState('server1'), useCurrentCall()];
+        });
+        act(() => setCallsState('server1', initialCallsState));
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], null);
+
+        // test joining a call and setting remote video url:
+        act(() => newCurrentCall('server1', 'channel-1', 'myUserId'));
+        act(() => userJoinedCall('server1', 'channel-1', 'myUserId', 'mySessionId'));
+        assert.deepEqual((result.current[1] as CurrentCall | null)?.remoteVideoURL, '');
+        act(() => setRemoteVideoURL('remoteVideoUrl'));
+        assert.deepEqual((result.current[1] as CurrentCall | null)?.remoteVideoURL, 'remoteVideoUrl');
+
+        act(() => {
+            myselfLeftCall();
+            userLeftCall('server1', 'channel-1', 'mySessionId');
+            setRemoteVideoURL('test');
+        });
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], null);
+    });
+
     it('setSpeakerPhoneOn', () => {
         const initialCallsState = {
             ...DefaultCallsState,
@@ -804,7 +917,7 @@ describe('useCallsState', () => {
             ...call1,
             sessions: {
                 ...call1.sessions,
-                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, raisedHand: 0},
+                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, video: false, raisedHand: 0},
             },
         };
         const expectedCallsState = {
@@ -850,7 +963,7 @@ describe('useCallsState', () => {
             ...call1,
             sessions: {
                 ...call1.sessions,
-                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, raisedHand: 0},
+                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, video: false, raisedHand: 0},
             },
         };
         const expectedCallsState = {
@@ -904,7 +1017,7 @@ describe('useCallsState', () => {
             ...call1,
             sessions: {
                 ...call1.sessions,
-                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, raisedHand: 0},
+                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, video: false, raisedHand: 0},
             },
         };
         const expectedCallsState: CallsState = {
@@ -925,9 +1038,11 @@ describe('useCallsState', () => {
         const secondExpectedCurrentCallState: CurrentCall = {
             ...expectedCurrentCallState,
             micPermissionsErrorDismissed: true,
+            cameraPermissionsErrorDismissed: false,
         };
         const expectedGlobalState: GlobalCallsState = {
             micPermissionsGranted: true,
+            cameraPermissionsGranted: false,
             joiningChannelId: null,
         };
 
@@ -973,6 +1088,87 @@ describe('useCallsState', () => {
         assert.deepEqual(result.current[1], null);
     });
 
+    it('CameraPermissions', () => {
+        const initialGlobalState = DefaultGlobalCallsState;
+        const initialCallsState: CallsState = {
+            ...DefaultCallsState,
+            myUserId: 'myUserId',
+            calls: {'channel-1': call1, 'channel-2': call2},
+        };
+        const newCall1: Call = {
+            ...call1,
+            sessions: {
+                ...call1.sessions,
+                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, video: false, raisedHand: 0},
+            },
+        };
+        const expectedCallsState: CallsState = {
+            ...initialCallsState,
+            calls: {
+                ...initialCallsState.calls,
+                'channel-1': newCall1,
+            },
+        };
+        const expectedCurrentCallState: CurrentCall = {
+            ...DefaultCurrentCall,
+            serverUrl: 'server1',
+            myUserId: 'myUserId',
+            mySessionId: 'mySessionId',
+            connected: true,
+            ...newCall1,
+        };
+        const secondExpectedCurrentCallState: CurrentCall = {
+            ...expectedCurrentCallState,
+            cameraPermissionsErrorDismissed: true,
+        };
+        const expectedGlobalState: GlobalCallsState = {
+            micPermissionsGranted: false,
+            cameraPermissionsGranted: true,
+            joiningChannelId: null,
+        };
+
+        // setup
+        const {result} = renderHook(() => {
+            return [useCallsState('server1'), useCurrentCall(), useGlobalCallsState()];
+        });
+        act(() => setCallsState('server1', initialCallsState));
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], null);
+        assert.deepEqual(result.current[2], initialGlobalState);
+
+        // join call
+        act(() => {
+            setCameraPermissionsGranted(false);
+            newCurrentCall('server1', 'channel-1', 'myUserId');
+            userJoinedCall('server1', 'channel-1', 'myUserId', 'mySessionId');
+        });
+        assert.deepEqual(result.current[0], expectedCallsState);
+        assert.deepEqual(result.current[1], expectedCurrentCallState);
+        assert.deepEqual(result.current[2], initialGlobalState);
+
+        // dismiss camera error
+        act(() => setCameraPermissionsErrorDismissed());
+        assert.deepEqual(result.current[0], expectedCallsState);
+        assert.deepEqual(result.current[1], secondExpectedCurrentCallState);
+        assert.deepEqual(result.current[2], initialGlobalState);
+
+        // grant permissions
+        act(() => setCameraPermissionsGranted(true));
+        assert.deepEqual(result.current[0], expectedCallsState);
+        assert.deepEqual(result.current[1], secondExpectedCurrentCallState);
+        assert.deepEqual(result.current[2], expectedGlobalState);
+
+        act(() => {
+            myselfLeftCall();
+            userLeftCall('server1', 'channel-1', 'mySessionId');
+
+            // reset state to default
+            setCameraPermissionsGranted(false);
+        });
+        assert.deepEqual(result.current[0], initialCallsState);
+        assert.deepEqual(result.current[1], null);
+    });
+
     it('joining call', () => {
         const initialGlobalState = DefaultGlobalCallsState;
         const expectedGlobalState: GlobalCallsState = {
@@ -1004,7 +1200,7 @@ describe('useCallsState', () => {
             ...call1,
             sessions: {
                 ...call1.sessions,
-                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, raisedHand: 0},
+                mySessionId: {sessionId: 'mySessionId', userId: 'myUserId', muted: true, video: false, raisedHand: 0},
             },
         };
         const expectedCallsState: CallsState = {
@@ -1108,7 +1304,7 @@ describe('useCallsState', () => {
         assert.deepEqual(result.current[0], initialCallsState);
 
         // test that voice state is cleared on reconnect
-        await act(() => setCalls('server1', 'myUserId', initialCallsState.calls, {}));
+        await act(async () => setCalls('server1', 'myUserId', initialCallsState.calls, {}));
         assert.deepEqual(result.current[1], initialCurrentCallState);
         assert.deepEqual(result.current[0], initialCallsState);
     });

--- a/app/products/calls/state/actions.ts
+++ b/app/products/calls/state/actions.ts
@@ -339,6 +339,7 @@ export const userJoinedCall = (serverUrl: string, channelId: string, userId: str
         sessionId,
         muted: true,
         raisedHand: 0,
+        video: false,
     };
     const nextCalls = {...callsState.calls, [channelId]: nextCall};
 
@@ -546,6 +547,38 @@ export const setUserMuted = (serverUrl: string, channelId: string, sessionId: st
     setCurrentCall(nextCurrentCall);
 };
 
+export const setUserVideo = (serverUrl: string, channelId: string, sessionId: string, video: boolean) => {
+    const callsState = getCallsState(serverUrl);
+    if (!callsState.calls[channelId] || !callsState.calls[channelId].sessions[sessionId]) {
+        return;
+    }
+
+    const nextUser = {...callsState.calls[channelId].sessions[sessionId], video};
+    const nextCall = {
+        ...callsState.calls[channelId],
+        sessions: {...callsState.calls[channelId].sessions},
+    };
+    nextCall.sessions[sessionId] = nextUser;
+    const nextCalls = {...callsState.calls};
+    nextCalls[channelId] = nextCall;
+    setCallsState(serverUrl, {...callsState, calls: nextCalls});
+
+    // Was it the current call? If so, update that too.
+    const currentCall = getCurrentCall();
+    if (!currentCall || currentCall.channelId !== channelId) {
+        return;
+    }
+
+    const nextCurrentCall = {
+        ...currentCall,
+        sessions: {
+            ...currentCall.sessions,
+            [sessionId]: {...currentCall.sessions[sessionId], video},
+        },
+    };
+    setCurrentCall(nextCurrentCall);
+};
+
 export const setUserVoiceOn = (channelId: string, sessionId: string, voiceOn: boolean) => {
     const currentCall = getCurrentCall();
     if (!currentCall || currentCall.channelId !== channelId) {
@@ -660,6 +693,20 @@ export const setScreenShareURL = (url: string) => {
     }
 };
 
+export const setLocalVideoURL = (url: string) => {
+    const call = getCurrentCall();
+    if (call) {
+        setCurrentCall({...call, localVideoURL: url});
+    }
+};
+
+export const setRemoteVideoURL = (url: string) => {
+    const call = getCurrentCall();
+    if (call) {
+        setCurrentCall({...call, remoteVideoURL: url});
+    }
+};
+
 export const setSpeakerPhone = (speakerphoneOn: boolean) => {
     const call = getCurrentCall();
     if (call) {
@@ -711,6 +758,29 @@ export const setMicPermissionsErrorDismissed = () => {
     const nextCurrentCall = {
         ...currentCall,
         micPermissionsErrorDismissed: true,
+    };
+    setCurrentCall(nextCurrentCall);
+};
+
+export const setCameraPermissionsGranted = (granted: boolean) => {
+    const globalState = getGlobalCallsState();
+
+    const nextGlobalState = {
+        ...globalState,
+        cameraPermissionsGranted: granted,
+    };
+    setGlobalCallsState(nextGlobalState);
+};
+
+export const setCameraPermissionsErrorDismissed = () => {
+    const currentCall = getCurrentCall();
+    if (!currentCall) {
+        return;
+    }
+
+    const nextCurrentCall = {
+        ...currentCall,
+        cameraPermissionsErrorDismissed: true,
     };
     setCurrentCall(nextCurrentCall);
 };

--- a/app/products/calls/types/calls.ts
+++ b/app/products/calls/types/calls.ts
@@ -13,11 +13,13 @@ import type UserModel from '@typings/database/models/servers/user';
 
 export type GlobalCallsState = {
     micPermissionsGranted: boolean;
+    cameraPermissionsGranted: boolean;
     joiningChannelId: string | null;
 }
 
 export const DefaultGlobalCallsState: GlobalCallsState = {
     micPermissionsGranted: false,
+    cameraPermissionsGranted: false,
     joiningChannelId: null,
 };
 
@@ -100,10 +102,13 @@ export type CurrentCall = Call & {
     myUserId: string;
     mySessionId: string;
     screenShareURL: string;
+    localVideoURL: string;
+    remoteVideoURL: string;
     speakerphoneOn: boolean;
     audioDeviceInfo: AudioDeviceInfo;
     voiceOn: Dictionary<boolean>;
     micPermissionsErrorDismissed: boolean;
+    cameraPermissionsErrorDismissed: boolean;
     reactionStream: ReactionStreamEmoji[];
     callQualityAlert: boolean;
     callQualityAlertDismissed: number;
@@ -117,10 +122,13 @@ export const DefaultCurrentCall: CurrentCall = {
     myUserId: '',
     mySessionId: '',
     screenShareURL: '',
+    localVideoURL: '',
+    remoteVideoURL: '',
     speakerphoneOn: false,
     audioDeviceInfo: {availableAudioDeviceList: [], selectedAudioDevice: AudioDevice.None},
     voiceOn: {},
     micPermissionsErrorDismissed: false,
+    cameraPermissionsErrorDismissed: false,
     reactionStream: [],
     callQualityAlert: false,
     callQualityAlertDismissed: 0,
@@ -131,6 +139,7 @@ export type CallSession = {
     sessionId: string;
     userId: string;
     muted: boolean;
+    video?: boolean;
     raisedHand: number;
     userModel?: UserModel;
     reaction?: UserReactionData;
@@ -140,12 +149,15 @@ export type ChannelsWithCalls = Dictionary<boolean>;
 
 export type CallsConnection = {
     disconnect: (err?: Error) => void;
+    stopVideo: () => void;
+    startVideo: () => void;
     mute: () => void;
     unmute: () => void;
     waitForPeerConnection: () => Promise<void>;
     raiseHand: () => void;
     unraiseHand: () => void;
     initializeVoiceTrack: () => void;
+    initializeVideoTrack: (start: boolean) => void;
     sendReaction: (emoji: EmojiData) => void;
 }
 
@@ -180,6 +192,7 @@ export const DefaultCallsConfig: CallsConfigState = {
     TranscribeAPI: TranscribeAPI.WhisperCPP,
     GroupCallsAllowed: true, // Set to true to keep backward compatibility with older servers.
     EnableDCSignaling: false,
+    EnableVideo: false,
 };
 
 export type ApiResp = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -17,7 +17,7 @@
         "@formatjs/intl-numberformat": "8.15.1",
         "@formatjs/intl-pluralrules": "5.4.1",
         "@gorhom/bottom-sheet": "5.0.6",
-        "@mattermost/calls": "github:mattermost/calls-common#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
+        "@mattermost/calls": "github:mattermost/calls-common#01b62e7001cffe01b4a64a38f8a6d960f570d31a",
         "@mattermost/compass-icons": "0.1.48",
         "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
         "@mattermost/react-native-emm": "1.6.1",
@@ -4596,8 +4596,8 @@
     "node_modules/@mattermost/calls": {
       "name": "@mattermost/calls-common",
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
-      "integrity": "sha512-qtMUUGHrl6VOGgjyQ+Ft4YddWo5RV8MDK8zSaYRU/1MiiY/zqq5kW6nvuzMB2S0xAvPwYlcFEBfmM4QZrReD6w==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#01b62e7001cffe01b4a64a38f8a6d960f570d31a",
+      "integrity": "sha512-yr+6lAAo9SjW7zh6C5EqNrfZ9fXFfyuaKacxewbwLbttnvzNGDnzOQd2v4kKos5PD/7/w3iWKGL+z0PmMUDDTg==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
         "fflate": "0.8.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-numberformat": "8.15.1",
     "@formatjs/intl-pluralrules": "5.4.1",
     "@gorhom/bottom-sheet": "5.0.6",
-    "@mattermost/calls": "github:mattermost/calls-common#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
+    "@mattermost/calls": "github:mattermost/calls-common#01b62e7001cffe01b4a64a38f8a6d960f570d31a",
     "@mattermost/compass-icons": "0.1.48",
     "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
     "@mattermost/react-native-emm": "1.6.1",


### PR DESCRIPTION
#### Summary

PR implements all the non-UI logic necessary to enable video calls in DMs. This will be the base branch for any upcoming additions.

The functionality is expected to be behind a global `EnableVideo` config flag in the plugin settings, which defaults to `false.` It's also expected to be backward compatible with regard to existing functionality, meaning that both new and older clients will work as expected against new or older backends. Of course, an older client won't be able to receive video from a newer client. Both sides will need to be on the latest version :)

The majority of changes on this side are around allowing to share video tracks. This means checking for camera permissions and implementing the necessary methods in our WebRTC connection wrapper (namely `startVideo`, `stopVideo` and `initializeVideoTrack`), plus any state synchronization (e.g., new video_on/video_off websocket events).

#### Related PRs

https://github.com/mattermost/calls-common/pull/47
https://github.com/mattermost/mattermost-plugin-calls/pull/997

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63431

#### Release Note

```release-note
Added experimental support for 1-1 video calls in DM channels.
```

