### PR TITLE
Fix roles not updating on channel members updated websocket event

### DIFF
--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -211,7 +211,7 @@ export async function handleChannelMemberUpdatedEvent(serverUrl: string, msg: an
             channelMemberships: [updatedChannelMember],
             prepareRecordsOnly: true,
         }));
-        const rolesRequest = await fetchRolesIfNeeded(serverUrl, updatedChannelMember.roles.split(','), true);
+        const rolesRequest = await fetchRolesIfNeeded(serverUrl, updatedChannelMember.roles.split(' '), true);
         if (rolesRequest.roles?.length) {
             models.push(...await operator.handleRole({roles: rolesRequest.roles, prepareRecordsOnly: true}));
         }


### PR DESCRIPTION
#### Summary
We were separating the roles on the channel members updated websocket event by `,` for fetching the roles. This is wrong, since roles come separated by a blank space.

Other places where we handle roles are properly separated by blank spaces.

#### Test steps
- Have a normal user that is not channel admin in any channel
- Verify that options not available to normal users are not visible (e.g. enable translations)
- While the app is open, promote them to channel admin
Expected:
- Options available for channel admins are visible
Observed:
- Options available for channel admins are not yet visible

#### Ticket Link
NONE

#### Release Note
```release-note
Fix error where changes in the channel level roles permissions were not visible in the mobile app
```
