### PR TITLE
workflow, fastlane: upload release artifacts new bucket

### DIFF
--- a/.github/workflows/build-android-beta.yml
+++ b/.github/workflows/build-android-beta.yml
@@ -39,17 +39,10 @@ jobs:
           STORE_PASSWORD: "${{ secrets.MM_MOBILE_STORE_PASSWORD }}"
           MATTERMOST_BUILD_GH_TOKEN: "${{ secrets.MATTERMOST_BUILD_GH_TOKEN }}"
 
-      - name: Configure AWS credentials new bucket
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
-
       - name: ci/build-and-deploy-android-beta
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.MM_MOBILE_BETA_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.MM_MOBILE_BETA_AWS_SECRET_ACCESS_KEY }}"
-          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
           MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
           SENTRY_AUTH_TOKEN: "${{ secrets.MM_MOBILE_SENTRY_AUTH_TOKEN }}"
           SENTRY_DSN_ANDROID: ${{ secrets.MM_MOBILE_BETA_SENTRY_DSN_ANDROID }}
@@ -68,3 +61,21 @@ jobs:
         with:
           name: android-build-beta-${{ github.run_id }}
           path: "*.apk"
+
+      # New AWS bucket deployment steps
+      - name: Configure AWS credentials new bucket
+        id: configure-aws-credentials-new-bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: ci/upload-android-beta-new-bucket
+        env:
+          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
+          MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
+        run: |
+          echo "::group::Upload to new S3 bucket"
+          bundle exec fastlane android upload_artifacts_to_s3 --env android.beta
+          echo "::endgroup::"
+        working-directory: ./fastlane

--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -39,17 +39,10 @@ jobs:
           STORE_PASSWORD: "${{ secrets.MM_MOBILE_STORE_PASSWORD }}"
           MATTERMOST_BUILD_GH_TOKEN: "${{ secrets.MATTERMOST_BUILD_GH_TOKEN }}"
 
-      - name: Configure AWS credentials new bucket
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
-
       - name: ci/build-and-deploy-android-release
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.MM_MOBILE_RELEASE_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.MM_MOBILE_RELEASE_AWS_SECRET_ACCESS_KEY }}"
-          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
           MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_RELEASE_MATTERMOST_WEBHOOK_URL }}"
           SENTRY_AUTH_TOKEN: "${{ secrets.MM_MOBILE_SENTRY_AUTH_TOKEN }}"
           SENTRY_DSN_ANDROID: ${{ secrets.MM_MOBILE_RELEASE_SENTRY_DSN_ANDROID }}
@@ -68,3 +61,19 @@ jobs:
         with:
           name: android-build-release-${{ github.run_id }}
           path: "*.apk"
+
+      - name: Configure AWS credentials new bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: ci/upload-android-release-new-bucket
+        env:
+          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
+          MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_RELEASE_MATTERMOST_WEBHOOK_URL }}"
+        run: |
+          echo "::group::Upload to new S3 bucket"
+          bundle exec fastlane android upload_artifacts_to_s3 --env android.release
+          echo "::endgroup::"
+        working-directory: ./fastlane

--- a/.github/workflows/build-ios-beta.yml
+++ b/.github/workflows/build-ios-beta.yml
@@ -37,18 +37,11 @@ jobs:
           intune-enabled: ${{ env.INTUNE_ENABLED }}
           intune-ssh-private-key: ${{ secrets.MM_MOBILE_INTUNE_DEPLOY_KEY }}
 
-      - name: Configure AWS credentials new bucket
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
-
       - name: ci/build-ios-simulator
         env:
           TAG: "${{ github.ref_name }}"
           AWS_ACCESS_KEY_ID: "${{ secrets.MM_MOBILE_BETA_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.MM_MOBILE_BETA_AWS_SECRET_ACCESS_KEY }}"
-          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
           MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
           GITHUB_TOKEN: "${{ secrets.MM_MOBILE_GITHUB_TOKEN }}"
         run: bundle exec fastlane ios simulator --env ios.simulator
@@ -59,6 +52,22 @@ jobs:
         with:
           name: ios-build-simulator-${{ github.run_id }}
           path: Mattermost-simulator-x86_64.app.zip
