### PR TITLE
upgrade to @mattermost/commonmark@0.31.2-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -46,7 +46,7 @@
         "@voximplant/react-native-foreground-service": "3.0.2",
         "APNG4Android": "github:mattermost/APNG4Android#15a7e93d59542d18c1e562d49b3f4896dd1643a6",
         "base-64": "1.0.0",
-        "commonmark": "npm:@mattermost/commonmark@0.30.1-4",
+        "commonmark": "npm:@mattermost/commonmark@0.31.2-0",
         "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#81b5d27509652bae50b4b510ede777dd3bd923cf",
         "deep-equal": "2.2.3",
         "deepmerge": "4.3.1",
@@ -9968,12 +9968,14 @@
     },
     "node_modules/commonmark": {
       "name": "@mattermost/commonmark",
-      "version": "0.30.1-4",
+      "version": "0.31.2-0",
+      "resolved": "https://registry.npmjs.org/@mattermost/commonmark/-/commonmark-0.31.2-0.tgz",
+      "integrity": "sha512-wScEj6fc158FIQD7cmJ5BlZ6o6z3J7Nh0cjIEwL9qDwdyQ0Q3LOH3+4e6PvjpUoIJlQByzmHFR2VCq3BfeZOTg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "entities": "~3.0.1",
         "mdurl": "~1.0.1",
-        "minimist": "~1.2.5",
+        "minimist": "~1.2.8",
         "string.prototype.repeat": "^1.0.0",
         "xregexp": "5.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@voximplant/react-native-foreground-service": "3.0.2",
     "APNG4Android": "github:mattermost/APNG4Android#15a7e93d59542d18c1e562d49b3f4896dd1643a6",
     "base-64": "1.0.0",
-    "commonmark": "npm:@mattermost/commonmark@0.30.1-4",
+    "commonmark": "npm:@mattermost/commonmark@0.31.2-0",
     "commonmark-react-renderer": "github:mattermost/commonmark-react-renderer#81b5d27509652bae50b4b510ede777dd3bd923cf",
     "deep-equal": "2.2.3",
     "deepmerge": "4.3.1",


### PR DESCRIPTION
#### Summary
Updates the mobile app with the latest (forked) commonmark dependency from https://github.com/mattermost/commonmark.js/pull/22. (Note the commit is temporary, to be replaced with a tagged version once merged.)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-63537

#### Checklist
- ~~[ ] Added or updated unit tests (required for all new features)~~
- ~~[ ] Has UI changes~~
- ~~[ ] Includes text changes and localization file updates~~
- ~~[ ] Have tested against the 5 core themes to ensure consistency between them.~~
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: iOS Simulator (iPhone 16 Pro, iOS 18.2)

#### Screenshots
N/A

#### Release Note
```release-note
Upgrade forked commonmark to 0.31.2-0
```