### PR TITLE
Android: Fix Rescheduling pop back calendar

### DIFF
--- a/app/screens/reschedule_draft/reschedule_draft.tsx
+++ b/app/screens/reschedule_draft/reschedule_draft.tsx
@@ -87,7 +87,6 @@ const RescheduledDraft: React.FC<Props> = ({
                 type: MESSAGE_TYPE.ERROR,
             });
         } else {
-            setIsUpdating(false);
             onClose();
         }
     }, [intl, onClose]);


### PR DESCRIPTION
#### Summary
I removed the unnecessary `setIsUpdating(false)` call from the `reschedule_draft` component.

When saving the updated date and time for a scheduled post, we were calling `setIsUpdating(false)` even after a successful update. This triggered a re-render of the component, which caused the DateTimePicker (calendar) to flash briefly after the modal was closed.

We don't actually need to reset `isUpdating` after a successful update because the `onClose` function dismisses the modal, and when the modal is reopened, everything is already reset to the initial state.

Now, we only update `isUpdating` if there's an error during the save.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63750

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots

https://github.com/user-attachments/assets/e8a8f3ee-3288-4d73-a784-0dddcfb67faa

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