+
+      # Logic for new bucket upload
+      - name: Configure AWS credentials new bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: ci/upload-ios-simulator-new-bucket
+        env:
+          TAG: "${{ github.ref_name }}"
+          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
+          MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
+          GITHUB_TOKEN: "${{ secrets.MM_MOBILE_GITHUB_TOKEN }}"
+        run: bundle exec fastlane ios upload_artifacts_to_s3 --env ios.simulator output_file:"Mattermost-simulator-x86_64.app.zip"
+        working-directory: ./fastlane
 
   build-and-deploy-ios-beta:
     runs-on: macos-15-large
@@ -83,17 +92,10 @@ jobs:
           intune-enabled: ${{ env.INTUNE_ENABLED }}
           intune-ssh-private-key: ${{ secrets.MM_MOBILE_INTUNE_DEPLOY_KEY }}
 
-      - name: Configure AWS credentials new bucket
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
-
       - name: ci/build-and-deploy-ios-beta
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.MM_MOBILE_BETA_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.MM_MOBILE_BETA_AWS_SECRET_ACCESS_KEY }}"
-          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
           MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
           FASTLANE_TEAM_ID: "${{ secrets.MM_MOBILE_FASTLANE_TEAM_ID }}"
           IOS_API_ISSUER_ID: "${{ secrets.MM_MOBILE_IOS_API_ISSUER_ID }}"
@@ -117,3 +119,20 @@ jobs:
         with:
           name: ios-build-beta-${{ github.run_id }}
           path: "*.ipa"
+
+      # Logic for new bucket upload
+      - name: Configure AWS credentials new bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: ci/upload-ios-beta-new-bucket
+        env:
+          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
+          MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
+        run: |
+          echo "::group::Upload to new S3 bucket"
+          bundle exec fastlane ios upload_artifacts_to_s3 --env ios.beta
+          echo "::endgroup::"
+        working-directory: ./fastlane

--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -45,12 +45,6 @@ jobs:
           intune-enabled: ${{ env.INTUNE_ENABLED }}
           intune-ssh-private-key: ${{ secrets.MM_MOBILE_INTUNE_DEPLOY_KEY }}
 
-      - name: Configure AWS credentials new bucket
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
-
       - name: ci/build-and-deploy-ios-release
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.MM_MOBILE_RELEASE_AWS_ACCESS_KEY_ID }}"
@@ -80,6 +74,23 @@ jobs:
           name: ios-build-release-${{ github.run_id }}
           path: "*.ipa"
 
+      # Upload artifacts to new bucket
+      - name: Configure AWS credentials new bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: ci/upload-ios-release-to-new-bucket
+        env:
+          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_RELEASE_AWS_NEW_BUCKET_NAME }}"
+          MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_RELEASE_MATTERMOST_WEBHOOK_URL }}"
+        run: |
+          echo "::group::Build"
+          bundle exec fastlane ios upload_artifacts_to_s3 --env ios.release
+          echo "::endgroup::"
+        working-directory: ./fastlane
+
   build-ios-simulator:
     runs-on: macos-15-large
     if: ${{ !contains(github.ref_name , 'release-ios') }}
@@ -95,18 +106,11 @@ jobs:
           intune-enabled: ${{ env.INTUNE_ENABLED }}
           intune-ssh-private-key: ${{ secrets.MM_MOBILE_INTUNE_DEPLOY_KEY }}
 
-      - name: Configure AWS credentials new bucket
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
-
       - name: ci/build-ios-simulator
         env:
           TAG: "${{ github.ref_name }}"
           AWS_ACCESS_KEY_ID: "${{ secrets.MM_MOBILE_BETA_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.MM_MOBILE_BETA_AWS_SECRET_ACCESS_KEY }}"
-          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_BETA_AWS_NEW_BUCKET_NAME }}"
           MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
           GITHUB_TOKEN: "${{ secrets.MM_MOBILE_GITHUB_TOKEN }}"
         run: bundle exec fastlane ios simulator --env ios.simulator
@@ -117,3 +121,18 @@ jobs:
         with:
           name: ios-build-simulator-${{ github.run_id }}
           path: Mattermost-simulator-x86_64.app.zip
