### PR TITLE
MM-68171 - Show team sidebar when other teams are available to join

### DIFF
--- a/app/components/team_sidebar/team_sidebar.tsx
+++ b/app/components/team_sidebar/team_sidebar.tsx
@@ -62,11 +62,11 @@ export default function TeamSidebar({iconPad, canJoinOtherTeams, hasMoreThanOneT
     }, [iconPad]);
 
     useEffect(() => {
-        width.value = (hasMoreThanOneTeam || canJoinOtherTeams) ? TEAM_SIDEBAR_WIDTH : 0;
+        width.value = shouldShowSidebar ? TEAM_SIDEBAR_WIDTH : 0;
 
     // width is a stable reanimated shared value ref
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hasMoreThanOneTeam, canJoinOtherTeams]);
+    }, [shouldShowSidebar]);
 
     return (
         <Animated.View style={[styles.container, transform]}>

--- a/app/components/team_sidebar/team_sidebar.tsx
+++ b/app/components/team_sidebar/team_sidebar.tsx
@@ -37,7 +37,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
 });
 
 export default function TeamSidebar({iconPad, canJoinOtherTeams, hasMoreThanOneTeam}: Props) {
-    const initialWidth = hasMoreThanOneTeam ? TEAM_SIDEBAR_WIDTH : 0;
+    const shouldShowSidebar = hasMoreThanOneTeam || canJoinOtherTeams;
+    const initialWidth = shouldShowSidebar ? TEAM_SIDEBAR_WIDTH : 0;
     const width = useSharedValue(initialWidth);
     const marginTop = useSharedValue(iconPad ? 44 : 0);
     const theme = useTheme();
@@ -61,11 +62,11 @@ export default function TeamSidebar({iconPad, canJoinOtherTeams, hasMoreThanOneT
     }, [iconPad]);
 
     useEffect(() => {
-        width.value = hasMoreThanOneTeam ? TEAM_SIDEBAR_WIDTH : 0;
+        width.value = (hasMoreThanOneTeam || canJoinOtherTeams) ? TEAM_SIDEBAR_WIDTH : 0;
 
-    // Update the shared value only when the hasMoreThanOneTeam changes.
+    // width is a stable reanimated shared value ref
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hasMoreThanOneTeam]);
+    }, [hasMoreThanOneTeam, canJoinOtherTeams]);
 
     return (
         <Animated.View style={[styles.container, transform]}>

--- a/app/screens/home/channel_list/channel_list.test.tsx
+++ b/app/screens/home/channel_list/channel_list.test.tsx
@@ -56,3 +56,32 @@ describe('performance metrics', () => {
         });
     });
 });
+
+describe('team sidebar visibility', () => {
+    let database: Database;
+    const serverUrl = 'http://www.someserverurl.com';
+    beforeAll(async () => {
+        const server = await TestHelper.setupServerDatabase(serverUrl);
+        database = server.database;
+    });
+
+    it('should render when canJoinOtherTeams is true and user has only one team', async () => {
+        const props = getBaseProps();
+        props.canJoinOtherTeams = true;
+        props.hasMoreThanOneTeam = false;
+        const {getByTestId} = renderWithEverything(<ChannelListScreen {...props}/>, {database, serverUrl});
+        await waitFor(() => {
+            expect(getByTestId('channel_list.screen')).toBeTruthy();
+        });
+    });
+
+    it('should render when canJoinOtherTeams is false and user has only one team', async () => {
+        const props = getBaseProps();
+        props.canJoinOtherTeams = false;
+        props.hasMoreThanOneTeam = false;
+        const {getByTestId} = renderWithEverything(<ChannelListScreen {...props}/>, {database, serverUrl});
+        await waitFor(() => {
+            expect(getByTestId('channel_list.screen')).toBeTruthy();
+        });
+    });
+});

