### PR TITLE
Fix category sorting difference between mobile and web

### DIFF
--- a/app/database/operator/server_data_operator/transformers/category.ts
+++ b/app/database/operator/server_data_operator/transformers/category.ts
@@ -32,7 +32,7 @@ export const transformCategoryRecord = ({action, database, value}: TransformerAr
     const fieldsMapper = (category: CategoryModel) => {
         category._raw.id = isCreateAction ? (raw?.id ?? category.id) : record!.id;
         category.displayName = raw.display_name;
-        category.sorting = raw.sorting || 'recent';
+        category.sorting = raw.sorting ?? '';
         category.sortOrder = raw.sort_order === 0 ? 0 : raw.sort_order / 10; // Sort order from server is in multiples of 10
         category.muted = raw.muted ?? false;
         category.collapsed = isCreateAction ? false : record!.collapsed;


### PR DESCRIPTION
#### Summary
By default, we were settings the categories to sort order `recent` on mobile. The default should have been the empty string, which defaults to alphabetical order. That fixes the inconsistencies with web.

The data in the database is already "wrong", so in order to fix it, we would need to log out and log back in.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-54396

#### Release Note
```release-note
Fix inconsistencies between web and mobile category sorting. (May require logging out and log back in to fix)
```
