### PR TITLE
Update transitive dependency prismjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "moment-timezone": "0.5.48",
         "node-html-parser": "7.0.1",
         "path-to-regexp": "8.2.0",
+        "prismjs": "1.30.0",
         "react": "18.3.1",
         "react-freeze": "1.0.4",
         "react-intl": "7.1.10",
@@ -18676,8 +18677,9 @@
       "license": "MIT"
     },
     "node_modules/prismjs": {
-      "version": "1.27.0",
-      "license": "MIT",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "engines": {
         "node": ">=6"
       }
@@ -21077,7 +21079,7 @@
         "highlight.js": "^10.4.1",
         "highlightjs-vue": "^1.0.0",
         "lowlight": "^1.17.0",
-        "prismjs": "^1.27.0",
+        "prismjs": "^1.30.0",
         "refractor": "^3.6.0"
       },
       "peerDependencies": {
@@ -21228,7 +21230,7 @@
       "dependencies": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": "~1.27.0"
+        "prismjs": "~1.30.0"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "moment-timezone": "0.5.48",
     "node-html-parser": "7.0.1",
     "path-to-regexp": "8.2.0",
+    "prismjs": "1.30.0",
     "react": "18.3.1",
     "react-freeze": "1.0.4",
     "react-intl": "7.1.10",
@@ -223,6 +224,12 @@
     },
     "@react-native/eslint-config@0.76.5": {
       "@typescript-eslint/eslint-plugin": "^8.29.1"
+    },
+    "react-syntax-highlighter": {
+      "prismjs": "1.30.0"
+    },
+    "refractor": {
+      "prismjs": "1.30.0"
     }
   },
   "expo": {


### PR DESCRIPTION
#### Summary
Updates prismjs to address CVE-2024-53382. No version of `react-syntax-highlighter` and `refactor` had the non-vulnerable version so we had to install prismjs as a direct dependency and then override the version for  `react-syntax-highlighter` and `refactor` 

#### Ticket Link
N/A

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
