### PR TITLE
chore(MM-64202): update expo-image to consume OOM crash fix

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -17,10 +17,11 @@ PODS:
     - ExpoModulesCore
   - ExpoFileSystem (18.0.12):
     - ExpoModulesCore
-  - ExpoImage (2.0.7):
+  - ExpoImage (2.1.6):
     - ExpoModulesCore
-    - SDWebImage (~> 5.19.1)
+    - SDWebImage (~> 5.21.0)
     - SDWebImageSVGCoder (~> 1.7.0)
+    - SDWebImageWebPCoder (~> 0.14.6)
   - ExpoLinearGradient (14.0.2):
     - ExpoModulesCore
   - ExpoModulesCore (2.2.3):
@@ -61,6 +62,18 @@ PODS:
   - hermes-engine/Pre-built (0.76.9)
   - HMSegmentedControl (1.5.6)
   - JitsiWebRTC (124.0.2)
+  - libwebp (1.5.0):
+    - libwebp/demux (= 1.5.0)
+    - libwebp/mux (= 1.5.0)
+    - libwebp/sharpyuv (= 1.5.0)
+    - libwebp/webp (= 1.5.0)
+  - libwebp/demux (1.5.0):
+    - libwebp/webp
+  - libwebp/mux (1.5.0):
+    - libwebp/demux
+  - libwebp/sharpyuv (1.5.0)
+  - libwebp/webp (1.5.0):
+    - libwebp/sharpyuv
   - mattermost-hardware-keyboard (0.0.0):
     - DoubleConversion
     - glog
@@ -2186,11 +2199,14 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - SDWebImage (5.19.7):
-    - SDWebImage/Core (= 5.19.7)
-  - SDWebImage/Core (5.19.7)
+  - SDWebImage (5.21.0):
+    - SDWebImage/Core (= 5.21.0)
+  - SDWebImage/Core (5.21.0)
   - SDWebImageSVGCoder (1.7.0):
     - SDWebImage/Core (~> 5.6)
+  - SDWebImageWebPCoder (0.14.6):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.17)
   - Sentry/HybridSDK (8.48.0)
   - simdjson (3.9.4)
   - SocketRocket (0.7.1)
@@ -2330,8 +2346,10 @@ SPEC REPOS:
     - CocoaLumberjack
     - HMSegmentedControl
     - JitsiWebRTC
+    - libwebp
     - SDWebImage
     - SDWebImageSVGCoder
+    - SDWebImageWebPCoder
     - Sentry
     - SocketRocket
     - Starscream
@@ -2586,7 +2604,7 @@ SPEC CHECKSUMS:
   ExpoCrypto: e97e864c8d7b9ce4a000bca45dddb93544a1b2b4
   ExpoDevice: d36ab4186b6799a28fd449bb9a1c77455f23fd1a
   ExpoFileSystem: 42d363d3b96f9afab980dcef60d5657a4443c655
-  ExpoImage: 043fcf882697fbcf4f50da1233b373d281f0456d
+  ExpoImage: 08a65a9eaf93aeaf07d72a8aea39afa83620a8d7
   ExpoLinearGradient: 35ebd83b16f80b3add053a2fd68cc328ed927f60
   ExpoModulesCore: 725faec070d590810d2ea5983d9f78f7cf6a38ec
   ExpoStoreReview: 92ad323dd14485e7aa67d5b47248fb22876ffaee
@@ -2599,6 +2617,7 @@ SPEC CHECKSUMS:
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   JitsiWebRTC: b47805ab5668be38e7ee60e2258f49badfe8e1d0
+  libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   mattermost-hardware-keyboard: a17b424a774fe564c6b90016ba0bc02e4b567a3e
   mattermost-react-native-turbo-log: 08d7dba812981a2c155f00df12878222ee6eb062
   mattermost-rnutils: 32f4f7ad85e2e470259a0e1e5ae6cd4fee83e77e
@@ -2691,8 +2710,9 @@ SPEC CHECKSUMS:
   RNShare: 00cd4a8167ab0755a7645c052f4637c74d709476
   RNSVG: a07e14363aa208062c6483bad24a438d5986d490
   RNVectorIcons: 4330d8f8f8f4184f436e0c08ae9950431ffe466e
-  SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
+  SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
+  SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
   simdjson: 7bb9e33d87737cec966e7b427773c67baa4458fe
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "expo-application": "6.0.2",
         "expo-crypto": "14.0.2",
         "expo-device": "7.0.3",
-        "expo-image": "2.0.7",
+        "expo-image": "2.1.6",
         "expo-linear-gradient": "14.0.2",
         "expo-store-review": "8.0.1",
         "expo-video-thumbnails": "9.0.3",