+
+      # Logic for new bucket upload
+      - name: Configure AWS credentials new bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_MOBILE_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: ci/upload-ios-simulator-new-bucket
+        env:
+          TAG: "${{ github.ref_name }}"
+          AWS_NEW_BUCKET_NAME: "${{ secrets.MM_MOBILE_BETA_AWS_NEW_BUCKET_NAME }}"
+          MATTERMOST_WEBHOOK_URL: "${{ secrets.MM_MOBILE_BETA_MATTERMOST_WEBHOOK_URL }}"
+        run: bundle exec fastlane ios simulator --env ios.simulator output_file:"Mattermost-simulator-x86_64.app.zip"
+        working-directory: ./fastlane

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -417,15 +417,6 @@ platform :ios do
     link_sentry({:os_type => "ios"})
     build_ios
     upload_file_to_s3({:os_type => "ios"})
-    # Only upload to new S3 bucket for release builds
-    if is_build_pr == false
-      UI.message("Uploading to new S3 bucket...")
-      begin
-        upload_file_to_s3({:os_type => "ios", :enable_s3_new_bucket => true})
-      rescue SyntaxError, StandardError
-        UI.error("Failed to upload to new S3 bucket")
-      end
-    end
   end
 
   desc 'Build an unsigned ipa'
@@ -474,18 +465,27 @@ platform :ios do
       :os_type => "ios",
       :file => output_file
     })
-    # Only upload to new S3 bucket for release builds
-    if is_build_pr == false
-      UI.message("Uploading to new S3 bucket...")
-      begin
+  end
+
+  desc 'Upload artifacts to S3'
+  lane :upload_artifacts_to_s3 do |options|
+    output_file = options[:output_file]
+    UI.message("Uploading to new S3 bucket..." + (output_file ? " file: #{output_file}" : ""))
+    begin
+      if output_file && !output_file.empty?
         upload_file_to_s3({
           :os_type => "ios",
           :file => output_file,
           :enable_s3_new_bucket => true
         })
-      rescue SyntaxError, StandardError
-        UI.error("Failed to upload to new S3 bucket")
+      else
+        upload_file_to_s3({
+          :os_type => "ios",
+          :enable_s3_new_bucket => true
+        })
       end
+    rescue SyntaxError, StandardError
+      UI.error("Failed to upload to new S3 bucket")
     end
   end
 
@@ -814,15 +814,6 @@ platform :android do
     build_android
     move_android_to_root
     upload_file_to_s3({:os_type => "android"})
-    # Only upload to new S3 bucket for release builds
-    if is_build_pr == false
-      UI.message("Uploading to new S3 bucket...")
-      begin
-        upload_file_to_s3({:os_type => "android", :enable_s3_new_bucket => true})
-      rescue SyntaxError, StandardError
-        UI.error("Failed to upload to new S3 bucket")
-      end
-    end
   end
 
   desc 'Build an unsigned apk'
@@ -844,6 +835,16 @@ platform :android do
     )
 
     sh "mv #{lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]} #{Pathname.new(File.expand_path(File.dirname(__FILE__))).parent.to_s}/Mattermost-unsigned.apk"
+  end
+
+  desc 'Upload artifacts to S3'
+  lane :upload_artifacts_to_s3 do
+    UI.message("Uploading to new S3 bucket...")
+    begin
+      upload_file_to_s3({:os_type => "android", :enable_s3_new_bucket => true})
+    rescue SyntaxError, StandardError
+      UI.error("Failed to upload to new S3 bucket")
+    end
   end
 
   lane :update_identifiers do


### PR DESCRIPTION
#### Summary
- Update release workflows and fastlane to support uploading release artifacts to both buckets (current and new) at the same time. It'll happen during a specific period for validation / testing phase.


#### Test
- PR Build (similar approach than official release) https://github.com/mattermost/mattermost-mobile/actions/runs/21284534953/job/61262556341?pr=9410
- Release: with current workflow it's challenging test it. I added a `begin ... rescue` when calling upload-to-s3 using for new bucket to avoid disrupt existing workflow.

#### Ticket Link
- https://mattermost.atlassian.net/browse/SEC-9225

#### Release Note
```release-note
NONE
```
