### PR TITLE
fix(MM-63466): hashtag displaying in smaller font size

### DIFF
--- a/app/components/markdown/markdown.test.tsx
+++ b/app/components/markdown/markdown.test.tsx
@@ -5,14 +5,21 @@ import {screen} from '@testing-library/react-native';
 import * as CommonMark from 'commonmark';
 const {Node} = CommonMark;
 import React from 'react';
+import {StyleSheet} from 'react-native';
 
 import {Preferences} from '@constants';
 import {renderWithIntl} from '@test/intl-test-helper';
+import {getMarkdownTextStyles} from '@utils/markdown';
+import {typography} from '@utils/typography';
 
-import Markdown from './markdown';
+import Markdown, {testExports} from './markdown';
 import * as Transforms from './transform';
 
 const Parser = jest.requireActual('commonmark').Parser;
+
+jest.mock('@screens/navigation', () => ({
+    dismissAllModalsAndPopToRoot: jest.fn(),
+}));
 
 describe('Markdown', () => {
     const baseProps: React.ComponentProps<typeof Markdown> = {
@@ -135,6 +142,113 @@ describe('Markdown', () => {
 
             expect(screen.queryByText('This is a text')).not.toBeVisible();
             expect(screen.getByText('An error occurred while rendering this text')).toBeVisible();
+        });
+    });
+
+    describe('renderHashtagWithStyles', () => {
+        const {renderHashtagWithStyles} = testExports;
+
+        test('should render hashtag with correct text and link styling', () => {
+            const baseTextStyle = {
+                color: '#000000',
+                ...typography('Body', 200),
+            };
+            const textStyles = getMarkdownTextStyles(baseProps.theme);
+            const context: string[] = [];
+
+            renderWithIntl(
+                renderHashtagWithStyles(context, 'test', textStyles, baseTextStyle),
+            );
+
+            const hashtagElement = screen.getByText('#test');
+            expect(hashtagElement).toBeVisible();
+
+            const flattenedStyle = StyleSheet.flatten(hashtagElement.props.style);
+            expect(flattenedStyle).toMatchObject({
+                fontSize: 16,
+                color: baseProps.theme.linkColor,
+            });
+        });
+
+        test('should render hashtag in heading with correct heading font size', () => {
+            const baseTextStyle = {
+                color: '#000000',
+                ...typography('Body', 200),
+            };
+            const textStyles = getMarkdownTextStyles(baseProps.theme);
+            const context: string[] = ['heading1'];
+
+            renderWithIntl(
+                renderHashtagWithStyles(context, 'hashtag', textStyles, baseTextStyle),
+            );
+
+            const hashtagElement = screen.getByText('#hashtag');
+            expect(hashtagElement).toBeVisible();
+
+            const flattenedStyle = StyleSheet.flatten(hashtagElement.props.style);
+            expect(flattenedStyle).toMatchObject({
+                fontSize: 28,
+            });
+        });
+
+        test('should apply heading2 styles when in heading2 context', () => {
+            const baseTextStyle = {
+                color: '#000000',
+                ...typography('Body', 200),
+            };
+            const textStyles = getMarkdownTextStyles(baseProps.theme);
+            const context: string[] = ['heading2'];
+
+            renderWithIntl(
+                renderHashtagWithStyles(context, 'heading2tag', textStyles, baseTextStyle),
+            );
+
+            const hashtagElement = screen.getByText('#heading2tag');
+            expect(hashtagElement).toBeVisible();
+
+            const flattenedStyle = StyleSheet.flatten(hashtagElement.props.style);
+            expect(flattenedStyle).toMatchObject({
+                fontSize: 25,
+            });
+        });
+
+        test('should have clickable onPress handler', () => {
+            const baseTextStyle = {
+                color: '#000000',
+                ...typography('Body', 200),
+            };
+            const textStyles = getMarkdownTextStyles(baseProps.theme);
+            const context: string[] = [];
+
+            renderWithIntl(
+                renderHashtagWithStyles(context, 'clickable', textStyles, baseTextStyle),
+            );
+
+            const hashtagElement = screen.getByText('#clickable');
+            expect(hashtagElement.props.onPress).toBeDefined();
+        });
+
+        test('should include both base text style and link color', () => {
+            const baseTextStyle = {
+                color: '#000000',
+                ...typography('Body', 200),
+                fontFamily: 'OpenSans',
+            };
+            const textStyles = getMarkdownTextStyles(baseProps.theme);
+            const context: string[] = [];
+
+            renderWithIntl(
+                renderHashtagWithStyles(context, 'styled', textStyles, baseTextStyle),
+            );
+
+            const hashtagElement = screen.getByText('#styled');
+            const flattenedStyle = StyleSheet.flatten(hashtagElement.props.style);
+
+            expect(flattenedStyle).toMatchObject({
+                fontSize: 16,
+                fontFamily: 'OpenSans',
+                color: baseProps.theme.linkColor,
+            });
         });
     });
 });

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -124,6 +124,27 @@ const getExtraPropsForNode = (node: any) => {
     return extraProps;
 };
 
