### PR TITLE
Add Accept Header on ClientTracking

### DIFF
--- a/app/actions/remote/performance.test.ts
+++ b/app/actions/remote/performance.test.ts
@@ -56,7 +56,7 @@ describe('sendPerformanceReport', () => {
     it('happy path', async () => {
         const {error} = await sendPerformanceReport(serverUrl, report);
         expect(error).toBeFalsy();
-        expect(mockApiClient.post).toHaveBeenCalledWith(`${serverUrl}/api/v4/client_perf`, {body: report, headers: {}});
+        expect(mockApiClient.post).toHaveBeenCalledWith(`${serverUrl}/api/v4/client_perf`, {body: report, headers: {Accept: 'application/json'}});
     });
 
     it('properly returns error', async () => {

--- a/app/client/rest/constants.ts
+++ b/app/client/rest/constants.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 export const HEADER_AUTH = 'Authorization';
+export const HEADER_ACCEPT = 'Accept';
 export const HEADER_ACCEPT_LANGUAGE = 'Accept-Language';
 export const HEADER_BEARER = 'BEARER';
 export const HEADER_CACHE_CONTROL = 'Cache-Control';

--- a/app/client/rest/tracking.ts
+++ b/app/client/rest/tracking.ts
@@ -338,7 +338,11 @@ export default class ClientTracking {
             requestOptions.timeoutInterval = options.timeoutInterval;
         }
         if (options.headers) {
-            requestOptions.headers = {...requestOptions.headers, ...options.headers};
+            requestOptions.headers = {
+                [ClientConstants.HEADER_ACCEPT]: 'application/json',
+                ...requestOptions.headers,
+                ...options.headers,
+            };
         }
         return requestOptions;
     }

--- a/app/client/rest/tracking.ts
+++ b/app/client/rest/tracking.ts
@@ -84,6 +84,8 @@ export default class ClientTracking {
     getRequestHeaders(requestMethod: string) {
         const headers = {...this.requestHeaders};
 
+        headers[ClientConstants.HEADER_ACCEPT]= 'application/json';
+
         if (this.csrfToken && requestMethod.toLowerCase() !== 'get') {
             headers[ClientConstants.HEADER_X_CSRF_TOKEN] = this.csrfToken;
         }
@@ -338,11 +340,7 @@ export default class ClientTracking {
             requestOptions.timeoutInterval = options.timeoutInterval;
         }
         if (options.headers) {
-            requestOptions.headers = {
-                [ClientConstants.HEADER_ACCEPT]: 'application/json',
-                ...requestOptions.headers,
-                ...options.headers,
-            };
+            requestOptions.headers = {...requestOptions.headers, ...options.headers};
         }
         return requestOptions;
     }

--- a/app/managers/performance_metrics_manager/test_utils.ts
+++ b/app/managers/performance_metrics_manager/test_utils.ts
@@ -11,6 +11,6 @@ export function getBaseReportRequest(start: number, end: number): {body: Perform
             histograms: [],
             counters: [],
         },
-        headers: {},
+        headers: {Accept: 'application/json'},
     };
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

The objective of this PR is trying to solve an old issue with the application that misses `Accept` headers on requests, and this triggers some security issues on monitoring the application like `ModSecurity` for example.

The `Accept` header will only be added if the `doFetch` is called without it, if it's specified it will replace what the ClientTracking does.

Let's discuss the implementation.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://github.com/mattermost/mattermost-mobile/issues/4760

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

Android API 33 and iOS 18.4

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Adds a default header to requests as `application/json`
```
