### PR TITLE
use the actual url in the metadata if there is an image proxy being used

### DIFF
--- a/app/components/markdown/markdown_image/index.tsx
+++ b/app/components/markdown/markdown_image/index.tsx
@@ -26,7 +26,7 @@ import {fileToGalleryItem, openGalleryAtIndex} from '@utils/gallery';
 import {generateId} from '@utils/general';
 import {bottomSheetSnapPoint} from '@utils/helpers';
 import {calculateDimensions, getViewPortWidth, isGifTooLarge} from '@utils/images';
-import {getMarkdownImageSize} from '@utils/markdown';
+import {getMarkdownImageSize, removeImageProxyForKey} from '@utils/markdown';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {secureGetFromRecord} from '@utils/types';
 import {normalizeProtocol, safeDecodeURIComponent, tryOpenURL} from '@utils/url';
@@ -79,7 +79,7 @@ const MarkdownImage = ({
     const style = getStyleSheet(theme);
     const managedConfig = useManagedConfig<ManagedConfig>();
     const genericFileId = useRef(generateId('uid')).current;
-    const metadata = secureGetFromRecord(imagesMetadata, source) || Object.values(imagesMetadata || {})[0];
+    const metadata = secureGetFromRecord(imagesMetadata, removeImageProxyForKey(source)) || Object.values(imagesMetadata || {})[0];
     const [failed, setFailed] = useState(isGifTooLarge(metadata));
     const originalSize = getMarkdownImageSize(isReplyPost, isTablet, sourceSize, metadata, layoutWidth, layoutHeight);
     const serverUrl = useServerUrl();

--- a/app/components/markdown/markdown_table_image/index.tsx
+++ b/app/components/markdown/markdown_table_image/index.tsx
@@ -13,6 +13,7 @@ import {useGalleryItem} from '@hooks/gallery';
 import {fileToGalleryItem, openGalleryAtIndex} from '@utils/gallery';
 import {generateId} from '@utils/general';
 import {calculateDimensions, isGifTooLarge} from '@utils/images';
+import {removeImageProxyForKey} from '@utils/markdown';
 import {secureGetFromRecord} from '@utils/types';
 import {safeDecodeURIComponent} from '@utils/url';
 
@@ -35,7 +36,8 @@ const style = StyleSheet.create({
 });
 
 const MarkTableImage = ({disabled, imagesMetadata, location, postId, serverURL, source}: MarkdownTableImageProps) => {
-    const metadata = secureGetFromRecord(imagesMetadata, source);
+    const sourceKey = removeImageProxyForKey(source);
+    const metadata = secureGetFromRecord(imagesMetadata, sourceKey);
     const fileId = useRef(generateId('uid')).current;
     const [failed, setFailed] = useState(isGifTooLarge(metadata));
     const currentServerUrl = useServerUrl();

--- a/app/utils/markdown/index.test.ts
+++ b/app/utils/markdown/index.test.ts
@@ -16,6 +16,7 @@ import {
     computeTextStyle,
     parseSearchTerms,
     convertSearchTermToRegex,
+    removeImageProxyForKey,
 } from './index';
 
 jest.mock('@utils/images', () => ({
@@ -203,6 +204,38 @@ describe('Utility functions', () => {
         it('should create regex for plain text', () => {
             const result = convertSearchTermToRegex('hello');
             expect(result.pattern).toEqual(/\b()(hello)\b/gi);
+        });
+    });
+
+    describe('removeImageProxyForKey', () => {
+        test('should return the original URL if the key contains a valid proxy URL with a query parameter', () => {
+            const proxyKey = 'https://proxy.example.com/image?url=https%3A%2F%2Foriginal.example.com%2Fimage.png';
+            const result = removeImageProxyForKey(proxyKey);
+            expect(result).toBe('https://original.example.com/image.png');
+        });
+
+        test('should return the key itself if it does not contain a query parameter', () => {
+            const key = 'https://proxy.example.com/image';
+            const result = removeImageProxyForKey(key);
+            expect(result).toBe(key);
+        });
+
+        test('should return the key itself if the query parameter does not contain a URL', () => {
+            const key = 'https://proxy.example.com/image?otherParam=value';
+            const result = removeImageProxyForKey(key);
+            expect(result).toBe(key);
+        });
+
+        test('should decode the URL if it is encoded in the query parameter', () => {
+            const proxyKey = 'https://proxy.example.com/image?url=https%3A%2F%2Foriginal.example.com%2Fpath%2Fto%2Fimage%3Fparam%3Dvalue';
+            const result = removeImageProxyForKey(proxyKey);
+            expect(result).toBe('https://original.example.com/path/to/image?param=value');
+        });
+
+        test('should handle keys with no query string gracefully', () => {
+            const key = 'https://proxy.example.com/image';
+            const result = removeImageProxyForKey(key);
+            expect(result).toBe(key);
         });
     });
 });

--- a/app/utils/markdown/index.ts
+++ b/app/utils/markdown/index.ts
@@ -2,11 +2,13 @@
 // See LICENSE.txt for license information.
 
 import {Platform, type StyleProp, StyleSheet, type TextStyle} from 'react-native';
+import parseUrl from 'url-parse';
 
 import {getViewPortWidth} from '@utils/images';
 import {logError} from '@utils/log';
 import {changeOpacity, concatStyles, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
+import {safeDecodeURIComponent} from '@utils/url';
 
 import type {MarkdownTextStyles, SearchPattern} from '@typings/global/markdown';
 
@@ -363,3 +365,12 @@ export function convertSearchTermToRegex(term: string): SearchPattern {
         term,
     };
 }
+
+export const removeImageProxyForKey = (key: string) => {
+    const parseKey = parseUrl(key, true);
+    if (parseKey.query.url) {
+        return safeDecodeURIComponent(parseKey.query.url);
+    }
+
+    return key;
+};


### PR DESCRIPTION
#### Summary
For markdown Images, if there is a presence of an image proxy, the key did not match the url in the metadata.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Release Note
```release-note
NONE
```
