### PR TITLE
[MM-66858] Fix email notification screen not updating

### DIFF
--- a/app/screens/settings/notifications/notifications.tsx
+++ b/app/screens/settings/notifications/notifications.tsx
@@ -64,7 +64,12 @@ const Notifications = ({
 }: NotificationsProps) => {
     const intl = useIntl();
     const serverUrl = useServerUrl();
-    const notifyProps = useMemo(() => getNotificationProps(currentUser), [currentUser]);
+
+    // We need to depend on the notifyProps object directly,
+    // since changes in it may not be reflected in the currentUser object
+    // (it is still the same object reference).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const notifyProps = useMemo(() => getNotificationProps(currentUser), [currentUser?.notifyProps]);
     const callsRingingEnabled = useMemo(() => getCallsConfig(serverUrl).EnableRinging, [serverUrl]);
     const [isRegistered, setIsRegistered] = useState(true);
 


### PR DESCRIPTION
#### Summary
The way WatermelonDB works, even if some fields of a model change, the model object may not be recreated. Therefore, sometimes we have to depend on the particular fields, instead of on the parent object.

This was causing the state not changing in the UI.

#### Ticket Link
Fix: https://mattermost.atlassian.net/browse/MM-66858

#### Release Note
```release-note
Fix notification settings screen sometimes not showing updates when changing the email notifications.
```
