### PR TITLE
Latex styling update for incorrect baseline for the respective mobile OS

### DIFF
--- a/app/components/markdown/markdown_latex_inline/index.tsx
+++ b/app/components/markdown/markdown_latex_inline/index.tsx
@@ -23,7 +23,7 @@ type MathViewErrorProps = {
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         mathStyle: {
-            marginVertical: Platform.OS==='android'? 0 : 1.5,
+            marginVertical: Platform.select({ios: 1.5, default: 0}),
             alignItems: 'center',
             color: theme.centerChannelColor,
         },


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost/issues/25561

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Has UI changes

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
Iphone 16e, Iphone 16 plus, Iphone 16 Pro, and Iphone 16 pro max,
Medium phone Android(as the dynamic style alignItems was working for android) rather than the margin vertical

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
Before Fix
<img width="342" height="209" alt="image" src="https://github.com/user-attachments/assets/0f20d001-99c2-4a12-b2c1-1cc570c4927d" />


After fix
<img width="335" height="205" alt="image" src="https://github.com/user-attachments/assets/8d60d252-2777-4c24-bb26-0706a8f41850" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
