### PR TITLE
Fix tables on playbook runs

### DIFF
--- a/app/products/playbooks/screens/playbook_run/playbook_run.tsx
+++ b/app/products/playbooks/screens/playbook_run/playbook_run.tsx
@@ -115,6 +115,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => ({
     scrollView: {
         paddingHorizontal: 20,
     },
+    markdownContainer: {
+        width: '100%',
+    },
 }));
 
 type Props = {
@@ -197,14 +200,16 @@ export default function PlaybookRun({
                                     size='m'
                                 />
                             )}
-                            <Markdown
-                                value={playbookRun.summary}
-                                theme={theme}
-                                location={componentId}
-                                baseTextStyle={styles.infoText}
-                                blockStyles={getMarkdownBlockStyles(theme)}
-                                textStyles={getMarkdownTextStyles(theme)}
-                            />
+                            <View style={styles.markdownContainer}>
+                                <Markdown
+                                    value={playbookRun.summary}
+                                    theme={theme}
+                                    location={componentId}
+                                    baseTextStyle={styles.infoText}
+                                    blockStyles={getMarkdownBlockStyles(theme)}
+                                    textStyles={getMarkdownTextStyles(theme)}
+                                />
+                            </View>
                         </View>
                         {(owner || participants.length > 0) && (
                             <View


### PR DESCRIPTION
#### Summary
Tables were not being properly shown on playbook runs descriptions. This is due to the Markdown component must be surrounded by a sized width view.

This also fix some scrolling problems we were seeing.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-64773
Fix https://mattermost.atlassian.net/browse/MM-64761

#### Release Note
```release-note
NONE
```
