### PR TITLE
[MM-63889] Calls: Add backend version check to enable DC locking

### DIFF
--- a/app/products/calls/client/rest.ts
+++ b/app/products/calls/client/rest.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ApiResp, CallsVersion} from '@calls/types/calls';
-import type {CallChannelState, CallJobState, CallsConfig} from '@mattermost/calls/lib/types';
+import type {ApiResp} from '@calls/types/calls';
+import type {CallChannelState, CallJobState, CallsConfig, CallsVersionInfo} from '@mattermost/calls/lib/types';
 import type {RTCIceServer} from 'react-native-webrtc';
 
 export interface ClientCallsMix {
@@ -10,7 +10,7 @@ export interface ClientCallsMix {
     getCalls: (groupLabel?: RequestGroupLabel) => Promise<CallChannelState[]>;
     getCallForChannel: (channelId: string) => Promise<CallChannelState>;
     getCallsConfig: (groupLabel?: RequestGroupLabel) => Promise<CallsConfig>;
-    getVersion: (groupLabel?: RequestGroupLabel) => Promise<CallsVersion>;
+    getVersion: (groupLabel?: RequestGroupLabel) => Promise<CallsVersionInfo>;
     enableChannelCalls: (channelId: string, enable: boolean) => Promise<CallChannelState>;
     endCall: (channelId: string) => Promise<ApiResp>;
     genTURNCredentials: () => Promise<RTCIceServer[]>;

--- a/app/products/calls/connection/connection.test.ts
+++ b/app/products/calls/connection/connection.test.ts
@@ -44,6 +44,9 @@ describe('newConnection', () => {
             AllowEnableCalls: true,
             EnableAV1: true,
         })),
+        getVersion: jest.fn(() => ({
+            version: '1.7.0',
+        })),
         genTURNCredentials: jest.fn(() => Promise.resolve([{
             urls: ['turn:turn.example.com'],
             username: 'user',

--- a/app/products/calls/types/calls.ts
+++ b/app/products/calls/types/calls.ts
@@ -7,6 +7,7 @@ import {
     type CallsConfig,
     type EmojiData,
     type UserReactionData,
+    type CallsVersionInfo,
 } from '@mattermost/calls/lib/types';
 
 import type UserModel from '@typings/database/models/servers/user';
@@ -153,7 +154,7 @@ export type CallsConfigState = CallsConfig & {
     AllowEnableCalls: boolean;
     GroupCallsAllowed: boolean;
     pluginEnabled: boolean;
-    version: CallsVersion;
+    version: CallsVersionInfo;
     last_retrieved_at: number;
 }
 
@@ -209,11 +210,6 @@ export type AudioDeviceInfoRaw = {
 export type AudioDeviceInfo = {
     availableAudioDeviceList: AudioDevice[];
     selectedAudioDevice: AudioDevice;
-};
-
-export type CallsVersion = {
-    version?: string;
-    build?: string;
 };
 
 export type LiveCaptionMobile = {

--- a/app/products/calls/utils.ts
+++ b/app/products/calls/utils.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {makeCallsBaseAndBadgeRGB, rgbToCSS} from '@mattermost/calls';
-import {type CallsConfig, type CallPostProps, isCaption, type Caption, isCallJobMetadata, type CallJobMetadata} from '@mattermost/calls/lib/types';
+import {type CallsConfig, type CallPostProps, isCaption, type Caption, isCallJobMetadata, type CallJobMetadata, type CallsVersionInfo} from '@mattermost/calls/lib/types';
 import {Alert} from 'react-native';
 import {SelectedTrackType, TextTrackType, type ISO639_1, type SelectedTrack, type TextTracks} from 'react-native-video';
 
@@ -17,7 +17,6 @@ import type {
     CallsConfigState,
     CallSession,
     CallsTheme,
-    CallsVersion,
 } from '@calls/types/calls';
 import type PostModel from '@typings/database/models/servers/post';
 import type UserModel from '@typings/database/models/servers/user';
@@ -96,7 +95,7 @@ export function isSupportedServerCalls(serverVersion?: string) {
     return false;
 }
 
-export function isMultiSessionSupported(callsVersion: CallsVersion) {
+export function isMultiSessionSupported(callsVersion: CallsVersionInfo) {
     return isMinimumServerVersion(
         callsVersion.version,
         Calls.MultiSessionCallsVersion.MAJOR_VERSION,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@formatjs/intl-numberformat": "8.15.4",
         "@formatjs/intl-pluralrules": "5.4.4",
         "@gorhom/bottom-sheet": "5.1.2",
-        "@mattermost/calls": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
+        "@mattermost/calls": "github:mattermost/calls-common#02b04117fcec88f158d3d9ba62546d8d942ed647",
         "@mattermost/compass-icons": "0.1.48",
         "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
         "@mattermost/react-native-emm": "1.6.1",
@@ -4820,8 +4820,8 @@
     "node_modules/@mattermost/calls": {
       "name": "@mattermost/calls-common",
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#d8e1c317584077d0ebc5e159477eb533d610ee08",
-      "integrity": "sha512-KuQuj/ln09tUvsfZRvcObgm1tmhqvn51BA4ZQ59rPYyGgX+hkW3aA/w1BvufmFEeZpXAEeGaiAtVW8CQu6qHSg==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#02b04117fcec88f158d3d9ba62546d8d942ed647",
+      "integrity": "sha512-jHlw8b8k0LrOyAzh/6cSnTg3GHL3yJEZhtNhjvvfEnmxso2CzproEX7juzATtMy0Z1NXOLgdBrn/M0naPxJqgA==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
         "fflate": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.27.0",
+      "version": "2.28.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -17,7 +17,7 @@
         "@formatjs/intl-numberformat": "8.15.4",
         "@formatjs/intl-pluralrules": "5.4.4",
         "@gorhom/bottom-sheet": "5.1.2",
-        "@mattermost/calls": "github:mattermost/calls-common#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
+        "@mattermost/calls": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
         "@mattermost/compass-icons": "0.1.48",
         "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
         "@mattermost/react-native-emm": "1.6.1",
@@ -4820,11 +4820,12 @@
     "node_modules/@mattermost/calls": {
       "name": "@mattermost/calls-common",
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
-      "integrity": "sha512-Wj2fclEcPVWYtX7WdrMOaLHXS2AP3y2x8Py9FqHyhoNNY9yUg+ihocUKDKpRwqfu1qM/R02Y26d/g6Mc4+yddg==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#d8e1c317584077d0ebc5e159477eb533d610ee08",
+      "integrity": "sha512-KuQuj/ln09tUvsfZRvcObgm1tmhqvn51BA4ZQ59rPYyGgX+hkW3aA/w1BvufmFEeZpXAEeGaiAtVW8CQu6qHSg==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
-        "fflate": "0.8.2"
+        "fflate": "0.8.2",
+        "semver": "7.7.1"
       }
     },
     "node_modules/@mattermost/calls/node_modules/@msgpack/msgpack": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-numberformat": "8.15.4",
     "@formatjs/intl-pluralrules": "5.4.4",
     "@gorhom/bottom-sheet": "5.1.2",
-    "@mattermost/calls": "github:mattermost/calls-common#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
+    "@mattermost/calls": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
     "@mattermost/compass-icons": "0.1.48",
     "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
     "@mattermost/react-native-emm": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-numberformat": "8.15.4",
     "@formatjs/intl-pluralrules": "5.4.4",
     "@gorhom/bottom-sheet": "5.1.2",
-    "@mattermost/calls": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
+    "@mattermost/calls": "github:mattermost/calls-common#02b04117fcec88f158d3d9ba62546d8d942ed647",
     "@mattermost/compass-icons": "0.1.48",
     "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
     "@mattermost/react-native-emm": "1.6.1",


### PR DESCRIPTION
#### Summary

PR addresses a forward compatibility issue triggered by running some new logic we added in https://github.com/mattermost/mattermost-mobile/pull/8745 against an older backend (either Calls plugin or RTCD service, depending on which one was configured).

A test plan for both backward and forward compatibility is attached to the JIRA ticket.

Fixes https://github.com/mattermost/mattermost-plugin-calls/issues/1010

#### Related PRs

https://github.com/mattermost/mattermost-plugin-calls/pull/1011
https://github.com/mattermost/calls-common/pull/52

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63889

#### Release Note

```release-note
Calls: fixed a regression that caused unmuting to fail when running the latest app against an older plugin version (earlier than v1.7.0).
```

