### PR TITLE
[MM-66739] revert MM-66316 containerStyle changes

### DIFF
--- a/app/screens/gallery/index.tsx
+++ b/app/screens/gallery/index.tsx
@@ -2,8 +2,8 @@
 // See LICENSE.txt for license information.
 
 import RNUtils from '@mattermost/rnutils';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {DeviceEventEmitter, Platform, View} from 'react-native';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {DeviceEventEmitter, Platform, StyleSheet, View} from 'react-native';
 
 import {Events} from '@constants';
 import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
@@ -28,6 +28,12 @@ type Props = {
     items: GalleryItemType[];
 }
 
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+});
+
 const GalleryScreen = ({componentId, galleryIdentifier, hideActions, initialIndex, items}: Props) => {
     const dim = useWindowDimensions();
     const isTablet = useIsTablet();
@@ -35,7 +41,13 @@ const GalleryScreen = ({componentId, galleryIdentifier, hideActions, initialInde
     const {headerAndFooterHidden, hideHeaderAndFooter, headerStyles, footerStyles} = useGalleryControls();
     const galleryRef = useRef<GalleryRef>(null);
 
-    const containerStyle = dim;
+    const containerStyle = useMemo(() => {
+        if (Platform.OS === 'ios') {
+            return dim;
+        }
+
+        return styles.container;
+    }, [dim]);
 
     const onClose = useCallback(() => {
         // We keep the un freeze here as we want


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
I've found out that https://github.com/mattermost/mattermost-mobile/pull/9247 changes of containerStyle cause the issue MM-66739

This change reverts containerStyle. I've tested with images from MM-66739 that there are no additional regression

 <del>I didn't understand how to reproduce an issue that https://github.com/mattermost/mattermost-mobile/pull/9247 was originally fixing (from https://mattermost.atlassian.net/browse/MM-66316) and I need help of someone who can say which images and emulators to use to reproduce it, or someone who can continue investigation of this issue instead of me </del>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-66739

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: Android Emulator (sdk_gphone64_x86_64, Android 16)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
Before
<img width="413" height="947" alt="image" src="https://github.com/user-attachments/assets/903c7d50-585e-40b2-81fa-e573e6b6834b" />

After
<img width="413" height="934" alt="image" src="https://github.com/user-attachments/assets/8cdbff09-327e-4e16-aaba-599c9aaf3ba8" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

(probably if this bug is not released yet, when release note is not needed):
```release-note
Fixed a regression issue where during image view in gallery no username, download or share icon visible at the bottom of the screen
```
