### PR TITLE
Explicitly build the universal apk

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -70,6 +70,7 @@ if (System.getenv("SENTRY_ENABLED") == "true") {
  * and want to have separate APKs to upload to the Play Store
  */
 def enableSeparateBuildPerCPUArchitecture = project.hasProperty('separateApk') ? project.property('separateApk').toBoolean() : false
+def enableUniversalBuild = project.hasProperty('universalApk') ? project.property('universalApk').toBoolean() : false
 
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
@@ -140,7 +141,7 @@ android {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
-            universalApk enableSeparateBuildPerCPUArchitecture  // If true, also generate a universal APK
+            universalApk enableUniversalBuild  // If true, also generate a universal APK
             include (*reactNativeArchitectures())
         }
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -874,7 +874,7 @@ platform :android do
           project_dir: 'android/',
           properties: {
             'separateApk' => ENV["SEPARATE_APKS"] || false,
-            'universalApk' => ENV["SEPARATE_APKS"] || false,
+            'universalApk' => ENV["UNIVERSAL_APK"] || false,
           }
       )
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -340,7 +340,6 @@ lane :github do
     android = [
       "    * [Mattermost arm64-v8a](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-arm64-v8a.apk)",
       "    * [Mattermost armeabi-v7a](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-armeabi-v7a.apk)",
-      "    * [Mattermost Universal](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost.apk)",
       "    * [Mattermost x86](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-x86.apk)",
       "    * [Mattermost x86_64](https://releases.mattermost.com/mattermost-mobile/#{version}/#{build}/Mattermost-x86_64.apk)",
     ]


### PR DESCRIPTION
#### Summary
This fixes the deployment of beta app and release app to the play store by not including the Universal APK.

The universal APK is no longer included in the Github release.

The reason for this is that the ABI's that we currently build cover all the supported devices at this point in time.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
