### PR TITLE
Add AI-generated post indicator to mobile app

### DIFF
--- a/app/components/post_list/post/header/header.test.tsx
+++ b/app/components/post_list/post/header/header.test.tsx
@@ -87,4 +87,37 @@ describe('Header', () => {
 
         expect(screen.queryByTestId('expiry-timer')).toBeVisible();
     });
+
+    it('should show AI generated tag when post has ai_generated_by props', () => {
+        const aiPost = TestHelper.fakePostModel({
+            props: {
+                ai_generated_by: 'bot_user_id',
+                ai_generated_by_username: 'aibot',
+            },
+        });
+
+        renderWithIntlAndTheme(
+            <Header
+                {...defaultProps}
+                post={aiPost}
+            />,
+        );
+
+        expect(screen.queryByTestId('post_header.ai_generated.tag')).toBeVisible();
+    });
+
+    it('should not show AI generated tag when post has no ai_generated_by props', () => {
+        const normalPost = TestHelper.fakePostModel({
+            props: {},
+        });
+
+        renderWithIntlAndTheme(
+            <Header
+                {...defaultProps}
+                post={normalPost}
+            />,
+        );
+
+        expect(screen.queryByTestId('post_header.ai_generated.tag')).toBeNull();
+    });
 });

--- a/app/components/post_list/post/header/header.tsx
+++ b/app/components/post_list/post/header/header.tsx
@@ -16,7 +16,7 @@ import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {DEFAULT_LOCALE} from '@i18n';
 import {isUnrevealedBoRPost} from '@utils/bor';
-import {getPostTranslation, postUserDisplayName} from '@utils/post';
+import {getPostTranslation, hasAiGeneratedMetadata, postUserDisplayName} from '@utils/post';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 import {ensureString} from '@utils/types';
 import {typography} from '@utils/typography';
