### PR TITLE
fix(MM-63596): custom theme cannot be reselected

### DIFF
--- a/app/screens/settings/display_theme/display_theme.test.tsx
+++ b/app/screens/settings/display_theme/display_theme.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {fireEvent, render, act, screen} from '@testing-library/react-native';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import {BackHandler} from 'react-native';
 
@@ -50,7 +50,7 @@ describe('DisplayTheme', () => {
         expect(screen.queryByTestId('theme_display_settings.sapphire.option.selected')).toBeFalsy();
     });
 
-    it('should render with custom theme', () => {
+    it('should render with custom theme, current theme is custom', () => {
         jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.denim, type: 'custom'}));
 
         renderWithIntl(
@@ -63,7 +63,7 @@ describe('DisplayTheme', () => {
         expect(screen.getByTestId('theme_display_settings.custom.option.selected')).toBeTruthy();
     });
 
-    it('should render with custom theme and user change to denim (non-custom)', async () => {
+    it('should render with custom theme (default) and user change to denim (non-custom)', async () => {
         jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.denim, type: 'custom'}));
 
         renderWithIntl(
@@ -77,26 +77,24 @@ describe('DisplayTheme', () => {
 
         const denimTile = screen.getByTestId('theme_display_settings.denim.option');
 
-        act(() => {
-            fireEvent.press(denimTile);
-        });
+        fireEvent.press(denimTile);
 
-        expect(savePreference).toHaveBeenCalledWith(
-            expect.any(String),
-            expect.arrayContaining([
-                expect.objectContaining({
-                    category: 'theme',
-                    value: expect.stringContaining('"type":"Denim"'),
-                }),
-            ]),
-        );
-        expect(savePreference).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(savePreference).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        category: 'theme',
+                        value: expect.stringContaining('"type":"Denim"'),
+                    }),
+                ]),
+            );
+            expect(savePreference).toHaveBeenCalledTimes(1);
+        });
 
         // since we're mocking useTheme and savePreference, savePreference will post changes to the backend API, and upon success,
         // it will update the `theme` preference via useTheme hook.
-        act(() => {
-            jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.denim, type: 'Denim'}));
-        });
+        jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.denim, type: 'Denim'}));
 
         // clearing the savePreference mock to show that it will not be called again after re-rendering the component
         jest.mocked(savePreference).mockClear();
@@ -113,7 +111,61 @@ describe('DisplayTheme', () => {
         expect(screen.getByTestId('theme_display_settings.denim.option.selected')).toBeTruthy();
     });
 
-    it('should not call popTopScreen (closes the screen) when changing theme', () => {
+    it('should render only with custom theme, it gets de-selected, and then user re-selects it', async () => {
+        jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.denim, type: 'custom'}));
+
+        renderWithIntl(
+            <DisplayTheme
+                allowedThemeKeys={[]}
+                {...displayThemeOtherProps}
+            />);
+
+        jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.denim, type: 'Denim'}));
+
+        screen.rerender(
+            <DisplayTheme
+                allowedThemeKeys={[]}
+                {...displayThemeOtherProps}
+            />);
+
+        const customTile = screen.getByTestId('theme_display_settings.custom.option');
+
+        fireEvent.press(customTile);
+
+        await waitFor(() => {
+            expect(savePreference).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        category: 'theme',
+                        value: expect.stringContaining('"type":"custom"'),
+                    }),
+                ]),
+            );
+        });
+    });
+
+    it('should render denim, then a different client set the theme to custom, and this client should render custom and automatically switch to it', () => {
+        renderWithIntl(
+            <DisplayTheme
+                allowedThemeKeys={['denim']}
+                {...displayThemeOtherProps}
+            />);
+
+        expect(screen.queryByTestId('theme_display_settings.custom.option.selected')).toBeFalsy();
+
+        jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.denim, type: 'custom'}));
+
+        screen.rerender(
+            <DisplayTheme
+                allowedThemeKeys={['denim']}
+                {...displayThemeOtherProps}
+            />);
+
+        expect(screen.getByTestId('theme_display_settings.custom.option.selected')).toBeTruthy();
+    });
+
+    it('should not call popTopScreen (closes the screen) when changing theme', async () => {
         renderWithIntl(
             <DisplayTheme
                 allowedThemeKeys={['denim', 'sapphire']}
@@ -123,13 +175,9 @@ describe('DisplayTheme', () => {
 
         const sapphireTile = screen.getByTestId('theme_display_settings.sapphire.option');
 
-        act(() => {
-            fireEvent.press(sapphireTile);
+        fireEvent.press(sapphireTile);
 
-            // useDidUpdate => saveThemePreference => savePreference => useTheme => useDidUpdate again
-
-            jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.sapphire, type: 'Sapphire'}));
-        });
+        jest.mocked(useTheme).mockImplementation(() => ({...Preferences.THEMES.sapphire, type: 'Sapphire'}));
 
         screen.rerender(
             <DisplayTheme
@@ -137,6 +185,10 @@ describe('DisplayTheme', () => {
                 {...displayThemeOtherProps}
             />,
         );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('theme_display_settings.sapphire.option.selected')).toBeTruthy();
+        });
 
         expect(popTopScreen).toHaveBeenCalledTimes(0);
     });
