### PR TITLE
Urgent mentions do not get the properly coloured mention badge

### DIFF
--- a/app/actions/local/channel.test.ts
+++ b/app/actions/local/channel.test.ts
@@ -632,13 +632,13 @@ describe('markChannelAsUnread', () => {
     });
 
     it('handle not found database', async () => {
-        const {member, error} = await markChannelAsUnread('foo', channelId, 10, 1, 123, false);
+        const {member, error} = await markChannelAsUnread('foo', channelId, 10, 1, 123, 0, false);
         expect(error).toBeTruthy();
         expect(member).toBeUndefined();
     });
 
     it('handle no member', async () => {
-        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, false);
+        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, 0, false);
         expect(error).toBe('not a member');
         expect(member).toBeUndefined();
     });
@@ -647,13 +647,27 @@ describe('markChannelAsUnread', () => {
         await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
         await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
 
-        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, false);
+        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, 0, false);
         expect(error).toBeUndefined();
         expect(member).toBeDefined();
         expect(member?.viewedAt).toBe(122);
         expect(member?.lastViewedAt).toBe(122);
         expect(member?.messageCount).toBe(10);
         expect(member?.mentionsCount).toBe(1);
+    });
+
+    it('mark channel as unread with with urgent mention count', async () => {
+        await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
+        await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
+
+        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, 1, false);
+        expect(error).toBeUndefined();
+        expect(member).toBeDefined();
+        expect(member?.viewedAt).toBe(122);
+        expect(member?.lastViewedAt).toBe(122);
+        expect(member?.messageCount).toBe(10);
+        expect(member?.mentionsCount).toBe(1);
+        expect(member?.urgentMentionsCount).toBe(1);
     });
 });
 

--- a/app/actions/local/channel.test.ts
+++ b/app/actions/local/channel.test.ts
@@ -667,7 +667,7 @@ describe('markChannelAsUnread', () => {
         expect(member?.lastViewedAt).toBe(122);
         expect(member?.messageCount).toBe(10);
         expect(member?.mentionsCount).toBe(1);
-        expect(member?.urgentMentionsCount).toBe(1);
+        expect(member?.urgentMentionCount).toBe(1);
     });
 });
 

--- a/app/actions/local/channel.test.ts
+++ b/app/actions/local/channel.test.ts
@@ -632,13 +632,33 @@ describe('markChannelAsUnread', () => {
     });
 
     it('handle not found database', async () => {
-        const {member, error} = await markChannelAsUnread('foo', channelId, 10, 1, 123, 0, false);
+        const {member, error} = await markChannelAsUnread(
+            'foo',
+            {
+                channelId,
+                messageCount: 10,
+                mentionsCount: 1,
+                lastViewed: 123,
+                urgentMentionCount: 0,
+            },
+            false,
+        );
         expect(error).toBeTruthy();
         expect(member).toBeUndefined();
     });
 
     it('handle no member', async () => {
-        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, 0, false);
+        const {member, error} = await markChannelAsUnread(
+            serverUrl,
+            {
+                channelId,
+                messageCount: 10,
+                mentionsCount: 1,
+                lastViewed: 123,
+                urgentMentionCount: 0,
+            },
+            false,
+        );
         expect(error).toBe('not a member');
         expect(member).toBeUndefined();
     });
