### PR TITLE
Unlicensed server should not show the tooltip on channel send button

### DIFF
--- a/app/actions/remote/scheduled_post.ts
+++ b/app/actions/remote/scheduled_post.ts
@@ -5,7 +5,8 @@ import {ActionType} from '@constants';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import websocketManager from '@managers/websocket_manager';
-import {getConfigValue, getCurrentUserId} from '@queries/servers/system';
+import {getIsScheduledPostEnabled} from '@queries/servers/scheduled_post';
+import {getCurrentUserId} from '@queries/servers/system';
 import ScheduledPostModel from '@typings/database/models/servers/scheduled_post';
 import {getFullErrorMessage} from '@utils/errors';
 import {logError} from '@utils/log';
@@ -71,7 +72,7 @@ export async function fetchScheduledPosts(serverUrl: string, teamId: string, inc
 
         const client = NetworkManager.getClient(serverUrl);
 
-        const scheduledPostEnabled = (await getConfigValue(database, 'ScheduledPosts')) === 'true';
+        const scheduledPostEnabled = await getIsScheduledPostEnabled(database);
         if (!scheduledPostEnabled) {
             return {scheduledPosts: []};
         }

--- a/app/components/post_draft/draft_input/draft_input.tsx
+++ b/app/components/post_draft/draft_input/draft_input.tsx
@@ -260,6 +260,7 @@ function DraftInput({
                             disabled={sendActionDisabled}
                             sendMessage={handleSendMessage}
                             showScheduledPostOptions={handleShowScheduledPostOptions}
+                            scheduledPostEnabled={scheduledPostsEnabled}
                         />
                     </View>
                 </ScrollView>

--- a/app/components/post_draft/draft_input/index.ts
+++ b/app/components/post_draft/draft_input/index.ts
@@ -3,14 +3,14 @@
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
 
-import {observeConfigBooleanValue} from '@queries/servers/system';
+import {observeScheduledPostEnabled} from '@queries/servers/scheduled_post';
 
 import DraftInput from './draft_input';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const scheduledPostsEnabled = observeConfigBooleanValue(database, 'ScheduledPosts');
+    const scheduledPostsEnabled = observeScheduledPostEnabled(database);
     return {
         scheduledPostsEnabled,
     };

--- a/app/components/post_draft/send_button/index.tsx
+++ b/app/components/post_draft/send_button/index.tsx
@@ -2,33 +2,14 @@
 // See LICENSE.txt for license information.
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
-import {combineLatest, of as of$} from 'rxjs';
-import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {SendButton} from '@components/post_draft/send_button/send_button';
 import {Tutorial} from '@constants';
 import {observeTutorialWatched} from '@queries/app/global';
-import {observeLicense} from '@queries/servers/system';
 
-import type {WithDatabaseArgs} from '@typings/database/database';
+const enhanced = withObservables([], () => {
+    const scheduledPostFeatureTooltipWatched = observeTutorialWatched(Tutorial.SCHEDULED_POST);
 
-type Props = WithDatabaseArgs & {
-    scheduledPostEnabled: boolean;
-}
-
-const enhanced = withObservables(['scheduledPostEnabled'], ({scheduledPostEnabled, database}: Props) => {
-    const scheduledPostTutorialWatched = observeTutorialWatched(Tutorial.SCHEDULED_POST);
-    const isLicense = observeLicense(database);
-
-    const scheduledPostFeatureTooltipWatched = combineLatest([scheduledPostTutorialWatched, isLicense]).pipe(
-        switchMap(([watched, license]) => {
-            if (license?.IsLicensed === 'true' && scheduledPostEnabled) {
-                return of$(watched);
-            }
-            return of$(true);
-        }),
-        distinctUntilChanged(),
-    );
     return {
         scheduledPostFeatureTooltipWatched,
     };

--- a/app/components/post_draft/send_button/index.tsx
+++ b/app/components/post_draft/send_button/index.tsx
@@ -2,14 +2,33 @@
 // See LICENSE.txt for license information.
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
+import {combineLatest, of as of$} from 'rxjs';
+import {switchMap, distinctUntilChanged} from 'rxjs/operators';
 
 import {SendButton} from '@components/post_draft/send_button/send_button';
 import {Tutorial} from '@constants';
 import {observeTutorialWatched} from '@queries/app/global';
+import {observeLicense} from '@queries/servers/system';
 
-const enhanced = withObservables([], () => {
-    const scheduledPostFeatureTooltipWatched = observeTutorialWatched(Tutorial.SCHEDULED_POST);
+import type {WithDatabaseArgs} from '@typings/database/database';
 
+type Props = WithDatabaseArgs & {
+    scheduledPostEnabled: boolean;
+}
+
+const enhanced = withObservables(['scheduledPostEnabled'], ({scheduledPostEnabled, database}: Props) => {
+    const scheduledPostTutorialWatched = observeTutorialWatched(Tutorial.SCHEDULED_POST);
+    const isLicense = observeLicense(database);
+
+    const scheduledPostFeatureTooltipWatched = combineLatest([scheduledPostTutorialWatched, isLicense]).pipe(
+        switchMap(([watched, license]) => {
+            if (license?.IsLicensed === 'true' && scheduledPostEnabled) {
+                return of$(watched);
+            }
+            return of$(true);
+        }),
+        distinctUntilChanged(),
+    );
     return {
         scheduledPostFeatureTooltipWatched,
     };

--- a/app/components/post_draft/send_button/send_button.test.tsx
+++ b/app/components/post_draft/send_button/send_button.test.tsx
@@ -9,11 +9,12 @@ import {SendButton} from '@components/post_draft/send_button/send_button';
 import {fireEvent, renderWithIntl} from '@test/intl-test-helper';
 
 describe('components/post_draft/send_button', () => {
-    const baseProps = {
+    const baseProps: Parameters<typeof SendButton>[0] = {
         disabled: false,
         sendMessage: jest.fn(),
         testID: 'test_id',
         showScheduledPostOptions: jest.fn(),
+        scheduledPostEnabled: true,
         scheduledPostFeatureTooltipWatched: true,
     };
 
@@ -136,6 +137,24 @@ describe('components/post_draft/send_button', () => {
 
         act(() => {
             expect(queryByText(text)).toBeTruthy();
+        });
+    });
+
+    it('should not show the tooltip if the scheduled post feature is disabled', async () => {
+        const handle = InteractionManager.createInteractionHandle();
+        const props = {...baseProps, scheduledPostFeatureTooltipWatched: false, scheduledPostEnabled: false};
+        const {queryByText} = renderWithIntl(
+            <SendButton
+                {...props}
+            />,
+        );
+        const text = 'Type a message and long press the send button to schedule it for a later time.';
+
+        InteractionManager.clearInteractionHandle(handle);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        act(() => {
+            expect(queryByText(text)).toBeFalsy();
         });
     });
 });

--- a/app/components/post_draft/send_button/send_button.tsx
+++ b/app/components/post_draft/send_button/send_button.tsx
@@ -19,6 +19,7 @@ type Props = {
     sendMessage: () => void;
     showScheduledPostOptions: () => void;
     scheduledPostFeatureTooltipWatched: boolean;
+    scheduledPostEnabled: boolean;
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
@@ -56,6 +57,7 @@ export function SendButton({
     sendMessage,
     showScheduledPostOptions,
     scheduledPostFeatureTooltipWatched,
+    scheduledPostEnabled,
 }: Props) {
     const theme = useTheme();
     const sendButtonTestID = `${testID}.send.button` + (disabled ? '.disabled' : '');
@@ -64,7 +66,7 @@ export function SendButton({
     const [scheduledPostTooltipVisible, setScheduledPostTooltipVisible] = useState(false);
 
     useEffect(() => {
-        if (scheduledPostFeatureTooltipWatched) {
+        if (scheduledPostFeatureTooltipWatched || !scheduledPostEnabled) {
             return;
         }
 
@@ -94,7 +96,7 @@ export function SendButton({
             style={style.sendButtonContainer}
             type={'opacity'}
             disabled={disabled}
-            onLongPress={showScheduledPostOptions}
+            onLongPress={scheduledPostEnabled ? showScheduledPostOptions : undefined}
         >
             <Tooltip
                 isVisible={scheduledPostTooltipVisible}

--- a/app/screens/global_drafts/index.ts
+++ b/app/screens/global_drafts/index.ts
@@ -2,11 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
+import {combineLatest, of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observeDraftCount} from '@queries/servers/drafts';
-import {observeScheduledPostCount} from '@queries/servers/scheduled_post';
-import {observeConfigBooleanValue, observeCurrentTeamId} from '@queries/servers/system';
+import {observeScheduledPostCount, observeScheduledPostEnabled} from '@queries/servers/scheduled_post';
+import {observeCurrentTeamId} from '@queries/servers/system';
 
 import GlobalDraftsAndScheduledPosts from './global_drafts';
 
@@ -14,9 +15,16 @@ import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const currentTeamId = observeCurrentTeamId(database);
-    const scheduledPostsEnabled = observeConfigBooleanValue(database, 'ScheduledPosts');
+    const scheduledPostsEnabled = observeScheduledPostEnabled(database);
     const draftsCount = currentTeamId.pipe(switchMap((teamId) => observeDraftCount(database, teamId))); // Observe draft count
-    const scheduledPostCount = currentTeamId.pipe(switchMap((teamId) => observeScheduledPostCount(database, teamId, true)));
+    const scheduledPostCount = combineLatest([currentTeamId, scheduledPostsEnabled]).pipe(
+        switchMap(([teamId, isEnabled]) => {
+            if (isEnabled) {
+                return observeScheduledPostCount(database, teamId, true);
+            }
+            return of$(0);
+        }),
+    );
     return {
         scheduledPostsEnabled,
         draftsCount,

--- a/app/screens/home/channel_list/categories_list/index.tsx
+++ b/app/screens/home/channel_list/categories_list/index.tsx
@@ -6,8 +6,8 @@ import {of} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observeDraftCount} from '@queries/servers/drafts';
-import {observeScheduledPostsForTeam} from '@queries/servers/scheduled_post';
-import {observeConfigBooleanValue, observeCurrentTeamId} from '@queries/servers/system';
+import {observeScheduledPostEnabled, observeScheduledPostsForTeam} from '@queries/servers/scheduled_post';
+import {observeCurrentTeamId} from '@queries/servers/system';
 import {observeTeamLastChannelId} from '@queries/servers/team';
 import {hasScheduledPostError} from '@utils/scheduled_post';
 
@@ -26,7 +26,7 @@ const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const scheduledPostHasError = allScheduledPost.pipe(
         switchMap((scheduledPosts) => of(hasScheduledPostError(scheduledPosts))),
     );
-    const scheduledPostsEnabled = observeConfigBooleanValue(database, 'ScheduledPosts');
+    const scheduledPostsEnabled = observeScheduledPostEnabled(database);
 
     return {
         lastChannelId,


### PR DESCRIPTION
#### Summary
I added a check to verify if a valid license exists before showing the scheduled post tooltip on the send draft button when opening a channel for the first time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63841


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```

Regarding test: We already have ticket for this: https://mattermost.atlassian.net/browse/MM-62286, will cover in it. 
