### PR TITLE
fix(ui): wrap ResetToDefault text to avoid overlapping header

### DIFF
--- a/app/components/settings/block.tsx
+++ b/app/components/settings/block.tsx
@@ -56,6 +56,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         rightHeader: {
             flex: 1,
+            alignItems: 'flex-end',
         },
     };
 });

--- a/app/components/settings/block.tsx
+++ b/app/components/settings/block.tsx
@@ -26,12 +26,18 @@ type SettingBlockProps = {
     headerStyles?: StyleProp<TextStyle>;
     headerText?: SectionText;
     onLayout?: (event: LayoutChangeEvent) => void;
+    headerRight?: React.ReactNode;
 };
 
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         container: {
             marginBottom: 30,
+        },
+        headerRow: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            flex: 1,
         },
         contentContainerStyle: {
             marginBottom: 0,
@@ -41,6 +47,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             ...typography('Heading', 300, 'SemiBold'),
             marginBottom: 8,
             marginTop: 12,
+            flex: 1,
         },
         footer: {
             marginTop: 10,
@@ -52,7 +59,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
 
 const SettingBlock = ({
     children, containerStyles, disableFooter, disableHeader,
-    footerStyles, footerText, headerStyles, headerText, onLayout,
+    footerStyles, footerText, headerStyles, headerText, onLayout, headerRight,
 }: SettingBlockProps) => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
@@ -63,16 +70,24 @@ const SettingBlock = ({
             onLayout={onLayout}
         >
             {(headerText && !disableHeader) &&
-            <FormattedText
-                defaultMessage={headerText.defaultMessage}
-                id={headerText.id}
-                values={headerText.values}
-                style={[styles.header, headerStyles]}
-            />
+                <View style={styles.headerRow}>
+                    <FormattedText
+                        defaultMessage={headerText.defaultMessage}
+                        id={headerText.id}
+                        values={headerText.values}
+                        style={[styles.header, headerStyles]}
+                    />
+                    {headerRight && (
+                        <View style={{flex: 1}}>
+                            {headerRight}
+                        </View>
+                    )}
+                </View>
             }
             <View style={[styles.contentContainerStyle, containerStyles]}>
                 {children}
             </View>
+
             {(footerText && !disableFooter) &&
             <FormattedText
                 defaultMessage={footerText.defaultMessage}

--- a/app/components/settings/block.tsx
+++ b/app/components/settings/block.tsx
@@ -54,6 +54,9 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
             fontSize: 12,
             color: changeOpacity(theme.centerChannelColor, 0.5),
         },
+        rightHeader: {
+            flex: 1,
+        },
     };
 });
 
