### PR TITLE
Fix scheduled messages tooltip entering an infinite resize loop

### DIFF
--- a/app/constants/tooltip.ts
+++ b/app/constants/tooltip.ts
@@ -6,8 +6,8 @@ import {StyleSheet} from 'react-native';
 export const staticStyles = StyleSheet.create({
     tooltipContent: {
         borderRadius: 8,
-        width: 247,
+        maxWidth: 247,
         padding: 16,
-        height: 160,
+        maxHeight: 160,
     },
 });


### PR DESCRIPTION
#### Summary
One of the detox tests was failing because the JS thread was busy. I tracked this down to the tooltip on the drafts/scheduled messages screen.

We were passing the width to the styles, which mess up with the width calculation done in the library. This ended up the library getting into an infinite loop measuring the child and trying to adjust the width.

It is fixed by setting a maxWidth instead of a hardcoded width.

There was almost no visual cue but a small flickering on the width of the component.

#### Ticket Link
NONE

#### Release Note
```release-note
Fix some flickering on the tooltip in the drafts screen.
```
