### PR TITLE
refactor(MM-64981): text change for no internet connection

### DIFF
--- a/app/components/connection_banner/connection_banner.tsx
+++ b/app/components/connection_banner/connection_banner.tsx
@@ -109,7 +109,7 @@ const ConnectionBanner = ({
             clearTimeoutRef(openTimeout);
             clearTimeoutRef(closeTimeout);
         };
-    }, []);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps -- only run on mount
 
     useDidUpdate(() => {
         if (isConnected) {
@@ -164,7 +164,7 @@ const ConnectionBanner = ({
     } else if (netInfo.isInternetReachable) {
         text = intl.formatMessage({id: 'connection_banner.not_reachable', defaultMessage: 'The server is not reachable'});
     } else {
-        text = intl.formatMessage({id: 'connection_banner.not_connected', defaultMessage: 'No internet connection'});
+        text = intl.formatMessage({id: 'connection_banner.not_connected', defaultMessage: 'Unable to connect to network'});
     }
 
     return (

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -272,7 +272,7 @@
   "combined_system_message.you": "You",
   "connection_banner.connected": "Connection restored",
   "connection_banner.connecting": "Connecting...",
-  "connection_banner.not_connected": "No internet connection",
+  "connection_banner.not_connected": "Unable to connect to network",
   "connection_banner.not_reachable": "The server is not reachable",
   "create_direct_message.title": "Create Direct Message",
   "create_post.deactivated": "You are viewing an archived channel with a deactivated user.",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Simple text change for ConnectionBanner "No internet connection" => "Unable to connect to network"

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-64981

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
- [X] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

iPHone 16 Simulator (iOS 17.1)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
