### PR TITLE
Fix: Keyboard opens on android when clicked on switch to keyboard btn inside the emoji picker

### DIFF
--- a/app/components/emoji_category_bar/index.tsx
+++ b/app/components/emoji_category_bar/index.tsx
@@ -9,6 +9,7 @@ import TouchableWithFeedback from '@components/touchable_with_feedback';
 import {useKeyboardAnimationContext} from '@context/keyboard_animation';
 import {useTheme} from '@context/theme';
 import {selectEmojiCategoryBarSection, useEmojiCategoryBar} from '@hooks/emoji_category_bar';
+import {useFocusAfterEmojiDismiss} from '@hooks/useFocusAfterEmojiDismiss';
 import {usePreventDoubleTap} from '@hooks/utils';
 import {deleteLastGrapheme} from '@utils/grapheme';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
@@ -61,10 +62,13 @@ const EmojiCategoryBar = ({onSelect}: Props) => {
     const keyboardContext = useKeyboardAnimationContext();
     const {
         focusInput,
+        inputRef,
         updateValue,
         updateCursorPosition,
         cursorPositionRef,
     } = keyboardContext;
+
+    const {focus: focusWithEmojiDismiss} = useFocusAfterEmojiDismiss(inputRef, focusInput);
 
     // Only show keyboard/delete buttons if we're in input accessory view mode
     // Check if updateValue is available (not null) to determine if we're in input accessory context
@@ -80,8 +84,8 @@ const EmojiCategoryBar = ({onSelect}: Props) => {
     }, [onSelect]);
 
     const handleKeyboardPress = usePreventDoubleTap(useCallback(() => {
-        focusInput();
-    }, [focusInput]));
+        focusWithEmojiDismiss();
+    }, [focusWithEmojiDismiss]));
 
     const deleteCharFromCurrentCursorPosition = useCallback(() => {
         if (!updateValue || !updateCursorPosition || !cursorPositionRef) {

--- a/app/hooks/useFocusAfterEmojiDismiss.ts
+++ b/app/hooks/useFocusAfterEmojiDismiss.ts
@@ -45,13 +45,16 @@ export const useFocusAfterEmojiDismiss = (
 
             inputRef.current?.blur();
 
-            const handleDelayedFocus = () => {
-                focusInput();
-                setIsManuallyFocusingAfterEmojiDismiss(false);
-                focusTimeoutRef.current = null;
-            };
+            // Use requestAnimationFrame to ensure state updates have been applied
+            requestAnimationFrame(() => {
+                const handleDelayedFocus = () => {
+                    focusInput();
+                    setIsManuallyFocusingAfterEmojiDismiss(false);
+                    focusTimeoutRef.current = null;
+                };
 
-            focusTimeoutRef.current = setTimeout(handleDelayedFocus, 200);
+                focusTimeoutRef.current = setTimeout(handleDelayedFocus, 200);
+            });
 
             return () => {
                 if (focusTimeoutRef.current) {
@@ -80,6 +83,20 @@ export const useFocusAfterEmojiDismiss = (
 
             setIsEmojiSearchFocused(false);
             setShowInputAccessoryView(false);
+
+            if (focusTimeoutRef.current) {
+                clearTimeout(focusTimeoutRef.current);
+            }
+
+            inputRef.current?.blur();
+
+            // Schedule focus after emoji picker closes
+            focusTimeoutRef.current = setTimeout(() => {
+                focusInput();
+                setIsManuallyFocusingAfterEmojiDismiss(false);
+                isDismissingEmojiPicker.current = false;
+                focusTimeoutRef.current = null;
+            }, 200);
         } else {
             focusInput();
         }
@@ -91,6 +108,7 @@ export const useFocusAfterEmojiDismiss = (
         keyboardTranslateY,
         isTransitioningFromCustomView,
         setIsEmojiSearchFocused,
+        inputRef,
         focusInput,
     ]);
 


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the keyboard did not open when clicking the “Switch to keyboard” button inside the emoji picker.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67249

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots

https://github.com/user-attachments/assets/0fbe5ed4-8035-4c46-9865-9a9c640f001e



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