--- a/app/screens/home/channel_list/channel_list.test.tsx
+++ b/app/screens/home/channel_list/channel_list.test.tsx
@@ -26,6 +26,7 @@ jest.mock('@react-native-camera-roll/camera-roll', () => ({
 
 function getBaseProps(): ComponentProps<typeof ChannelListScreen> {
     return {
+        canJoinOtherTeams: false,
         hasChannels: true,
         hasCurrentUser: true,
         hasMoreThanOneTeam: true,

--- a/app/screens/home/channel_list/channel_list.tsx
+++ b/app/screens/home/channel_list/channel_list.tsx
@@ -3,7 +3,7 @@
 
 import {useManagedConfig} from '@mattermost/react-native-emm';
 import {useIsFocused, useNavigation, useRoute} from '@react-navigation/native';
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {BackHandler, DeviceEventEmitter, StyleSheet, ToastAndroid, View} from 'react-native';
 import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
@@ -20,6 +20,7 @@ import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {resetToTeams, openToS} from '@screens/navigation';
+import EphemeralStore from '@store/ephemeral_store';
 import NavigationStore from '@store/navigation_store';
 import {isMainActivity} from '@utils/helpers';
 import {tryRunAppReview} from '@utils/reviews';
@@ -79,6 +80,7 @@ const ChannelListScreen = (props: ChannelProps) => {
     const navigation = useNavigation();
     const insets = useSafeAreaInsets();
     const serverUrl = useServerUrl();
+    const [canJoinOtherTeams, setCanJoinOtherTeams] = useState(false);
     const params = route.params as {direction: string};
     const canAddOtherServers = managedConfig?.allowOtherServers !== 'false';
 
@@ -148,6 +150,11 @@ const ChannelListScreen = (props: ChannelProps) => {
     }, [serverUrl]);
 
     useEffect(() => {
+        const subscription = EphemeralStore.observeCanJoinOtherTeams(serverUrl).subscribe(setCanJoinOtherTeams);
+        return () => subscription.unsubscribe();
+    }, [serverUrl]);
+
+    useEffect(() => {
         if (props.showToS && !NavigationStore.isToSOpen()) {
             openToS();
         }
@@ -201,7 +208,7 @@ const ChannelListScreen = (props: ChannelProps) => {
                             hasMoreThanOneTeam={props.hasMoreThanOneTeam}
                         />
                         <CategoriesList
-                            iconPad={canAddOtherServers && !props.hasMoreThanOneTeam}
+                            iconPad={canAddOtherServers && !props.hasMoreThanOneTeam && !canJoinOtherTeams}
                             isCRTEnabled={props.isCRTEnabled}
                             moreThanOneTeam={props.hasMoreThanOneTeam}
                             hasChannels={props.hasChannels}

--- a/app/screens/home/channel_list/channel_list.tsx
+++ b/app/screens/home/channel_list/channel_list.tsx
@@ -3,7 +3,7 @@
 
 import {useManagedConfig} from '@mattermost/react-native-emm';
 import {useIsFocused, useNavigation, useRoute} from '@react-navigation/native';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect} from 'react';
 import {useIntl} from 'react-intl';
 import {BackHandler, DeviceEventEmitter, StyleSheet, ToastAndroid, View} from 'react-native';
 import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
@@ -20,7 +20,6 @@ import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {resetToTeams, openToS} from '@screens/navigation';
-import EphemeralStore from '@store/ephemeral_store';
 import NavigationStore from '@store/navigation_store';
 import {isMainActivity} from '@utils/helpers';
 import {tryRunAppReview} from '@utils/reviews';
@@ -33,6 +32,7 @@ import Servers from './servers';
 import type {LaunchType} from '@typings/launch';
 
 type ChannelProps = {
+    canJoinOtherTeams: boolean;
     hasChannels: boolean;
     isCRTEnabled: boolean;
     hasTeams: boolean;
@@ -80,7 +80,6 @@ const ChannelListScreen = (props: ChannelProps) => {
     const navigation = useNavigation();
     const insets = useSafeAreaInsets();
     const serverUrl = useServerUrl();
-    const [canJoinOtherTeams, setCanJoinOtherTeams] = useState(false);
     const params = route.params as {direction: string};
     const canAddOtherServers = managedConfig?.allowOtherServers !== 'false';
 
@@ -150,11 +149,6 @@ const ChannelListScreen = (props: ChannelProps) => {
     }, [serverUrl]);
 
     useEffect(() => {
-        const subscription = EphemeralStore.observeCanJoinOtherTeams(serverUrl).subscribe(setCanJoinOtherTeams);
-        return () => subscription.unsubscribe();
-    }, [serverUrl]);
-
-    useEffect(() => {
         if (props.showToS && !NavigationStore.isToSOpen()) {
             openToS();
         }
@@ -208,7 +202,7 @@ const ChannelListScreen = (props: ChannelProps) => {
                             hasMoreThanOneTeam={props.hasMoreThanOneTeam}
                         />
                         <CategoriesList
-                            iconPad={canAddOtherServers && !props.hasMoreThanOneTeam && !canJoinOtherTeams}
+                            iconPad={canAddOtherServers && !props.hasMoreThanOneTeam && !props.canJoinOtherTeams}
                             isCRTEnabled={props.isCRTEnabled}
                             moreThanOneTeam={props.hasMoreThanOneTeam}
                             hasChannels={props.hasChannels}

--- a/app/screens/home/channel_list/index.ts
+++ b/app/screens/home/channel_list/index.ts
@@ -6,18 +6,24 @@ import {of as of$} from 'rxjs';
 import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
 import {observeIncomingCalls} from '@calls/state';
+import {withServerUrl} from '@context/server';
 import {queryAllMyChannelsForTeam} from '@queries/servers/channel';
 import {observeCurrentTeamId, observeCurrentUserId, observeLicense} from '@queries/servers/system';
 import {queryMyTeams} from '@queries/servers/team';
 import {observeShowToS} from '@queries/servers/terms_of_service';
 import {observeIsCRTEnabled} from '@queries/servers/thread';
 import {observeCurrentUser} from '@queries/servers/user';
+import EphemeralStore from '@store/ephemeral_store';
 
 import ChannelsList from './channel_list';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
-const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
+type EnhanceProps = WithDatabaseArgs & {
+    serverUrl?: string;
+}
+
+const enhanced = withObservables([], ({database, serverUrl}: EnhanceProps) => {
     const isLicensed = observeLicense(database).pipe(
         switchMap((lcs) => (lcs ? of$(lcs.IsLicensed === 'true') : of$(false))),
     );
@@ -52,7 +58,8 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
             distinctUntilChanged(),
         ),
         showIncomingCalls,
+        canJoinOtherTeams: EphemeralStore.observeCanJoinOtherTeams(serverUrl || ''),
     };
 });
 
-export default withDatabase(enhanced(ChannelsList));
+export default withDatabase(withServerUrl(enhanced(ChannelsList)));


### PR DESCRIPTION
## Summary
- The team sidebar collapsed to zero width when the user was a member of only one team, hiding the "Join Another Team" plus button
- Updated the sidebar visibility logic to also show when `canJoinOtherTeams` is true (not just `hasMoreThanOneTeam`)
- Adjusted the `CategoriesList` header `iconPad` to account for the sidebar being visible due to joinable teams

## Ticket
[MM-68171](https://mattermost.atlassian.net/browse/MM-68171)

## Test plan
- [ ] Connect to a server with multiple public teams
- [ ] Be a member of only one team
- [ ] Verify the team sidebar is now visible with the plus (+) button
- [ ] Tap the plus button — "Join Another Team" modal should open
- [ ] Join another team — verify the sidebar continues to show with both teams
- [ ] If no more teams to join, verify the plus button disappears but the sidebar stays (now showing 2+ teams)
- [ ] Verify header alignment is correct (no extra left margin when sidebar is visible)

[MM-68171]: https://mattermost.atlassian.net/browse/MM-68171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Release Note
```release-note
The team sidebar now displays to the left of the channel sidebar if you belong to more than one team or if other teams are available to join."
```
