### PR TITLE
Edit mode when no text and no attachment on save calls delete post

### DIFF
--- a/app/components/autocomplete/autocomplete.tsx
+++ b/app/components/autocomplete/autocomplete.tsx
@@ -59,9 +59,8 @@ type Props = {
     isAppsEnabled: boolean;
     nestedScrollEnabled?: boolean;
     updateValue: (v: string) => void;
-    hasFilesAttached?: boolean;
+    shouldDirectlyReact?: boolean;
     availableSpace: SharedValue<number>;
-    inPost?: boolean;
     growDown?: boolean;
     teamId?: string;
     containerStyle?: StyleProp<ViewStyle>;
@@ -80,8 +79,7 @@ const Autocomplete = ({
     isAppsEnabled,
     nestedScrollEnabled = false,
     updateValue,
-    hasFilesAttached,
-    inPost = false,
+    shouldDirectlyReact = false,
     growDown = false,
     containerStyle,
     teamId,
@@ -178,8 +176,7 @@ const Autocomplete = ({
                         value={value || ''}
                         nestedScrollEnabled={nestedScrollEnabled}
                         rootId={rootId}
-                        hasFilesAttached={hasFilesAttached}
-                        inPost={inPost}
+                        shouldDirectlyReact={shouldDirectlyReact}
                     />
                 }
                 {showCommands && channelId &&

--- a/app/components/autocomplete/emoji_suggestion/emoji_suggestion.tsx
+++ b/app/components/autocomplete/emoji_suggestion/emoji_suggestion.tsx
@@ -70,8 +70,7 @@ type Props = {
     value: string;
     nestedScrollEnabled: boolean;
     skinTone: string;
-    hasFilesAttached?: boolean;
-    inPost: boolean;
+    shouldDirectlyReact?: boolean;
     listStyle: StyleProp<ViewStyle>;
 }
 const EmojiSuggestion = ({
@@ -83,8 +82,7 @@ const EmojiSuggestion = ({
     value,
     nestedScrollEnabled,
     skinTone,
-    hasFilesAttached = false,
-    inPost,
+    shouldDirectlyReact = false,
     listStyle,
 }: Props) => {
     const insets = useSafeAreaInsets();
@@ -118,7 +116,7 @@ const EmojiSuggestion = ({
     const showingElements = Boolean(data.length);
 
     const completeSuggestion = useCallback((emoji: string) => {
-        if (!hasFilesAttached && inPost) {
+        if (shouldDirectlyReact) {
             const match = value.match(REACTION_REGEX);
             if (match) {
                 handleReactionToLatestPost(serverUrl, emoji, match[1] === '+', rootId);
@@ -160,7 +158,7 @@ const EmojiSuggestion = ({
                 updateValue(completedDraft.replace(`::${emoji}: `, `:${emoji}: `));
             });
         }
-    }, [value, updateValue, rootId, cursorPosition, hasFilesAttached]);
+    }, [value, updateValue, rootId, cursorPosition, shouldDirectlyReact]);
 
     const renderItem = useCallback(({item}: {item: string}) => {
         const completeItemSuggestion = () => completeSuggestion(item);

--- a/app/components/post_draft/post_draft.tsx
+++ b/app/components/post_draft/post_draft.tsx
@@ -117,8 +117,7 @@ function PostDraft({
             cursorPosition={cursorPosition}
             value={value}
             isSearch={isSearch}
-            hasFilesAttached={Boolean(files?.length)}
-            inPost={true}
+            shouldDirectlyReact={!Boolean(files?.length)}
             availableSpace={animatedAutocompleteAvailableSpace}
             serverUrl={serverUrl}
         />

--- a/app/screens/create_or_edit_channel/channel_info_form.tsx
+++ b/app/screens/create_or_edit_channel/channel_info_form.tsx
@@ -400,7 +400,7 @@ export default function ChannelInfoForm({
                 value={header}
                 nestedScrollEnabled={true}
                 availableSpace={animatedAutocompleteAvailableSpace}
-                inPost={false}
+                shouldDirectlyReact={false}
                 growDown={growDown}
             />
         </SafeAreaView>

--- a/app/screens/edit_post/edit_post.test.tsx
+++ b/app/screens/edit_post/edit_post.test.tsx
@@ -96,7 +96,7 @@ describe('Edit Post', () => {
             metadata: {},
         } as PostModel,
         maxPostSize: TEST_CONFIG.maxPostSize,
-        hasFilesAttached: true,
+
         canDelete: true,
         files: [TEST_FILES.existingFile1, TEST_FILES.existingFile2],
         maxFileCount: TEST_CONFIG.maxFileCount,

--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -101,7 +101,7 @@ const EditPost = ({
     const intl = useIntl();
     const serverUrl = useServerUrl();
 
-    const shouldDeleteOnSave = !postMessage && canDelete && !hasFilesAttached;
+    const shouldDeleteOnSave = !postMessage && canDelete && postFiles.length === 0;
 
     const shouldEnableSaveButton = useCallback(() => {
         const loadingFiles = postFiles.filter((v) => v.clientId && DraftEditPostUploadManager.isUploading(v.clientId));

--- a/app/screens/edit_post/edit_post.tsx
+++ b/app/screens/edit_post/edit_post.tsx
@@ -63,7 +63,6 @@ type EditPostProps = {
     closeButtonId: string;
     post: PostModel;
     maxPostSize: number;
-    hasFilesAttached: boolean;
     canDelete: boolean;
     files?: FileInfo[];
     maxFileCount: number;
@@ -76,7 +75,6 @@ const EditPost = ({
     maxPostSize,
     post,
     closeButtonId,
-    hasFilesAttached,
     canDelete,
     files,
     maxFileCount,
@@ -101,7 +99,8 @@ const EditPost = ({
     const intl = useIntl();
     const serverUrl = useServerUrl();
 
-    const shouldDeleteOnSave = !postMessage && canDelete && postFiles.length === 0;
+    const hasNoCurrentFiles = postFiles.length === 0;
+    const shouldDeleteOnSave = !postMessage && canDelete && hasNoCurrentFiles;
 
     const shouldEnableSaveButton = useCallback(() => {
         const loadingFiles = postFiles.filter((v) => v.clientId && DraftEditPostUploadManager.isUploading(v.clientId));
@@ -479,7 +478,7 @@ const EditPost = ({
             </SafeAreaView>
             <Autocomplete
                 channelId={post.channelId}
-                hasFilesAttached={hasFilesAttached}
+                shouldDirectlyReact={false}
                 nestedScrollEnabled={true}
                 rootId={post.rootId}
                 updateValue={onAutocompleteChangeText}
@@ -487,7 +486,6 @@ const EditPost = ({
                 cursorPosition={cursorPosition}
                 position={animatedAutocompletePosition}
                 availableSpace={animatedAutocompleteAvailableSpace}
-                inPost={false}
                 serverUrl={serverUrl}
             />
         </EditPostProvider>

--- a/app/screens/edit_post/index.test.tsx
+++ b/app/screens/edit_post/index.test.tsx
@@ -70,7 +70,6 @@ describe('EditPost', () => {
             expect(editPost.props.maxFileCount).toBe(10);
             expect(editPost.props.maxFileSize).toBe(1000);
             expect(editPost.props.canUploadFiles).toBe(true);
-            expect(editPost.props.hasFilesAttached).toBe(false);
         });
     });
 });

--- a/app/screens/edit_post/index.tsx
+++ b/app/screens/edit_post/index.tsx
@@ -2,30 +2,23 @@
 // See LICENSE.txt for license information.
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
 
 import {DEFAULT_SERVER_MAX_FILE_SIZE, MAX_MESSAGE_LENGTH_FALLBACK} from '@constants/post_draft';
-import {observeFilesForPost} from '@queries/servers/file';
 import {observeCanUploadFiles} from '@queries/servers/security';
 import {observeConfigIntValue, observeMaxFileCount} from '@queries/servers/system';
 
 import EditPost from './edit_post';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
-import type PostModel from '@typings/database/models/servers/post';
 
-const enhance = withObservables([], ({database, post}: WithDatabaseArgs & { post: PostModel}) => {
+const enhance = withObservables([], ({database}: WithDatabaseArgs) => {
     const maxPostSize = observeConfigIntValue(database, 'MaxPostSize', MAX_MESSAGE_LENGTH_FALLBACK);
     const canUploadFiles = observeCanUploadFiles(database);
     const maxFileSize = observeConfigIntValue(database, 'MaxFileSize', DEFAULT_SERVER_MAX_FILE_SIZE);
     const maxFileCount = observeMaxFileCount(database);
 
-    const hasFilesAttached = observeFilesForPost(database, post.id).pipe(switchMap((files) => of$(files?.length > 0)));
-
     return {
         maxPostSize,
-        hasFilesAttached,
         canUploadFiles,
         maxFileSize,
         maxFileCount,

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -471,7 +471,7 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
                 cursorPosition={cursorPosition}
                 value={searchValue}
                 isSearch={true}
-                hasFilesAttached={false}
+                shouldDirectlyReact={false}
                 availableSpace={autocompleteMaxHeight}
                 position={autocompletePosition}
                 growDown={true}


### PR DESCRIPTION
#### Summary
The issue was in the edit post functionality, where users editing a post with file attachments but no text would incorrectly see a delete confirmation dialog when clicking save, instead of being able to save the post with just the attachments. This happened because the code was checking whether the post originally had files attached rather than checking the current state of files in the post editor. The fix involved changing the logic to check the current file state instead of the original post state, ensuring that posts with attachments but no text will save normally, while truly empty posts with no text and no files will still appropriately trigger the delete confirmation dialog. This simple change resolved the user experience issue where legitimate posts containing only file attachments were being treated as candidates for deletion.

#### Note: 
The tests for testing this scenario were becoming complex. Will create a ticket for taking this up later. 


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64806

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
