### PR TITLE
Fix playbooks not getting updated by websocket

### DIFF
--- a/app/products/playbooks/actions/remote/runs.test.ts
+++ b/app/products/playbooks/actions/remote/runs.test.ts
@@ -120,6 +120,20 @@ describe('fetchPlaybookRunsForChannel', () => {
         expect(handlePlaybookRuns).not.toHaveBeenCalled();
     });
 
+    it('should update the channel in the ephemeral store when there are no runs', async () => {
+        mockClient.fetchPlaybookRuns.mockResolvedValueOnce({
+            items: [],
+            has_more: false,
+        });
+
+        const result = await fetchPlaybookRunsForChannel(serverUrl, channelId);
+        expect(result).toBeDefined();
+        expect(result.error).toBeUndefined();
+        expect(result.runs).toEqual([]);
+        expect(handlePlaybookRuns).not.toHaveBeenCalled();
+        expect(EphemeralStore.getChannelPlaybooksSynced(serverUrl, channelId)).toBe(true);
+    });
+
     it('should update the channel in the ephemeral store', async () => {
         mockClient.fetchPlaybookRuns.mockResolvedValueOnce({
             items: [mockPlaybookRun],

--- a/app/products/playbooks/actions/remote/runs.ts
+++ b/app/products/playbooks/actions/remote/runs.ts
@@ -45,6 +45,7 @@ export const fetchPlaybookRunsForChannel = async (serverUrl: string, channelId: 
         }
 
         if (!allRuns.length) {
+            EphemeralStore.setChannelPlaybooksSynced(serverUrl, channelId);
             return {runs: []};
         }
 


### PR DESCRIPTION
#### Summary
When we received no new playbooks on a channel, we didn't considered the channel synced. This made it so websocket messages don't update the playbooks.

Now, if there is no error when fetching the playbooks, we consider the channel synced.

#### Ticket Link
NONE

#### Release Note
```release-note
Fix playbooks not being updated on some scenarios
```
