### PR TITLE
MM-64243 Fix the animation delay while send the post in the channel

### DIFF
--- a/app/components/draft_scheduled_post/draft_scheduled_post_actions/send_draft/send_draft.test.tsx
+++ b/app/components/draft_scheduled_post/draft_scheduled_post_actions/send_draft/send_draft.test.tsx
@@ -162,6 +162,7 @@ describe('Send Draft', () => {
     });
 
     it('should call dismissBottomSheet after sending the draft and should call createPost', async () => {
+        jest.mocked(canPostDraftInChannelOrThread).mockResolvedValueOnce(true);
         jest.mocked(sendMessageWithAlert).mockImplementation(() => {
             return Promise.resolve();
         });

--- a/app/components/post_draft/send_handler/send_handler.test.tsx
+++ b/app/components/post_draft/send_handler/send_handler.test.tsx
@@ -8,12 +8,10 @@ import {removeDraft} from '@actions/local/draft';
 import {createPost} from '@actions/remote/post';
 import {General} from '@constants';
 import {DRAFT_TYPE_DRAFT, DRAFT_TYPE_SCHEDULED} from '@constants/draft';
-import {SNACK_BAR_TYPE} from '@constants/snack_bar';
 import {renderWithEverything} from '@test/intl-test-helper';
 import TestHelper from '@test/test_helper';
 import {sendMessageWithAlert} from '@utils/post';
 import {canPostDraftInChannelOrThread} from '@utils/scheduled_post';
-import {showSnackBar} from '@utils/snack_bar';
 
 import SendHandler from './send_handler';
 
@@ -259,54 +257,5 @@ describe('components/post_draft/send_handler/SendHandler', () => {
 
         // Varify removeDraft function is been called.
         expect(removeDraft).toHaveBeenCalled();
-    });
-
-    it('should show snackbar if creating post failing when executing sendMessageHandler when send_draft_button is checked', async () => {
-        // Mock implementation to capture the sendMessageHandler
-        let capturedHandler: Function;
-        jest.mocked(sendMessageWithAlert).mockImplementation((params) => {
-            capturedHandler = params.sendMessageHandler;
-            return Promise.resolve();
-        });
-        jest.mocked(createPost).mockResolvedValueOnce({
-            error: new Error('Failed to create post'),
-        });
-
-        const props = {
-            ...baseProps,
-            isFromDraftView: true,
-            draftType: DRAFT_TYPE_DRAFT,
-            value: 'test message',
-        };
-
-        const wrapper = renderWithEverything(
-            <SendHandler {...props}/>, {database},
-        );
-
-        // Find and press the send button
-        const sendButton = wrapper.getByTestId('send_draft_button');
-
-        await act(async () => {
-            fireEvent.press(sendButton);
-        });
-
-        // Verify sendMessageWithAlert was called
-        expect(sendMessageWithAlert).toHaveBeenCalledWith(expect.objectContaining({
-            sendMessageHandler: expect.any(Function),
-        }));
-
-        // Now execute the captured handler to simulate user confirming the send
-        await act(async () => {
-            await capturedHandler();
-        });
-
-        expect(showSnackBar).toHaveBeenCalledWith({
-            barType: SNACK_BAR_TYPE.CREATE_POST_ERROR,
-            customMessage: 'Failed to create post',
-            type: 'error',
-        });
-
-        // Varify removeDraft function is been called.
-        expect(removeDraft).not.toHaveBeenCalled();
     });
 });

--- a/app/hooks/handle_send_message.ts
+++ b/app/hooks/handle_send_message.ts
@@ -106,7 +106,7 @@ export const useHandleSendMessage = ({
         setSendingMessage(false);
     }, [serverUrl, rootId, clearDraft]);
 
-    const doSubmitMessage = useCallback(async (schedulingInfo?: SchedulingInfo): Promise<CreateResponse> => {
+    const doSubmitMessage = useCallback(async (schedulingInfo?: SchedulingInfo) => {
         const postFiles = files.filter((f) => !f.failed);
         const post = {
             user_id: currentUserId,
@@ -128,20 +128,16 @@ export const useHandleSendMessage = ({
         let response: CreateResponse;
         if (schedulingInfo) {
             response = await createScheduledPost(serverUrl, scheduledPostFromPost(post, schedulingInfo, postPriority, postFiles));
-        } else {
-            response = await createPost(serverUrl, post, postFiles);
-        }
-
-        if (response.error && isFromDraftView) {
-            showSnackBar({
-                barType: SNACK_BAR_TYPE.CREATE_POST_ERROR,
-                customMessage: getErrorMessage(response.error),
-                type: MESSAGE_TYPE.ERROR,
-            });
-            return response;
-        }
-
-        if (isFromDraftView) {
+            if (response.error) {
+                showSnackBar({
+                    barType: SNACK_BAR_TYPE.SCHEDULED_POST_CREATION_ERROR,
+                    customMessage: getErrorMessage(response.error),
+                    type: MESSAGE_TYPE.ERROR,
+                });
+            } else {
+                clearDraft();
+            }
+        } else if (isFromDraftView) {
             const shouldClearDraft = await canPostDraftInChannelOrThread({
                 serverUrl,
                 rootId,
@@ -152,16 +148,31 @@ export const useHandleSendMessage = ({
                 deactivatedChannel,
             });
 
-            if (shouldClearDraft) {
+            if (!shouldClearDraft) {
+                return;
+            }
+
+            response = await createPost(serverUrl, post, postFiles);
+            if (response.error) {
+                showSnackBar({
+                    barType: SNACK_BAR_TYPE.CREATE_POST_ERROR,
+                    customMessage: getErrorMessage(response.error),
+                    type: MESSAGE_TYPE.ERROR,
+                });
+            } else {
                 clearDraft();
             }
+
+            // Early return to avoid calling DeviceEventEmitter.emit
+            return;
         } else {
+            // Response error is handled at the post level so don't have to wait to clear draft
+            createPost(serverUrl, post, postFiles);
             clearDraft();
         }
+
         setSendingMessage(false);
         DeviceEventEmitter.emit(Events.POST_LIST_SCROLL_TO_BOTTOM, rootId ? Screens.THREAD : Screens.CHANNEL);
-
-        return response;
     }, [files, currentUserId, channelId, rootId, value, postPriority, isFromDraftView, serverUrl, intl, canPost, channelIsArchived, channelIsReadOnly, deactivatedChannel, clearDraft]);
 
     const showSendToAllOrChannelOrHereAlert = useCallback((calculatedMembersCount: number, atHere: boolean, schedulingInfo?: SchedulingInfo) => {


### PR DESCRIPTION
#### Summary
The delay in clearing the draft after posting a message was caused by waiting for the server's response to confirm whether the post was successful. This delay is unnecessary, as the draft posting response is handled at the post level rather than within the draft logic.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64243

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