@@ -12796,10 +12796,9 @@
       }
     },
     "node_modules/expo-image": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.0.7.tgz",
-      "integrity": "sha512-kv40OIJOkItwznhdqFmKxTMC5O8GkpyTf8ng7Py4Hy6IBiH59dkeP6vUZQhzPhJOm5v1kZK4XldbskBosqzOug==",
-      "license": "MIT",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.1.6.tgz",
+      "integrity": "sha512-AFQxeAI1iTXFZ4dMxUB+SOACGMQxEk+t7PvT3j4mrvffRFoOLfHZ4uJc8SAdDFJak7ByqKhCIPIEhL+1Deq4Sg==",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "expo-application": "6.0.2",
     "expo-crypto": "14.0.2",
     "expo-device": "7.0.3",
-    "expo-image": "2.0.7",
+    "expo-image": "2.1.6",
     "expo-linear-gradient": "14.0.2",
     "expo-store-review": "8.0.1",
     "expo-video-thumbnails": "9.0.3",

--- a/patches/expo-image+2.1.6.patch
+++ b/patches/expo-image+2.1.6.patch
@@ -1,16 +1,3 @@
-diff --git a/node_modules/expo-image/android/build.gradle b/node_modules/expo-image/android/build.gradle
-index 11492a2..b6bb941 100644
---- a/node_modules/expo-image/android/build.gradle
-+++ b/node_modules/expo-image/android/build.gradle
-@@ -44,7 +44,7 @@ dependencies {
-   kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
-   api 'com.caverock:androidsvg-aar:1.4'
- 
--  implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.2"
-+  implementation("com.github.penfeizhou.android.animation:glide-plugin:3.0.3")
-   implementation "com.github.bumptech.glide:avif-integration:${GLIDE_VERSION}"
- 
-   api 'com.github.bumptech.glide:okhttp3-integration:4.11.0'
 diff --git a/node_modules/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt b/node_modules/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
 index 071907c..edf10c1 100644
 --- a/node_modules/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -33,21 +20,22 @@ index 071907c..edf10c1 100644
      // to make sure that the app will use only one client.
      registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
 diff --git a/node_modules/expo-image/ios/ExpoImage.podspec b/node_modules/expo-image/ios/ExpoImage.podspec
-index 21bef71..d662d23 100644
+index 40e2b49..695f137 100644
 --- a/node_modules/expo-image/ios/ExpoImage.podspec
 +++ b/node_modules/expo-image/ios/ExpoImage.podspec
-@@ -20,9 +20,7 @@ Pod::Spec.new do |s|
+@@ -20,10 +20,8 @@ Pod::Spec.new do |s|
  
    s.dependency 'ExpoModulesCore'
-   s.dependency 'SDWebImage', '~> 5.19.1'
+   s.dependency 'SDWebImage', '~> 5.21.0'
 -  s.dependency 'SDWebImageAVIFCoder', '~> 0.11.0'
    s.dependency 'SDWebImageSVGCoder', '~> 1.7.0'
+   s.dependency 'SDWebImageWebPCoder', '~> 0.14.6'
 -  s.dependency 'libavif/libdav1d'
  
    # Swift/Objective-C compatibility
    s.pod_target_xcconfig = {
 diff --git a/node_modules/expo-image/ios/ImageModule.swift b/node_modules/expo-image/ios/ImageModule.swift
-index 4bab386..a41d924 100644
+index 1145411..d372be7 100644
 --- a/node_modules/expo-image/ios/ImageModule.swift
 +++ b/node_modules/expo-image/ios/ImageModule.swift
 @@ -2,7 +2,6 @@
@@ -58,10 +46,10 @@ index 4bab386..a41d924 100644
  import SDWebImageSVGCoder
  
  public final class ImageModule: Module {
-@@ -211,7 +210,6 @@ public final class ImageModule: Module {
+@@ -210,7 +209,6 @@ public final class ImageModule: Module {
+ 
    static func registerCoders() {
-     // By default Animated WebP is not supported
-     SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
+     SDImageCodersManager.shared.addCoder(WebPCoder.shared)
 -    SDImageCodersManager.shared.addCoder(SDImageAVIFCoder.shared)
      SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
      SDImageCodersManager.shared.addCoder(SDImageHEICCoder.shared)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
This PR updates expo-image from 2.0.7 to 2.1.6 which replaces the patching we were doing on expo-image to consume the latest of APNG4Android library for Android.  The upgrade to expo-image@2.1.6 also comes with a few other [changes](https://github.com/expo/expo/blob/sdk-53/packages/expo-image/CHANGELOG.md).  I doubt that it will break anything but I would recommend testing on a few different images.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-64202

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
