### PR TITLE
Add watchman watch-del to clean script

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -2,10 +2,10 @@
 
 echo Cleaning started
 
-# Reset watchman watches
+# Reset watchman watches for this project only
 if command -v watchman &> /dev/null; then
-  echo "Resetting watchman watches"
-  watchman watch-del-all
+  echo "Resetting watchman watches for this project"
+  watchman watch-del . 2>/dev/null || echo "No watch found for this directory"
 fi
 
 rm -rf ios/Pods

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -2,6 +2,12 @@
 
 echo Cleaning started
 
+# Reset watchman watches
+if command -v watchman &> /dev/null; then
+  echo "Resetting watchman watches"
+  watchman watch-del-all
+fi
+
 rm -rf ios/Pods
 rm -rf node_modules
 rm -rf dist


### PR DESCRIPTION
## Summary
- Added `watchman watch-del-all` command to the clean script to ensure watchman watches for the mobile repo are properly reset during cleanup
- Added this command with a check to verify that watchman is installed
- Prevents issues that can occur after upgrades where stale watchman watches cause problems

## Test plan
1. Run `npm run clean` with watchman installed and verify the "Resetting watchman watches" message appears
2. Verify that after the clean operation and reinstalling dependencies, the development server works properly

🤖 Generated with [Claude Code](https://claude.ai/code)