### PR TITLE
Auto-retry sending the message when posting fails.

### DIFF
--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -62,7 +62,7 @@ type AuthorsRequest = {
     error?: unknown;
 }
 
-function isErrorThatWarrantsNotPostingTheMessage(error: any): boolean {
+export function isErrorThatWarrantsNotPostingTheMessage(error: any): boolean {
     // If the failure was because: the root post was deleted or
     // TownSquareIsReadOnly=true
     return isServerError(error) && (
@@ -72,10 +72,10 @@ function isErrorThatWarrantsNotPostingTheMessage(error: any): boolean {
     );
 }
 
-async function createPostWithRetries(client: Client, newPost: Post): Promise<{created?: Post; lastError?: unknown}> {
+export async function createPostWithRetries(client: Client, newPost: Post, backoffTimes = [1000, 2000, 4000]): Promise<{created?: Post; lastError?: unknown}> {
     let created;
     let lastError;
-    const backoffTimes = [1000, 2000, 4000];
+
     for (let attempt = 0; attempt < backoffTimes.length+1; attempt++) {
         try {
             // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION

#### Summary
Introduced an incremental backoff for sending messages, if a message fails. This saves the user clicking the "retry" when posting the message fails. Nothing visible to the user.

There's a __DEV__ statement to show a toast if the fault is triggered in emulator mode. 

DRYed up the server error handling.

#### Ticket Link

https://github.com/mattermost/mattermost-mobile/issues/8964 Once every few messages, mattermost-mobile on android will fail to send a message. A retry immediately works. See video.

#### Device Information
This PR was tested on: 
Android 15 emulator
Motorola Razr 50 Ultra


#### Release Note

```release-note
Auto-retries sending the message if failure is detected
```