### PR TITLE
Fix race condition that prevents bottom tab bar from showing

### DIFF
--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -54,6 +54,12 @@ function setNavigationBarColor(screen: AvailableScreens, th?: Theme) {
     }
 }
 
+function showBottomTabsIfNeeded(screen: AvailableScreens) {
+    if (screen === Screens.HOME) {
+        DeviceEventEmitter.emit(Events.TAB_BAR_VISIBLE, true);
+    }
+}
+
 export function registerNavigationListeners() {
     subscriptions?.forEach((v) => v.remove());
     subscriptions = [
@@ -107,10 +113,7 @@ function onCommandListener(name: string, params: any) {
     }
 
     const screen = NavigationStore.getVisibleScreen();
-    if (screen === Screens.HOME) {
-        DeviceEventEmitter.emit(Events.TAB_BAR_VISIBLE, true);
-    }
-
+    showBottomTabsIfNeeded(screen);
     setNavigationBarColor(screen);
 }
 
@@ -118,13 +121,15 @@ function onPoppedListener({componentId}: ScreenPoppedEvent) {
     // screen pop does not trigger registerCommandListener, but does trigger screenPoppedListener
     const screen = componentId as AvailableScreens;
     NavigationStore.removeScreenFromStack(screen);
+
+    // If we pop to home, we need to show the tab bar
+    showBottomTabsIfNeeded(NavigationStore.getVisibleScreen());
+
     setNavigationBarColor(screen);
 }
 
 function onScreenWillAppear(event: ComponentWillAppearEvent) {
-    if (event.componentId === Screens.HOME) {
-        DeviceEventEmitter.emit(Events.TAB_BAR_VISIBLE, true);
-    }
+    showBottomTabsIfNeeded(event.componentId as AvailableScreens);
 }
 
 export const loginAnimationOptions = () => {


### PR DESCRIPTION
#### Summary
Fixed a race condition where the bottom tab bar would remain hidden when navigating back to the home screen after the app opens directly to a channel from a cold start.

The issue occurred because during cold start navigation to a channel, the HOME screen's lifecycle events could fire before the channel navigation completed, preventing proper tab bar visibility restoration when the user navigated back.

This PR adds defensive tab bar visibility checks across all navigation lifecycle events to ensure the tab bar is always shown when the HOME screen is visible.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65139

#### Release Note
```release-note
NONE
```
