### PR TITLE
Fix: Keyboard gets stuck and does not collapse

### DIFF
--- a/app/screens/bottom_sheet/index.tsx
+++ b/app/screens/bottom_sheet/index.tsx
@@ -3,7 +3,7 @@
 
 import BottomSheetM, {BottomSheetBackdrop, BottomSheetScrollView, BottomSheetView, type BottomSheetBackdropProps} from '@gorhom/bottom-sheet';
 import React, {type ReactNode, useCallback, useEffect, useMemo, useRef} from 'react';
-import {DeviceEventEmitter, type Handle, InteractionManager, Keyboard, ScrollView, type StyleProp, View, type ViewStyle} from 'react-native';
+import {DeviceEventEmitter, type Handle, InteractionManager, ScrollView, type StyleProp, View, type ViewStyle} from 'react-native';
 import {ReduceMotion, useReducedMotion, type WithSpringConfig} from 'react-native-reanimated';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
@@ -16,6 +16,7 @@ import useNavButtonPressed from '@hooks/navigation_button_pressed';
 import SecurityManager from '@managers/security_manager';
 import {dismissModal} from '@screens/navigation';
 import {hapticFeedback} from '@utils/general';
+import {dismissKeyboard} from '@utils/keyboard';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
 import Indicator from './indicator';
@@ -179,7 +180,7 @@ const BottomSheet = ({
 
     useEffect(() => {
         hapticFeedback();
-        Keyboard.dismiss();
+        dismissKeyboard();
 
         return () => {
             if (timeoutRef.current) {

--- a/app/screens/navigation.test.ts
+++ b/app/screens/navigation.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {DeviceEventEmitter, Keyboard, type EmitterSubscription} from 'react-native';
+import {DeviceEventEmitter, type EmitterSubscription} from 'react-native';
 import {Navigation} from 'react-native-navigation';
 
 import {Events, Preferences, Screens} from '@constants';
@@ -15,6 +15,11 @@ import type {IntlShape} from 'react-intl';
 jest.mock('@utils/helpers', () => ({
     ...jest.requireActual('@utils/helpers'),
     isTablet: jest.fn(),
+}));
+
+const mockDismissKeyboard = jest.fn();
+jest.mock('@utils/keyboard', () => ({
+    dismissKeyboard: (...args: unknown[]) => mockDismissKeyboard(...args),
 }));
 
 jest.mock('@components/compass_icon', () => {
@@ -96,7 +101,7 @@ describe('openUserProfileModal', () => {
 
     it('should dismiss the keyboard', () => {
         openUserProfileModal(intl, theme, props);
-        expect(Keyboard.dismiss).toHaveBeenCalled();
+        expect(mockDismissKeyboard).toHaveBeenCalled();
     });
 
     it('should dismiss the bottom sheet if screenToDismiss is provided', async () => {

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -5,7 +5,7 @@
 
 import RNUtils from '@mattermost/rnutils';
 import merge from 'deepmerge';
-import {Appearance, DeviceEventEmitter, Platform, Alert, type EmitterSubscription, Keyboard, StatusBar} from 'react-native';
+import {Appearance, DeviceEventEmitter, Platform, Alert, type EmitterSubscription, StatusBar} from 'react-native';
 import {type ComponentWillAppearEvent, type ImageResource, type LayoutOrientation, Navigation, type Options, OptionsModalPresentationStyle, type OptionsTopBarButton, type ScreenPoppedEvent, type EventSubscription} from 'react-native-navigation';
 import tinyColor from 'tinycolor2';
 
@@ -16,6 +16,7 @@ import {getDefaultThemeByAppearance} from '@context/theme';
 import EphemeralStore from '@store/ephemeral_store';
 import NavigationStore from '@store/navigation_store';
 import {isTablet} from '@utils/helpers';
+import {dismissKeyboard} from '@utils/keyboard';
 import {logError} from '@utils/log';
 import {appearanceControlledScreens, mergeNavigationOptions} from '@utils/navigation';
 import {changeOpacity, setNavigatorStyles} from '@utils/theme';
@@ -993,6 +994,6 @@ export async function openUserProfileModal(
     const title = intl.formatMessage({id: 'mobile.routes.user_profile', defaultMessage: 'Profile'});
     const closeButtonId = 'close-user-profile';
 
-    Keyboard.dismiss();
+    dismissKeyboard();
     openAsBottomSheet({screen, title, theme, closeButtonId, props: {...props}});
 }

--- a/app/screens/scheduled_post_options/scheduled_post_picker.test.tsx
+++ b/app/screens/scheduled_post_options/scheduled_post_picker.test.tsx
@@ -16,6 +16,10 @@ jest.mock('@screens/navigation', () => ({
     dismissBottomSheet: jest.fn(),
 }));
 
+jest.mock('@utils/keyboard', () => ({
+    dismissKeyboard: jest.fn(),
+}));
+
 jest.mock('@utils/snack_bar', () => ({
     showScheduledPostCreationErrorSnackbar: jest.fn(),
 }));


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the keyboard gets stuck and doesn’t close.

Steps to reproduce:
- On iOS, open any channel with posts
- Tap on the input field to open the keyboard
- Tap on a user’s avatar in any post
- A bottom sheet opens
- Tap on Send Message
- You are taken to a DM with the keyboard still open
- Press the back button to go to the channel list

At this point, the keyboard stays open, and there’s no way to close it

After fix: 

https://github.com/user-attachments/assets/db8f5c29-888e-4159-abe0-b1e360ca639d



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67770

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized keyboard dismissal across the app by switching call sites to a centralized dismissKeyboard utility for consistent behaviour.

* **Tests**
  * Updated and added tests/mocks to reflect the new keyboard dismissal utility and verify it is invoked where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->