### PR TITLE
fix: disable syntax highlighting and line numbers for code blocks without language

### DIFF
--- a/app/components/syntax_highlight/index.tsx
+++ b/app/components/syntax_highlight/index.tsx
@@ -45,7 +45,7 @@ const Highlighter = ({code, language, textStyle, selectable = false}: SyntaxHigl
     ],
     [theme, selectable, style]);
     const maximumLineLength = useMemo(() => getMaximumLineLength(code), [code]);
-    const languageToUse = maximumLineLength > MAXIMUM_CODE_LINE_LENGTH ? 'text' : language;
+    const languageToUse = (!language || maximumLineLength > MAXIMUM_CODE_LINE_LENGTH) ? 'text' : language;
 
     const nativeRenderer = useCallback(({rows, stylesheet}: rendererProps) => {
         const digits = rows.length.toString().length;
@@ -75,7 +75,7 @@ const Highlighter = ({code, language, textStyle, selectable = false}: SyntaxHigl
             style={style}
             language={languageToUse}
             horizontal={true}
-            showLineNumbers={true}
+            showLineNumbers={Boolean(language)}
             renderer={nativeRenderer}
             PreTag={preTag}
             CodeTag={View}


### PR DESCRIPTION
#### Summary

Fix code blocks without a language tag showing unwanted syntax highlighting and line numbers on mobile. The desktop app correctly renders these as plain text.

**Root cause:** Two issues in `app/components/syntax_highlight/index.tsx`:

1. When no language is specified, `language` is an empty string `''`. This was passed directly to `react-syntax-highlighter`, which auto-detects a language and applies colorful syntax highlighting — producing what the reporter described as "colorful trash."

2. `showLineNumbers={true}` was hardcoded, so line numbers appeared on every code block regardless of whether a language was specified.

**Fix (2-line change):**
- Treat empty language the same as the existing `MAXIMUM_CODE_LINE_LENGTH` fallback: use `'text'` (which disables highlighting) when no language is given
- Only show line numbers when a language is explicitly provided: `showLineNumbers={Boolean(language)}`

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-mobile/issues/9644

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information

This PR was tested on: Root cause identified via source analysis. The fix aligns mobile behavior with the desktop app (which shows plain text for code blocks without a language tag).

#### Screenshots

Before: code blocks without a language tag show syntax highlighting colors and line numbers.

After: code blocks without a language tag render as plain text with no line numbers (matching desktop behavior).

#### Release Note

```release-note
Fixed code blocks without a language specified incorrectly showing syntax highlighting and line numbers on mobile.
```