@@ -647,7 +667,16 @@ describe('markChannelAsUnread', () => {
         await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
         await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
 
-        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, 0, false);
+        const {member, error} = await markChannelAsUnread(
+            serverUrl, {
+                channelId,
+                messageCount: 10,
+                mentionsCount: 1,
+                urgentMentionCount: 0,
+                lastViewed: 123,
+            },
+            false,
+        );
         expect(error).toBeUndefined();
         expect(member).toBeDefined();
         expect(member?.viewedAt).toBe(122);
@@ -660,7 +689,17 @@ describe('markChannelAsUnread', () => {
         await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
         await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
 
-        const {member, error} = await markChannelAsUnread(serverUrl, channelId, 10, 1, 123, 1, false);
+        const {member, error} = await markChannelAsUnread(
+            serverUrl,
+            {
+                channelId,
+                messageCount: 10,
+                mentionsCount: 1,
+                lastViewed: 123,
+                urgentMentionCount: 1,
+            },
+            false,
+        );
         expect(error).toBeUndefined();
         expect(member).toBeDefined();
         expect(member?.viewedAt).toBe(122);

--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -176,7 +176,7 @@ export async function markChannelAsViewed(serverUrl: string, channelId: string, 
             m.isUnread = false;
             m.mentionsCount = 0;
             m.manuallyUnread = false;
-            m.urgentMentionsCount = 0;
+            m.urgentMentionCount = 0;
             if (!onlyCounts) {
                 m.viewedAt = member.lastViewedAt;
                 m.lastViewedAt = Date.now();
@@ -194,7 +194,7 @@ export async function markChannelAsViewed(serverUrl: string, channelId: string, 
     }
 }
 
-export async function markChannelAsUnread(serverUrl: string, channelId: string, messageCount: number, mentionsCount: number, lastViewed: number, urgentMentionsCount: number, prepareRecordsOnly = false) {
+export async function markChannelAsUnread(serverUrl: string, channelId: string, messageCount: number, mentionsCount: number, lastViewed: number, urgentMentionCount: number, prepareRecordsOnly = false) {
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const member = await getMyChannel(database, channelId);
@@ -207,7 +207,7 @@ export async function markChannelAsUnread(serverUrl: string, channelId: string, 
             m.lastViewedAt = lastViewed - 1;
             m.messageCount = messageCount;
             m.mentionsCount = mentionsCount;
-            m.urgentMentionsCount = urgentMentionsCount;
+            m.urgentMentionCount = urgentMentionCount;
             m.manuallyUnread = true;
             m.isUnread = true;
         });

--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -176,6 +176,7 @@ export async function markChannelAsViewed(serverUrl: string, channelId: string, 
             m.isUnread = false;
             m.mentionsCount = 0;
             m.manuallyUnread = false;
+            m.urgentMentionsCount = 0;
             if (!onlyCounts) {
                 m.viewedAt = member.lastViewedAt;
                 m.lastViewedAt = Date.now();
@@ -193,7 +194,7 @@ export async function markChannelAsViewed(serverUrl: string, channelId: string, 
     }
 }
 
-export async function markChannelAsUnread(serverUrl: string, channelId: string, messageCount: number, mentionsCount: number, lastViewed: number, prepareRecordsOnly = false) {
+export async function markChannelAsUnread(serverUrl: string, channelId: string, messageCount: number, mentionsCount: number, lastViewed: number, urgentMentionsCount: number, prepareRecordsOnly = false) {
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const member = await getMyChannel(database, channelId);
@@ -206,6 +207,7 @@ export async function markChannelAsUnread(serverUrl: string, channelId: string, 
             m.lastViewedAt = lastViewed - 1;
             m.messageCount = messageCount;
             m.mentionsCount = mentionsCount;
+            m.urgentMentionsCount = urgentMentionsCount;
             m.manuallyUnread = true;
             m.isUnread = true;
         });

--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -194,7 +194,16 @@ export async function markChannelAsViewed(serverUrl: string, channelId: string, 
     }
 }
 
-export async function markChannelAsUnread(serverUrl: string, channelId: string, messageCount: number, mentionsCount: number, lastViewed: number, urgentMentionCount: number, prepareRecordsOnly = false) {
+type UnreadArgs = {
+    channelId: string;
+    lastViewed: number;
+    messageCount: number;
+    mentionsCount: number;
+    urgentMentionCount: number;
+}
+
+export async function markChannelAsUnread(serverUrl: string, args: UnreadArgs, prepareRecordsOnly = false) {
+    const {channelId, lastViewed, messageCount, mentionsCount, urgentMentionCount} = args;
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const member = await getMyChannel(database, channelId);

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -899,17 +899,23 @@ export const markPostAsUnread = async (serverUrl: string, postId: string) => {
                 const isCRTEnabled = await getIsCRTEnabled(database);
                 let totalMessages = channel.total_msg_count;
                 let messages = channelMember.msg_count;
-                let mentionCount = channelMember.mention_count;
+                let mentionsCount = channelMember.mention_count;
                 const urgentMentionCount = channelMember.urgent_mention_count || 0;
 
                 if (isCRTEnabled) {
                     totalMessages = channel.total_msg_count_root!;
                     messages = channelMember.msg_count_root!;
-                    mentionCount = channelMember.mention_count_root!;
+                    mentionsCount = channelMember.mention_count_root!;
                 }
 
                 const messageCount = totalMessages - messages;
-                await markChannelAsUnread(serverUrl, channelId, messageCount, mentionCount, post.createAt, urgentMentionCount);
+                await markChannelAsUnread(serverUrl, {
+                    channelId,
+                    messageCount,
+                    mentionsCount,
+                    urgentMentionCount,
+                    lastViewed: post.createAt,
+                });
                 return {post};
             }
         }

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -900,7 +900,7 @@ export const markPostAsUnread = async (serverUrl: string, postId: string) => {
                 let totalMessages = channel.total_msg_count;
                 let messages = channelMember.msg_count;
                 let mentionCount = channelMember.mention_count;
-                const urgentMentionsCount = channelMember.urgent_mention_count || 0;
+                const urgentMentionCount = channelMember.urgent_mention_count || 0;
 
                 if (isCRTEnabled) {
                     totalMessages = channel.total_msg_count_root!;
@@ -909,7 +909,7 @@ export const markPostAsUnread = async (serverUrl: string, postId: string) => {
                 }
 
                 const messageCount = totalMessages - messages;
-                await markChannelAsUnread(serverUrl, channelId, messageCount, mentionCount, post.createAt, urgentMentionsCount);
+                await markChannelAsUnread(serverUrl, channelId, messageCount, mentionCount, post.createAt, urgentMentionCount);
                 return {post};
             }
         }

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -900,6 +900,7 @@ export const markPostAsUnread = async (serverUrl: string, postId: string) => {
                 let totalMessages = channel.total_msg_count;
                 let messages = channelMember.msg_count;
                 let mentionCount = channelMember.mention_count;
+                const urgentMentionsCount = channelMember.urgent_mention_count || 0;
 
                 if (isCRTEnabled) {
                     totalMessages = channel.total_msg_count_root!;
@@ -908,7 +909,7 @@ export const markPostAsUnread = async (serverUrl: string, postId: string) => {
                 }
 
                 const messageCount = totalMessages - messages;
-                await markChannelAsUnread(serverUrl, channelId, messageCount, mentionCount, post.createAt);
+                await markChannelAsUnread(serverUrl, channelId, messageCount, mentionCount, post.createAt, urgentMentionsCount);
                 return {post};
             }
         }

--- a/app/actions/websocket/posts.test.ts
+++ b/app/actions/websocket/posts.test.ts
@@ -395,7 +395,7 @@ describe('WebSocket Post Actions', () => {
 
             await handlePostUnread(serverUrl, msg);
 
-            expect(mockedMarkChannelAsUnread).toHaveBeenCalledWith(serverUrl, 'channel1', 1, 1, 12345);
+            expect(mockedMarkChannelAsUnread).toHaveBeenCalledWith(serverUrl, 'channel1', 1, 1, 12345, 0);
         });
 
         it('should handle post unread event - CRT enabled, manually marked read', async () => {

--- a/app/actions/websocket/posts.test.ts
+++ b/app/actions/websocket/posts.test.ts
@@ -395,7 +395,16 @@ describe('WebSocket Post Actions', () => {
 
             await handlePostUnread(serverUrl, msg);
 
-            expect(mockedMarkChannelAsUnread).toHaveBeenCalledWith(serverUrl, 'channel1', 1, 1, 12345, 0);
+            expect(mockedMarkChannelAsUnread).toHaveBeenCalledWith(
+                serverUrl,
+                {
+                    channelId: 'channel1',
+                    messageCount: 1,
+                    mentionsCount: 1,
+                    lastViewed: 12345,
+                    urgentMentionCount: 0,
+                },
+            );
         });
 
         it('should handle post unread event - CRT enabled, manually marked read', async () => {

--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -149,11 +149,13 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
             preparedMyChannelHack(myChannel);
             const {member: unreadAt} = await markChannelAsUnread(
                 serverUrl,
-                post.channel_id,
-                myChannel.messageCount + 1,
-                myChannel.mentionsCount + (hasMentions ? 1 : 0),
-                myChannel.lastViewedAt,
-                myChannel.urgentMentionCount + (hasUrgentMentions ? 1 : 0),
+                {
+                    channelId: post.channel_id,
+                    messageCount: myChannel.messageCount + 1,
+                    mentionsCount: myChannel.mentionsCount + (hasMentions ? 1 : 0),
+                    lastViewed: myChannel.lastViewedAt,
+                    urgentMentionCount: myChannel.urgentMentionCount + (hasUrgentMentions ? 1 : 0),
+                },
                 true,
             );
             if (unreadAt) {
@@ -326,7 +328,13 @@ export async function handlePostUnread(serverUrl: string, msg: WebSocketMessage)
         const postNumber = isCRTEnabled ? channel?.total_msg_count_root : channel?.total_msg_count;
         const delta = postNumber ? postNumber - messages : messages;
 
-        markChannelAsUnread(serverUrl, channelId, delta, mentions, lastViewedAt, membership?.urgent_mention_count || 0);
+        markChannelAsUnread(serverUrl, {
+            channelId,
+            messageCount: delta,
+            mentionsCount: mentions,
+            urgentMentionCount: membership?.urgent_mention_count || 0,
+            lastViewed: lastViewedAt,
+        });
     }
 }
 

--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -152,6 +152,7 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
                 myChannel.messageCount + 1,
                 myChannel.mentionsCount + (hasMentions ? 1 : 0),
                 myChannel.lastViewedAt,
+                myChannel.urgentMentionsCount,
                 true,
             );
             if (unreadAt) {
@@ -318,12 +319,13 @@ export async function handlePostUnread(serverUrl: string, msg: WebSocketMessage)
     }
 
     if (!myChannel?.manuallyUnread) {
-        const {channels} = await fetchMyChannel(serverUrl, teamId, channelId, true);
+        const {channels, memberships} = await fetchMyChannel(serverUrl, teamId, channelId, true);
         const channel = channels?.[0];
+        const membership = memberships?.[0];
         const postNumber = isCRTEnabled ? channel?.total_msg_count_root : channel?.total_msg_count;
         const delta = postNumber ? postNumber - messages : messages;
 
-        markChannelAsUnread(serverUrl, channelId, delta, mentions, lastViewedAt);
+        markChannelAsUnread(serverUrl, channelId, delta, mentions, lastViewedAt, membership?.urgent_mention_count || 0);
     }
 }
 

--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -152,7 +152,7 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
                 myChannel.messageCount + 1,
                 myChannel.mentionsCount + (hasMentions ? 1 : 0),
                 myChannel.lastViewedAt,
-                myChannel.urgentMentionsCount,
+                myChannel.urgentMentionCount,
                 true,
             );
             if (unreadAt) {

--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -145,6 +145,7 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
             }
         } else if (!isCRTEnabled || !post.root_id) {
             const hasMentions = msg.data.mentions?.includes(currentUserId);
+            const hasUrgentMentions = post.metadata.priority?.priority === 'urgent';
             preparedMyChannelHack(myChannel);
             const {member: unreadAt} = await markChannelAsUnread(
                 serverUrl,
@@ -152,7 +153,7 @@ export async function handleNewPostEvent(serverUrl: string, msg: WebSocketMessag
                 myChannel.messageCount + 1,
                 myChannel.mentionsCount + (hasMentions ? 1 : 0),
                 myChannel.lastViewedAt,
-                myChannel.urgentMentionCount,
+                myChannel.urgentMentionCount + (hasUrgentMentions ? 1 : 0),
                 true,
             );
             if (unreadAt) {

--- a/app/components/channel_item/channel_item.tsx
+++ b/app/components/channel_item/channel_item.tsx
@@ -37,7 +37,7 @@ type Props = {
     isOnCenterBg?: boolean;
     showChannelName?: boolean;
     isOnHome?: boolean;
-    urgentMentionsCount?: number;
+    urgentMentionCount?: number;
 }
 
 export const ROW_HEIGHT = 40;
@@ -125,7 +125,7 @@ const ChannelItem = ({
     isOnCenterBg = false,
     showChannelName = false,
     isOnHome = false,
-    urgentMentionsCount = 0,
+    urgentMentionCount = 0,
 }: Props) => {
     const {formatMessage} = useIntl();
     const theme = useTheme();
@@ -133,7 +133,7 @@ const ChannelItem = ({
     const styles = getStyleSheet(theme);
 
     const channelName = (showChannelName && !isDMorGM(channel)) ? channel.name : '';
-    const hasUrgent = urgentMentionsCount > 0;
+    const hasUrgent = urgentMentionCount > 0;
 
     // Make it bolded if it has unreads or mentions
     const isBolded = isUnread || mentionsCount > 0;

--- a/app/components/channel_item/channel_item.tsx
+++ b/app/components/channel_item/channel_item.tsx
@@ -37,6 +37,7 @@ type Props = {
     isOnCenterBg?: boolean;
     showChannelName?: boolean;
     isOnHome?: boolean;
+    urgentMentionsCount?: number;
 }
 
 export const ROW_HEIGHT = 40;
@@ -80,6 +81,10 @@ export const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         backgroundColor: theme.buttonBg,
         borderColor: theme.centerChannelBg,
     },
+    hasUrgent: {
+        color: theme.sidebarText,
+        backgroundColor: theme.dndIndicator,
+    },
     mutedBadge: {
         opacity: 0.32,
     },
@@ -120,6 +125,7 @@ const ChannelItem = ({
     isOnCenterBg = false,
     showChannelName = false,
     isOnHome = false,
+    urgentMentionsCount = 0,
 }: Props) => {
     const {formatMessage} = useIntl();
     const theme = useTheme();
@@ -127,6 +133,7 @@ const ChannelItem = ({
     const styles = getStyleSheet(theme);
 
     const channelName = (showChannelName && !isDMorGM(channel)) ? channel.name : '';
+    const hasUrgent = urgentMentionsCount > 0;
 
     // Make it bolded if it has unreads or mentions
     const isBolded = isUnread || mentionsCount > 0;
@@ -202,9 +209,15 @@ const ChannelItem = ({
                 />
                 <View style={styles.filler}/>
                 <Badge
+                    testID={`${channelItemTestId}.badge`}
                     visible={mentionsCount > 0}
                     value={mentionsCount}
-                    style={[styles.badge, isMuted && styles.mutedBadge, isOnCenterBg && styles.badgeOnCenterBg]}
+                    style={[
+                        styles.badge,
+                        isMuted && styles.mutedBadge,
+                        isOnCenterBg && styles.badgeOnCenterBg,
+                        hasUrgent && styles.hasUrgent,
+                    ]}
                 />
                 {hasCall &&
                 <CompassIcon

--- a/app/components/channel_item/channel_item.tsx
+++ b/app/components/channel_item/channel_item.tsx
@@ -133,6 +133,11 @@ const ChannelItem = ({
     const styles = getStyleSheet(theme);
 
     const channelName = (showChannelName && !isDMorGM(channel)) ? channel.name : '';
+
+    // Note: urgentMentionCount is a subset of mentionsCount.
+    // All urgent mentions are also included in mentionsCount,
+    // so we use urgentMentionCount only for styling (e.g., red badge),
+    // not for counting total mentions.
     const hasUrgent = urgentMentionCount > 0;
 
     // Make it bolded if it has unreads or mentions

--- a/app/components/channel_item/index.ts
+++ b/app/components/channel_item/index.ts
@@ -95,7 +95,7 @@ const enhance = withObservables(['channel', 'showTeamName', 'shouldHighlightActi
             distinctUntilChanged(),
         ) : of$(0);
 
-    const urgentMentionsCount = myChannel.pipe(
+    const urgentMentionCount = myChannel.pipe(
         switchMap((mc) => of$(mc?.urgentMentionCount)),
     );
 
@@ -115,7 +115,7 @@ const enhance = withObservables(['channel', 'showTeamName', 'shouldHighlightActi
         mentionsCount,
         teamDisplayName,
         hasCall,
-        urgentMentionsCount,
+        urgentMentionCount,
     };
 });
 

--- a/app/components/channel_item/index.ts
+++ b/app/components/channel_item/index.ts
@@ -96,7 +96,7 @@ const enhance = withObservables(['channel', 'showTeamName', 'shouldHighlightActi
         ) : of$(0);
 
     const urgentMentionsCount = myChannel.pipe(
-        switchMap((mc) => of$(mc?.urgentMentionsCount)),
+        switchMap((mc) => of$(mc?.urgentMentionCount)),
     );
 
     const hasCall = observeChannelsWithCalls(serverUrl || '').pipe(

--- a/app/components/channel_item/index.ts
+++ b/app/components/channel_item/index.ts
@@ -95,6 +95,10 @@ const enhance = withObservables(['channel', 'showTeamName', 'shouldHighlightActi
             distinctUntilChanged(),
         ) : of$(0);
 
+    const urgentMentionsCount = myChannel.pipe(
+        switchMap((mc) => of$(mc?.urgentMentionsCount)),
+    );
+
     const hasCall = observeChannelsWithCalls(serverUrl || '').pipe(
         switchMap((calls) => of$(Boolean(calls[channel.id]))),
         distinctUntilChanged(),
@@ -111,6 +115,7 @@ const enhance = withObservables(['channel', 'showTeamName', 'shouldHighlightActi
         mentionsCount,
         teamDisplayName,
         hasCall,
+        urgentMentionsCount,
     };
 });
 


### PR DESCRIPTION
#### Summary
On the webapp, messages that have the urgent priority set and have mentions show as red. This is not the case on mobile. 

Before 

<img width="843" alt="Screenshot 2025-04-25 at 2 55 09 PM" src="https://github.com/user-attachments/assets/a6a45083-e84a-41e6-aa1b-7d5e4a29ac40" />

After:

<img width="393" alt="Screenshot 2025-04-22 at 6 01 09 PM" src="https://github.com/user-attachments/assets/41a36871-0716-4dd4-939f-0e1be46b341b" />



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62038

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Urgent mentions get a properly coloured mention badge
```
