### PR TITLE
Add ellipsis to the checklist title

### DIFF
--- a/app/products/playbooks/screens/playbook_run/checklist/checklist.tsx
+++ b/app/products/playbooks/screens/playbook_run/checklist/checklist.tsx
@@ -61,6 +61,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => ({
     skippedText: {
         textDecorationLine: 'line-through',
     },
+    titleContainer: {
+        flexShrink: 1,
+    },
 }));
 
 type Props = {
@@ -134,7 +137,14 @@ const Checklist = ({
                         name={expanded ? 'chevron-down' : 'chevron-right'}
                         style={styles.chevron}
                     />
-                    <Text style={titleTextStyle}>{checklist.title}</Text>
+                    <View style={styles.titleContainer}>
+                        <Text
+                            style={titleTextStyle}
+                            numberOfLines={1}
+                        >
+                            {checklist.title}
+                        </Text>
+                    </View>
                     <Text style={styles.progressText}>{`${completed} / ${totalNumber} done`}</Text>
                 </View>
                 <ProgressBar


### PR DESCRIPTION
#### Summary
On playbooks, a long checklist name was moving the "done" text out of the box, and didn't look "right". We added an ellipsis.

We still need to consider whether we want an ellipsis or we want to keep it multiline, so the whole name can be read.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-64764

#### Screenshots
<img width="381" height="110" alt="Captura de pantalla 2025-08-05 a las 10 48 08" src="https://github.com/user-attachments/assets/fa823380-86f8-4ca8-a92f-c4a36a8a0e23" />

#### Release Note
```release-note
NONE
```
