### PR TITLE
Fix cross-device sync for attach logs preference (MM-67856)

### DIFF
--- a/app/actions/websocket/preferences.ts
+++ b/app/actions/websocket/preferences.ts
@@ -9,6 +9,7 @@ import DatabaseManager from '@database/manager';
 import {getPostById} from '@queries/servers/post';
 import {deletePreferences, differsFromLocalNameFormat, getHasCRTChanged} from '@queries/servers/preference';
 import EphemeralStore from '@store/ephemeral_store';
+import {logDebug} from '@utils/log';
 
 export async function handlePreferenceChangedEvent(serverUrl: string, msg: WebSocketMessage): Promise<void> {
     if (EphemeralStore.isEnablingCRT()) {
@@ -18,6 +19,7 @@ export async function handlePreferenceChangedEvent(serverUrl: string, msg: WebSo
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const preference: PreferenceType = JSON.parse(msg.data.preference);
+        logDebug('[WS] PREFERENCE_CHANGED', preference.category, preference.name, preference.value);
         handleSavePostAdded(serverUrl, [preference]);
 
         const hasDiffNameFormatPref = await differsFromLocalNameFormat(database, [preference]);
@@ -48,6 +50,7 @@ export async function handlePreferencesChangedEvent(serverUrl: string, msg: WebS
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const preferences: PreferenceType[] = JSON.parse(msg.data.preferences);
+        logDebug('[WS] PREFERENCES_CHANGED', preferences.map((p) => `${p.category}/${p.name}=${p.value}`).join(', '));
         handleSavePostAdded(serverUrl, preferences);
 
         const hasDiffNameFormatPref = await differsFromLocalNameFormat(database, preferences);

--- a/app/actions/websocket/preferences.ts
+++ b/app/actions/websocket/preferences.ts
@@ -13,6 +13,7 @@ import {logDebug} from '@utils/log';
 
 export async function handlePreferenceChangedEvent(serverUrl: string, msg: WebSocketMessage): Promise<void> {
     if (EphemeralStore.isEnablingCRT()) {
+        logDebug('[handlePreferenceChangedEvent] skipping: CRT is being enabled');
         return;
     }
 
@@ -44,6 +45,7 @@ export async function handlePreferenceChangedEvent(serverUrl: string, msg: WebSo
 
 export async function handlePreferencesChangedEvent(serverUrl: string, msg: WebSocketMessage): Promise<void> {
     if (EphemeralStore.isEnablingCRT()) {
+        logDebug('[handlePreferencesChangedEvent] skipping: CRT is being enabled');
         return;
     }
 

--- a/app/actions/websocket/preferences.ts
+++ b/app/actions/websocket/preferences.ts
@@ -19,7 +19,7 @@ export async function handlePreferenceChangedEvent(serverUrl: string, msg: WebSo
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const preference: PreferenceType = JSON.parse(msg.data.preference);
-        logDebug('[WS] PREFERENCE_CHANGED', preference.category, preference.name, preference.value);
+        logDebug('[WS] PREFERENCE_CHANGED', preference.category, preference.name);
         handleSavePostAdded(serverUrl, [preference]);
 
         const hasDiffNameFormatPref = await differsFromLocalNameFormat(database, [preference]);
@@ -50,7 +50,7 @@ export async function handlePreferencesChangedEvent(serverUrl: string, msg: WebS
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const preferences: PreferenceType[] = JSON.parse(msg.data.preferences);
-        logDebug('[WS] PREFERENCES_CHANGED', preferences.map((p) => `${p.category}/${p.name}=${p.value}`).join(', '));
+        logDebug('[WS] PREFERENCES_CHANGED', preferences.map((p) => `${p.category}/${p.name}`).join(', '));
         handleSavePostAdded(serverUrl, preferences);
 
         const hasDiffNameFormatPref = await differsFromLocalNameFormat(database, preferences);

--- a/app/actions/websocket/preferences.ts
+++ b/app/actions/websocket/preferences.ts
@@ -19,7 +19,7 @@ export async function handlePreferenceChangedEvent(serverUrl: string, msg: WebSo
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const preference: PreferenceType = JSON.parse(msg.data.preference);
-        logDebug('[WS] PREFERENCE_CHANGED', preference.category, preference.name);
+        logDebug('[handlePreferenceChangedEvent] PREFERENCE_CHANGED', preference.category, preference.name);
         handleSavePostAdded(serverUrl, [preference]);
 
         const hasDiffNameFormatPref = await differsFromLocalNameFormat(database, [preference]);
@@ -50,7 +50,7 @@ export async function handlePreferencesChangedEvent(serverUrl: string, msg: WebS
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const preferences: PreferenceType[] = JSON.parse(msg.data.preferences);
-        logDebug('[WS] PREFERENCES_CHANGED', preferences.map((p) => `${p.category}/${p.name}`).join(', '));
+        logDebug('[handlePreferencesChangedEvent] PREFERENCES_CHANGED', preferences.map((p) => `${p.category}/${p.name}`).join(', '));
         handleSavePostAdded(serverUrl, preferences);
 
         const hasDiffNameFormatPref = await differsFromLocalNameFormat(database, preferences);

--- a/app/components/post_draft/quick_actions/attachment_quick_action/index.test.tsx
+++ b/app/components/post_draft/quick_actions/attachment_quick_action/index.test.tsx
@@ -278,6 +278,28 @@ describe('AttachmentQuickAction', () => {
             });
         });
 
+        it('should pass showAttachLogs to openAttachmentOptions', async () => {
+            const {getByTestId} = renderWithIntlAndTheme(
+                <AttachmentQuickAction
+                    {...baseProps}
+                    showAttachLogs={true}
+                />,
+            );
+
+            const button = getByTestId('test-attachment');
+            fireEvent.press(button);
+
+            await waitFor(() => {
+                expect(mockOpenAttachmentOptions).toHaveBeenCalledWith(
+                    expect.any(Object), // intl
+                    expect.any(Object), // theme
+                    expect.objectContaining({
+                        showAttachLogs: true,
+                    }),
+                );
+            });
+        });
+
         it('should handle default fileCount when not provided', async () => {
             const propsWithoutFileCount = {
                 ...baseProps,

--- a/app/components/post_draft/quick_actions/index.ts
+++ b/app/components/post_draft/quick_actions/index.ts
@@ -10,7 +10,7 @@ import {map} from 'rxjs/operators';
 import {Preferences} from '@constants';
 import {withServerUrl} from '@context/server';
 import {observeIsBoREnabled, observeIsPostPriorityEnabled} from '@queries/servers/post';
-import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
+import {observePreferenceAsBool} from '@queries/servers/preference';
 import {observeCanUploadFiles} from '@queries/servers/security';
 import {observeConfigBooleanValue, observeMaxFileCount} from '@queries/servers/system';
 
@@ -26,11 +26,7 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhancedProps) => {
     const canUploadFiles = observeCanUploadFiles(database);
     const maxFileCount = observeMaxFileCount(database);
     const allowDownloadLogs = observeConfigBooleanValue(database, 'AllowDownloadLogs', true);
-    const attachLogsPref = queryPreferencesByCategoryAndName(
-        database,
-        Preferences.CATEGORIES.ADVANCED_SETTINGS,
-        Preferences.ATTACH_APP_LOGS,
-    ).observe();
+    const attachLogsPref = observePreferenceAsBool(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS);
 
     return {
         canUploadFiles,
@@ -39,7 +35,7 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhancedProps) => {
         isBoREnabled: observeIsBoREnabled(database),
         maxFileCount,
         showAttachLogs: combineLatest([allowDownloadLogs, attachLogsPref]).pipe(
-            map(([allowed, prefs]) => allowed && prefs?.[0]?.value === 'true'),
+            map(([allowed, enabled]) => allowed && enabled),
         ),
     };
 });

--- a/app/components/post_draft/quick_actions/index.ts
+++ b/app/components/post_draft/quick_actions/index.ts
@@ -26,7 +26,7 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhancedProps) => {
     const canUploadFiles = observeCanUploadFiles(database);
     const maxFileCount = observeMaxFileCount(database);
     const allowDownloadLogs = observeConfigBooleanValue(database, 'AllowDownloadLogs', true);
-    const attachLogsPref = observePreferenceAsBool(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS);
+    const attachLogsEnabled = observePreferenceAsBool(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS);
 
     return {
         canUploadFiles,
@@ -34,7 +34,7 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhancedProps) => {
         isPostPriorityEnabled: observeIsPostPriorityEnabled(database),
         isBoREnabled: observeIsBoREnabled(database),
         maxFileCount,
-        showAttachLogs: combineLatest([allowDownloadLogs, attachLogsPref]).pipe(
+        showAttachLogs: combineLatest([allowDownloadLogs, attachLogsEnabled]).pipe(
             map(([allowed, enabled]) => allowed && enabled),
         ),
     };

--- a/app/components/post_draft/quick_actions/index.ts
+++ b/app/components/post_draft/quick_actions/index.ts
@@ -10,7 +10,7 @@ import {map} from 'rxjs/operators';
 import {Preferences} from '@constants';
 import {withServerUrl} from '@context/server';
 import {observeIsBoREnabled, observeIsPostPriorityEnabled} from '@queries/servers/post';
-import {observePreferenceAsBool} from '@queries/servers/preference';
+import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeCanUploadFiles} from '@queries/servers/security';
 import {observeConfigBooleanValue, observeMaxFileCount} from '@queries/servers/system';
 
@@ -26,7 +26,9 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhancedProps) => {
     const canUploadFiles = observeCanUploadFiles(database);
     const maxFileCount = observeMaxFileCount(database);
     const allowDownloadLogs = observeConfigBooleanValue(database, 'AllowDownloadLogs', true);
-    const attachLogsEnabled = observePreferenceAsBool(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS);
+    const attachLogsEnabled = queryPreferencesByCategoryAndName(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS).
+        observeWithColumns(['value']).
+        pipe(map((prefs) => prefs[0]?.value === 'true'));
 
     return {
         canUploadFiles,

--- a/app/queries/servers/preference.ts
+++ b/app/queries/servers/preference.ts
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 import {Database, Model, Q} from '@nozbe/watermelondb';
+import {of as of$, type Observable} from 'rxjs';
+import {map, switchMap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
@@ -117,4 +119,13 @@ export const queryEmojiPreferences = (database: Database, name: string) => {
 
 export const queryAdvanceSettingsPreferences = (database: Database, name?: string, value?: string) => {
     return queryPreferencesByCategoryAndName(database, ADVANCED_SETTINGS, name, value);
+};
+
+export const observePreferenceAsBool = (database: Database, category: string, name: string, defaultValue = false): Observable<boolean> => {
+    return queryPreferencesByCategoryAndName(database, category, name).
+        observe().
+        pipe(
+            switchMap((prefs) => (prefs.length ? prefs[0].observe() : of$(undefined))),
+            map((pref) => (pref ? pref.value === 'true' : defaultValue)),
+        );
 };

--- a/app/queries/servers/preference.ts
+++ b/app/queries/servers/preference.ts
@@ -2,8 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {Database, Model, Q} from '@nozbe/watermelondb';
-import {of as of$, type Observable} from 'rxjs';
-import {map, switchMap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
@@ -119,13 +117,4 @@ export const queryEmojiPreferences = (database: Database, name: string) => {
 
 export const queryAdvanceSettingsPreferences = (database: Database, name?: string, value?: string) => {
     return queryPreferencesByCategoryAndName(database, ADVANCED_SETTINGS, name, value);
-};
-
-export const observePreferenceAsBool = (database: Database, category: string, name: string, defaultValue = false): Observable<boolean> => {
-    return queryPreferencesByCategoryAndName(database, category, name).
-        observe().
-        pipe(
-            switchMap((prefs) => (prefs.length ? prefs[0].observe() : of$(undefined))),
-            map((pref) => (pref ? pref.value === 'true' : defaultValue)),
-        );
 };

--- a/app/screens/report_a_problem/index.test.tsx
+++ b/app/screens/report_a_problem/index.test.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Database} from '@nozbe/watermelondb';
+import {act} from '@testing-library/react-native';
 import React, {type ComponentProps} from 'react';
 import {View, Text} from 'react-native';
 
@@ -170,5 +171,39 @@ describe('screens/report_a_problem/index', () => {
         expect(getByTestId('isLicensed')).toHaveTextContent('false');
         expect(getByTestId('attachLogsEnabled')).toHaveTextContent('false');
         expect(getByTestId('currentUserId')).toHaveTextContent('user2');
+    });
+
+    it('should react to attachLogsEnabled preference value changes', async () => {
+        await operator.handlePreferences({
+            preferences: [{
+                user_id: 'user1',
+                category: 'advanced_settings',
+                name: 'attach_app_logs',
+                value: 'true',
+            }],
+            prepareRecordsOnly: false,
+        });
+
+        const Component = enhanced;
+        const {getByTestId} = renderWithEverything(<Component componentId={'ReportProblem'}/>, {database});
+
+        // * Initially true
+        expect(getByTestId('attachLogsEnabled')).toHaveTextContent('true');
+
+        // # Update the existing preference value from 'true' to 'false'
+        await act(async () => {
+            await operator.handlePreferences({
+                preferences: [{
+                    user_id: 'user1',
+                    category: 'advanced_settings',
+                    name: 'attach_app_logs',
+                    value: 'false',
+                }],
+                prepareRecordsOnly: false,
+            });
+        });
+
+        // * Should react to the value change
+        expect(getByTestId('attachLogsEnabled')).toHaveTextContent('false');
     });
 });

--- a/app/screens/report_a_problem/index.test.tsx
+++ b/app/screens/report_a_problem/index.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Database} from '@nozbe/watermelondb';
-import {act} from '@testing-library/react-native';
+import {act, waitFor} from '@testing-library/react-native';
 import React, {type ComponentProps} from 'react';
 import {View, Text} from 'react-native';
 
@@ -204,6 +204,8 @@ describe('screens/report_a_problem/index', () => {
         });
 
         // * Should react to the value change
-        expect(getByTestId('attachLogsEnabled')).toHaveTextContent('false');
+        await waitFor(() => {
+            expect(getByTestId('attachLogsEnabled')).toHaveTextContent('false');
+        });
     });
 });

--- a/app/screens/report_a_problem/index.ts
+++ b/app/screens/report_a_problem/index.ts
@@ -3,12 +3,11 @@
 
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import {withObservables} from '@nozbe/watermelondb/react';
-import {switchMap} from '@nozbe/watermelondb/utils/rx';
 import {of as of$} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {switchMap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
-import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
+import {observePreferenceAsBool} from '@queries/servers/preference';
 import {observeConfigBooleanValue, observeConfigValue, observeCurrentUserId, observeLicense, observeReportAProblemMetadata} from '@queries/servers/system';
 
 import ReportProblem from './report_problem';
@@ -23,9 +22,7 @@ const enhanced = withObservables([], ({database}) => {
         isLicensed: observeLicense(database).pipe(switchMap((license) => (license ? of$(license.IsLicensed) : of$(false)))),
         metadata: observeReportAProblemMetadata(database),
         currentUserId: observeCurrentUserId(database),
-        attachLogsEnabled: queryPreferencesByCategoryAndName(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS).
-            observe().
-            pipe(map((prefs) => prefs?.[0]?.value === 'true')),
+        attachLogsEnabled: observePreferenceAsBool(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS),
     };
 });
 

--- a/app/screens/report_a_problem/index.ts
+++ b/app/screens/report_a_problem/index.ts
@@ -4,10 +4,10 @@
 import {withDatabase} from '@nozbe/watermelondb/DatabaseProvider';
 import {withObservables} from '@nozbe/watermelondb/react';
 import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {map, switchMap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
-import {observePreferenceAsBool} from '@queries/servers/preference';
+import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeConfigBooleanValue, observeConfigValue, observeCurrentUserId, observeLicense, observeReportAProblemMetadata} from '@queries/servers/system';
 
 import ReportProblem from './report_problem';
@@ -22,7 +22,9 @@ const enhanced = withObservables([], ({database}) => {
         isLicensed: observeLicense(database).pipe(switchMap((license) => (license ? of$(license.IsLicensed) : of$(false)))),
         metadata: observeReportAProblemMetadata(database),
         currentUserId: observeCurrentUserId(database),
-        attachLogsEnabled: observePreferenceAsBool(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS),
+        attachLogsEnabled: queryPreferencesByCategoryAndName(database, Preferences.CATEGORIES.ADVANCED_SETTINGS, Preferences.ATTACH_APP_LOGS).
+            observeWithColumns(['value']).
+            pipe(map((prefs) => prefs[0]?.value === 'true')),
     };
 });
 

--- a/app/screens/report_a_problem/report_problem.tsx
+++ b/app/screens/report_a_problem/report_problem.tsx
@@ -25,7 +25,7 @@ import {getCommonStyleSheet} from './styles';
 
 import type {AvailableScreens} from '@typings/screens/navigation';
 import type {ReportAProblemMetadata} from '@typings/screens/report_a_problem';
-export const REPORT_PROBLEM_CLOSE_BUTTON_ID = 'close-report-problem';
+
 
 type Props = {
     componentId: AvailableScreens;
@@ -150,7 +150,10 @@ const ReportProblem = ({
     });
 
     return (
-        <View style={styles.container}>
+        <View
+            style={styles.container}
+            testID='report_problem.screen'
+        >
             <View style={styles.body}>
                 <ScrollView contentContainerStyle={styles.content}>
                     <View style={styles.detailsSection}>

--- a/app/screens/report_a_problem/report_problem.tsx
+++ b/app/screens/report_a_problem/report_problem.tsx
@@ -26,7 +26,6 @@ import {getCommonStyleSheet} from './styles';
 import type {AvailableScreens} from '@typings/screens/navigation';
 import type {ReportAProblemMetadata} from '@typings/screens/report_a_problem';
 
-
 type Props = {
     componentId: AvailableScreens;
     reportAProblemMail?: string;

--- a/detox/e2e/support/ui/screen/index.ts
+++ b/detox/e2e/support/ui/screen/index.ts
@@ -39,6 +39,7 @@ import PostOptionsScreen from './post_options';
 import PushNotificationSettingsScreen from './push_notification_settings';
 import ReactionsScreen from './reactions';
 import RecentMentionsScreen from './recent_mentions';
+import ReportProblemScreen from './report_problem';
 import SavedMessagesScreen from './saved_messages';
 import ScheduleMessageScreen from './scheduled_message_screen';
 import SearchMessagesScreen from './search_messages';
@@ -92,6 +93,7 @@ export {
     PushNotificationSettingsScreen,
     ReactionsScreen,
     RecentMentionsScreen,
+    ReportProblemScreen,
     SavedMessagesScreen,
     SearchMessagesScreen,
     SelectTimezoneScreen,

--- a/detox/e2e/support/ui/screen/report_problem.ts
+++ b/detox/e2e/support/ui/screen/report_problem.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {SettingsScreen} from '@support/ui/screen';
+import {timeouts} from '@support/utils';
+
+class ReportProblemScreen {
+    testID = {
+        reportProblemScreen: 'ReportProblem',
+        enableLogAttachmentsToggleOff: 'report_problem.enable_log_attachments.toggled.false.button',
+        enableLogAttachmentsToggleOn: 'report_problem.enable_log_attachments.toggled.true.button',
+        closeButton: 'close-report-problem',
+    };
+
+    reportProblemScreen = element(by.id(this.testID.reportProblemScreen));
+    enableLogAttachmentsToggleOff = element(by.id(this.testID.enableLogAttachmentsToggleOff));
+    enableLogAttachmentsToggleOn = element(by.id(this.testID.enableLogAttachmentsToggleOn));
+    closeButton = element(by.id(this.testID.closeButton));
+
+    toBeVisible = async () => {
+        await waitFor(this.reportProblemScreen).toExist().withTimeout(timeouts.TEN_SEC);
+
+        return this.reportProblemScreen;
+    };
+
+    open = async () => {
+        await SettingsScreen.reportProblemOption.tap();
+
+        return this.toBeVisible();
+    };
+
+    close = async () => {
+        await this.closeButton.tap();
+        await waitFor(this.reportProblemScreen).not.toBeVisible().withTimeout(timeouts.TEN_SEC);
+    };
+
+    enableAttachLogs = async () => {
+        await waitFor(this.enableLogAttachmentsToggleOff).toExist().withTimeout(timeouts.FOUR_SEC);
+        await this.enableLogAttachmentsToggleOff.tap();
+        await waitFor(this.enableLogAttachmentsToggleOn).toExist().withTimeout(timeouts.FOUR_SEC);
+    };
+
+    disableAttachLogs = async () => {
+        await waitFor(this.enableLogAttachmentsToggleOn).toExist().withTimeout(timeouts.FOUR_SEC);
+        await this.enableLogAttachmentsToggleOn.tap();
+        await waitFor(this.enableLogAttachmentsToggleOff).toExist().withTimeout(timeouts.FOUR_SEC);
+    };
+}
+
+const reportProblemScreen = new ReportProblemScreen();
+export default reportProblemScreen;

--- a/detox/e2e/support/ui/screen/report_problem.ts
+++ b/detox/e2e/support/ui/screen/report_problem.ts
@@ -6,16 +6,16 @@ import {timeouts} from '@support/utils';
 
 class ReportProblemScreen {
     testID = {
-        reportProblemScreen: 'ReportProblem',
+        reportProblemScreen: 'report_problem.screen',
+        backButton: 'screen.back.button',
         enableLogAttachmentsToggleOff: 'report_problem.enable_log_attachments.toggled.false.button',
         enableLogAttachmentsToggleOn: 'report_problem.enable_log_attachments.toggled.true.button',
-        closeButton: 'close-report-problem',
     };
 
     reportProblemScreen = element(by.id(this.testID.reportProblemScreen));
+    backButton = element(by.id(this.testID.backButton));
     enableLogAttachmentsToggleOff = element(by.id(this.testID.enableLogAttachmentsToggleOff));
     enableLogAttachmentsToggleOn = element(by.id(this.testID.enableLogAttachmentsToggleOn));
-    closeButton = element(by.id(this.testID.closeButton));
 
     toBeVisible = async () => {
         await waitFor(this.reportProblemScreen).toExist().withTimeout(timeouts.TEN_SEC);
@@ -29,8 +29,8 @@ class ReportProblemScreen {
         return this.toBeVisible();
     };
 
-    close = async () => {
-        await this.closeButton.tap();
+    back = async () => {
+        await this.backButton.tap();
         await waitFor(this.reportProblemScreen).not.toBeVisible().withTimeout(timeouts.TEN_SEC);
     };
 

--- a/detox/e2e/support/ui/screen/report_problem.ts
+++ b/detox/e2e/support/ui/screen/report_problem.ts
@@ -18,7 +18,7 @@ class ReportProblemScreen {
     enableLogAttachmentsToggleOn = element(by.id(this.testID.enableLogAttachmentsToggleOn));
 
     toBeVisible = async () => {
-        await waitFor(this.reportProblemScreen).toExist().withTimeout(timeouts.TEN_SEC);
+        await waitFor(this.reportProblemScreen).toBeVisible().withTimeout(timeouts.TEN_SEC);
 
         return this.reportProblemScreen;
     };

--- a/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
+++ b/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
@@ -1,0 +1,176 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {
+    Preference,
+    Setup,
+    System,
+} from '@support/server_api';
+import {
+    serverOneUrl,
+    siteOneUrl,
+} from '@support/test_config';
+import {
+    AccountScreen,
+    ChannelScreen,
+    HomeScreen,
+    LoginScreen,
+    ReportProblemScreen,
+    ServerScreen,
+    SettingsScreen,
+} from '@support/ui/screen';
+import {timeouts} from '@support/utils';
+import {expect} from 'detox';
+
+describe('Account - Attach App Logs', () => {
+    const serverOneDisplayName = 'Server 1';
+    let testUser: any;
+    let testChannel: any;
+
+    beforeAll(async () => {
+        // # Ensure AllowDownloadLogs is enabled on the server
+        await System.apiUpdateConfig(siteOneUrl, {
+            LogSettings: {
+                AllowDownloadLogs: true,
+            },
+        });
+
+        const {channel, user} = await Setup.apiInit(siteOneUrl);
+        testUser = user;
+        testChannel = channel;
+
+        // # Log in to server
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await LoginScreen.login(testUser);
+    });
+
+    afterAll(async () => {
+        // # Ensure preference is reset
+        await Preference.apiSaveUserPreferences(siteOneUrl, testUser.id, [{
+            user_id: testUser.id,
+            category: 'advanced_settings',
+            name: 'attach_app_logs',
+            value: 'false',
+        }]);
+
+        // # Log out
+        await HomeScreen.logout();
+    });
+
+    it('MM-T67856_1 - should show attach logs toggle on Report a Problem screen', async () => {
+        // # Navigate to Report a Problem screen
+        await AccountScreen.open();
+        await SettingsScreen.open();
+        await ReportProblemScreen.open();
+
+        // * Verify the attach logs toggle is visible and off by default
+        await expect(ReportProblemScreen.enableLogAttachmentsToggleOff).toExist();
+
+        // # Close Report a Problem and Settings screens
+        await ReportProblemScreen.close();
+        await SettingsScreen.close();
+    });
+
+    it('MM-T67856_2 - should show Attach app logs option in attachment menu after enabling toggle', async () => {
+        // # Navigate to Report a Problem screen and enable the toggle
+        await AccountScreen.open();
+        await SettingsScreen.open();
+        await ReportProblemScreen.open();
+        await ReportProblemScreen.enableAttachLogs();
+
+        // # Close Report a Problem and Settings screens
+        await ReportProblemScreen.close();
+        await SettingsScreen.close();
+
+        // # Open a channel
+        await ChannelScreen.open('channels', testChannel.name);
+
+        // # Tap the attachment action button to open attachment options
+        const attachmentAction = element(by.id('channel.post_draft.quick_actions.attachment_action'));
+        await attachmentAction.tap();
+
+        // * Wait for the attachment options bottom sheet to appear
+        const attachmentScreen = element(by.id('channel.post_draft.quick_actions.attachment_action.screen'));
+        await waitFor(attachmentScreen).toExist().withTimeout(timeouts.TEN_SEC);
+
+        // * Verify "Attach app logs" option is visible in the bottom sheet
+        await expect(element(by.id('file_attachment.attach_logs'))).toExist();
+
+        // # Close the attachment options bottom sheet
+        await attachmentScreen.swipe('down', 'fast', 0.5);
+
+        // # Go back to channel list
+        await ChannelScreen.back();
+    });
+
+    it('MM-T67856_3 - should not show Attach app logs option when toggle is off', async () => {
+        // # Navigate to Report a Problem screen and disable the toggle
+        await AccountScreen.open();
+        await SettingsScreen.open();
+        await ReportProblemScreen.open();
+        await ReportProblemScreen.disableAttachLogs();
+
+        // # Close Report a Problem and Settings screens
+        await ReportProblemScreen.close();
+        await SettingsScreen.close();
+
+        // # Open the channel
+        await ChannelScreen.open('channels', testChannel.name);
+
+        // # Tap the attachment action button to open attachment options
+        const attachmentAction = element(by.id('channel.post_draft.quick_actions.attachment_action'));
+        await attachmentAction.tap();
+
+        // * Wait for the attachment options bottom sheet to appear
+        const attachmentScreen = element(by.id('channel.post_draft.quick_actions.attachment_action.screen'));
+        await waitFor(attachmentScreen).toExist().withTimeout(timeouts.TEN_SEC);
+
+        // * Verify "Attach app logs" option is NOT visible
+        await expect(element(by.id('file_attachment.attach_logs'))).not.toExist();
+
+        // * Verify other attachment options are still present
+        await expect(element(by.id('file_attachment.photo_library'))).toExist();
+        await expect(element(by.id('file_attachment.attach_file'))).toExist();
+
+        // # Close the attachment options bottom sheet
+        await attachmentScreen.swipe('down', 'fast', 0.5);
+
+        // # Go back to channel list
+        await ChannelScreen.back();
+    });
+
+    it('MM-T67856_4 - should not show attach logs toggle when AllowDownloadLogs is disabled', async () => {
+        // # Disable AllowDownloadLogs server config
+        await System.apiUpdateConfig(siteOneUrl, {
+            LogSettings: {
+                AllowDownloadLogs: false,
+            },
+        });
+
+        // # Navigate to Report a Problem screen
+        await AccountScreen.open();
+        await SettingsScreen.open();
+        await ReportProblemScreen.open();
+
+        // * Verify the attach logs toggle is NOT visible
+        await expect(ReportProblemScreen.enableLogAttachmentsToggleOff).not.toExist();
+        await expect(ReportProblemScreen.enableLogAttachmentsToggleOn).not.toExist();
+
+        // # Close Report a Problem and Settings screens
+        await ReportProblemScreen.close();
+        await SettingsScreen.close();
+
+        // # Re-enable AllowDownloadLogs for other tests
+        await System.apiUpdateConfig(siteOneUrl, {
+            LogSettings: {
+                AllowDownloadLogs: true,
+            },
+        });
+    });
+});

--- a/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
+++ b/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
@@ -73,7 +73,7 @@ describe('Account - Attach App Logs', () => {
         await expect(ReportProblemScreen.enableLogAttachmentsToggleOff).toExist();
 
         // # Close Report a Problem and Settings screens
-        await ReportProblemScreen.close();
+        await ReportProblemScreen.back();
         await SettingsScreen.close();
     });
 
@@ -85,7 +85,7 @@ describe('Account - Attach App Logs', () => {
         await ReportProblemScreen.enableAttachLogs();
 
         // # Close Report a Problem and Settings screens
-        await ReportProblemScreen.close();
+        await ReportProblemScreen.back();
         await SettingsScreen.close();
 
         // # Open a channel
@@ -117,7 +117,7 @@ describe('Account - Attach App Logs', () => {
         await ReportProblemScreen.disableAttachLogs();
 
         // # Close Report a Problem and Settings screens
-        await ReportProblemScreen.close();
+        await ReportProblemScreen.back();
         await SettingsScreen.close();
 
         // # Open the channel
@@ -163,7 +163,7 @@ describe('Account - Attach App Logs', () => {
         await expect(ReportProblemScreen.enableLogAttachmentsToggleOn).not.toExist();
 
         // # Close Report a Problem and Settings screens
-        await ReportProblemScreen.close();
+        await ReportProblemScreen.back();
         await SettingsScreen.close();
 
         // # Re-enable AllowDownloadLogs for other tests

--- a/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
+++ b/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
@@ -18,6 +18,7 @@ import {
 } from '@support/test_config';
 import {
     AccountScreen,
+    ChannelListScreen,
     ChannelScreen,
     HomeScreen,
     LoginScreen,
@@ -34,9 +35,10 @@ describe('Account - Attach App Logs', () => {
     let testChannel: any;
 
     beforeAll(async () => {
-        // # Ensure AllowDownloadLogs is enabled on the server
+        // # Ensure AllowDownloadLogs is enabled on the server before login so the
+        //   client fetches the expected config on startup
         await System.apiUpdateConfig(siteOneUrl, {
-            LogSettings: {
+            SupportSettings: {
                 AllowDownloadLogs: true,
             },
         });
@@ -89,6 +91,7 @@ describe('Account - Attach App Logs', () => {
         await SettingsScreen.close();
 
         // # Open a channel
+        await ChannelListScreen.open();
         await ChannelScreen.open('channels', testChannel.name);
 
         // # Tap the attachment action button to open attachment options
@@ -121,6 +124,7 @@ describe('Account - Attach App Logs', () => {
         await SettingsScreen.close();
 
         // # Open the channel
+        await ChannelListScreen.open();
         await ChannelScreen.open('channels', testChannel.name);
 
         // # Tap the attachment action button to open attachment options
@@ -146,19 +150,21 @@ describe('Account - Attach App Logs', () => {
     });
 
     it('MM-T67856_4 - should not show attach logs toggle when AllowDownloadLogs is disabled', async () => {
-        // # Disable AllowDownloadLogs server config
+        // # Disable AllowDownloadLogs and reload so the client re-fetches the
+        //   updated config on startup
         await System.apiUpdateConfig(siteOneUrl, {
-            LogSettings: {
+            SupportSettings: {
                 AllowDownloadLogs: false,
             },
         });
+        await device.reloadReactNative();
 
         // # Navigate to Report a Problem screen
         await AccountScreen.open();
         await SettingsScreen.open();
         await ReportProblemScreen.open();
 
-        // * Verify the attach logs toggle is NOT visible
+        // * Verify the attach logs toggle is NOT visible in either state
         await expect(ReportProblemScreen.enableLogAttachmentsToggleOff).not.toExist();
         await expect(ReportProblemScreen.enableLogAttachmentsToggleOn).not.toExist();
 
@@ -166,9 +172,9 @@ describe('Account - Attach App Logs', () => {
         await ReportProblemScreen.back();
         await SettingsScreen.close();
 
-        // # Re-enable AllowDownloadLogs for other tests
+        // # Restore AllowDownloadLogs for subsequent test suites
         await System.apiUpdateConfig(siteOneUrl, {
-            LogSettings: {
+            SupportSettings: {
                 AllowDownloadLogs: true,
             },
         });

--- a/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
+++ b/detox/e2e/test/products/channels/account/attach_logs.e2e.ts
@@ -159,24 +159,27 @@ describe('Account - Attach App Logs', () => {
         });
         await device.reloadReactNative();
 
-        // # Navigate to Report a Problem screen
-        await AccountScreen.open();
-        await SettingsScreen.open();
-        await ReportProblemScreen.open();
+        try {
+            // # Navigate to Report a Problem screen
+            await AccountScreen.open();
+            await SettingsScreen.open();
+            await ReportProblemScreen.open();
 
-        // * Verify the attach logs toggle is NOT visible in either state
-        await expect(ReportProblemScreen.enableLogAttachmentsToggleOff).not.toExist();
-        await expect(ReportProblemScreen.enableLogAttachmentsToggleOn).not.toExist();
+            // * Verify the attach logs toggle is NOT visible in either state
+            await expect(ReportProblemScreen.enableLogAttachmentsToggleOff).not.toExist();
+            await expect(ReportProblemScreen.enableLogAttachmentsToggleOn).not.toExist();
 
-        // # Close Report a Problem and Settings screens
-        await ReportProblemScreen.back();
-        await SettingsScreen.close();
-
-        // # Restore AllowDownloadLogs for subsequent test suites
-        await System.apiUpdateConfig(siteOneUrl, {
-            SupportSettings: {
-                AllowDownloadLogs: true,
-            },
-        });
+            // # Close Report a Problem and Settings screens
+            await ReportProblemScreen.back();
+            await SettingsScreen.close();
+        } finally {
+            // # Restore AllowDownloadLogs for subsequent test suites even if
+            //   an assertion or interaction above fails
+            await System.apiUpdateConfig(siteOneUrl, {
+                SupportSettings: {
+                    AllowDownloadLogs: true,
+                },
+            });
+        }
     });
 });


### PR DESCRIPTION
#### Summary

Follow up of https://github.com/mattermost/mattermost-mobile/pull/9633

WatermelonDB query .observe() only emits when records enter/leave the result set, not when a field on an existing record changes. This caused the attach logs toggle to not sync across devices after the initial creation. Fix by subscribing to the individual record's .observe() via switchMap, which emits on any field change.

Also adds unit tests, E2E tests, and debug logging for preference WS events.

#### Ticket Link

MM-67856

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: pixel 8, ios sim

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
fix realtime UI update when changing the settings for the attach logs for debugging functionality
```
