### PR TITLE
feat(MM-64361): categoryChannels update ONLY when necessary

### DIFF
--- a/app/database/operator/server_data_operator/handlers/category.test.ts
+++ b/app/database/operator/server_data_operator/handlers/category.test.ts
@@ -12,47 +12,55 @@ import type ServerDataOperator from '..';
 
 describe('*** Operator: Category Handlers tests ***', () => {
     let operator: ServerDataOperator;
+    let spyOnHandleRecords: jest.SpyInstance;
     beforeAll(async () => {
         await DatabaseManager.init(['baseHandler.test.com']);
         operator = DatabaseManager.serverDatabases['baseHandler.test.com']!.operator;
+        spyOnHandleRecords = jest.spyOn(operator, 'handleRecords');
     });
 
-    it('=> handleCategories: should write to the CATEGORY table', async () => {
-        expect.assertions(2);
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
 
-        const spyOnHandleRecords = jest.spyOn(operator, 'handleRecords');
-        const categories: Category[] = [
-            {
-                id: 'kjlw9j1ttnxwig7tnqgebg7dtipno',
-                collapsed: false,
-                display_name: 'Test',
-                muted: false,
-                sort_order: 1,
-                sorting: 'recent',
-                team_id: '',
-                type: 'direct_messages',
-            },
-        ];
+    afterAll(async () => {
+        DatabaseManager.destroyServerDatabase('baseHandler.test.com');
+    });
 
-        await operator.handleCategories({
-            categories,
-            prepareRecordsOnly: false,
+    describe('handleCategories', () => {
+        it('should write to the CATEGORY table', async () => {
+            expect.assertions(2);
+
+            const categories: Category[] = [
+                {
+                    id: 'kjlw9j1ttnxwig7tnqgebg7dtipno',
+                    collapsed: false,
+                    display_name: 'Test',
+                    muted: false,
+                    sort_order: 1,
+                    sorting: 'recent',
+                    team_id: '',
+                    type: 'direct_messages',
+                },
+            ];
+
+            await operator.handleCategories({
+                categories,
+                prepareRecordsOnly: false,
+            });
+
+            expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
+            expect(spyOnHandleRecords).toHaveBeenCalledWith({
+                fieldName: 'id',
+                createOrUpdateRawValues: categories,
+                tableName: MM_TABLES.SERVER.CATEGORY,
+                prepareRecordsOnly: false,
+                transformer: transformCategoryRecord,
+            }, 'handleCategories');
         });
-
-        expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
-        expect(spyOnHandleRecords).toHaveBeenCalledWith({
-            fieldName: 'id',
-            createOrUpdateRawValues: categories,
-            tableName: MM_TABLES.SERVER.CATEGORY,
-            prepareRecordsOnly: false,
-            transformer: transformCategoryRecord,
-        }, 'handleCategories');
     });
 
-    it('=> handleCategoryChannels: should write to the CATEGORY_CHANNEL table', async () => {
-        expect.assertions(2);
-
-        const spyOnHandleRecords = jest.spyOn(operator, 'handleRecords');
+    describe('handleCategoryChannels', () => {
         const categoryChannels: CategoryChannel[] = [
             {
                 id: 'team_id-channel_id',
@@ -62,18 +70,79 @@ describe('*** Operator: Category Handlers tests ***', () => {
             },
         ];
 
-        await operator.handleCategoryChannels({
-            categoryChannels,
-            prepareRecordsOnly: false,
+        it('should write to the CATEGORY_CHANNEL table', async () => {
+            expect.assertions(2);
+
+            await operator.handleCategoryChannels({
+                categoryChannels,
+                prepareRecordsOnly: false,
+            });
+
+            expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
+            expect(spyOnHandleRecords).toHaveBeenCalledWith({
+                fieldName: 'id',
+                createOrUpdateRawValues: categoryChannels,
+                tableName: MM_TABLES.SERVER.CATEGORY_CHANNEL,
+                prepareRecordsOnly: false,
+                transformer: transformCategoryChannelRecord,
+            }, 'handleCategoryChannels');
         });
 
-        expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
-        expect(spyOnHandleRecords).toHaveBeenCalledWith({
-            fieldName: 'id',
-            createOrUpdateRawValues: categoryChannels,
-            tableName: MM_TABLES.SERVER.CATEGORY_CHANNEL,
-            prepareRecordsOnly: false,
-            transformer: transformCategoryChannelRecord,
-        }, 'handleCategoryChannels');
+        it('should not update an existing record if no changes are made', async () => {
+
+            await operator.handleCategoryChannels({
+                categoryChannels,
+                prepareRecordsOnly: false,
+            });
+
+            expect(spyOnHandleRecords).not.toHaveBeenCalled();
+        });
+
+        it('should update an existing record if changes are made', async () => {
+
+            await operator.handleCategoryChannels({
+                categoryChannels: [
+                    {
+                        ...categoryChannels[0],
+                        sort_order: 2,
+                    },
+                ],
+                prepareRecordsOnly: false,
+            });
+
+            expect(spyOnHandleRecords).toHaveBeenCalledTimes(1);
+            expect(spyOnHandleRecords).toHaveBeenCalledWith(expect.objectContaining({
+                createOrUpdateRawValues: [
+                    expect.objectContaining({
+                        sort_order: 2,
+                    }),
+                ],
+            }), 'handleCategoryChannels');
+        });
+
+        it('should not update when missing id', async () => {
+
+            const result = await operator.handleCategoryChannels({
+                categoryChannels: [
+                    {
+                        ...categoryChannels[0],
+                        id: undefined,
+                    },
+                ],
+                prepareRecordsOnly: false,
+            });
+
+            expect(spyOnHandleRecords).not.toHaveBeenCalled();
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array when no category channels are provided', async () => {
+            const result = await operator.handleCategoryChannels({
+                categoryChannels: undefined,
+                prepareRecordsOnly: false,
+            });
+
+            expect(result).toEqual([]);
+        });
     });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Category Channels are being updated every time the app starts.  This caused unnecessary strain on the device's resources.  This PR adds a check to ensure that it only creates an array of raw data when there are changes.

A sample of 1 of the category channels model:

```
"__original": {"_changed": "", "_status": "created", "category_id": "channels_nujm848e1t8s7rak8wbi3anwar_1fmcqbq1uigyunw3uon39cgg9r", "channel_id": "jcwpsc9bd7gxj8npen3qupqjsr", "id": "1fmcqbq1uigyunw3uon39cgg9r_jcwpsc9bd7gxj8npen3qupqjsr", "sort_order": 0}
"_raw": {"_changed": "", "_status": "created", "category_id": "channels_nujm848e1t8s7rak8wbi3anwar_1fmcqbq1uigyunw3uon39cgg9r", "channel_id": "jcwpsc9bd7gxj8npen3qupqjsr", "id": "1fmcqbq1uigyunw3uon39cgg9r_jcwpsc9bd7gxj8npen3qupqjsr", "sort_order": 0}
```

Nothing changed, but this is one of 8629 models created for this category channel.  Which will then be batched through watermelon db, unnecessarily.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-64361

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: 
* iOS 18.4 simulator 16.4
* Android 14, Google Pixel 6

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

```
 PASS  app/database/operator/server_data_operator/handlers/category.test.ts
  *** Operator: Category Handlers tests ***
    handleCategories
      ✓ should write to the CATEGORY table (4 ms)
    handleCategoryChannels
      ✓ should write to the CATEGORY_CHANNEL table (1 ms)
      ✓ should not update an existing record if no changes are made
      ✓ should update an existing record if changes are made (1 ms)
      ✓ should not update when missing id
      ✓ should return empty array when no category channels are provided

A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

=============================== Coverage summary ===============================
Statements   : 87.5% ( 42/48 )
Branches     : 51.61% ( 16/31 )
Functions    : 90% ( 9/10 )
Lines        : 88.09% ( 37/42 )
================================================================================
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.726 s
Ran all test suites matching /app\/database\/operator\/server_data_operator\/handlers\/category.test.ts/i.
```

Before:

```
 PASS  app/database/operator/server_data_operator/handlers/category.test.ts (10.31 s)
  *** Operator: Category Handlers tests ***
    ✓ => handleCategories: should write to the CATEGORY table (6 ms)
    ✓ => handleCategoryChannels: should write to the CATEGORY_CHANNEL table (1 ms)

A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

=============================== Coverage summary ===============================
Statements   : 73.33% ( 22/30 )
Branches     : 20% ( 4/20 )
Functions    : 83.33% ( 5/6 )
Lines        : 74.07% ( 20/27 )
================================================================================
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        13.43 s
Ran all test suites matching /app\/database\/operator\/server_data_operator\/handlers\/category.test.ts/i.
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
