### PR TITLE
Update calls-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -17,7 +17,7 @@
         "@formatjs/intl-numberformat": "8.15.1",
         "@formatjs/intl-pluralrules": "5.4.1",
         "@gorhom/bottom-sheet": "5.0.6",
-        "@mattermost/calls": "github:mattermost/calls-common#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
+        "@mattermost/calls": "github:mattermost/calls-common#df3b1cd6b66bdc34423a246a91305c943e3ac59c",
         "@mattermost/compass-icons": "0.1.48",
         "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
         "@mattermost/react-native-emm": "1.6.1",
@@ -4596,8 +4596,8 @@
     "node_modules/@mattermost/calls": {
       "name": "@mattermost/calls-common",
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
-      "integrity": "sha512-qtMUUGHrl6VOGgjyQ+Ft4YddWo5RV8MDK8zSaYRU/1MiiY/zqq5kW6nvuzMB2S0xAvPwYlcFEBfmM4QZrReD6w==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#df3b1cd6b66bdc34423a246a91305c943e3ac59c",
+      "integrity": "sha512-cqJQRHkWkawx44gGQnWswzgWFpAlom1dYMStDBj5I4tPzFuiv+FC0dr4kHfA9rNQvKa1lq+/ihNl+gZRzcw2Fg==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
         "fflate": "0.8.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-numberformat": "8.15.1",
     "@formatjs/intl-pluralrules": "5.4.1",
     "@gorhom/bottom-sheet": "5.0.6",
-    "@mattermost/calls": "github:mattermost/calls-common#030ff7c0a37ee9b0ccc5fae0b2ea9c0e1c08473f",
+    "@mattermost/calls": "github:mattermost/calls-common#df3b1cd6b66bdc34423a246a91305c943e3ac59c",
     "@mattermost/compass-icons": "0.1.48",
     "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
     "@mattermost/react-native-emm": "1.6.1",


### PR DESCRIPTION
#### Summary

Manual cherry-pick of https://github.com/mattermost/mattermost-mobile/pull/8745 to `release-2.27`.

#### Release Note

```release-note
NONE
```

