### PR TITLE
Fix: Add horizontal margin to custom status emoji in post header

### DIFF
--- a/app/components/post_list/post/header/display_name/index.tsx
+++ b/app/components/post_list/post/header/display_name/index.tsx
@@ -55,7 +55,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         customStatusEmoji: {
             color: theme.centerChannelColor,
-            marginRight: 4,
+            marginHorizontal: 4,
         },
     };
 });


### PR DESCRIPTION
This commit resolves an issue where the custom status emoji in a post header was visually crammed against the username and the timestamp on mobile.

By adding `marginHorizontal: 4` to the `customStatusEmoji` style in `index.tsx`, we ensure a consistent 4px separation from the surrounding elements, improving readability and adhering to the intended design alignment.

- Fixes #9222

#### Summary
- Fix: Add horizontal margin to custom status emoji in post header

#### Ticket Link
- Fixes https://github.com/mattermost/mattermost-mobile/issues/9222

#### Checklist
- [x] Has UI changes

#### Device Information
- iOS Simulator: iPhone 16 (iOS 18.5)
- Android Device: Samsung S22 Ultra (Android 16)

#### Screenshots

| Platform | Before Fix (Cramped) | After Fix (Aligned) |
| :---: | :---: | :---: |
| **iOS** | ![iOS Before](https://github.com/user-attachments/assets/c7494cda-2e0f-4213-b756-a5b40c48d0f1) | ![iOS After](https://github.com/user-attachments/assets/e30ab87c-7a08-4ba8-94e3-01238638f0fa) |
| **Android** | ![Android Before](https://github.com/user-attachments/assets/68664d41-d6d4-41c8-b321-a2839431ee0a) | ![Android After](https://github.com/user-attachments/assets/f452f13c-4bf7-4b80-8559-7db7ef04bbe7) |

#### Release Note
```release-note
Fixed an issue on mobile where the custom status emoji in a post header was improperly cramped against the username and timestamp.```
