### PR TITLE
[MM-63382] Calls: Fix rendering of long user/channel name in call bar

### DIFF
--- a/app/products/calls/components/current_call_bar/current_call_bar.tsx
+++ b/app/products/calls/components/current_call_bar/current_call_bar.tsx
@@ -193,7 +193,11 @@ const CurrentCallBar = ({
         </Text>);
     if (speaker) {
         talkingMessage = (
-            <Text style={style.speakingUser} numberOfLines={1} ellipsizeMode='middle'>
+            <Text
+                style={style.speakingUser}
+                numberOfLines={1}
+                ellipsizeMode='middle'
+            >
                 {displayUsername(sessionsDict[speaker].userModel, intl.locale, teammateNameDisplay)}
                 {' '}
                 <Text style={style.speakingPostfix}>{
@@ -249,7 +253,11 @@ const CurrentCallBar = ({
                     </View>
                     <View style={style.text}>
                         {talkingMessage}
-                        <Text style={style.channelAndTime} numberOfLines={1} ellipsizeMode='middle'>
+                        <Text
+                            style={style.channelAndTime}
+                            numberOfLines={1}
+                            ellipsizeMode='middle'
+                        >
                             {`~${displayName}`}
                             <Text style={style.separator}>{'  •  '}</Text>
                             <CallDuration

--- a/app/products/calls/components/current_call_bar/current_call_bar.tsx
+++ b/app/products/calls/components/current_call_bar/current_call_bar.tsx
@@ -193,7 +193,7 @@ const CurrentCallBar = ({
         </Text>);
     if (speaker) {
         talkingMessage = (
-            <Text style={style.speakingUser}>
+            <Text style={style.speakingUser} numberOfLines={1} ellipsizeMode='middle'>
                 {displayUsername(sessionsDict[speaker].userModel, intl.locale, teammateNameDisplay)}
                 {' '}
                 <Text style={style.speakingPostfix}>{
@@ -249,7 +249,7 @@ const CurrentCallBar = ({
                     </View>
                     <View style={style.text}>
                         {talkingMessage}
-                        <Text style={style.channelAndTime}>
+                        <Text style={style.channelAndTime} numberOfLines={1} ellipsizeMode='middle'>
                             {`~${displayName}`}
                             <Text style={style.separator}>{'  •  '}</Text>
                             <CallDuration


### PR DESCRIPTION
#### Summary

PR fixes a UX issue with how we render the call bar in case of long user/channel names. The fix is pretty simple and I opted to use `ellipsizeMode=middle` since we want to retain the end of the two lines ("is talking..." and the call duration respectively).

Unfortunately, doing something fancier (e.g. wrapping on multi lines) is either fairly complex or not well supported. (see https://reactnative.dev/docs/text#ellipsizemode for details). 

I think this is a good enough compromise.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63382

#### Device Information

Tested on Google Pixel 7 Pro (Android 13)

#### Screenshots

*Before*
![screen_bugged](https://github.com/user-attachments/assets/ec661955-379c-40ba-be6c-d92582ac0f9a)
*After*
![screen_fixed](https://github.com/user-attachments/assets/d14ebc04-3e56-4d26-ac67-64182e0386b0)

#### Release Note

```release-note
Fixed a UX issue where the call bar did not render correctly when displaying exceptionally long user or channel names.
```

