### PR TITLE
Fix commit hashes for download artifacts

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: ci/download-sboms
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47c8a # v4.2.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ github.workspace }}
           pattern: |
@@ -177,7 +177,7 @@ jobs:
         working-directory: ./fastlane
 
       - name: ci/download-artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47c8a # v4.2.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ github.workspace }}
           merge-multiple: true


### PR DESCRIPTION
#### Summary

- Fix commit hash for download-artifact (https://github.com/actions/download-artifact/releases/tag/v4.3.0)

#### Release Note

```release-note
NONE
```
