### PR TITLE
[MM-65720] - Add "Save as draft" button on the Share extension

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -208,6 +208,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation "com.google.firebase:firebase-messaging:$firebaseVersion"
+    implementation 'androidx.work:work-runtime-ktx:2.10.5'
     androidTestImplementation('com.wix:detox:+')
     androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test:runner:1.6.2'

--- a/android/app/src/main/java/com/mattermost/helpers/AppStateHelper.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/AppStateHelper.kt
@@ -1,0 +1,6 @@
+package com.mattermost.helpers
+
+object AppStateHelper {
+    @Volatile
+    var isMainAppActive: Boolean = false
+}

--- a/android/app/src/main/java/com/mattermost/helpers/DraftDataHelper.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/DraftDataHelper.kt
@@ -1,0 +1,30 @@
+package com.mattermost.helpers
+
+import android.content.Context
+import com.mattermost.helpers.database_extension.getDatabaseForServer
+import com.mattermost.helpers.database_extension.insertOrUpdateDraft
+import com.nozbe.watermelondb.WMDatabase
+import org.json.JSONArray
+
+class DraftDataHelper(private val context: Context) {
+    private val dbHelper = DatabaseHelper.instance!!
+
+    fun saveDraft(
+        serverUrl: String,
+        channelId: String,
+        message: String,
+        files: JSONArray
+    ) {
+        try {
+            dbHelper.init(context.applicationContext)
+            val db: WMDatabase? = dbHelper.getDatabaseForServer(context, serverUrl)
+
+            if (db != null) {
+                dbHelper.insertOrUpdateDraft(db, channelId, message, files)
+                db.close()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Draft.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Draft.kt
@@ -1,0 +1,118 @@
+package com.mattermost.helpers.database_extension
+
+import com.mattermost.helpers.DatabaseHelper
+import com.nozbe.watermelondb.WMDatabase
+import org.json.JSONArray
+import org.json.JSONException
+import kotlin.Exception
+import java.util.UUID
+
+data class Draft(
+    val id: String? = null,
+    val channelId: String,
+    val rootId: String,
+    val message: String,
+    val files: JSONArray = JSONArray(),
+    val metadata: String = "{}",
+    val updateAt: Double
+)
+
+internal fun insertDraft(db: WMDatabase, draft: Draft) {
+    try {
+        val id = draft.id ?: generateId()
+        db.execute(
+            """
+            INSERT OR REPLACE INTO Draft 
+            (id, channel_id, root_id, message, files, metadata, update_at, _status) 
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'created')
+            """.trimIndent(),
+            arrayOf(
+                id,
+                draft.channelId,
+                draft.rootId,
+                draft.message,
+                draft.files.toString(),
+                draft.metadata,
+                draft.updateAt
+            )
+        )
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}
+
+internal fun getDraft(db: WMDatabase, channelId: String, rootId: String = ""): Draft? {
+    try {
+        val query = """ 
+            SELECT id, channel_id, root_id, message, files, metadata, update_at 
+            FROM Draft 
+            WHERE channel_id=? AND root_id=? 
+            LIMIT 1
+        """.trimIndent()
+        db.rawQuery(query, arrayOf(channelId, rootId)).use { cursor ->
+            if (cursor.count == 1) {
+                cursor.moveToFirst()
+                val id = cursor.getString(0)
+                val chId = cursor.getString(1)
+                val rId = cursor.getString(2)
+                val message = cursor.getString(3)
+                val filesStr = cursor.getString(4)
+                val metadata = cursor.getString(5)
+                val updateAt = cursor.getDouble(6)
+
+                val filesJson = try {
+                    JSONArray(filesStr)
+                } catch (e: JSONException) {
+                    JSONArray()
+                }
+                return Draft(id, chId, rId, message, filesJson, metadata, updateAt)
+            }
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+    return null
+}
+
+fun generateId(): String {
+    return UUID.randomUUID().toString().replace("-", "")
+}
+
+fun DatabaseHelper.insertOrUpdateDraft(
+    db: WMDatabase,
+    channelId: String,
+    message: String,
+    files: JSONArray
+) {
+    try {
+        val existing = getDraft(db, channelId, "")
+        val now = System.currentTimeMillis().toDouble()
+
+        if (existing != null) {
+            val updated = Draft(
+                id = existing.id,
+                channelId = channelId,
+                rootId = existing.rootId,
+                message = message,
+                files = files,
+                metadata = existing.metadata,
+                updateAt = now
+            )
+            insertDraft(db, updated)
+        } else {
+            if (message.isEmpty() && files.length() == 0) return
+
+            val newDraft = Draft(
+                channelId = channelId,
+                rootId = "",
+                message = message,
+                files = files,
+                metadata = "{}",
+                updateAt = now
+            )
+            insertDraft(db, newDraft)
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}

--- a/android/app/src/main/java/com/mattermost/rnbeta/DraftWorker.kt
+++ b/android/app/src/main/java/com/mattermost/rnbeta/DraftWorker.kt
@@ -9,12 +9,16 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableArray
 import com.mattermost.rnshare.MattermostShareModule
+import com.mattermost.helpers.DraftDataHelper
+import com.mattermost.helpers.AppStateHelper
 import com.mattermost.turbolog.TurboLog
+import org.json.JSONArray
 import org.json.JSONObject
 
 class DraftWorker(appContext: Context, params: WorkerParameters) : Worker (appContext, params) {
     override fun doWork(): Result {
         val draftJson = inputData.getString("draft_data") ?: return Result.failure()
+        val serverUrl = inputData.getString("serverUrl")
 
         return try {
             val draft = JSONObject(draftJson)
@@ -30,6 +34,7 @@ class DraftWorker(appContext: Context, params: WorkerParameters) : Worker (appCo
                     fileMap.putString("name", info.optString("name"))
                     fileMap.putString("extension", info.optString("extension"))
                     fileMap.putString("mime_type", info.optString("mime_type"))
+                    fileMap.putDouble("size", info.optDouble("size"))
                     filesArray.pushMap(fileMap)
                 }
             }
@@ -38,14 +43,16 @@ class DraftWorker(appContext: Context, params: WorkerParameters) : Worker (appCo
                 "message" to draft.optString("message"),
                 "files" to filesArray
             )
-            val reactApp = applicationContext as? ReactApplication
-            val reactInstanceManager: ReactInstanceManager? = reactApp?.reactNativeHost?.reactInstanceManager
-            val reactContext = reactInstanceManager?.currentReactContext
 
-            if (reactContext != null && reactInstanceManager.hasStartedCreatingInitialContext()) {
-                handleDraftWhileAppRunning(draftMap, reactContext)
+            if (AppStateHelper.isMainAppActive) {
+                val reactApp = applicationContext as? ReactApplication
+                val reactInstanceManager: ReactInstanceManager? = reactApp?.reactNativeHost?.reactInstanceManager
+                val reactContext = reactInstanceManager?.currentReactContext
+                if (reactContext != null && reactInstanceManager.hasStartedCreatingInitialContext()) {
+                    handleDraftWhileAppRunning(draftMap, reactContext)
+                }
             } else {
-                handleDraftInBackground(draftMap)
+                handleDraftInBackground(serverUrl, draftMap)
             }
 
             Result.success()
@@ -59,10 +66,34 @@ class DraftWorker(appContext: Context, params: WorkerParameters) : Worker (appCo
     private fun handleDraftWhileAppRunning(draft: Map<String, Any?>, reactContext: ReactContext) {
         val writableDraft = Arguments.makeNativeMap(draft)
         val module = reactContext.getNativeModule(MattermostShareModule::class.java)
-            module?.sendDraftUpdate(writableDraft)
+        module?.sendDraftUpdate(writableDraft)
     }
 
-    private fun handleDraftInBackground(draft: Map<String, Any?>) {
-        // TODO
+    private fun handleDraftInBackground(serverUrl: String?, draft: Map<String, Any?>) {
+        if (serverUrl == null) return
+        try {
+            val channelId = draft["channelId"] as? String ?: return
+            val message = draft["message"] as? String ?: ""
+
+            val files = JSONArray()
+            val filesList = draft["files"]
+            if (filesList is WritableArray) {
+                for (i in 0 until filesList.size()) {
+                    val map = filesList.getMap(i)
+                    val obj = JSONObject()
+                    obj.put("id", map.getString("id") ?: "")
+                    obj.put("name", map.getString("name") ?: "")
+                    obj.put("extension", map.getString("extension") ?: "")
+                    obj.put("mime_type", map.getString("mime_type") ?: "")
+                    obj.put("size", map.getDouble("size"))
+                    files.put(obj)
+                }
+            }
+            val helper = DraftDataHelper(applicationContext)
+            helper.saveDraft(serverUrl, channelId, message, files)
+        } catch (e: Exception) {
+            val eMessage = e.message ?: "Error with no message"
+            TurboLog.e("ReactNative", "DraftWorker: Failed to save draft in background error=${eMessage}")
+        }
     }
 }

--- a/android/app/src/main/java/com/mattermost/rnbeta/DraftWorker.kt
+++ b/android/app/src/main/java/com/mattermost/rnbeta/DraftWorker.kt
@@ -1,0 +1,68 @@
+package com.mattermost.rnbeta
+
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.WritableArray
+import com.mattermost.rnshare.MattermostShareModule
+import com.mattermost.turbolog.TurboLog
+import org.json.JSONObject
+
+class DraftWorker(appContext: Context, params: WorkerParameters) : Worker (appContext, params) {
+    override fun doWork(): Result {
+        val draftJson = inputData.getString("draft_data") ?: return Result.failure()
+
+        return try {
+            val draft = JSONObject(draftJson)
+            val filesArray: WritableArray = Arguments.createArray()
+
+            if (draft.has("file_infos")) {
+                val filesInfo = draft.getJSONArray("file_infos")
+
+                for (i in 0 until filesInfo.length()) {
+                    val info = filesInfo.getJSONObject(i)
+                    val fileMap = Arguments.createMap()
+                    fileMap.putString("id", info.optString("id"))
+                    fileMap.putString("name", info.optString("name"))
+                    fileMap.putString("extension", info.optString("extension"))
+                    fileMap.putString("mime_type", info.optString("mime_type"))
+                    filesArray.pushMap(fileMap)
+                }
+            }
+            val draftMap = mapOf(
+                "channelId" to draft.optString("channel_id"),
+                "message" to draft.optString("message"),
+                "files" to filesArray
+            )
+            val reactApp = applicationContext as? ReactApplication
+            val reactInstanceManager: ReactInstanceManager? = reactApp?.reactNativeHost?.reactInstanceManager
+            val reactContext = reactInstanceManager?.currentReactContext
+
+            if (reactContext != null && reactInstanceManager.hasStartedCreatingInitialContext()) {
+                handleDraftWhileAppRunning(draftMap, reactContext)
+            } else {
+                handleDraftInBackground(draftMap)
+            }
+
+            Result.success()
+        } catch (e: Exception) {
+            val eMessage = e.message ?: "Error with no message"
+            TurboLog.e("ReactNative", "DraftWorker Failed to process draft error=$eMessage")
+            Result.failure()
+        }
+    }
+
+    private fun handleDraftWhileAppRunning(draft: Map<String, Any?>, reactContext: ReactContext) {
+        val writableDraft = Arguments.makeNativeMap(draft)
+        val module = reactContext.getNativeModule(MattermostShareModule::class.java)
+            module?.sendDraftUpdate(writableDraft)
+    }
+
+    private fun handleDraftInBackground(draft: Map<String, Any?>) {
+        // TODO
+    }
+}

--- a/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.kt
+++ b/android/app/src/main/java/com/mattermost/rnbeta/MainActivity.kt
@@ -7,6 +7,7 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 import com.mattermost.hardware.keyboard.MattermostHardwareKeyboardImpl
+import com.mattermost.helpers.AppStateHelper
 import com.mattermost.rnutils.helpers.FoldableObserver
 import com.reactnativenavigation.NavigationActivity
 import expo.modules.ReactActivityDelegateWrapper
@@ -42,6 +43,7 @@ class MainActivity : NavigationActivity() {
     override fun onStart() {
         super.onStart()
         foldableObserver.onStart()
+        AppStateHelper.isMainAppActive = true
     }
 
     override fun onStop() {
@@ -52,6 +54,7 @@ class MainActivity : NavigationActivity() {
     override fun onDestroy() {
         super.onDestroy()
         foldableObserver.onDestroy()
+        AppStateHelper.isMainAppActive = false
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/init/app.ts
+++ b/app/init/app.ts
@@ -4,6 +4,7 @@
 import {CallsManager} from '@calls/calls_manager';
 import DatabaseManager from '@database/manager';
 import {getAllServerCredentials} from '@init/credentials';
+import DraftsUpdate from '@init/drafts_updates';
 import {initialLaunch} from '@init/launch';
 import ManagedApp from '@init/managed_app';
 import PushNotifications from '@init/push_notifications';
@@ -61,6 +62,7 @@ export async function start() {
     await initialize();
 
     PushNotifications.init(serverCredentials.length > 0);
+    DraftsUpdate.init();
 
     registerNavigationListeners();
     registerScreens();

--- a/app/init/drafts_updates.ts
+++ b/app/init/drafts_updates.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {NativeEventEmitter, NativeModules, type EmitterSubscription} from 'react-native';
+
+import {addFilesToDraft, updateDraftMessage} from '@actions/local/draft';
+import DatabaseManager from '@database/manager';
+import {getFullErrorMessage} from '@utils/errors';
+import {logDebug} from '@utils/log';
+
+const {MattermostShare} = NativeModules;
+
+class DraftsUpdatesSingleton {
+    private emitter: NativeEventEmitter;
+    private subscription?: EmitterSubscription;
+
+    constructor() {
+        this.emitter = new NativeEventEmitter(MattermostShare);
+    }
+
+    init() {
+        this.subscription?.remove();
+        this.subscription = this.emitter.addListener('onDraftUpdated', async (draft) => {
+            try {
+                const serverUrl = await DatabaseManager.getActiveServerUrl();
+                if (serverUrl) {
+                    await updateDraftMessage(serverUrl, draft.channelId, '', draft.message);
+
+                    if (draft.files?.length > 0) {
+                        addFilesToDraft(serverUrl, draft.channelId, '', draft.files);
+                    }
+                }
+            } catch (error) {
+                logDebug('error on draftsUpdates', getFullErrorMessage(error));
+            }
+        });
+    }
+}
+
+const DraftUpdates = new DraftsUpdatesSingleton();
+export default DraftUpdates;

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1277,6 +1277,7 @@
   "share_extension.max_resolution": "Image exceeds maximum dimensions of 7680 x 4320 px",
   "share_extension.message": "Enter a message (optional)",
   "share_extension.multiple_label": "{count, number} attachments",
+  "share_extension.save_draft": "Save as draft",
   "share_extension.server_label": "Server",
   "share_extension.servers_screen.title": "Select server",
   "share_extension.share_screen.title": "Share to {applicationName}",

--- a/ios/Gekidou/Sources/Gekidou/DataTypes/Draft.swift
+++ b/ios/Gekidou/Sources/Gekidou/DataTypes/Draft.swift
@@ -12,7 +12,7 @@ public struct Draft: Codable {
     public init(
         id: String,
         channelId: String,
-        rootId: String ,
+        rootId: String,
         message: String,
         files: [[String: Any]],
         metadata: String,

--- a/ios/Gekidou/Sources/Gekidou/DataTypes/Draft.swift
+++ b/ios/Gekidou/Sources/Gekidou/DataTypes/Draft.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public struct Draft: Codable {
+    let id: String
+    let channelId: String
+    let rootId: String
+    let message: String
+    let files: [[String: Any]]
+    let metadata: String
+    let updateAt: Double
+
+    public init(
+        id: String,
+        channelId: String,
+        rootId: String ,
+        message: String,
+        files: [[String: Any]],
+        metadata: String,
+        updateAt: Double
+    ) {
+        self.id = id
+        self.channelId = channelId
+        self.rootId = rootId
+        self.message = message
+        self.files = files
+        self.metadata = metadata
+        self.updateAt = updateAt
+    }
+
+    public enum DraftKeys: String, CodingKey {
+        case id, message, files, metadata
+        case channelId = "channel_id"
+        case rootId = "root_id"
+        case updateAt = "update_at"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: DraftKeys.self)
+        id = try values.decode(String.self, forKey: .id)
+        channelId = try values.decode(String.self, forKey: .channelId)
+        rootId = values.decodeIfPresent(forKey: .rootId, defaultValue: "")
+        message = values.decodeIfPresent(forKey: .message, defaultValue: "")
+        updateAt = values.decodeIfPresent(forKey: .updateAt, defaultValue: 0)
+
+        if let rawFiles = try? values.decode(String.self, forKey: .files),
+           let data = rawFiles.data(using: .utf8),
+           let parsed = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] {
+            files = parsed
+        } else {
+            files = []
+        }
+        
+        if let meta = try? values.decode([String:Any].self, forKey: .metadata) {
+            metadata = Database.default.json(from: meta) ?? "{}"
+        } else {
+            metadata = "{}"
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DraftKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(channelId, forKey: .channelId)
+        try container.encode(rootId, forKey: .rootId)
+        try container.encode(message, forKey: .message)
+        try container.encode(updateAt, forKey: .updateAt)
+        
+        if let data = try? JSONSerialization.data(withJSONObject: files, options: []),
+           let jsonString = String(data: data, encoding: .utf8) {
+            try container.encode(jsonString, forKey: .files)
+        } else {
+            try container.encode("[]", forKey: .files)
+        }
+        
+        try container.encode(metadata, forKey: .metadata)
+    }
+}

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Delegate.swift
@@ -75,7 +75,7 @@ extension ShareExtension: URLSessionDataDelegate {
                 let fileData = fileInfos[0] as! NSDictionary
                 let fileId = fileData.object(forKey: "id") as? String ?? "no file id"
                 let filename = fileData.object(forKey: "name") as? String ?? "no file name"
-                appendCompletedUploadToSession(id: id, fileId: fileId)
+                appendCompletedUploadToSession(id: id, fileId: fileId, fileData: fileData)
                 let total = uploadData.totalFiles
                 let count = uploadData.fileIds.count + 1
                 

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
@@ -183,7 +183,6 @@ extension ShareExtension {
         let draftData: [String: Any] = [
             "channelId": channelId,
             "message": data.message,
-            "fileIds": data.fileIds,
             "files": filesArray
         ]
         

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
@@ -164,12 +164,12 @@ extension ShareExtension {
         guard let serverUrl = data.serverUrl,
               let channelId = data.channelId else { return }
         
-        let isRunning = (Gekidou.Preferences.default.object(forKey: "ApplicationIsRunning") as? String) == "true"
+        let isAppRunning = (Gekidou.Preferences.default.object(forKey: "ApplicationIsRunning") as? String) == "true"
         let filesArray = data.fileIds.compactMap { fileId in
             data.filesInfo[fileId] as? [String: Any]
         }
 
-        if isRunning {
+        if isAppRunning {
             handleDraftWhileAppRunning(channelId: channelId, data: data, filesArray: filesArray, completionHandler: completionHandler)
         } else {
             handleDraftInBackground(id: id, serverUrl: serverUrl, channelId: channelId, data: data, filesArray: filesArray, completionHandler: completionHandler)
@@ -190,7 +190,7 @@ extension ShareExtension {
         Preferences.default.set(draftData, forKey: "ShareExtensionDraftUpdate")
         CFNotificationCenterPostNotification(
             CFNotificationCenterGetDarwinNotifyCenter(),
-            CFNotificationName("share.extension.draftUploadFinished" as CFString),
+            CFNotificationName("share.extension.draftUpdate" as CFString),
             nil, nil, true
         )
         completionHandler?()

--- a/ios/Gekidou/Sources/Gekidou/Storage/Database+Draft.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database+Draft.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SQLite
+
+extension Database {
+    public func insertDraft(_ db: Connection, _ draft: Draft) throws {
+        try? db.transaction {
+            let idCol = Expression<String>("id")
+            let channelIdCol = Expression<String>("channel_id")
+            let rootIdCol = Expression<String>("root_id")
+            let messageCol = Expression<String>("message")
+            let filesCol = Expression<String>("files")
+            let metadataCol = Expression<String>("metadata")
+            let updateAtCol = Expression<Double>("update_at")
+            let statusCol = Expression<String>("_status")
+            
+            let filesJSON: String
+            if let data = try? JSONSerialization.data(withJSONObject: draft.files, options: []),
+               let jsonString = String(data: data, encoding: .utf8) {
+                filesJSON = jsonString
+            } else {
+                filesJSON = "[]"
+            }
+            
+            let setters: [Setter] = [
+                idCol <- draft.id,
+                channelIdCol <- draft.channelId,
+                rootIdCol <- draft.rootId,
+                messageCol <- draft.message,
+                filesCol <- filesJSON,
+                metadataCol <- draft.metadata,
+                updateAtCol <- draft.updateAt,
+                statusCol <- "created"
+            ]
+
+            let insertQuery = draftTable.insert(or: .replace, setters)
+            try db.run(insertQuery)
+        }
+    }
+
+    public func insertDraft(_ draft: Draft, serverUrl: String) throws {
+        if let db = try? getDatabaseForServer(serverUrl) {
+            try insertDraft(db, draft)
+        }
+    }
+
+    public func getDraft(db: Connection, channelId: String, rootId: String) throws -> Draft? {
+        let channelIdCol = Expression<String>("channel_id")
+        let rootIdCol = Expression<String>("root_id")
+
+        let query = draftTable
+            .filter(channelIdCol == channelId && rootIdCol == rootId)
+            .limit(1)
+
+        if let result = try? db.pluck(query) {
+            let id = result[Expression<String>("id")]
+            let channelId = result[channelIdCol]
+            let rootId = result[rootIdCol]
+            let message = result[Expression<String>("message")]
+            let fileJSON = result[Expression<String>("files")]
+            let metadata = result[Expression<String>("metadata")]
+            let updateAt = result[Expression<Double>("update_at")]
+
+            var files: [[String: Any]] = []
+            if let data = fileJSON.data(using: .utf8),
+               let parsed = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] {
+                files = parsed
+            }
+
+            return Draft(
+                id: id,
+                channelId: channelId,
+                rootId: rootId,
+                message: message,
+                files: files,
+                metadata: metadata,
+                updateAt: updateAt
+            )
+        }
+        return nil
+    }
+
+    public func getDraft(serverUrl: String, channelId: String, rootId: String) throws -> Draft? {
+        if let db = try? getDatabaseForServer(serverUrl) {
+            return try getDraft(db: db, channelId: channelId, rootId: rootId)
+        }
+        return nil
+    }
+}

--- a/ios/Gekidou/Sources/Gekidou/Storage/Database.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database.swift
@@ -68,6 +68,7 @@ public class Database: NSObject {
     internal var preferenceTable = Table("Preference")
     internal var categoryTable = Table("Category")
     internal var categoryChannelTable = Table("CategoryChannel")
+    internal var draftTable = Table("Draft")
     
     @objc public static let `default` = Database()
     

--- a/ios/Mattermost/AppDelegate.h
+++ b/ios/Mattermost/AppDelegate.h
@@ -5,7 +5,7 @@
 #import "ExpoModulesCore-Swift.h"
 #import <mattermost_rnutils-Swift.h>
 #import <mattermost_hardware_keyboard-Swift.h>
-
+#import <mattermost_rnshare-Swift.h>
 
 @interface AppDelegate : EXAppDelegateWrapper<OrientationLockable>
 

--- a/ios/MattermostShare/ShareViewController.swift
+++ b/ios/MattermostShare/ShareViewController.swift
@@ -95,6 +95,7 @@ class ShareViewController: UIViewController {
       let linkPreviewUrl = userInfo["linkPreviewUrl"] as? String
       let fileCount = attachments.count
       let files: [String] = attachments.map{ $0.fileUrl.absoluteString }
+      let isDraft = userInfo["isDraft"] as? Bool ?? false
       
      
      
@@ -128,7 +129,8 @@ class ShareViewController: UIViewController {
           completionHandler: { [weak self] in
             self?.removeObservers()
             self?.extensionContext!.completeRequest(returningItems: [])
-          })
+          },
+          isDraft: isDraft)
         if uploadError != nil {
           NotificationCenter.default.post(name: Notification.Name("errorPosting"), object: nil, userInfo: ["info": uploadError as Any])
         }

--- a/ios/MattermostShare/Views/ContentViews/ContentView.swift
+++ b/ios/MattermostShare/Views/ContentViews/ContentView.swift
@@ -78,6 +78,13 @@ struct ContentView: View {
       }
       
       Spacer()
+
+      PostButton(
+        attachments: $attachments,
+        linkPreviewUrl: linkPreviewUrl,
+        message: $message,
+        isDraft: true
+      )
     }
 //    .keyboardAdaptive()
   }

--- a/ios/MattermostShare/Views/FontIconViews/CompassIcons.swift
+++ b/ios/MattermostShare/Views/FontIconViews/CompassIcons.swift
@@ -29,4 +29,5 @@ public enum CompassIconsCode: String, CaseIterable {
   case patchFile = "\u{e909}"
   case zipFile = "\u{e90a}"
   case codeFile = "\u{e90b}"
+  case pen = "\u{f0cb6}"
 }

--- a/ios/MattermostShare/Views/NavigationButtons/PostButton.swift
+++ b/ios/MattermostShare/Views/NavigationButtons/PostButton.swift
@@ -58,7 +58,6 @@ struct PostButton: View {
             .font(Font.custom("Metropolis-SemiBold", size: 14))
             .foregroundColor(Color.theme.linkColor)
           }
-          .padding(.leading, 15)
           .padding(.vertical, 10)
         }
       } else {

--- a/ios/MattermostShare/Views/NavigationButtons/PostButton.swift
+++ b/ios/MattermostShare/Views/NavigationButtons/PostButton.swift
@@ -52,7 +52,7 @@ struct PostButton: View {
             FontIcon.text(.compassIcons(code: .pen), fontsize: 24, color: Color.theme.linkColor)
             Text(
               NSLocalizedString("share_extension.save_draft",
-                value: "Save as a draft",
+                value: "Save as draft",
                 comment: "")
             )
             .font(Font.custom("Metropolis-SemiBold", size: 14))

--- a/ios/MattermostShare/Views/NavigationButtons/PostButton.swift
+++ b/ios/MattermostShare/Views/NavigationButtons/PostButton.swift
@@ -14,6 +14,7 @@ struct PostButton: View {
   var linkPreviewUrl: String
   @Binding var message: String
   @State var pressed: Bool = false
+  var isDraft: Bool = false
   
   let submitPublisher = NotificationCenter.default.publisher(for: Notification.Name("submit"))
   
@@ -24,6 +25,7 @@ struct PostButton: View {
       "attachments": attachments,
       "linkPreviewUrl": linkPreviewUrl,
       "message": message,
+      "isDraft": isDraft
     ]
     pressed = true
     NotificationCenter.default.post(name: Notification.Name("doPost"), object: nil, userInfo: userInfo)
@@ -43,14 +45,33 @@ struct PostButton: View {
       ($0.fileSize > shareViewModel.server!.maxFileSize)
     }
     
-    FontIcon.button(
-      .compassIcons(code: .send),
-      action: submit,
-      fontsize: 24,
-      color: disabled || pressed ? .white.opacity(0.16) : .white
-    )
-    .padding(.leading, 10)
-    .padding(.vertical, 5)
+    Group {
+      if isDraft {
+        Button(action: submit) {
+          HStack {
+            FontIcon.text(.compassIcons(code: .pen), fontsize: 24, color: Color.theme.linkColor)
+            Text(
+              NSLocalizedString("share_extension.save_draft",
+                value: "Save as a draft",
+                comment: "")
+            )
+            .font(Font.custom("Metropolis-SemiBold", size: 14))
+            .foregroundColor(Color.theme.linkColor)
+          }
+          .padding(.leading, 15)
+          .padding(.vertical, 10)
+        }
+      } else {
+        FontIcon.button(
+          .compassIcons(code: .send),
+          action: submit,
+          fontsize: 24,
+          color: disabled || pressed ? .white.opacity(0.16) : .white
+        )
+        .padding(.leading, 10)
+        .padding(.vertical, 5)
+      }
+    }
     .disabled(disabled || pressed)
     .onReceive(submitPublisher) {_ in
       submit()

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -104,6 +104,27 @@ PODS:
     - ReactCommon/turbomodule/core
     - TurboLogIOSNative
     - Yoga
+  - mattermost-rnshare (0.0.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - mattermost-rnutils (0.0.0):
     - DoubleConversion
     - glog
@@ -2247,6 +2268,7 @@ DEPENDENCIES:
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - "mattermost-hardware-keyboard (from `../node_modules/@mattermost/hardware-keyboard`)"
   - "mattermost-react-native-turbo-log (from `../node_modules/@mattermost/react-native-turbo-log`)"
+  - "mattermost-rnshare (from `../node_modules/@mattermost/rnshare`)"
   - "mattermost-rnutils (from `../node_modules/@mattermost/rnutils`)"
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -2403,6 +2425,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@mattermost/hardware-keyboard"
   mattermost-react-native-turbo-log:
     :path: "../node_modules/@mattermost/react-native-turbo-log"
+  mattermost-rnshare:
+    :path: "../node_modules/@mattermost/rnshare"
   mattermost-rnutils:
     :path: "../node_modules/@mattermost/rnutils"
   RCT-Folly:
@@ -2625,6 +2649,7 @@ SPEC CHECKSUMS:
   JitsiWebRTC: b47805ab5668be38e7ee60e2258f49badfe8e1d0
   mattermost-hardware-keyboard: a17b424a774fe564c6b90016ba0bc02e4b567a3e
   mattermost-react-native-turbo-log: 08d7dba812981a2c155f00df12878222ee6eb062
+  mattermost-rnshare: 25c13cef98b442d7f0474fe21d428f0370a46421
   mattermost-rnutils: 32f4f7ad85e2e470259a0e1e5ae6cd4fee83e77e
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83

--- a/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/MattermostShareImpl.kt
+++ b/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/MattermostShareImpl.kt
@@ -60,8 +60,10 @@ class MattermostShareImpl(private val reactContext: ReactApplicationContext) {
         if (data != null && data.hasKey("serverUrl") && data.hasKey("token")) {
             val jsonObject = data.toJson()
             val jsonString = jsonObject.toString()
+            val isDraft = data.getBoolean("isDraft")
             val inputData = Data.Builder()
                     .putString("json_data", jsonString)
+                    .putBoolean("isDraft", isDraft)
                     .putString("tempFolder", this.tempFolder?.absolutePath)
                     .build()
 

--- a/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/ShareWorker.kt
+++ b/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/ShareWorker.kt
@@ -105,7 +105,7 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
             val postData = buildPostObject(jsonObject)
 
             if (isDraft) {
-                enqueueDraftWorker(postData)
+                enqueueDraftWorker(serverUrl, postData)
             }
             if (files != null && files.length() > 0) {
                 setForegroundAsync(createForegroundInfo())
@@ -216,7 +216,7 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
 
                         return if (isDraft) {
                             postData.put("file_infos", fileInfoArray)
-                            enqueueDraftWorker(postData)
+                            enqueueDraftWorker(serverUrl, postData)
                         } else {
                             post(serverUrl, token, preauthSecret, postData)
                         }
@@ -233,10 +233,11 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
         }
     }
 
-    private fun enqueueDraftWorker(postData: JSONObject): Result {
+    private fun enqueueDraftWorker(serverUrl: String, postData: JSONObject): Result {
         val packageName = context.applicationContext.packageName
         val inputDataDraft = Data.Builder()
             .putString("draft_data", postData.toString())
+            .putString("serverUrl", serverUrl)
             .build()
         val draftWorkerClass = Class.forName("$packageName.DraftWorker")
             .asSubclass(ListenableWorker::class.java)

--- a/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/ShareWorker.kt
+++ b/libraries/@mattermost/rnshare/android/src/main/java/com/mattermost/rnshare/ShareWorker.kt
@@ -6,7 +6,11 @@ import android.os.Build
 import android.util.Base64
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.work.Data
 import androidx.work.ForegroundInfo
+import androidx.work.ListenableWorker
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.mattermost.rnshare.helpers.RealPathUtil
@@ -87,6 +91,7 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
     override fun doWork(): Result {
         val jsonString = inputData.getString("json_data") ?: return Result.failure()
         val tempFolder = inputData.getString("tempFolder")
+        val isDraft = inputData.getBoolean("isDraft", false)
 
         try {
             val jsonObject = JSONObject(jsonString)
@@ -99,9 +104,15 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
             } else null
             val postData = buildPostObject(jsonObject)
 
+            if (isDraft) {
+                enqueueDraftWorker(postData)
+            }
             if (files != null && files.length() > 0) {
                 setForegroundAsync(createForegroundInfo())
-                return uploadFiles(serverUrl, token, preauthSecret, files, postData)
+                return uploadFiles(serverUrl, token, preauthSecret, files, postData, isDraft)
+            }
+            return if (isDraft) {
+                Result.success()
             } else {
                 try {
                     return post(serverUrl, token, preauthSecret, postData)
@@ -150,7 +161,13 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
         return Result.success()
     }
 
-    private fun uploadFiles(serverUrl: String, token: String, preauthSecret: String?, files: JSONArray, postData: JSONObject): Result {
+    private fun uploadFiles(serverUrl: String,
+                            token: String,
+                            preauthSecret: String?,
+                            files: JSONArray,
+                            postData: JSONObject,
+                            isDraft: Boolean
+    ): Result {
         try {
             val builder = MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -196,7 +213,13 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
                             fileIds.put(fileInfo.getString("id"))
                         }
                         postData.put("file_ids", fileIds)
-                        return post(serverUrl, token, preauthSecret, postData)
+
+                        return if (isDraft) {
+                            postData.put("file_infos", fileInfoArray)
+                            enqueueDraftWorker(postData)
+                        } else {
+                            post(serverUrl, token, preauthSecret, postData)
+                        }
                     }
                     return Result.failure()
                 }
@@ -208,6 +231,21 @@ class ShareWorker(private val context: Context, workerParameters: WorkerParamete
             Log.e(MattermostShareImpl.NAME, "Failed to create the multipart body to upload the files", e)
             return Result.failure()
         }
+    }
+
+    private fun enqueueDraftWorker(postData: JSONObject): Result {
+        val packageName = context.applicationContext.packageName
+        val inputDataDraft = Data.Builder()
+            .putString("draft_data", postData.toString())
+            .build()
+        val draftWorkerClass = Class.forName("$packageName.DraftWorker")
+            .asSubclass(ListenableWorker::class.java)
+        val draftWorkerRequest = OneTimeWorkRequest.Builder(draftWorkerClass)
+            .setInputData(inputDataDraft)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext).enqueue(draftWorkerRequest)
+        return Result.success()
     }
 
     private fun createForegroundInfo(): ForegroundInfo {

--- a/libraries/@mattermost/rnshare/android/src/newarch/MattermostShareModule.kt
+++ b/libraries/@mattermost/rnshare/android/src/newarch/MattermostShareModule.kt
@@ -27,4 +27,14 @@ class MattermostShareModule(private val reactContext: ReactApplicationContext) :
             .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
             .emit("onDraftUpdated", draft)
     }
+
+    @com.facebook.react.bridge.ReactMethod
+    fun addListener(eventName: String) {
+        //No-op: Required for RN  built-in emitters
+    }
+
+    @com.facebook.react.bridge.ReactMethod
+    fun removeListeners(count: Int) {
+        //No-op: Required for RN  built-in emitters
+    }
 }

--- a/libraries/@mattermost/rnshare/android/src/newarch/MattermostShareModule.kt
+++ b/libraries/@mattermost/rnshare/android/src/newarch/MattermostShareModule.kt
@@ -1,5 +1,6 @@
 package com.mattermost.rnshare
 
+import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
@@ -19,5 +20,11 @@ class MattermostShareModule(private val reactContext: ReactApplicationContext) :
 
     override fun getSharedData(promise: Promise?) {
         implementation.getSharedData(promise)
+    }
+
+    override fun sendDraftUpdate(draft: ReadableMap) {
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onDraftUpdated", draft)
     }
 }

--- a/libraries/@mattermost/rnshare/android/src/oldarch/MattermostShareModule.kt
+++ b/libraries/@mattermost/rnshare/android/src/oldarch/MattermostShareModule.kt
@@ -5,7 +5,11 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.modules.core.DeviceEventManagerModule
 
+@ReactModule(name = MattermostShareImpl.NAME)
 class MattermostShareModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
     private val implementation = MattermostShareImpl(reactContext)
 
@@ -28,4 +32,11 @@ class MattermostShareModule(reactContext: ReactApplicationContext) : ReactContex
     fun getSharedData(promise: Promise?) {
         implementation.getSharedData(promise)
     }
+
+    fun sendDraftUpdate(draft: WritableNativeMap) {
+        reactApplicationContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onDraftUpdated", draft)
+    }
+
 }

--- a/libraries/@mattermost/rnshare/android/src/oldarch/MattermostShareModule.kt
+++ b/libraries/@mattermost/rnshare/android/src/oldarch/MattermostShareModule.kt
@@ -39,4 +39,13 @@ class MattermostShareModule(reactContext: ReactApplicationContext) : ReactContex
             .emit("onDraftUpdated", draft)
     }
 
+    @ReactMethod
+    fun addListener(eventName: String) {
+        //No-op: Required for RN  built-in emitters
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+        //No-op: Required for RN  built-in emitters
+    }
 }

--- a/libraries/@mattermost/rnshare/ios/MattermostShare.m
+++ b/libraries/@mattermost/rnshare/ios/MattermostShare.m
@@ -1,0 +1,5 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE(MattermostShare, RCTEventEmitter)
+@end

--- a/libraries/@mattermost/rnshare/ios/MattermostShare.swift
+++ b/libraries/@mattermost/rnshare/ios/MattermostShare.swift
@@ -18,4 +18,12 @@ public class MattermostShare: RCTEventEmitter {
     @objc public func sendDraftUpdate(_ draft: [String: Any]) {
         sendEvent(withName: "onDraftUpdated", body: draft)
     }
+    
+    @objc override public func addListener(_ eventName: String!) {
+        //No-op: Required for RN  built-in emitters
+    }
+    
+    @objc override public func removeListeners(_ count: Double) {
+        //No-op: Required for RN  built-in emitters
+    }
 }

--- a/libraries/@mattermost/rnshare/ios/MattermostShare.swift
+++ b/libraries/@mattermost/rnshare/ios/MattermostShare.swift
@@ -1,0 +1,21 @@
+import Foundation
+import React
+
+@objc(MattermostShare)
+public class MattermostShare: RCTEventEmitter {
+    @objc override public static func moduleName() -> String! {
+        return "MattermostShare"
+    }
+    
+    @objc override public static func requiresMainQueueSetup() -> Bool {
+        return true
+    }
+    
+    override public func supportedEvents() -> [String]! {
+        return ["onDraftUpdated"]
+    }
+    
+    @objc public func sendDraftUpdate(_ draft: [String: Any]) {
+        sendEvent(withName: "onDraftUpdated", body: draft)
+    }
+}

--- a/libraries/@mattermost/rnshare/mattermost-rnshare.podspec
+++ b/libraries/@mattermost/rnshare/mattermost-rnshare.podspec
@@ -1,0 +1,39 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "mattermost-rnshare"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.authors      = package["author"]
+
+  s.platforms    = { :ios => min_ios_version_supported }
+  s.source       = { :git => ".git", :tag => "#{s.version}" }
+
+  s.source_files = "ios/**/*.{h,m,mm,swift}"
+
+  fabric_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+  other_cpp_flags = fabric_enabled ? "-DRCT_NEW_ARCH_ENABLED=1" : ""
+
+  install_modules_dependencies(s)
+
+  s.pod_target_xcconfig    = {
+    'USE_HEADERMAP' => 'YES',
+    "DEFINES_MODULE" => "YES",
+    'SWIFT_COMPILATION_MODE' => 'wholemodule',
+    "BUILD_LIBRARY_FOR_DISTRIBUTION" => "YES",
+    "OTHER_CPLUSPLUSFLAGS" => other_cpp_flags,
+    "OTHER_SWIFT_FLAGS" => "-no-verify-emitted-module-interface",
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
+  }
+
+  user_header_search_paths = [
+    '"${PODS_CONFIGURATION_BUILD_DIR}/mattermost-rnshare/Swift Compatibility Header"',
+  ]
+  s.user_target_xcconfig = {
+    "HEADER_SEARCH_PATHS" => user_header_search_paths,
+  }
+end

--- a/libraries/@mattermost/rnshare/package.json
+++ b/libraries/@mattermost/rnshare/package.json
@@ -1,15 +1,19 @@
 {
   "name": "@mattermost/rnshare",
   "version": "0.0.0",
-  "description": "Mattermost Share extension for android",
+  "description": "Mattermost Share extension",
   "main": "src/index",
   "codegenConfig": {
     "name": "MattermostShareSpec",
     "type": "modules",
     "jsSrcsDir": "src",
-    "platforms": ["android"],
+    "platforms": ["android", "ios"],
     "android": {
       "javaPackageName": "com.mattermost.rnshare"
+    },
+    "ios": {
+      "prefix": "MM",
+      "moduleName": "MattermostShare"
     }
   },
   "author": "Mattermost, Inc.",

--- a/libraries/@mattermost/rnshare/src/NativeMattermostShare.ts
+++ b/libraries/@mattermost/rnshare/src/NativeMattermostShare.ts
@@ -27,11 +27,24 @@ export type ShareExtensionDataToSend = {
   preauthSecret?: string;
 }
 
+export type DraftUpdatePayload = {
+  channelId: string;
+  message: string;
+  files: Array<{
+    id?: string;
+    mime_type?: string;
+    extension?: string;
+    name?: string;
+    size?: Double;
+  }>;
+}
+
 export interface Spec extends TurboModule {
   getCurrentActivityName: () => string;
   clear: () => void;
   close: (data: ShareExtensionDataToSend | null) => void;
   getSharedData: () => Promise<SharedItem[]>;
+  sendDraftUpdate?: (draft: DraftUpdatePayload) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('MattermostShare');

--- a/libraries/@mattermost/rnshare/src/NativeMattermostShare.ts
+++ b/libraries/@mattermost/rnshare/src/NativeMattermostShare.ts
@@ -25,6 +25,7 @@ export type ShareExtensionDataToSend = {
   token: string;
   userId: string;
   preauthSecret?: string;
+  isDraft?: boolean;
 }
 
 export type DraftUpdatePayload = {

--- a/share_extension/components/content_view/content_view.tsx
+++ b/share_extension/components/content_view/content_view.tsx
@@ -12,6 +12,7 @@ import Attachments from './attachments';
 import LinkPreview from './link_preview';
 import Message from './message';
 import Options from './options';
+import SaveDraftButton from './save_draft_button';
 
 import type {Database} from '@nozbe/watermelondb';
 
@@ -27,6 +28,7 @@ const getStyles = makeStyleSheetFromTheme((theme: Theme) => ({
         flex: 1,
     },
     content: {
+        flex: 1,
         paddingTop: 0,
     },
     divider: {
@@ -81,6 +83,7 @@ const ContentView = ({database, currentChannelId, currentUserId, theme}: Props) 
                 />
                 <View style={styles.divider}/>
                 <Message theme={theme}/>
+                <SaveDraftButton theme={theme}/>
             </KeyboardAwareScrollView>
         </View>
     );

--- a/share_extension/components/content_view/save_draft_button/index.tsx
+++ b/share_extension/components/content_view/save_draft_button/index.tsx
@@ -75,7 +75,7 @@ const SaveDraftButton = ({theme}: Props) => {
                 style={styles.draftIcon}
             />
             <Text style={styles.buttonText}>
-                {intl.formatMessage({id: 'share_extension.save_draft', defaultMessage: 'Save as a draft'})}
+                {intl.formatMessage({id: 'share_extension.save_draft', defaultMessage: 'Save as draft'})}
             </Text>
         </TouchableWithFeedback>
     );

--- a/share_extension/components/content_view/save_draft_button/index.tsx
+++ b/share_extension/components/content_view/save_draft_button/index.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback} from 'react';
+import {useIntl} from 'react-intl';
+import {Text} from 'react-native';
+
+import {updateDraftMessage} from '@actions/local/draft';
+import CompassIcon from '@components/compass_icon';
+import TouchableWithFeedback from '@components/touchable_with_feedback';
+import {usePreventDoubleTap} from '@hooks/utils';
+import {useShareExtensionState} from '@share/state';
+import {makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
+
+type Props = {
+    theme: Theme;
+}
+
+const hitSlop = {top: 10, left: 10, right: 10, bottom: 10};
+
+const getStyleSheet = makeStyleSheetFromTheme((theme) => {
+    return {
+        buttonContainer: {
+            alignSelf: 'center',
+            marginTop: 'auto',
+            flexDirection: 'row',
+            marginBottom: 40,
+            alignItems: 'center',
+        },
+        draftIcon: {
+            color: theme.linkColor,
+            ...typography('Body', 500),
+        },
+        buttonText: {
+            marginLeft: 10,
+            color: theme.linkColor,
+            ...typography('Body', 200, 'SemiBold'),
+        },
+    };
+});
+
+const SaveDraftButton = ({theme}: Props) => {
+    const intl = useIntl();
+    const {
+        closeExtension, channelId, linkPreviewUrl, message, serverUrl,
+    } = useShareExtensionState();
+    const styles = getStyleSheet(theme);
+
+    const onPress = usePreventDoubleTap(useCallback(async () => {
+        if (serverUrl && channelId && message?.length) {
+            let text = message || '';
+            if (linkPreviewUrl) {
+                if (text) {
+                    text = `${text}\n\n${linkPreviewUrl}`;
+                } else {
+                    text = linkPreviewUrl;
+                }
+            }
+
+            await updateDraftMessage(serverUrl, channelId, '', text);
+            closeExtension(null);
+        }
+    }, [serverUrl, channelId, message, linkPreviewUrl, closeExtension]));
+
+    return (
+        <TouchableWithFeedback
+            onPress={onPress}
+            type={'opacity'}
+            hitSlop={hitSlop}
+            style={styles.buttonContainer}
+        >
+            <CompassIcon
+                name='pencil-outline'
+                style={styles.draftIcon}
+            />
+            <Text style={styles.buttonText}>
+                {intl.formatMessage({id: 'share_extension.save_draft', defaultMessage: 'Save as a draft'})}
+            </Text>
+        </TouchableWithFeedback>
+    );
+};
+
+export default SaveDraftButton;

--- a/share_extension/components/header/post_button.tsx
+++ b/share_extension/components/header/post_button.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback} from 'react';
+import React from 'react';
 import {StyleSheet, TouchableOpacity, View} from 'react-native';
 
 import CompassIcon from '@components/compass_icon';
-import {getServerCredentials} from '@init/credentials';
-import {useShareExtensionState} from '@share/state';
+import {usePreventDoubleTap} from '@hooks/utils';
+import {useShareExtensionSubmit} from '@share/hooks/use_share_extension_submit';
 import {changeOpacity} from '@utils/theme';
 
 type Props = {
@@ -22,41 +22,8 @@ const styles = StyleSheet.create({
 });
 
 const PostButton = ({theme}: Props) => {
-    const {
-        closeExtension, channelId, files, globalError,
-        linkPreviewUrl, message, serverUrl, userId,
-    } = useShareExtensionState();
-
-    const disabled = !serverUrl || !channelId || (!message && !files.length && !linkPreviewUrl) || globalError;
-
-    const onPress = useCallback(async () => {
-        if (!serverUrl || !channelId || !userId) {
-            return;
-        }
-
-        let text = message || '';
-        if (linkPreviewUrl) {
-            if (text) {
-                text = `${text}\n\n${linkPreviewUrl}`;
-            } else {
-                text = linkPreviewUrl;
-            }
-        }
-
-        const credentials = await getServerCredentials(serverUrl);
-
-        if (credentials?.token) {
-            closeExtension({
-                serverUrl,
-                token: credentials.token,
-                channelId,
-                files,
-                message: text,
-                userId,
-                preauthSecret: credentials.preauthSecret,
-            });
-        }
-    }, [serverUrl, channelId, message, files, linkPreviewUrl, userId]);
+    const {submit, disabled} = useShareExtensionSubmit();
+    const onPress = usePreventDoubleTap(submit);
 
     return (
         <TouchableOpacity

--- a/share_extension/hooks/use_share_extension_submit.ts
+++ b/share_extension/hooks/use_share_extension_submit.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useCallback} from 'react';
+
+import {getServerCredentials} from '@init/credentials';
+import {useShareExtensionState} from '@share/state';
+
+type Props = {
+    isDraft?: boolean;
+}
+
+export function useShareExtensionSubmit() {
+    const {
+        closeExtension, channelId, files, globalError,
+        linkPreviewUrl, message, serverUrl, userId,
+    } = useShareExtensionState();
+
+    const buildText = useCallback(() => {
+        let text = message || '';
+        if (linkPreviewUrl) {
+            if (text) {
+                text = `${text}\n\n${linkPreviewUrl}`;
+            } else {
+                text = linkPreviewUrl;
+            }
+        }
+        return text;
+    }, [message, linkPreviewUrl]);
+
+    const disabled =
+        !serverUrl ||
+        !channelId ||
+        (!message && !files.length && !linkPreviewUrl) ||
+        globalError;
+
+    const submit = useCallback(async ({isDraft = false}: Props = {}) => {
+        if (!serverUrl || !channelId || !userId) {
+            return;
+        }
+
+        const credentials = await getServerCredentials(serverUrl);
+        if (!credentials?.token) {
+            return;
+        }
+
+        closeExtension({
+            serverUrl,
+            token: credentials.token,
+            channelId,
+            files,
+            message: buildText(),
+            userId,
+            preauthSecret: credentials.preauthSecret,
+            isDraft,
+        });
+    }, [serverUrl, channelId, userId, closeExtension, files, buildText]);
+
+    return {submit, disabled};
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Adds a new `Save as a draft` button when sharing media through Mattermost, this functionality has two different implementations, for **iOS** it has a native Share Extension and for **Android** it uses React Native. It works whether the app is closed, or running in the background.

### iOS

- Updates the current `PostButton` and adds a new Save as draft variant to reuse the current logic.
- Updates Gekidou to insert/update drafts in the database from the native side when the app is closed.
- Adds `registerDraftUpdateObserver` inside `GekidouWrapper` that observes `share.extension.draftUpdate` Darwin notifications. This allows communication from the `ShareExtension` to the main app if it's running to send the draft data to the React Native side.
- Extends iOS support for the `@mattermost/rnshare` library to communicate draft data from the native side to the React Native side.

### Android

- Adds a new `SaveDraftButton` component and introduces a new hook `useShareExtensionSubmit` which extracts the submit logic from the PostButton from the React Native Share Extension so it can be reused in both cases.
- Adds a new `AppStateHelper` to track if the main app is active, since we can't rely only on the React Native context (the `ShareExtension` also uses its own React Native context)
- Adds `DraftDataHelper` and `Draft` database extension to handle insert/update drafts in the database from the native side.
- Adds `DraftWorker` which is enqueued from the `ShareWorker` to determine whether the draft should be stored from the native side or the React Native side. 

### React Native

- Adds a new `DraftsUpdate` singleton that listens for native `onDraftUpdated` events from `@mattermost/rnshare` and updates the local database by inserting/updating draft messages and attaching uploaded files when the app is running.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-65720

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Testing

<details>
<summary>iOS</summary>

- Open the photos app
- Select some images
- Tap on the share button
- Tap on the Mattermost app
- **Expect** to see the images added
- Type a message and select a channel
- Tap on `Save as draft`
- **Expect** the Share extension to close
- Open the app
- Go to the channel you selected for the draft
- The draft message and media should be visible
</details>

<details>
<summary>Android</summary>

- Open the web broswer
- Go to any site
- Share the site into the Mattermost app
- **Expect** the Share modal to show up
- Type a message and select a channel
- Tap on `Save as draft`
- **Expect** the Share modal to close
- Open the app
- **Expect** to see the new draft in the sidebar and under the Drafts list
</details>

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

- iPhone 16 Pro Simulator, 18.4
- iPad Simulator, 18.4
- Pixel 8 Pro Emulator, 16.0

#### Screenshots

iOS|Android
-|-
<img width="200" src="https://github.com/user-attachments/assets/b4f750a0-d64b-4c4e-8fa7-582b3d18006a" />|<img width="200" src="https://github.com/user-attachments/assets/c6f6d62f-64a9-47e9-b684-79373e50cb6e" />

iOS|Android
-|-
<img width="250" alt="iOS" src="https://github.com/user-attachments/assets/00d6b6fd-cc05-48a8-9db2-2e4a0aae1225" />|<img width="250" alt="Android" src="https://github.com/user-attachments/assets/378f6d65-f77c-43f9-a0f6-e25e91d63b32" />

iPad|
-|
<img width="400"  alt="iPad" src="https://github.com/user-attachments/assets/4e0407a3-c1d0-46e9-b380-bbee5d61ec7a" />|


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
* Added a new "Save as draft" functionality when sharing media through Mattermost
```
