### PR TITLE
Fix the issue when click on see all tab in from channel takes to the empty scheduled post screen. 

### DIFF
--- a/app/actions/local/draft.test.ts
+++ b/app/actions/local/draft.test.ts
@@ -63,11 +63,8 @@ jest.mock('@utils/helpers', () => ({
 }));
 
 jest.mock('@screens/navigation', () => ({
-    goToScreen: jest.fn(),
-}));
-
-jest.mock('@screens/navigation', () => ({
     popTo: jest.fn(),
+    goToScreen: jest.fn(),
 }));
 
 describe('updateDraftFile', () => {
@@ -282,6 +279,19 @@ describe('switchToGlobalDrafts', () => {
         expect(emitSpy).toHaveBeenCalledWith(Navigation.NAVIGATION_HOME, Screens.GLOBAL_DRAFTS, {});
     });
 
+    it('if prepareRecordsOnly is true, should emit navigation event on tablet for Scheduled post tab and also call batchRecord', async () => {
+        jest.mocked(isTablet).mockReturnValue(true);
+        const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
+        const batchRecordSpy = jest.spyOn(operator, 'batchRecords');
+
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_TEAM_ID, value: teamId}], prepareRecordsOnly: false});
+
+        await switchToGlobalDrafts(serverUrl, '', DRAFT_SCREEN_TAB_SCHEDULED_POSTS, true);
+
+        expect(batchRecordSpy).toHaveBeenCalled();
+        expect(emitSpy).toHaveBeenCalled();
+    });
+
     it('should fail to emit navigation event on tablet', async () => {
         jest.mocked(isTablet).mockReturnValue(true);
         const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
@@ -306,20 +316,23 @@ describe('switchToGlobalDrafts', () => {
         jest.mocked(isTablet).mockReturnValue(false);
         const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
 
+        const goToScreenMock = jest.mocked(goToScreen);
+
         await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_TEAM_ID, value: teamId}], prepareRecordsOnly: false});
         await switchToGlobalDrafts(serverUrl);
 
-        expect(goToScreen).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS, '', {}, {topBar: {visible: false}});
+        expect(goToScreenMock).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS, '', {}, {topBar: {visible: false}});
         expect(emitSpy).not.toHaveBeenCalled();
     });
 
     it('should not call goToScreen on non-tablet when server url is a non existent URL', async () => {
         jest.mocked(isTablet).mockReturnValue(false);
         const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
+        const goToScreenMock = jest.mocked(goToScreen);
 
         await switchToGlobalDrafts('nonexistent');
 
-        expect(goToScreen).not.toHaveBeenCalled();
+        expect(goToScreenMock).not.toHaveBeenCalled();
         expect(emitSpy).not.toHaveBeenCalled();
     });
 
@@ -337,12 +350,13 @@ describe('switchToGlobalDrafts', () => {
     it('should pass initialTab param when provided on non-tablet', async () => {
         jest.mocked(isTablet).mockReturnValue(false);
         const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
+        const goToScreenMock = jest.mocked(goToScreen);
 
         await switchToGlobalDrafts(serverUrl, teamId, DRAFT_SCREEN_TAB_SCHEDULED_POSTS);
-        expect(goToScreen).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS, '', {initialTab: DRAFT_SCREEN_TAB_SCHEDULED_POSTS}, {topBar: {visible: false}});
+        expect(goToScreenMock).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS, '', {initialTab: DRAFT_SCREEN_TAB_SCHEDULED_POSTS}, {topBar: {visible: false}});
 
         await switchToGlobalDrafts(serverUrl, teamId, DRAFT_SCREEN_TAB_DRAFTS);
-        expect(goToScreen).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS, '', {initialTab: DRAFT_SCREEN_TAB_DRAFTS}, {topBar: {visible: false}});
+        expect(goToScreenMock).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS, '', {initialTab: DRAFT_SCREEN_TAB_DRAFTS}, {topBar: {visible: false}});
         expect(emitSpy).not.toHaveBeenCalled();
     });
 
