### PR TITLE
workflow: fix build ios simulator for new bucket

### DIFF
--- a/.github/workflows/build-ios-beta.yml
+++ b/.github/workflows/build-ios-beta.yml
@@ -27,6 +27,9 @@ jobs:
     if: ${{ !contains(github.ref_name, 'beta-ios') }}
     needs:
       - test
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
#### Summary

This https://github.com/mattermost/mattermost-mobile/actions/runs/21746898064/job/62735186824
 failed with
```
It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.
```

#### Ticket Link
- https://github.com/mattermost/mattermost-mobile/actions/runs/21746898064/job/62735186824


#### Release Note

```release-note
NONE
```
