### PR TITLE
Fix GM/DM unread threads highlighting all teams as unreads

### DIFF
--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -249,7 +249,7 @@ export async function processReceivedThreads(serverUrl: string, threads: Thread[
 export async function markTeamThreadsAsRead(serverUrl: string, teamId: string, prepareRecordsOnly = false) {
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const threads = await queryThreadsInTeam(database, teamId, true, true, true).fetch();
+        const threads = await queryThreadsInTeam(database, teamId, {onlyUnreads: true, hasReplies: true, isFollowing: true}).fetch();
         const models = threads.map((thread) => thread.prepareUpdate((record) => {
             record.unreadMentions = 0;
             record.unreadReplies = 0;

--- a/app/components/threads_button/index.ts
+++ b/app/components/threads_button/index.ts
@@ -6,7 +6,7 @@ import {switchMap} from 'rxjs/operators';
 
 import {observeCurrentChannelId, observeCurrentTeamId} from '@queries/servers/system';
 import {observeTeamLastChannelId} from '@queries/servers/team';
-import {observeUnreadsAndMentionsInTeam} from '@queries/servers/thread';
+import {observeUnreadsAndMentions} from '@queries/servers/thread';
 
 import ThreadsButton from './threads_button';
 
@@ -24,7 +24,7 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
         ),
         unreadsAndMentions: currentTeamId.pipe(
             switchMap(
-                (teamId) => observeUnreadsAndMentionsInTeam(database, teamId),
+                (teamId) => observeUnreadsAndMentions(database, {teamId, includeDmGm: true}),
             ),
         ),
     };

--- a/app/queries/servers/team.ts
+++ b/app/queries/servers/team.ts
@@ -14,7 +14,7 @@ import {prepareDeleteCategory} from './categories';
 import {prepareDeleteChannel, getDefaultChannelForTeam, observeMyChannelMentionCount, observeMyChannelUnreads} from './channel';
 import {queryPreferencesByCategoryAndName} from './preference';
 import {patchTeamHistory, getConfig, getTeamHistory, observeCurrentTeamId, getCurrentTeamId} from './system';
-import {observeThreadMentionCount, observeUnreadsAndMentionsInTeam} from './thread';
+import {observeThreadMentionCount, observeUnreadsAndMentions} from './thread';
 import {getCurrentUser} from './user';
 
 import type {MyChannelModel} from '@database/models/server';
@@ -416,7 +416,7 @@ export const observeCurrentTeam = (database: Database) => {
 
 export function observeMentionCount(database: Database, teamId?: string, includeDmGm?: boolean): Observable<number> {
     const channelMentionCountObservable = observeMyChannelMentionCount(database, teamId);
-    const threadMentionCountObservable = observeThreadMentionCount(database, teamId, includeDmGm);
+    const threadMentionCountObservable = observeThreadMentionCount(database, {teamId, includeDmGm});
 
     return channelMentionCountObservable.pipe(
         combineLatestWith(threadMentionCountObservable),
@@ -427,7 +427,7 @@ export function observeMentionCount(database: Database, teamId?: string, include
 
 export function observeIsTeamUnread(database: Database, teamId: string): Observable<boolean> {
     const channelUnreads = observeMyChannelUnreads(database, teamId);
-    const threadsUnreadsAndMentions = observeUnreadsAndMentionsInTeam(database, teamId, false);
+    const threadsUnreadsAndMentions = observeUnreadsAndMentions(database, {teamId});
 
     return channelUnreads.pipe(
         combineLatestWith(threadsUnreadsAndMentions),

--- a/app/queries/servers/team.ts
+++ b/app/queries/servers/team.ts
@@ -427,7 +427,7 @@ export function observeMentionCount(database: Database, teamId?: string, include
 
 export function observeIsTeamUnread(database: Database, teamId: string): Observable<boolean> {
     const channelUnreads = observeMyChannelUnreads(database, teamId);
-    const threadsUnreadsAndMentions = observeUnreadsAndMentionsInTeam(database, teamId);
+    const threadsUnreadsAndMentions = observeUnreadsAndMentionsInTeam(database, teamId, false);
 
     return channelUnreads.pipe(
         combineLatestWith(threadsUnreadsAndMentions),

--- a/app/queries/servers/thread.ts
+++ b/app/queries/servers/thread.ts
@@ -87,8 +87,16 @@ export const observeTeamIdByThread = (database: Database, thread: ThreadModel) =
     return observeTeamIdByThreadId(database, thread.id);
 };
 
-export const observeUnreadsAndMentionsInTeam = (database: Database, teamId?: string, includeDmGm?: boolean): Observable<{unreads: boolean; mentions: number}> => {
-    const observeThreads = () => queryThreads(database, teamId, true, includeDmGm).
+type ObserveUnreadsAndMentionsOptions = {
+    teamId?: string;
+    includeDmGm?: boolean;
+};
+
+export const observeUnreadsAndMentions = (database: Database, {
+    teamId,
+    includeDmGm,
+}: ObserveUnreadsAndMentionsOptions): Observable<{unreads: boolean; mentions: number}> => {
+    const observeThreads = () => queryThreads(database, {teamId, onlyUnreads: true, includeDmGm}).
         observeWithColumns(['unread_replies', 'unread_mentions']).
         pipe(
             switchMap((threads) => {
@@ -154,7 +162,21 @@ export const prepareThreadsFromReceivedPosts = async (operator: ServerDataOperat
     return models;
 };
 
-export const queryThreadsInTeam = (database: Database, teamId: string, onlyUnreads?: boolean, hasReplies?: boolean, isFollowing?: boolean, sort?: boolean, earliest?: number): Query<ThreadModel> => {
+type QueryThreadsInTeamOptions = {
+    onlyUnreads?: boolean;
+    hasReplies?: boolean;
+    isFollowing?: boolean;
+    sort?: boolean;
+    earliest?: number;
+};
+
+export const queryThreadsInTeam = (database: Database, teamId: string, {
+    onlyUnreads,
+    hasReplies,
+    isFollowing,
+    sort,
+    earliest,
+}: QueryThreadsInTeamOptions): Query<ThreadModel> => {
     const query: Q.Clause[] = [
         Q.experimentalNestedJoin(POST, CHANNEL),
         Q.on(POST, Q.on(CHANNEL, Q.where('delete_at', 0))),
@@ -193,14 +215,32 @@ export const queryTeamThreadsSync = (database: Database, teamId: string) => {
     );
 };
 
-export function observeThreadMentionCount(database: Database, teamId?: string, includeDmGm?: boolean): Observable<number> {
-    return observeUnreadsAndMentionsInTeam(database, teamId, includeDmGm).pipe(
+type ObserveThreadMentionCountOptions = {
+    teamId?: string;
+    includeDmGm?: boolean;
+};
+
+export function observeThreadMentionCount(database: Database, {
+    teamId,
+    includeDmGm,
+}: ObserveThreadMentionCountOptions): Observable<number> {
+    return observeUnreadsAndMentions(database, {teamId, includeDmGm}).pipe(
         switchMap(({mentions}) => of$(mentions)),
         distinctUntilChanged(),
     );
 }
 
-export const queryThreads = (database: Database, teamId?: string, onlyUnreads = false, includeDmGm = true): Query<ThreadModel> => {
+type QueryThreadsOptions = {
+    teamId?: string;
+    onlyUnreads?: boolean;
+    includeDmGm?: boolean;
+};
+
+export const queryThreads = (database: Database, {
+    teamId,
+    onlyUnreads,
+    includeDmGm,
+}: QueryThreadsOptions): Query<ThreadModel> => {
     const query: Q.Clause[] = [
         Q.where('is_following', true),
         Q.where('reply_count', Q.gt(0)),

--- a/app/screens/global_threads/index.tsx
+++ b/app/screens/global_threads/index.tsx
@@ -14,7 +14,7 @@ import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const teamId = observeCurrentTeamId(database);
-    const unreadsCount = teamId.pipe(switchMap((id) => queryThreadsInTeam(database, id, true, true, true).observeCount(false)));
+    const unreadsCount = teamId.pipe(switchMap((id) => queryThreadsInTeam(database, id, {onlyUnreads: true, hasReplies: true, isFollowing: true}).observeCount(false)));
     const hasUnreads = unreadsCount.pipe(
         switchMap((count) => of$(count > 0)),
         distinctUntilChanged(),

--- a/app/screens/global_threads/threads_list/index.ts
+++ b/app/screens/global_threads/threads_list/index.ts
@@ -31,7 +31,7 @@ const enhanced = withObservables(['tab', 'teamId'], ({database, tab, teamId}: Pr
         threads: teamThreadsSyncObserver.pipe(
             switchMap((teamThreadsSync) => {
                 const earliest = tab === 'all' ? teamThreadsSync?.[0]?.earliest : 0;
-                return queryThreadsInTeam(database, teamId, getOnlyUnreads, true, true, true, earliest).observe();
+                return queryThreadsInTeam(database, teamId, {onlyUnreads: getOnlyUnreads, hasReplies: true, isFollowing: true, sort: true, earliest}).observe();
             }),
         ),
     };

--- a/app/screens/home/channel_list/categories_list/categories/unreads/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/unreads/index.ts
@@ -11,7 +11,7 @@ import {filterAndSortMyChannels, makeChannelsMap} from '@helpers/database';
 import {getChannelById, observeChannelsByLastPostAt, observeNotifyPropsByChannels, queryMyChannelUnreads} from '@queries/servers/channel';
 import {querySidebarPreferences} from '@queries/servers/preference';
 import {observeLastUnreadChannelId} from '@queries/servers/system';
-import {observeUnreadsAndMentionsInTeam} from '@queries/servers/thread';
+import {observeUnreadsAndMentions} from '@queries/servers/thread';
 
 import UnreadCategories from './unreads';
 
@@ -62,7 +62,7 @@ const enhanced = withObservables(['currentTeamId', 'isTablet', 'onlyUnreads'], (
         }
         return of$([]);
     }));
-    const unreadThreads = observeUnreadsAndMentionsInTeam(database, currentTeamId, true);
+    const unreadThreads = observeUnreadsAndMentions(database, {teamId: currentTeamId, includeDmGm: true});
 
     return {
         unreadChannels,


### PR DESCRIPTION
#### Summary
While simplifying the logic around team unreads, a "default true" argument got the best of me, provoking that we include DM and GMs on the calculations for thread unreads.

This PR add relevant tests and fix the issue by passing the correct argument.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64335

#### Release Note
```release-note
Fix issue where a unread thread on a dm/gm would mark all teams as unread.
```