@@ -354,19 +368,6 @@ describe('switchToGlobalDrafts', () => {
         await switchToGlobalDrafts(serverUrl, teamId, DRAFT_SCREEN_TAB_SCHEDULED_POSTS);
 
         expect(popTo).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS);
-    });
-
-    it('if prepareRecordsOnly is true, should emit navigation event on tablet for Scheduled post tab and also call batchRecord', async () => {
-        jest.mocked(isTablet).mockReturnValue(true);
-        const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
-        const batchRecordSpy = jest.spyOn(operator, 'batchRecords');
-
-        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_TEAM_ID, value: teamId}], prepareRecordsOnly: false});
-
-        await switchToGlobalDrafts(serverUrl, '', DRAFT_SCREEN_TAB_SCHEDULED_POSTS, true);
-
-        expect(batchRecordSpy).toHaveBeenCalled();
-        expect(emitSpy).toHaveBeenCalled();
     });
 });
 

--- a/app/actions/local/draft.test.ts
+++ b/app/actions/local/draft.test.ts
@@ -9,7 +9,8 @@ import {Navigation, Screens} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import {DRAFT_SCREEN_TAB_DRAFTS, DRAFT_SCREEN_TAB_SCHEDULED_POSTS} from '@screens/global_drafts/global_drafts';
-import {goToScreen} from '@screens/navigation';
+import {goToScreen, popTo} from '@screens/navigation';
+import NavigationStore from '@store/navigation_store';
 import {isTablet} from '@utils/helpers';
 
 import {
@@ -63,6 +64,10 @@ jest.mock('@utils/helpers', () => ({
 
 jest.mock('@screens/navigation', () => ({
     goToScreen: jest.fn(),
+}));
+
+jest.mock('@screens/navigation', () => ({
+    popTo: jest.fn(),
 }));
 
 describe('updateDraftFile', () => {
@@ -339,6 +344,16 @@ describe('switchToGlobalDrafts', () => {
         await switchToGlobalDrafts(serverUrl, teamId, DRAFT_SCREEN_TAB_DRAFTS);
         expect(goToScreen).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS, '', {initialTab: DRAFT_SCREEN_TAB_DRAFTS}, {topBar: {visible: false}});
         expect(emitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call popto from navigation store if Global draft is alreay present', async () => {
+        NavigationStore.addScreenToStack(Screens.GLOBAL_DRAFTS);
+        NavigationStore.addScreenToStack(Screens.CHANNEL);
+        NavigationStore.addScreenToStack(Screens.THREAD);
+
+        await switchToGlobalDrafts(serverUrl, teamId, DRAFT_SCREEN_TAB_SCHEDULED_POSTS);
+
+        expect(popTo).toHaveBeenCalledWith(Screens.GLOBAL_DRAFTS);
     });
 
     it('if prepareRecordsOnly is true, should emit navigation event on tablet for Scheduled post tab and also call batchRecord', async () => {

--- a/app/screens/global_drafts/components/tabbed_contents/draftTabsHeader.tsx
+++ b/app/screens/global_drafts/components/tabbed_contents/draftTabsHeader.tsx
@@ -143,6 +143,7 @@ export function DraftTabsHeader({draftsCount, scheduledPostCount, selectedTab, o
                 <TouchableOpacity
                     onPress={onDraftTabPress}
                     testID='draft_tab'
+                    accessibilityState={{selected: selectedTab === DRAFT_TAB_INDEX}}
                 >
                     <View style={draftsContanerStyle}>
                         <FormattedText
@@ -156,6 +157,7 @@ export function DraftTabsHeader({draftsCount, scheduledPostCount, selectedTab, o
                 <TouchableOpacity
                     onPress={onScheduledPostTabPress}
                     testID='scheduled_post_tab'
+                    accessibilityState={{selected: selectedTab === DRAFT_SCREEN_TAB_SCHEDULED_POSTS}}
                 >
                     <View style={scheduledContainerStyle}>
                         <FormattedText

--- a/app/screens/global_drafts/components/tabbed_contents/tabbed_contents.test.tsx
+++ b/app/screens/global_drafts/components/tabbed_contents/tabbed_contents.test.tsx
@@ -5,7 +5,7 @@ import {act, fireEvent, screen} from '@testing-library/react-native';
 import React from 'react';
 import {Text} from 'react-native';
 
-import {DRAFT_SCREEN_TAB_DRAFTS} from '@screens/global_drafts/global_drafts';
+import {DRAFT_SCREEN_TAB_DRAFTS, DRAFT_SCREEN_TAB_SCHEDULED_POSTS} from '@screens/global_drafts/global_drafts';
 import {renderWithIntlAndTheme} from '@test/intl-test-helper';
 import TestHelper from '@test/test_helper';
 
@@ -59,11 +59,41 @@ describe('TabbedContents', () => {
             await TestHelper.wait(300); // Wait until the badge renders
         });
 
+        const scheduledTab = screen.getByTestId('scheduled_post_tab');
+        const draftTab = screen.getByTestId('draft_tab');
+
         // Check that the drafts tab is selected
-        expect(screen.getByTestId('draft_tab')).toBeTruthy();
-        expect(screen.getByTestId('drafts-content')).toBeTruthy();
+        expect(scheduledTab.props.accessibilityState).toEqual({selected: false});
+        expect(draftTab.props.accessibilityState).toEqual({selected: true});
 
         // Check that the counts are displayed correctly
+        expect(screen.getByText('5')).toBeTruthy();
+        expect(screen.getByText('3')).toBeTruthy();
+    });
+
+    it('renders correctly with initial tab set to scheduled post', async () => {
+        const props: Parameters<typeof TabbedContents>[0] = {
+            ...defaultProps,
+            initialTab: DRAFT_SCREEN_TAB_SCHEDULED_POSTS,
+        };
+        renderWithIntlAndTheme(<TabbedContents {...props}/>);
+
+        await act(async () => {
+            await TestHelper.wait(300); // Wait until the badge renders
+        });
+
+        await act(async () => {
+            await TestHelper.wait(300);
+        });
+
+        const scheduledTab = screen.getByTestId('scheduled_post_tab');
+        const draftTab = screen.getByTestId('draft_tab');
+
+        // ✅ Check accessibilityState
+        expect(scheduledTab.props.accessibilityState).toEqual({selected: true});
+        expect(draftTab.props.accessibilityState).toEqual({selected: false});
+
+        // Badge counts
         expect(screen.getByText('5')).toBeTruthy();
         expect(screen.getByText('3')).toBeTruthy();
     });

--- a/app/screens/global_drafts/components/tabbed_contents/tabbed_contents.tsx
+++ b/app/screens/global_drafts/components/tabbed_contents/tabbed_contents.tsx
@@ -39,8 +39,8 @@ const getStyleSheet = (width: number) => {
 
 export default function TabbedContents({draftsCount, scheduledPostCount, initialTab, drafts, scheduledPosts}: Props) {
     const [selectedTab, setSelectedTab] = useState(initialTab);
-    const [freezeDraft, setFreezeDraft] = useState(false);
-    const [freezeScheduledPosts, setFreezeScheduledPosts] = useState(true);
+    const [freezeDraft, setFreezeDraft] = useState(initialTab !== DRAFT_SCREEN_TAB_DRAFTS);
+    const [freezeScheduledPosts, setFreezeScheduledPosts] = useState(initialTab !== DRAFT_SCREEN_TAB_SCHEDULED_POSTS);
     const [width, setWidth] = useState(0);
 
     const onLayout = useCallback((e: LayoutChangeEvent) => {

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -523,6 +523,15 @@ export async function popTopScreen(screenId?: AvailableScreens) {
     }
 }
 
+export async function popTo(screenId: AvailableScreens) {
+    try {
+        await Navigation.popTo(screenId);
+    } catch (error) {
+        // RNN returns a promise rejection if there are no screens
+        // atop the root screen to pop. We'll do nothing in this case.
+    }
+}
+
 export async function popToRoot() {
     const componentId = NavigationStore.getVisibleScreen();
 


### PR DESCRIPTION
#### Summary
Issue: When clicking "See All" from the scheduled post indicator in the channel, it navigates to the draft screen with the Scheduled Posts tab selected — but the tab appears empty. Also, when you tap the back button, it takes you to an empty channel screen.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63634

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
