### PR TITLE
Fix share screenshot on ios 26

### DIFF
--- a/ios/MattermostShare/Utils/LocalFileManager.swift
+++ b/ios/MattermostShare/Utils/LocalFileManager.swift
@@ -148,9 +148,9 @@ class LocalFileManager {
                         var attachment = self?.saveAttachmentImage(data) {
                 attachment.imagePixels = self?.getImagePixels(image: uiImage)
                 models.append(attachment)
-              } else if let imageData = image as? Data,
-                        var attachment = self?.saveAttachmentImage(imageData),
-                        let uiImage = UIImage(data: imageData)
+              } else if let data = image as? Data,
+                        var attachment = self?.saveAttachmentImage(data),
+                        let uiImage = UIImage(data: data)
               {
                 attachment.imagePixels = self?.getImagePixels(image: uiImage)
                 models.append(attachment)


### PR DESCRIPTION
#### Summary
On iOS 26, when you share an screenshot without saving it, it was not attaching the image.

This is because our code handles 2 types of images: URL or UIImage. But seems like what we receive from share in this particular case is "Data".

Handling this case also solves the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-64620

#### Release Note
```release-note
Fix screenshot share problem for iOS 26 devices
```
