### PR TITLE
Ability to show attachment if the permalink post contains attachments.

### DIFF
--- a/app/components/files/file.tsx
+++ b/app/components/files/file.tsx
@@ -45,7 +45,6 @@ type FileProps = {
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         fileWrapper: {
-            flex: 1,
             flexDirection: 'row',
             alignItems: 'center',
             borderWidth: 1,
@@ -64,7 +63,6 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
             margin: 4,
         },
         audioFile: {
-            flex: 1,
             flexDirection: 'row',
             alignItems: 'center',
         },

--- a/app/components/files/files.tsx
+++ b/app/components/files/files.tsx
@@ -31,11 +31,11 @@ type FilesProps = {
 const MAX_VISIBLE_ROW_IMAGES = 4;
 const styles = StyleSheet.create({
     row: {
-        flex: 1,
         flexDirection: 'row',
         marginTop: 5,
+        flexShrink: 0,
     },
-    container: {
+    rowItemContainer: {
         flex: 1,
     },
     gutter: {
@@ -86,7 +86,8 @@ const Files = ({
 
     const renderItems = (items: FileInfo[], moreImagesCount = 0, includeGutter = false) => {
         let nonVisibleImagesCount: number;
-        let container: StyleProp<ViewStyle> = items.length > 1 ? styles.container : undefined;
+
+        let container: StyleProp<ViewStyle> = (includeGutter && items.length > 1) ? styles.rowItemContainer : undefined;
         const containerWithGutter = [container, styles.gutter];
         const wrapperWidth = getViewPortWidth(isReplyPost, isTablet) - 6;
 

--- a/app/components/post_list/post/body/content/index.tsx
+++ b/app/components/post_list/post/body/content/index.tsx
@@ -112,6 +112,8 @@ const Content = ({isReplyPost, layoutWidth, location, post, theme}: ContentProps
                 <PermalinkPreview
                     embedData={post.metadata!.embeds![0].data as PermalinkEmbedData}
                     location={location}
+                    parentLocation={location}
+                    parentPostId={post.id}
                 />
             );
     }

--- a/app/components/post_list/post/body/content/permalink_preview/permalink_files.tsx
+++ b/app/components/post_list/post/body/content/permalink_preview/permalink_files.tsx
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect} from 'react';
-import {DeviceEventEmitter} from 'react-native';
+import React, {useEffect, useState} from 'react';
+import {DeviceEventEmitter, View, type LayoutChangeEvent} from 'react-native';
 
 import Files from '@components/files/files';
 import {Events} from '@constants';
 
 const PermalinkFiles = (props: React.ComponentProps<typeof Files> & {parentLocation?: string; parentPostId?: string}) => {
     const {parentLocation, parentPostId, ...filesProps} = props;
+    const [layoutWidth, setLayoutWidth] = useState(0);
 
     useEffect(() => {
         if (!parentLocation || !parentPostId) {
@@ -27,7 +28,18 @@ const PermalinkFiles = (props: React.ComponentProps<typeof Files> & {parentLocat
         return () => DeviceEventEmitter.removeAllListeners(Events.ITEM_IN_VIEWPORT);
     }, [parentLocation, parentPostId, props.location, props.postId]);
 
-    return <Files {...filesProps}/>;
+    const onLayout = (event: LayoutChangeEvent) => {
+        setLayoutWidth(event.nativeEvent.layout.width);
+    };
+
+    return (
+        <View onLayout={onLayout}>
+            <Files
+                {...filesProps}
+                layoutWidth={layoutWidth}
+            />
+        </View>
+    );
 };
 
 export default PermalinkFiles;

--- a/app/components/post_list/post/body/content/permalink_preview/permalink_files.tsx
+++ b/app/components/post_list/post/body/content/permalink_preview/permalink_files.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect} from 'react';
+import {DeviceEventEmitter} from 'react-native';
+
+import Files from '@components/files/files';
+import {Events} from '@constants';
+
+const PermalinkFiles = (props: React.ComponentProps<typeof Files> & {parentLocation?: string; parentPostId?: string}) => {
+    const {parentLocation, parentPostId, ...filesProps} = props;
+
+    useEffect(() => {
+        if (!parentLocation || !parentPostId) {
+            return undefined;
+        }
+
+        const listener = (viewableItemsMap: Record<string, boolean>) => {
+            const parentKey = `${parentLocation}-${parentPostId}`;
+            if (viewableItemsMap[parentKey]) {
+                const viewableItems = {[`${props.location}-${props.postId}`]: true};
+                DeviceEventEmitter.emit(Events.ITEM_IN_VIEWPORT, viewableItems);
+            }
+        };
+
+        DeviceEventEmitter.addListener(Events.ITEM_IN_VIEWPORT, listener);
+        return () => DeviceEventEmitter.removeAllListeners(Events.ITEM_IN_VIEWPORT);
+    }, [parentLocation, parentPostId, props.location, props.postId]);
+
+    return <Files {...filesProps}/>;
+};
+
+export default PermalinkFiles;

--- a/app/components/post_list/post/body/content/permalink_preview/permalink_preview.test.tsx
+++ b/app/components/post_list/post/body/content/permalink_preview/permalink_preview.test.tsx
@@ -46,6 +46,11 @@ describe('components/post_list/post/body/content/permalink_preview/PermalinkPrev
         teammateNameDisplay: 'username',
         location: Screens.CHANNEL,
         isOriginPostDeleted: false,
+        canDownloadFiles: true,
+        enableSecureFilePreview: false,
+        filesInfo: [],
+        parentLocation: Screens.CHANNEL,
+        parentPostId: 'parent-post-123',
     };
 
     it('should render permalink preview correctly', () => {
@@ -242,5 +247,264 @@ describe('components/post_list/post/body/content/permalink_preview/PermalinkPrev
         // Profile picture should be rendered (check for the image component)
         const profilePicture = root.findByType('ViewManagerAdapter_ExpoImage');
         expect(profilePicture).toBeTruthy();
+    });
+
+    describe('File Attachments', () => {
+        const mockFileInfo: FileInfo = {
+            id: 'file-123',
+            name: 'test-file.pdf',
+            extension: 'pdf',
+            size: 1024,
+            mime_type: 'application/pdf',
+            width: 0,
+            height: 0,
+            has_preview_image: false,
+            user_id: 'user-123',
+        };
+
+        it('should not render PermalinkFiles when filesInfo is empty', () => {
+            const {queryByTestId} = renderWithIntlAndTheme(
+                <PermalinkPreview {...baseProps}/>,
+            );
+
+            expect(queryByTestId('files-container')).toBeNull();
+        });
+
+        it('should render PermalinkFiles when filesInfo has files', () => {
+            const props = {
+                ...baseProps,
+                filesInfo: [mockFileInfo],
+            };
+            const {getByTestId} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByTestId('files-container')).toBeTruthy();
+        });
+
+        it('should render multiple file attachments', () => {
+            const multipleFiles = [
+                mockFileInfo,
+                {...mockFileInfo, id: 'file-456', name: 'image.jpg', mime_type: 'image/jpeg'},
+                {...mockFileInfo, id: 'file-789', name: 'document.txt', mime_type: 'text/plain'},
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: multipleFiles,
+            };
+            const {getByTestId} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByTestId('files-container')).toBeTruthy();
+        });
+
+        it('should handle undefined filesInfo gracefully', () => {
+            const props = {
+                ...baseProps,
+                filesInfo: undefined as unknown as FileInfo[],
+            };
+
+            expect(() => {
+                renderWithIntlAndTheme(<PermalinkPreview {...props}/>);
+            }).not.toThrow();
+        });
+
+        it('should display file names correctly', () => {
+            const filesWithNames = [
+                {...mockFileInfo, id: 'file-1', name: 'important-document.pdf', mime_type: 'application/pdf'},
+                {...mockFileInfo, id: 'file-2', name: 'meeting-notes.docx', mime_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'},
+                {...mockFileInfo, id: 'file-3', name: 'vacation-photo.jpg', mime_type: 'image/jpeg', width: 1920, height: 1080, has_preview_image: true},
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: filesWithNames,
+            };
+
+            const {getByText, queryByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('important-document.pdf')).toBeTruthy();
+            expect(getByText('meeting-notes.docx')).toBeTruthy();
+
+            expect(queryByText('vacation-photo.jpg')).toBeNull();
+        });
+
+        it('should display file sizes correctly', () => {
+            const filesWithSizes = [
+                {...mockFileInfo, id: 'file-1', name: 'small-file.txt', size: 1024}, // 1024 B
+                {...mockFileInfo, id: 'file-2', name: 'large-file.pdf', size: 5242880}, // 5 MB
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: filesWithSizes,
+            };
+
+            const {getByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('1024 B')).toBeTruthy();
+            expect(getByText('5 MB')).toBeTruthy();
+        });
+
+        it('should render different file types with appropriate icons', () => {
+            const mixedFiles = [
+                {...mockFileInfo, id: 'file-1', name: 'document.pdf', mime_type: 'application/pdf', extension: 'pdf'},
+                {...mockFileInfo, id: 'file-2', name: 'spreadsheet.xlsx', mime_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', extension: 'xlsx'},
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: mixedFiles,
+            };
+
+            const {getByTestId, getByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByTestId('files-container')).toBeTruthy();
+
+            expect(getByText('document.pdf')).toBeTruthy();
+            expect(getByText('spreadsheet.xlsx')).toBeTruthy();
+        });
+
+        it('should handle files with zero size', () => {
+            const fileWithZeroSize = {
+                ...mockFileInfo,
+                id: 'file-zero',
+                name: 'empty-file.txt',
+                size: 0,
+            };
+            const props = {
+                ...baseProps,
+                filesInfo: [fileWithZeroSize],
+            };
+
+            const {getByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('empty-file.txt')).toBeTruthy();
+            expect(getByText('0 B')).toBeTruthy();
+        });
+
+        it('should display file extension correctly', () => {
+            const fileWithExtension = {
+                ...mockFileInfo,
+                id: 'file-ext',
+                name: 'presentation.pptx',
+                extension: 'pptx',
+                mime_type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                size: 2097152,
+            };
+            const props = {
+                ...baseProps,
+                filesInfo: [fileWithExtension],
+            };
+
+            const {getByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('presentation.pptx')).toBeTruthy();
+            expect(getByText('2 MB')).toBeTruthy();
+        });
+
+        it('should display file size conversions correctly', () => {
+            const filesWithVariousSizes = [
+                {...mockFileInfo, id: 'file-bytes', name: 'tiny.txt', size: 512},
+                {...mockFileInfo, id: 'file-kb', name: 'small.doc', size: 1536},
+                {...mockFileInfo, id: 'file-mb', name: 'medium.pdf', size: 3145728},
+                {...mockFileInfo, id: 'file-gb', name: 'large.zip', size: 2147483648},
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: filesWithVariousSizes,
+            };
+
+            const {getByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('512 B')).toBeTruthy();
+            expect(getByText('1 KB')).toBeTruthy();
+            expect(getByText('3 MB')).toBeTruthy();
+            expect(getByText('2 GB')).toBeTruthy();
+        });
+
+        it('should handle edge case file sizes', () => {
+            const edgeCaseFiles = [
+                {...mockFileInfo, id: 'file-1b', name: 'single-byte.txt', size: 1},
+                {...mockFileInfo, id: 'file-1kb', name: 'exactly-1kb.txt', size: 1024},
+                {...mockFileInfo, id: 'file-1mb', name: 'exactly-1mb.pdf', size: 1048576},
+                {...mockFileInfo, id: 'file-999b', name: 'almost-kb.txt', size: 999},
+                {...mockFileInfo, id: 'file-1025b', name: 'just-over-kb.txt', size: 1025},
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: edgeCaseFiles,
+            };
+
+            const {getByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('1 B')).toBeTruthy();
+            expect(getByText('1024 B')).toBeTruthy();
+            expect(getByText('1024 KB')).toBeTruthy();
+            expect(getByText('999 B')).toBeTruthy();
+            expect(getByText('1 KB')).toBeTruthy();
+        });
+
+        it('should display file names with special characters', () => {
+            const filesWithSpecialNames = [
+                {...mockFileInfo, id: 'file-special1', name: 'file with spaces.pdf', size: 1024},
+                {...mockFileInfo, id: 'file-special2', name: 'file-with-dashes.docx', size: 2048},
+                {...mockFileInfo, id: 'file-special3', name: 'file_with_underscores.txt', size: 512},
+                {...mockFileInfo, id: 'file-special4', name: 'file(with)parentheses.xlsx', size: 4096},
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: filesWithSpecialNames,
+            };
+
+            const {getByText} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('file with spaces.pdf')).toBeTruthy();
+            expect(getByText('file-with-dashes.docx')).toBeTruthy();
+            expect(getByText('file_with_underscores.txt')).toBeTruthy();
+            expect(getByText('file(with)parentheses.xlsx')).toBeTruthy();
+        });
+
+        it('should differentiate between image and document file display', () => {
+            const mixedFileTypes = [
+
+                {...mockFileInfo, id: 'doc-1', name: 'report.pdf', mime_type: 'application/pdf', extension: 'pdf'},
+                {...mockFileInfo, id: 'doc-2', name: 'spreadsheet.xlsx', mime_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', extension: 'xlsx'},
+
+                {...mockFileInfo, id: 'img-1', name: 'screenshot.png', mime_type: 'image/png', extension: 'png', width: 1024, height: 768, has_preview_image: true},
+                {...mockFileInfo, id: 'img-2', name: 'photo.jpeg', mime_type: 'image/jpeg', extension: 'jpeg', width: 1920, height: 1080, has_preview_image: true},
+            ];
+            const props = {
+                ...baseProps,
+                filesInfo: mixedFileTypes,
+            };
+
+            const {getByText, queryByText, getByTestId} = renderWithIntlAndTheme(
+                <PermalinkPreview {...props}/>,
+            );
+
+            expect(getByText('report.pdf')).toBeTruthy();
+            expect(getByText('spreadsheet.xlsx')).toBeTruthy();
+
+            expect(queryByText('screenshot.png')).toBeNull();
+            expect(queryByText('photo.jpeg')).toBeNull();
+
+            expect(getByTestId('image-row')).toBeTruthy();
+            expect(getByTestId('files-container')).toBeTruthy();
+        });
     });
 });

--- a/app/components/post_list/post/body/content/permalink_preview/permalink_preview.tsx
+++ b/app/components/post_list/post/body/content/permalink_preview/permalink_preview.tsx
@@ -24,8 +24,6 @@ import type {AvailableScreens} from '@typings/screens/navigation';
 const MAX_PERMALINK_PREVIEW_LINES = 4;
 const MAX_PERMALINK_HEIGHT = 506;
 
-const MAX_PERMALINK_HEIGHT = 506;
-
 type PermalinkPreviewProps = {
     embedData: PermalinkEmbedData;
     showPermalinkPreviews: boolean;
@@ -82,6 +80,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         messageContainer: {
             marginBottom: 8,
+            maxHeight: 20 * MAX_PERMALINK_PREVIEW_LINES,
+            overflow: 'hidden',
         },
         messageText: {
             color: theme.centerChannelColor,
@@ -114,16 +114,16 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
 });
 
 const PermalinkPreview = ({embedData, showPermalinkPreviews, author, locale, teammateNameDisplay, isOriginPostDeleted, location, canDownloadFiles = true, enableSecureFilePreview = false, filesInfo = [], parentLocation, parentPostId}: PermalinkPreviewProps) => {
+    if (!showPermalinkPreviews || isOriginPostDeleted) {
+        return null;
+    }
+
     const theme = useTheme();
     const styles = getStyleSheet(theme);
     const [showGradient, setShowGradient] = useState(false);
 
     const textStyles = getMarkdownTextStyles(theme);
     const blockStyles = getMarkdownBlockStyles(theme);
-
-    if (!showPermalinkPreviews || isOriginPostDeleted) {
-        return null;
-    }
 
     const {
         post,
@@ -168,11 +168,6 @@ const PermalinkPreview = ({embedData, showPermalinkPreviews, author, locale, tea
     const handlePress = usePreventDoubleTap(useCallback(() => {
         // Navigation will be implemented in Task 5
     }, []));
-
-    const handleContentLayout = useCallback((event: LayoutChangeEvent) => {
-        const {height} = event.nativeEvent.layout;
-        setShowGradient(height >= MAX_PERMALINK_HEIGHT);
-    }, []);
 
     const handleContentLayout = useCallback((event: LayoutChangeEvent) => {
         const {height} = event.nativeEvent.layout;

--- a/app/components/post_list/post/body/content/permalink_preview/permalink_preview.tsx
+++ b/app/components/post_list/post/body/content/permalink_preview/permalink_preview.tsx
@@ -24,6 +24,8 @@ import type {AvailableScreens} from '@typings/screens/navigation';
 const MAX_PERMALINK_PREVIEW_LINES = 4;
 const MAX_PERMALINK_HEIGHT = 506;
 
+const MAX_PERMALINK_HEIGHT = 506;
+
 type PermalinkPreviewProps = {
     embedData: PermalinkEmbedData;
     showPermalinkPreviews: boolean;
@@ -166,6 +168,11 @@ const PermalinkPreview = ({embedData, showPermalinkPreviews, author, locale, tea
     const handlePress = usePreventDoubleTap(useCallback(() => {
         // Navigation will be implemented in Task 5
     }, []));
+
+    const handleContentLayout = useCallback((event: LayoutChangeEvent) => {
+        const {height} = event.nativeEvent.layout;
+        setShowGradient(height >= MAX_PERMALINK_HEIGHT);
+    }, []);
 
     const handleContentLayout = useCallback((event: LayoutChangeEvent) => {
         const {height} = event.nativeEvent.layout;

--- a/app/utils/permalink_sync.test.ts
+++ b/app/utils/permalink_sync.test.ts
@@ -327,6 +327,115 @@ describe('Permalink Sync Utils', () => {
             expect(result).toBeNull();
         });
 
+        it('should update permalink metadata including file metadata when fresh post is newer', async () => {
+            const referencedPostId = 'referenced_post_with_files';
+
+            const oldFileMetadata: FileInfo[] = [
+                {
+                    id: 'file1',
+                    name: 'old_file.txt',
+                    extension: 'txt',
+                    size: 100,
+                    mime_type: 'text/plain',
+                    width: 0,
+                    height: 0,
+                    has_preview_image: false,
+                    user_id: 'user_123',
+                },
+            ];
+
+            const newFileMetadata: FileInfo[] = [
+                {
+                    id: 'file1',
+                    name: 'old_file.txt',
+                    extension: 'txt',
+                    size: 100,
+                    mime_type: 'text/plain',
+                    width: 0,
+                    height: 0,
+                    has_preview_image: false,
+                    user_id: 'user_123',
+                },
+                {
+                    id: 'file2',
+                    name: 'new_file.jpg',
+                    extension: 'jpg',
+                    size: 2000,
+                    mime_type: 'image/jpeg',
+                    width: 1920,
+                    height: 1080,
+                    has_preview_image: true,
+                    user_id: 'user_123',
+                },
+            ];
+
+            const referencingPost = TestHelper.fakePost({
+                id: 'referencing_post_files',
+                channel_id: 'channel1',
+                metadata: {
+                    embeds: [
+                        {
+                            type: 'permalink',
+                            url: '',
+                            data: {
+                                post_id: referencedPostId,
+                                post: {
+                                    id: referencedPostId,
+                                    message: 'Post with old files',
+                                    edit_at: 1000,
+                                    update_at: 1000,
+                                    user_id: 'user_123',
+                                    create_at: 500,
+                                    metadata: {
+                                        files: oldFileMetadata,
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+            });
+
+            const models = await operator.handlePosts({
+                actionType: ActionType.POSTS.RECEIVED_NEW,
+                order: [referencingPost.id],
+                posts: [referencingPost],
+                prepareRecordsOnly: true,
+            });
+            await operator.batchRecords(models, 'test');
+
+            const postModel = await database.get('Post').find(referencingPost.id) as PostModel;
+
+            const freshPostData = TestHelper.fakePost({
+                id: referencedPostId,
+                message: 'Post with updated files',
+                edit_at: 2000,
+                update_at: 2000,
+                user_id: 'user_123',
+                create_at: 500,
+                metadata: {
+                    files: newFileMetadata,
+                },
+            });
+
+            const result = updatePermalinkMetadata(postModel, referencedPostId, freshPostData);
+
+            expect(result).not.toBeNull();
+            expect(result!.id).toBe(referencingPost.id);
+            expect(result!._preparedState).toBe('update');
+
+            // Verify the metadata changes
+            expect(result!.metadata!.embeds![0].data.post.message).toBe('Post with updated files');
+            expect(result!.metadata!.embeds![0].data.post.edit_at).toBe(2000);
+            expect(result!.metadata!.embeds![0].data.post.metadata).toEqual({
+                files: newFileMetadata,
+            });
+            expect(result!.metadata!.embeds![0].data.post.metadata!.files).toHaveLength(2);
+            expect(result!.metadata!.embeds![0].data.post.metadata!.files![1].name).toBe('new_file.jpg');
+
+            await operator.batchRecords([result!], 'test file metadata update');
+        });
+
         it('should handle errors during post update gracefully', async () => {
             const referencedPostId = 'referenced_post_456';
 

--- a/app/utils/permalink_sync.ts
+++ b/app/utils/permalink_sync.ts
@@ -61,6 +61,8 @@ export function updatePermalinkMetadata(
                                 update_at: freshPostData.update_at,
                                 user_id: freshPostData.user_id,
                                 create_at: freshPostData.create_at,
+                                file_ids: freshPostData.file_ids,
+                                metadata: freshPostData.metadata,
                             },
                         },
                     };


### PR DESCRIPTION
#### Summary
This PR adds file attachment support and conditional gradient overflow handling to the permalink preview component. It introduces a new `PermalinkFiles` wrapper that integrates with the existing Files system to display both image previews (in horizontal rows) and document files (with names, sizes, and icons). The implementation includes a conditional `LinearGradient` that appears only when the content exceeds 506px in height (as per design).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65000

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<img width="381" height="817" alt="Screenshot 2025-09-02 at 12 56 57 PM" src="https://github.com/user-attachments/assets/27eeb370-e8e1-4088-83f1-29aeab77ae26" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
