### PR TITLE
MM-65579 E2E/Detox: fixed sorting test scripts

### DIFF
--- a/detox/package-lock.json
+++ b/detox/package-lock.json
@@ -24,6 +24,7 @@
         "client-oauth2": "4.3.3",
         "deepmerge": "4.3.1",
         "detox": "20.37.0",
+        "dotenv": "17.2.1",
         "form-data": "4.0.1",
         "jest": "29.7.0",
         "jest-circus": "29.7.0",
@@ -5505,6 +5506,19 @@
       },
       "optionalDependencies": {
         "highlight.js": "11.9.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dtrace-provider": {

--- a/detox/package.json
+++ b/detox/package.json
@@ -22,6 +22,7 @@
     "client-oauth2": "4.3.3",
     "deepmerge": "4.3.1",
     "detox": "20.37.0",
+    "dotenv": "17.2.1",
     "form-data": "4.0.1",
     "jest": "29.7.0",
     "jest-circus": "29.7.0",

--- a/detox/utils/test_cases.js
+++ b/detox/utils/test_cases.js
@@ -115,11 +115,7 @@ async function createTestExecutions(allTests, testCycle) {
     const promises = [];
     Object.entries(testCases).forEach(([key, steps], index) => {
         const testScriptResults = steps.
-            sort((a, b) => {
-                const aKey = a.title.match(/(MM-T\d+_\d+)/)[0].split('_')[1];
-                const bKey = b.title.match(/(MM-T\d+_\d+)/)[0].split('_')[1];
-                return parseInt(aKey, 10) - parseInt(bKey, 10);
-            }).
+            sort((a, b) => a.title.localeCompare(b.title)).
             map((item) => {
                 return {
                     title: item.title,


### PR DESCRIPTION
#### Summary
Fixed sort of test scripts prior to saving test reports

Other: Added `dotenv` to e2e/detox packages which is required when saving test reports and artifacts

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65579

#### Checklist
n/a

#### Device Information
n/a

#### Screenshots
See (dry-run) test cycle saved [MM-R12580](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testPlayer/MM-R12580)

#### Release Note
```release-note
NONE
```
