### PR TITLE
[MM-64358] don't save unneeded custom profile attributes

### DIFF
--- a/app/screens/edit_profile/components/form.test.tsx
+++ b/app/screens/edit_profile/components/form.test.tsx
@@ -436,4 +436,197 @@ describe('ProfileForm', () => {
         // Should render as a text field since no field definition exists
         expect(getByTestId('edit_profile_form.customAttributes.unknownField')).toBeTruthy();
     });
+
+    describe('SAML Field Disabling', () => {
+        it('should disable custom fields when SAML-linked', () => {
+            const customFields = [
+                TestHelper.fakeCustomProfileFieldModel({
+                    id: 'saml-field',
+                    name: 'SAML Field',
+                    type: 'text',
+                    attrs: {
+                        saml: 'Department', // SAML-linked
+                    },
+                }),
+                TestHelper.fakeCustomProfileFieldModel({
+                    id: 'normal-field',
+                    name: 'Normal Field',
+                    type: 'text',
+                    attrs: {
+                        saml: '', // Not SAML-linked
+                    },
+                }),
+            ];
+
+            const props = {
+                ...baseProps,
+                enableCustomAttributes: true,
+                customFields,
+                userInfo: {
+                    ...baseProps.userInfo,
+                    customAttributes: {
+                        'saml-field': {
+                            id: 'saml-field',
+                            name: 'SAML Field',
+                            type: 'text',
+                            value: 'Engineering',
+                        },
+                        'normal-field': {
+                            id: 'normal-field',
+                            name: 'Normal Field',
+                            type: 'text',
+                            value: 'Mobile Team',
+                        },
+                    },
+                },
+            };
+
+            const {getByTestId} = renderWithIntl(
+                <ProfileForm {...props}/>,
+            );
+
+            const samlField = getByTestId('edit_profile_form.customAttributes.saml-field.input');
+            const normalField = getByTestId('edit_profile_form.customAttributes.normal-field.input');
+
+            // SAML field should be disabled
+            expect(samlField.props.editable).toBe(false);
+
+            // Normal field should be enabled
+            expect(normalField.props.editable).toBe(true);
+        });
+
+        it('should enable custom fields when SAML attribute is empty', () => {
+            const customFields = [
+                TestHelper.fakeCustomProfileFieldModel({
+                    id: 'normal-field',
+                    name: 'Normal Field',
+                    type: 'text',
+                    attrs: {
+                        saml: '', // Empty SAML attribute
+                    },
+                }),
+            ];
+
+            const props = {
+                ...baseProps,
+                enableCustomAttributes: true,
+                customFields,
+                userInfo: {
+                    ...baseProps.userInfo,
+                    customAttributes: {
+                        'normal-field': {
+                            id: 'normal-field',
+                            name: 'Normal Field',
+                            type: 'text',
+                            value: 'Some value',
+                        },
+                    },
+                },
+            };
+
+            const {getByTestId} = renderWithIntl(
+                <ProfileForm {...props}/>,
+            );
+
+            const normalField = getByTestId('edit_profile_form.customAttributes.normal-field.input');
+            expect(normalField.props.editable).toBe(true);
+        });
+
+        it('should enable custom fields when SAML attribute is missing', () => {
+            const customFields = [
+                TestHelper.fakeCustomProfileFieldModel({
+                    id: 'normal-field',
+                    name: 'Normal Field',
+                    type: 'text',
+                    attrs: {
+
+                        // No saml attribute at all
+                    },
+                }),
+            ];
+
+            const props = {
+                ...baseProps,
+                enableCustomAttributes: true,
+                customFields,
+                userInfo: {
+                    ...baseProps.userInfo,
+                    customAttributes: {
+                        'normal-field': {
+                            id: 'normal-field',
+                            name: 'Normal Field',
+                            type: 'text',
+                            value: 'Some value',
+                        },
+                    },
+                },
+            };
+
+            const {getByTestId} = renderWithIntl(
+                <ProfileForm {...props}/>,
+            );
+
+            const normalField = getByTestId('edit_profile_form.customAttributes.normal-field.input');
+            expect(normalField.props.editable).toBe(true);
+        });
+
+        it('should handle custom fields without field definitions (defaults to enabled)', () => {
+            const props = {
+                ...baseProps,
+                enableCustomAttributes: true,
+                customFields: [], // No field definitions
+                userInfo: {
+                    ...baseProps.userInfo,
+                    customAttributes: {
+                        'unknown-field': {
+                            id: 'unknown-field',
+                            name: 'Unknown Field',
+                            type: 'text',
+                            value: 'Some value',
+                        },
+                    },
+                },
+            };
+
+            const {getByTestId} = renderWithIntl(
+                <ProfileForm {...props}/>,
+            );
+
+            const unknownField = getByTestId('edit_profile_form.customAttributes.unknown-field.input');
+
+            // Should default to enabled when no field definition exists
+            expect(unknownField.props.editable).toBe(true);
+        });
+
+        it('should disable standard profile fields when SAML/LDAP locked', () => {
+            const props = {
+                ...baseProps,
+                currentUser: TestHelper.fakeUserModel({
+                    ...baseProps.currentUser,
+                    authService: 'saml',
+                }),
+                lockedFirstName: true,
+                lockedLastName: false,
+                lockedNickname: true,
+                lockedPosition: false,
+            };
+
+            const {getByTestId} = renderWithIntl(
+                <ProfileForm {...props}/>,
+            );
+
+            const firstNameField = getByTestId('edit_profile_form.firstName.input');
+            const lastNameField = getByTestId('edit_profile_form.lastName.input');
+            const nicknameField = getByTestId('edit_profile_form.nickname.input');
+            const positionField = getByTestId('edit_profile_form.position.input');
+
+            // Locked fields should be disabled
+            expect(firstNameField.props.editable).toBe(false);
+            expect(nicknameField.props.editable).toBe(false);
+
+            // Unlocked fields should be enabled
+            expect(lastNameField.props.editable).toBe(true);
+            expect(positionField.props.editable).toBe(true);
+        });
+    });
 });

