### PR TITLE
Custom Emojis not updating on application

### DIFF
--- a/app/database/operator/server_data_operator/handlers/index.test.ts
+++ b/app/database/operator/server_data_operator/handlers/index.test.ts
@@ -70,10 +70,68 @@ describe('*** DataOperator: Base Handlers tests ***', () => {
         expect(spyOnHandleRecords).toHaveBeenCalledWith({
             fieldName: 'name',
             createOrUpdateRawValues: emojis,
+            deleteRawValues: [],
             tableName: 'CustomEmoji',
             prepareRecordsOnly: false,
             transformer: transformCustomEmojiRecord,
         }, 'handleCustomEmojis');
+    });
+
+    it('=> HandleCustomEmojis: should write to the CUSTOM_EMOJI table and delete custom emojis that have the same name but the id is different', async () => {
+        expect.assertions(2);
+
+        const spyOnHandleRecords = jest.spyOn(operator, 'handleRecords');
+        const emojis: CustomEmoji[] = [
+            {
+                id: 'i',
+                create_at: 1580913641769,
+                update_at: 1580913641769,
+                delete_at: 0,
+                creator_id: '4cprpki7ri81mbx8efixcsb8jo',
+                name: 'boomI',
+            },
+        ];
+
+        await operator.handleCustomEmojis({
+            emojis,
+            prepareRecordsOnly: false,
+        });
+
+        const emojiWithTheSameName: CustomEmoji[] = [
+            {
+                id: 'j',
+                create_at: 1580913641770,
+                update_at: 1580913641770,
+                delete_at: 0,
+                creator_id: 'ounobhp3c7f6xcj3bs6ngenhdo',
+                name: 'boomI',
+            },
+        ];
+
+        await operator.handleCustomEmojis({
+            emojis: emojiWithTheSameName,
+            prepareRecordsOnly: false,
+        });
+
+        expect(spyOnHandleRecords).toHaveBeenCalledTimes(2);
+        expect(spyOnHandleRecords.mock.calls).toEqual([
+            [{
+                fieldName: 'name',
+                createOrUpdateRawValues: emojis,
+                deleteRawValues: [],
+                tableName: 'CustomEmoji',
+                prepareRecordsOnly: false,
+                transformer: transformCustomEmojiRecord,
+            }, 'handleCustomEmojis'],
+            [{
+                fieldName: 'name',
+                createOrUpdateRawValues: emojiWithTheSameName,
+                deleteRawValues: [{name: 'boomI'}],
+                tableName: 'CustomEmoji',
+                prepareRecordsOnly: false,
+                transformer: transformCustomEmojiRecord,
+            }, 'handleCustomEmojis'],
+        ]);
     });
 
     it('=> HandleSystem: should write to the SYSTEM table', async () => {

--- a/app/database/operator/server_data_operator/handlers/index.ts
+++ b/app/database/operator/server_data_operator/handlers/index.ts
@@ -54,12 +54,14 @@ export default class ServerDataOperatorBase extends BaseDataOperator {
             return [];
         }
 
-        const names = Array.from(new Set(emojis.map((e) => e.name)));
+        const uniqueNamesToSearch = [...new Set(emojis.map((e) => e.name))];
 
-        const locals = await queryCustomEmojisByName(this.database, names).fetch();
+        const customEmojisFound = await queryCustomEmojisByName(this.database, uniqueNamesToSearch).fetch();
 
-        const deleteRawValues = locals.
-            filter((local) => !emojis.find((raw) => raw.id === local.id)).
+        const emojiIds = new Set(emojis.map((e) => e.id));
+
+        const deleteRawValues = customEmojisFound.
+            filter((local) => !emojiIds.has(local.id)).
             map((local) => ({name: local.name}));
 
         return this.handleRecords({


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

This PR fixes the issue of not updating the custom emojis image when they are updated on the web application but didn't change it's name.

For example, if the user creates a custom emoji named `test` and then renders it on Mobile, after that the user goes and deletes this custom emoji and creates another one with the same name `test`, the image was not being updated on Mobile, it would keep using the image of the first one created, this PR fixes that.

### How does it fixes?

When the custom emojis are to be updated on the WatermelonDB, I just fetch for emojis with the same name as the ones to be created on the DB, and if it finds it, I delete this ones so it can be created again with a new id, since we use this property to render the images.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://github.com/mattermost/mattermost/issues/30711

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

## Android (API 33)

Custom Emoji created:
<img width="397" alt="image" src="https://github.com/user-attachments/assets/9abccaae-440c-44d9-ab0c-d99c806feb81" />

Deleted and created emoji with the same name but different image without restarting the app:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/625ce0c3-0568-4ca2-a2cd-0bd67d395585" />

## iOS (18.4)

Custom Emoji created:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/69563e76-9a4f-4bfd-8788-93dd82823efb" />

Deleted and created emoji with the same name but different image without restarting the app:
<img width="418" alt="image" src="https://github.com/user-attachments/assets/22615474-470e-411e-853b-3a0c7ee075e2" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
- Custom Emojis being updated with the new image once they are created with the same name on the web application.
```
