### PR TITLE
MM-64415 Attachment style updated for draft and Edit post screen

### DIFF
--- a/app/components/post_draft/uploads/index.test.tsx
+++ b/app/components/post_draft/uploads/index.test.tsx
@@ -1,0 +1,238 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithEverything} from '@test/intl-test-helper';
+import TestHelper from '@test/test_helper';
+
+import Uploads from './index';
+
+import type {Database} from '@nozbe/watermelondb';
+
+jest.mock('@managers/draft_upload_manager', () => ({
+    isUploading: jest.fn(() => false),
+    registerProgressHandler: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('@utils/gallery', () => ({
+    fileToGalleryItem: jest.fn((file) => ({
+        id: file.id,
+        type: 'image',
+        uri: file.localPath || file.uri,
+        name: file.name,
+        width: file.width,
+        height: file.height,
+    })),
+    openGalleryAtIndex: jest.fn(),
+}));
+
+describe('Uploads', () => {
+    const serverUrl = 'serverUrl';
+    let database: Database;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        database = (await TestHelper.setupServerDatabase(serverUrl)).database;
+    });
+
+    const baseProps = {
+        currentUserId: 'currentUserId',
+        channelId: 'channelId',
+        rootId: 'rootId',
+        uploadFileError: null,
+    };
+
+    it('should render without files', () => {
+        const props = {
+            ...baseProps,
+            files: [],
+        };
+
+        const {getByTestId} = renderWithEverything(
+            <Uploads {...props}/>,
+            {database},
+        );
+
+        expect(getByTestId('uploads')).toBeTruthy();
+    });
+
+    it('should render with image files', () => {
+        const imageFiles = [
+            {
+                id: 'image1',
+                clientId: 'client1',
+                name: 'image1.jpg',
+                extension: 'jpg',
+                mime_type: 'image/jpeg',
+                size: 1024,
+                width: 800,
+                height: 600,
+                localPath: '/path/to/image1.jpg',
+                failed: false,
+            },
+            {
+                id: 'image2',
+                clientId: 'client2',
+                name: 'image2.png',
+                extension: 'png',
+                mime_type: 'image/png',
+                size: 2048,
+                width: 1024,
+                height: 768,
+                localPath: '/path/to/image2.png',
+                failed: false,
+            },
+        ] as FileInfo[];
+
+        const props = {
+            ...baseProps,
+            files: imageFiles,
+        };
+
+        const {getByTestId} = renderWithEverything(
+            <Uploads {...props}/>,
+            {database},
+        );
+
+        expect(getByTestId('uploads')).toBeTruthy();
+    });
+
+    it('should render with document files', () => {
+        const documentFiles = [
+            {
+                id: 'doc1',
+                clientId: 'client1',
+                name: 'document.pdf',
+                extension: 'pdf',
+                mime_type: 'application/pdf',
+                size: 5120,
+                width: 0,
+                height: 0,
+                localPath: '/path/to/document.pdf',
+                failed: false,
+            },
+            {
+                id: 'doc2',
+                clientId: 'client2',
+                name: 'spreadsheet.xlsx',
+                extension: 'xlsx',
+                mime_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                size: 3072,
+                width: 0,
+                height: 0,
+                localPath: '/path/to/spreadsheet.xlsx',
+                failed: false,
+            },
+        ] as FileInfo[];
+
+        const props = {
+            ...baseProps,
+            files: documentFiles,
+        };
+
+        const {getByTestId} = renderWithEverything(
+            <Uploads {...props}/>,
+            {database},
+        );
+
+        expect(getByTestId('uploads')).toBeTruthy();
+    });
+
+    it('should render with mixed file types', () => {
+        const mixedFiles = [
+            {
+                id: 'image1',
+                clientId: 'client1',
+                name: 'photo.jpg',
+                extension: 'jpg',
+                mime_type: 'image/jpeg',
+                size: 1024,
+                width: 800,
+                height: 600,
+                localPath: '/path/to/photo.jpg',
+                failed: false,
+            },
+            {
+                id: 'doc1',
+                clientId: 'client2',
+                name: 'report.pdf',
+                extension: 'pdf',
+                mime_type: 'application/pdf',
+                size: 5120,
+                width: 0,
+                height: 0,
+                localPath: '/path/to/report.pdf',
+                failed: false,
+            },
+        ] as FileInfo[];
+
+        const props = {
+            ...baseProps,
+            files: mixedFiles,
+        };
+
+        const {getByTestId} = renderWithEverything(
+            <Uploads {...props}/>,
+            {database},
+        );
+
+        expect(getByTestId('uploads')).toBeTruthy();
+    });
+
+    it('should display upload error when present', () => {
+        const props = {
+            ...baseProps,
+            files: [],
+            uploadFileError: 'File upload failed',
+        };
+
+        const {getByText} = renderWithEverything(
+            <Uploads {...props}/>,
+            {database},
+        );
+
+        expect(getByText('File upload failed')).toBeTruthy();
+    });
+
+    it('should filter out failed and uploading files from gallery', () => {
+        const filesWithFailedAndUploading = [
+            {
+                id: 'file1',
+                clientId: 'client1',
+                name: 'success.jpg',
+                extension: 'jpg',
+                mime_type: 'image/jpeg',
+                size: 1024,
+                width: 800,
+                height: 600,
+                localPath: '/path/to/success.jpg',
+                failed: false,
+            },
+            {
+                id: 'file2',
+                clientId: 'client2',
+                name: 'failed.jpg',
+                extension: 'jpg',
+                mime_type: 'image/jpeg',
+                size: 1024,
+                width: 800,
+                height: 600,
+                localPath: '/path/to/failed.jpg',
+                failed: true,
+            },
+        ] as FileInfo[];
+
+        const props = {
+            ...baseProps,
+            files: filesWithFailedAndUploading,
+        };
+
+        const {getByTestId} = renderWithEverything(
+            <Uploads {...props}/>,
+            {database},
+        );
+
+        expect(getByTestId('uploads')).toBeTruthy();
+    });
+});

--- a/app/components/post_draft/uploads/index.tsx
+++ b/app/components/post_draft/uploads/index.tsx
@@ -18,7 +18,7 @@ import {makeStyleSheetFromTheme} from '@utils/theme';
 
 import UploadItem from './upload_item';
 
-const CONTAINER_HEIGHT_MAX = 67;
+const CONTAINER_HEIGHT_MAX = 80;
 const CONTAINER_HEIGHT_MIN = 0;
 const ERROR_HEIGHT_MAX = 20;
 const ERROR_HEIGHT_MIN = 0;

--- a/app/components/post_draft/uploads/upload_item/index.test.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.test.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 
 import {updateDraftFile} from '@actions/local/draft';
+import FileIcon from '@components/files/file_icon';
+import ImageFile from '@components/files/image_file';
 import {EditPostProvider} from '@context/edit_post';
 import DraftEditPostUploadManager from '@managers/draft_upload_manager';
 import {fireEvent, renderWithEverything} from '@test/intl-test-helper';
@@ -34,30 +36,17 @@ jest.mock('@utils/file', () => ({
     getFormattedFileSize: jest.fn((size) => `${size} KB`),
 }));
 
-jest.mock('@components/files/image_file', () => {
-    const {View} = require('react-native');
-    const MockImageFile = (props: any, ref: any) => (
-        <View
-            testID='image-file'
-            ref={ref}
-            {...props}
-        />
-    );
-    MockImageFile.displayName = 'MockImageFile';
-    return require('react').forwardRef(MockImageFile);
-});
+jest.mock('@components/files/image_file', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+jest.mocked(ImageFile).mockImplementation((props) => React.createElement('ImageFile', {testID: 'image-file', ...props}));
 
-jest.mock('@components/files/file_icon', () => {
-    const {View} = require('react-native');
-    const MockFileIcon = (props: any) => (
-        <View
-            testID={props.testID}
-            {...props}
-        />
-    );
-    MockFileIcon.displayName = 'MockFileIcon';
-    return MockFileIcon;
-});
+jest.mock('@components/files/file_icon', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+jest.mocked(FileIcon).mockImplementation((props) => React.createElement('FileIcon', {...props}));
 
 const {isImage} = require('@utils/file');
 

--- a/app/components/post_draft/uploads/upload_item/index.test.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.test.tsx
@@ -29,6 +29,38 @@ jest.mock('@context/server', () => ({
     useServerUrl: () => 'serverUrl',
 }));
 
+jest.mock('@utils/file', () => ({
+    isImage: jest.fn(),
+    getFormattedFileSize: jest.fn((size) => `${size} KB`),
+}));
+
+jest.mock('@components/files/image_file', () => {
+    const {View} = require('react-native');
+    const MockImageFile = (props: any, ref: any) => (
+        <View
+            testID='image-file'
+            ref={ref}
+            {...props}
+        />
+    );
+    MockImageFile.displayName = 'MockImageFile';
+    return require('react').forwardRef(MockImageFile);
+});
+
+jest.mock('@components/files/file_icon', () => {
+    const {View} = require('react-native');
+    const MockFileIcon = (props: any) => (
+        <View
+            testID={props.testID}
+            {...props}
+        />
+    );
+    MockFileIcon.displayName = 'MockFileIcon';
+    return MockFileIcon;
+});
+
+const {isImage} = require('@utils/file');
+
 describe('UploadItem', () => {
     const serverUrl = 'serverUrl';
     let database: Database;
@@ -38,13 +70,13 @@ describe('UploadItem', () => {
         database = (await TestHelper.setupServerDatabase(serverUrl)).database;
     });
 
-    const baseProps: Parameters<typeof UploadItem>[0] = {
-        channelId: 'channelId',
-        galleryIdentifier: 'galleryIdentifier',
-        index: 0,
+    const baseProps = {
+        channelId: 'channelId' as string,
+        galleryIdentifier: 'galleryIdentifier' as string,
+        index: 0 as number,
         file: {
-            id: 'fileId',
-            name: 'fileName',
+            id: 'id',
+            name: 'name',
             extension: 'extension',
             has_preview_image: false,
             height: 0,
@@ -53,11 +85,187 @@ describe('UploadItem', () => {
             width: 0,
             bytesRead: 0,
             clientId: 'clientId',
+            localPath: 'localPath',
             failed: false,
         } as FileInfo,
         openGallery: jest.fn(),
         rootId: 'rootId' as string,
     };
+
+    describe('Image Files', () => {
+        beforeEach(() => {
+            isImage.mockReturnValue(true);
+        });
+
+        it('should display thumbnail for image files', () => {
+            const imageFile = {
+                ...baseProps.file,
+                name: 'image.jpg',
+                extension: 'jpg',
+                mime_type: 'image/jpeg',
+                size: 1024,
+            } as FileInfo;
+
+            const props = {
+                ...baseProps,
+                file: imageFile,
+            };
+
+            const {getByTestId, queryByText} = renderWithEverything(
+                <EditPostProvider isEditMode={false}>
+                    <UploadItem {...props}/>
+                </EditPostProvider>,
+                {database},
+            );
+
+            // Should display image thumbnail
+            expect(getByTestId('image-file')).toBeTruthy();
+
+            // For image files, file name and size should not be displayed
+            expect(queryByText('image.jpg')).toBeNull();
+            expect(queryByText('JPG')).toBeNull();
+            expect(queryByText('1024 KB')).toBeNull();
+        });
+
+        it('should not display file info for image files', () => {
+            const imageFile = {
+                ...baseProps.file,
+                name: 'test-image.png',
+                extension: 'png',
+                mime_type: 'image/png',
+                size: 2048,
+            } as FileInfo;
+
+            const props = {
+                ...baseProps,
+                file: imageFile,
+            };
+
+            const {queryByText} = renderWithEverything(
+                <EditPostProvider isEditMode={false}>
+                    <UploadItem {...props}/>
+                </EditPostProvider>,
+                {database},
+            );
+
+            // Should not display file name or size information
+            expect(queryByText('test-image.png')).toBeNull();
+            expect(queryByText('PNG')).toBeNull();
+            expect(queryByText('2048 KB')).toBeNull();
+        });
+    });
+
+    describe('Non-Image Files', () => {
+        beforeEach(() => {
+            isImage.mockReturnValue(false);
+        });
+
+        it('should display file name, extension, and size for non-image files', () => {
+            const documentFile = {
+                ...baseProps.file,
+                name: 'document.pdf',
+                extension: 'pdf',
+                mime_type: 'application/pdf',
+                size: 5120,
+            } as FileInfo;
+
+            const props = {
+                ...baseProps,
+                file: documentFile,
+            };
+
+            const {getByText, getByTestId} = renderWithEverything(
+                <EditPostProvider isEditMode={false}>
+                    <UploadItem {...props}/>
+                </EditPostProvider>,
+                {database},
+            );
+
+            // Should display file icon
+            expect(getByTestId('id')).toBeTruthy();
+
+            // Should display file name
+            expect(getByText('document.pdf')).toBeTruthy();
+
+            // Should display extension and formatted size
+            expect(getByText('PDF 5120 KB')).toBeTruthy();
+        });
+
+        it('should display file info for different file types', () => {
+            const excelFile = {
+                ...baseProps.file,
+                name: 'spreadsheet.xlsx',
+                extension: 'xlsx',
+                mime_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                size: 3072,
+            } as FileInfo;
+
+            const props = {
+                ...baseProps,
+                file: excelFile,
+            };
+
+            const {getByText} = renderWithEverything(
+                <EditPostProvider isEditMode={false}>
+                    <UploadItem {...props}/>
+                </EditPostProvider>,
+                {database},
+            );
+
+            expect(getByText('spreadsheet.xlsx')).toBeTruthy();
+            expect(getByText('XLSX 3072 KB')).toBeTruthy();
+        });
+
+        it('should handle files without extension gracefully', () => {
+            const fileWithoutExtension = {
+                ...baseProps.file,
+                name: 'document',
+                extension: '',
+                mime_type: 'application/octet-stream',
+                size: 1024,
+            } as FileInfo;
+
+            const props = {
+                ...baseProps,
+                file: fileWithoutExtension,
+            };
+
+            const {getByText} = renderWithEverything(
+                <EditPostProvider isEditMode={false}>
+                    <UploadItem {...props}/>
+                </EditPostProvider>,
+                {database},
+            );
+
+            expect(getByText('document')).toBeTruthy();
+            expect(getByText('DOCUMENT 1024 KB')).toBeTruthy();
+        });
+
+        it('should extract extension from file name when extension field is missing', () => {
+            const fileNameWithExtension = {
+                ...baseProps.file,
+                name: 'report.docx',
+                extension: '',
+                mime_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                size: 2048,
+            } as FileInfo;
+
+            const props = {
+                ...baseProps,
+                file: fileNameWithExtension,
+            };
+
+            const {getByText} = renderWithEverything(
+                <EditPostProvider isEditMode={false}>
+                    <UploadItem {...props}/>
+                </EditPostProvider>,
+                {database},
+            );
+
+            expect(getByText('report.docx')).toBeTruthy();
+            expect(getByText('DOCX 2048 KB')).toBeTruthy();
+        });
+    });
 
     it('When file is failed, onclick of retry button, it should call prepareUpload with correct arguments in edit mode', () => {
         const updateFileCallback = jest.fn();

--- a/app/components/post_draft/uploads/upload_item/index.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.tsx
@@ -31,6 +31,14 @@ type Props = {
     rootId: string;
 }
 
+// Constants for dimensions
+const DIMENSIONS = {
+    THUMBNAIL_SIZE: 64,
+    ICON_SIZE: 48,
+    FILE_CONTAINER_WIDTH: 294,
+    FILE_CONTAINER_HEIGHT: 64,
+} as const;
+
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         preview: {
@@ -45,13 +53,13 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             alignItems: 'center',
         },
         imageOnlyContainer: {
-            width: 64,
-            height: 64,
+            width: DIMENSIONS.THUMBNAIL_SIZE,
+            height: DIMENSIONS.THUMBNAIL_SIZE,
             padding: 0,
         },
         fileWithInfoContainer: {
-            width: 294,
-            height: 64,
+            width: DIMENSIONS.FILE_CONTAINER_WIDTH,
+            height: DIMENSIONS.FILE_CONTAINER_HEIGHT,
             flexDirection: 'row',
             alignItems: 'center',
             flexShrink: 0,
@@ -61,16 +69,16 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             paddingRight: 16,
         },
         iconContainer: {
-            width: 48,
-            height: 48,
+            width: DIMENSIONS.ICON_SIZE,
+            height: DIMENSIONS.ICON_SIZE,
             borderRadius: 4,
             marginRight: 8,
             justifyContent: 'center',
             alignItems: 'center',
         },
         imageContainer: {
-            width: 64,
-            height: 64,
+            width: DIMENSIONS.THUMBNAIL_SIZE,
+            height: DIMENSIONS.THUMBNAIL_SIZE,
             borderRadius: 4,
             marginRight: 8,
             overflow: 'hidden',
@@ -86,8 +94,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             elevation: 1,
         },
         imageOnlyThumbnail: {
-            width: 64,
-            height: 64,
+            width: DIMENSIONS.THUMBNAIL_SIZE,
+            height: DIMENSIONS.THUMBNAIL_SIZE,
             borderRadius: 4,
             overflow: 'hidden',
             shadowColor: '#000000',

--- a/app/components/post_draft/uploads/upload_item/index.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.tsx
@@ -35,7 +35,7 @@ type Props = {
 const DIMENSIONS = {
     THUMBNAIL_SIZE: 64,
     ICON_SIZE: 48,
-    FILE_CONTAINER_WIDTH: 294,
+    FILE_CONTAINER_WIDTH: 264,
     FILE_CONTAINER_HEIGHT: 64,
 } as const;
 
@@ -63,7 +63,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flexDirection: 'row',
             alignItems: 'center',
             flexShrink: 0,
-            gap: 12,
+            gap: 8,
             paddingVertical: 12,
             paddingLeft: 12,
             paddingRight: 16,
@@ -72,7 +72,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             width: DIMENSIONS.ICON_SIZE,
             height: DIMENSIONS.ICON_SIZE,
             borderRadius: 4,
-            marginRight: 8,
             justifyContent: 'center',
             alignItems: 'center',
         },
@@ -224,7 +223,6 @@ export default function UploadItem({
         return (
             <View style={style.iconContainer}>
                 <FileIcon
-                    backgroundColor={changeOpacity(theme.centerChannelColor, 0.08)}
                     iconSize={48}
                     file={file}
                     testID={file.id}

--- a/app/components/post_draft/uploads/upload_item/index.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.tsx
@@ -55,7 +55,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flexDirection: 'row',
             alignItems: 'center',
             flexShrink: 0,
-            gap: 16,
+            gap: 12,
             paddingVertical: 12,
             paddingLeft: 12,
             paddingRight: 16,

--- a/app/components/post_draft/uploads/upload_item/index.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.tsx
@@ -66,7 +66,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             flexShrink: 0,
             gap: 8,
             paddingVertical: 12,
-            paddingLeft: 12,
+            paddingLeft: 8,
             paddingRight: 16,
         },
         iconContainer: {
@@ -130,7 +130,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             backgroundColor: 'rgba(0, 0, 0, 0.1)',
             borderRadius: 4,
             justifyContent: 'flex-end',
-            paddingLeft: 3,
         },
         progressContainer: {
             paddingVertical: undefined,

--- a/app/components/post_draft/uploads/upload_item/index.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.tsx
@@ -51,6 +51,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             borderColor: changeOpacity(theme.centerChannelColor, 0.16),
             backgroundColor: theme.centerChannelBg,
             alignItems: 'center',
+            position: 'relative',
         },
         imageOnlyContainer: {
             width: DIMENSIONS.THUMBNAIL_SIZE,

--- a/app/components/post_draft/uploads/upload_item/index.tsx
+++ b/app/components/post_draft/uploads/upload_item/index.tsx
@@ -208,7 +208,7 @@ export default function UploadItem({
 
     const {styles, onGestureEvent, ref} = useGalleryItem(galleryIdentifier, index, handlePress);
 
-    const fileDisplayComponent = useMemo(() => {
+    const fileDisplayComponent = () => {
         if (isImage(file)) {
             return (
                 <View style={style.imageOnlyThumbnail}>
@@ -231,25 +231,17 @@ export default function UploadItem({
                 />
             </View>
         );
-    }, [file, ref, theme.centerChannelColor, style.imageOnlyThumbnail, style.iconContainer]);
+    };
 
-    const fileExtension = useMemo(() => {
-        return file.extension?.toUpperCase() || file.name?.split('.').pop()?.toUpperCase() || '';
-    }, [file.extension, file.name]);
+    const fileExtension = file.extension?.toUpperCase() || file.name?.split('.').pop()?.toUpperCase() || '';
 
-    const formattedSize = useMemo(() => {
-        return getFormattedFileSize(file.size || 0);
-    }, [file.size]);
-
-    const fileName = useMemo(() => {
-        return file.name || 'Unknown file';
-    }, [file.name]);
+    const formattedSize = getFormattedFileSize(file.size || 0);
 
     const isImageFile = isImage(file);
-    const containerStyle = [
+    const containerStyle = useMemo(() => [
         style.previewContainer,
         isImageFile ? style.imageOnlyContainer : style.fileWithInfoContainer,
-    ];
+    ], [isImageFile, style.fileWithInfoContainer, style.imageOnlyContainer, style.previewContainer]);
 
     return (
         <View
@@ -259,7 +251,7 @@ export default function UploadItem({
             <View style={containerStyle}>
                 <TouchableWithoutFeedback onPress={onGestureEvent}>
                     <Animated.View style={styles}>
-                        {fileDisplayComponent}
+                        {fileDisplayComponent()}
                     </Animated.View>
                 </TouchableWithoutFeedback>
 
@@ -270,7 +262,7 @@ export default function UploadItem({
                             numberOfLines={1}
                             ellipsizeMode='tail'
                         >
-                            {fileName}
+                            {file.name || 'Unknown file'}
                         </Text>
                         <Text style={style.fileSize}>
                             {fileExtension && `${fileExtension} `}{formattedSize}

--- a/app/components/post_draft/uploads/upload_item/upload_remove.tsx
+++ b/app/components/post_draft/uploads/upload_item/upload_remove.tsx
@@ -25,8 +25,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         tappableContainer: {
             position: 'absolute',
             elevation: 11,
-            top: -7,
-            right: -8,
+            top: -12,
+            right: -10,
             width: 24,
             height: 24,
         },

--- a/app/components/post_draft/uploads/upload_item/upload_retry.tsx
+++ b/app/components/post_draft/uploads/upload_item/upload_retry.tsx
@@ -15,8 +15,10 @@ const style = StyleSheet.create({
     failed: {
         backgroundColor: 'rgba(0, 0, 0, 0.8)',
         position: 'absolute',
-        height: '100%',
-        width: '100%',
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
         alignItems: 'center',
         justifyContent: 'center',
         borderRadius: 4,

--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -18,7 +18,6 @@ import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
 import {useAutocompleteDefaultAnimatedValues} from '@hooks/autocomplete';
 import {useKeyboardOverlap} from '@hooks/device';
 import useDidUpdate from '@hooks/did_update';
-import useFileUploadError from '@hooks/file_upload_error';
 import {useInputPropagation} from '@hooks/input';
 import useNavButtonPressed from '@hooks/navigation_button_pressed';
 import DraftEditPostUploadManager from '@managers/draft_upload_manager';
@@ -103,7 +102,6 @@ const EditPost = ({
     const serverUrl = useServerUrl();
 
     const shouldDeleteOnSave = !postMessage && canDelete && !hasFilesAttached;
-    const {uploadError, newUploadError} = useFileUploadError();
 
     const shouldEnableSaveButton = useCallback(() => {
         const loadingFiles = postFiles.filter((v) => v.clientId && DraftEditPostUploadManager.isUploading(v.clientId));
@@ -189,20 +187,20 @@ const EditPost = ({
         }
 
         if (!canUploadFiles) {
-            newUploadError(uploadDisabledWarning(intl));
+            setErrorLine(uploadDisabledWarning(intl));
             return;
         }
 
         const currentFileCount = postFiles?.length || 0;
         const availableCount = maxFileCount - currentFileCount;
         if (newFiles.length > availableCount) {
-            newUploadError(fileMaxWarning(intl, maxFileCount));
+            setErrorLine(fileMaxWarning(intl, maxFileCount));
             return;
         }
 
         const largeFile = newFiles.find((file) => file.size > maxFileSize);
         if (largeFile) {
-            newUploadError(fileSizeWarning(intl, maxFileSize));
+            setErrorLine(fileSizeWarning(intl, maxFileSize));
             return;
         }
 
@@ -219,11 +217,11 @@ const EditPost = ({
                 true, // isEditPost = true
                 updateFileInPostFiles,
             );
-            uploadErrorHandlers.current[file.clientId!] = DraftEditPostUploadManager.registerErrorHandler(file.clientId!, newUploadError);
+            uploadErrorHandlers.current[file.clientId!] = DraftEditPostUploadManager.registerErrorHandler(file.clientId!, setErrorLine);
         }
 
-        newUploadError(null);
-    }, [canUploadFiles, postFiles?.length, maxFileCount, newUploadError, intl, maxFileSize, serverUrl, post.channelId, post.rootId, updateFileInPostFiles]);
+        setErrorLine(undefined);
+    }, [canUploadFiles, postFiles?.length, maxFileCount, setErrorLine, intl, maxFileSize, serverUrl, post.channelId, post.rootId, updateFileInPostFiles]);
 
     const handleFileRemoval = useCallback((id: string) => {
 
@@ -321,20 +319,23 @@ const EditPost = ({
 
         for (const file of loadingFiles) {
             if (file.clientId && !uploadErrorHandlers.current[file.clientId]) {
-                uploadErrorHandlers.current[file.clientId] = DraftEditPostUploadManager.registerErrorHandler(file.clientId, newUploadError);
+                uploadErrorHandlers.current[file.clientId] = DraftEditPostUploadManager.registerErrorHandler(file.clientId, setErrorLine);
             }
         }
-    }, [postFiles, postMessage, newUploadError, shouldEnableSaveButton, toggleSaveButton]);
+    }, [postFiles, postMessage, setErrorLine, shouldEnableSaveButton, toggleSaveButton]);
 
     const onChangeTextCommon = useCallback((message: string) => {
         const tooLong = message.trim().length > maxPostSize;
-        setErrorLine(undefined);
         setErrorExtra(undefined);
+
         if (tooLong) {
             const line = intl.formatMessage({id: 'mobile.message_length.message_split_left', defaultMessage: 'Message exceeds the character limit'});
             const extra = `${message.trim().length} / ${maxPostSize}`;
             setErrorLine(line);
             setErrorExtra(extra);
+        } else {
+            // Clear any error when message is valid
+            setErrorLine(undefined);
         }
     }, [intl, maxPostSize]);
 
@@ -461,7 +462,7 @@ const EditPost = ({
                         }
                         <View style={styles.inputContainer}>
                             <EditPostInput
-                                hasError={Boolean(errorLine)}
+                                hasError={Boolean(errorLine || errorExtra)}
                                 message={postMessage}
                                 onChangeText={onInputChangeText}
                                 onTextSelectionChange={onTextSelectionChange}
@@ -469,7 +470,6 @@ const EditPost = ({
                                 post={post}
                                 postFiles={postFiles}
                                 addFiles={addFiles}
-                                uploadFileError={uploadError}
                             />
                         </View>
                     </View>

--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -106,8 +106,7 @@ const EditPost = ({
     const shouldEnableSaveButton = useCallback(() => {
         const loadingFiles = postFiles.filter((v) => v.clientId && DraftEditPostUploadManager.isUploading(v.clientId));
         const hasUploadingFiles = loadingFiles.length > 0;
-
-        const tooLong = postMessage.trim().length > maxPostSize;
+        const tooLong = postMessage.length > maxPostSize;
 
         const messageChanged = editingMessage !== postMessage;
 
@@ -220,7 +219,7 @@ const EditPost = ({
             uploadErrorHandlers.current[file.clientId!] = DraftEditPostUploadManager.registerErrorHandler(file.clientId!, setErrorLine);
         }
 
-        const currentMessageTooLong = postMessage.trim().length > maxPostSize;
+        const currentMessageTooLong = postMessage.length > maxPostSize;
         if (!currentMessageTooLong) {
             setErrorLine(undefined);
         }
@@ -328,12 +327,12 @@ const EditPost = ({
     }, [postFiles, postMessage, setErrorLine, shouldEnableSaveButton, toggleSaveButton]);
 
     const onChangeTextCommon = useCallback((message: string) => {
-        const tooLong = message.trim().length > maxPostSize;
+        const tooLong = message.length > maxPostSize;
         setErrorExtra(undefined);
 
         if (tooLong) {
             const line = intl.formatMessage({id: 'mobile.message_length.message_split_left', defaultMessage: 'Message exceeds the character limit'});
-            const extra = `${message.trim().length} / ${maxPostSize}`;
+            const extra = `${message.length} / ${maxPostSize}`;
             setErrorLine(line);
             setErrorExtra(extra);
         } else {

--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -220,8 +220,11 @@ const EditPost = ({
             uploadErrorHandlers.current[file.clientId!] = DraftEditPostUploadManager.registerErrorHandler(file.clientId!, setErrorLine);
         }
 
-        setErrorLine(undefined);
-    }, [canUploadFiles, postFiles?.length, maxFileCount, setErrorLine, intl, maxFileSize, serverUrl, post.channelId, post.rootId, updateFileInPostFiles]);
+        const currentMessageTooLong = postMessage.trim().length > maxPostSize;
+        if (!currentMessageTooLong) {
+            setErrorLine(undefined);
+        }
+    }, [canUploadFiles, postFiles?.length, maxFileCount, setErrorLine, intl, maxFileSize, serverUrl, post.channelId, post.rootId, updateFileInPostFiles, postMessage, maxPostSize]);
 
     const handleFileRemoval = useCallback((id: string) => {
 

--- a/app/screens/edit_post/edit_post_input/edit_post_input.test.tsx
+++ b/app/screens/edit_post/edit_post_input/edit_post_input.test.tsx
@@ -56,7 +56,6 @@ describe('EditPostInput', () => {
         onTextSelectionChange: jest.fn(),
         onChangeText: jest.fn(),
         addFiles: jest.fn(),
-        uploadFileError: undefined,
     };
 
     beforeAll(async () => {

--- a/app/screens/edit_post/edit_post_input/edit_post_input.tsx
+++ b/app/screens/edit_post/edit_post_input/edit_post_input.tsx
@@ -47,7 +47,6 @@ type PostInputProps = {
     onChangeText: (text: string) => void;
     inputRef: React.MutableRefObject<PasteInputRef | undefined>;
     addFiles: (file: FileInfo[]) => void;
-    uploadFileError: React.ReactNode;
 }
 
 const EditPostInput = ({
@@ -60,7 +59,6 @@ const EditPostInput = ({
     version,
     inputRef,
     addFiles,
-    uploadFileError,
 }: PostInputProps) => {
     const intl = useIntl();
     const theme = useTheme();
@@ -133,7 +131,7 @@ const EditPostInput = ({
                         channelId={post.channelId}
                         currentUserId={post.userId}
                         files={postFiles}
-                        uploadFileError={uploadFileError}
+                        uploadFileError={null}
                         rootId={post.rootId}
                     />
                     <QuickActions

--- a/app/screens/edit_post/post_error/index.tsx
+++ b/app/screens/edit_post/post_error/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {StyleSheet, View} from 'react-native';
 
 import ErrorText from '@components/error_text';
+import MenuDivider from '@components/menu_divider';
 
 type PostErrorProps = {
     errorLine?: string;
@@ -13,13 +14,13 @@ type PostErrorProps = {
 
 const styles = StyleSheet.create({
     errorContainerSplit: {
-        paddingHorizontal: 15,
+        paddingHorizontal: 16,
         flexDirection: 'row',
         justifyContent: 'space-between',
         width: '100%',
     },
     errorContainer: {
-        paddingHorizontal: 10,
+        paddingHorizontal: 16,
         width: '100%',
     },
     errorWrap: {
@@ -29,28 +30,45 @@ const styles = StyleSheet.create({
     errorWrapper: {
         alignItems: 'center',
     },
+    errorText: {
+        fontSize: 13,
+    },
 });
 
 const PostError = ({errorLine, errorExtra}: PostErrorProps) => {
+    const hasError = Boolean(errorLine || errorExtra);
+
+    if (!hasError) {
+        return null;
+    }
+
     return (
-        <View
-            style={errorExtra ? styles.errorContainerSplit : styles.errorContainer}
-        >
-            {Boolean(errorLine) && (
-                <ErrorText
-                    testID='edit_post.message.input.error'
-                    error={errorLine!}
-                    textStyle={styles.errorWrap}
-                />
-            )}
-            {Boolean(errorExtra) && (
-                <ErrorText
-                    testID='edit_post.message.input.error.extra'
-                    error={errorExtra!}
-                    textStyle={!errorLine && styles.errorWrapper}
-                />
-            )}
-        </View>
+        <>
+            <View
+                style={errorExtra ? styles.errorContainerSplit : styles.errorContainer}
+            >
+                {Boolean(errorLine) && (
+                    <ErrorText
+                        testID='edit_post.message.input.error'
+                        error={errorLine!}
+                        textStyle={[styles.errorWrap, styles.errorText]}
+                    />
+                )}
+                {Boolean(errorExtra) && (
+                    <ErrorText
+                        testID='edit_post.message.input.error.extra'
+                        error={errorExtra!}
+                        textStyle={[!errorLine && styles.errorWrapper, styles.errorText]}
+                    />
+                )}
+            </View>
+            <MenuDivider
+                marginTop={0}
+                marginBottom={0}
+                marginLeft={0}
+                marginRight={0}
+            />
+        </>
     );
 };
 


### PR DESCRIPTION
#### Summary
Updated style for showing the attachments in the draft and Edit post screen. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64415

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots

![Screenshot 2025-06-24 at 3 32 01 PM](https://github.com/user-attachments/assets/90a2afe8-d3d1-43a8-9d34-351c5c237dc6)

![Screenshot 2025-06-24 at 3 34 26 PM](https://github.com/user-attachments/assets/8d01cc7a-f32a-4c7b-9b72-8ab3408368cf)

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
