### PR TITLE
[MM-63643] Show file name for video if public link is disabled

### DIFF
--- a/app/components/files/files.tsx
+++ b/app/components/files/files.tsx
@@ -64,7 +64,7 @@ const Files = ({
     const [inViewPort, setInViewPort] = useState(false);
     const isTablet = useIsTablet();
 
-    const {images: imageAttachments, nonImages: nonImageAttachments} = useImageAttachments(filesInfo);
+    const {images: imageAttachments, nonImages: nonImageAttachments} = useImageAttachments(filesInfo, publicLinkEnabled);
     const [filesForGallery, setFilesForGallery] = useState(() => [...imageAttachments, ...nonImageAttachments]);
 
     const attachmentIndex = (fileId: string) => {

--- a/app/components/files_search/file_results.tsx
+++ b/app/components/files_search/file_results.tsx
@@ -76,7 +76,7 @@ const FileResults = ({
     const containerStyle = useMemo(() => ([paddingTop, {flexGrow: 1}]), [paddingTop]);
     const numOptions = getNumberFileMenuOptions(canDownloadFiles, publicLinkEnabled);
 
-    const {images: imageAttachments, nonImages: nonImageAttachments} = useImageAttachments(fileInfos);
+    const {images: imageAttachments, nonImages: nonImageAttachments} = useImageAttachments(fileInfos, publicLinkEnabled);
     const filesForGallery = useMemo(() => imageAttachments.concat(nonImageAttachments), [imageAttachments, nonImageAttachments]);
 
     const channelNames = useMemo(() => getChannelNamesWithID(fileChannels), [fileChannels]);

--- a/app/hooks/files.test.ts
+++ b/app/hooks/files.test.ts
@@ -40,7 +40,7 @@ describe('useImageAttachments', () => {
         jest.mocked(useServerUrl).mockReturnValue(serverUrl);
     });
 
-    it('should separate images and non-images correctly', () => {
+    it('should separate images and non-images correctly, with public link enabled', () => {
         const filesInfo = [
             TestHelper.fakeFileInfo({id: '1', localPath: 'path/to/image1', uri: `${serverUrl}/files/image1`}),
             TestHelper.fakeFileInfo({id: '2', localPath: 'path/to/video1', uri: `${serverUrl}/files/video1`}),
@@ -53,7 +53,7 @@ describe('useImageAttachments', () => {
         jest.mocked(buildFilePreviewUrl).mockImplementation((url, id) => `${url}/preview/${id}`);
         jest.mocked(buildFileUrl).mockImplementation((url, id) => `${url}/file/${id}`);
 
-        const {result} = renderHook(() => useImageAttachments(filesInfo));
+        const {result} = renderHook(() => useImageAttachments(filesInfo, true));
 
         expect(result.current.images).toEqual([
             TestHelper.fakeFileInfo({id: '1', localPath: 'path/to/image1', uri: 'path/to/image1'}),
@@ -61,6 +61,31 @@ describe('useImageAttachments', () => {
         ]);
 
         expect(result.current.nonImages).toEqual([
+            TestHelper.fakeFileInfo({id: '3', localPath: 'path/to/file1', uri: `${serverUrl}/files/file1`}),
+        ]);
+    });
+
+    it('should separate images and non-images correctly, with public link disabled', () => {
+        const filesInfo = [
+            TestHelper.fakeFileInfo({id: '1', localPath: 'path/to/image1', uri: `${serverUrl}/files/image1`}),
+            TestHelper.fakeFileInfo({id: '2', localPath: 'path/to/video1', uri: `${serverUrl}/files/video1`}),
+            TestHelper.fakeFileInfo({id: '3', localPath: 'path/to/file1', uri: `${serverUrl}/files/file1`}),
+        ];
+
+        jest.mocked(isImage).mockImplementation((file) => file?.id === '1');
+        jest.mocked(isVideo).mockImplementation((file) => file?.id === '2');
+        jest.mocked(isGif).mockReturnValue(false);
+        jest.mocked(buildFilePreviewUrl).mockImplementation((url, id) => `${url}/preview/${id}`);
+        jest.mocked(buildFileUrl).mockImplementation((url, id) => `${url}/file/${id}`);
+
+        const {result} = renderHook(() => useImageAttachments(filesInfo, false));
+
+        expect(result.current.images).toEqual([
+            TestHelper.fakeFileInfo({id: '1', localPath: 'path/to/image1', uri: 'path/to/image1'}),
+        ]);
+
+        expect(result.current.nonImages).toEqual([
+            TestHelper.fakeFileInfo({id: '2', localPath: 'path/to/video1', uri: 'path/to/video1'}),
             TestHelper.fakeFileInfo({id: '3', localPath: 'path/to/file1', uri: `${serverUrl}/files/file1`}),
         ]);
     });
@@ -75,7 +100,7 @@ describe('useImageAttachments', () => {
         jest.mocked(isGif).mockReturnValue(false);
         jest.mocked(buildFilePreviewUrl).mockImplementation((url, id) => `${url}/preview/${id}`);
 
-        const {result} = renderHook(() => useImageAttachments(filesInfo));
+        const {result} = renderHook(() => useImageAttachments(filesInfo, true));
 
         expect(result.current.images).toEqual([
             TestHelper.fakeFileInfo({id: '1', localPath: '', uri: 'https://example.com/preview/1'}),
@@ -93,7 +118,7 @@ describe('useImageAttachments', () => {
         jest.mocked(isGif).mockImplementation((file) => file?.id === '1');
         jest.mocked(buildFileUrl).mockImplementation((url, id) => `${url}/file/${id}`);
 
-        const {result} = renderHook(() => useImageAttachments(filesInfo));
+        const {result} = renderHook(() => useImageAttachments(filesInfo, true));
 
         expect(result.current.images).toEqual([
             TestHelper.fakeFileInfo({id: '1', localPath: '', uri: 'https://example.com/file/1'}),
@@ -113,7 +138,7 @@ describe('useImageAttachments', () => {
         jest.mocked(buildFilePreviewUrl).mockImplementation((url, id) => `${url}/preview/${id}`);
         jest.mocked(buildFileUrl).mockImplementation((url, id) => `${url}/file/${id}`);
 
-        const {result, rerender} = renderHook(() => useImageAttachments(filesInfo));
+        const {result, rerender} = renderHook(() => useImageAttachments(filesInfo, true));
 
         const firstResult = result.current;
 
@@ -127,7 +152,7 @@ describe('useImageAttachments', () => {
     it('should handle empty filesInfo array', () => {
         const filesInfo: FileInfo[] = [];
 
-        const {result} = renderHook(() => useImageAttachments(filesInfo));
+        const {result} = renderHook(() => useImageAttachments(filesInfo, true));
 
         expect(result.current.images).toEqual([]);
         expect(result.current.nonImages).toEqual([]);
@@ -144,7 +169,7 @@ describe('useImageAttachments', () => {
         jest.mocked(isGif).mockReturnValue(false);
         jest.mocked(buildFilePreviewUrl).mockImplementation((url, id) => `${url}/preview/${id}`);
 
-        const {result} = renderHook(() => useImageAttachments(filesInfo));
+        const {result} = renderHook(() => useImageAttachments(filesInfo, true));
 
         expect(result.current.images).toEqual([
             TestHelper.fakeFileInfo({id: '', localPath: 'path/to/image1', uri: 'path/to/image1'}),

--- a/app/hooks/files.ts
+++ b/app/hooks/files.ts
@@ -59,12 +59,12 @@ const getFileInfo = async (serverUrl: string, bookmarks: ChannelBookmarkModel[],
     }
 };
 
-export const useImageAttachments = (filesInfo: FileInfo[]) => {
+export const useImageAttachments = (filesInfo: FileInfo[], publicLinkEnabled: boolean) => {
     const serverUrl = useServerUrl();
     return useMemo(() => {
         return filesInfo.reduce(({images, nonImages}: {images: FileInfo[]; nonImages: FileInfo[]}, file) => {
             const imageFile = isImage(file);
-            const videoFile = isVideo(file);
+            const videoFile = isVideo(file) && publicLinkEnabled; // we don't render previews for videos if public link is disabled
             const audioFile = isAudio(file);
 
             if (imageFile || videoFile || audioFile) {


### PR DESCRIPTION
#### Summary

Video files when public links are disabled doesn't count as attachment with images.

#### Ticket Link
[MM-63643](https://mattermost.atlassian.net/browse/MM-63643)
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: android pixel 8

#### Screenshots
![image](https://github.com/user-attachments/assets/25415ae8-0b68-4929-bc55-d135ed8461c4)

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
fixed video names when public links are disabled
```
