### PR TITLE
[MM-66485] Add separator to add a new run button

### DIFF
--- a/app/products/playbooks/components/run_list/run_list.tsx
+++ b/app/products/playbooks/components/run_list/run_list.tsx
@@ -41,6 +41,8 @@ const itemSeparatorStyle = StyleSheet.create({
         height: 12,
     },
 });
+
+const START_NEW_RUN_BUTTON_PADDING = 20;
 const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => ({
     container: {
         padding: 20,
@@ -54,7 +56,9 @@ const getStyleFromTheme = makeStyleSheetFromTheme((theme: Theme) => ({
         paddingHorizontal: 16,
     },
     startANewRunButtonContainer: {
-        padding: 20,
+        padding: START_NEW_RUN_BUTTON_PADDING,
+        borderTopWidth: 1,
+        borderTopColor: changeOpacity(theme.centerChannelColor, 0.12),
     },
 }));
 
@@ -130,7 +134,7 @@ const RunList = ({
     ), [fetching, onShowMorePress, showMoreButton, activeTab]);
 
     const startANewRunButtonContainerStyle = useMemo(() => {
-        return [styles.startANewRunButtonContainer, {paddingBottom: insets.bottom}];
+        return [styles.startANewRunButtonContainer, {paddingBottom: insets.bottom + START_NEW_RUN_BUTTON_PADDING}];
     }, [insets.bottom, styles]);
 
     const renderItem: ListRenderItem<PlaybookRunModel> = useCallback(({item}) => {


### PR DESCRIPTION
#### Summary
Add some padding to the start a new run button, and a border to make it stand out more.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-66485

#### Screenshots
<img width="412" height="148" alt="Captura de pantalla 2025-11-19 a las 13 07 37" src="https://github.com/user-attachments/assets/14057d7c-e655-404d-92dd-bcb7d954fc64" />

#### Release Note
```release-note
Minor visual tweak to start a new run button
```
