### PR TITLE
Update supported ESR version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mattermost Mobile v2
 
-- **Minimum Server versions:** Current ESR version (9.11.0+)
+- **Minimum Server versions:** Current ESR version (10.5.0+)
 - **Supported iOS versions:** 15.1+
 - **Supported Android versions:** 7.0+
 

--- a/app/constants/supported_server.ts
+++ b/app/constants/supported_server.ts
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 export const MIN_REQUIRED_VERSION = '5.26.2';
-export const FULL_VERSION = '9.11.0';
-export const MAJOR_VERSION = 9;
-export const MIN_VERSION = 11;
+export const FULL_VERSION = '10.5.0';
+export const MAJOR_VERSION = 10;
+export const MIN_VERSION = 5;
 export const PATCH_VERSION = 0;
 
 export default {

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Requires Mattermost Server v9.11.0+. Older servers may not be able to connect or have unexpected behavior.
+Requires Mattermost Server v10.5.0+. Older servers may not be able to connect or have unexpected behavior.
 
 -------
 

--- a/fastlane/metadata/changelog
+++ b/fastlane/metadata/changelog
@@ -1,4 +1,4 @@
-This version is compatible with Mattermost servers v9.11.0+.
+This version is compatible with Mattermost servers v10.5.0+.
 
 Please see [changelog](https://docs.mattermost.com/administration/mobile-changelog.html) for full release notes. If you're interested in helping beta test upcoming versions before they are released, please see our [documentation](https://github.com/mattermost/mattermost-mobile#testing).
 


### PR DESCRIPTION
To be merged mid-May.

QA Test Steps:
1. Connect to a server with a version lower than ESR (e.g. v10.4). Expected: Prompt to upgrade the server is received.
2. Connect to a server with a version equal to ESR (v10.5). Expected: Prompt to upgrade the server is not received.
3. Connect to a server with a version greater than ESR (e.g. v10.6). Expected: Prompt to upgrade the server is not received.

```release-note
Updated minimum supported version to v10.5.0.
```
