### PR TITLE
Fix version typo in scripts/build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -110,7 +110,7 @@ function setup() {
 
         echo "Installing Fastane"
         if !gem list bundler -i --version 2.5.11 > /dev/null 2>&1; then
-          gem install bundler --versio 2.5.11
+          gem install bundler --version 2.5.11
         fi
         cd fastlane && bundle install && cd .. || exit 1
     fi


### PR DESCRIPTION
#### Summary
This is just a small typo fix which caught my eye in building package.

#### Ticket Link
There is no JIRA ticket, I couldn't find anything relevant to this in contributing docs.

#### Checklist
Irrelevant.

#### Device Information
Irrelevant.

#### Screenshots
Irrelevant.

#### Release Note
```release-note
NONE
```