### PR TITLE
Fix SSO auto-redirect when only one provider is enabled

### DIFF
--- a/app/utils/server/index.test.ts
+++ b/app/utils/server/index.test.ts
@@ -135,6 +135,30 @@ describe('loginOptions', () => {
             numberSSOs: 5,
         });
     });
+
+    it('should only count enabled SSOs in enabledSSOs and numberSSOs', () => {
+        const config = {
+            EnableSaml: 'false',
+            EnableSignUpWithGitLab: 'true',
+            EnableSignUpWithGoogle: 'false',
+            EnableSignUpWithOffice365: 'false',
+            EnableSignUpWithOpenId: 'false',
+            EnableLdap: 'false',
+            EnableSignInWithEmail: 'false',
+            EnableSignInWithUsername: 'false',
+            Version: '7.6.0',
+        } as ClientConfig;
+        const license = {
+            IsLicensed: 'false',
+        } as ClientLicense;
+
+        (isMinimumServerVersion as jest.Mock).mockReturnValue(true);
+        const result = loginOptions(config, license);
+
+        expect(result.enabledSSOs).toEqual([Sso.GITLAB]);
+        expect(result.numberSSOs).toBe(1);
+        expect(result.hasLoginForm).toBe(false);
+    });
 });
 
 describe('loginToServer', () => {
@@ -166,14 +190,12 @@ describe('loginToServer', () => {
         expect(showModal).toHaveBeenCalledWith(Screens.LOGIN, '', expect.any(Object), expect.any(Object));
     });
 
-    /* Commented out for now as the test is failing potentially due to incorrect logic in the function
-
     it('should call showModal with SSO screen if redirectSSO is true', async () => {
         const configWithSingleSSO = {...config, EnableSignInWithEmail: 'false', EnableSignInWithUsername: 'false'};
         await loginToServer(theme, serverUrl, displayName, configWithSingleSSO, license);
 
         expect(showModal).toHaveBeenCalledWith(Screens.SSO, '', expect.any(Object), expect.any(Object));
-    });*/
+    });
 });
 
 describe('editServer', () => {

--- a/app/utils/server/index.ts
+++ b/app/utils/server/index.ts
@@ -81,7 +81,7 @@ export function loginOptions(config: ClientConfig, license: ClientLicense) {
         [Sso.OFFICE365]: {enabled: o365Enabled},
         [Sso.OPENID]: {enabled: openIdEnabled, text: config.OpenIdButtonText},
     };
-    const enabledSSOs = Object.keys(ssoOptions).filter((key) => ssoOptions[key]);
+    const enabledSSOs = Object.keys(ssoOptions).filter((key) => ssoOptions[key].enabled);
     const numberSSOs = enabledSSOs.length;
 
     return {


### PR DESCRIPTION
## Summary

`loginOptions()` in `app/utils/server/index.ts` filters `enabledSSOs` by object truthiness instead of the `.enabled` property. Since `{enabled: false}` is truthy in JavaScript, `numberSSOs` is always 5, making the `redirectSSO` condition (`!hasLoginForm && numberSSOs === 1`) unreachable.

This means users always see the Login screen with SSO buttons instead of being auto-redirected to the sole SSO provider — even when email/username/LDAP login are all disabled and only one SSO method is enabled.

## Fix

```diff
- const enabledSSOs = Object.keys(ssoOptions).filter((key) => ssoOptions[key]);
+ const enabledSSOs = Object.keys(ssoOptions).filter((key) => ssoOptions[key].enabled);
```

The Login screen component (`app/screens/login/index.tsx:103`) already filters correctly using `.enabled` — only `loginOptions()` and `loginToServer()` had the bug.

## How to reproduce

1. Configure the server with only GitLab SSO enabled (disable email, username, LDAP, and all other SSO providers)
2. Open the mobile app and enter the server URL
3. **Expected:** App auto-redirects to GitLab SSO browser session (skips login screen)
4. **Actual:** App shows the Login screen with a single "GitLab" button that the user must tap

## Tests

- Uncommented the existing test that was disabled with the note *"potentially due to incorrect logic in the function"* — it now passes
- Added a new test verifying `enabledSSOs` only contains enabled providers and `numberSSOs` reflects the correct count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SSO filtering so only enabled authentication options are counted and shown, improving single sign-on display and redirect behaviour across configurations.

* **Tests**
  * Added and re-enabled tests to verify SSO option visibility and that the authentication modal shows the expected screen under redirect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->