### PR TITLE
[MM-67564] Reduce channel banner height to 26px with 14pt font

### DIFF
--- a/app/constants/view.ts
+++ b/app/constants/view.ts
@@ -31,7 +31,7 @@ export const CALL_NOTIFICATION_BAR_HEIGHT = 40;
 
 export const ANNOUNCEMENT_BAR_HEIGHT = 40;
 export const BOOKMARKS_BAR_HEIGHT = 48;
-export const CHANNEL_BANNER_HEIGHT = 32;
+export const CHANNEL_BANNER_HEIGHT = 26;
 
 export const HOME_PADDING = {
     paddingLeft: 18,

--- a/app/screens/channel/header/channel_banner/channel_banner.tsx
+++ b/app/screens/channel/header/channel_banner/channel_banner.tsx
@@ -27,8 +27,8 @@ const CLOSE_BUTTON_ID = 'channel-banner-close';
 
 const getStyleSheet = (bannerTextColor: string) => ({
     container: {
-        paddingTop: 5,
-        paddingBottom: 5,
+        paddingTop: 2,
+        paddingBottom: 2,
         paddingLeft: 16,
         paddingRight: 16,
         height: CHANNEL_BANNER_HEIGHT,
@@ -51,7 +51,6 @@ const getStyleSheet = (bannerTextColor: string) => ({
     },
     bannerText: {
         textAlign: 'center' as const,
-
     },
 });
 


### PR DESCRIPTION
#### Ticket Link

https://mattermost.atlassian.net/browse/MM-67564

#### Device Information

This PR was tested on: iOS Simulator / iPhone 16e / iOS 26.0

#### Screenshots

| Before | After |
| ------ | ----- |
| <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-02-16 at 16 40 39" src="https://github.com/user-attachments/assets/35414108-9406-4c9e-b02b-e39cec5adfe5" /> | <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-02-17 at 15 15 04" src="https://github.com/user-attachments/assets/6fd004e1-bfea-4beb-802f-3393048a9f45" /> |


#### Release Note

```release-note
NONE
```