### PR TITLE
MM-65968 - prevent duplicate search when navigating back with a new hashtag

### DIFF
--- a/app/screens/home/search/search.test.tsx
+++ b/app/screens/home/search/search.test.tsx
@@ -75,6 +75,10 @@ describe('SearchScreen', () => {
         jest.clearAllMocks();
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('renders search screen correctly', () => {
         const {getByTestId, getByText, getByPlaceholderText} = renderWithEverything(
             <SearchScreen {...baseProps}/>,
@@ -234,6 +238,54 @@ describe('SearchScreen', () => {
 
         await waitFor(() => {
             expect(searchInput.props.value).toBe('');
+        });
+    });
+
+    it('should not trigger a duplicate search via useDidUpdate when refocused with a new searchTerm', async () => {
+        let currentIsFocused = false;
+        let currentSearchTerm = '#old';
+
+        jest.spyOn(require('@react-navigation/native'), 'useIsFocused').mockImplementation(() => currentIsFocused);
+        jest.spyOn(require('@react-navigation/native'), 'useNavigation').mockImplementation(() => ({
+            getState: () => ({
+                index: 0,
+                routes: [{params: {searchTerm: currentSearchTerm}}],
+            }),
+        }));
+
+        const {rerender} = renderWithEverything(<SearchScreen {...baseProps}/>, {database});
+
+        // Initial focus with #old triggers useEffect search
+        await act(async () => {
+            currentIsFocused = true;
+            rerender(<SearchScreen {...baseProps}/>);
+        });
+
+        await waitFor(() => expect(searchPosts).toHaveBeenCalledWith(
+            expect.any(String), 'team1', expect.objectContaining({terms: '#old'}),
+        ));
+
+        // Navigate away
+        await act(async () => {
+            currentIsFocused = false;
+            rerender(<SearchScreen {...baseProps}/>);
+        });
+
+        jest.clearAllMocks();
+
+        // Navigate back with a new hashtag — useDidUpdate and useEffect both fire,
+        // but useDidUpdate guard should skip since searchTerm !== lastSearchedValue
+        await act(async () => {
+            currentSearchTerm = '#new';
+            currentIsFocused = true;
+            rerender(<SearchScreen {...baseProps}/>);
+        });
+
+        await waitFor(() => {
+            expect(searchPosts).toHaveBeenCalledTimes(1);
+            expect(searchPosts).toHaveBeenCalledWith(
+                expect.any(String), 'team1', expect.objectContaining({terms: '#new'}),
+            );
         });
     });
 

--- a/app/screens/home/search/search.tsx
+++ b/app/screens/home/search/search.tsx
@@ -391,6 +391,11 @@ const SearchScreen = ({teamId, teams, crossTeamSearchEnabled}: Props) => {
     }, [isFocused]);
 
     useDidUpdate(() => {
+        if (searchTerm && searchTerm !== lastSearchedValue) {
+            // searchTerm changed (case for hashtag tap) — useEffect handles it; skip to avoid double search
+            return;
+        }
+
         if (isFocused && lastSearchedValue && showResults) {
             // requestAnimationFrame for smooth UI updates
             requestAnimationFrame(() => {


### PR DESCRIPTION
#### Summary
Tapping a hashtag while search screen was showing previous results will cause both useEffect and useDidUpdate to fire causing two concurrent search calls. This guard prevents that scenario.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65968

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: Android 16 emulator

#### Release Note
```release-note
Fixed an issue showing wrong search results on hashtag tapping
```
