### PR TITLE
Fix the Edited post incorrect line spacing on Android

### DIFF
--- a/app/components/edited_indicator/index.tsx
+++ b/app/components/edited_indicator/index.tsx
@@ -39,12 +39,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
 
     return {
         editedIndicatorText: {
-            ...baseTextStyle,
             ...typography('Body', 25, 'Regular'),
+            ...baseTextStyle,
         },
         editedText: {
-            ...baseTextStyle,
             ...typography('Body', 100, 'Regular'),
+            ...baseTextStyle,
         },
         icon: {
             color: editedColor,


### PR DESCRIPTION
#### Summary
The PR fixed the shrinking issue when the message is edited compared with the non edited message. This was because of the way React Native handles text rendering and syle inheritance. When the `lineHeight` is set, it make the text to fit within that height. So when the message is edited here is tree that is created 
```
<View>
  <Text style={messageStyle}>
    This is the main message text.
    <Text style={editedIndicatorStyle}>
      <CompassIcon name='pencil-outline' size={iconSize} color={iconColor} />
      <FormattedText id='post_message_view.edited' defaultMessage='Edited' />
    </Text>
  </Text>
</View>
```

When we use `typograph` for the edited indicator, we end up setting a `lineHeight` that is different from the main message. This happens because the edited indicator uses a smaller font size, which leads to a different line height. Due to the style propagation through nested `<Text>` component, if a child element has a fixed `lineHeight`, it can affect the layout height of the parent or sibling text elements. This is extactly what makes the edited post shrinking.

By setting `lineHeight: undefined`, the text uses it's natual line height and avoid shirnking. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65130

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
Before: 
<img width="458" height="491" alt="Screenshot 2025-09-30 at 2 24 50 PM" src="https://github.com/user-attachments/assets/5748afdc-bd67-44a1-b3c3-be1370d215ed" />

After:
<img width="453" height="513" alt="Screenshot 2025-09-30 at 2 25 11 PM" src="https://github.com/user-attachments/assets/f0214f0f-deb8-420b-bc08-6e801471a46b" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fix the Edited message line height. 
```
