### PR TITLE
[MM-61995] Correct copying instructions when long-pressing an email in messages & headers

### DIFF
--- a/app/components/markdown/markdown_link/markdown_link.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.tsx
@@ -129,7 +129,7 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                             testID='at_mention.bottom_sheet.copy_url'
                             text={intl.formatMessage({
                                 id: isEmail(href.replace(/^mailto:/, '')) ? 'mobile.markdown.link.copy_email' : 'mobile.markdown.link.copy_url',
-                                defaultMessage: isEmail(href.replace(/^mailto:/, '')) ? 'Copy Email' : 'Copy URL',
+                                defaultMessage: isEmail(href.replace(/^mailto:/, '')) ? 'Copy Email Address' : 'Copy URL',
                             })}
                         />
                         <SlideUpPanelItem

--- a/app/components/markdown/markdown_link/markdown_link.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.tsx
@@ -4,7 +4,7 @@
 import {useManagedConfig} from '@mattermost/react-native-emm';
 import Clipboard from '@react-native-clipboard/clipboard';
 import React, {Children, type ReactElement, useCallback} from 'react';
-import {useIntl} from 'react-intl';
+import {useIntl, defineMessages} from 'react-intl';
 import {Alert, StyleSheet, Text, View} from 'react-native';
 import urlParse from 'url-parse';
 
@@ -24,6 +24,17 @@ type MarkdownLinkProps = {
     siteURL: string;
     onLinkLongPress?: (url?: string) => void;
 }
