### PR TITLE
[MM-67563] Change websocket format for translation update events

### DIFF
--- a/app/actions/websocket/posts.ts
+++ b/app/actions/websocket/posts.ts
@@ -409,18 +409,18 @@ export async function handlePostAcknowledgementRemoved(serverUrl: string, msg: W
 export async function handlePostTranslationUpdatedEvent(serverUrl: string, msg: WebSocketMessage) {
     try {
         const translationData: PostTranslationUpdateData = msg.data;
-        const translationObject: PostTranslation['object'] = translationData.translation ? JSON.parse(translationData.translation) : undefined;
         const locale = await getCurrentUserLocale(serverUrl);
-        if (locale !== translationData.language) {
+        const myLanguageTranslation = translationData.translations[locale];
+
+        if (!myLanguageTranslation) {
             return;
         }
-        if (locale === translationData.src_lang) {
-            return;
-        }
-        await updatePostTranslation(serverUrl, translationData.object_id, translationData.language, {
+
+        const translationObject: PostTranslation['object'] = myLanguageTranslation?.translation ? JSON.parse(myLanguageTranslation.translation) : undefined;
+        await updatePostTranslation(serverUrl, translationData.object_id, locale, {
             object: translationObject,
-            state: translationData.state,
-            source_lang: translationData.src_lang,
+            state: myLanguageTranslation.state,
+            source_lang: myLanguageTranslation.src_lang,
         });
     } catch (error) {
         // Do nothing

--- a/types/api/websocket.d.ts
+++ b/types/api/websocket.d.ts
@@ -23,9 +23,11 @@ type ThreadReadChangedData = {
 };
 
 type PostTranslationUpdateData = {
-    language: string;
     object_id: string;
-    src_lang: string;
-    state: PostTranslationState;
-    translation: string; // JSON-encoded PostTranslation['object']
+    translations: Record<string, {
+        state: 'ready' | 'skipped' | 'processing' | 'unavailable';
+        translation: string; // JSON-encoded PostTranslation['object']
+        translation_type?: string;
+        src_lang?: string;
+    }>;
 }


### PR DESCRIPTION
#### Summary
Changing the websocket format to an array opens up our options for potentially batching translations in websockets. I originally thought of doing a map but an array makes more sense based off the frontend code

To be tested alongside https://github.com/mattermost/enterprise/pull/2066 and https://github.com/mattermost/mattermost/pull/35268

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67563

#### Release Note
Part of the autotranslations feature
```release-note
NONE
```
