### PR TITLE
[MM-67680] Add e2e tests for autotranslations

### DIFF
--- a/app/screens/channel/header/header.tsx
+++ b/app/screens/channel/header/header.tsx
@@ -329,6 +329,7 @@ const ChannelHeader = ({
                     name='translate'
                     size={16}
                     color={changeOpacity(theme.sidebarHeaderTextColor, 0.72)}
+                    testID='channel_header.autotranslation.icon'
                 />
             );
         }

--- a/detox/README.md
+++ b/detox/README.md
@@ -110,6 +110,38 @@ xcrun simctl list devices | grep Booted
 The Local Runs generate artifacts under `detox/artifacts/ios-debug-**` or `detox/artifacts/android-debug-**`.
 You can see the html report, failure screenshot under that folder.
 
+# Auto-Translation E2E Tests
+
+Auto-translation tests require a running LibreTranslate mock and a Mattermost server with auto-translation enabled and the translation plugin configured to use the mock.
+
+### 1. Start the LibreTranslate mock
+
+From the project root or the `detox` folder:
+
+```sh
+node detox/mock_libre_translate.js
+```
+
+The mock listens on port 3010 by default. Set `PORT` to use another port. Optional: set `LIBRE_TRANSLATE_MOCK_URL` (e.g. `http://localhost:3010`) when running tests if the mock is on a different host/port.
+
+### 2. Server configuration
+
+- Enable auto-translation on the server (e.g. **EnableAutoTranslation** in config).
+- Configure the translation plugin (e.g. mattermost-plugin-autotranslate) to use the LibreTranslate API URL pointing at the mock.
+- For the app running in the emulator/device to reach the mock, use a URL reachable from the device (e.g. `http://10.0.2.2:3010` for Android emulator, or your machine’s IP and the mock port). Configure this in the plugin/translation service settings on the server.
+
+### 3. Run auto-translation tests
+
+```sh
+npm run e2e:android-test e2e/test/products/channels/autotranslation
+# or
+npm run e2e:ios-test e2e/test/products/channels/autotranslation
+```
+
+Tests use `setMockSourceLanguage` from `@support/libre_translate_mock` to set the mock’s detected source language (e.g. so messages are treated as Spanish and translated for an English-preference user).
+
+---
+
 # Playbooks Tests (AI-Powered Testing)
 
 The Playbooks tests leverage AI-powered testing through the Wix Pilot framework, enabling natural language test creation and execution.

--- a/detox/e2e/support/libre_translate_mock.ts
+++ b/detox/e2e/support/libre_translate_mock.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Helper to control the LibreTranslate mock (detox/mock_libre_translate.js) from e2e tests.
+ * Use this to set the detected source language so messages are translated (or not) as needed.
+ *
+ * Start the mock before running auto-translation tests:
+ *   node detox/mock_libre_translate.js
+ *
+ * Mock endpoints:
+ *   POST /__control/source  body: { "language": "es" }  - set detected source language
+ */
+
+import axios from 'axios';
+
+import {libreTranslateMockUrl} from './test_config';
+
+/**
+ * Set the detected source language returned by the mock for /detect and for /translate when source=auto.
+ * @param baseUrl - mock base URL (default from test_config)
+ * @param language - language code e.g. 'es', 'en', 'fr', 'de'
+ * @returns response with { ok, language } or throws on failure
+ */
+export const setMockSourceLanguage = async (
+    baseUrl: string = libreTranslateMockUrl,
+    language: string,
+): Promise<{ok: boolean; language: string}> => {
+    const {data} = await axios.post(
+        `${baseUrl.replace(/\/$/, '')}/__control/source`,
+        {language},
+        {timeout: 5000, validateStatus: () => true},
+    );
+    if (data?.ok !== true) {
+        throw new Error(`LibreTranslate mock setMockSourceLanguage failed: ${JSON.stringify(data)}`);
+    }
+    return data;
+};
+
+export default {
+    setMockSourceLanguage,
+};

