### PR TITLE
Remove unused rnshield dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -183,11 +183,6 @@
       "version": "0.0.0",
       "license": "Apache 2.0"
     },
-    "libraries/@mattermost/rnshield": {
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache 2.0"
-    },
     "libraries/@mattermost/rnutils": {
       "version": "0.0.0",
       "license": "Apache 2.0"


### PR DESCRIPTION
#### Summary

TDLR:
- Remove unused `rnshield` dependency

Full description:
While working on SBOM things I realized the dependency was called out in `package-lock.json` but not the SBOM, so then I did some investigation and realized it's because it's not used at all.

If you delete `node_modules/` and `package-lock.json` and regenerate it, the dependency gets removed, but I didn't want to make a bunch of other changes so I just opted to remove the one unused dependency. 

#### Ticket Link

NA

#### Screenshots

<img width="1073" alt="no_rnshield_found" src="https://github.com/user-attachments/assets/bb431903-472f-4717-83a2-f2b6c4717dca" />

#### Release Note

```release-note
NONE
```