### PR TITLE
[MM-64354] Simplify snappoints based on team numbers

### DIFF
--- a/app/screens/home/search/bottom_sheet_team_list.tsx
+++ b/app/screens/home/search/bottom_sheet_team_list.tsx
@@ -1,12 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useMemo} from 'react';
-import {useIntl} from 'react-intl';
+import React, {useCallback} from 'react';
 import {StyleSheet, View} from 'react-native';
 
 import TeamList from '@components/team_list';
-import {ALL_TEAMS_ID} from '@constants/team';
 import {useIsTablet} from '@hooks/device';
 import BottomSheetContent from '@screens/bottom_sheet/content';
 import {dismissBottomSheet} from '@screens/navigation';
@@ -28,7 +26,6 @@ const styles = StyleSheet.create({
 });
 
 export default function BottomSheetTeamList({teams, title, setTeamId, teamId, crossTeamSearchEnabled}: Props) {
-    const intl = useIntl();
     const isTablet = useIsTablet();
     const showTitle = !isTablet && Boolean(teams.length);
 
@@ -36,14 +33,6 @@ export default function BottomSheetTeamList({teams, title, setTeamId, teamId, cr
         setTeamId(newTeamId);
         dismissBottomSheet();
     }, [setTeamId]);
-
-    const teamList = useMemo(() => {
-        const list = [...teams];
-        if (crossTeamSearchEnabled) {
-            list.unshift({id: ALL_TEAMS_ID, displayName: intl.formatMessage({id: 'mobile.search.team.all_teams', defaultMessage: 'All teams'})} as TeamModel);
-        }
-        return list;
-    }, [teams, crossTeamSearchEnabled, intl]);
 
     return (
         <BottomSheetContent
@@ -55,7 +44,7 @@ export default function BottomSheetTeamList({teams, title, setTeamId, teamId, cr
             <View style={styles.container} >
                 <TeamList
                     selectedTeamId={teamId}
-                    teams={teamList}
+                    teams={teams}
                     onPress={onPress}
                     testID='search.select_team_slide_up.team_list'
                     type={isTablet ? 'FlatList' : 'BottomSheetFlatList'}

--- a/app/screens/home/search/team_picker.tsx
+++ b/app/screens/home/search/team_picker.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {useIntl} from 'react-intl';
 import {Text, View} from 'react-native';
 
@@ -52,11 +52,17 @@ const TeamPicker = ({setTeamId, teams, teamId, crossTeamSearchEnabled}: Props) =
     const intl = useIntl();
     const theme = useTheme();
     const styles = getStyleFromTheme(theme);
+    const AllTeams: TeamModel = useMemo(() => ({id: ALL_TEAMS_ID, displayName: intl.formatMessage({id: 'mobile.search.team.all_teams', defaultMessage: 'All teams'})} as TeamModel), [intl]);
 
-    let selectedTeam = teams.find((t) => t.id === teamId);
-    if (teamId === ALL_TEAMS_ID) {
-        selectedTeam = {id: ALL_TEAMS_ID, displayName: intl.formatMessage({id: 'mobile.search.team.all_teams', defaultMessage: 'All teams'})} as TeamModel;
-    }
+    const teamList = useMemo(() => {
+        const list = [...teams];
+        if (crossTeamSearchEnabled) {
+            list.unshift(AllTeams);
+        }
+        return list;
+    }, [teams, crossTeamSearchEnabled, AllTeams]);
+
+    const selectedTeam = teamList.find((t) => t.id === teamId);
 
     const title = intl.formatMessage({id: 'mobile.search.team.select', defaultMessage: 'Select a team to search'});
 
@@ -65,7 +71,7 @@ const TeamPicker = ({setTeamId, teams, teamId, crossTeamSearchEnabled}: Props) =
             return (
                 <BottomSheetTeamList
                     setTeamId={setTeamId}
-                    teams={teams}
+                    teams={teamList}
                     teamId={teamId}
                     title={title}
                     crossTeamSearchEnabled={crossTeamSearchEnabled}
@@ -75,10 +81,12 @@ const TeamPicker = ({setTeamId, teams, teamId, crossTeamSearchEnabled}: Props) =
 
         const snapPoints: Array<string | number> = [
             1,
-            teams.length ? bottomSheetSnapPoint(Math.min(3, teams.length), ITEM_HEIGHT) + (2 * TITLE_HEIGHT) : NO_TEAMS_HEIGHT,
+
+            // use teams to check if teams is empty
+            teams.length ? bottomSheetSnapPoint(Math.min(3, teamList.length), ITEM_HEIGHT) + (2 * TITLE_HEIGHT) : NO_TEAMS_HEIGHT,
         ];
 
-        if (teams.length > 3) {
+        if (teamList.length > 3) {
             snapPoints.push('80%');
         }
 
@@ -89,7 +97,7 @@ const TeamPicker = ({setTeamId, teams, teamId, crossTeamSearchEnabled}: Props) =
             theme,
             title,
         });
-    }, [teams, theme, title, setTeamId, teamId, crossTeamSearchEnabled]));
+    }, [teams, teamList, theme, title, setTeamId, teamId, crossTeamSearchEnabled]));
 
     return (
         <>


### PR DESCRIPTION
#### Summary

On a two team setup, the second team was unreachable. To fix it, I simplified the logic to display.

Note: cutting in half the third team was intentional to prompt the user to scroll

#### Ticket Link
[MM-64354](https://mattermost.atlassian.net/issues/MM-64354)
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: Android 8

#### Screenshots
| 3+ Teams | 2 Teams |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/d0d4dbf1-36a1-4250-a2c2-033e1cd2a139) | ![image](https://github.com/user-attachments/assets/45a2f4a0-5d33-482e-bd28-75ad7726b1d8) |


#### Release Note
```release-note
Fixed being unable to reach the second team on team selection in the search screen.
```


[MM-64354]: https://mattermost.atlassian.net/browse/MM-64354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