+
+const messages = defineMessages({
+    copyEmail: {
+        id: 'mobile.markdown.link.copy_email',
+        defaultMessage: 'Copy Email Address',
+    },
+    copyURL: {
+        id: 'mobile.markdown.link.copy_url',
+        defaultMessage: 'Copy URL',
+    },
+});
 
 const style = StyleSheet.create({
     bottomSheet: {
@@ -113,6 +124,9 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                 return;
             }
 
+            const cleanHref = href.replace(/^mailto:/, '');
+            const isEmailLink = isEmail(cleanHref);
+
             const renderContent = () => {
                 return (
                     <View
@@ -123,14 +137,10 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                             leftIcon='content-copy'
                             onPress={() => {
                                 dismissBottomSheet();
-                                const cleanHref = href.replace(/^mailto:/, '');
                                 Clipboard.setString(cleanHref);
                             }}
                             testID='at_mention.bottom_sheet.copy_url'
-                            text={intl.formatMessage({
-                                id: isEmail(href.replace(/^mailto:/, '')) ? 'mobile.markdown.link.copy_email' : 'mobile.markdown.link.copy_url',
-                                defaultMessage: isEmail(href.replace(/^mailto:/, '')) ? 'Copy Email Address' : 'Copy URL',
-                            })}
+                            text={intl.formatMessage(isEmailLink ? messages.copyEmail : messages.copyURL)}
                         />
                         <SlideUpPanelItem
                             destructive={true}

--- a/app/components/markdown/markdown_link/markdown_link.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.tsx
@@ -13,7 +13,7 @@ import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {bottomSheet, dismissBottomSheet} from '@screens/navigation';
 import {handleDeepLink, matchDeepLink} from '@utils/deep_link';
-import {bottomSheetSnapPoint} from '@utils/helpers';
+import {bottomSheetSnapPoint, isEmail} from '@utils/helpers';
 import {preventDoubleTap} from '@utils/tap';
 import {normalizeProtocol, tryOpenURL} from '@utils/url';
 
@@ -123,10 +123,14 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                             leftIcon='content-copy'
                             onPress={() => {
                                 dismissBottomSheet();
-                                Clipboard.setString(href);
+                                const cleanHref = href.replace(/^mailto:/, '');
+                                Clipboard.setString(cleanHref);
                             }}
                             testID='at_mention.bottom_sheet.copy_url'
-                            text={intl.formatMessage({id: 'mobile.markdown.link.copy_url', defaultMessage: 'Copy URL'})}
+                            text={intl.formatMessage({
+                                id: isEmail(href.replace(/^mailto:/, '')) ? 'mobile.markdown.link.copy_email' : 'mobile.markdown.link.copy_url',
+                                defaultMessage: isEmail(href.replace(/^mailto:/, '')) ? 'Copy Email' : 'Copy URL',
+                            })}
                         />
                         <SlideUpPanelItem
                             destructive={true}

--- a/app/screens/channel_info/extra/extra.tsx
+++ b/app/screens/channel_info/extra/extra.tsx
@@ -5,7 +5,7 @@ import {useManagedConfig} from '@mattermost/react-native-emm';
 import Clipboard from '@react-native-clipboard/clipboard';
 import moment from 'moment';
 import React, {useCallback, useMemo} from 'react';
-import {useIntl} from 'react-intl';
+import {useIntl, defineMessages} from 'react-intl';
 import {Platform, StyleSheet, Text, View} from 'react-native';
 
 import CustomStatusExpiry from '@components/custom_status/custom_status_expiry';
@@ -84,6 +84,17 @@ const style = StyleSheet.create({
 
 const headerTestId = 'channel_info.extra.header';
 
+const messages = defineMessages({
+    copyEmail: {
+        id: 'mobile.markdown.link.copy_email',
+        defaultMessage: 'Copy Email Address',
+    },
+    copyURL: {
+        id: 'mobile.markdown.link.copy_url',
+        defaultMessage: 'Copy URL',
+    },
+});
+
 const onCopy = async (text: string, isLink?: boolean) => {
     Clipboard.setString(text);
     await dismissBottomSheet();
@@ -114,6 +125,10 @@ const Extra = ({channelId, createdAt, createdBy, customStatus, header, isCustomS
 
     const handleLongPress = useCallback((url?: string) => {
         if (managedConfig?.copyAndPasteProtection !== 'true') {
+
+            const cleanUrl = url?.replace(/^mailto:/, '') || '';
+            const isEmailLink = isEmail(cleanUrl);
+
             const renderContent = () => (
                 <View
                     testID={`${headerTestId}.bottom_sheet`}
@@ -134,14 +149,10 @@ const Extra = ({channelId, createdAt, createdBy, customStatus, header, isCustomS
                         <SlideUpPanelItem
                             leftIcon='link-variant'
                             onPress={() => {
-                                const cleanUrl = url!.replace(/^mailto:/, '');
-                                onCopy(cleanUrl, isEmail(cleanUrl));
+                                onCopy(cleanUrl, true);
                             }}
                             testID={`${headerTestId}.bottom_sheet.copy_url`}
-                            text={intl.formatMessage({
-                                id: isEmail(url!.replace(/^mailto:/, '')) ? 'mobile.markdown.link.copy_email' : 'mobile.markdown.link.copy_url',
-                                defaultMessage: isEmail(url!.replace(/^mailto:/, '')) ? 'Copy Email Address' : 'Copy URL',
-                            })}
+                            text={intl.formatMessage(isEmailLink ? messages.copyEmail : messages.copyURL)}
                         />
                     )}
                     <SlideUpPanelItem

--- a/app/screens/channel_info/extra/extra.tsx
+++ b/app/screens/channel_info/extra/extra.tsx
@@ -20,7 +20,7 @@ import {SNACK_BAR_TYPE} from '@constants/snack_bar';
 import {ANDROID_33, OS_VERSION} from '@constants/versions';
 import {useTheme} from '@context/theme';
 import {bottomSheet, dismissBottomSheet} from '@screens/navigation';
-import {bottomSheetSnapPoint} from '@utils/helpers';
+import {bottomSheetSnapPoint, isEmail} from '@utils/helpers';
 import {getMarkdownBlockStyles, getMarkdownTextStyles} from '@utils/markdown';
 import {showSnackBar} from '@utils/snack_bar';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
@@ -134,12 +134,13 @@ const Extra = ({channelId, createdAt, createdBy, customStatus, header, isCustomS
                         <SlideUpPanelItem
                             leftIcon='link-variant'
                             onPress={() => {
-                                onCopy(url!, true);
+                                const cleanUrl = url!.replace(/^mailto:/, '');
+                                onCopy(cleanUrl, isEmail(cleanUrl));
                             }}
                             testID={`${headerTestId}.bottom_sheet.copy_url`}
                             text={intl.formatMessage({
-                                id: 'mobile.markdown.link.copy_url',
-                                defaultMessage: 'Copy URL',
+                                id: isEmail(url!.replace(/^mailto:/, '')) ? 'mobile.markdown.link.copy_email' : 'mobile.markdown.link.copy_url',
+                                defaultMessage: isEmail(url!.replace(/^mailto:/, '')) ? 'Copy Email Address' : 'Copy URL',
                             })}
                         />
                     )}

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -727,6 +727,7 @@
   "mobile.markdown.code.plusMoreLines": "+{count, number} more {count, plural, one {line} other {lines}}",
   "mobile.markdown.copy_header": "Copy header text",
   "mobile.markdown.image.too_large": "Image exceeds max dimensions of {maxWidth} by {maxHeight}:",
+  "mobile.markdown.link.copy_email": "Copy Email Address",
   "mobile.markdown.link.copy_url": "Copy URL",
   "mobile.mention.copy_mention": "Copy Mention",
   "mobile.message_length.message": "Your current message is too long. Current character count: {count}/{max}",


### PR DESCRIPTION
#### Summary

This pull request improves the UX of copying links by detecting whether a copied value is an email address or a regular URL. If the link is an email (e.g., `mailto:example@example.com`), the copy action will now:
- Strip the `mailto:` prefix before copying.
- Show the bottom sheet option as “Copy Email Address” instead of “Copy URL” as requested [here](https://github.com/mattermost/mattermost/issues/29525).

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/29525 (https://mattermost.atlassian.net/browse/MM-61995)

#### Checklist

- [x] Has UI changes
- [x] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iPhone 16 Pro, iOS 18.4

#### Screenshots

<img src="https://github.com/user-attachments/assets/8ba26f86-18a3-4393-8bfa-395a84fac507" width="400" />
<img src="https://github.com/user-attachments/assets/2f1b44a2-31e0-43b4-92e2-a634fbbd5a65" width="400" />


#### Release Note

```release-note
Updated the copy action label to “Copy Email Address” for Markdown-rendered email links.
```

