### PR TITLE
Fix stale search results when files are deleted from posts

### DIFF
--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -374,6 +374,15 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
         }
     }, [isFocused]);
 
+    useDidUpdate(() => {
+        if (isFocused && lastSearchedValue && showResults) {
+            // Use requestAnimationFrame for smooth UI updates
+            requestAnimationFrame(() => {
+                handleSearch(searchTeamId, lastSearchedValue);
+            });
+        }
+    }, [isFocused, lastSearchedValue, showResults, handleSearch, searchTeamId]);
+
     const handleEnterPressed = useCallback(() => {
         const topScreen = NavigationStore.getVisibleScreen();
         if (topScreen === Screens.HOME && isFocused) {

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -376,7 +376,7 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
 
     useDidUpdate(() => {
         if (isFocused && lastSearchedValue && showResults) {
-            // Use requestAnimationFrame for smooth UI updates
+            // requestAnimationFrame for smooth UI updates
             requestAnimationFrame(() => {
                 handleSearch(searchTeamId, lastSearchedValue);
             });


### PR DESCRIPTION
#### Summary
Problem
When users search for files, navigate away to delete files from posts, and then return to the search screen, the deleted files still appear in the cached search results. This creates a confusing user experience where users see files that no longer exist.
Steps to reproduce:
- Search for files (e.g., files with the name "ABC")
- Navigate to a channel containing one of the found files
- Edit the post and remove the file
- Navigate back to the search screen
- ❌ The deleted file still appears in search results

Solution
Added automatic search result refresh when users return to the search screen. The implementation uses `requestAnimationFrame` to ensure optimal timing and smooth UI updates.
How it works:
- When you go back to the search screen, the app automatically checks for updated results
- It re-runs your previous search to get the latest information
- Any files that were deleted will no longer appear in the results
- ✅ You always see current, accurate search results

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64664

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
