### PR TITLE
Update GitHub Actions workflow for SBOM generation and Snyk versioning

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+  SNYK_VERSION: "1.1297.2"
+  CYCLONEDX_VERSION: "v0.27.2"
 
 jobs:
   test:
@@ -57,14 +59,14 @@ jobs:
           name: Mattermost-unsigned.ipa
 
       - name: ci/install-snyk
-        run: npm install -g snyk@1.1296.1
+        run: npm install -g snyk@${{ env.SNYK_VERSION }}
 
       - name: ci/generate-ios-sbom
         env:
           SNYK_TOKEN: "${{ secrets.SNYK_TOKEN }}"
         run: |
-          cd ios/
           snyk sbom --format=cyclonedx1.6+json --json-file-output=../sbom-ios.json --all-projects
+        working-directory: ./ios
         shell: bash
 
       - name: ci/upload-ios-sbom
@@ -100,14 +102,14 @@ jobs:
           name: Mattermost-unsigned.apk
 
       - name: ci/install-snyk
-        run: npm install -g snyk@1.1296.1
+        run: npm install -g snyk@${{ env.SNYK_VERSION }}
 
       - name: ci/generate-android-sbom
         env:
           SNYK_TOKEN: "${{ secrets.SNYK_TOKEN }}"
         run: |
-          cd android/
-          snyk sbom --format=cyclonedx1.6+json --all-projects --json-file-output=../sbom-android.json
+          snyk sbom --format=cyclonedx1.6+json --all-projects --json-file-output=sbom-android.json
+        working-directory: ./android
         shell: bash
 
       - name: ci/upload-android-sbom
@@ -128,26 +130,54 @@ jobs:
       - name: ci/download-sboms
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          pattern: sbom-*.json
           path: ${{ github.workspace }}
-          pattern: |
-            sbom-ios.json
-            sbom-android.json
           merge-multiple: true
 
       - name: ci/install-snyk
-        run: npm install -g snyk@1.1296.1
+        run: npm install -g snyk@${{ env.SNYK_VERSION }}
 
       - name: ci/setup-cyclonedx-cli
         run: |
-          curl -sSfL https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.27.2/cyclonedx-linux-x64 -o cyclonedx
+          set -e
+          CYCLONEDX_BINARY="cyclonedx-linux-x64"
+          CYCLONEDX_URL="https://github.com/CycloneDX/cyclonedx-cli/releases/download/${{ env.CYCLONEDX_VERSION }}/${CYCLONEDX_BINARY}"
+
+          # Download with better error handling and retry
+          echo "Downloading CycloneDX CLI ${{ env.CYCLONEDX_VERSION }}..."
+          curl -sSfL --retry 3 --retry-delay 5 "${CYCLONEDX_URL}" -o cyclonedx
+
+          # Verify the binary is executable and not corrupted
+          if [ ! -s cyclonedx ]; then
+            echo "Error: Downloaded file is empty or corrupted"
+            exit 1
+          fi
+
+          # Make executable and move to PATH
           chmod +x cyclonedx
           sudo mv cyclonedx /usr/local/bin/
+
+          # Verify installation
+          cyclonedx --version
 
       - name: ci/generate-consolidated-sbom
         env:
           SNYK_TOKEN: "${{ secrets.SNYK_TOKEN }}"
           SBOM_FILENAME: "sbom-${{ github.event.repository.name }}-${{ env.RELEASE_TAG }}.json"
         run: |
+          # Check if required SBOM files are available
+          if [ ! -f "sbom-android.json" ]; then
+            echo "Error: sbom-android.json not found. Android SBOM generation may have failed."
+            exit 1
+          fi
+
+          if [ ! -f "sbom-ios.json" ]; then
+            echo "Error: sbom-ios.json not found. iOS SBOM generation may have failed."
+            exit 1
+          fi
+
+          echo "All required SBOM files are available. Proceeding with consolidation..."
+
           # Generate top-level SBOM
           snyk sbom --format=cyclonedx1.6+json --json-file-output=sbom-top-level.json
 


### PR DESCRIPTION
#### Summary
<!--
A brief description of what this pull request does.
-->
Update GitHub Actions workflow for SBOM generation and Snyk versioning
- Set SNYK_VERSION and CYCLONEDX_VERSION as environment variables for easier updates.
- Modify Snyk installation to use the defined SNYK_VERSION.
- Adjust working directories for iOS and Android SBOM generation.
- Enhance error handling for CycloneDX CLI download and SBOM file checks.
- Ensure required SBOM files are present before consolidation.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
