### PR TITLE
[MM-67173] to-fix: skip flaky playIncomingCallsRinging test in calls state

### DIFF
--- a/app/products/calls/state/actions.test.ts
+++ b/app/products/calls/state/actions.test.ts
@@ -1454,6 +1454,7 @@ describe('useCallsState', () => {
     });
 
     // TODO: Flaky test - disabled until root cause is identified
+    // See https://mattermost.atlassian.net/browse/MM-67173
     it.skip('playIncomingCallsRinging', async () => {
         const initialIncomingCalls = {
             ...DefaultIncomingCalls,


### PR DESCRIPTION
#### Summary

Skip the playIncomingCallsRinging test that has been causing intermittent failures. Added TODO comment to track that the root cause still needs to be identified.

#### Ticket Link
Created ticket to fix: https://mattermost.atlassian.net/browse/MM-67173

```release-note
NONE
```