### PR TITLE
Fix back button not closing the app

### DIFF
--- a/patches/react-native-navigation+7.45.0.patch
+++ b/patches/react-native-navigation+7.45.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
-index f3f0d5a..3af346d 100644
+index f3f0d5a..970296d 100644
 --- a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
 +++ b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
 @@ -1,13 +1,12 @@
@@ -37,7 +37,7 @@ index f3f0d5a..3af346d 100644
          StatusBarPresenter.Companion.init(this);
      }
  
-@@ -96,15 +94,15 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
+@@ -96,15 +94,16 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
  
      @Override
      public void invokeDefaultOnBackPressed() {
@@ -51,6 +51,7 @@ index f3f0d5a..3af346d 100644
 +        //     NavigationActivity.super.onBackPressed();
 +        //     callback.setEnabled(true);
 +        // }
++        super.invokeDefaultOnBackPressed();
      }
  
      @Override
@@ -59,7 +60,7 @@ index f3f0d5a..3af346d 100644
          super.onActivityResult(requestCode, resultCode, data);
          getReactGateway().onActivityResult(this, requestCode, resultCode, data);
      }
-@@ -126,7 +124,6 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
+@@ -126,7 +125,6 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
          return navigator;
      }
  


### PR DESCRIPTION
#### Summary
During the dependency upgrade, we removed one line in the patch for react native navigation that was overriding the default behavior of the back button. Removing this line made it so the default behavior (in general close the app) translated into doing nothing.

Reverting that small change in the patch seems to do the trick.

#### Ticket Link
FIX https://mattermost.atlassian.net/browse/MM-63921

#### Release Note
```release-note
Fix back button not closing the app
```