@@ -182,6 +182,7 @@ const Header = ({
                     />
                     {(!isSystemPost || isAutoResponse) && (
                         <HeaderTag
+                            isAiGenerated={hasAiGeneratedMetadata(post)}
                             isAutoResponder={isAutoResponse}
                             isAutomation={isWebHook || author?.isBot}
                             showGuestTag={author?.isGuest && !hideGuestTags}

--- a/app/components/post_list/post/header/tag/index.tsx
+++ b/app/components/post_list/post/header/tag/index.tsx
@@ -4,9 +4,10 @@
 import React from 'react';
 import {defineMessage} from 'react-intl';
 
-import Tag, {BotTag, GuestTag} from '@components/tag';
+import Tag, {AiGeneratedTag, BotTag, GuestTag} from '@components/tag';
 
 type HeaderTagProps = {
+    isAiGenerated?: boolean;
     isAutomation?: boolean;
     isAutoResponder?: boolean;
     showGuestTag?: boolean;
@@ -15,7 +16,7 @@ type HeaderTagProps = {
 const autoResponderMessage = defineMessage({id: 'post_info.auto_responder', defaultMessage: 'Automatic Reply'});
 
 const HeaderTag = ({
-    isAutomation, isAutoResponder, showGuestTag,
+    isAiGenerated, isAutomation, isAutoResponder, showGuestTag,
 }: HeaderTagProps) => {
     if (isAutomation) {
         return (
@@ -32,6 +33,10 @@ const HeaderTag = ({
                 testID='post_header.auto_responder.tag'
                 uppercase={true}
             />
+        );
+    } else if (isAiGenerated) {
+        return (
+            <AiGeneratedTag testID='post_header.ai_generated.tag'/>
         );
     }
 

--- a/app/components/tag/ai_generated_tag.test.tsx
+++ b/app/components/tag/ai_generated_tag.test.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import AiGeneratedTag from './ai_generated_tag';
+import Tag from './base_tag';
+
+jest.mock('./base_tag', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+jest.mocked(Tag).mockImplementation((props) => React.createElement('Tag', {...props}));
+
+describe('AiGeneratedTag', () => {
+    it('should render with the correct props', () => {
+        const {getByTestId} = renderWithIntlAndTheme(
+            <AiGeneratedTag
+                testID='ai-tag'
+                size='m'
+            />,
+        );
+
+        const tag = getByTestId('ai-tag');
+        expect(tag.props.message.id).toBe('post_info.ai_generated');
+        expect(tag.props.message.defaultMessage).toBe('AI');
+        expect(tag.props.icon).toBe('creation-outline');
+        expect(tag.props.uppercase).toBe(true);
+        expect(tag.props.size).toBe('m');
+    });
+
+    it('should render with default props', () => {
+        const {getByTestId} = renderWithIntlAndTheme(
+            <AiGeneratedTag
+                testID='ai-tag'
+            />,
+        );
+
+        const tag = getByTestId('ai-tag');
+        expect(tag.props.message.id).toBe('post_info.ai_generated');
+        expect(tag.props.icon).toBe('creation-outline');
+        expect(tag.props.uppercase).toBe(true);
+        expect(tag.props.size).toBeUndefined();
+    });
+});

--- a/app/components/tag/ai_generated_tag.tsx
+++ b/app/components/tag/ai_generated_tag.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {type ComponentProps} from 'react';
+import {defineMessage} from 'react-intl';
+
+import Tag from './base_tag';
+
+const aiGeneratedMessage = defineMessage({
+    id: 'post_info.ai_generated',
+    defaultMessage: 'AI',
+});
+
+type AiGeneratedTagProps = Omit<ComponentProps<typeof Tag>, 'message' | 'icon' | 'type'>;
+
+const AiGeneratedTag = ({
+    size,
+    testID,
+}: AiGeneratedTagProps) => {
+    return (
+        <Tag
+            message={aiGeneratedMessage}
+            icon='creation-outline'
+            testID={testID}
+            uppercase={true}
+            size={size}
+        />
+    );
+};
+
+export default AiGeneratedTag;

--- a/app/components/tag/index.tsx
+++ b/app/components/tag/index.tsx
@@ -1,12 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import AiGeneratedTag from './ai_generated_tag';
 import Tag from './base_tag';
 import BotTag from './bot_tag';
 import GuestTag from './guest_tag';
 
 export default Tag;
 export {
+    AiGeneratedTag,
     GuestTag,
     BotTag,
 };

--- a/app/utils/post/index.test.ts
+++ b/app/utils/post/index.test.ts
@@ -15,6 +15,7 @@ import {toMilliseconds} from '@utils/datetime';
 import {
     areConsecutivePosts,
     isFromWebhook,
+    hasAiGeneratedMetadata,
     isEdited,
     isPostEphemeral,
     isPostFailed,
@@ -78,6 +79,38 @@ describe('post utils', () => {
             const result = areConsecutivePosts(post, previousPost, 'en');
             expect(result).toBe(false);
         });
+
+        it('should return false when ai_generated_by status differs between posts', () => {
+            const post = TestHelper.fakePostModel({
+                userId: 'user1',
+                createAt: 1000,
+                props: {ai_generated_by: 'bot1', ai_generated_by_username: 'aibot'},
+            });
+            const previousPost = TestHelper.fakePostModel({
+                userId: 'user1',
+                createAt: 500,
+                props: {},
+            });
+
+            const result = areConsecutivePosts(post, previousPost, 'en');
+            expect(result).toBe(false);
+        });
+
+        it('should return true when both posts have the same ai_generated_by', () => {
+            const post = TestHelper.fakePostModel({
+                userId: 'user1',
+                createAt: 1000,
+                props: {ai_generated_by: 'bot1', ai_generated_by_username: 'aibot'},
+            });
+            const previousPost = TestHelper.fakePostModel({
+                userId: 'user1',
+                createAt: 500,
+                props: {ai_generated_by: 'bot1', ai_generated_by_username: 'aibot'},
+            });
+
+            const result = areConsecutivePosts(post, previousPost, 'en');
+            expect(result).toBe(true);
+        });
     });
 
     describe('isFromWebhook', () => {
@@ -101,6 +134,58 @@ describe('post utils', () => {
 
             const result = isFromWebhook(post);
             expect(result).toBe(false);
+        });
+    });
+
+    describe('hasAiGeneratedMetadata', () => {
+        it('should return true when both ai_generated_by and ai_generated_by_username are set', () => {
+            const post = TestHelper.fakePostModel({
+                props: {
+                    ai_generated_by: 'bot_user_id',
+                    ai_generated_by_username: 'aibot',
+                },
+            });
+
+            expect(hasAiGeneratedMetadata(post)).toBe(true);
+        });
+
+        it('should return false when ai_generated_by is missing', () => {
+            const post = TestHelper.fakePostModel({
+                props: {
+                    ai_generated_by_username: 'aibot',
+                },
+            });
+
+            expect(hasAiGeneratedMetadata(post)).toBe(false);
+        });
+
+        it('should return false when ai_generated_by_username is missing', () => {
+            const post = TestHelper.fakePostModel({
+                props: {
+                    ai_generated_by: 'bot_user_id',
+                },
+            });
+
+            expect(hasAiGeneratedMetadata(post)).toBe(false);
+        });
+
+        it('should return false when props are empty', () => {
+            const post = TestHelper.fakePostModel({
+                props: {},
+            });
+
+            expect(hasAiGeneratedMetadata(post)).toBe(false);
+        });
+
+        it('should return false when values are empty strings', () => {
+            const post = TestHelper.fakePostModel({
+                props: {
+                    ai_generated_by: '',
+                    ai_generated_by_username: '',
+                },
+            });
+
+            expect(hasAiGeneratedMetadata(post)).toBe(false);
         });
     });
 

--- a/app/utils/post/index.ts
+++ b/app/utils/post/index.ts
@@ -41,11 +41,25 @@ export function areConsecutivePosts(post: PostModel, previousPost: PostModel, us
         }
     }
 
+    if (consecutive) {
+        const sameAiGeneratedStatus = post.props?.ai_generated_by === previousPost.props?.ai_generated_by;
+        if (!sameAiGeneratedStatus) {
+            consecutive = false;
+        }
+    }
+
     return consecutive;
 }
 
 export function isFromWebhook(post: PostModel | Post): boolean {
     return post.props?.from_webhook === 'true';
+}
+
+export function hasAiGeneratedMetadata(post: PostModel | Post): boolean {
+    return typeof post.props?.ai_generated_by === 'string' &&
+        typeof post.props?.ai_generated_by_username === 'string' &&
+        post.props.ai_generated_by.length > 0 &&
+        post.props.ai_generated_by_username.length > 0;
 }
 
 export function isEdited(post: PostModel): boolean {

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1251,6 +1251,7 @@
   "post_body.deleted": "(message deleted)",
   "post_header.translation_processing": "Translating...",
   "post_header.visible_message": "(Only visible to you)",
+  "post_info.ai_generated": "AI",
   "post_info.auto_responder": "Automatic Reply",
   "post_info.bot": "Bot",
   "post_info.del": "Delete",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Show a sparkle "AI" tag in the post header when a post has ai_generated_by and ai_generated_by_username props set, matching the webapp's existing behavior. Also break consecutive post grouping when AI generation status differs between posts.

Opted to add the "AI" text since there are no tooltips - on Desktop a text is displayed on hover.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
- [X] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: iOS Simulator - iPhone 16 Pro iOS 18.3

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

<img width="352" height="76" alt="Screenshot 2026-03-08 at 21 22 24" src="https://github.com/user-attachments/assets/d6369462-41c7-4351-aff8-939223bfdcab" />

<img width="119" height="54" alt="Screenshot 2026-03-08 at 21 27 20" src="https://github.com/user-attachments/assets/c7e7cc23-6c7f-4efb-9ff6-6de751742bd6" />

<img width="111" height="67" alt="Screenshot 2026-03-08 at 21 27 57" src="https://github.com/user-attachments/assets/a8ab9ffb-948d-43b8-8eda-197e31dadba4" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Added the same AI indicator for posts as on the desktop app.
```
