### PR TITLE
Add CSRF header to native code

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/CredentialsHelper.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/CredentialsHelper.kt
@@ -1,0 +1,54 @@
+package com.mattermost.helpers
+
+import android.webkit.CookieManager
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.mattermost.turbolog.TurboLog
+import java.net.HttpCookie
+
+
+object HeadersHelper {
+    fun getHeadersWithCredentials(serverUrl: String, includeCsrfToken: Boolean = false): WritableMap {
+        val headers = Arguments.createMap()
+        
+        if (includeCsrfToken) {
+            val csrfToken = getCSRFCookieToken(serverUrl)
+            if (csrfToken != null && csrfToken.isNotEmpty()) {
+                headers.putString("X-CSRF-Token", csrfToken)
+            }
+        }
+        
+        return headers
+    }
+
+    private fun getCSRFCookieToken(serverUrl: String): String? {
+        try {
+            val cookieString = CookieManager.getInstance().getCookie(serverUrl)
+            val cookiesMap = createCookieList(cookieString)
+            return cookiesMap.getString("MMCSRF")
+        } catch (e: Exception) {
+            TurboLog.d("HeadersHelper", "Error getting CSRF cookie token: ${e.message}")
+            return null
+        }
+    }
+
+    private fun createCookieList(allCookies: String?): WritableMap {
+        val allCookiesMap = Arguments.createMap()
+
+        if (!allCookies.isNullOrEmpty()) {
+            val cookieHeaders = allCookies.split(";")
+            for (singleCookie in cookieHeaders) {
+                val cookies = HttpCookie.parse(singleCookie)
+                for (cookie in cookies) {
+                    val name = cookie.name
+                    val value = cookie.value
+                    if (!name.isNullOrEmpty() && !value.isNullOrEmpty()) {
+                        allCookiesMap.putString(name, value)
+                    }
+                }
+            }
+        }
+
+        return allCookiesMap
+    }
+}

--- a/android/app/src/main/java/com/mattermost/helpers/HeadersHelper.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/HeadersHelper.kt
@@ -1,10 +1,14 @@
 package com.mattermost.helpers
 
