### PR TITLE
fix(MM-64763): search page doesn't clear hashtag on search input

### DIFF
--- a/app/screens/home/search/search.test.tsx
+++ b/app/screens/home/search/search.test.tsx
@@ -204,4 +204,65 @@ describe('SearchScreen', () => {
             expect.any(String),
         );
     });
+
+    it('does not restore searchTerm after clearing when navigated with hashtag', async () => {
+        const mockNavigation = {
+            getState: () => ({
+                index: 0,
+                routes: [{params: {searchTerm: '#hashtag'}}],
+            }),
+        };
+
+        jest.spyOn(require('@react-navigation/native'), 'useNavigation').mockReturnValue(mockNavigation);
+
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+
+        await waitFor(() => {
+            const searchInput = getByTestId('navigation.header.search_bar.search.input');
+            expect(searchInput.props.value).toBe('#hashtag');
+        });
+
+        const searchInput = getByTestId('navigation.header.search_bar.search.input');
+        const clearButton = getByTestId('navigation.header.search_bar.search.clear.button');
+
+        act(() => {
+            fireEvent.press(clearButton);
+        });
+
+        await waitFor(() => {
+            expect(searchInput.props.value).toBe('');
+        });
+    });
+
+    it('populates searchTerm when navigating to screen with hashtag', async () => {
+        const mockNavigation = {
+            getState: () => ({
+                index: 0,
+                routes: [{params: {searchTerm: '#newtag'}}],
+            }),
+        };
+
+        jest.spyOn(require('@react-navigation/native'), 'useNavigation').mockReturnValue(mockNavigation);
+
+        const {getByTestId} = renderWithEverything(
+            <SearchScreen {...baseProps}/>,
+            {database},
+        );
+
+        await waitFor(() => {
+            const searchInput = getByTestId('navigation.header.search_bar.search.input');
+            expect(searchInput.props.value).toBe('#newtag');
+        });
+
+        await waitFor(() => {
+            expect(searchPosts).toHaveBeenCalledWith(
+                expect.any(String),
+                'team1',
+                expect.objectContaining({terms: '#newtag'}),
+            );
+        });
+    });
 });

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -112,6 +112,7 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
     const clearRef = useRef<boolean>(false);
     const cancelRef = useRef<boolean>(false);
     const searchRef = useRef<SearchRef>(null);
+    const processedSearchTermRef = useRef<string>('');
 
     const [cursorPosition, setCursorPosition] = useState(searchTerm?.length || 0);
     const [searchValue, setSearchValue] = useState<string>(searchTerm || '');
@@ -137,6 +138,7 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
 
     const onSnap = useCallback((offset: number, animated = true) => {
         scrollRef.current?.scrollToOffset({offset, animated});
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scrollRef is a ref object, so its reference should not change between renders
     }, []);
 
     const onSnapWithTimeout = useCallback((offset: number, animated = true) => {
@@ -365,7 +367,8 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
     }, [unlock, onSnapWithTimeout]);
 
     useEffect(() => {
-        if (searchTerm) {
+        if (searchTerm && searchTerm !== processedSearchTermRef.current) {
+            processedSearchTermRef.current = searchTerm;
             clearInputs();
             setSearchValue(searchTerm);
             handleSearch(searchTeamId, searchTerm);
@@ -379,6 +382,7 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
             }, 300);
         } else {
             setAutoScroll(false);
+            processedSearchTermRef.current = '';
         }
     }, [isFocused]);
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
The issue occurred when users navigated to the search screen by clicking a hashtag in a message. After arriving at the search page with the hashtag pre-populated in the input field, clicking the clear (x) button would cause the hashtag to immediately reappear. This happened because the search term from the navigation parameters remained unchanged, and the useEffect hook responsible for processing search terms would re-run on every render, detecting the search term and re-populating it even after the user explicitly cleared it.

To fix this, we introduced a `processedSearchTermRef` that tracks which search term has already been processed. The useEffect now only processes a search term if it differs from the previously processed one, preventing the unwanted re-population when the user clears the input. However, this created a secondary issue: when users navigated away from the search screen and returned with a new (or the same) hashtag, it wouldn't populate because the ref still held the old value. We solved this by adding logic to reset the ref when the screen loses focus, using useDidUpdate to detect focus changes. When the screen becomes unfocused (user navigates away), the ref is reset to an empty string, allowing the next navigation with a hashtag to work correctly. We also combined two separate useDidUpdate hooks that were both watching the isFocused state into a single hook for cleaner, more maintainable code. The solution ensures that clearing the search works as expected while still allowing hashtags to populate correctly when navigating to the screen, with comprehensive test coverage for both scenarios.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-64763

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
iPhone 16 Simulator (iOS 18.2)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

https://github.com/user-attachments/assets/1f9b74a4-fc52-49b9-ad3b-029a20231e65




#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
