### PR TITLE
Fix progress numbers on playbook runs

### DIFF
--- a/app/products/playbooks/screens/playbook_run/checklist/checklist.test.tsx
+++ b/app/products/playbooks/screens/playbook_run/checklist/checklist.test.tsx
@@ -49,7 +49,7 @@ describe('Checklist', () => {
             playbookRunId: 'run-id-1',
             isFinished: false,
             isParticipant: true,
-            checkListProgress: {
+            checklistProgress: {
                 skipped: false,
                 completed: 0,
                 totalNumber: 0,
@@ -60,8 +60,8 @@ describe('Checklist', () => {
 
     it('renders checklist header correctly', () => {
         const props = getBaseProps();
-        props.checkListProgress.completed = 1;
-        props.checkListProgress.totalNumber = 2;
+        props.checklistProgress.completed = 1;
+        props.checklistProgress.totalNumber = 2;
 
         const {getByText} = renderWithIntl(<Checklist {...props}/>);
 
@@ -102,15 +102,15 @@ describe('Checklist', () => {
 
     it('shows correct progress for completed and skippeditems', () => {
         const props = getBaseProps();
-        props.checkListProgress.completed = 2;
-        props.checkListProgress.totalNumber = 2;
+        props.checklistProgress.completed = 2;
+        props.checklistProgress.totalNumber = 2;
 
         const {getByText, rerender} = renderWithIntl(<Checklist {...props}/>);
 
         expect(getByText('2 / 2 done')).toBeTruthy();
 
-        props.checkListProgress.completed = 1;
-        props.checkListProgress.totalNumber = 2;
+        props.checklistProgress.completed = 1;
+        props.checklistProgress.totalNumber = 2;
 
         rerender(<Checklist {...props}/>);
 
@@ -205,7 +205,7 @@ describe('Checklist', () => {
     it('passes the correct props to the ProgressBar', () => {
         const props = getBaseProps();
         props.isFinished = false;
-        props.checkListProgress.progress = 0;
+        props.checklistProgress.progress = 0;
 
         const {getByTestId, rerender} = renderWithIntl(<Checklist {...props}/>);
 
@@ -214,14 +214,14 @@ describe('Checklist', () => {
         expect(progressBar.props.isActive).toBe(true);
 
         props.isFinished = true;
-        props.checkListProgress.progress = 50;
+        props.checklistProgress.progress = 50;
 
         rerender(<Checklist {...props}/>);
 
         expect(progressBar.props.progress).toBe(50);
         expect(progressBar.props.isActive).toBe(false);
 
-        props.checkListProgress.progress = 100;
+        props.checklistProgress.progress = 100;
         rerender(<Checklist {...props}/>);
 
         expect(progressBar.props.progress).toBe(100);

--- a/app/products/playbooks/screens/playbook_run/checklist/checklist.test.tsx
+++ b/app/products/playbooks/screens/playbook_run/checklist/checklist.test.tsx
@@ -49,11 +49,20 @@ describe('Checklist', () => {
             playbookRunId: 'run-id-1',
             isFinished: false,
             isParticipant: true,
+            checkListProgress: {
+                skipped: false,
+                completed: 0,
+                totalNumber: 0,
+                progress: 0,
+            },
         };
     }
 
     it('renders checklist header correctly', () => {
         const props = getBaseProps();
+        props.checkListProgress.completed = 1;
+        props.checkListProgress.totalNumber = 2;
+
         const {getByText} = renderWithIntl(<Checklist {...props}/>);
 
         expect(getByText('Test Checklist')).toBeTruthy();
@@ -93,40 +102,16 @@ describe('Checklist', () => {
 
     it('shows correct progress for completed and skippeditems', () => {
         const props = getBaseProps();
-        props.items = [
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-1',
-                title: 'Item 1',
-                state: 'closed',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-2',
-                title: 'Item 2',
-                state: 'closed',
-            }),
-        ];
+        props.checkListProgress.completed = 2;
+        props.checkListProgress.totalNumber = 2;
 
         const {getByText, rerender} = renderWithIntl(<Checklist {...props}/>);
 
         expect(getByText('2 / 2 done')).toBeTruthy();
 
-        props.items = [
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-1',
-                title: 'Item 1',
-                state: 'closed',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-2',
-                title: 'Item 2',
-                state: '',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-3',
-                title: 'Item 3',
-                state: 'skipped',
-            }),
-        ];
+        props.checkListProgress.completed = 1;
+        props.checkListProgress.totalNumber = 2;
+
         rerender(<Checklist {...props}/>);
 
         expect(getByText('1 / 2 done')).toBeTruthy();
@@ -220,23 +205,7 @@ describe('Checklist', () => {
     it('passes the correct props to the ProgressBar', () => {
         const props = getBaseProps();
         props.isFinished = false;
-        props.items = [
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-1',
-                title: 'Item 1',
-                state: '',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-2',
-                title: 'Item 2',
-                state: '',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-3',
-                title: 'Item 3',
-                state: '',
-            }),
-        ];
+        props.checkListProgress.progress = 0;
 
         const {getByTestId, rerender} = renderWithIntl(<Checklist {...props}/>);
 
@@ -245,67 +214,14 @@ describe('Checklist', () => {
         expect(progressBar.props.isActive).toBe(true);
 
         props.isFinished = true;
-        props.items = [
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-1',
-                title: 'Item 1',
-                state: 'closed',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-2',
-                title: 'Item 2',
-                state: '',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-3',
-                title: 'Item 3',
-                state: '',
-            }),
-        ];
-        rerender(<Checklist {...props}/>);
+        props.checkListProgress.progress = 50;
 
-        expect(progressBar.props.progress).toBe(33);
-        expect(progressBar.props.isActive).toBe(false);
-
-        props.items = [
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-1',
-                title: 'Item 1',
-                state: 'closed',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-2',
-                title: 'Item 2',
-                state: 'skipped',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-3',
-                title: 'Item 3',
-                state: '',
-            }),
-        ];
         rerender(<Checklist {...props}/>);
 
         expect(progressBar.props.progress).toBe(50);
         expect(progressBar.props.isActive).toBe(false);
 
-        props.items = [
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-1',
-                title: 'Item 1',
-                state: 'closed',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-2',
-                title: 'Item 2',
-                state: 'skipped',
-            }),
-            TestHelper.fakePlaybookChecklistItemModel({
-                id: 'item-3',
-                title: 'Item 3',
-                state: 'closed',
-            }),
-        ];
+        props.checkListProgress.progress = 100;
         rerender(<Checklist {...props}/>);
 
         expect(progressBar.props.progress).toBe(100);

--- a/app/products/playbooks/screens/playbook_run/checklist/checklist.tsx
+++ b/app/products/playbooks/screens/playbook_run/checklist/checklist.tsx
@@ -71,6 +71,7 @@ type Props = {
     playbookRunId: string;
     isFinished: boolean;
     isParticipant: boolean;
+    checkListProgress: ReturnType<typeof getChecklistProgress>;
 }
 
 const Checklist = ({
@@ -81,14 +82,18 @@ const Checklist = ({
     playbookRunId,
     isFinished,
     isParticipant,
+    checkListProgress: {
+        skipped,
+        completed,
+        totalNumber,
+        progress,
+    },
 }: Props) => {
     const [expanded, setExpanded] = useState(true);
     const theme = useTheme();
     const styles = getStyleSheet(theme);
     const height = useSharedValue(0);
     const windowDimensions = useWindowDimensions();
-
-    const {skipped, completed, totalNumber, progress} = useMemo(() => getChecklistProgress(items), [items]);
 
     const toggleExpanded = useCallback(() => {
         setExpanded((prev) => !prev);

--- a/app/products/playbooks/screens/playbook_run/checklist/checklist.tsx
+++ b/app/products/playbooks/screens/playbook_run/checklist/checklist.tsx
@@ -71,7 +71,7 @@ type Props = {
     playbookRunId: string;
     isFinished: boolean;
     isParticipant: boolean;
-    checkListProgress: ReturnType<typeof getChecklistProgress>;
+    checklistProgress: ReturnType<typeof getChecklistProgress>;
 }
 
 const Checklist = ({
@@ -82,7 +82,7 @@ const Checklist = ({
     playbookRunId,
     isFinished,
     isParticipant,
-    checkListProgress: {
+    checklistProgress: {
         skipped,
         completed,
         totalNumber,

--- a/app/products/playbooks/screens/playbook_run/checklist/index.test.tsx
+++ b/app/products/playbooks/screens/playbook_run/checklist/index.test.tsx
@@ -76,7 +76,7 @@ describe('Checklist', () => {
             expect(checklist).toBeTruthy();
             expect(checklist.props.checklist).toBe(props.checklist);
             expect(checklist.props.items).toBe(props.checklist.items);
-            expect(checklist.props.checkListProgress).toBe(mockProgressReturn);
+            expect(checklist.props.checklistProgress).toBe(mockProgressReturn);
             expect(getChecklistProgress).toHaveBeenCalledWith(props.checklist.items);
         });
     });
@@ -118,7 +118,7 @@ describe('Checklist', () => {
             expect(checklist.props.checklist.id).toBe(props.checklist.id);
             expect(checklist.props.items[0].id).toBe(itemsIds[1]);
             expect(checklist.props.items[1].id).toBe(itemsIds[0]);
-            expect(checklist.props.checkListProgress).toBe(mockProgressReturn);
+            expect(checklist.props.checklistProgress).toBe(mockProgressReturn);
             expect(getChecklistProgress).toHaveBeenCalledWith([
                 expect.objectContaining({id: itemsIds[1]}),
                 expect.objectContaining({id: itemsIds[0]}),

--- a/app/products/playbooks/screens/playbook_run/checklist/index.test.tsx
+++ b/app/products/playbooks/screens/playbook_run/checklist/index.test.tsx
@@ -4,6 +4,7 @@
 import React, {type ComponentProps} from 'react';
 
 import DatabaseManager from '@database/manager';
+import {getChecklistProgress} from '@playbooks/utils/progress';
 import {renderWithEverything, waitFor} from '@test/intl-test-helper';
 import TestHelper from '@test/test_helper';
 
@@ -20,10 +21,20 @@ jest.mocked(ChecklistComponent).mockImplementation(
     (props) => React.createElement('Checklist', {testID: 'checklist', ...props}),
 );
 
+jest.mock('@playbooks/utils/progress');
+
 const serverUrl = 'server-url';
 
 describe('Checklist', () => {
     const checklistId = 'checklist-id';
+    const mockProgressReturn = {
+        skipped: false,
+        completed: 0,
+        totalNumber: 0,
+        progress: 0,
+    };
+
+    jest.mocked(getChecklistProgress).mockReturnValue(mockProgressReturn);
 
     let database: Database;
     let operator: ServerDataOperator;
@@ -65,6 +76,8 @@ describe('Checklist', () => {
             expect(checklist).toBeTruthy();
             expect(checklist.props.checklist).toBe(props.checklist);
             expect(checklist.props.items).toBe(props.checklist.items);
+            expect(checklist.props.checkListProgress).toBe(mockProgressReturn);
+            expect(getChecklistProgress).toHaveBeenCalledWith(props.checklist.items);
         });
     });
 
@@ -105,6 +118,11 @@ describe('Checklist', () => {
             expect(checklist.props.checklist.id).toBe(props.checklist.id);
             expect(checklist.props.items[0].id).toBe(itemsIds[1]);
             expect(checklist.props.items[1].id).toBe(itemsIds[0]);
+            expect(checklist.props.checkListProgress).toBe(mockProgressReturn);
+            expect(getChecklistProgress).toHaveBeenCalledWith([
+                expect.objectContaining({id: itemsIds[1]}),
+                expect.objectContaining({id: itemsIds[0]}),
+            ]);
 
             database.write(async () => {
                 if ('update' in props.checklist) {

--- a/app/products/playbooks/screens/playbook_run/checklist/index.ts
+++ b/app/products/playbooks/screens/playbook_run/checklist/index.ts
@@ -41,21 +41,21 @@ const enhanced = withObservables(['checklist'], ({checklist}: OwnProps) => {
             distinctUntilChanged((a, b) => areItemsOrdersEqual(getIds(a), getIds(b))),
         );
 
-        const checkListProgress = items.pipe(
+        const checklistProgress = items.pipe(
             switchMap((i) => of$(getChecklistProgress(i))),
         );
 
         return {
             checklist: observedChecklist,
             items: sortedItems,
-            checkListProgress,
+            checklistProgress,
         };
     }
 
     return {
         checklist: of$(checklist),
         items: of$(checklist.items),
-        checkListProgress: of$(getChecklistProgress(checklist.items)),
+        checklistProgress: of$(getChecklistProgress(checklist.items)),
     };
 });
 

--- a/app/products/playbooks/screens/playbook_run/checklist/index.ts
+++ b/app/products/playbooks/screens/playbook_run/checklist/index.ts
@@ -5,6 +5,7 @@ import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
 import {combineLatest, distinctUntilChanged, of as of$, switchMap} from 'rxjs';
 
 import {areItemsOrdersEqual} from '@playbooks/utils/items_order';
+import {getChecklistProgress} from '@playbooks/utils/progress';
 
 import Checklist from './checklist';
 
@@ -39,15 +40,22 @@ const enhanced = withObservables(['checklist'], ({checklist}: OwnProps) => {
             }),
             distinctUntilChanged((a, b) => areItemsOrdersEqual(getIds(a), getIds(b))),
         );
+
+        const checkListProgress = items.pipe(
+            switchMap((i) => of$(getChecklistProgress(i))),
+        );
+
         return {
             checklist: observedChecklist,
             items: sortedItems,
+            checkListProgress,
         };
     }
 
     return {
         checklist: of$(checklist),
         items: of$(checklist.items),
+        checkListProgress: of$(getChecklistProgress(checklist.items)),
     };
 });
 


### PR DESCRIPTION
#### Summary
In the runs view, we were listening to the ordered items, and then calculating the progress from that. The problem was that when a item changes, the order doesn't change, so the `items` object stays the same.

Instead of that, we moved all the progress to a observer on the list of items (instead of the sorted items).

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-64722

#### Release Note
```release-note
NONE
```
