### PR TITLE
disable intune in the release build

### DIFF
--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -11,7 +11,7 @@ on:
 env:
   NODE_VERSION: 22.14.0
   TERM: xterm
-  INTUNE_ENABLED: 1
+  INTUNE_ENABLED: 0
 
 jobs:
   test:


### PR DESCRIPTION
#### Summary
I think this is all the is needed to disable INTUNE in the release build, after we can enable it again, although we still need the proper Entra Client ID for this.

#### Ticket Link
N/A

#### Release Note
```release-note
Disables INTUNE for this release so that it does not crash on iOS 15 and 16
```