### PR TITLE
Fix error on notification reply on iOS

### DIFF
--- a/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
+++ b/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
@@ -77,7 +77,7 @@ static SendReplyCompletionHandlerIMP originalSendReplyCompletionHandlerImplement
   if (rootId == nil) {
     rootId = [parsedResponse valueForKeyPath:@"notification.post_id"];
   }
-
+  
   NSDictionary *post = @{
     @"message": message,
     @"channel_id": channelId,
@@ -99,7 +99,7 @@ static SendReplyCompletionHandlerIMP originalSendReplyCompletionHandlerImplement
   [request setValue:@"application/json; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
   
   // Add preauth secret header if available
-  if (preauthSecret != nil && ![preauthSecret isEqualToString:@""]) {
+  if (preauthSecret != nil && ![preauthSecret isKindOfClass:[NSNull class]] && ![preauthSecret isEqualToString:@""]) {
     [request setValue:preauthSecret forHTTPHeaderField:@"X-Mattermost-Preauth-Secret"];
   }
   

--- a/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
+++ b/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
@@ -77,7 +77,7 @@ static SendReplyCompletionHandlerIMP originalSendReplyCompletionHandlerImplement
   if (rootId == nil) {
     rootId = [parsedResponse valueForKeyPath:@"notification.post_id"];
   }
-  
+
   NSDictionary *post = @{
     @"message": message,
     @"channel_id": channelId,

--- a/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
+++ b/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
@@ -99,7 +99,7 @@ static SendReplyCompletionHandlerIMP originalSendReplyCompletionHandlerImplement
   [request setValue:@"application/json; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
   
   // Add preauth secret header if available
-  if (preauthSecret != nil && ![preauthSecret isKindOfClass:[NSNull class]] && ![preauthSecret isEqualToString:@""]) {
+  if ([preauthSecret isKindOfClass:NSString.class] && [(NSString *)preauthSecret length] > 0) {
     [request setValue:preauthSecret forHTTPHeaderField:@"X-Mattermost-Preauth-Secret"];
   }
   


### PR DESCRIPTION

#### Summary
In some places, a "nil" value is not possible to pass. In those scenarios, on iOS they may use an object called NSNull to represent nil values.

Since it is an object, it will return true to the `!= nil` check, so we have to check directly for NSNull.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66069


#### Release Note
```release-note
NONE
```