+const renderHashtagWithStyles = (
+    context: string[],
+    hashtag: string,
+    textStyles: MarkdownTextStyles,
+    baseTextStyle: StyleProp<TextStyle>,
+) => {
+    const computedStyle = computeTextStyle(textStyles, baseTextStyle, context);
+    const linkStyle = [computedStyle, textStyles.link];
+    const headingIndex = context.findIndex((c) => c.includes('heading'));
+    if (headingIndex > -1) {
+        linkStyle.push(textStyles[context[headingIndex]]);
+    }
+
+    return (
+        <Hashtag
+            hashtag={hashtag}
+            linkStyle={linkStyle}
+        />
+    );
+};
+
 const Markdown = ({
     autolinkedUrlSchemes, baseTextStyle, blockStyles, channelId, channelMentions,
     disableAtChannelMentionHighlight, disableAtMentions, disableBlockQuote, disableChannelLink,
@@ -277,18 +298,7 @@ const Markdown = ({
             return renderText({context, literal: `#${hashtag}`});
         }
 
-        const linkStyle = [textStyles.link];
-        const headingIndex = context.findIndex((c) => c.includes('heading'));
-        if (headingIndex > -1) {
-            linkStyle.push(textStyles[context[headingIndex]]);
-        }
-
-        return (
-            <Hashtag
-                hashtag={hashtag}
-                linkStyle={linkStyle}
-            />
-        );
+        return renderHashtagWithStyles(context, hashtag, textStyles, baseTextStyle);
     };
 
     const renderHeading = ({children, level}: {children: ReactElement; level: string}) => {
@@ -660,6 +670,10 @@ const Markdown = ({
     }
 
     return output;
+};
+
+export const testExports = {
+    renderHashtagWithStyles,
 };
 
 export default Markdown;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Fixed hashtags appearing smaller than surrounding text in markdown messages.

#### Problem

Hashtags in markdown were rendered with a smaller font size than the surrounding text because they weren't inheriting the base text style's fontSize property.

#### Root Cause

The `renderHashtag` function only passed `textStyles.link` to the Hashtag component, which contained color and fontFamily but was missing the fontSize from the base text style. Without an explicit fontSize, React Native Text defaulted to a smaller size.

#### Changes

1. Updated `renderHashtag` in `markdown.tsx`
  * Now computes the full text style including base fontSize using `computeTextStyle()`
  * Combines computed base style with link color
  * Properly applies heading styles when hashtags appear in headings
2. Created `renderHashtagWithStyles` helper function
- Extracts hashtag rendering logic for testability
- Computes style as: `[computedStyle, textStyles.link]`
- Ensures hashtags receive base text style (fontSize, fontFamily, lineHeight) + link color

3. Simplified `Hashtag` component
- Uses single Text component with combined styles
- Maintains clickability and link styling

4. Added comprehensive tests
- Verifies hashtags have correct fontSize (16px) in body text
- Tests hashtags scale properly in headings (28px for h1, 25px for h2)
- Confirms both base styles and link color are applied together

#### Result

Hashtags now match the size of surrounding text (16px in body, larger in headings) while maintaining their link styling and clickability.

#### Testing

All tests passing (11/11):
- 6 existing error handling tests
- 5 new hashtag styling tests

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-63466

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
iPhone 16 simulator (18.2)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

Before

<img width="50%" height="50%" alt="MM-63466-hashtag-displaying-in-smaller-font-size-before" src="https://github.com/user-attachments/assets/c35c134d-7331-46c4-9cf1-72adb8e6ab83" />

After

<img width="50%" height="50%" alt="MM-63466-hashtag-displaying-in-smaller-font-size-after" src="https://github.com/user-attachments/assets/6ddff895-4199-44ff-b1c3-42ab7ad377bb" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
