### PR TITLE
Purge playbooks data when the plugin gets disabled

### DIFF
--- a/app/products/playbooks/actions/local/version.ts
+++ b/app/products/playbooks/actions/local/version.ts
@@ -3,6 +3,7 @@
 
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
+import {PLAYBOOK_TABLES} from '@playbooks/constants/database';
 
 export const setPlaybooksVersion = async (serverUrl: string, version: string) => {
     try {
@@ -15,8 +16,31 @@ export const setPlaybooksVersion = async (serverUrl: string, version: string) =>
             prepareRecordsOnly: false,
         });
 
+        if (version === '') {
+            await purgePlaybooks(serverUrl);
+        }
+
         return {data: true};
     } catch (error) {
         return {error};
     }
+};
+
+const purgePlaybooks = async (serverUrl: string) => {
+    try {
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        await database.write(() => {
+            return database.adapter.unsafeExecute({
+                sqls: [
+                    [`DELETE FROM ${PLAYBOOK_TABLES.PLAYBOOK_RUN}`, []],
+                    [`DELETE FROM ${PLAYBOOK_TABLES.PLAYBOOK_CHECKLIST}`, []],
+                    [`DELETE FROM ${PLAYBOOK_TABLES.PLAYBOOK_CHECKLIST_ITEM}`, []],
+                ],
+            });
+        });
+    } catch (error) {
+        return {error};
+    }
+
+    return {data: true};
 };

--- a/app/products/playbooks/actions/local/version.ts
+++ b/app/products/playbooks/actions/local/version.ts
@@ -17,7 +17,10 @@ export const setPlaybooksVersion = async (serverUrl: string, version: string) =>
         });
 
         if (version === '') {
-            await purgePlaybooks(serverUrl);
+            const {error} = await purgePlaybooks(serverUrl);
+            if (error) {
+                return {error};
+            }
         }
 
         return {data: true};


### PR DESCRIPTION
#### Summary
We want to remove the playbooks information as soon as the user does not have access to it. To do so, we remove all the information the moment the we notice the plugin is not longer enabled.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-64803

#### Release Note
```release-note
NONE
```
