### PR TITLE
workflows: adjust permissions in releases

### DIFF
--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -96,6 +96,9 @@ jobs:
     if: ${{ !contains(github.ref_name , 'release-ios') }}
     needs:
       - test
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
#### Summary
- adjust permissions in releases pipelines

#### Ticket Link
- https://github.com/mattermost/mattermost-mobile/actions/runs/22089238110


#### Release Note
```release-note
NONE
```

