### PR TITLE
[MM-63576] Send websocket ping immediately after connecting

### DIFF
--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -183,7 +183,12 @@ export default class WebSocketClient {
                 }
             }
 
-            this.waitingForPong = false;
+            // Send a ping immediately to test the socket
+            this.waitingForPong = true;
+            this.ping();
+
+            // And every 30 seconds after, checking to ensure
+            // we're getting responses from the server
             this.pingInterval = setInterval(
                 () => {
                     if (!this.waitingForPong) {


### PR DESCRIPTION
### Summary
In https://github.com/mattermost/mattermost-mobile/pull/8633, we introduced a client side PING message to the websocket. This sends a PING message every 30 seconds to help ensure the connection is still alive.

In that initial implementation, we wait 30 seconds before sending the first PING message. To detect broken connections more quickly (specifically broken connections that are never fully open), this PR will send the first PING immediately (with no delay).

### Testing Steps

If you force close then re-open the mobile app, you should immediately see something like the following in the server logs:

`{"timestamp":"2025-03-26 11:14:52.925 -04:00","level":"debug","msg":"Websocket request","caller":"wsapi/websocket_handler.go:26","action":"ping"}`

_**Important note:** the server Site URL has to be set properly for websockets to connect properly on mobile._

### Ticket Link
https://mattermost.atlassian.net/browse/MM-63576

### Release Note

This change doesn't need a specific release note.

```release-note
NONE
```