### PR TITLE
Enable channel links on the Title of message attachments

### DIFF
--- a/app/components/post_list/post/body/content/message_attachments/attachment_title.tsx
+++ b/app/components/post_list/post/body/content/message_attachments/attachment_title.tsx
@@ -71,7 +71,6 @@ const AttachmentTitle = ({channelId, link, location, theme, value}: Props) => {
                 isReplyPost={false}
                 disableHashtags={true}
                 disableAtMentions={true}
-                disableChannelLink={true}
                 disableGallery={true}
                 autolinkedUrlSchemes={[]}
                 mentionKeys={[]}


### PR DESCRIPTION
#### Summary

This PR enables the Channel links on the title on Mobile to make it more consistent to the Web application since it works there.

#### Ticket Link

Closes https://github.com/mattermost/mattermost/issues/16291

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: Android API 33 and iOS 18.4

#### Screenshots

Same message on:

#### Web Application

<img width="729" height="260" alt="image" src="https://github.com/user-attachments/assets/753c0158-5d17-4791-ac0d-ed999f7cdacf" />

#### Android API 33

<img width="424" height="232" alt="image" src="https://github.com/user-attachments/assets/265cc4c6-d685-4195-a366-a2b140520d69" />

#### iOS 18.4

<img width="431" height="286" alt="image" src="https://github.com/user-attachments/assets/ba8fd103-a464-48c8-a03e-221718849622" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
- Enables channel links on the Title of message attachments
```
