### PR TITLE
Fix long name playbooks channel header

### DIFF
--- a/app/components/navigation_header/header.tsx
+++ b/app/components/navigation_header/header.tsx
@@ -73,7 +73,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
         justifyContent: 'center',
         flex: 3,
         height: '100%',
-        paddingHorizontal: 8,
         ...Platform.select({
             ios: {
                 flex: undefined,
@@ -181,6 +180,7 @@ const Header = ({
             marginLeft: Platform.select({android: showBackButton && !leftComponent ? 20 : 0}),
             paddingHorizontal: Platform.select({
                 ios: rightButtons?.length === 2 ? 90 : 60,
+                android: 8,
             }),
         };
     }, [leftComponent, showBackButton, rightButtons]);


### PR DESCRIPTION
#### Summary
For iOS, we do some juggling to get the channel header centered.

This PR adds to that juggling the case where we have two buttons on the right side of the channel header, by making the space smaller, but still centered.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64762

#### Screenshots
Result:
<img width="401" height="57" alt="Captura de pantalla 2025-08-04 a las 15 25 44" src="https://github.com/user-attachments/assets/908416f4-e8cf-474f-a413-1629eb0ab2fb" />


#### Release Note
```release-note
NONE
```
