### PR TITLE
[MM-63553] Fix for: messages received on the background on iOS lose the props

### DIFF
--- a/app/actions/remote/notifications.ts
+++ b/app/actions/remote/notifications.ts
@@ -124,30 +124,31 @@ export const backgroundNotification = async (serverUrl: string, notification: No
                 // we validate message attachments before displaying them.
                 // This is a problem from the NSJSONSerialization call in AppDelegate.mm -- there
                 // is no true/false in Objective-C, only NSNumber with value 1 or 0
-
-                // Convert attachment.fields.short, and attachment.actions.disabled
-                postsData.posts.forEach((post) => {
-                    if (post.props?.attachments) {
-                        (post.props.attachments as MessageAttachment[])?.forEach((attachment) => {
-                            if (attachment.fields?.length) {
-                                // eslint-disable-next-line max-nested-callbacks
-                                attachment.fields.forEach((field) => {
-                                    if (field.short !== undefined) {
-                                        field.short = Boolean(field.short);
-                                    }
-                                });
-                            }
-                            if (attachment.actions?.length) {
-                                // eslint-disable-next-line max-nested-callbacks
-                                attachment.actions.forEach((action) => {
-                                    if (action.disabled !== undefined) {
-                                        action.disabled = Boolean(action.disabled);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+                if (Platform.OS === 'ios') {
+                    // Convert attachment.fields.short, and attachment.actions.disabled
+                    postsData.posts.forEach((post) => {
+                        if (post.props?.attachments) {
+                            (post.props.attachments as MessageAttachment[])?.forEach((attachment) => {
+                                if (attachment.fields?.length) {
+                                    // eslint-disable-next-line max-nested-callbacks
+                                    attachment.fields.forEach((field) => {
+                                        if (field.short !== undefined) {
+                                            field.short = Boolean(field.short);
+                                        }
+                                    });
+                                }
+                                if (attachment.actions?.length) {
+                                    // eslint-disable-next-line max-nested-callbacks
+                                    attachment.actions.forEach((action) => {
+                                        if (action.disabled !== undefined) {
+                                            action.disabled = Boolean(action.disabled);
+                                        }
+                                    });
+                                }
+                            });
+                        }
+                    });
+                }
 
                 const isThreadNotification = isCRTEnabled && Boolean(notification.payload.root_id);
                 const actionType = isThreadNotification ? ActionType.POSTS.RECEIVED_IN_THREAD : ActionType.POSTS.RECEIVED_IN_CHANNEL;

--- a/app/actions/remote/notifications.ts
+++ b/app/actions/remote/notifications.ts
@@ -132,7 +132,7 @@ export const backgroundNotification = async (serverUrl: string, notification: No
                             if (attachment.fields?.length) {
                                 // eslint-disable-next-line max-nested-callbacks
                                 attachment.fields.forEach((field) => {
-                                    if (field.short) {
+                                    if (field.short !== undefined) {
                                         field.short = Boolean(field.short);
                                     }
                                 });
@@ -140,7 +140,7 @@ export const backgroundNotification = async (serverUrl: string, notification: No
                             if (attachment.actions?.length) {
                                 // eslint-disable-next-line max-nested-callbacks
                                 attachment.actions.forEach((action) => {
-                                    if (action.disabled) {
+                                    if (action.disabled !== undefined) {
                                         action.disabled = Boolean(action.disabled);
                                     }
                                 });

--- a/app/actions/remote/notifications.ts
+++ b/app/actions/remote/notifications.ts
@@ -119,6 +119,36 @@ export const backgroundNotification = async (serverUrl: string, notification: No
 
             if (posts) {
                 const postsData = processPostsFetched(posts);
+
+                // We need to convert the following properties from 1/0 to true/false, because
+                // we validate message attachments before displaying them.
+                // This is a problem from the NSJSONSerialization call in AppDelegate.mm -- there
+                // is no true/false in Objective-C, only NSNumber with value 1 or 0
+
+                // Convert attachment.fields.short, and attachment.actions.disabled
+                postsData.posts.forEach((post) => {
+                    if (post.props?.attachments) {
+                        (post.props.attachments as MessageAttachment[])?.forEach((attachment) => {
+                            if (attachment.fields?.length) {
+                                // eslint-disable-next-line max-nested-callbacks
+                                attachment.fields.forEach((field) => {
+                                    if (field.short) {
+                                        field.short = Boolean(field.short);
+                                    }
+                                });
+                            }
+                            if (attachment.actions?.length) {
+                                // eslint-disable-next-line max-nested-callbacks
+                                attachment.actions.forEach((action) => {
+                                    if (action.disabled) {
+                                        action.disabled = Boolean(action.disabled);
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+
                 const isThreadNotification = isCRTEnabled && Boolean(notification.payload.root_id);
                 const actionType = isThreadNotification ? ActionType.POSTS.RECEIVED_IN_THREAD : ActionType.POSTS.RECEIVED_IN_CHANNEL;
 


### PR DESCRIPTION
#### Summary
- After a long couple days of debugging and log setting, I discovered the issue: we were validating message attachments, and at this point: https://github.com/mattermost/mattermost-mobile/blob/5c2153f83b14d44e8f1b51b6a6ce1e079fa46c1d/app/utils/message_attachment.ts#L98-L100
we were failing the validation because (in the customer's example post), we were sending `"short": true` but it was ending up as `"short": 1` at this point, thus failing the validation.
- I was about to push a fix that changed the validation, but that didn't feel right. /Why/ was `short` being converted to a 1? - It turns out, `NSJSONSerialization` was serializing data's bools as 1 and 0 here: https://github.com/mattermost/mattermost-mobile/blob/58830b5acb26388a4f042d56ccb799651f414b6d/ios/Mattermost/AppDelegate.mm#L116
- This is unavoidable, because Objective-C has no true or false. It should have been converted by the RN bridge back to true/false, but it isn't, and I'm not sure why. I think it might be we are not typing things fully (we're using a `props: Record<string, unknown> | undefined` in the Post type definition? But anyway, the solution I decided on is to manually convert them, if they exist.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-63553

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
- iPhone 14

#### Release Note

```release-note
Fixed a bug where message attachments (e.g. from a webhook) would not appear if received while the app was in the background.
```
