### PR TITLE
e2e: don't upload artifacts to s3 in e2e pipeline

### DIFF
--- a/.github/workflows/e2e-detox-pr.yml
+++ b/.github/workflows/e2e-detox-pr.yml
@@ -68,10 +68,8 @@ jobs:
       - name: Build iOS Simulator
         env:
           TAG: "${{ github.event.pull_request.head.sha }}"
-          AWS_ACCESS_KEY_ID: "${{ secrets.MM_MOBILE_BETA_AWS_ACCESS_KEY_ID }}"
-          AWS_SECRET_ACCESS_KEY: "${{ secrets.MM_MOBILE_BETA_AWS_SECRET_ACCESS_KEY }}"
           GITHUB_TOKEN: "${{ secrets.MM_MOBILE_GITHUB_TOKEN }}"
-        run: bundle exec fastlane ios simulator --env ios.simulator
+        run: bundle exec fastlane ios simulator --env ios.simulator skip_upload_to_s3_bucket:true
         working-directory: ./fastlane
 
       - name: Upload iOS Simulator Build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -438,7 +438,8 @@ platform :ios do
     )
   end
 
-  lane :simulator do
+  lane :simulator do |options|
+    skip_upload_to_s3_bucket = options[:skip_upload_to_s3_bucket] == true
     UI.success('Building iOS app for simulator')
 
     # Detect the host architecture
@@ -461,10 +462,12 @@ platform :ios do
       output_file: output_file,
     )
 
-    upload_file_to_s3({
-      :os_type => "ios",
-      :file => output_file
-    })
+    unless skip_upload_to_s3_bucket
+      upload_file_to_s3({
+        :os_type => "ios",
+        :file => output_file
+      })
+    end
   end
 
   desc 'Upload artifacts to S3'


### PR DESCRIPTION
#### Summary
- e2e: we don't need to upload artifacts to s3 in e2e pipeline in pull-request only GitHub artifacts are required.

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/actions

#### Release Note
```release-note
NONE
```
