### PR TITLE
[MM-66380] Only show playbook runs if enabled

### DIFF
--- a/app/screens/home/channel_list/categories_list/categories_list.tsx
+++ b/app/screens/home/channel_list/categories_list/categories_list.tsx
@@ -38,6 +38,7 @@ type ChannelListProps = {
     scheduledPostHasError: boolean;
     lastChannelId?: string;
     scheduledPostsEnabled?: boolean;
+    playbooksEnabled?: boolean;
 };
 
 const getTabletWidth = (moreThanOneTeam: boolean) => {
@@ -56,6 +57,7 @@ const CategoriesList = ({
     scheduledPostHasError,
     lastChannelId,
     scheduledPostsEnabled,
+    playbooksEnabled,
 }: ChannelListProps) => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
@@ -126,10 +128,14 @@ const CategoriesList = ({
     }, [activeScreen, draftsCount, isTablet, scheduledPostCount, scheduledPostHasError, scheduledPostsEnabled]);
 
     const playbooksButtonComponent = useMemo(() => {
+        if (!playbooksEnabled) {
+            return null;
+        }
+
         return (
             <PlaybooksButton/>
         );
-    }, []);
+    }, [playbooksEnabled]);
 
     const content = useMemo(() => {
         if (!hasChannels) {

--- a/app/screens/home/channel_list/categories_list/index.test.tsx
+++ b/app/screens/home/channel_list/categories_list/index.test.tsx
@@ -170,4 +170,34 @@ describe('components/categories_list', () => {
         );
         expect(wrapper.queryByText('Drafts')).not.toBeTruthy();
     });
+
+    it('should not render channel list with Playbooks menu if playbooks feature is disabled', () => {
+        const wrapper = renderWithEverything(
+            <CategoriesList
+                moreThanOneTeam={false}
+                hasChannels={true}
+                draftsCount={0}
+                scheduledPostCount={0}
+                scheduledPostHasError={false}
+                playbooksEnabled={false}
+            />,
+            {database},
+        );
+        expect(wrapper.queryByText('Playbook runs')).not.toBeTruthy();
+    });
+
+    it('should render channel list with Playbooks menu if playbooks feature is enabled', () => {
+        const wrapper = renderWithEverything(
+            <CategoriesList
+                moreThanOneTeam={false}
+                hasChannels={true}
+                draftsCount={0}
+                scheduledPostCount={0}
+                scheduledPostHasError={false}
+                playbooksEnabled={true}
+            />,
+            {database},
+        );
+        expect(wrapper.getByText('Playbook runs')).toBeTruthy();
+    });
 });

--- a/app/screens/home/channel_list/categories_list/index.tsx
+++ b/app/screens/home/channel_list/categories_list/index.tsx
@@ -5,6 +5,7 @@ import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
 import {of} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
+import {observeIsPlaybooksEnabled} from '@playbooks/database/queries/version';
 import {observeDraftCount} from '@queries/servers/drafts';
 import {observeScheduledPostEnabled, observeScheduledPostsForTeam} from '@queries/servers/scheduled_post';
 import {observeCurrentTeamId} from '@queries/servers/system';
@@ -27,6 +28,7 @@ const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
         switchMap((scheduledPosts) => of(hasScheduledPostError(scheduledPosts))),
     );
     const scheduledPostsEnabled = observeScheduledPostEnabled(database);
+    const playbooksEnabled = observeIsPlaybooksEnabled(database);
 
     return {
         lastChannelId,
@@ -34,6 +36,7 @@ const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
         scheduledPostCount,
         scheduledPostHasError,
         scheduledPostsEnabled,
+        playbooksEnabled,
     };
 });
 


### PR DESCRIPTION
#### Summary
Add a check to show the "Playbook runs" unified menu in the channel list only if playbooks are enabled.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-66380

#### Release Note
```release-note
NONE
```