@@ -156,5 +208,83 @@ describe('DisplayTheme', () => {
         androidBackButtonHandler.mock.calls[0][1]();
 
         expect(popTopScreen).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow user to select two different themes using normal interaction', async () => {
+        jest.useFakeTimers();
+
+        const numOfSavePreferenceCalls = 2;
+        renderWithIntl(
+            <DisplayTheme
+                allowedThemeKeys={['denim', 'sapphire']}
+                {...displayThemeOtherProps}
+            />,
+        );
+
+        const sapphireTile = screen.getByTestId('theme_display_settings.sapphire.option');
+
+        fireEvent.press(sapphireTile);
+
+        jest.advanceTimersByTime(750);
+        jest.useRealTimers();
+
+        await waitFor(() => {
+            expect(savePreference).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        category: 'theme',
+                        value: expect.stringContaining('"type":"Sapphire"'),
+                    }),
+                ]),
+            );
+            expect(savePreference).toHaveBeenCalledTimes(1);
+        });
+
+        jest.useFakeTimers();
+        jest.advanceTimersByTime(750);
+
+        const denimTile = screen.getByTestId('theme_display_settings.denim.option');
+
+        fireEvent.press(denimTile);
+
+        // firing denimTile will not cause the savePreference to be called again since we have the prevent double tap
+        expect(savePreference).toHaveBeenCalledTimes(numOfSavePreferenceCalls);
+
+        jest.useRealTimers();
+    });
+
+    it('should not allow user to select a theme rapidly', async () => {
+        const numOfSavePreferenceCalls = 1;
+        renderWithIntl(
+            <DisplayTheme
+                allowedThemeKeys={['denim', 'sapphire']}
+                {...displayThemeOtherProps}
+            />,
+        );
+
+        const sapphireTile = screen.getByTestId('theme_display_settings.sapphire.option');
+
+        fireEvent.press(sapphireTile);
+
+        await waitFor(() => {
+            expect(savePreference).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        category: 'theme',
+                        value: expect.stringContaining('"type":"Sapphire"'),
+                    }),
+                ]),
+            );
+            expect(savePreference).toHaveBeenCalledTimes(numOfSavePreferenceCalls);
+        });
+
+        const denimTile = screen.getByTestId('theme_display_settings.denim.option');
+
+        fireEvent.press(denimTile);
+
+        // firing denimTile will not cause the savePreference to be called again since we have the prevent double tap
+        expect(savePreference).toHaveBeenCalledTimes(numOfSavePreferenceCalls);
     });
 });

--- a/app/screens/settings/display_theme/display_theme.tsx
+++ b/app/screens/settings/display_theme/display_theme.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useState, useRef} from 'react';
+import React, {useCallback, useState} from 'react';
 
 import {savePreference} from '@actions/remote/preference';
 import SettingContainer from '@components/settings/container';
@@ -10,6 +10,7 @@ import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
 import useDidUpdate from '@hooks/did_update';
+import {usePreventDoubleTap} from '@hooks/utils';
 import {popTopScreen} from '@screens/navigation';
 
 import CustomTheme from './custom_theme';
