### PR TITLE
use alertOnlyPDFSupported for document files

### DIFF
--- a/app/components/document/index.tsx
+++ b/app/components/document/index.tsx
@@ -4,7 +4,7 @@
 import {forwardRef, useImperativeHandle, type ReactNode, useCallback} from 'react';
 import {useIntl} from 'react-intl';
 
-import {alertDownloadDocumentDisabled} from '@utils/document';
+import {alertDownloadDocumentDisabled, alertOnlyPDFSupported} from '@utils/document';
 import {isPdf} from '@utils/file';
 
 export type DocumentRef = {
@@ -23,8 +23,13 @@ const Document = forwardRef<DocumentRef, DocumentProps>(({canDownloadFiles, chil
     const intl = useIntl();
 
     const handlePreviewPress = useCallback(async () => {
-        if (!canDownloadFiles || (enableSecureFilePreview && !isPdf(file))) {
+        if (!canDownloadFiles) {
             alertDownloadDocumentDisabled(intl);
+            return;
+        }
+
+        if (enableSecureFilePreview && !isPdf(file)) {
+            alertOnlyPDFSupported(intl);
             return;
         }
 


### PR DESCRIPTION
#### Summary
We want to display a specific alert when Secure File Mode Preview is enabled and the document is not a PDF.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
