### PR TITLE
Fix direct message screen showing deactivated accounts

### DIFF
--- a/app/screens/create_direct_message/create_direct_message.tsx
+++ b/app/screens/create_direct_message/create_direct_message.tsx
@@ -233,9 +233,9 @@ export default function CreateDirectMessage({
     const userFetchFunction = useCallback(async (page: number) => {
         let results;
         if (restrictDirectMessage) {
-            results = await fetchProfilesInTeam(serverUrl, currentTeamId, page, General.PROFILE_CHUNK_SIZE);
+            results = await fetchProfilesInTeam(serverUrl, currentTeamId, page, General.PROFILE_CHUNK_SIZE, '', {active: true});
         } else {
-            results = await fetchProfiles(serverUrl, page, General.PROFILE_CHUNK_SIZE);
+            results = await fetchProfiles(serverUrl, page, General.PROFILE_CHUNK_SIZE, {active: true});
         }
 
         if (results.users?.length) {
@@ -249,9 +249,9 @@ export default function CreateDirectMessage({
         const lowerCasedTerm = searchTerm.toLowerCase();
         let results;
         if (restrictDirectMessage) {
-            results = await searchProfiles(serverUrl, lowerCasedTerm, {team_id: currentTeamId, allow_inactive: true});
+            results = await searchProfiles(serverUrl, lowerCasedTerm, {team_id: currentTeamId, allow_inactive: false});
         } else {
-            results = await searchProfiles(serverUrl, lowerCasedTerm, {allow_inactive: true});
+            results = await searchProfiles(serverUrl, lowerCasedTerm, {allow_inactive: false});
         }
 
         if (results.data) {

--- a/detox/e2e/test/channels/create_direct_message.e2e.ts
+++ b/detox/e2e/test/channels/create_direct_message.e2e.ts
@@ -197,7 +197,7 @@ describe('Channels - Create Direct Message', () => {
         await wait(timeouts.ONE_SEC);
 
         // * Verify the deactivated user does not appear in search results
-        await expect(element(by.text(`No matches found for "${deactivatedUser.username}"`))).toBeVisible();
+        await expect(element(by.text(`No matches found for “${deactivatedUser.username}”`))).toBeVisible();
 
         // # Go back to channel list screen
         await CreateDirectMessageScreen.close();

--- a/detox/e2e/test/channels/create_direct_message.e2e.ts
+++ b/detox/e2e/test/channels/create_direct_message.e2e.ts
@@ -171,4 +171,35 @@ describe('Channels - Create Direct Message', () => {
         // # Go back to channel list screen
         await CreateDirectMessageScreen.close();
     });
+
+    it('MM-T63374 - should not display deactivated users in the create direct message screen', async () => {
+        // # As admin, create a new user to test with
+        const {user: deactivatedUser} = await User.apiCreateUser(siteOneUrl);
+        await Team.apiAddUserToTeam(siteOneUrl, deactivatedUser.id, testTeam.id);
+
+        // # Open create direct message screen and verify we can find the user
+        await CreateDirectMessageScreen.open();
+        await CreateDirectMessageScreen.searchInput.replaceText(deactivatedUser.username);
+        await wait(timeouts.ONE_SEC);
+
+        // * Verify the new user appears in search results before deactivation
+        await expect(CreateDirectMessageScreen.getUserItemDisplayName(deactivatedUser.id)).toBeVisible();
+
+        // # Close the create direct message screen
+        await CreateDirectMessageScreen.close();
+
+        // # Deactivate the user
+        await User.apiDeactivateUser(siteOneUrl, deactivatedUser.id);
+
+        // # Open create direct message screen again and search for the deactivated user
+        await CreateDirectMessageScreen.open();
+        await CreateDirectMessageScreen.searchInput.replaceText(deactivatedUser.username);
+        await wait(timeouts.ONE_SEC);
+
+        // * Verify the deactivated user does not appear in search results
+        await expect(element(by.text(`No matches found for "${deactivatedUser.username}"`))).toBeVisible();
+
+        // # Go back to channel list screen
+        await CreateDirectMessageScreen.close();
+    });
 });


### PR DESCRIPTION
#### Summary
The create direct message screen was showing deactivated accounts in the user list, which was confusing for users. This PR fixes the issue by properly filtering out deactivated users.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-63374

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [x] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: iOS simulator

#### Screenshots
N/A

#### Release Note
```release-note
Fixed an issue where deactivated accounts would appear in the create direct message screen.
```