@@ -26,14 +27,13 @@ type DisplayThemeProps = {
 const DisplayTheme = ({allowedThemeKeys, componentId, currentTeamId, currentUserId}: DisplayThemeProps) => {
     const serverUrl = useServerUrl();
     const theme = useTheme();
-    const initialTheme = useRef(theme);
-    const [newTheme, setNewTheme] = useState<string | undefined>(undefined);
+    const [customTheme, setCustomTheme] = useState(theme.type?.toLowerCase() === 'custom' ? theme : undefined);
 
     const close = () => popTopScreen(componentId);
 
-    const setThemePreference = useCallback(() => {
-        const allowedTheme = allowedThemeKeys.find((tk) => tk === newTheme);
-        const themeJson = Preferences.THEMES[allowedTheme as ThemeKey] || initialTheme.current;
+    const handleThemeChange = usePreventDoubleTap(useCallback(async (themeSelected: string) => {
+        const allowedTheme = allowedThemeKeys.find((tk) => tk === themeSelected);
+        const themeJson = Preferences.THEMES[allowedTheme as ThemeKey] || customTheme;
 
         const pref: PreferenceType = {
             category: Preferences.CATEGORIES.THEME,
@@ -41,33 +41,30 @@ const DisplayTheme = ({allowedThemeKeys, componentId, currentTeamId, currentUser
             user_id: currentUserId,
             value: JSON.stringify(themeJson),
         };
-        savePreference(serverUrl, [pref]);
-    }, [allowedThemeKeys, currentTeamId, currentUserId, serverUrl, newTheme]);
+        await savePreference(serverUrl, [pref]);
+    }, [allowedThemeKeys, currentTeamId, currentUserId, customTheme, serverUrl]));
 
     useDidUpdate(() => {
-        if (theme.type?.toLowerCase() !== newTheme?.toLowerCase()) {
-            setThemePreference();
+        // when the user selects any of the predefined theme when the current theme is custom, the custom theme will disappear.
+        // by storing the current theme in the state, the custom theme will remain, and the user can switch back to it
+        if (theme.type?.toLowerCase() === 'custom') {
+            setCustomTheme(theme);
         }
-    }, [newTheme, setThemePreference, theme.type]);
+    }, [theme.type]);
 
-    const onAndroidBack = () => {
-        setThemePreference();
-        close();
-    };
-
-    useAndroidHardwareBackHandler(componentId, onAndroidBack);
+    useAndroidHardwareBackHandler(componentId, close);
 
     return (
         <SettingContainer testID='theme_display_settings'>
             <ThemeTiles
                 allowedThemeKeys={allowedThemeKeys}
-                onThemeChange={setNewTheme}
+                onThemeChange={handleThemeChange}
                 selectedTheme={theme.type}
             />
-            {initialTheme.current.type === 'custom' && (
+            {customTheme && (
                 <CustomTheme
-                    setTheme={setNewTheme}
-                    displayTheme={initialTheme.current.type}
+                    setTheme={handleThemeChange}
+                    displayTheme={'custom'}
                 />
             )}
         </SettingContainer>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Fix a regression in which the display theme screen close after selecting a different theme.  The root cause is useDidUpdate gets fired twice, one when the user tap on a new theme, and the second when useTheme returns the new theme (after being saved on the backend through savePreference).  Since the value of the themes are the same on the second update, it closes it due to:

```
        const differentTheme = theme.type?.toLowerCase() !== newTheme?.toLowerCase();

        if (!differentTheme) {
            close();
            return;
        }
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-63596

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

```
 PASS  app/screens/settings/display_theme/display_theme.test.tsx
  DisplayTheme
    ✓ should render with default theme (25 ms)
    ✓ should render with custom theme (6 ms)
    ✓ should render with custom theme and change to denim (11 ms)
    ✓ should not call popTopScreen when changing theme (6 ms)
    ✓ should call popTopScreen when Android back button is pressed (9 ms)


=============================== Coverage summary ===============================
Statements   : 100% ( 21/21 )
Branches     : 100% ( 6/6 )
Functions    : 100% ( 6/6 )
Lines        : 100% ( 19/19 )
================================================================================
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        2.398 s, estimated 22 s
Ran all test suites matching /app\/screens\/settings\/display_theme\/display_theme.test.tsx/i.
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