+import android.os.Handler
+import android.os.Looper
 import android.webkit.CookieManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.mattermost.turbolog.TurboLog
 import java.net.HttpCookie
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 
 object HeadersHelper {
@@ -23,12 +27,50 @@ object HeadersHelper {
 
     private fun getCSRFCookieToken(serverUrl: String): String? {
         try {
-            val cookieString = CookieManager.getInstance().getCookie(serverUrl)
+            val cookieString = getCookieOnMainThread(serverUrl)
             val cookiesMap = createCookieList(cookieString)
             return cookiesMap.getString("MMCSRF")
         } catch (e: Exception) {
             TurboLog.d("HeadersHelper", "Error getting CSRF cookie token: ${e.message}")
             return null
+        }
+    }
+
+    private fun getCookieOnMainThread(serverUrl: String): String? {
+        // Check if we're already on the main thread
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return CookieManager.getInstance().getCookie(serverUrl)
+        }
+
+        // If not on main thread, use CountDownLatch to synchronously wait for result
+        val latch = CountDownLatch(1)
+        var cookieString: String? = null
+        var exception: Exception? = null
+
+        Handler(Looper.getMainLooper()).post {
+            try {
+                cookieString = CookieManager.getInstance().getCookie(serverUrl)
+            } catch (e: Exception) {
+                exception = e
+            } finally {
+                latch.countDown()
+            }
+        }
+
+        // Wait for the result with a timeout to avoid blocking indefinitely
+        return try {
+            if (latch.await(5, TimeUnit.SECONDS)) {
+                if (exception != null) {
+                    throw exception!!
+                }
+                cookieString
+            } else {
+                TurboLog.w("HeadersHelper", "Timeout waiting for cookie retrieval on main thread")
+                null
+            }
+        } catch (e: InterruptedException) {
+            TurboLog.w("HeadersHelper", "Interrupted while waiting for cookie retrieval: ${e.message}")
+            null
         }
     }
 

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Category.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Category.kt
@@ -3,6 +3,7 @@ package com.mattermost.helpers.push_notification
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.mattermost.helpers.HeadersHelper
 import com.mattermost.helpers.PushNotificationDataRunnable
 import com.mattermost.helpers.database_extension.findByColumns
 import com.mattermost.helpers.database_extension.queryCurrentUserId
@@ -12,7 +13,9 @@ import com.nozbe.watermelondb.WMDatabase
 suspend fun PushNotificationDataRunnable.Companion.fetchMyTeamCategories(db: WMDatabase, serverUrl: String, teamId: String): ReadableMap? {
     return try {
         val userId = queryCurrentUserId(db)
-        val categories = fetch(serverUrl, "/api/v4/users/$userId/teams/$teamId/channels/categories")
+        val options = Arguments.createMap()
+        options.putMap("headers", HeadersHelper.getHeadersWithCredentials(serverUrl, false))
+        val categories = fetch(serverUrl, "/api/v4/users/$userId/teams/$teamId/channels/categories", options)
         categories?.getMap("data")
     } catch (e: Exception) {
         e.printStackTrace()

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Channel.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Channel.kt
@@ -3,6 +3,7 @@ package com.mattermost.helpers.push_notification
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.mattermost.helpers.HeadersHelper
 import com.mattermost.helpers.PushNotificationDataRunnable
 import com.mattermost.helpers.database_extension.findChannel
 import com.mattermost.helpers.database_extension.getCurrentUserLocale
@@ -13,7 +14,9 @@ import java.text.Collator
 import java.util.Locale
 
 suspend fun PushNotificationDataRunnable.Companion.fetchMyChannel(db: WMDatabase, serverUrl: String, channelId: String, isCRTEnabled: Boolean): Triple<ReadableMap?, ReadableMap?, ReadableArray?> {
-    val channel = fetch(serverUrl, "/api/v4/channels/$channelId")
+    val options = Arguments.createMap()
+    options.putMap("headers", HeadersHelper.getHeadersWithCredentials(serverUrl, false))
+    val channel = fetch(serverUrl, "/api/v4/channels/$channelId", options)
     var channelData = channel?.getMap("data")
     val myChannelData = channelData?.let { fetchMyChannelData(serverUrl, channelId, isCRTEnabled, it) }
     val channelType = channelData?.getString("type")
@@ -59,7 +62,9 @@ suspend fun PushNotificationDataRunnable.Companion.fetchMyChannel(db: WMDatabase
 
 private suspend fun PushNotificationDataRunnable.Companion.fetchMyChannelData(serverUrl: String, channelId: String, isCRTEnabled: Boolean, channelData: ReadableMap): ReadableMap? {
     try {
-        val myChannel = fetch(serverUrl, "/api/v4/channels/$channelId/members/me")
+        val options = Arguments.createMap()
+        options.putMap("headers", HeadersHelper.getHeadersWithCredentials(serverUrl, false))
+        val myChannel = fetch(serverUrl, "/api/v4/channels/$channelId/members/me", options)
         val myChannelData = myChannel?.getMap("data")
         if (myChannelData != null) {
             val data = Arguments.createMap()
@@ -111,7 +116,9 @@ private suspend fun PushNotificationDataRunnable.Companion.fetchMyChannelData(se
 private suspend fun PushNotificationDataRunnable.Companion.fetchProfileInChannel(db: WMDatabase, serverUrl: String, channelId: String): ReadableArray? {
     return try {
         val currentUserId = queryCurrentUserId(db)
-        val profilesInChannel = fetch(serverUrl, "/api/v4/users?in_channel=${channelId}&page=0&per_page=8&sort=")
+        val options = Arguments.createMap()
+        options.putMap("headers", HeadersHelper.getHeadersWithCredentials(serverUrl, false))
+        val profilesInChannel = fetch(serverUrl, "/api/v4/users?in_channel=${channelId}&page=0&per_page=8&sort=", options)
         val profilesArray = profilesInChannel?.getArray("data")
         val result = Arguments.createArray()
         if (profilesArray != null) {

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/General.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/General.kt
@@ -9,9 +9,9 @@ import java.io.IOException
 
 import kotlin.coroutines.suspendCoroutine
 
-internal suspend fun PushNotificationDataRunnable.Companion.fetch(serverUrl: String, endpoint: String): ReadableMap? {
+internal suspend fun PushNotificationDataRunnable.Companion.fetch(serverUrl: String, endpoint: String, options: ReadableMap?): ReadableMap? {
     return suspendCoroutine { cont ->
-        Network.get(serverUrl, endpoint, null, object : ResolvePromise() {
+        Network.get(serverUrl, endpoint, options, object : ResolvePromise() {
             override fun resolve(value: Any?) {
                 val response = value as ReadableMap?
                 if (response != null && !response.getBoolean("ok")) {

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Post.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Post.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.NoSuchKeyException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
+import com.mattermost.helpers.HeadersHelper
 import com.mattermost.helpers.PushNotificationDataRunnable
 import com.mattermost.helpers.ReadableArrayUtils
 import com.mattermost.helpers.ReadableMapUtils
@@ -12,8 +13,8 @@ import com.mattermost.helpers.database_extension.*
 import com.nozbe.watermelondb.WMDatabase
 
 internal suspend fun PushNotificationDataRunnable.Companion.fetchPosts(
-        db: WMDatabase, serverUrl: String, channelId: String, isCRTEnabled: Boolean,
-        rootId: String?, loadedProfiles: ReadableArray?
+    db: WMDatabase, serverUrl: String, channelId: String, isCRTEnabled: Boolean,
+    rootId: String?, loadedProfiles: ReadableArray?
 ): ReadableMap? {
     return try {
         val regex = Regex("""\B@(([a-z\d-._]*[a-z\d_])[.-]*)""", setOf(RegexOption.IGNORE_CASE))
@@ -39,7 +40,9 @@ internal suspend fun PushNotificationDataRunnable.Companion.fetchPosts(
             "/api/v4/channels/$channelId/posts$queryParams$additionalParams"
         }
 
-        val postsResponse = fetch(serverUrl, endpoint)
+        val options = Arguments.createMap()
+        options.putMap("headers", HeadersHelper.getHeadersWithCredentials(serverUrl, false))
+        val postsResponse = fetch(serverUrl, endpoint, options)
         val postData = postsResponse?.getMap("data")
         val results = Arguments.createMap()
 

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Team.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Team.kt
@@ -1,6 +1,8 @@
 package com.mattermost.helpers.push_notification
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
+import com.mattermost.helpers.HeadersHelper
 import com.mattermost.helpers.PushNotificationDataRunnable
 import com.mattermost.helpers.database_extension.findMyTeam
 import com.mattermost.helpers.database_extension.findTeam
@@ -12,12 +14,14 @@ suspend fun PushNotificationDataRunnable.Companion.fetchTeamIfNeeded(db: WMDatab
         var myTeam: ReadableMap? = null
         val teamExists = findTeam(db, teamId)
         val myTeamExists = findMyTeam(db, teamId)
+        val options = Arguments.createMap()
+        options.putMap("headers", HeadersHelper.getHeadersWithCredentials(serverUrl, false))
         if (!teamExists) {
-            team = fetch(serverUrl, "/api/v4/teams/$teamId")
+            team = fetch(serverUrl, "/api/v4/teams/$teamId", options)
         }
 
         if (!myTeamExists) {
-            myTeam = fetch(serverUrl, "/api/v4/teams/$teamId/members/me")
+            myTeam = fetch(serverUrl, "/api/v4/teams/$teamId/members/me", options)
         }
 
         Pair(team, myTeam)

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/Thread.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/Thread.kt
@@ -1,6 +1,8 @@
 package com.mattermost.helpers.push_notification
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
+import com.mattermost.helpers.HeadersHelper
 import com.mattermost.helpers.PushNotificationDataRunnable
 import com.mattermost.helpers.database_extension.*
 import com.nozbe.watermelondb.WMDatabase
@@ -9,8 +11,11 @@ internal suspend fun PushNotificationDataRunnable.Companion.fetchThread(db: WMDa
     val currentUserId = queryCurrentUserId(db) ?: return null
     val threadTeamId = (if (teamId.isNullOrEmpty()) queryCurrentTeamId(db) else teamId) ?: return null
 
+    val options = Arguments.createMap()
+    options.putMap("headers", HeadersHelper.getHeadersWithCredentials(serverUrl, false))
+
     return try {
-        val thread = fetch(serverUrl, "/api/v4/users/$currentUserId/teams/${threadTeamId}/threads/$threadId")
+        val thread = fetch(serverUrl, "/api/v4/users/$currentUserId/teams/${threadTeamId}/threads/$threadId", options)
         thread?.getMap("data")
     } catch (e: Exception) {
         e.printStackTrace()

--- a/android/app/src/main/java/com/mattermost/helpers/push_notification/User.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/push_notification/User.kt
@@ -3,6 +3,7 @@ package com.mattermost.helpers.push_notification
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.mattermost.helpers.HeadersHelper
 import com.mattermost.helpers.PushNotificationDataRunnable
 import com.mattermost.helpers.ReadableArrayUtils
 
@@ -11,6 +12,10 @@ internal suspend fun PushNotificationDataRunnable.Companion.fetchUsersById(serve
         val endpoint = "api/v4/users/ids"
         val options = Arguments.createMap()
         options.putArray("body", ReadableArrayUtils.toWritableArray(ReadableArrayUtils.toArray(userIds)))
+
+        val headers = HeadersHelper.getHeadersWithCredentials(serverUrl, true)
+        options.putMap("headers", headers)
+
         val result = fetchWithPost(serverUrl, endpoint, options)
         result?.getArray("data")
     } catch (e: Exception) {
@@ -24,6 +29,10 @@ internal suspend fun PushNotificationDataRunnable.Companion.fetchUsersByUsername
         val endpoint = "api/v4/users/usernames"
         val options = Arguments.createMap()
         options.putArray("body", ReadableArrayUtils.toWritableArray(ReadableArrayUtils.toArray(usernames)))
+
+        val headers = HeadersHelper.getHeadersWithCredentials(serverUrl, true)
+        options.putMap("headers", headers)
+
         val result = fetchWithPost(serverUrl, endpoint, options)
         result?.getArray("data")
     } catch (e: Exception) {

--- a/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/NotificationReplyBroadcastReceiver.java
@@ -66,7 +66,7 @@ public class NotificationReplyBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
-        WritableMap headers = Arguments.createMap();
+        WritableMap headers = HeadersHelper.INSTANCE.getHeadersWithCredentials(serverUrl, true);
         headers.putString("Content-Type", "application/json");
 
         WritableMap body = Arguments.createMap();

--- a/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
+++ b/android/app/src/main/java/com/mattermost/rnbeta/ReceiptDelivery.java
@@ -21,7 +21,7 @@ public class ReceiptDelivery {
     public static Bundle send(final String ackId, final String serverUrl, final String postId, final String type, final boolean isIdLoaded) {
         TurboLog.Companion.i("ReactNative", String.format("Send receipt delivery ACK=%s TYPE=%s to URL=%s with ID-LOADED=%s", ackId, type, serverUrl, isIdLoaded));
         WritableMap options = Arguments.createMap();
-        WritableMap headers = Arguments.createMap();
+        WritableMap headers = HeadersHelper.INSTANCE.getHeadersWithCredentials(serverUrl, true);
         WritableMap body = Arguments.createMap();
         headers.putString("Content-Type", "application/json");
         options.putMap("headers", headers);

--- a/app/components/files/video_file.tsx
+++ b/app/components/files/video_file.tsx
@@ -92,6 +92,9 @@ const VideoFile = ({
                     if (cred?.token) {
                         headers.Authorization = `Bearer ${cred.token}`;
                     }
+                    if (cred?.preauthSecret) {
+                        headers['X-Mattermost-Preauth-Secret'] = cred.preauthSecret;
+                    }
                     const {uri, height, width} = await getThumbnailAsync(data.localPath || videoUrl, {time: 1000, headers});
                     data.mini_preview = uri;
                     data.height = height;

--- a/app/init/credentials.ts
+++ b/app/init/credentials.ts
@@ -5,6 +5,7 @@ import {Platform} from 'react-native';
 import * as KeyChain from 'react-native-keychain';
 
 import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
 import {logWarning} from '@utils/log';
 import {getIOSAppGroupDetails} from '@utils/mattermost_managed';
 
@@ -124,11 +125,20 @@ export const getServerCredentials = async (serverUrl: string): Promise<ServerCre
             preauthSecret = undefined;
         }
 
+        let csrfToken: string | undefined;
+        try {
+            const client = NetworkManager.getClient(serverUrl);
+            csrfToken = client.csrfToken;
+        } catch (e) {
+            // CSRF token is optional, so ignore errors
+        }
+
         return {
             serverUrl,
             userId,
             token,
             preauthSecret,
+            csrfToken,
         };
     } catch (e) {
         return null;

--- a/ios/Gekidou/Sources/Gekidou/Constants.swift
+++ b/ios/Gekidou/Sources/Gekidou/Constants.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public struct GekidouConstants {
     public static let HEADER_X_MATTERMOST_PREAUTH_SECRET = "X-Mattermost-Preauth-Secret"
+    public static let HEADER_X_CSRF_TOKEN = "X-CSRF-Token"
 }

--- a/ios/Gekidou/Sources/Gekidou/Keychain.swift
+++ b/ios/Gekidou/Sources/Gekidou/Keychain.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import os.log
 
 public struct ServerCredentials {
     public let token: String?
@@ -137,7 +136,7 @@ public class Keychain: NSObject {
             return nil
         }
         
-        guard let appGroupId = Bundle.main.infoDictionary!["AppGroupIdentifier"] as? String else { return nil}
+        guard let appGroupId = Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String else { return nil }
         
         // Use the shared cookie storage for the app group since the CSRF token
         // is set from the main app, and not the other extensions.

--- a/ios/Gekidou/Sources/Gekidou/Keychain.swift
+++ b/ios/Gekidou/Sources/Gekidou/Keychain.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import os.log
 
 public struct ServerCredentials {
     public let token: String?
     public let preauthSecret: String?
+    public let csrfToken: String?
 }
 
 enum KeychainError: Error {
@@ -84,7 +86,8 @@ public class Keychain: NSObject {
         guard let credentials = try? getCredentials(for: serverUrl) else { return nil }
         return [
             "token": credentials.token as Any,
-            "preauthSecret": credentials.preauthSecret as Any
+            "preauthSecret": credentials.preauthSecret as Any,
+            "csrfToken": credentials.csrfToken as Any
         ]
     }
 
@@ -92,8 +95,9 @@ public class Keychain: NSObject {
         // Get main token from serverUrl key
         let token = try getMainToken(for: serverUrl)
         let preauthSecret = try? getPreauthSecret(for: serverUrl)
+        let csrfToken = try? getCsrfToken(for: serverUrl)
 
-        return ServerCredentials(token: token, preauthSecret: preauthSecret)
+        return ServerCredentials(token: token, preauthSecret: preauthSecret, csrfToken: csrfToken)
     }
 
     private func getMainToken(for serverUrl: String) throws -> String? {
@@ -125,6 +129,26 @@ public class Keychain: NSObject {
             return preauthSecret
         }
 
+        return nil
+    }
+
+    private func getCsrfToken(for serverUrl: String) throws -> String? {
+        guard let url = URL(string: serverUrl) else {
+            return nil
+        }
+        
+        guard let appGroupId = Bundle.main.infoDictionary!["AppGroupIdentifier"] as? String else { return nil}
+        
+        // Use the shared cookie storage for the app group since the CSRF token
+        // is set from the main app, and not the other extensions.
+        let cookies = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: appGroupId).cookies(for: url) ?? []
+        
+        for cookie in cookies {
+            if cookie.name == "MMCSRF" {
+                return cookie.value
+            }
+        }
+        
         return nil
     }
 

--- a/ios/Gekidou/Sources/Gekidou/Networking/Network.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/Network.swift
@@ -101,7 +101,11 @@ public class Network: NSObject {
             if let preauthSecret = credentials.preauthSecret {
                 request.addValue(preauthSecret, forHTTPHeaderField: GekidouConstants.HEADER_X_MATTERMOST_PREAUTH_SECRET)
             }
-        }
+            if let csrfToken = credentials.csrfToken {
+                if method.lowercased() != "get" {
+                    request.addValue(csrfToken, forHTTPHeaderField: GekidouConstants.HEADER_X_CSRF_TOKEN)
+                }
+            }
         
         return request as URLRequest
     }
@@ -109,11 +113,22 @@ public class Network: NSObject {
     internal func request(_ url: URL, usingMethod method: String, forServerUrl serverUrl: String, completionHandler: @escaping ResponseHandler) {
         return request(url, withMethod: method, withBody: nil, andHeaders: nil, forServerUrl: serverUrl, completionHandler: completionHandler)
     }
+
+    internal func ensureCSRFCookieIsShared(serverUrl: String) {
+        let cookies = HTTPCookieStorage.shared.cookies(for: URL(string: serverUrl)!) ?? []
+        for cookie in cookies {
+            if cookie.name == "MMCSRF" {
+                guard let appGroupId = Bundle.main.infoDictionary!["AppGroupIdentifier"] as? String else { return }
+                HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: appGroupId).setCookie(cookie)
+            }
+        }
+    }
     
     internal func request(_ url: URL, withMethod method: String, withBody body: Data?, andHeaders headers: [String:String]?, forServerUrl serverUrl: String, completionHandler: @escaping ResponseHandler) {
         let urlRequest = buildURLRequest(for: url, usingMethod: method, withBody: body, andHeaders: headers, forServerUrl: serverUrl)
         
         let task = session!.dataTask(with: urlRequest) { data, response, error in
+            self.ensureCSRFCookieIsShared(serverUrl: serverUrl)
             completionHandler(data, response, error)
         }
         

--- a/ios/Gekidou/Sources/Gekidou/Networking/Network.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/Network.swift
@@ -102,10 +102,11 @@ public class Network: NSObject {
                 request.addValue(preauthSecret, forHTTPHeaderField: GekidouConstants.HEADER_X_MATTERMOST_PREAUTH_SECRET)
             }
             if let csrfToken = credentials.csrfToken {
-                if method.lowercased() != "get" {
+                if method.caseInsensitiveCompare("get") != .orderedSame {
                     request.addValue(csrfToken, forHTTPHeaderField: GekidouConstants.HEADER_X_CSRF_TOKEN)
                 }
             }
+        }
         
         return request as URLRequest
     }
@@ -115,10 +116,11 @@ public class Network: NSObject {
     }
 
     internal func ensureCSRFCookieIsShared(serverUrl: String) {
-        let cookies = HTTPCookieStorage.shared.cookies(for: URL(string: serverUrl)!) ?? []
+        guard let url = URL(string: serverUrl) else {return}
+        let cookies = HTTPCookieStorage.shared.cookies(for: url) ?? []
         for cookie in cookies {
             if cookie.name == "MMCSRF" {
-                guard let appGroupId = Bundle.main.infoDictionary!["AppGroupIdentifier"] as? String else { return }
+                guard let appGroupId = Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String else { return }
                 HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: appGroupId).setCookie(cookie)
             }
         }

--- a/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
+++ b/ios/Gekidou/Sources/Gekidou/Networking/ShareExtension+Post.swift
@@ -45,6 +45,10 @@ extension ShareExtension {
                             uploadRequest.addValue(preauthSecret, forHTTPHeaderField: GekidouConstants.HEADER_X_MATTERMOST_PREAUTH_SECRET)
                         }
 
+                        if let csrfToken = credentials.csrfToken {
+                            uploadRequest.addValue(csrfToken, forHTTPHeaderField: GekidouConstants.HEADER_X_CSRF_TOKEN)
+                        }
+
                         if let task = backgroundSession?.uploadTask(with: uploadRequest, fromFile: fileUrl) {
                             os_log(
                                 OSLogType.default,

--- a/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
+++ b/ios/Mattermost/Extensions/RNNotificationEventHandler+HandleReplyAction.m
@@ -65,6 +65,7 @@ static SendReplyCompletionHandlerIMP originalSendReplyCompletionHandlerImplement
   NSDictionary *credentials = [[Keychain default] getCredentialsObjcFor:serverUrl];
   NSString *sessionToken = [credentials objectForKey:@"token"];
   NSString *preauthSecret = [credentials objectForKey:@"preauthSecret"];
+  NSString *csrfToken = [credentials objectForKey:@"csrfToken"];
   if (sessionToken == nil) {
     [self handleReplyFailure:@"" completionHandler:notificationCompletionHandler];
     return;
@@ -101,6 +102,10 @@ static SendReplyCompletionHandlerIMP originalSendReplyCompletionHandlerImplement
   // Add preauth secret header if available
   if ([preauthSecret isKindOfClass:NSString.class] && [(NSString *)preauthSecret length] > 0) {
     [request setValue:preauthSecret forHTTPHeaderField:@"X-Mattermost-Preauth-Secret"];
+  }
+
+  if ([csrfToken isKindOfClass:NSString.class] && [(NSString *)csrfToken length] > 0) {
+    [request setValue:csrfToken forHTTPHeaderField:@"X-CSRF-Token"];
   }
   
   [request setHTTPBody:postData];

--- a/types/credentials/index.d.ts
+++ b/types/credentials/index.d.ts
@@ -6,4 +6,5 @@ type ServerCredential = {
     userId: string;
     token: string;
     preauthSecret?: string;
+    csrfToken?: string;
 };


### PR DESCRIPTION
#### Summary
The native side of the app didn't add the CSRF header. Now this header is required, so we need to add it.

On Android, we just take the token from the cookie jar.

On iOS, the cookiejar is not shared, so I added the MMCSRF cookie to the shared cookie jar. This still may have some issues with the first time we try to retrieve the information of the push notification, but at the second time, it should be able to handle it perfectly. Happy to consider other approaches.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-66141
Fix https://mattermost.atlassian.net/browse/MM-66069

#### Release Note
```release-note
Fix notification related features on v11 servers.
```
