### PR TITLE
MM-65959: Add FIPS indicator to about dialog

### DIFF
--- a/app/screens/settings/about/about.test.tsx
+++ b/app/screens/settings/about/about.test.tsx
@@ -1,0 +1,124 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {screen, waitFor} from '@testing-library/react-native';
+import React from 'react';
+
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import About from './about';
+
+import type {AvailableScreens} from '@typings/screens/navigation';
+
+jest.mock('@hooks/android_back_handler', () => jest.fn());
+
+jest.mock('@context/server', () => ({
+    useServerUrl: jest.fn(() => 'https://test.mattermost.com'),
+}));
+
+jest.mock('@hooks/utils', () => ({
+    usePreventDoubleTap: jest.fn((callback) => callback),
+}));
+
+jest.mock('@actions/remote/license', () => ({
+    getLicenseLoadMetric: jest.fn(() => Promise.resolve(null)),
+}));
+
+describe('About', () => {
+    const baseConfig: ClientConfig = {
+        Version: '9.5.0',
+        BuildNumber: '9.5.0.12345',
+        BuildDate: '2024-01-01',
+        BuildHash: 'abc123',
+        BuildHashEnterprise: 'def456',
+        SQLDriverName: 'postgres',
+        SchemaVersion: '123',
+        SiteName: 'Test Server',
+    } as ClientConfig;
+
+    const defaultProps = {
+        componentId: 'About' as AvailableScreens,
+        config: baseConfig,
+        license: undefined,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('rendering', () => {
+        it('should render about screen', async () => {
+            renderWithIntlAndTheme(<About {...defaultProps}/>);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('about.screen')).toBeTruthy();
+            });
+        });
+
+        it('should render server version', async () => {
+            renderWithIntlAndTheme(<About {...defaultProps}/>);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('about.server_version.value')).toBeTruthy();
+            });
+        });
+    });
+
+    describe('FIPS indicator', () => {
+        it('should show FIPS indicator when IsFipsEnabled is true', async () => {
+            const fipsConfig = {
+                ...baseConfig,
+                IsFipsEnabled: 'true',
+            };
+
+            renderWithIntlAndTheme(
+                <About
+                    {...defaultProps}
+                    config={fipsConfig}
+                />,
+            );
+
+            await waitFor(() => {
+                const serverVersionElement = screen.getByTestId('about.server_version.value');
+                expect(serverVersionElement.props.children).toContain('(FIPS)');
+            });
+        });
+
+        it('should not show FIPS indicator when IsFipsEnabled is false', async () => {
+            const nonFipsConfig = {
+                ...baseConfig,
+                IsFipsEnabled: 'false',
+            };
+
+            renderWithIntlAndTheme(
+                <About
+                    {...defaultProps}
+                    config={nonFipsConfig}
+                />,
+            );
+
+            await waitFor(() => {
+                const serverVersionElement = screen.getByTestId('about.server_version.value');
+                expect(serverVersionElement.props.children).not.toContain('(FIPS)');
+            });
+        });
+
+        it('should not show FIPS indicator when IsFipsEnabled is not set', async () => {
+            const configWithoutFips = {
+                ...baseConfig,
+            };
+
+            renderWithIntlAndTheme(
+                <About
+                    {...defaultProps}
+                    config={configWithoutFips}
+                />,
+            );
+
+            await waitFor(() => {
+                const serverVersionElement = screen.getByTestId('about.server_version.value');
+                expect(serverVersionElement.props.children).not.toContain('(FIPS)');
+            });
+        });
+    });
+});

--- a/app/screens/settings/about/about.tsx
+++ b/app/screens/settings/about/about.tsx
@@ -168,12 +168,13 @@ const About = ({componentId, config, license}: AboutProps) => {
     const serverVersion = useMemo(() => {
         const buildNumber = config.BuildNumber;
         const version = config.Version;
+        const fipsSuffix = config.IsFipsEnabled === 'true' ? ' (FIPS)' : '';
 
         if (buildNumber === version) {
-            return version;
+            return version + fipsSuffix;
         }
 
-        return intl.formatMessage({id: 'settings.about.server.version.value', defaultMessage: '{version} (Build {buildNumber})'}, {version, buildNumber});
+        return intl.formatMessage({id: 'settings.about.server.version.value', defaultMessage: '{version} (Build {buildNumber})'}, {version, buildNumber}) + fipsSuffix;
     }, [config, intl]);
 
     const close = useCallback(() => {
@@ -187,7 +188,8 @@ const About = ({componentId, config, license}: AboutProps) => {
             const appVersion = intl.formatMessage({id: 'settings.about.app.version', defaultMessage: 'App Version: {version} (Build {number})'}, {version: nativeApplicationVersion, number: nativeBuildVersion});
             const buildNumber = config.BuildNumber;
             const version = config.Version;
-            const server = buildNumber === version ? intl.formatMessage({id: 'settings.about.server.version.noBuild', defaultMessage: 'Server Version: {version}'}, {version}) : intl.formatMessage({id: 'settings.about.server.version', defaultMessage: 'Server Version: {version} (Build {buildNumber})'}, {version, buildNumber});
+            const fipsSuffix = config.IsFipsEnabled === 'true' ? ' (FIPS)' : '';
+            const server = buildNumber === version ? intl.formatMessage({id: 'settings.about.server.version.noBuild', defaultMessage: 'Server Version: {version}'}, {version}) + fipsSuffix : intl.formatMessage({id: 'settings.about.server.version', defaultMessage: 'Server Version: {version} (Build {buildNumber})'}, {version, buildNumber}) + fipsSuffix;
             const database = intl.formatMessage({id: 'settings.about.database', defaultMessage: 'Database: {driverName}'}, {driverName: config.SQLDriverName});
             const databaseSchemaVersion = intl.formatMessage({id: 'settings.about.database.schema', defaultMessage: 'Database Schema Version: {version}'}, {version: config.SchemaVersion});
             let copiedString = `${appVersion}\n${server}\n${database}\n${databaseSchemaVersion}`;
@@ -200,7 +202,7 @@ const About = ({componentId, config, license}: AboutProps) => {
             Clipboard.setString(copiedString);
             showSnackBar({barType: SNACK_BAR_TYPE.INFO_COPIED, sourceScreen: componentId});
         },
-        [intl, config.BuildNumber, config.Version, config.SQLDriverName, config.SchemaVersion, loadMetric, componentId],
+        [intl, config.BuildNumber, config.Version, config.IsFipsEnabled, config.SQLDriverName, config.SchemaVersion, loadMetric, componentId],
     );
 
     return (

--- a/types/api/config.d.ts
+++ b/types/api/config.d.ts
@@ -22,6 +22,7 @@ interface ClientConfig {
     BuildHash: string;
     BuildHashEnterprise: string;
     BuildNumber: string;
+    IsFipsEnabled: string;
     CloseUnusedDirectMessages: string;
     CollapsedThreads: string;
     CustomBrandText: string;


### PR DESCRIPTION
#### Summary

Adds a "(FIPS)" indicator to the server version in the About dialog when the server is running in FIPS mode. This change complements the server-side PR that exposes the `IsFipsEnabled` field in the client config.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-65959

Related server PR: https://github.com/mattermost/mattermost/pull/34463

#### Checklist

- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: <!-- Requires manual testing -->

```release-note
NONE
```