--- a/app/screens/edit_profile/components/form.test.tsx
+++ b/app/screens/edit_profile/components/form.test.tsx
@@ -485,7 +485,7 @@ describe('ProfileForm', () => {
                 <ProfileForm {...props}/>,
             );
 
-            const samlField = getByTestId('edit_profile_form.customAttributes.saml-field.input');
+            const samlField = getByTestId('edit_profile_form.customAttributes.saml-field.input.disabled');
             const normalField = getByTestId('edit_profile_form.customAttributes.normal-field.input');
 
             // SAML field should be disabled
@@ -615,9 +615,9 @@ describe('ProfileForm', () => {
                 <ProfileForm {...props}/>,
             );
 
-            const firstNameField = getByTestId('edit_profile_form.firstName.input');
+            const firstNameField = getByTestId('edit_profile_form.firstName.input.disabled');
             const lastNameField = getByTestId('edit_profile_form.lastName.input');
-            const nicknameField = getByTestId('edit_profile_form.nickname.input');
+            const nicknameField = getByTestId('edit_profile_form.nickname.input.disabled');
             const positionField = getByTestId('edit_profile_form.position.input');
 
             // Locked fields should be disabled

--- a/app/screens/edit_profile/components/form.tsx
+++ b/app/screens/edit_profile/components/form.tsx
@@ -87,6 +87,8 @@ const POSITION_FIELD = 'position';
 
 const profileKeys = [FIRST_NAME_FIELD, LAST_NAME_FIELD, USERNAME_FIELD, EMAIL_FIELD, NICKNAME_FIELD, POSITION_FIELD];
 
+export const getFieldKey = (key: string) => `${CUSTOM_ATTRS_PREFIX}.${key}`;
+
 const ProfileForm = ({
     canSave, currentUser, isTablet,
     lockedFirstName, lockedLastName, lockedNickname, lockedPosition,
@@ -107,7 +109,7 @@ const ProfileForm = ({
         const newKeys = Object.keys(userInfo.customAttributes).sort(
             (a: string, b: string): number => {
                 return sortCustomProfileAttributes(userInfo.customAttributes[a], userInfo.customAttributes[b]);
-            }).map((k) => `${CUSTOM_ATTRS_PREFIX}.${k}`);
+            }).map((k) => getFieldKey(k));
 
         return totalCustomAttrs === 0 ? profileKeys : [...profileKeys, ...newKeys];
     }, [userInfo.customAttributes, totalCustomAttrs]);
@@ -171,10 +173,9 @@ const ProfileForm = ({
         // Handle custom attributes - check if SAML linked
         Object.keys(userInfo.customAttributes).forEach((key) => {
             const customField = customFieldsMap.get(key);
-            if (customField && fields[key]) {
-                fields[`${CUSTOM_ATTRS_PREFIX}.${key}`] = {
-                    isDisabled: isCustomFieldSamlLinked(customField),
-                };
+            const fieldKey = getFieldKey(key);
+            if (customField && fields[fieldKey]) {
+                fields[fieldKey].isDisabled = isCustomFieldSamlLinked(customField);
             }
         });
 

--- a/app/screens/edit_profile/components/form.tsx
+++ b/app/screens/edit_profile/components/form.tsx
@@ -10,7 +10,7 @@ import useFieldRefs from '@hooks/field_refs';
 import {t} from '@i18n';
 import {getErrorMessage} from '@utils/errors';
 import {logError} from '@utils/log';
-import {sortCustomProfileAttributes, formatOptionsForSelector} from '@utils/user';
+import {sortCustomProfileAttributes, formatOptionsForSelector, isCustomFieldSamlLinked} from '@utils/user';
 
 import DisabledFields from './disabled_fields';
 import EmailField from './email_field';
@@ -167,8 +167,19 @@ const ProfileForm = ({
                     };
             }
         });
+
+        // Handle custom attributes - check if SAML linked
+        Object.keys(userInfo.customAttributes).forEach((key) => {
+            const customField = customFieldsMap.get(key);
+            if (customField && fields[key]) {
+                fields[`${CUSTOM_ATTRS_PREFIX}.${key}`] = {
+                    isDisabled: isCustomFieldSamlLinked(customField),
+                };
+            }
+        });
+
         return fields;
-    }, [lockedFirstName, lockedLastName, lockedNickname, lockedPosition, currentUser.authService, formKeys, errorMessage]);
+    }, [lockedFirstName, lockedLastName, lockedNickname, lockedPosition, currentUser.authService, formKeys, errorMessage, customFieldsMap, userInfo.customAttributes]);
 
     const onFocusNextField = useCallback(((fieldKey: string) => {
         const findNextField = () => {

--- a/app/screens/edit_profile/components/form.tsx
+++ b/app/screens/edit_profile/components/form.tsx
@@ -99,7 +99,7 @@ const ProfileForm = ({
     const {formatMessage} = intl;
     const errorMessage = error == null ? undefined : getErrorMessage(error, intl) as string;
 
-    const total_custom_attrs = useMemo(() => (
+    const totalCustomAttrs = useMemo(() => (
         enableCustomAttributes ? Object.keys(userInfo.customAttributes).length : 0
     ), [enableCustomAttributes, userInfo.customAttributes]);
 
@@ -109,8 +109,8 @@ const ProfileForm = ({
                 return sortCustomProfileAttributes(userInfo.customAttributes[a], userInfo.customAttributes[b]);
             }).map((k) => `${CUSTOM_ATTRS_PREFIX}.${k}`);
 
-        return total_custom_attrs === 0 ? profileKeys : [...profileKeys, ...newKeys];
-    }, [userInfo.customAttributes, total_custom_attrs]);
+        return totalCustomAttrs === 0 ? profileKeys : [...profileKeys, ...newKeys];
+    }, [userInfo.customAttributes, totalCustomAttrs]);
 
     // Create a map of field definitions for quick lookup
     const customFieldsMap = useMemo(() => {

--- a/app/screens/edit_profile/edit_profile.test.tsx
+++ b/app/screens/edit_profile/edit_profile.test.tsx
@@ -1,11 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+/* eslint-disable max-lines */
 import {act} from '@testing-library/react-hooks';
 import {fireEvent, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 
 import AvailableScreens from '@constants/screens';
 import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+import TestHelper from '@test/test_helper';
 
 import EditProfile from './edit_profile';
 
@@ -621,5 +624,255 @@ describe('EditProfile', () => {
         // Verify the ProfileForm component is rendered (which means customFields was passed)
         const scrollView = screen.getByTestId('edit_profile.scroll_view');
         expect(scrollView).toBeTruthy();
+    });
+
+    describe('SAML Field Handling', () => {
+        const samlLinkedCustomField = TestHelper.fakeCustomProfileFieldModel({
+            id: 'saml-field-1',
+            attrs: {
+                saml: 'Department',
+                sort_order: 1,
+            },
+        });
+
+        const nonSamlCustomField = TestHelper.fakeCustomProfileFieldModel({
+            id: 'normal-field-1',
+            attrs: {
+                saml: '',
+                sort_order: 2,
+            },
+        });
+
+        const customAttributesWithSaml = {
+            'saml-field-1': {
+                id: 'saml-field-1',
+                name: 'Department',
+                value: 'Engineering',
+                type: 'text',
+                sort_order: 1,
+            },
+            'normal-field-1': {
+                id: 'normal-field-1',
+                name: 'Team',
+                value: 'Mobile',
+                type: 'text',
+                sort_order: 2,
+            },
+        };
+
+        beforeEach(() => {
+            // Mock successful fetch
+            mockFetchCustomProfileAttributes.mockResolvedValue({
+                attributes: customAttributesWithSaml,
+                error: undefined,
+            });
+        });
+
+        it('should not submit SAML-linked custom fields during profile update', async () => {
+            const {getByTestId} = renderWithIntlAndTheme(
+                <EditProfile
+                    componentId={AvailableScreens.EDIT_PROFILE}
+                    currentUser={mockCurrentUser}
+                    isModal={false}
+                    isTablet={true}
+                    lockedFirstName={false}
+                    lockedLastName={false}
+                    lockedNickname={false}
+                    lockedPosition={false}
+                    lockedPicture={false}
+                    enableCustomAttributes={true}
+                    customFields={[samlLinkedCustomField, nonSamlCustomField]}
+                    customAttributesSet={customAttributesWithSaml}
+                />,
+            );
+
+            // Wait for component to load
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, 100));
+            });
+
+            // Modify the non-SAML field
+            const customAttributeItems = await screen.findAllByTestId(new RegExp('^edit_profile_form.customAttributes.*input$'));
+            const nonSamlFieldInput = customAttributeItems.find((item) =>
+                item.props.testID.includes('normal-field-1'),
+            );
+
+            if (nonSamlFieldInput) {
+                await act(async () => {
+                    fireEvent.changeText(nonSamlFieldInput, 'Updated Mobile Team');
+                });
+            }
+
+            // Trigger form submission
+            const saveButton = getByTestId('edit_profile.save.button');
+            await act(async () => {
+                fireEvent.press(saveButton);
+            });
+
+            // Verify that updateCustomProfileAttributes was called only with non-SAML fields
+            expect(mockUpdateCustomProfileAttributes).toHaveBeenCalledWith(
+                'http://localhost:8065',
+                'user1',
+                expect.objectContaining({
+                    'normal-field-1': expect.objectContaining({
+                        value: 'Updated Mobile Team',
+                    }),
+                }),
+            );
+
+            // Verify SAML field was not included
+            const lastCall = mockUpdateCustomProfileAttributes.mock.calls[mockUpdateCustomProfileAttributes.mock.calls.length - 1];
+            const submittedAttributes = lastCall[2];
+            expect(submittedAttributes).not.toHaveProperty('saml-field-1');
+        });
+
+        it('should not submit SAML-locked standard profile fields', async () => {
+            const mockUpdateMe = jest.fn().mockResolvedValue({error: undefined});
+            jest.doMock('@actions/remote/user', () => ({
+                updateMe: mockUpdateMe,
+                uploadUserProfileImage: jest.fn().mockResolvedValue({error: undefined}),
+                setDefaultProfileImage: jest.fn().mockResolvedValue({}),
+                buildProfileImageUrlFromUser: jest.fn().mockReturnValue('http://example.com/profile.jpg'),
+            }));
+
+            const {getByTestId} = renderWithIntlAndTheme(
+                <EditProfile
+                    componentId={AvailableScreens.EDIT_PROFILE}
+                    currentUser={mockCurrentUser}
+                    isModal={false}
+                    isTablet={true}
+                    lockedFirstName={true} // SAML-locked
+                    lockedLastName={false}
+                    lockedNickname={true} // SAML-locked
+                    lockedPosition={false}
+                    lockedPicture={false}
+                    enableCustomAttributes={false}
+                    customFields={[]}
+                    customAttributesSet={{}}
+                />,
+            );
+
+            // Modify unlocked fields
+            const lastNameField = getByTestId('edit_profile_form.lastName.input');
+            const positionField = getByTestId('edit_profile_form.position.input');
+
+            await act(async () => {
+                fireEvent.changeText(lastNameField, 'Updated Doe');
+                fireEvent.changeText(positionField, 'Senior Developer');
+            });
+
+            // Trigger form submission
+            const saveButton = getByTestId('edit_profile.save.button');
+            await act(async () => {
+                fireEvent.press(saveButton);
+            });
+
+            // Verify updateMe was called with only unlocked fields
+            expect(mockUpdateMe).toHaveBeenCalledWith(
+                'http://localhost:8065',
+                expect.objectContaining({
+                    last_name: 'Updated Doe',
+                    position: 'Senior Developer',
+                }),
+            );
+
+            // Verify locked fields were not included
+            const lastCall = mockUpdateMe.mock.calls[mockUpdateMe.mock.calls.length - 1];
+            const submittedUserInfo = lastCall[1];
+            expect(submittedUserInfo).not.toHaveProperty('first_name');
+            expect(submittedUserInfo).not.toHaveProperty('nickname');
+        });
+
+        it('should only submit fields that have actually changed', async () => {
+            const mockUpdateMe = jest.fn().mockResolvedValue({error: undefined});
+            jest.doMock('@actions/remote/user', () => ({
+                updateMe: mockUpdateMe,
+                uploadUserProfileImage: jest.fn().mockResolvedValue({error: undefined}),
+                setDefaultProfileImage: jest.fn().mockResolvedValue({}),
+                buildProfileImageUrlFromUser: jest.fn().mockReturnValue('http://example.com/profile.jpg'),
+            }));
+
+            const {getByTestId} = renderWithIntlAndTheme(
+                <EditProfile
+                    componentId={AvailableScreens.EDIT_PROFILE}
+                    currentUser={mockCurrentUser}
+                    isModal={false}
+                    isTablet={true}
+                    lockedFirstName={false}
+                    lockedLastName={false}
+                    lockedNickname={false}
+                    lockedPosition={false}
+                    lockedPicture={false}
+                    enableCustomAttributes={false}
+                    customFields={[]}
+                    customAttributesSet={{}}
+                />,
+            );
+
+            // Only modify the position field (leave others unchanged)
+            const positionField = getByTestId('edit_profile_form.position.input');
+            await act(async () => {
+                fireEvent.changeText(positionField, 'Lead Developer');
+            });
+
+            // Trigger form submission
+            const saveButton = getByTestId('edit_profile.save.button');
+            await act(async () => {
+                fireEvent.press(saveButton);
+            });
+
+            // Verify updateMe was called with only the changed field
+            expect(mockUpdateMe).toHaveBeenCalledWith(
+                'http://localhost:8065',
+                expect.objectContaining({
+                    position: 'Lead Developer',
+                }),
+            );
+
+            // Verify unchanged fields were not included
+            const lastCall = mockUpdateMe.mock.calls[mockUpdateMe.mock.calls.length - 1];
+            const submittedUserInfo = lastCall[1];
+            expect(submittedUserInfo).not.toHaveProperty('first_name');
+            expect(submittedUserInfo).not.toHaveProperty('last_name');
+            expect(submittedUserInfo).not.toHaveProperty('nickname');
+            expect(submittedUserInfo).not.toHaveProperty('email');
+            expect(submittedUserInfo).not.toHaveProperty('username');
+        });
+
+        it('should skip user profile update when no fields have changed or all changed fields are locked', async () => {
+            const mockUpdateMe = jest.fn().mockResolvedValue({error: undefined});
+            jest.doMock('@actions/remote/user', () => ({
+                updateMe: mockUpdateMe,
+                uploadUserProfileImage: jest.fn().mockResolvedValue({error: undefined}),
+                setDefaultProfileImage: jest.fn().mockResolvedValue({}),
+                buildProfileImageUrlFromUser: jest.fn().mockReturnValue('http://example.com/profile.jpg'),
+            }));
+
+            const {getByTestId} = renderWithIntlAndTheme(
+                <EditProfile
+                    componentId={AvailableScreens.EDIT_PROFILE}
+                    currentUser={mockCurrentUser}
+                    isModal={false}
+                    isTablet={true}
+                    lockedFirstName={true}
+                    lockedLastName={true}
+                    lockedNickname={true}
+                    lockedPosition={true}
+                    lockedPicture={false}
+                    enableCustomAttributes={false}
+                    customFields={[]}
+                    customAttributesSet={{}}
+                />,
+            );
+
+            // Try to modify locked fields (should not trigger submission)
+            const saveButton = getByTestId('edit_profile.save.button');
+            await act(async () => {
+                fireEvent.press(saveButton);
+            });
+
+            // Verify updateMe was not called since no unlocked fields changed
+            expect(mockUpdateMe).not.toHaveBeenCalled();
+        });
     });
 });

--- a/app/screens/edit_profile/edit_profile.tsx
+++ b/app/screens/edit_profile/edit_profile.tsx
@@ -21,12 +21,15 @@ import SecurityManager from '@managers/security_manager';
 import {dismissModal, popTopScreen, setButtons} from '@screens/navigation';
 import {logError} from '@utils/log';
 import {preventDoubleTap} from '@utils/tap';
+import {isCustomFieldSamlLinked} from '@utils/user';
 
 import ProfileForm, {CUSTOM_ATTRS_PREFIX} from './components/form';
 import ProfileError from './components/profile_error';
 import Updating from './components/updating';
 import UserProfilePicture from './components/user_profile_picture';
 
+import type {CustomProfileFieldModel} from '@database/models/server';
+import type {CustomAttributeSet} from '@typings/api/custom_profile_attributes';
 import type {EditProfileProps, NewProfileImage, UserInfo} from '@typings/screens/edit_profile';
 
 const edges: Edge[] = ['bottom', 'left', 'right'];
@@ -157,14 +160,29 @@ const EditProfile = ({
         setError(undefined);
         setUpdating(true);
         try {
-            const newUserInfo: Partial<UserProfile> = {
-                email: userInfo.email.trim(),
-                first_name: userInfo.firstName.trim(),
-                last_name: userInfo.lastName.trim(),
-                nickname: userInfo.nickname.trim(),
-                position: userInfo.position.trim(),
-                username: userInfo.username.trim(),
-            };
+            // Build update object with only changed and unlocked fields
+            const newUserInfo: Partial<UserProfile> = {};
+
+            // Only include fields that have changed and are not locked by SAML
+            if (userInfo.email.trim() !== currentUser.email && !currentUser.authService) {
+                newUserInfo.email = userInfo.email.trim();
+            }
+            if (userInfo.firstName.trim() !== currentUser.firstName && !lockedFirstName) {
+                newUserInfo.first_name = userInfo.firstName.trim();
+            }
+            if (userInfo.lastName.trim() !== currentUser.lastName && !lockedLastName) {
+                newUserInfo.last_name = userInfo.lastName.trim();
+            }
+            if (userInfo.nickname.trim() !== currentUser.nickname && !lockedNickname) {
+                newUserInfo.nickname = userInfo.nickname.trim();
+            }
+            if (userInfo.position.trim() !== currentUser.position && !lockedPosition) {
+                newUserInfo.position = userInfo.position.trim();
+            }
+            if (userInfo.username.trim() !== currentUser.username && !currentUser.authService) {
+                newUserInfo.username = userInfo.username.trim();
+            }
+
             const localPath = changedProfilePicture.current?.localPath;
             const profileImageRemoved = changedProfilePicture.current?.isRemoved;
             if (localPath) {
@@ -179,16 +197,55 @@ const EditProfile = ({
                 await setDefaultProfileImage(serverUrl, currentUser.id);
             }
 
-            if (hasUpdateUserInfo.current) {
+            // Only update user info if there are actually changes to unlocked fields
+            if (Object.keys(newUserInfo).length > 0) {
                 const {error: reqError} = await updateMe(serverUrl, newUserInfo);
                 if (reqError) {
                     resetScreenForProfileError(reqError);
                     return;
                 }
+            }
 
-                // Update custom attributes if changed
-                if (userInfo.customAttributes && enableCustomAttributes) {
-                    const {error: attrError} = await updateCustomProfileAttributes(serverUrl, currentUser.id, userInfo.customAttributes);
+            // Update custom attributes if changed and not SAML-linked
+            if (userInfo.customAttributes && enableCustomAttributes) {
+                // Create a map of custom fields for quick lookup
+                const customFieldsMap = new Map<string, CustomProfileFieldModel>();
+                customFields?.forEach((field) => {
+                    customFieldsMap.set(field.id, field);
+                });
+
+                // Only send custom attributes that have actually changed and are not SAML-linked
+                const changedCustomAttributes: CustomAttributeSet = {};
+                let hasCustomAttributeChanges = false;
+
+                if (customAttributesSet) {
+                    Object.keys(userInfo.customAttributes).forEach((key) => {
+                        const currentValue = customAttributesSet[key]?.value || '';
+                        const newValue = userInfo.customAttributes[key]?.value || '';
+                        const customAttribute = userInfo.customAttributes[key];
+                        const customField = customFieldsMap.get(customAttribute?.id);
+
+                        // Only include if value changed and field is not SAML-linked
+                        if (currentValue !== newValue && !isCustomFieldSamlLinked(customField)) {
+                            changedCustomAttributes[key] = userInfo.customAttributes[key];
+                            hasCustomAttributeChanges = true;
+                        }
+                    });
+                } else {
+                    // If no original custom attributes, send all current non-SAML-linked ones
+                    Object.keys(userInfo.customAttributes).forEach((key) => {
+                        const customAttribute = userInfo.customAttributes[key];
+                        const customField = customFieldsMap.get(customAttribute?.id);
+
+                        if (!isCustomFieldSamlLinked(customField)) {
+                            changedCustomAttributes[key] = userInfo.customAttributes[key];
+                            hasCustomAttributeChanges = true;
+                        }
+                    });
+                }
+
+                if (hasCustomAttributeChanges) {
+                    const {error: attrError} = await updateCustomProfileAttributes(serverUrl, currentUser.id, changedCustomAttributes);
                     if (attrError) {
                         logError('Error updating custom attributes', attrError);
                         resetScreenForProfileError(attrError);
@@ -201,7 +258,7 @@ const EditProfile = ({
         } catch (e) {
             resetScreen(e);
         }
-    }), [userInfo, enableSaveButton]);
+    }), [userInfo, enableSaveButton, currentUser, lockedFirstName, lockedLastName, lockedNickname, lockedPosition, customAttributesSet, enableCustomAttributes, customFields, serverUrl]);
 
     useAndroidHardwareBackHandler(componentId, close);
     useNavButtonPressed(UPDATE_BUTTON_ID, componentId, submitUser, [userInfo]);

--- a/app/screens/edit_profile/edit_profile.tsx
+++ b/app/screens/edit_profile/edit_profile.tsx
@@ -216,35 +216,20 @@ const EditProfile = ({
 
                 // Only send custom attributes that have actually changed and are not SAML-linked
                 const changedCustomAttributes: CustomAttributeSet = {};
-                let hasCustomAttributeChanges = false;
 
-                if (customAttributesSet) {
-                    Object.keys(userInfo.customAttributes).forEach((key) => {
-                        const currentValue = customAttributesSet[key]?.value || '';
-                        const newValue = userInfo.customAttributes[key]?.value || '';
-                        const customAttribute = userInfo.customAttributes[key];
-                        const customField = customFieldsMap.get(customAttribute?.id);
+                Object.keys(userInfo.customAttributes).forEach((key) => {
+                    const currentValue = (customAttributesSet && customAttributesSet[key]?.value) || '';
+                    const newValue = userInfo.customAttributes[key]?.value || '';
+                    const customAttribute = userInfo.customAttributes[key];
+                    const customField = customFieldsMap.get(customAttribute?.id);
 
-                        // Only include if value changed and field is not SAML-linked
-                        if (currentValue !== newValue && !isCustomFieldSamlLinked(customField)) {
-                            changedCustomAttributes[key] = userInfo.customAttributes[key];
-                            hasCustomAttributeChanges = true;
-                        }
-                    });
-                } else {
-                    // If no original custom attributes, send all current non-SAML-linked ones
-                    Object.keys(userInfo.customAttributes).forEach((key) => {
-                        const customAttribute = userInfo.customAttributes[key];
-                        const customField = customFieldsMap.get(customAttribute?.id);
+                    // Only include if value changed and field is not SAML-linked
+                    if (currentValue !== newValue && !isCustomFieldSamlLinked(customField)) {
+                        changedCustomAttributes[key] = userInfo.customAttributes[key];
+                    }
+                });
 
-                        if (!isCustomFieldSamlLinked(customField)) {
-                            changedCustomAttributes[key] = userInfo.customAttributes[key];
-                            hasCustomAttributeChanges = true;
-                        }
-                    });
-                }
-
-                if (hasCustomAttributeChanges) {
+                if (Object.keys(changedCustomAttributes).length > 0) {
                     const {error: attrError} = await updateCustomProfileAttributes(serverUrl, currentUser.id, changedCustomAttributes);
                     if (attrError) {
                         logError('Error updating custom attributes', attrError);

--- a/app/utils/user/index.ts
+++ b/app/utils/user/index.ts
@@ -706,3 +706,7 @@ export const convertValueFromServer = (value: string | string[], fieldType: stri
 
     return String(value);
 };
+
+export const isCustomFieldSamlLinked = (customField?: CustomProfileFieldModel): boolean => {
+    return Boolean(customField?.attrs?.saml);
+};

--- a/types/api/custom_profile_attributes.d.ts
+++ b/types/api/custom_profile_attributes.d.ts
@@ -22,6 +22,7 @@ type CustomProfileField = {
     /** any extra properties of the field **/
     attrs?: {
         sort_order?: number;
+        saml?: string;
         [key: string]: unknown;
     };
 


### PR DESCRIPTION
#### Summary

Previously it was saving everythin wether it changed or not, this caused some issues when something in the profile is linked via saml

#### Ticket Link

https://mattermost.atlassian.net/issues/MM-64358

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: iPhone 13 pro using Hub

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
fix error when saving non-editable custom profile attributes
```
