### PR TITLE
Fix Find channels not being interactable

### DIFF
--- a/app/components/chips/base_chip.tsx
+++ b/app/components/chips/base_chip.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Text, TouchableOpacity, useWindowDimensions} from 'react-native';
+import {Platform, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
 import Animated, {FadeIn, FadeOut} from 'react-native-reanimated';
 
 import CompassIcon from '@components/compass_icon';
@@ -103,10 +103,13 @@ export default function BaseChip({
             </TouchableOpacity>
         );
     }
+
+    // https://mattermost.atlassian.net/browse/MM-63814?focusedCommentId=178584
+    const useFadeOut = showAnimation && Platform.OS !== 'android';
     return (
         <Animated.View
             entering={showAnimation ? FadeIn.duration(FADE_DURATION) : undefined}
-            exiting={showAnimation ? FadeOut.duration(FADE_DURATION) : undefined}
+            exiting={useFadeOut ? FadeOut.duration(FADE_DURATION) : undefined}
             style={style.container}
             testID={testID}
         >

--- a/app/screens/emoji_picker/picker/header/skintone_selector/skintone_selector.tsx
+++ b/app/screens/emoji_picker/picker/header/skintone_selector/skintone_selector.tsx
@@ -145,7 +145,7 @@ const SkinToneSelector = ({skinTone = 'default', containerWidth, isSearching, tu
             >
                 <Animated.View
                     style={widthAnimatedStyle}
-                    exiting={FadeOut}
+                    exiting={Platform.OS === 'android' ? undefined : FadeOut /* https://mattermost.atlassian.net/browse/MM-63814?focusedCommentId=178584 */}
                     entering={FadeIn}
                 >
                     <Animated.View style={[styles.container, opacityStyle]}>

--- a/app/screens/find_channels/filtered_list/filtered_list.tsx
+++ b/app/screens/find_channels/filtered_list/filtered_list.tsx
@@ -4,7 +4,7 @@
 import {debounce, type DebouncedFunc} from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
-import {Alert, FlatList, type ListRenderItemInfo, StyleSheet, View} from 'react-native';
+import {Alert, FlatList, type ListRenderItemInfo, Platform, StyleSheet, View} from 'react-native';
 import Animated, {FadeInDown, FadeOutUp} from 'react-native-reanimated';
 
 import {switchToGlobalThreads} from '@actions/local/thread';
@@ -336,7 +336,7 @@ const FilteredList = ({
     return (
         <Animated.View
             entering={FadeInDown.duration(100)}
-            exiting={FadeOutUp.duration(100)}
+            exiting={Platform.OS === 'android' ? undefined : FadeOutUp.duration(100) /* https://mattermost.atlassian.net/browse/MM-63814?focusedCommentId=178584 */}
             style={style.flex}
         >
             <FlatList

--- a/app/screens/find_channels/quick_options/quick_options.tsx
+++ b/app/screens/find_channels/quick_options/quick_options.tsx
@@ -3,7 +3,7 @@
 
 import React, {useCallback} from 'react';
 import {useIntl} from 'react-intl';
-import {StyleSheet, View} from 'react-native';
+import {Platform, StyleSheet, View} from 'react-native';
 import Animated, {FadeInDown, FadeOutUp} from 'react-native-reanimated';
 
 import CompassIcon from '@components/compass_icon';
@@ -66,7 +66,7 @@ const QuickOptions = ({canCreateChannels, canJoinChannels, close}: Props) => {
     return (
         <Animated.View
             entering={FadeInDown.duration(200)}
-            exiting={FadeOutUp.duration(100)}
+            exiting={Platform.OS === 'android' ? undefined : FadeOutUp.duration(100) /* https://mattermost.atlassian.net/browse/MM-63814?focusedCommentId=178584 */}
             style={styles.container}
         >
             <Animated.View style={styles.wrapper}>

--- a/app/screens/find_channels/unfiltered_list/unfiltered_list.tsx
+++ b/app/screens/find_channels/unfiltered_list/unfiltered_list.tsx
@@ -3,7 +3,7 @@
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useIntl} from 'react-intl';
-import {SectionList, type SectionListRenderItemInfo, StyleSheet} from 'react-native';
+import {Platform, SectionList, type SectionListRenderItemInfo, StyleSheet} from 'react-native';
 import Animated, {FadeInDown, FadeOutUp} from 'react-native-reanimated';
 
 import {switchToChannelById} from '@actions/remote/channel';
@@ -81,7 +81,7 @@ const UnfilteredList = ({close, keyboardOverlap, recentChannels, showTeamName, t
     return (
         <Animated.View
             entering={FadeInDown.duration(200)}
-            exiting={FadeOutUp.duration(100)}
+            exiting={Platform.OS === 'android' ? undefined : FadeOutUp.duration(100) /* https://mattermost.atlassian.net/browse/MM-63814?focusedCommentId=178584 */}
             style={style.flex}
         >
             <SectionList

--- a/share_extension/components/search_channels/search_channels.tsx
+++ b/share_extension/components/search_channels/search_channels.tsx
@@ -4,7 +4,7 @@
 import {useNavigation} from '@react-navigation/native';
 import React, {useCallback, useMemo} from 'react';
 import {useIntl} from 'react-intl';
-import {FlatList, type ListRenderItemInfo, StyleSheet, View} from 'react-native';
+import {FlatList, type ListRenderItemInfo, Platform, StyleSheet, View} from 'react-native';
 import Animated, {FadeInDown, FadeOutUp} from 'react-native-reanimated';
 
 import NoResultsWithTerm from '@components/no_results_with_term';
@@ -94,7 +94,7 @@ const SearchChannels = ({
     return (
         <Animated.View
             entering={FadeInDown.duration(100)}
-            exiting={FadeOutUp.duration(100)}
+            exiting={Platform.OS === 'android' ? undefined : FadeOutUp.duration(100) /* https://mattermost.atlassian.net/browse/MM-63814?focusedCommentId=178584 */}
             style={style.flex}
         >
             <FlatList


### PR DESCRIPTION
#### Summary
There has been a bug where the find channels screen becomes not responsive the moment we start searching for a channel. This happens because we have two lists that get mounted / unmounted depending whether we are searching or not. When they get unmounted, they use the "fade out" animation to disappear.

For some reason, that leaves a "phantom" view, impeding interaction with anything that was in that position. This also happens with other fade out animations through the app, but seem less prominent.

Other animations (like slide) don't seem to be affected, just FadeOut.

This fix is a quick fix until the library is updated to fix this issue. The current latest (3.17.4) doesn't solve the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-63814

#### Release Note
This should be fixing a bug that never got to release, therefore no release notes.
```release-note
NONE
```
