### PR TITLE
Update app to target Android 15 (API level 35)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         supportLibVersion = "35.0.0"
         kotlinVersion = "1.9.25"
         kotlin_version = kotlinVersion


### PR DESCRIPTION
App must target Android 15 (API level 35) or higher

**Status**: You won't be able to release app updates
**Deadline**: Nov 1, 2025

To provide users with a safe and secure experience, Google Play requires all apps to meet target API level requirements.

From Nov 1, 2025, if your target API level is not within 1 year of the latest Android release, you won't be able to update your app.

How to fix
 - Your highest non-compliant target API level is Android 14 (API level 34).
 - To ensure that you can continue to make updates to your app you must update your app to target Android 15 (API level 35) or higher.

Once you've done this, we'll send you an Inbox message to confirm that your app update was successful, and that your app is no longer affected.

For more information:
 - [Learn more about the requirements](https://support.google.com/googleplay/android-developer/answer/11926878)
 - [Learn how to update your app](https://support.google.com/googleplay/android-developer/answer/9859350)
 - [Learn what changes you may need to make in your app](https://developer.android.com/google/play/requirements/target-sdk)
 - [Read the policy announcement](https://support.google.com/googleplay/android-developer/answer/13411745)

```release-note
NONE
```