--- a/detox/e2e/support/server_api/channel.ts
+++ b/detox/e2e/support/server_api/channel.ts
@@ -207,6 +207,28 @@ export const apiRestoreChannel = async (baseUrl: string, channelId: string): Pro
 };
 
 /**
+ * Update a channel member's roles.
+ * See https://api.mattermost.com/#operation/UpdateChannelMemberRoles
+ * @param {string} baseUrl - the base server URL
+ * @param {string} channelId - The channel ID
+ * @param {string} userId - The user ID
+ * @param {string} roles - Space-delimited list of role names (e.g. 'channel_user channel_admin')
+ * @return {Object} returns {status} on success or {error, status} on error
+ */
+export const apiUpdateChannelMemberRoles = async (baseUrl: string, channelId: string, userId: string, roles: string): Promise<any> => {
+    try {
+        const response = await client.put(
+            `${baseUrl}/api/v4/channels/${channelId}/members/${userId}/roles`,
+            {roles},
+        );
+
+        return {status: response.status};
+    } catch (err) {
+        return getResponseFromError(err);
+    }
+};
+
+/**
  * Remove user from channel.
  * See https://api.mattermost.com/#operation/RemoveUserFromChannel
  * @param {string} baseUrl - the base server URL
@@ -271,6 +293,7 @@ export const Channel = {
     apiGetUnreadMessages,
     apiRestoreChannel,
     apiRemoveUserFromChannel,
+    apiUpdateChannelMemberRoles,
     apiViewChannel,
     generateRandomChannel,
 };

--- a/detox/e2e/support/test_config.ts
+++ b/detox/e2e/support/test_config.ts
@@ -13,3 +13,6 @@ export const adminUsername = process.env.ADMIN_USERNAME || 'sysadmin';
 export const adminPassword = process.env.ADMIN_PASSWORD || 'Sys@dmin-sample1';
 export const ldapServer = process.env.LDAP_SERVER || '127.0.0.1';
 export const ldapPort = process.env.LDAP_PORT || 389;
+
+// LibreTranslate mock for auto-translation e2e tests (run with: node detox/mock_libre_translate.js)
+export const libreTranslateMockUrl = process.env.LIBRE_TRANSLATE_MOCK_URL || 'http://localhost:3010';

--- a/detox/e2e/support/ui/screen/channel_info.ts
+++ b/detox/e2e/support/ui/screen/channel_info.ts
@@ -37,6 +37,11 @@ class ChannelInfoScreen {
         copyChannelLinkOption: 'channel_info.options.copy_channel_link.option',
         channelSettingsOption: 'channel_info.options.channel_settings.option',
         leaveChannelOption: 'channel_info.options.leave_channel.option',
+        myAutotranslationOption: 'channel_info.options.my_autotranslation.option',
+        myAutotranslationOptionToggledOn: 'channel_info.options.my_autotranslation.option.toggled.true',
+        myAutotranslationOptionToggledOff: 'channel_info.options.my_autotranslation.option.toggled.false',
+        myAutotranslationToggleOnButton: 'channel_info.options.my_autotranslation.option.toggled.true.toggled.true.button',
+        myAutotranslationToggleOffButton: 'channel_info.options.my_autotranslation.option.toggled.false.toggled.false.button',
     };
 
     channelInfoScreen = element(by.id(this.testID.channelInfoScreen));
@@ -64,6 +69,11 @@ class ChannelInfoScreen {
     copyChannelLinkOption = element(by.id(this.testID.copyChannelLinkOption));
     channelSettingsOption = element(by.id(this.testID.channelSettingsOption));
     leaveChannelOption = element(by.id(this.testID.leaveChannelOption));
+    myAutotranslationOption = element(by.id(this.testID.myAutotranslationOption));
+    myAutotranslationOptionToggledOn = element(by.id(this.testID.myAutotranslationOptionToggledOn));
+    myAutotranslationOptionToggledOff = element(by.id(this.testID.myAutotranslationOptionToggledOff));
+    myAutotranslationToggleOnButton = element(by.id(this.testID.myAutotranslationToggleOnButton));
+    myAutotranslationToggleOffButton = element(by.id(this.testID.myAutotranslationToggleOffButton));
 
     getDirectMessageTitle = (userId: string) => {
         const directMessageTitleTestId = `${this.testID.directMessageTitlePrefix}${userId}`;

--- a/detox/e2e/support/ui/screen/channel_settings.ts
+++ b/detox/e2e/support/ui/screen/channel_settings.ts
@@ -16,6 +16,10 @@ class ChannelSettingsScreen {
         convertPrivateOption: 'channel_settings.convert_private.option',
         archiveChannelOption: 'channel_settings.archive_channel.option',
         unarchiveChannelOption: 'channel_settings.unarchive_channel.option',
+        channelAutotranslationOptionToggledOn: 'channel_settings.channel_autotranslation.option.toggled.true',
+        channelAutotranslationOptionToggledOff: 'channel_settings.channel_autotranslation.option.toggled.false',
+        channelAutotranslationToggleOnButton: 'channel_settings.channel_autotranslation.option.toggled.true.toggled.true.button',
+        channelAutotranslationToggleOffButton: 'channel_settings.channel_autotranslation.option.toggled.false.toggled.false.button',
     };
 
     channelSettingsScreen = element(by.id(this.testID.channelSettingsScreen));
@@ -25,6 +29,10 @@ class ChannelSettingsScreen {
     convertPrivateOption = element(by.id(this.testID.convertPrivateOption));
     archiveChannelOption = element(by.id(this.testID.archiveChannelOption));
     unarchiveChannelOption = element(by.id(this.testID.unarchiveChannelOption));
+    channelAutotranslationOptionToggledOn = element(by.id(this.testID.channelAutotranslationOptionToggledOn));
+    channelAutotranslationOptionToggledOff = element(by.id(this.testID.channelAutotranslationOptionToggledOff));
+    channelAutotranslationToggleOnButton = element(by.id(this.testID.channelAutotranslationToggleOnButton));
+    channelAutotranslationToggleOffButton = element(by.id(this.testID.channelAutotranslationToggleOffButton));
 
     toBeVisible = async () => {
         await waitFor(this.channelSettingsScreen).toExist().withTimeout(timeouts.TEN_SEC);

--- a/detox/e2e/support/ui/screen/post_options.ts
+++ b/detox/e2e/support/ui/screen/post_options.ts
@@ -22,6 +22,7 @@ class PostOptionsScreen {
         unpinPostOption: 'post_options.unpin_post.option',
         editPostOption: 'post_options.edit_post.option',
         deletePostOption: 'post_options.delete_post.option',
+        showTranslationOption: 'post_options.show_translation.option',
         pinnedPostListItemPrefix: 'pinned_messages.post_list.post',
     };
 
@@ -41,6 +42,7 @@ class PostOptionsScreen {
     unpinPostOption = element(by.id(this.testID.unpinPostOption));
     editPostOption = element(by.id(this.testID.editPostOption));
     deletePostOption = element(by.id(this.testID.deletePostOption));
+    showTranslationOption = element(by.id(this.testID.showTranslationOption));
 
     getReactionEmoji = (emojiName: string) => {
         return element(by.id(`${this.testID.reactionEmojiPrefix}${emojiName}`));

--- a/detox/e2e/test/products/channels/autotranslation/autotranslation.e2e.ts
+++ b/detox/e2e/test/products/channels/autotranslation/autotranslation.e2e.ts
@@ -1,0 +1,545 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// Auto-translation E2E tests. Requires:
+// - LibreTranslate mock running: node detox/mock_libre_translate.js
+// - Server with EnableAutoTranslation and translation plugin pointing at the mock
+// *******************************************************************
+
+/* eslint-disable max-lines */
+
+import {setMockSourceLanguage} from '@support/libre_translate_mock';
+import {
+    Channel,
+    Post,
+    Setup,
+    Team,
+    User,
+} from '@support/server_api';
+import {
+    serverOneUrl,
+    siteOneUrl,
+} from '@support/test_config';
+import {
+    ChannelInfoScreen,
+    ChannelListScreen,
+    ChannelScreen,
+    ChannelSettingsScreen,
+    EditPostScreen,
+    HomeScreen,
+    LoginScreen,
+    PostOptionsScreen,
+    ServerScreen,
+    ThreadScreen,
+} from '@support/ui/screen';
+import {getRandomId, timeouts, wait} from '@support/utils';
+import {expect, waitFor} from 'detox';
+
+const SHOW_TRANSLATION_SCREEN_ID = 'show_translation.screen';
+const CHANNEL_HEADER_AUTOTRANSLATION_ICON_ID = 'channel_header.autotranslation.icon';
+
+type TestChannel = { id: string; name: string; display_name?: string };
+type TestTeam = { id: string };
+type TestUser = { id: string; username?: string };
+
+async function isElementVisible(el: Detox.NativeElement, timeoutMs = 2000): Promise<boolean> {
+    try {
+        await waitFor(el).toBeVisible().withTimeout(timeoutMs);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+describe('Auto-Translation', () => {
+    const serverOneDisplayName = 'Server 1';
+    const channelsCategory = 'channels';
+    let testChannel: TestChannel;
+    let testTeam: TestTeam;
+    let testUser: TestUser;
+
+    beforeAll(async () => {
+        const {team, user} = await Setup.apiInit(siteOneUrl);
+        testTeam = team;
+        testUser = user;
+
+        await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'en'});
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await LoginScreen.login(testUser);
+    });
+
+    beforeEach(async () => {
+        const {channel} = await Channel.apiCreateChannel(siteOneUrl, {
+            teamId: testTeam.id,
+            name: `at-${getRandomId()}`,
+            displayName: `AT ${getRandomId()}`,
+            type: 'O',
+        });
+        await Channel.apiAddUserToChannel(siteOneUrl, testUser.id, channel.id);
+        await Channel.apiUpdateChannelMemberRoles(siteOneUrl, channel.id, testUser.id, 'channel_user channel_admin');
+        testChannel = channel;
+        await wait(timeouts.ONE_SEC);
+        await ChannelListScreen.toBeVisible();
+    });
+
+    afterAll(async () => {
+        await HomeScreen.logout();
+    });
+
+    const scrollToChannelAutotranslation = async () => {
+        await waitFor(ChannelSettingsScreen.channelAutotranslationOptionToggledOff).
+            toBeVisible().
+            withTimeout(timeouts.TEN_SEC).
+            catch(() => null);
+        const visible = await isElementVisible(ChannelSettingsScreen.channelAutotranslationOptionToggledOff);
+        if (!visible) {
+            await ChannelSettingsScreen.scrollView.scroll(150, 'down');
+            await wait(timeouts.ONE_SEC);
+        }
+    };
+
+    const scrollToChannelAutotranslationToggledOn = async () => {
+        await waitFor(ChannelSettingsScreen.channelAutotranslationOptionToggledOn).
+            toBeVisible().
+            withTimeout(timeouts.TEN_SEC).
+            catch(() => null);
+        const visible = await isElementVisible(ChannelSettingsScreen.channelAutotranslationOptionToggledOn);
+        if (!visible) {
+            await ChannelSettingsScreen.scrollView.scroll(150, 'down');
+            await wait(timeouts.ONE_SEC);
+        }
+    };
+
+    const enableChannelAutotranslation = async () => {
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        await ChannelInfoScreen.open();
+        await ChannelInfoScreen.openChannelSettings();
+        await ChannelSettingsScreen.toBeVisible();
+        await scrollToChannelAutotranslation();
+        await waitFor(ChannelSettingsScreen.channelAutotranslationToggleOffButton).toBeVisible().withTimeout(timeouts.TEN_SEC);
+        await ChannelSettingsScreen.channelAutotranslationToggleOffButton.tap();
+        await wait(timeouts.TWO_SEC);
+        await ChannelSettingsScreen.close();
+        await ChannelInfoScreen.close();
+        await wait(timeouts.ONE_SEC);
+    };
+
+    const ensureUserOptedIn = async () => {
+        await ChannelInfoScreen.open();
+        const myOffVisible = await isElementVisible(ChannelInfoScreen.myAutotranslationOptionToggledOff, 5000);
+        if (myOffVisible) {
+            await ChannelInfoScreen.myAutotranslationToggleOffButton.tap();
+            await wait(timeouts.TWO_SEC);
+        }
+        await ChannelInfoScreen.close();
+        await wait(timeouts.ONE_SEC);
+    };
+
+    const ensureUserOptedOut = async () => {
+        await ChannelInfoScreen.open();
+        const myOnVisible = await isElementVisible(ChannelInfoScreen.myAutotranslationOptionToggledOn, 5000);
+        if (myOnVisible) {
+            await ChannelInfoScreen.myAutotranslationToggleOnButton.tap();
+            await wait(timeouts.TWO_SEC);
+            await element(by.text('Yes, turn off')).tap();
+            await wait(timeouts.TWO_SEC);
+        }
+        await ChannelInfoScreen.close();
+        await wait(timeouts.ONE_SEC);
+    };
+
+    describe('B. Permissions', () => {
+        it('AT-PERM-06 - User without permission cannot enable for a channel', async () => {
+            const {user: memberUser} = await User.apiCreateUser(siteOneUrl, {prefix: 'member'});
+            await Team.apiAddUserToTeam(siteOneUrl, memberUser.id, testTeam.id);
+            const {channel: memberChannel} = await Channel.apiCreateChannel(siteOneUrl, {
+                teamId: testTeam.id,
+                name: `perm-test-${getRandomId()}`,
+                displayName: `Perm Test ${getRandomId()}`,
+                type: 'O',
+            });
+            await Channel.apiAddUserToChannel(siteOneUrl, testUser.id, memberChannel.id);
+            await Channel.apiAddUserToChannel(siteOneUrl, memberUser.id, memberChannel.id);
+            await wait(timeouts.TWO_SEC);
+
+            await HomeScreen.logout();
+            await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+            await LoginScreen.login(memberUser);
+
+            await ChannelScreen.open(channelsCategory, memberChannel.name);
+            await ChannelInfoScreen.open();
+            await ChannelInfoScreen.openChannelSettings();
+            await ChannelSettingsScreen.toBeVisible();
+            await ChannelSettingsScreen.scrollView.scroll(200, 'down');
+            await wait(timeouts.ONE_SEC);
+            await expect(ChannelSettingsScreen.channelSettingsScreen).toBeVisible();
+            await expect(ChannelSettingsScreen.channelAutotranslationOptionToggledOff).not.toExist();
+            await expect(ChannelSettingsScreen.channelAutotranslationOptionToggledOn).not.toExist();
+            await ChannelSettingsScreen.close();
+            await ChannelInfoScreen.close();
+            await ChannelScreen.back();
+
+            await HomeScreen.logout();
+            await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+            await LoginScreen.login(testUser);
+        });
+    });
+
+    describe('C. Channel-level enable/disable', () => {
+        it('AT-CH-01 - Channel admin can enable auto-translation in Channel Settings', async () => {
+            await ChannelScreen.open(channelsCategory, testChannel.name);
+            await ChannelInfoScreen.open();
+            await ChannelInfoScreen.openChannelSettings();
+            await ChannelSettingsScreen.toBeVisible();
+
+            await scrollToChannelAutotranslation();
+            await waitFor(ChannelSettingsScreen.channelAutotranslationToggleOffButton).
+                toBeVisible().
+                withTimeout(timeouts.TEN_SEC);
+            await ChannelSettingsScreen.channelAutotranslationToggleOffButton.tap();
+            await wait(timeouts.TWO_SEC);
+
+            await scrollToChannelAutotranslationToggledOn();
+            await expect(ChannelSettingsScreen.channelAutotranslationOptionToggledOn).toBeVisible();
+
+            await ChannelSettingsScreen.close();
+            await ChannelInfoScreen.close();
+            await ChannelScreen.back();
+        });
+
+        it('AT-CH-02 - Enabling posts a system message in the channel', async () => {
+            await ChannelScreen.open(channelsCategory, testChannel.name);
+            await ChannelInfoScreen.open();
+            await ChannelInfoScreen.openChannelSettings();
+            await ChannelSettingsScreen.toBeVisible();
+            await scrollToChannelAutotranslation();
+            await waitFor(ChannelSettingsScreen.channelAutotranslationToggleOffButton).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelSettingsScreen.channelAutotranslationToggleOffButton.tap();
+            await wait(timeouts.TWO_SEC);
+            await ChannelSettingsScreen.close();
+            await ChannelInfoScreen.close();
+
+            await wait(timeouts.TWO_SEC);
+            const {post: systemPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const expectedSubstrings = ['enabled Auto-translation for this channel', 'All new messages will appear in your preferred language'];
+            if (!systemPost?.message || !expectedSubstrings.every((s) => systemPost.message.includes(s))) {
+                throw new Error(`Expected system message like "@user enabled Auto-translation for this channel. All new messages will appear in your preferred language.", got: ${systemPost?.message ?? 'no post'}`);
+            }
+            const {postListPostItem} = ChannelScreen.getPostListPostItem(systemPost.id);
+            await expect(postListPostItem).toBeVisible();
+            await ChannelScreen.back();
+        });
+
+        it('AT-CH-03 - Applies only to new messages', async () => {
+            const messageBefore = `Before enable ${getRandomId()}`;
+            await ChannelScreen.open(channelsCategory, testChannel.name);
+            await ChannelScreen.postMessage(messageBefore);
+            await wait(timeouts.ONE_SEC);
+
+            const {post: postBefore} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+
+            await ChannelInfoScreen.open();
+            await ChannelInfoScreen.openChannelSettings();
+            await ChannelSettingsScreen.toBeVisible();
+            await scrollToChannelAutotranslation();
+            await waitFor(ChannelSettingsScreen.channelAutotranslationOptionToggledOff).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelSettingsScreen.channelAutotranslationToggleOffButton.tap();
+            await wait(timeouts.TWO_SEC);
+            await ChannelSettingsScreen.close();
+            await ChannelInfoScreen.close();
+
+            await setMockSourceLanguage(undefined, 'es');
+            const messageAfter = `After enable ${getRandomId()}`;
+            await ChannelScreen.postMessage(messageAfter);
+            await wait(timeouts.FOUR_SEC);
+
+            const translatedBeforeText = `[en] ${messageBefore}`;
+            const translatedAfterText = `[en] ${messageAfter}`;
+
+            const {post: postAfter} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const {postListPostItem: itemAfter} = ChannelScreen.getPostListPostItem(postAfter.id, translatedAfterText);
+            await expect(itemAfter).toBeVisible();
+            const {postListPostItem: itemBefore} = ChannelScreen.getPostListPostItem(postBefore.id, translatedBeforeText);
+            await expect(itemBefore).not.toBeVisible();
+            await ChannelScreen.back();
+        });
+
+        it('AT-CH-04 - Channel header shows auto-translated icon when enabled and user opted in', async () => {
+            await ChannelScreen.open(channelsCategory, testChannel.name);
+            await ChannelInfoScreen.open();
+            await ChannelInfoScreen.openChannelSettings();
+            await ChannelSettingsScreen.toBeVisible();
+            await scrollToChannelAutotranslation();
+            await waitFor(ChannelSettingsScreen.channelAutotranslationToggleOffButton).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelSettingsScreen.channelAutotranslationToggleOffButton.tap();
+            await wait(timeouts.TWO_SEC);
+            await ChannelSettingsScreen.close();
+            await ChannelInfoScreen.close();
+
+            await wait(timeouts.ONE_SEC);
+            await expect(element(by.id(CHANNEL_HEADER_AUTOTRANSLATION_ICON_ID))).toBeVisible();
+            await ChannelScreen.back();
+        });
+    });
+
+    describe('E. Per-user opt-out / opt-in', () => {
+        it('AT-USER-01 - Auto-translation starts ON for all members when channel admin enables', async () => {
+            await ChannelScreen.open(channelsCategory, testChannel.name);
+            await ChannelInfoScreen.open();
+            await ChannelInfoScreen.openChannelSettings();
+            await ChannelSettingsScreen.toBeVisible();
+            await scrollToChannelAutotranslation();
+            await waitFor(ChannelSettingsScreen.channelAutotranslationOptionToggledOff).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelSettingsScreen.channelAutotranslationToggleOffButton.tap();
+            await wait(timeouts.TWO_SEC);
+            await ChannelSettingsScreen.close();
+            await ChannelInfoScreen.close();
+
+            await wait(timeouts.ONE_SEC);
+            await ChannelInfoScreen.open();
+            await waitFor(ChannelInfoScreen.myAutotranslationOptionToggledOn).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await expect(ChannelInfoScreen.myAutotranslationOptionToggledOn).toBeVisible();
+            await ChannelInfoScreen.close();
+            await ChannelScreen.back();
+        });
+
+        it('AT-USER-02 - User can toggle auto-translation OFF from channel menu', async () => {
+            await enableChannelAutotranslation();
+            await ensureUserOptedIn();
+            await ChannelInfoScreen.open();
+            await waitFor(ChannelInfoScreen.myAutotranslationToggleOnButton).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelInfoScreen.myAutotranslationToggleOnButton.tap();
+            await wait(timeouts.ONE_SEC);
+            await element(by.text('Yes, turn off')).tap();
+            await wait(timeouts.TWO_SEC);
+            await expect(ChannelInfoScreen.myAutotranslationOptionToggledOff).toBeVisible();
+            await ChannelInfoScreen.close();
+            await ChannelScreen.back();
+        });
+
+        it('AT-USER-04 - Opting out removes header icon for that user', async () => {
+            await enableChannelAutotranslation();
+            await ensureUserOptedIn();
+            await ensureUserOptedOut();
+            await expect(element(by.id(CHANNEL_HEADER_AUTOTRANSLATION_ICON_ID))).not.toBeVisible();
+            await ChannelScreen.back();
+        });
+
+        it('AT-USER-05 - Opting back in restores header icon', async () => {
+            await enableChannelAutotranslation();
+            await ensureUserOptedOut();
+            await ChannelInfoScreen.open();
+            await waitFor(ChannelInfoScreen.myAutotranslationToggleOffButton).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelInfoScreen.myAutotranslationToggleOffButton.tap();
+            await wait(timeouts.TWO_SEC);
+            await ChannelInfoScreen.close();
+            await wait(timeouts.ONE_SEC);
+            await expect(element(by.id(CHANNEL_HEADER_AUTOTRANSLATION_ICON_ID))).toBeVisible();
+            await ChannelScreen.back();
+        });
+
+        it('AT-USER-06 - Disabling for self reverts translated messages to original', async () => {
+            await enableChannelAutotranslation();
+            await ensureUserOptedIn();
+            await ChannelInfoScreen.open();
+            await waitFor(ChannelInfoScreen.myAutotranslationToggleOnButton).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelInfoScreen.myAutotranslationToggleOnButton.tap();
+            await wait(timeouts.ONE_SEC);
+            await element(by.text('Yes, turn off')).tap();
+            await wait(timeouts.THREE_SEC);
+            await ChannelInfoScreen.close();
+            await expect(element(by.id(CHANNEL_HEADER_AUTOTRANSLATION_ICON_ID))).not.toExist();
+            await ChannelScreen.back();
+        });
+
+        it('AT-USER-07 - Confirmation prompt when disabling', async () => {
+            await enableChannelAutotranslation();
+            await ensureUserOptedIn();
+            await ChannelInfoScreen.open();
+            await waitFor(ChannelInfoScreen.myAutotranslationToggleOnButton).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await ChannelInfoScreen.myAutotranslationToggleOnButton.tap();
+            await wait(timeouts.ONE_SEC);
+            await expect(element(by.text('Turn off auto-translation'))).toBeVisible();
+            await element(by.text('cancel')).tap();
+            await wait(timeouts.ONE_SEC);
+            await ChannelInfoScreen.close();
+            await ChannelScreen.back();
+        });
+    });
+
+    describe('H. Message-level and Show Translation', () => {
+        it('AT-MSG-01 - Translated messages show indicator; tapping opens Show Translation', async () => {
+            await setMockSourceLanguage(undefined, 'es');
+            await enableChannelAutotranslation();
+            const message = `Indicator test ${getRandomId()}`;
+            await ChannelScreen.postMessage(message);
+            await wait(timeouts.FOUR_SEC);
+            const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            await ChannelScreen.openPostOptionsFor(post.id, `[en] ${message}`);
+            await waitFor(PostOptionsScreen.showTranslationOption).toBeVisible().withTimeout(timeouts.THREE_SEC);
+            await PostOptionsScreen.showTranslationOption.tap();
+            await wait(timeouts.TWO_SEC);
+            await expect(element(by.id(SHOW_TRANSLATION_SCREEN_ID))).toBeVisible();
+            await device.pressBack();
+            await ChannelScreen.back();
+        });
+    });
+
+    describe('F. Language support', () => {
+        it('AT-LANG-01 - If user language not in target list, toggle is disabled', async () => {
+            await enableChannelAutotranslation();
+            await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'zh-CN'});
+            await wait(timeouts.TWO_SEC);
+            await ChannelInfoScreen.open();
+            await waitFor(ChannelInfoScreen.myAutotranslationOption).toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await expect(ChannelInfoScreen.myAutotranslationOption).toBeVisible();
+            await expect(element(by.text('Your language is not supported'))).toBeVisible();
+            await ChannelInfoScreen.close();
+            await ChannelScreen.back();
+            await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'en'});
+            await wait(timeouts.ONE_SEC);
+        });
+
+        it('AT-LANG-03 - Only translate when source differs from user language', async () => {
+            await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'en'});
+            await enableChannelAutotranslation();
+            await wait(timeouts.ONE_SEC);
+            await setMockSourceLanguage(undefined, 'es');
+            const spanishMessage = `Spanish text ${getRandomId()}`;
+            await ChannelScreen.postMessage(spanishMessage);
+            await wait(timeouts.FOUR_SEC);
+            const {post: spanishPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            await expect(ChannelScreen.getPostListPostItem(spanishPost.id, `[en] ${spanishMessage}`).postListPostItem).toBeVisible();
+            await setMockSourceLanguage(undefined, 'en');
+            const englishMessage = `English text ${getRandomId()}`;
+            await ChannelScreen.postMessage(englishMessage);
+            await wait(timeouts.FOUR_SEC);
+            const {post: englishPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            await expect(ChannelScreen.getPostListPostItem(englishPost.id, englishMessage).postListPostItem).toBeVisible();
+            await ChannelScreen.back();
+        });
+    });
+
+    describe('G. Changing preferred language', () => {
+        it('AT-PREF-01 - New messages translate into updated preferred language', async () => {
+            await enableChannelAutotranslation();
+            await ensureUserOptedIn();
+            await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'fr'});
+            await wait(timeouts.TWO_SEC);
+            await setMockSourceLanguage(undefined, 'es');
+            const message = `For French ${getRandomId()}`;
+            await ChannelScreen.postMessage(message);
+            await wait(timeouts.FOUR_SEC);
+            const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const translatedMessage = `[fr] ${message}`;
+            const {postListPostItem} = ChannelScreen.getPostListPostItem(post.id, translatedMessage);
+            await expect(postListPostItem).toBeVisible();
+            await ChannelScreen.back();
+            await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'en'});
+            await wait(timeouts.ONE_SEC);
+        });
+
+        it('AT-PREF-04 - New preferred language not in target list', async () => {
+            await enableChannelAutotranslation();
+            await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'zh-CN'});
+            await wait(timeouts.TWO_SEC);
+            await ChannelInfoScreen.open();
+            await expect(ChannelInfoScreen.myAutotranslationOption).toBeVisible();
+            await expect(element(by.id(CHANNEL_HEADER_AUTOTRANSLATION_ICON_ID))).not.toBeVisible();
+            await ChannelInfoScreen.close();
+            const message = `No translation prefix ${getRandomId()}`;
+            await ChannelScreen.postMessage(message);
+            await wait(timeouts.FOUR_SEC);
+            const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const {postListPostItem} = ChannelScreen.getPostListPostItem(post.id, message);
+            await expect(postListPostItem).toBeVisible();
+            await ChannelScreen.back();
+            await User.apiPatchUser(siteOneUrl, testUser.id, {locale: 'en'});
+            await wait(timeouts.ONE_SEC);
+        });
+    });
+
+    describe('J. Editing', () => {
+        it('AT-EDIT-01 - Edit translated message re-translates', async () => {
+            await setMockSourceLanguage(undefined, 'es');
+            await enableChannelAutotranslation();
+            const message = `Edit me ${getRandomId()}`;
+            await ChannelScreen.postMessage(message);
+            await wait(timeouts.FOUR_SEC);
+            const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const translatedInitial = `[en] ${message}`;
+            const {postListPostItem: initialPostItem} = ChannelScreen.getPostListPostItem(post.id, translatedInitial);
+            await expect(initialPostItem).toBeVisible();
+            await ChannelScreen.openPostOptionsFor(post.id, translatedInitial);
+            await PostOptionsScreen.editPostOption.tap();
+            await EditPostScreen.toBeVisible();
+            const editedMessage = `${message} edited`;
+            await EditPostScreen.messageInput.replaceText(editedMessage);
+            await EditPostScreen.saveButton.tap();
+            await wait(timeouts.FOUR_SEC);
+            const translatedEdited = `[en] ${editedMessage}`;
+            const {postListPostItem: editedPostItem} = ChannelScreen.getPostListPostItem(post.id);
+            await expect(editedPostItem).toBeVisible();
+            await ChannelScreen.assertPostMessageEdited(post.id, translatedEdited);
+            await ChannelScreen.back();
+        });
+    });
+
+    describe('K. Threads', () => {
+        it('AT-THR-01 - Thread view shows translated content', async () => {
+            await setMockSourceLanguage(undefined, 'es');
+            await enableChannelAutotranslation();
+            await ensureUserOptedIn();
+            const parentMessage = `Thread parent ${getRandomId()}`;
+            await ChannelScreen.postMessage(parentMessage);
+            await wait(timeouts.FOUR_SEC);
+            const {post: parentPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const translatedParent = `[en] ${parentMessage}`;
+            await ChannelScreen.openReplyThreadFor(parentPost.id, translatedParent);
+            await wait(timeouts.ONE_SEC);
+            await expect(ThreadScreen.threadScreen).toBeVisible();
+            const {postListPostItem: parentPostItem} = ThreadScreen.getPostListPostItem(parentPost.id, translatedParent);
+            await expect(parentPostItem).toBeVisible();
+            const replyMessage = `Thread reply ${getRandomId()}`;
+            await ThreadScreen.postMessage(replyMessage);
+            await wait(timeouts.FOUR_SEC);
+            const {post: replyPost} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const translatedReply = `[en] ${replyMessage}`;
+            const {postListPostItem: replyPostItem} = ThreadScreen.getPostListPostItem(replyPost.id, translatedReply);
+            await expect(replyPostItem).toBeVisible();
+            await ThreadScreen.back();
+            await ChannelScreen.back();
+        });
+    });
+
+    describe('L. Permalink', () => {
+        it('AT-PL-01 - Permalink preview shows translated message', async () => {
+            await enableChannelAutotranslation();
+            await setMockSourceLanguage(undefined, 'es');
+            const message = `Permalink source ${getRandomId()}`;
+            await ChannelScreen.postMessage(message);
+            await wait(timeouts.FOUR_SEC);
+            const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+            const translatedMessage = `[en] ${message}`;
+            await ChannelScreen.openPostOptionsFor(post.id, translatedMessage);
+            await PostOptionsScreen.copyLinkOption.tap();
+            await wait(timeouts.TWO_SEC);
+            const {channel: otherChannel} = await Channel.apiCreateChannel(siteOneUrl, {teamId: testTeam.id, prefix: 'at-pl'});
+            await Channel.apiAddUserToChannel(siteOneUrl, testUser.id, otherChannel.id);
+            await wait(timeouts.TWO_SEC);
+            await ChannelScreen.back();
+            await ChannelScreen.open(channelsCategory, otherChannel.name);
+            const permalinkUrl = `${serverOneUrl}/${(testTeam as {id: string; name: string}).name}/pl/${post.id}`;
+            await ChannelScreen.postMessage(`See ${permalinkUrl}`);
+            await wait(timeouts.FOUR_SEC);
+            await expect(
+                element(by.text(translatedMessage).withAncestor(by.id('permalink-preview-container'))),
+            ).toBeVisible();
+            await expect(
+                element(by.text(`Originally posted in ~${testChannel.display_name || testChannel.name}`).withAncestor(by.id('permalink-preview-container'))),
+            ).toBeVisible();
+            await ChannelScreen.back();
+        });
+    });
+});

