### PR TITLE
Renamed premium SKU to Enterprise Advanced

### DIFF
--- a/app/constants/license.ts
+++ b/app/constants/license.ts
@@ -8,7 +8,7 @@ export default {
         Starter: 'starter',
         Professional: 'professional',
         Enterprise: 'enterprise',
-        Premium: 'premium',
+        EnterpriseAdvanced: 'advanced',
     },
     SelfHostedProducts: {
         STARTER: 'starter',

--- a/app/screens/channel/channel_feature_checks.test.tsx
+++ b/app/screens/channel/channel_feature_checks.test.tsx
@@ -6,7 +6,7 @@ import {shouldShowChannelBanner} from '@screens/channel/channel_feature_checks';
 
 describe('shouldShowChannelBanner', () => {
     const validLicense = {
-        SkuShortName: License.SKU_SHORT_NAME.Premium,
+        SkuShortName: License.SKU_SHORT_NAME.EnterpriseAdvanced,
     } as ClientLicense;
 
     const validBannerInfo = {
@@ -24,17 +24,17 @@ describe('shouldShowChannelBanner', () => {
     });
 
     it('should return false when license is not professional', () => {
-        const nonPremiumLicense = {
+        const nonEnterpriseAdvancedLicense = {
             SkuShortName: License.SKU_SHORT_NAME.Professional,
         } as ClientLicense;
-        expect(shouldShowChannelBanner(General.OPEN_CHANNEL, nonPremiumLicense, validBannerInfo)).toBe(false);
+        expect(shouldShowChannelBanner(General.OPEN_CHANNEL, nonEnterpriseAdvancedLicense, validBannerInfo)).toBe(false);
     });
 
     it('should return false when license is not enterprise', () => {
-        const nonPremiumLicense = {
+        const nonEnterpriseAdvancedLicense = {
             SkuShortName: License.SKU_SHORT_NAME.Enterprise,
         } as ClientLicense;
-        expect(shouldShowChannelBanner(General.OPEN_CHANNEL, nonPremiumLicense, validBannerInfo)).toBe(false);
+        expect(shouldShowChannelBanner(General.OPEN_CHANNEL, nonEnterpriseAdvancedLicense, validBannerInfo)).toBe(false);
     });
 
     it('should return false when banner info is incomplete', () => {
@@ -60,11 +60,11 @@ describe('shouldShowChannelBanner', () => {
         expect(shouldShowChannelBanner(General.GM_CHANNEL, validLicense, validBannerInfo)).toBe(false);
     });
 
-    it('should return true for valid open channel with complete banner info and premium license', () => {
+    it('should return true for valid open channel with complete banner info and enterprise advanced license', () => {
         expect(shouldShowChannelBanner(General.OPEN_CHANNEL, validLicense, validBannerInfo)).toBe(true);
     });
 
-    it('should return true for valid private channel with complete banner info and premium license', () => {
+    it('should return true for valid private channel with complete banner info and enterprise advanced license', () => {
         expect(shouldShowChannelBanner(General.PRIVATE_CHANNEL, validLicense, validBannerInfo)).toBe(true);
     });
 });

--- a/app/screens/channel/channel_feature_checks.ts
+++ b/app/screens/channel/channel_feature_checks.ts
@@ -8,9 +8,9 @@ export function shouldShowChannelBanner(channelType?: ChannelType, license?: Cli
         return false;
     }
 
-    const isPremiumLicense = license.SkuShortName === License.SKU_SHORT_NAME.Premium;
+    const isEnterpriseAdvancedLicense = license.SkuShortName === License.SKU_SHORT_NAME.EnterpriseAdvanced;
     const bannerInfoComplete = Boolean(bannerInfo.enabled && bannerInfo.text && bannerInfo.background_color);
     const isValidChannelType = channelType === General.OPEN_CHANNEL || channelType === General.PRIVATE_CHANNEL;
 
-    return isPremiumLicense && bannerInfoComplete && isValidChannelType;
+    return isEnterpriseAdvancedLicense && bannerInfoComplete && isValidChannelType;
 }

--- a/app/screens/channel/header/channel_banner/channel_banner.test.tsx
+++ b/app/screens/channel/header/channel_banner/channel_banner.test.tsx
@@ -50,7 +50,7 @@ describe('ChannelBanner', () => {
             });
         });
 
-        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.LICENSE, value: {IsLicensed: 'true', SkuShortName: License.SKU_SHORT_NAME.Premium}}], prepareRecordsOnly: false});
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.LICENSE, value: {IsLicensed: 'true', SkuShortName: License.SKU_SHORT_NAME.EnterpriseAdvanced}}], prepareRecordsOnly: false});
     });
 
     it('renders correctly with valid props', () => {


### PR DESCRIPTION
#### Summary
Renamed Premium SKU to `Enterprise Advanced`.

Server PR - https://github.com/mattermost/mattermost/pull/30882

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-63928

#### Release Note
```release-note
None
```
