### PR TITLE
[MM-67456] Allow OptionItem labels to wrap to two lines

### DIFF
--- a/app/components/common_post_options/base_option/index.test.tsx
+++ b/app/components/common_post_options/base_option/index.test.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import OptionItem from '@components/option_item';
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import BaseOption from './index';
+
+jest.mock('@components/option_item');
+jest.mocked(OptionItem).mockImplementation((props) => React.createElement('OptionItem', props));
+
+describe('BaseOption', () => {
+    it('should force single line labels', () => {
+        renderWithIntlAndTheme(
+            <BaseOption
+                message={{id: 'test.base_option.label', defaultMessage: 'Option label'}}
+                iconName='icon-name'
+                onPress={jest.fn()}
+                testID='base-option'
+            />,
+        );
+
+        expect(jest.mocked(OptionItem)).toHaveBeenCalled();
+        expect(jest.mocked(OptionItem).mock.calls[0][0]).toEqual(expect.objectContaining({
+            label: 'Option label',
+            labelNumberOfLines: 1,
+            type: 'default',
+            testID: 'base-option',
+        }));
+    });
+});

--- a/app/components/common_post_options/base_option/index.tsx
+++ b/app/components/common_post_options/base_option/index.tsx
@@ -29,6 +29,7 @@ const BaseOption = ({
             destructive={isDestructive}
             icon={iconName}
             label={intl.formatMessage(message)}
+            labelNumberOfLines={1}
             testID={testID}
             type='default'
         />

--- a/app/components/option_item/index.tsx
+++ b/app/components/option_item/index.tsx
@@ -132,6 +132,7 @@ export type OptionItemProps = {
     value?: string;
     onLayout?: (event: LayoutChangeEvent) => void;
     descriptionNumberOfLines?: number;
+    labelNumberOfLines?: number;
     longInfo?: boolean;
     nonDestructiveDescription?: boolean;
     isRadioCheckmark?: boolean;
@@ -155,6 +156,7 @@ const OptionItem = ({
     value,
     onLayout,
     descriptionNumberOfLines,
+    labelNumberOfLines = 2,
     longInfo,
     nonDestructiveDescription = false,
     isRadioCheckmark = false,
@@ -326,7 +328,7 @@ const OptionItem = ({
                     <Text
                         style={labelTextStyle}
                         testID={`${testID}.label`}
-                        numberOfLines={2}
+                        numberOfLines={labelNumberOfLines}
                     >
                         {label}
                     </Text>

--- a/app/components/option_item/option_item.test.tsx
+++ b/app/components/option_item/option_item.test.tsx
@@ -40,6 +40,7 @@ describe('OptionItem', () => {
         const label = getByText('Test Option');
         expect(label).toBeTruthy();
         expect(label).toHaveStyle({fontWeight: '400'});
+        expect(label.props.numberOfLines).toBe(2);
 
         // No description
         expect(queryByTestId('option-item.description')).toBeNull();
@@ -63,6 +64,16 @@ describe('OptionItem', () => {
         expect(queryByTestId('option-item.toggled.true.button')).toBeNull();
         expect(queryByTestId('option-item.remove.button')).toBeNull();
         expect(queryByTestId('option-item.arrow.icon')).toBeNull();
+    });
+
+    it('respects custom label number of lines', () => {
+        const props = getBaseProps();
+        props.labelNumberOfLines = 1;
+
+        const {getByText} = renderWithIntlAndTheme(<OptionItem {...props}/>);
+
+        const label = getByText('Test Option');
+        expect(label.props.numberOfLines).toBe(1);
     });
 
     it('renders with description when provided', () => {

--- a/app/screens/post_options/options/app_bindings_post_option.tsx
+++ b/app/screens/post_options/options/app_bindings_post_option.tsx
@@ -77,6 +77,7 @@ const BindingOptionItem = ({binding, onPress}: {binding: AppBinding; onPress: (b
     return (
         <OptionItem
             label={binding.label || ''}
+            labelNumberOfLines={1}
             icon={binding.icon}
             action={handlePress}
             type='default'


### PR DESCRIPTION
#### Summary
Allow options to expand to 2 lines so there is enough space for the option name

#### Ticket Link
[MM-67456](https://mattermost.atlassian.net/browse/MM-67456)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: ios Simulator, pixel 8

#### Screenshots
Whle the original was about having only the threads notification, this also fixes the same thing in other places as well. I'm attaching a few images 
<img width="762" height="1504" alt="CleanShot 2026-02-11 at 15 40 40@2x" src="https://github.com/user-attachments/assets/efbb08e5-6300-4fba-b596-53630614ce08" />
<img width="770" height="1530" alt="CleanShot 2026-02-11 at 15 40 10@2x" src="https://github.com/user-attachments/assets/552eaca4-3256-4d0e-a917-ca6d9da07515" />
<img width="788" height="966" alt="CleanShot 2026-02-11 at 15 37 59@2x" src="https://github.com/user-attachments/assets/af21669b-d55d-419e-b0fe-d28d2ae89f1a" />


#### Release Note
```release-note
expand space for option description so it is readable
```


[MM-67456]: https://mattermost.atlassian.net/browse/MM-67456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