--- a/detox/mock_libre_translate.js
+++ b/detox/mock_libre_translate.js
@@ -1,0 +1,126 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable no-console */
+
+const {createServer} = require('http');
+
+const PORT = Number(process.env.PORT) || 3010; // eslint-disable-line no-process-env
+
+if (process.argv[2]) {
+    process.title = process.argv[2];
+}
+
+const LANGUAGES = [
+    {code: 'en', name: 'English'},
+    {code: 'es', name: 'Spanish'},
+    {code: 'fr', name: 'French'},
+    {code: 'de', name: 'German'},
+];
+
+// Source language to return from /translate when source=auto. Set via POST /__control/detect_queue.
+// Applies to all messages until changed. Default 'es'. /detect always returns 'es'.
+let sourceLanguage = 'es';
+
+function parseJsonBody(req) {
+    return new Promise((resolve, reject) => {
+        let body = '';
+        req.on('data', (chunk) => {
+            body += chunk;
+        });
+        req.on('end', () => {
+            try {
+                resolve(body ? JSON.parse(body) : {});
+            } catch (e) {
+                reject(e);
+            }
+        });
+        req.on('error', reject);
+    });
+}
+
+function sendJson(res, statusCode, data) {
+    res.setHeader('Content-Type', 'application/json');
+    res.writeHead(statusCode);
+    res.end(JSON.stringify(data));
+}
+
+const server = createServer(async (req, res) => {
+    const method = req.method;
+    const path = req.url.split('?')[0];
+
+    if (method === 'GET' && path === '/') {
+        sendJson(res, 200, {
+            message: 'LibreTranslate mock',
+            endpoints: [
+                'GET /',
+                'POST /translate',
+                'POST /detect',
+                'GET /languages',
+                'POST /__control/detect_queue',
+            ],
+        });
+        return;
+    }
+
+    if (method === 'POST' && path === '/__control/source') {
+        let body;
+        try {
+            body = await parseJsonBody(req);
+        } catch {
+            sendJson(res, 400, {error: 'Invalid JSON'});
+            return;
+        }
+        if (typeof body.language === 'string') {
+            sourceLanguage = body.language;
+        }
+        sendJson(res, 200, {ok: true, language: sourceLanguage});
+        return;
+    }
+
+    if (method === 'GET' && path === '/languages') {
+        sendJson(res, 200, LANGUAGES);
+        return;
+    }
+
+    if (method === 'POST' && path === '/detect') {
+        sendJson(res, 200, [
+            {language: sourceLanguage, confidence: 95},
+        ]);
+        return;
+    }
+
+    if (method === 'POST' && path === '/translate') {
+        let body;
+        try {
+            body = await parseJsonBody(req);
+        } catch {
+            sendJson(res, 400, {error: 'Invalid JSON'});
+            return;
+        }
+
+        const q = body.q || '';
+        const source = body.source || 'auto';
+        const target = body.target || 'en';
+        const translatedText = `[${target}] ${q}`;
+        const response = {translatedText};
+        if (source === 'auto') {
+            response.detectedLanguage = {language: sourceLanguage, confidence: 90};
+        }
+
+        // Returning too fast may cause a race condition where the post
+        // is not yet saved in the client with the correct id (just the
+        // pending_post_id) and the websocket event cannot be handled
+        // because the "post does not exist".
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        sendJson(res, 200, response);
+        return;
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+    console.log(`LibreTranslate mock listening on port ${PORT}!`);
+});


### PR DESCRIPTION
#### Summary
Add e2e tests for autotranslations.

We are mocking the libre translate interface for these tests.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-67680

#### Release Note
No user facing changes
```release-note
NONE
```
