### PR TITLE
Fix ephemeral messages disappearing when updating them

### DIFF
--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -12,6 +12,7 @@ import {openChannelIfNeeded} from '@actions/remote/preference';
 import {fetchThread} from '@actions/remote/thread';
 import {fetchMissingProfilesByIds} from '@actions/remote/user';
 import {ActionType, Events, Screens} from '@constants';
+import {PostTypes} from '@constants/post';
 import DatabaseManager from '@database/manager';
 import {getChannelById, getMyChannel} from '@queries/servers/channel';
 import {getPostById} from '@queries/servers/post';
@@ -213,6 +214,13 @@ export async function handlePostEdited(serverUrl: string, msg: WebSocketMessage)
     if (!oldPost) {
         EphemeralStore.addEditingPost(serverUrl, post);
         return;
+    }
+
+    if (post.type === PostTypes.EPHEMERAL && post.create_at === 0) {
+        // Updated ephemeral messages don't have a create_at value
+        // since the server has no persistence for ephemeral messages,
+        // so we need to use the old post's create_at value
+        post.create_at = oldPost.createAt;
     }
 
     if (oldPost.isPinned !== post.is_pinned) {


### PR DESCRIPTION
#### Summary
Updated epehemeral posts didn't provide a create at, making it to 0. Our logic, on update, update any field provided by the server (the server has the source of truth), and therefore was setting the create at to 0. This made so the chunk logic for messages hide the ephemeral message.

The fix just make sure that when the create at is 0, we don't update it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58461

#### Release Note
```release-note
Fix actions on ephemeral messages hiding the message.
```
