### PR TITLE
Fix the E2E test for edited post

### DIFF
--- a/detox/e2e/test/products/channels/messaging/message_edit.e2e.ts
+++ b/detox/e2e/test/products/channels/messaging/message_edit.e2e.ts
@@ -83,7 +83,7 @@ describe('Messaging - Message Edit', () => {
         const postItemTestID = `channel.post_list.post.${post.id}`;
         const postItemMatcher = by.id(postItemTestID);
 
-        // Escape special characters in the message for regex this is for pencil icon
+        // Escape special characters in the message for regex
         const escapedMessage = updatedMessage.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
         // Match text that contains the updated message followed by "Edited" (with possible spacing/icon)
@@ -163,7 +163,7 @@ describe('Messaging - Message Edit', () => {
         const replyPostItemTestID = `thread.post_list.post.${replyPost.id}`;
         const replyPostItemMatcher = by.id(replyPostItemTestID);
 
-        // Escape special characters in the message for regex this is for pencil icon
+        // Escape special characters in the message for regex
         const escapedReplyMessage = updatedReplyMessage.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
         // Match text that contains the updated message followed by "Edited" (with possible spacing/icon)


### PR DESCRIPTION
#### Summary
#### Issue
After editing a post, the test needs to verify:
- The post message was updated (e.g., "Message abc123" → "Message abc123 edit")
- The edited indicator appears (pencil icon + "Edited" text)

The original approach failed because:
- toHaveText('Edited') tried to match text on a container element, edited indicator is not a separate accessible element, it is part of the post's text content.

#### Solution
The test now uses a regex pattern to find text within the post item that contains both the updated message and "Edited".
- When the post is edited, the post contains the original `message` + pencil icon + `Edited` text. 
- First, escape the special character from the message if any. 
- Create a Regex pattern, i.e.
```
const completeTextPattern = new RegExp(`${escapedMessage}.*Edited`, 'i');
```
- After the message is edited, the pattern will become: "Message abc123 edit.*Edited"
- `.*` matches any characters (including the pencil icon and spacing)
- `i` flag makes it case-insensitive
- This will create a pattern that matches the edited text that contains an icon in between the updated text and `Edited` text. 
- This will confirm that both the updated message and the text `Edited` are present. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65024

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
