### PR TITLE
Fix edit post scroll

### DIFF
--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -8,6 +8,7 @@ import {Alert, Keyboard, type LayoutChangeEvent, Platform, SafeAreaView, View, S
 import {deletePost, editPost} from '@actions/remote/post';
 import Autocomplete from '@components/autocomplete';
 import Loading from '@components/loading';
+import {ExtraKeyboardProvider} from '@context/extra_keyboard';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
@@ -39,6 +40,9 @@ const styles = StyleSheet.create({
         flex: 1,
         alignItems: 'center',
         justifyContent: 'center',
+    },
+    inputContainer: {
+        flex: 1,
     },
 });
 
@@ -93,11 +97,11 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
     const onClose = useCallback(() => {
         Keyboard.dismiss();
         dismissModal({componentId});
-    }, []);
+    }, [componentId]);
 
     const onTextSelectionChange = useCallback((curPos: number = cursorPosition) => {
         setCursorPosition(curPos);
-    }, [cursorPosition, postMessage]);
+    }, [cursorPosition]);
 
     const toggleSaveButton = useCallback((enabled = true) => {
         setButtons(componentId, {
@@ -128,7 +132,7 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
         setPostMessage(message);
         propagateValue(message);
         onChangeTextCommon(message);
-    }, [onChangeTextCommon]);
+    }, [onChangeTextCommon, propagateValue]);
 
     const onInputChangeText = useCallback((message: string) => {
         if (!shouldProcessEvent(message)) {
@@ -136,7 +140,7 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
         }
         setPostMessage(message);
         onChangeTextCommon(message);
-    }, [onChangeTextCommon]);
+    }, [onChangeTextCommon, shouldProcessEvent]);
 
     const handleUIUpdates = useCallback((res: {error?: unknown}) => {
         if (res.error) {
@@ -148,7 +152,7 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
             setIsUpdating(false);
             onClose();
         }
-    }, []);
+    }, [intl, onClose]);
 
     const handleDeletePost = useCallback(async () => {
         Alert.alert(
@@ -174,7 +178,7 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
                 },
             }],
         );
-    }, [serverUrl, editingMessage]);
+    }, [intl, toggleSaveButton, editingMessage, serverUrl, post, handleUIUpdates]);
 
     const onSavePostMessage = useCallback(async () => {
         setIsUpdating(true);
@@ -188,7 +192,7 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
 
         const res = await editPost(serverUrl, post.id, postMessage);
         handleUIUpdates(res);
-    }, [toggleSaveButton, serverUrl, post.id, postMessage, onClose]);
+    }, [toggleSaveButton, postMessage, canDelete, hasFilesAttached, serverUrl, post.id, handleUIUpdates, handleDeletePost]);
 
     const onLayout = useCallback((e: LayoutChangeEvent) => {
         setContainerHeight(e.nativeEvent.layout.height);
@@ -201,8 +205,6 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
     const overlap = useKeyboardOverlap(mainView, containerHeight);
     const autocompletePosition = overlap + AUTOCOMPLETE_SEPARATION;
     const autocompleteAvailableSpace = containerHeight - autocompletePosition;
-
-    const inputHeight = containerHeight - overlap;
 
     const [animatedAutocompletePosition, animatedAutocompleteAvailableSpace] = useAutocompleteDefaultAnimatedValues(autocompletePosition, autocompleteAvailableSpace);
 
@@ -225,25 +227,28 @@ const EditPost = ({componentId, maxPostSize, post, closeButtonId, hasFilesAttach
                 onLayout={onLayout}
                 nativeID={SecurityManager.getShieldScreenId(componentId)}
             >
-                <View
-                    style={styles.body}
-                    ref={mainView}
-                >
-                    {Boolean((errorLine || errorExtra)) &&
-                        <PostError
-                            errorExtra={errorExtra}
-                            errorLine={errorLine}
-                        />
-                    }
-                    <EditPostInput
-                        inputHeight={inputHeight}
-                        hasError={Boolean(errorLine)}
-                        message={postMessage}
-                        onChangeText={onInputChangeText}
-                        onTextSelectionChange={onTextSelectionChange}
-                        ref={postInputRef}
-                    />
-                </View>
+                <ExtraKeyboardProvider>
+                    <View
+                        style={styles.body}
+                        ref={mainView}
+                    >
+                        {Boolean((errorLine || errorExtra)) &&
+                            <PostError
+                                errorExtra={errorExtra}
+                                errorLine={errorLine}
+                            />
+                        }
+                        <View style={styles.inputContainer}>
+                            <EditPostInput
+                                hasError={Boolean(errorLine)}
+                                message={postMessage}
+                                onChangeText={onInputChangeText}
+                                onTextSelectionChange={onTextSelectionChange}
+                                ref={postInputRef}
+                            />
+                        </View>
+                    </View>
+                </ExtraKeyboardProvider>
             </SafeAreaView>
             <Autocomplete
                 channelId={post.channelId}


### PR DESCRIPTION
#### Summary
We were hardcoding the size of the input on edit. That along not sharing the flexbox with the error message made the error message to push down the input, behind the keyboard.

Now it covers the whole screen, share flexbox with the error message, and handles properly the keyboard space.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56679

#### Release Note
```release-note
Fix issue where the error message when editing a message may push part of the input out of view.
```