@@ -78,7 +81,7 @@ const SettingBlock = ({
                         style={[styles.header, headerStyles]}
                     />
                     {headerRight && (
-                        <View style={{flex: 1}}>
+                        <View style={styles.rightHeader}>
                             {headerRight}
                         </View>
                     )}

--- a/app/screens/channel_notification_preferences/channel_notification_preferences.tsx
+++ b/app/screens/channel_notification_preferences/channel_notification_preferences.tsx
@@ -3,7 +3,6 @@
 
 import React, {useCallback, useState} from 'react';
 import {LayoutAnimation} from 'react-native';
-import {useSharedValue} from 'react-native-reanimated';
 
 import {updateChannelNotifyProps} from '@actions/remote/channel';
 import SettingsContainer from '@components/settings/container';
@@ -16,8 +15,8 @@ import {isTypeDMorGM} from '@utils/channel';
 
 import {popTopScreen} from '../navigation';
 
-import MutedBanner, {MUTED_BANNER_HEIGHT} from './muted_banner';
-import NotifyAbout, {BLOCK_TITLE_HEIGHT} from './notify_about';
+import MutedBanner from './muted_banner';
+import NotifyAbout from './notify_about';
 import ResetToDefault from './reset';
 import ThreadReplies from './thread_replies';
 
@@ -51,7 +50,6 @@ const ChannelNotificationPreferences = ({
     const serverUrl = useServerUrl();
     const defaultNotificationReplies = defaultThreadReplies === 'all';
     const diffNotificationLevel = notifyLevel !== NotificationLevel.DEFAULT && notifyLevel !== defaultLevel;
-    const notifyTitleTop = useSharedValue((isMuted ? MUTED_BANNER_HEIGHT : 0) + BLOCK_TITLE_HEIGHT);
     const [notifyAbout, setNotifyAbout] = useState<NotificationLevel>(notifyLevel === NotificationLevel.DEFAULT ? defaultLevel : notifyLevel);
     const [threadReplies, setThreadReplies] = useState<boolean>((notifyThreadReplies || defaultThreadReplies) === 'all');
     const [resetDefaultVisible, setResetDefaultVisible] = useState(diffNotificationLevel || defaultNotificationReplies !== threadReplies);
@@ -105,18 +103,12 @@ const ChannelNotificationPreferences = ({
     return (
         <SettingsContainer testID='push_notification_settings'>
             {isMuted && <MutedBanner channelId={channelId}/>}
-            {resetDefaultVisible &&
-            <ResetToDefault
-                onPress={onResetPressed}
-                topPosition={notifyTitleTop}
-            />
-            }
             <NotifyAbout
                 defaultLevel={defaultLevel}
                 isMuted={isMuted}
                 notifyLevel={notifyAbout}
-                notifyTitleTop={notifyTitleTop}
                 onPress={onNotificationLevel}
+                rightHeaderComponent={resetDefaultVisible && <ResetToDefault onPress={onResetPressed}/>}
             />
             {showThreadReplies &&
             <ThreadReplies

--- a/app/screens/channel_notification_preferences/notify_about.tsx
+++ b/app/screens/channel_notification_preferences/notify_about.tsx
@@ -1,23 +1,22 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback} from 'react';
+import React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
-import {type LayoutChangeEvent, View} from 'react-native';
+import {View} from 'react-native';
 
 import SettingBlock from '@components/settings/block';
 import SettingOption from '@components/settings/option';
 import SettingSeparator from '@components/settings/separator';
 import {NotificationLevel} from '@constants';
 
-import type {SharedValue} from 'react-native-reanimated';
-
 type Props = {
     isMuted: boolean;
     defaultLevel: NotificationLevel;
     notifyLevel: NotificationLevel;
-    notifyTitleTop: SharedValue<number>;
     onPress: (level: NotificationLevel) => void;
+        rightHeaderComponent?: React.ReactNode;
+
 }
 
 type NotifPrefOptions = {
@@ -72,18 +71,10 @@ const NotifyAbout = ({
     defaultLevel,
     isMuted,
     notifyLevel,
-    notifyTitleTop,
     onPress,
+    rightHeaderComponent,
 }: Props) => {
     const {formatMessage} = useIntl();
-    const onLayout = useCallback((e: LayoutChangeEvent) => {
-        const {y} = e.nativeEvent.layout;
-
-        notifyTitleTop.value = y > 0 ? y + 10 : BLOCK_TITLE_HEIGHT;
-
-        // NotifyTitleTop is a shared value, so its reference should not change between renders.
-        // we add it to the dependencies to satisfy the linter.
-    }, [notifyTitleTop]);
 
     let notifyLevelToUse = notifyLevel;
     if (notifyLevel === NotificationLevel.DEFAULT) {
@@ -94,7 +85,7 @@ const NotifyAbout = ({
         <SettingBlock
             headerText={NOTIFY_ABOUT}
             headerStyles={{marginTop: isMuted ? 8 : 12}}
-            onLayout={onLayout}
+            headerRight={rightHeaderComponent}
         >
             {Object.keys(NOTIFY_OPTIONS).map((key) => {
                 const {id, defaultMessage, value, testID} = NOTIFY_OPTIONS[key];

--- a/app/screens/channel_notification_preferences/notify_about.tsx
+++ b/app/screens/channel_notification_preferences/notify_about.tsx
@@ -15,8 +15,7 @@ type Props = {
     defaultLevel: NotificationLevel;
     notifyLevel: NotificationLevel;
     onPress: (level: NotificationLevel) => void;
-        rightHeaderComponent?: React.ReactNode;
-
+    rightHeaderComponent?: React.ReactNode;
 }
 
 type NotifPrefOptions = {

--- a/app/screens/channel_notification_preferences/reset.tsx
+++ b/app/screens/channel_notification_preferences/reset.tsx
@@ -43,7 +43,7 @@ const ResetToDefault = ({onPress}: Props) => {
                     color={theme.linkColor}
                 />
                 <FormattedText
-                    id='channel_notification_preferences.reet_default'
+                    id='channel_notification_preferences.reset_default'
                     defaultMessage='Reset to default'
                     style={styles.text}
                 />

--- a/app/screens/channel_notification_preferences/reset.tsx
+++ b/app/screens/channel_notification_preferences/reset.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import {TouchableOpacity} from 'react-native';
-import Animated, {type SharedValue, useAnimatedStyle, withTiming} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 
 import CompassIcon from '@components/compass_icon';
 import FormattedText from '@components/formatted_text';
@@ -13,16 +13,13 @@ import {typography} from '@utils/typography';
 
 type Props = {
     onPress: () => void;
-    topPosition: SharedValue<number>;
 }
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
-    container: {
-        position: 'absolute',
-        right: 20,
-        zIndex: 1,
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
     },
-    row: {flexDirection: 'row'},
     text: {
         color: theme.linkColor,
         marginLeft: 7,
@@ -30,16 +27,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const ResetToDefault = ({onPress, topPosition}: Props) => {
+const ResetToDefault = ({onPress}: Props) => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
 
-    const animatedStyle = useAnimatedStyle(() => ({
-        top: withTiming(topPosition.value, {duration: 100}),
-    }));
-
     return (
-        <Animated.View style={[styles.container, animatedStyle]}>
+        <Animated.View>
             <TouchableOpacity
                 onPress={onPress}
                 style={styles.row}
@@ -50,7 +43,7 @@ const ResetToDefault = ({onPress, topPosition}: Props) => {
                     color={theme.linkColor}
                 />
                 <FormattedText
-                    id='channel_notification_preferences.reset_default'
+                    id='channel_notification_preferences.reet_default'
                     defaultMessage='Reset to default'
                     style={styles.text}
                 />


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix for the responsive layout of the default reset message in the channel notification menu.

**Problem**
The error message was rendered outside of the header component, so it appeared in an absolute position next to the title.

**Solution**
I moved the error message inside the header using the `headerRight` prop.  
I also set the header and its two children (the title and the error message) to `flex: 1` so they share the available space equally within the header, and made the text wrap when it’s too long.

<!--
A brief description of what this pull request does.
-->

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/issues/9282
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: Pixel 8, iPhone 12 mini <!-- Device name(s), OS version(s) -->

#### Screenshots

| Avant | Après |
|:------:|:------:|
| <img width="323" height="733" alt="image" src="https://github.com/user-attachments/assets/674ce5f1-8a45-4c56-9891-1600580cd2f5" /> | <img width="433" height="459" alt="Capture d’écran 2025-11-13 à 11 42 08" src="https://github.com/user-attachments/assets/900fa5ec-7e6a-4a21-8b16-33e3c18142f4" />|
|  |  <img width="379" height="323" alt="Capture d’écran 2025-11-13 à 11 41 26" src="https://github.com/user-attachments/assets/5a016565-603a-4ac3-921e-8a86ef92e0b3" /> |

<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
