### PR TITLE
remove duplicate models in processTeamChannels

### DIFF
--- a/app/actions/remote/post.auxiliary.ts
+++ b/app/actions/remote/post.auxiliary.ts
@@ -6,6 +6,7 @@ import {chunk} from 'lodash';
 import {prepareModelsForChannelPosts} from '@actions/local/post';
 import {ActionType} from '@constants';
 import DatabaseManager from '@database/manager';
+import {removeDuplicatesModels} from '@helpers/database';
 
 import {fetchPostAuthors, fetchPostsForChannel} from './post';
 
@@ -68,7 +69,7 @@ export async function processChannelPostsByTeam(
         const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
 
         const models = await Promise.all(prepareModelsPromises);
-        operator.batchRecords(models.flat(), 'processTeamChannels');
+        operator.batchRecords(removeDuplicatesModels(models.flat()), 'processTeamChannels');
     }
     if (!skipAuthors && allPosts.length) {
         await fetchPostAuthors(serverUrl, allPosts, false, groupLabel);


### PR DESCRIPTION
#### Summary
As I was working on another project, testing in different servers with different accounts I found myself seeing this error constantly on one of the test accounts

```
batchRecords error  processTeamChannels [Error: Failed to execute db update - sqlite error 1555 (UNIQUE constraint failed: CustomEmoji.id)]
```

The area of the code relevant to this executes multiple prepareModels that could cause the same models with the same data to be prepared multiple times and then the attempt to batch them causes problems.

Added the utility function to remove those duplicates before the batch.

#### Ticket Link
N/A

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Release Note
```release-note
NONE
```
