### PR TITLE
MM-63935- abac end user indicators db fix

### DIFF
--- a/types/api/channels.d.ts
+++ b/types/api/channels.d.ts
@@ -45,6 +45,9 @@ type Channel = {
     group_constrained: boolean|null;
     shared: boolean;
     banner_info?: ChannelBannerInfo;
+
+    /** Whether the channel has Attribute-Based Access Control (ABAC) policy enforcement enabled, controlling access based on user attributes */
+    policy_enforced?: boolean;
 };
 type ChannelPatch = {
     name?: string;


### PR DESCRIPTION
#### Summary
as part of https://github.com/mattermost/mattermost-mobile/pull/8860 a value was missing from the types api model. This PR adds that type and fixes the TSC errors in main.

#### Ticket Link
N/A

#### Checklist


#### Release Note
```release-note
NONE
```
