### PR TITLE
[MM-63963] Remove unused constants from SelfHostedProducts

### DIFF
--- a/app/constants/license.ts
+++ b/app/constants/license.ts
@@ -12,7 +12,5 @@ export default {
     },
     SelfHostedProducts: {
         STARTER: 'starter',
-        PROFESSIONAL: 'professional',
-        ENTERPRISE: 'enterprise',
     },
 };


### PR DESCRIPTION
#### Summary
Remove unused constants (`PROFESSIONAL` and `ENTERPRISE`) from the `SelfHostedProducts` object in license.ts while keeping the `STARTER` constant which is used in the codebase.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-63963
Referenced from: https://github.com/mattermost/mattermost-mobile/pull/8819#discussion_r2069852616

#### Checklist
- [x] Has UI changes: No
- [x] Includes text changes and localization file updates: No
- [x] Have tested against the 5 core themes to ensure consistency between them: N/A - no UI changes
- [x] Have run E2E tests: N/A - no UI or interaction changes

#### Device Information
This PR was tested on: iOS Simulator, Android Emulator

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)