### PR TITLE
Automated cherry pick of #9088

### DIFF
--- a/app/products/playbooks/actions/remote/runs.test.ts
+++ b/app/products/playbooks/actions/remote/runs.test.ts
@@ -120,6 +120,20 @@ describe('fetchPlaybookRunsForChannel', () => {
         expect(handlePlaybookRuns).not.toHaveBeenCalled();
     });
 
+    it('should update the channel in the ephemeral store when there are no runs', async () => {
+        mockClient.fetchPlaybookRuns.mockResolvedValueOnce({
+            items: [],
+            has_more: false,
+        });
+
+        const result = await fetchPlaybookRunsForChannel(serverUrl, channelId);
+        expect(result).toBeDefined();
+        expect(result.error).toBeUndefined();
+        expect(result.runs).toEqual([]);
+        expect(handlePlaybookRuns).not.toHaveBeenCalled();
+        expect(EphemeralStore.getChannelPlaybooksSynced(serverUrl, channelId)).toBe(true);
+    });
+
     it('should update the channel in the ephemeral store', async () => {
         mockClient.fetchPlaybookRuns.mockResolvedValueOnce({
             items: [mockPlaybookRun],

--- a/app/products/playbooks/actions/remote/runs.ts
+++ b/app/products/playbooks/actions/remote/runs.ts
@@ -45,6 +45,7 @@ export const fetchPlaybookRunsForChannel = async (serverUrl: string, channelId: 
         }
 
         if (!allRuns.length) {
+            EphemeralStore.setChannelPlaybooksSynced(serverUrl, channelId);
             return {runs: []};
         }
 


### PR DESCRIPTION
Cherry pick of #9088 on release-2.32.

/cc  @larkox

```release-note
NONE
```