### PR TITLE
[MM-62176] fix ordering after edit

### DIFF
--- a/app/screens/edit_profile/edit_profile.test.tsx
+++ b/app/screens/edit_profile/edit_profile.test.tsx
@@ -1,0 +1,108 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {act} from '@testing-library/react-hooks';
+import {fireEvent} from '@testing-library/react-native';
+import React from 'react';
+
+import AvailableScreens from '@constants/screens';
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import EditProfile from './edit_profile';
+
+import type {UserModel} from '@database/models/server';
+
+// Mock CompassIcon
+jest.mock('@components/compass_icon', () => {
+    function CompassIcon() {
+        return null;
+    }
+    CompassIcon.getImageSourceSync = jest.fn().mockReturnValue({});
+    return {
+        __esModule: true,
+        default: CompassIcon,
+    };
+});
+
+// Mock server context
+jest.mock('@context/server', () => ({
+    useServerUrl: jest.fn().mockReturnValue('http://localhost:8065'),
+}));
+
+// Mock remote user actions
+jest.mock('@actions/remote/user', () => ({
+    fetchCustomAttributes: jest.fn().mockResolvedValue({
+        attributes: {
+            attr1: {
+                id: 'attr1',
+                name: 'Custom Attribute 1',
+                value: 'original value',
+                sort_order: 1,
+            },
+        },
+        error: undefined,
+    }),
+    updateCustomAttributes: jest.fn().mockResolvedValue({}),
+    updateMe: jest.fn().mockResolvedValue({}),
+    uploadUserProfileImage: jest.fn().mockResolvedValue({}),
+    setDefaultProfileImage: jest.fn().mockResolvedValue({}),
+    buildProfileImageUrlFromUser: jest.fn().mockReturnValue('http://example.com/profile.jpg'),
+}));
+
+describe('EditProfile', () => {
+    const mockCurrentUser = {
+        id: 'user1',
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        nickname: 'Johnny',
+        position: 'Developer',
+        username: 'johndoe',
+    } as UserModel;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should update custom attribute value while preserving name and sort order', async () => {
+        const {getByTestId} = renderWithIntlAndTheme(
+            <EditProfile
+                componentId={AvailableScreens.EDIT_PROFILE}
+                currentUser={mockCurrentUser}
+                isModal={false}
+                isTablet={false}
+                lockedFirstName={false}
+                lockedLastName={false}
+                lockedNickname={false}
+                lockedPosition={false}
+                lockedPicture={false}
+                enableCustomAttributes={true}
+            />,
+        );
+
+        // Wait for the custom attributes to be loaded
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        // Verify the mock was called with correct arguments
+        const {fetchCustomAttributes} = require('@actions/remote/user');
+        expect(fetchCustomAttributes).toHaveBeenCalledWith('http://localhost:8065', 'user1');
+        const TEST_ID = 'edit_profile_form.customAttributes.attr1.input';
+
+        // Find the input field and update its value
+        const input = getByTestId(TEST_ID);
+
+        await act(async () => {
+            fireEvent.changeText(input, 'new value');
+        });
+
+        const updatedCustomAttr = getByTestId(TEST_ID);
+
+        // Verify the value was updated
+        expect(updatedCustomAttr.props.value).toBe('new value');
+
+        // Verify name and sort_order were preserved
+        expect(updatedCustomAttr.props.name).toBe(input.props.name);
+        expect(updatedCustomAttr.props.sort_order).toBe(input.props.sort_order);
+    });
+});

--- a/app/screens/edit_profile/edit_profile.test.tsx
+++ b/app/screens/edit_profile/edit_profile.test.tsx
@@ -11,7 +11,6 @@ import EditProfile from './edit_profile';
 
 import type {UserModel} from '@database/models/server';
 
-// Mock CompassIcon
 jest.mock('@components/compass_icon', () => {
     function CompassIcon() {
         return null;
@@ -23,12 +22,10 @@ jest.mock('@components/compass_icon', () => {
     };
 });
 
-// Mock server context
 jest.mock('@context/server', () => ({
     useServerUrl: jest.fn().mockReturnValue('http://localhost:8065'),
 }));
 
-// Mock remote user actions
 jest.mock('@actions/remote/user', () => ({
     fetchCustomAttributes: jest.fn().mockResolvedValue({
         attributes: {
@@ -79,17 +76,14 @@ describe('EditProfile', () => {
             />,
         );
 
-        // Wait for the custom attributes to be loaded
         await act(async () => {
             await new Promise((resolve) => setTimeout(resolve, 0));
         });
 
-        // Verify the mock was called with correct arguments
         const {fetchCustomAttributes} = require('@actions/remote/user');
         expect(fetchCustomAttributes).toHaveBeenCalledWith('http://localhost:8065', 'user1');
         const TEST_ID = 'edit_profile_form.customAttributes.attr1.input';
 
-        // Find the input field and update its value
         const input = getByTestId(TEST_ID);
 
         await act(async () => {
@@ -98,10 +92,8 @@ describe('EditProfile', () => {
 
         const updatedCustomAttr = getByTestId(TEST_ID);
 
-        // Verify the value was updated
         expect(updatedCustomAttr.props.value).toBe('new value');
 
-        // Verify name and sort_order were preserved
         expect(updatedCustomAttr.props.name).toBe(input.props.name);
         expect(updatedCustomAttr.props.sort_order).toBe(input.props.sort_order);
     });

--- a/app/screens/edit_profile/edit_profile.tsx
+++ b/app/screens/edit_profile/edit_profile.tsx
@@ -127,7 +127,7 @@ const EditProfile = ({
             }
             const {error: fetchError, attributes} = await fetchCustomAttributes(serverUrl, currentUser.id);
             if (!fetchError && attributes) {
-                setUserInfo((prev) => ({...prev, customAttributes: attributes} as UserInfo));
+                setUserInfo((prev: UserInfo) => ({...prev, customAttributes: attributes} as UserInfo));
             }
         };
 
@@ -200,7 +200,7 @@ const EditProfile = ({
         const update = {...userInfo};
         if (fieldKey.startsWith(CUSTOM_ATTRS_PREFIX_NAME)) {
             const attrKey = fieldKey.slice(CUSTOM_ATTRS_PREFIX_NAME.length);
-            update.customAttributes = {...update.customAttributes, [attrKey]: {id: attrKey, name: userInfo.customAttributes[attrKey].name, value}};
+            update.customAttributes = {...update.customAttributes, [attrKey]: {id: attrKey, name: userInfo.customAttributes[attrKey].name, value, sort_order: userInfo.customAttributes[attrKey].sort_order}};
         } else {
             switch (fieldKey) {
             // typescript doesn't like to do update[fieldkey] as it might containg a customAttribute case


### PR DESCRIPTION
#### Summary

Order wasn't maintained when editing a field (deletion or modification)

#### Ticket Link
[MM-62176](https://mattermost.atlassian.net/browse/MM-62176)
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: ios Simulator, Pixel 8, Xiaomi 8

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
fix fields being reordered after editing
```


[MM-62176]: https://mattermost.atlassian.net/browse/MM-62176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