### PR TITLE
Fix typo troubleshouting vs troubleshooting

### DIFF
--- a/app/screens/report_a_problem/report_problem.test.tsx
+++ b/app/screens/report_a_problem/report_problem.test.tsx
@@ -60,7 +60,7 @@ describe('screens/report_a_problem/report_problem', () => {
             <ReportProblem {...baseProps}/>,
         );
 
-        expect(getByText('Troubleshouting details')).toBeTruthy();
+        expect(getByText('Troubleshooting details')).toBeTruthy();
         expect(getByText('When reporting a problem, share the metadata and app logs given below to help troubleshoot your problem faster')).toBeTruthy();
         expect(getByTestId('app-logs')).toBeVisible();
     });

--- a/app/screens/report_a_problem/report_problem.tsx
+++ b/app/screens/report_a_problem/report_problem.tsx
@@ -129,7 +129,7 @@ const ReportProblem = ({
                         <Text style={styles.detailsTitle}>
                             {intl.formatMessage({
                                 id: 'screen.report_problem.details.title',
-                                defaultMessage: 'Troubleshouting details',
+                                defaultMessage: 'Troubleshooting details',
                             })}
                         </Text>
                         <Text style={styles.bodyText}>

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1072,7 +1072,7 @@
   "screen.report_problem.button": "Report a problem",
   "screen.report_problem.details.description": "When reporting a problem, share the metadata and app logs given below to help troubleshoot your problem faster",
   "screen.report_problem.details.description_without_logs": "When reporting a problem, share the metadata given below to help troubleshoot your problem faster",
-  "screen.report_problem.details.title": "Troubleshouting details",
+  "screen.report_problem.details.title": "Troubleshooting details",
   "screen.report_problem.logs.download": "Download App Logs",
   "screen.report_problem.logs.title": "APP LOGS:",
   "screen.report_problem.metadata.title": "METADATA:",


### PR DESCRIPTION
#### Summary
On the report a problem PR, we missed a typo where we said troubleshouting instead of troubleshooting.

#### Ticket Link
NONE

#### Release Note
Caught just after the merge.
```release-note
NONE
```
