### PR TITLE
[MM-64936] Fix sort_order 0 being converted to MAX_INTEGER

### DIFF
--- a/app/utils/user/index.ts
+++ b/app/utils/user/index.ts
@@ -528,7 +528,7 @@ export const convertProfileAttributesToCustomAttributes = (
         fieldsMap.set(field.id, {
             name: field.name,
             type: customType,
-            sort_order: field.attrs?.sort_order || Number.MAX_SAFE_INTEGER,
+            sort_order: field.attrs?.sort_order ?? Number.MAX_SAFE_INTEGER,
             originalField: field,
         });
 
@@ -556,7 +556,7 @@ export const convertProfileAttributesToCustomAttributes = (
             name: field?.name || attr.fieldId,
             type: field?.type || 'text',
             value: displayValue,
-            sort_order: field?.sort_order || Number.MAX_SAFE_INTEGER,
+            sort_order: field?.sort_order ?? Number.MAX_SAFE_INTEGER,
         });
     });
 


### PR DESCRIPTION
#### Summary
if sort_order is not present it is converted to MAX_INTEGER as a fail-safe mechanism. In a couple of places of the code this was not properly checked and it was converting 0 to MAX_INTEGER causing the wrong sorting.

#### Ticket Link
[MM-64936](https://mattermost.atlassian.net/browse/MM-64936)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: android and ios emulators

#### Release Note
```release-note
Fix sorting problem when moving a field from CPA to the first position
```


[MM-64936]: https://mattermost.atlassian.net/browse/MM-64936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