### PR TITLE
[MM-68255] Enable mobile support for Managed Categories

### DIFF
--- a/app/actions/local/category.ts
+++ b/app/actions/local/category.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {CHANNELS_CATEGORY, DMS_CATEGORY, MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
+import {CHANNELS_CATEGORY, DMS_CATEGORY} from '@constants/categories';
 import DatabaseManager from '@database/manager';
-import {prepareCategoryChannels, queryCategoriesByTeamIds, getCategoryById, prepareCategoriesAndCategoriesChannels, queryCategoryChannelsByChannelId, getChannelCategory} from '@queries/servers/categories';
+import {prepareCategoryChannels, queryCategoriesByTeamIds, getCategoryById, prepareCategoriesAndCategoriesChannels, queryCategoryChannelsByChannelId, getManagedCategoryForChannel, getManagedCategoryChannelById} from '@queries/servers/categories';
 import {getConfigValue, getCurrentUserId} from '@queries/servers/system';
 import {queryMyTeams} from '@queries/servers/team';
 import {isDMorGM} from '@utils/channel';
@@ -120,18 +120,16 @@ export async function removeChannelFromManagedCategoryIfNeeded(serverUrl: string
             return;
         }
 
-        const category = await getChannelCategory(database, teamId, channelId);
-        if (!category || !category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
+        const category = await getManagedCategoryForChannel(database, teamId, channelId);
+        if (!category) {
             return;
         }
 
         const models: Model[] = [];
 
-        const categoryChannels = await queryCategoryChannelsByChannelId(database, channelId).fetch();
-        for (const cc of categoryChannels) {
-            if (cc.categoryId === category.id) {
-                models.push(cc.prepareDestroyPermanently());
-            }
+        const cc = await getManagedCategoryChannelById(database, teamId, channelId);
+        if (cc) {
+            models.push(cc.prepareDestroyPermanently());
         }
 
         const cwc = await category.toCategoryWithChannels();

--- a/app/actions/local/category.ts
+++ b/app/actions/local/category.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {CHANNELS_CATEGORY, DMS_CATEGORY} from '@constants/categories';
+import {CHANNELS_CATEGORY, DMS_CATEGORY, MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
 import DatabaseManager from '@database/manager';
-import {prepareCategoryChannels, queryCategoriesByTeamIds, getCategoryById, prepareCategoriesAndCategoriesChannels, queryCategoryChannelsByChannelId} from '@queries/servers/categories';
-import {getCurrentUserId} from '@queries/servers/system';
+import {prepareCategoryChannels, queryCategoriesByTeamIds, getCategoryById, prepareCategoriesAndCategoriesChannels, queryCategoryChannelsByChannelId, getChannelCategory} from '@queries/servers/categories';
+import {getConfigValue, getCurrentUserId} from '@queries/servers/system';
 import {queryMyTeams} from '@queries/servers/team';
 import {isDMorGM} from '@utils/channel';
+import {getFullErrorMessage} from '@utils/errors';
 import {logDebug, logError} from '@utils/log';
 
 import type {Database, Model} from '@nozbe/watermelondb';
@@ -108,6 +109,41 @@ export async function addChannelToDefaultCategory(serverUrl: string, channel: Ch
     } catch (error) {
         logError('Failed to add channel to default category', error);
         return {error};
+    }
+}
+
+export async function removeChannelFromManagedCategoryIfNeeded(serverUrl: string, teamId: string, channelId: string) {
+    try {
+        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
+        if (managedEnabled !== 'true') {
+            return;
+        }
+
+        const category = await getChannelCategory(database, teamId, channelId);
+        if (!category || !category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
+            return;
+        }
+
+        const models: Model[] = [];
+
+        const categoryChannels = await queryCategoryChannelsByChannelId(database, channelId).fetch();
+        for (const cc of categoryChannels) {
+            if (cc.categoryId === category.id) {
+                models.push(cc.prepareDestroyPermanently());
+            }
+        }
+
+        const cwc = await category.toCategoryWithChannels();
+        if (cwc.channel_ids.filter((id) => id !== channelId).length === 0) {
+            models.push(category.prepareDestroyPermanently());
+        }
+
+        if (models.length) {
+            await operator.batchRecords(models, 'removeChannelFromManagedCategory');
+        }
+    } catch (error) {
+        logDebug('[removeChannelFromManagedCategoryIfNeeded]', getFullErrorMessage(error));
     }
 }
 

--- a/app/actions/local/session/index.ts
+++ b/app/actions/local/session/index.ts
@@ -15,6 +15,7 @@ import WebsocketManager from '@managers/websocket_manager';
 import {getDeviceToken} from '@queries/app/global';
 import {getExpiredSession} from '@queries/servers/system';
 import {getCurrentUser} from '@queries/servers/user';
+import EphemeralStore from '@store/ephemeral_store';
 import {deleteFileCache, deleteFileCacheByDir} from '@utils/file';
 import {logError, logWarning} from '@utils/log';
 import {clearCookiesForServer, getCSRFFromCookie, urlSafeBase64Encode} from '@utils/security';
@@ -145,6 +146,8 @@ export const terminateSession = async (serverUrl: string, removeServer: boolean)
     await safeExecute('invalidateWebsocketClient', async () => {
         await WebsocketManager.invalidateClient(serverUrl);
     });
+
+    EphemeralStore.clearManagedCategoryPropertyIds(serverUrl);
 
     // Remove push disabled acknowledgment (non-critical)
     if (removeServer) {

--- a/app/actions/remote/category.test.ts
+++ b/app/actions/remote/category.test.ts
@@ -43,7 +43,7 @@ describe('fetchCategories', () => {
         const result = await fetchCategories(serverUrl, teamId);
 
         expect(NetworkManager.getClient).toHaveBeenCalledWith(serverUrl);
-        expect(mockClient.getCategories).toHaveBeenCalledWith('me', teamId);
+        expect(mockClient.getCategories).toHaveBeenCalledWith('me', teamId, undefined);
         expect(storeCategories).toHaveBeenCalledWith(serverUrl, mockCategories, false);
         expect(result).toEqual({categories: mockCategories});
     });
@@ -57,7 +57,7 @@ describe('fetchCategories', () => {
         const result = await fetchCategories(serverUrl, teamId, false, true);
 
         expect(NetworkManager.getClient).toHaveBeenCalledWith(serverUrl);
-        expect(mockClient.getCategories).toHaveBeenCalledWith('me', teamId);
+        expect(mockClient.getCategories).toHaveBeenCalledWith('me', teamId, undefined);
         expect(result).toEqual({categories: mockCategories});
     });
 
@@ -71,7 +71,7 @@ describe('fetchCategories', () => {
         const result = await fetchCategories(serverUrl, teamId);
 
         expect(NetworkManager.getClient).toHaveBeenCalledWith(serverUrl);
-        expect(mockClient.getCategories).toHaveBeenCalledWith('me', teamId);
+        expect(mockClient.getCategories).toHaveBeenCalledWith('me', teamId, undefined);
         expect(logDebug).toHaveBeenCalledWith('error on fetchCategories', 'Full error message');
         expect(result).toEqual({error});
     });

--- a/app/actions/remote/category.ts
+++ b/app/actions/remote/category.ts
@@ -112,33 +112,38 @@ export async function addChannelToManagedCategoryIfNeeded(serverUrl: string, cha
 }
 
 export async function removeChannelFromManagedCategoryIfNeeded(serverUrl: string, teamId: string, channelId: string) {
-    const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-    const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
-    if (managedEnabled !== 'true') {
-        return;
-    }
-
-    const category = await getChannelCategory(database, teamId, channelId);
-    if (!category || !category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
-        return;
-    }
-
-    const models: Model[] = [];
-
-    const categoryChannels = await queryCategoryChannelsByChannelId(database, channelId).fetch();
-    for (const cc of categoryChannels) {
-        if (cc.categoryId === category.id) {
-            models.push(cc.prepareDestroyPermanently());
+    try {
+        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
+        if (managedEnabled !== 'true') {
+            return;
         }
-    }
 
-    const cwc = await category.toCategoryWithChannels();
-    if (cwc.channel_ids.filter((id) => id !== channelId).length === 0) {
-        models.push(category.prepareDestroyPermanently());
-    }
+        const category = await getChannelCategory(database, teamId, channelId);
+        if (!category || !category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
+            return;
+        }
 
-    if (models.length) {
-        await operator.batchRecords(models, 'removeChannelFromManagedCategory');
+        const models: Model[] = [];
+
+        const categoryChannels = await queryCategoryChannelsByChannelId(database, channelId).fetch();
+        for (const cc of categoryChannels) {
+            if (cc.categoryId === category.id) {
+                models.push(cc.prepareDestroyPermanently());
+            }
+        }
+
+        const cwc = await category.toCategoryWithChannels();
+        if (cwc.channel_ids.filter((id) => id !== channelId).length === 0) {
+            models.push(category.prepareDestroyPermanently());
+        }
+
+        if (models.length) {
+            await operator.batchRecords(models, 'removeChannelFromManagedCategory');
+        }
+    } catch (error) {
+        logDebug('[removeChannelFromManagedCategoryIfNeeded]', getFullErrorMessage(error));
+        forceLogoutIfNecessary(serverUrl, error);
     }
 }
 

--- a/app/actions/remote/category.ts
+++ b/app/actions/remote/category.ts
@@ -7,7 +7,7 @@ import {CHANNELS_CATEGORY, DMS_CATEGORY, FAVORITES_CATEGORY, MANAGED_CHANNEL_CAT
 import DatabaseManager from '@database/manager';
 import {makeManagedCategoryId, mergeManagedMappingsIntoSidebarCategories} from '@helpers/sidebar/managed_categories_merge';
 import NetworkManager from '@managers/network_manager';
-import {getCategoryById, getChannelCategory, queryCategoriesByTeamIds, queryCategoryChannelsByChannelId} from '@queries/servers/categories';
+import {getCategoryById, getChannelCategory, queryCategoriesByTeamIds} from '@queries/servers/categories';
 import {getChannelById} from '@queries/servers/channel';
 import {getConfigValue, getCurrentTeamId} from '@queries/servers/system';
 import {isDMorGM} from '@utils/channel';
@@ -17,7 +17,6 @@ import {showFavoriteChannelSnackbar} from '@utils/snack_bar';
 
 import {forceLogoutIfNecessary} from './session';
 
-import type {Model} from '@nozbe/watermelondb';
 import type ChannelModel from '@typings/database/models/servers/channel';
 
 export type CategoriesRequest = {
@@ -107,42 +106,6 @@ export async function addChannelToManagedCategoryIfNeeded(serverUrl: string, cha
         await storeCategories(serverUrl, [managedCwc]);
     } catch (error) {
         logDebug('[addChannelToManagedCategoryIfNeeded]', getFullErrorMessage(error));
-        forceLogoutIfNecessary(serverUrl, error);
-    }
-}
-
-export async function removeChannelFromManagedCategoryIfNeeded(serverUrl: string, teamId: string, channelId: string) {
-    try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
-        if (managedEnabled !== 'true') {
-            return;
-        }
-
-        const category = await getChannelCategory(database, teamId, channelId);
-        if (!category || !category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
-            return;
-        }
-
-        const models: Model[] = [];
-
-        const categoryChannels = await queryCategoryChannelsByChannelId(database, channelId).fetch();
-        for (const cc of categoryChannels) {
-            if (cc.categoryId === category.id) {
-                models.push(cc.prepareDestroyPermanently());
-            }
-        }
-
-        const cwc = await category.toCategoryWithChannels();
-        if (cwc.channel_ids.filter((id) => id !== channelId).length === 0) {
-            models.push(category.prepareDestroyPermanently());
-        }
-
-        if (models.length) {
-            await operator.batchRecords(models, 'removeChannelFromManagedCategory');
-        }
-    } catch (error) {
-        logDebug('[removeChannelFromManagedCategoryIfNeeded]', getFullErrorMessage(error));
         forceLogoutIfNecessary(serverUrl, error);
     }
 }

--- a/app/actions/remote/category.ts
+++ b/app/actions/remote/category.ts
@@ -56,13 +56,13 @@ export async function addChannelToManagedCategoryIfNeeded(serverUrl: string, cha
     if (!teamId || isDMorGM(channel)) {
         return;
     }
-    const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-    const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
-    if (managedEnabled !== 'true') {
-        return;
-    }
-    const channelId = channel.id;
     try {
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
+        if (managedEnabled !== 'true') {
+            return;
+        }
+        const channelId = channel.id;
         const client = NetworkManager.getClient(serverUrl);
         const values = await client.getPropertyValues<string>(
             MANAGED_CHANNEL_CATEGORIES_GROUP,
@@ -87,8 +87,13 @@ export async function addChannelToManagedCategoryIfNeeded(serverUrl: string, cha
         } else {
             channelIds = [channelId];
             const allCategories = await queryCategoriesByTeamIds(database, [teamId]).fetch();
-            const managedCount = allCategories.filter((c) => c.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)).length;
-            sortOrder = (-1000 + managedCount) * 10;
+            const managedNames = allCategories.
+                filter((c) => c.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)).
+                map((c) => c.displayName);
+            managedNames.push(categoryName);
+            managedNames.sort((a, b) => a.localeCompare(b, undefined, {numeric: true}));
+            const index = managedNames.indexOf(categoryName);
+            sortOrder = (-1000 + index) * 10;
         }
 
         const managedCwc: CategoryWithChannels = {

--- a/app/actions/remote/category.ts
+++ b/app/actions/remote/category.ts
@@ -3,27 +3,42 @@
 
 import {storeCategories} from '@actions/local/category';
 import {General} from '@constants';
-import {CHANNELS_CATEGORY, DMS_CATEGORY, FAVORITES_CATEGORY} from '@constants/categories';
+import {CHANNELS_CATEGORY, DMS_CATEGORY, FAVORITES_CATEGORY, MANAGED_CHANNEL_CATEGORIES_GROUP, MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
 import DatabaseManager from '@database/manager';
+import {makeManagedCategoryId, mergeManagedMappingsIntoSidebarCategories} from '@helpers/sidebar/managed_categories_merge';
 import NetworkManager from '@managers/network_manager';
-import {getChannelCategory, queryCategoriesByTeamIds} from '@queries/servers/categories';
+import {getCategoryById, getChannelCategory, queryCategoriesByTeamIds, queryCategoryChannelsByChannelId} from '@queries/servers/categories';
 import {getChannelById} from '@queries/servers/channel';
-import {getCurrentTeamId} from '@queries/servers/system';
+import {getConfigValue, getCurrentTeamId} from '@queries/servers/system';
+import {isDMorGM} from '@utils/channel';
 import {getFullErrorMessage} from '@utils/errors';
 import {logDebug} from '@utils/log';
 import {showFavoriteChannelSnackbar} from '@utils/snack_bar';
 
 import {forceLogoutIfNecessary} from './session';
 
+import type {Model} from '@nozbe/watermelondb';
+import type ChannelModel from '@typings/database/models/servers/channel';
+
 export type CategoriesRequest = {
      categories?: CategoryWithChannels[];
      error?: unknown;
  }
 
-export const fetchCategories = async (serverUrl: string, teamId: string, prune = false, fetchOnly = false): Promise<CategoriesRequest> => {
+export const fetchCategories = async (serverUrl: string, teamId: string, prune = false, fetchOnly = false, groupLabel?: RequestGroupLabel): Promise<CategoriesRequest> => {
     try {
         const client = NetworkManager.getClient(serverUrl);
-        const {categories} = await client.getCategories('me', teamId);
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const managedCategoriesEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
+
+        const {categories: nonManagedCategories} = await client.getCategories('me', teamId, groupLabel);
+        let categories = nonManagedCategories;
+        if (managedCategoriesEnabled === 'true') {
+            const mappings = await client.getManagedCategories(teamId, groupLabel);
+            if (mappings) {
+                categories = await mergeManagedMappingsIntoSidebarCategories(database, teamId, nonManagedCategories, mappings);
+            }
+        }
 
         if (!fetchOnly) {
             storeCategories(serverUrl, categories, prune);
@@ -36,6 +51,96 @@ export const fetchCategories = async (serverUrl: string, teamId: string, prune =
         return {error};
     }
 };
+
+export async function addChannelToManagedCategoryIfNeeded(serverUrl: string, channel: Channel | ChannelModel) {
+    const teamId = 'teamId' in channel ? channel.teamId : channel.team_id;
+    if (!teamId || isDMorGM(channel)) {
+        return;
+    }
+    const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+    const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
+    if (managedEnabled !== 'true') {
+        return;
+    }
+    const channelId = channel.id;
+    try {
+        const client = NetworkManager.getClient(serverUrl);
+        const values = await client.getPropertyValues<string>(
+            MANAGED_CHANNEL_CATEGORIES_GROUP,
+            'channel',
+            channelId,
+        );
+        const categoryValue = values[0];
+        if (!categoryValue?.value || String(categoryValue.value).length === 0) {
+            return;
+        }
+
+        const categoryName = String(categoryValue.value);
+        const managedCategoryId = makeManagedCategoryId(teamId, categoryName);
+        const existingCategory = await getCategoryById(database, managedCategoryId);
+
+        let channelIds: string[];
+        let sortOrder: number;
+        if (existingCategory) {
+            const cwc = await existingCategory.toCategoryWithChannels();
+            channelIds = cwc.channel_ids.includes(channelId) ? cwc.channel_ids : [...cwc.channel_ids, channelId];
+            sortOrder = existingCategory.sortOrder;
+        } else {
+            channelIds = [channelId];
+            const allCategories = await queryCategoriesByTeamIds(database, [teamId]).fetch();
+            const managedCount = allCategories.filter((c) => c.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)).length;
+            sortOrder = (-1000 + managedCount) * 10;
+        }
+
+        const managedCwc: CategoryWithChannels = {
+            id: managedCategoryId,
+            team_id: teamId,
+            display_name: categoryName,
+            sort_order: sortOrder,
+            sorting: 'alpha',
+            type: 'custom',
+            muted: false,
+            collapsed: existingCategory?.collapsed ?? false,
+            channel_ids: channelIds,
+        };
+
+        await storeCategories(serverUrl, [managedCwc]);
+    } catch (error) {
+        logDebug('[addChannelToManagedCategoryIfNeeded]', getFullErrorMessage(error));
+        forceLogoutIfNecessary(serverUrl, error);
+    }
+}
+
+export async function removeChannelFromManagedCategoryIfNeeded(serverUrl: string, teamId: string, channelId: string) {
+    const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+    const managedEnabled = await getConfigValue(database, 'EnableManagedChannelCategories');
+    if (managedEnabled !== 'true') {
+        return;
+    }
+
+    const category = await getChannelCategory(database, teamId, channelId);
+    if (!category || !category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
+        return;
+    }
+
+    const models: Model[] = [];
+
+    const categoryChannels = await queryCategoryChannelsByChannelId(database, channelId).fetch();
+    for (const cc of categoryChannels) {
+        if (cc.categoryId === category.id) {
+            models.push(cc.prepareDestroyPermanently());
+        }
+    }
+
+    const cwc = await category.toCategoryWithChannels();
+    if (cwc.channel_ids.filter((id) => id !== channelId).length === 0) {
+        models.push(category.prepareDestroyPermanently());
+    }
+
+    if (models.length) {
+        await operator.batchRecords(models, 'removeChannelFromManagedCategory');
+    }
+}
 
 export const toggleFavoriteChannel = async (serverUrl: string, channelId: string, showSnackBar = false) => {
     try {

--- a/app/actions/remote/category.ts
+++ b/app/actions/remote/category.ts
@@ -5,7 +5,7 @@ import {storeCategories} from '@actions/local/category';
 import {General} from '@constants';
 import {CHANNELS_CATEGORY, DMS_CATEGORY, FAVORITES_CATEGORY, MANAGED_CHANNEL_CATEGORIES_GROUP, MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
 import DatabaseManager from '@database/manager';
-import {makeManagedCategoryId, mergeManagedMappingsIntoSidebarCategories} from '@helpers/sidebar/managed_categories_merge';
+import {computeManagedSortOrder, fetchManagedCategoryPropertyIds, makeManagedCategoryId, mergeManagedMappingsIntoSidebarCategories} from '@helpers/sidebar/managed_categories_merge';
 import NetworkManager from '@managers/network_manager';
 import {getCategoryById, getChannelCategory, queryCategoriesByTeamIds} from '@queries/servers/categories';
 import {getChannelById} from '@queries/servers/channel';
@@ -33,10 +33,9 @@ export const fetchCategories = async (serverUrl: string, teamId: string, prune =
         const {categories: nonManagedCategories} = await client.getCategories('me', teamId, groupLabel);
         let categories = nonManagedCategories;
         if (managedCategoriesEnabled === 'true') {
+            fetchManagedCategoryPropertyIds(serverUrl);
             const mappings = await client.getManagedCategories(teamId, groupLabel);
-            if (mappings) {
-                categories = await mergeManagedMappingsIntoSidebarCategories(database, teamId, nonManagedCategories, mappings);
-            }
+            categories = await mergeManagedMappingsIntoSidebarCategories(database, teamId, nonManagedCategories, mappings);
         }
 
         if (!fetchOnly) {
@@ -78,23 +77,41 @@ export async function addChannelToManagedCategoryIfNeeded(serverUrl: string, cha
         const managedCategoryId = makeManagedCategoryId(teamId, categoryName);
         const existingCategory = await getCategoryById(database, managedCategoryId);
 
+        const categoriesToStore: CategoryWithChannels[] = [];
         let channelIds: string[];
-        let sortOrder: number;
+
         if (existingCategory) {
             const cwc = await existingCategory.toCategoryWithChannels();
             channelIds = cwc.channel_ids.includes(channelId) ? cwc.channel_ids : [...cwc.channel_ids, channelId];
-            sortOrder = existingCategory.sortOrder;
         } else {
             channelIds = [channelId];
-            const allCategories = await queryCategoriesByTeamIds(database, [teamId]).fetch();
-            const managedNames = allCategories.
-                filter((c) => c.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)).
-                map((c) => c.displayName);
-            managedNames.push(categoryName);
-            managedNames.sort((a, b) => a.localeCompare(b, undefined, {numeric: true}));
-            const index = managedNames.indexOf(categoryName);
-            sortOrder = (-1000 + index) * 10;
         }
+
+        const allCategories = await queryCategoriesByTeamIds(database, [teamId]).fetch();
+        const managedCategories = allCategories.filter((c) => c.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX));
+        const managedNames = managedCategories.map((c) => c.displayName);
+        if (!existingCategory) {
+            managedNames.push(categoryName);
+        }
+        managedNames.sort((a, b) => a.localeCompare(b, undefined, {numeric: true}));
+        const sortedNames = [...new Set(managedNames)];
+        const sortOrder = computeManagedSortOrder(sortedNames.indexOf(categoryName));
+
+        const reorderPromises = managedCategories.map(async (cat) => {
+            const idx = sortedNames.indexOf(cat.displayName);
+            if (idx >= 0) {
+                const newOrder = computeManagedSortOrder(idx);
+                if (cat.sortOrder !== newOrder) {
+                    const cwc = await cat.toCategoryWithChannels();
+                    return {...cwc, sort_order: newOrder};
+                }
+            }
+            return undefined;
+        });
+        const reordered = (await Promise.all(reorderPromises)).filter(
+            (c): c is CategoryWithChannels => c !== undefined,
+        );
+        categoriesToStore.push(...reordered);
 
         const managedCwc: CategoryWithChannels = {
             id: managedCategoryId,
@@ -107,8 +124,9 @@ export async function addChannelToManagedCategoryIfNeeded(serverUrl: string, cha
             collapsed: existingCategory?.collapsed ?? false,
             channel_ids: channelIds,
         };
+        categoriesToStore.push(managedCwc);
 
-        await storeCategories(serverUrl, [managedCwc]);
+        await storeCategories(serverUrl, categoriesToStore);
     } catch (error) {
         logDebug('[addChannelToManagedCategoryIfNeeded]', getFullErrorMessage(error));
         forceLogoutIfNecessary(serverUrl, error);

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -4,7 +4,7 @@
 /* eslint-disable max-lines */
 import {DeviceEventEmitter} from 'react-native';
 
-import {addChannelToDefaultCategory, handleConvertedGMCategories, storeCategories} from '@actions/local/category';
+import {addChannelToDefaultCategory, handleConvertedGMCategories, removeChannelFromManagedCategoryIfNeeded, storeCategories} from '@actions/local/category';
 import {markChannelAsViewed, removeCurrentUserFromChannel, setChannelDeleteAt, storeAllMyChannels, storeMyChannelsForTeam, switchToChannel, deletePostsForChannel} from '@actions/local/channel';
 import {switchToGlobalDrafts} from '@actions/local/draft';
 import {switchToGlobalThreads} from '@actions/local/thread';
@@ -32,7 +32,7 @@ import {logDebug, logError, logInfo} from '@utils/log';
 import {showMuteChannelSnackbar} from '@utils/snack_bar';
 import {displayGroupMessageName, displayUsername} from '@utils/user';
 
-import {addChannelToManagedCategoryIfNeeded, fetchCategories, removeChannelFromManagedCategoryIfNeeded} from './category';
+import {addChannelToManagedCategoryIfNeeded, fetchCategories} from './category';
 import {fetchChannelBookmarks} from './channel_bookmark';
 import {fetchGroupsForChannelIfConstrained} from './groups';
 import {fetchPostsForChannel} from './post';

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -323,16 +323,16 @@ export async function leaveChannel(serverUrl: string, channelId: string) {
             }
         }
 
+        if (teamIdForManagedCategories && channelBeforeLeave && !isDMorGM(channelBeforeLeave)) {
+            await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamIdForManagedCategories, channelId);
+        }
+
         const {models: removeUserModels} = await removeCurrentUserFromChannel(serverUrl, channelId, true);
         if (removeUserModels) {
             models.push(...removeUserModels);
         }
 
         await operator.batchRecords(models, 'leaveChannel');
-
-        if (teamIdForManagedCategories && channelBeforeLeave && !isDMorGM(channelBeforeLeave)) {
-            await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamIdForManagedCategories, channelId);
-        }
 
         if (isTabletDevice) {
             switchToLastChannel(serverUrl);

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -32,6 +32,7 @@ import {logDebug, logError, logInfo} from '@utils/log';
 import {showMuteChannelSnackbar} from '@utils/snack_bar';
 import {displayGroupMessageName, displayUsername} from '@utils/user';
 
+import {addChannelToManagedCategoryIfNeeded, fetchCategories, removeChannelFromManagedCategoryIfNeeded} from './category';
 import {fetchChannelBookmarks} from './channel_bookmark';
 import {fetchGroupsForChannelIfConstrained} from './groups';
 import {fetchPostsForChannel} from './post';
@@ -310,6 +311,9 @@ export async function leaveChannel(serverUrl: string, channelId: string) {
             return {error: 'current user not found'};
         }
 
+        const channelBeforeLeave = await getChannelById(database, channelId);
+        const teamIdForManagedCategories = channelBeforeLeave?.teamId;
+
         await client.removeFromChannel(user.id, channelId);
 
         if (user.isGuest) {
@@ -325,6 +329,10 @@ export async function leaveChannel(serverUrl: string, channelId: string) {
         }
 
         await operator.batchRecords(models, 'leaveChannel');
+
+        if (teamIdForManagedCategories && channelBeforeLeave && !isDMorGM(channelBeforeLeave)) {
+            await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamIdForManagedCategories, channelId);
+        }
 
         if (isTabletDevice) {
             switchToLastChannel(serverUrl);
@@ -441,7 +449,6 @@ export async function fetchAllMyChannelsForAllTeams(serverUrl: string, since: nu
             fetchAllMemberships(),
         ];
         const [channels, memberships] = await Promise.all(promises);
-        const categoriesPromises = [];
 
         const teamIdsSet = channels.reduce<Set<string>>((set, c) => {
             if (c.team_id) {
@@ -450,15 +457,9 @@ export async function fetchAllMyChannelsForAllTeams(serverUrl: string, since: nu
             return set;
         }, new Set());
 
-        for (const teamId of teamIdsSet) {
-            categoriesPromises.push(client.getCategories('me', teamId, groupLabel));
-        }
-
-        const categories: CategoryWithChannels[] = [];
-        const results = await Promise.all(categoriesPromises);
-        for (const result of results) {
-            categories.push(...result.categories);
-        }
+        const teamIds = Array.from(teamIdsSet);
+        const categoriesResults = await Promise.all(teamIds.map((tid) => fetchCategories(serverUrl, tid, false, true, groupLabel)));
+        const categories: CategoryWithChannels[] = categoriesResults.flatMap((r) => r.categories ?? []);
 
         if (!fetchOnly) {
             const {models: chModels} = await storeAllMyChannels(serverUrl, channels, memberships, isCRTEnabled, true);
@@ -492,10 +493,10 @@ export async function fetchMyChannelsForTeam(
         }
         const client = NetworkManager.getClient(serverUrl);
         const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const [allChannels, channelMemberships, categoriesWithOrder] = await Promise.all([
+        const [allChannels, channelMemberships, categoriesResult] = await Promise.all([
             client.getMyChannels(teamId, includeDeleted, since, groupLabel),
             client.getMyChannelMembers(teamId, groupLabel),
-            client.getCategories('me', teamId, groupLabel),
+            fetchCategories(serverUrl, teamId, false, true, groupLabel),
         ]);
 
         let channels = allChannels;
@@ -505,7 +506,7 @@ export async function fetchMyChannelsForTeam(
         }
 
         const channelIds = new Set<string>(channels.map((c) => c.id));
-        const {categories} = categoriesWithOrder;
+        const categories = categoriesResult.categories ?? [];
         memberships = memberships.reduce((result: ChannelMembership[], m: ChannelMembership) => {
             if (channelIds.has(m.channel_id)) {
                 result.push(m);
@@ -707,6 +708,7 @@ export async function joinChannel(serverUrl: string, teamId: string, channelId?:
                     }
                 }
             }
+            await addChannelToManagedCategoryIfNeeded(serverUrl, channel);
         }
     } catch (error) {
         logDebug('error on joinChannel', getFullErrorMessage(error));

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -4,7 +4,7 @@
 /* eslint-disable max-lines */
 import {DeviceEventEmitter} from 'react-native';
 
-import {addChannelToDefaultCategory, handleConvertedGMCategories, removeChannelFromManagedCategoryIfNeeded, storeCategories} from '@actions/local/category';
+import {addChannelToDefaultCategory, removeChannelFromManagedCategoryIfNeeded, handleConvertedGMCategories, storeCategories} from '@actions/local/category';
 import {markChannelAsViewed, removeCurrentUserFromChannel, setChannelDeleteAt, storeAllMyChannels, storeMyChannelsForTeam, switchToChannel, deletePostsForChannel} from '@actions/local/channel';
 import {switchToGlobalDrafts} from '@actions/local/draft';
 import {switchToGlobalThreads} from '@actions/local/thread';
@@ -312,19 +312,18 @@ export async function leaveChannel(serverUrl: string, channelId: string) {
         }
 
         const channelBeforeLeave = await getChannelById(database, channelId);
-        const teamIdForManagedCategories = channelBeforeLeave?.teamId;
 
         await client.removeFromChannel(user.id, channelId);
+
+        if (channelBeforeLeave?.teamId) {
+            await removeChannelFromManagedCategoryIfNeeded(serverUrl, channelBeforeLeave.teamId, channelId);
+        }
 
         if (user.isGuest) {
             const {models: updateVisibleModels} = await updateUsersNoLongerVisible(serverUrl, true);
             if (updateVisibleModels) {
                 models.push(...updateVisibleModels);
             }
-        }
-
-        if (teamIdForManagedCategories && channelBeforeLeave && !isDMorGM(channelBeforeLeave)) {
-            await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamIdForManagedCategories, channelId);
         }
 
         const {models: removeUserModels} = await removeCurrentUserFromChannel(serverUrl, channelId, true);
@@ -1335,11 +1334,16 @@ export const archiveChannel = async (serverUrl: string, channelId: string) => {
         const client = NetworkManager.getClient(serverUrl);
         const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const config = await getConfig(database);
+        const channelBeforeArchive = await getChannelById(database, channelId);
         await client.deleteChannel(channelId);
         if (config?.ExperimentalViewArchivedChannels === 'true') {
             await setChannelDeleteAt(serverUrl, channelId, Date.now());
         } else {
             removeCurrentUserFromChannel(serverUrl, channelId);
+        }
+
+        if (channelBeforeArchive?.teamId) {
+            await removeChannelFromManagedCategoryIfNeeded(serverUrl, channelBeforeArchive.teamId, channelId);
         }
 
         return {};

--- a/app/actions/websocket/channel.test.ts
+++ b/app/actions/websocket/channel.test.ts
@@ -25,6 +25,7 @@ import type ChannelModel from '@typings/database/models/servers/channel';
 jest.mock('@database/manager');
 jest.mock('@store/ephemeral_store');
 jest.mock('@actions/local/category');
+jest.mock('@actions/remote/category');
 jest.mock('@actions/remote/channel');
 jest.mock('@actions/remote/role');
 jest.mock('@actions/remote/post');

--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {addChannelToDefaultCategory, handleConvertedGMCategories, removeChannelFromManagedCategoryIfNeeded} from '@actions/local/category';
+import {addChannelToDefaultCategory, removeChannelFromManagedCategoryIfNeeded, handleConvertedGMCategories} from '@actions/local/category';
 import {
     markChannelAsViewed, removeCurrentUserFromChannel, setChannelDeleteAt,
     storeMyChannelsForTeam, updateChannelInfoFromChannel, updateMyChannelFromWebsocket, deletePostsForChannel,
@@ -22,7 +22,6 @@ import {getConfig, getCurrentChannelId, getCurrentTeamId, setCurrentTeamId} from
 import {getCurrentUser, getTeammateNameDisplay, getUserById} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
 import MyChannelModel from '@typings/database/models/servers/my_channel';
-import {isDMorGM} from '@utils/channel';
 import {logDebug} from '@utils/log';
 
 import type {Model} from '@nozbe/watermelondb';
@@ -58,7 +57,10 @@ export async function handleChannelCreatedEvent(serverUrl: string, msg: any) {
                 }
             }
         }
-        operator.batchRecords(models, 'handleChannelCreatedEvent');
+        await operator.batchRecords(models, 'handleChannelCreatedEvent');
+        if (channels?.[0]) {
+            await addChannelToManagedCategoryIfNeeded(serverUrl, channels[0]);
+        }
     } catch {
         // do nothing
     }
@@ -397,10 +399,8 @@ export async function handleUserRemovedFromChannelEvent(serverUrl: string, msg: 
 
         if (user.id === userId) {
             const channelBeforeRemove = await getChannelById(database, channelId);
-            const managedTeamId = channelBeforeRemove?.teamId;
-
-            if (managedTeamId && channelBeforeRemove && !isDMorGM(channelBeforeRemove)) {
-                await removeChannelFromManagedCategoryIfNeeded(serverUrl, managedTeamId, channelId);
+            if (channelBeforeRemove?.teamId) {
+                await removeChannelFromManagedCategoryIfNeeded(serverUrl, channelBeforeRemove.teamId, channelId);
             }
 
             const currentChannelId = await getCurrentChannelId(database);
@@ -439,6 +439,8 @@ export async function handleChannelDeletedEvent(serverUrl: string, msg: WebSocke
             return;
         }
 
+        const channelBeforeDelete = await getChannelById(database, channelId);
+
         await setChannelDeleteAt(serverUrl, channelId, deleteAt);
         if (user.isGuest) {
             updateUsersNoLongerVisible(serverUrl);
@@ -452,6 +454,10 @@ export async function handleChannelDeletedEvent(serverUrl: string, msg: WebSocke
                 await handleKickFromChannel(serverUrl, channelId, Events.CHANNEL_ARCHIVED);
             }
             await removeCurrentUserFromChannel(serverUrl, channelId);
+        }
+
+        if (channelBeforeDelete?.teamId) {
+            await removeChannelFromManagedCategoryIfNeeded(serverUrl, channelBeforeDelete.teamId, channelId);
         }
     } catch {
         // Do nothing

--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -399,6 +399,10 @@ export async function handleUserRemovedFromChannelEvent(serverUrl: string, msg: 
             const channelBeforeRemove = await getChannelById(database, channelId);
             const managedTeamId = channelBeforeRemove?.teamId;
 
+            if (managedTeamId && channelBeforeRemove && !isDMorGM(channelBeforeRemove)) {
+                await removeChannelFromManagedCategoryIfNeeded(serverUrl, managedTeamId, channelId);
+            }
+
             const currentChannelId = await getCurrentChannelId(database);
             if (currentChannelId && currentChannelId === channelId) {
                 await handleKickFromChannel(serverUrl, currentChannelId);
@@ -408,10 +412,6 @@ export async function handleUserRemovedFromChannelEvent(serverUrl: string, msg: 
 
             if (getCurrentCall()?.channelId === channelId) {
                 leaveCall(userRemovedFromChannelErr);
-            }
-
-            if (managedTeamId && channelBeforeRemove && !isDMorGM(channelBeforeRemove)) {
-                await removeChannelFromManagedCategoryIfNeeded(serverUrl, managedTeamId, channelId);
             }
         } else {
             const {models: deleteMemberModels} = await deleteChannelMembership(operator, userId, channelId, true);

--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -7,6 +7,7 @@ import {
     storeMyChannelsForTeam, updateChannelInfoFromChannel, updateMyChannelFromWebsocket, deletePostsForChannel,
 } from '@actions/local/channel';
 import {storePostsForChannel} from '@actions/local/post';
+import {addChannelToManagedCategoryIfNeeded, removeChannelFromManagedCategoryIfNeeded} from '@actions/remote/category';
 import {fetchMissingDirectChannelsInfo, fetchMyChannel, fetchChannelStats, fetchChannelById, handleKickFromChannel} from '@actions/remote/channel';
 import {fetchPostsForChannel} from '@actions/remote/post';
 import {fetchRolesIfNeeded} from '@actions/remote/role';
@@ -21,6 +22,7 @@ import {getConfig, getCurrentChannelId, getCurrentTeamId, setCurrentTeamId} from
 import {getCurrentUser, getTeammateNameDisplay, getUserById} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
 import MyChannelModel from '@typings/database/models/servers/my_channel';
+import {isDMorGM} from '@utils/channel';
 import {logDebug} from '@utils/log';
 
 import type {Model} from '@nozbe/watermelondb';
@@ -295,6 +297,7 @@ export async function handleUserAddedToChannelEvent(serverUrl: string, msg: any)
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const currentUser = await getCurrentUser(database);
         const models: Model[] = [];
+        let joinedChannel: Channel | undefined;
 
         if (userId === currentUser?.id) {
             if (EphemeralStore.isAddingToTeam(teamId) || EphemeralStore.isJoiningChannel(channelId)) {
@@ -303,6 +306,7 @@ export async function handleUserAddedToChannelEvent(serverUrl: string, msg: any)
 
             const {channels, memberships} = await fetchMyChannel(serverUrl, teamId, channelId, true);
             if (channels && memberships) {
+                joinedChannel = channels[0];
                 const prepare = await prepareMyChannelsForTeam(operator, teamId, channels, memberships);
                 if (prepare.length) {
                     const prepareModels = await Promise.all(prepare);
@@ -352,6 +356,10 @@ export async function handleUserAddedToChannelEvent(serverUrl: string, msg: any)
             await operator.batchRecords(models, 'handleUserAddedToChannelEvent');
         }
 
+        if (joinedChannel) {
+            await addChannelToManagedCategoryIfNeeded(serverUrl, joinedChannel);
+        }
+
         await fetchChannelStats(serverUrl, channelId, false);
     } catch {
         // Do nothing
@@ -388,6 +396,9 @@ export async function handleUserRemovedFromChannelEvent(serverUrl: string, msg: 
         }
 
         if (user.id === userId) {
+            const channelBeforeRemove = await getChannelById(database, channelId);
+            const managedTeamId = channelBeforeRemove?.teamId;
+
             const currentChannelId = await getCurrentChannelId(database);
             if (currentChannelId && currentChannelId === channelId) {
                 await handleKickFromChannel(serverUrl, currentChannelId);
@@ -397,6 +408,10 @@ export async function handleUserRemovedFromChannelEvent(serverUrl: string, msg: 
 
             if (getCurrentCall()?.channelId === channelId) {
                 leaveCall(userRemovedFromChannelErr);
+            }
+
+            if (managedTeamId && channelBeforeRemove && !isDMorGM(channelBeforeRemove)) {
+                await removeChannelFromManagedCategoryIfNeeded(serverUrl, managedTeamId, channelId);
             }
         } else {
             const {models: deleteMemberModels} = await deleteChannelMembership(operator, userId, channelId, true);

--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -1,13 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {addChannelToDefaultCategory, handleConvertedGMCategories} from '@actions/local/category';
+import {addChannelToDefaultCategory, handleConvertedGMCategories, removeChannelFromManagedCategoryIfNeeded} from '@actions/local/category';
 import {
     markChannelAsViewed, removeCurrentUserFromChannel, setChannelDeleteAt,
     storeMyChannelsForTeam, updateChannelInfoFromChannel, updateMyChannelFromWebsocket, deletePostsForChannel,
 } from '@actions/local/channel';
 import {storePostsForChannel} from '@actions/local/post';
-import {addChannelToManagedCategoryIfNeeded, removeChannelFromManagedCategoryIfNeeded} from '@actions/remote/category';
+import {addChannelToManagedCategoryIfNeeded} from '@actions/remote/category';
 import {fetchMissingDirectChannelsInfo, fetchMyChannel, fetchChannelStats, fetchChannelById, handleKickFromChannel} from '@actions/remote/channel';
 import {fetchPostsForChannel} from '@actions/remote/post';
 import {fetchRolesIfNeeded} from '@actions/remote/role';

--- a/app/actions/websocket/event.ts
+++ b/app/actions/websocket/event.ts
@@ -21,6 +21,7 @@ import * as channel from './channel';
 import * as files from './files';
 import * as group from './group';
 import {handleOpenDialogEvent} from './integrations';
+import {handleManagedChannelCategoriesPropertyValuesUpdated} from './managed_categories';
 import * as posts from './posts';
 import {handlePostTranslationUpdatedEvent} from './posts';
 import * as preferences from './preferences';
@@ -311,6 +312,10 @@ export async function handleWebSocketEvent(serverUrl: string, msg: WebSocketMess
 
         case WebsocketEvents.CUSTOM_PROFILE_ATTRIBUTES_FIELD_DELETED:
             handleCustomProfileAttributesFieldDeletedEvent(serverUrl, msg);
+            break;
+
+        case WebsocketEvents.PROPERTY_VALUES_UPDATED:
+            handleManagedChannelCategoriesPropertyValuesUpdated(serverUrl, msg);
             break;
 
         // Agents

--- a/app/actions/websocket/managed_categories.ts
+++ b/app/actions/websocket/managed_categories.ts
@@ -35,8 +35,6 @@ export async function handleManagedChannelCategoriesPropertyValuesUpdated(server
             return;
         }
 
-        const first = values[0];
-
         let propertyIds = EphemeralStore.getManagedCategoryPropertyIds(serverUrl);
         if (!propertyIds) {
             propertyIds = await fetchManagedCategoryPropertyIds(serverUrl);
@@ -45,7 +43,8 @@ export async function handleManagedChannelCategoriesPropertyValuesUpdated(server
             return;
         }
 
-        if (first.group_id !== propertyIds.groupId || first.field_id !== propertyIds.fieldId) {
+        const matched = values.find((v) => v.group_id === propertyIds!.groupId && v.field_id === propertyIds!.fieldId);
+        if (!matched) {
             return;
         }
 
@@ -54,7 +53,7 @@ export async function handleManagedChannelCategoriesPropertyValuesUpdated(server
             return;
         }
 
-        const categoryName = first.value;
+        const categoryName = matched.value;
         const teamId = channel.teamId;
         if (!teamId) {
             return;

--- a/app/actions/websocket/managed_categories.ts
+++ b/app/actions/websocket/managed_categories.ts
@@ -3,10 +3,12 @@
 
 import {removeChannelFromManagedCategoryIfNeeded} from '@actions/local/category';
 import {addChannelToManagedCategoryIfNeeded} from '@actions/remote/category';
-import {MANAGED_CHANNEL_CATEGORIES_GROUP} from '@constants/categories';
 import DatabaseManager from '@database/manager';
+import {fetchManagedCategoryPropertyIds} from '@helpers/sidebar/managed_categories_merge';
+import {getManagedCategoryForChannel} from '@queries/servers/categories';
 import {getChannelById} from '@queries/servers/channel';
 import {getConfigValue} from '@queries/servers/system';
+import EphemeralStore from '@store/ephemeral_store';
 import {logDebug} from '@utils/log';
 
 export async function handleManagedChannelCategoriesPropertyValuesUpdated(serverUrl: string, msg: WebSocketMessage) {
@@ -18,20 +20,32 @@ export async function handleManagedChannelCategoriesPropertyValuesUpdated(server
         }
 
         const data = msg.data as PropertyValuesUpdatedData;
-        const fieldName = data.field_name ?? data.name;
-        const groupName = data.group_name;
-        const isMatchingGroup = groupName === MANAGED_CHANNEL_CATEGORIES_GROUP;
-        const isFallbackMatch = !groupName && fieldName === 'category_name';
-        if (!isMatchingGroup && !isFallbackMatch) {
-            return;
-        }
 
         if (data.object_type && data.object_type !== 'channel') {
             return;
         }
 
-        const channelId = data.target_id ?? data.channel_id;
+        const channelId = data.target_id;
         if (!channelId) {
+            return;
+        }
+
+        const values: PropertyValue[] = JSON.parse(data.values);
+        if (!values.length) {
+            return;
+        }
+
+        const first = values[0];
+
+        let propertyIds = EphemeralStore.getManagedCategoryPropertyIds(serverUrl);
+        if (!propertyIds) {
+            propertyIds = await fetchManagedCategoryPropertyIds(serverUrl);
+        }
+        if (!propertyIds) {
+            return;
+        }
+
+        if (first.group_id !== propertyIds.groupId || first.field_id !== propertyIds.fieldId) {
             return;
         }
 
@@ -40,15 +54,23 @@ export async function handleManagedChannelCategoriesPropertyValuesUpdated(server
             return;
         }
 
-        if (data.delete_at && data.delete_at > 0) {
-            const teamId = channel.teamId;
-            if (teamId) {
-                await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamId, channelId);
+        const categoryName = first.value;
+        const teamId = channel.teamId;
+        if (!teamId) {
+            return;
+        }
+
+        if (categoryName) {
+            const currentManaged = await getManagedCategoryForChannel(database, teamId, channelId);
+            if (currentManaged?.displayName === String(categoryName)) {
+                return;
             }
-        } else {
+            await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamId, channelId);
             await addChannelToManagedCategoryIfNeeded(serverUrl, channel);
+        } else {
+            await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamId, channelId);
         }
     } catch (error) {
-        logDebug('handleManagedChannelCategoriesPropertyValuesUpdated', error);
+        logDebug('[handleManagedCategoryWS]', error);
     }
 }

--- a/app/actions/websocket/managed_categories.ts
+++ b/app/actions/websocket/managed_categories.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {addChannelToManagedCategoryIfNeeded, removeChannelFromManagedCategoryIfNeeded} from '@actions/remote/category';
+import {removeChannelFromManagedCategoryIfNeeded} from '@actions/local/category';
+import {addChannelToManagedCategoryIfNeeded} from '@actions/remote/category';
 import {MANAGED_CHANNEL_CATEGORIES_GROUP} from '@constants/categories';
 import DatabaseManager from '@database/manager';
 import {getChannelById} from '@queries/servers/channel';

--- a/app/actions/websocket/managed_categories.ts
+++ b/app/actions/websocket/managed_categories.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {addChannelToManagedCategoryIfNeeded, removeChannelFromManagedCategoryIfNeeded} from '@actions/remote/category';
+import {MANAGED_CHANNEL_CATEGORIES_GROUP} from '@constants/categories';
+import DatabaseManager from '@database/manager';
+import {getChannelById} from '@queries/servers/channel';
+import {getConfigValue} from '@queries/servers/system';
+import {logDebug} from '@utils/log';
+
+export async function handleManagedChannelCategoriesPropertyValuesUpdated(serverUrl: string, msg: WebSocketMessage) {
+    try {
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const enabled = await getConfigValue(database, 'EnableManagedChannelCategories');
+        if (enabled !== 'true') {
+            return;
+        }
+
+        const data = msg.data as PropertyValuesUpdatedData;
+        const fieldName = data.field_name ?? data.name;
+        const groupName = data.group_name;
+        const isMatchingGroup = groupName === MANAGED_CHANNEL_CATEGORIES_GROUP;
+        const isFallbackMatch = !groupName && fieldName === 'category_name';
+        if (!isMatchingGroup && !isFallbackMatch) {
+            return;
+        }
+
+        if (data.object_type && data.object_type !== 'channel') {
+            return;
+        }
+
+        const channelId = data.target_id ?? data.channel_id;
+        if (!channelId) {
+            return;
+        }
+
+        const channel = await getChannelById(database, channelId);
+        if (!channel) {
+            return;
+        }
+
+        if (data.delete_at && data.delete_at > 0) {
+            const teamId = channel.teamId;
+            if (teamId) {
+                await removeChannelFromManagedCategoryIfNeeded(serverUrl, teamId, channelId);
+            }
+        } else {
+            await addChannelToManagedCategoryIfNeeded(serverUrl, channel);
+        }
+    } catch (error) {
+        logDebug('handleManagedChannelCategoriesPropertyValuesUpdated', error);
+    }
+}

--- a/app/actions/websocket/system.ts
+++ b/app/actions/websocket/system.ts
@@ -3,9 +3,11 @@
 
 import {updateDmGmDisplayName} from '@actions/local/channel';
 import {storeConfig} from '@actions/local/systems';
+import {fetchCategories} from '@actions/remote/category';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {getConfig, getLicense} from '@queries/servers/system';
+import {getConfig, getCurrentTeamId, getLicense} from '@queries/servers/system';
+import EphemeralStore from '@store/ephemeral_store';
 
 export async function handleLicenseChangedEvent(serverUrl: string, msg: WebSocketMessage): Promise<void> {
     try {
@@ -33,6 +35,15 @@ export async function handleConfigChangedEvent(serverUrl: string, msg: WebSocket
         await storeConfig(serverUrl, config);
         if (config?.LockTeammateNameDisplay && (prevConfig?.LockTeammateNameDisplay !== config.LockTeammateNameDisplay)) {
             updateDmGmDisplayName(serverUrl);
+        }
+        const prevManagedSetting = prevConfig?.EnableManagedChannelCategories;
+        const newManagedSetting = config?.EnableManagedChannelCategories;
+        if (newManagedSetting !== prevManagedSetting) {
+            EphemeralStore.clearManagedCategoryPropertyIds(serverUrl);
+            const currentTeamId = await getCurrentTeamId(database);
+            if (currentTeamId) {
+                await fetchCategories(serverUrl, currentTeamId, true);
+            }
         }
     } catch {
         // do nothing

--- a/app/client/rest/channels.test.ts
+++ b/app/client/rest/channels.test.ts
@@ -222,6 +222,16 @@ describe('ClientChannels', () => {
         expect(client.doFetch).toHaveBeenCalledWith(`${client.getTeamRoute(teamId)}/channels?page=0&per_page=${PER_PAGE_DEFAULT}`, expectedOptions);
     });
 
+    test('getManagedCategories', async () => {
+        const teamId = 'team1';
+        const expectedUrl = `${client.getTeamRoute(teamId)}/channels/managed_categories`;
+        const expectedOptions = {method: 'get'};
+
+        await client.getManagedCategories(teamId);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
     test('getArchivedChannels', async () => {
         const teamId = 'team1';
         const page = 1;

--- a/app/client/rest/channels.ts
+++ b/app/client/rest/channels.ts
@@ -51,6 +51,7 @@ export interface ClientChannelsMix {
     convertGroupMessageToPrivateChannel: (channelId: string, teamId: string, displayName: string, name: string) => Promise<Channel>;
     getAllChannelsFromAllTeams: (lastDeleteAt: number, includeDeleted: boolean, groupLabel?: RequestGroupLabel) => Promise<Channel[]>;
     getAllMyChannelMembersFromAllTeams: (page: number, perPage: number, groupLabel?: RequestGroupLabel) => Promise<ChannelMembership[]>;
+    getManagedCategories: (teamId: string, groupLabel?: RequestGroupLabel) => Promise<Record<string, string>>;
 }
 
 const ClientChannels = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
@@ -88,6 +89,13 @@ const ClientChannels = <TBase extends Constructor<ClientBase>>(superclass: TBase
 
         return this.doFetch(
             `${this.getUserRoute('me')}/channel_members${buildQueryString(queryData)}`,
+            {method: 'get', groupLabel},
+        );
+    };
+
+    getManagedCategories = async (teamId: string, groupLabel?: RequestGroupLabel) => {
+        return this.doFetch(
+            `${this.getTeamRoute(teamId)}/channels/managed_categories`,
             {method: 'get', groupLabel},
         );
     };

--- a/app/client/rest/index.ts
+++ b/app/client/rest/index.ts
@@ -23,6 +23,7 @@ import ClientIntegrations, {type ClientIntegrationsMix} from './integrations';
 import ClientNPS, {type ClientNPSMix} from './nps';
 import ClientPosts, {type ClientPostsMix} from './posts';
 import ClientPreferences, {type ClientPreferencesMix} from './preferences';
+import ClientProperties, {type ClientPropertiesMix} from './properties';
 import ClientScheduledPost, {type ClientScheduledPostMix} from './scheduled_post';
 import ClientTeams, {type ClientTeamsMix} from './teams';
 import ClientThreads, {type ClientThreadsMix} from './threads';
@@ -44,6 +45,7 @@ interface Client extends ClientBase,
     ClientIntegrationsMix,
     ClientPostsMix,
     ClientPreferencesMix,
+    ClientPropertiesMix,
     ClientScheduledPostMix,
     ClientTeamsMix,
     ClientThreadsMix,
@@ -72,6 +74,7 @@ class Client extends mix(ClientBase).with(
     ClientIntegrations,
     ClientPosts,
     ClientPreferences,
+    ClientProperties,
     ClientScheduledPost,
     ClientTeams,
     ClientThreads,

--- a/app/client/rest/properties.test.ts
+++ b/app/client/rest/properties.test.ts
@@ -18,10 +18,22 @@ describe('ClientProperties', () => {
         const groupName = 'managed_channel_categories';
         const objectType = 'channel';
         const targetId = 'channel_id_1';
-        const expectedUrl = `${client.urlVersion}/properties/groups/${encodeURIComponent(groupName)}/${encodeURIComponent(objectType)}/values/${encodeURIComponent(targetId)}`;
+        const expectedUrl = `${client.urlVersion}/properties/groups/${groupName}/${objectType}/values/${targetId}`;
         const expectedOptions = {method: 'get'};
 
         await client.getPropertyValues<string>(groupName, objectType, targetId);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    test('getPropertyFields', async () => {
+        const groupName = 'managed_channel_categories';
+        const objectType = 'channel';
+        const targetType = 'system';
+        const expectedUrl = `${client.urlVersion}/properties/groups/${groupName}/${objectType}/fields?target_type=${targetType}`;
+        const expectedOptions = {method: 'get'};
+
+        await client.getPropertyFields(groupName, objectType, targetType);
 
         expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
     });

--- a/app/client/rest/properties.test.ts
+++ b/app/client/rest/properties.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import TestHelper from '@test/test_helper';
+
+import type ClientBase from './base';
+import type {ClientPropertiesMix} from './properties';
+
+describe('ClientProperties', () => {
+    let client: ClientPropertiesMix & ClientBase;
+
+    beforeAll(() => {
+        client = TestHelper.createClient();
+        client.doFetch = jest.fn();
+    });
+
+    test('getPropertyValues', async () => {
+        const groupName = 'managed_channel_categories';
+        const objectType = 'channel';
+        const targetId = 'channel_id_1';
+        const expectedUrl = `${client.urlVersion}/properties/groups/${encodeURIComponent(groupName)}/${encodeURIComponent(objectType)}/values/${encodeURIComponent(targetId)}`;
+        const expectedOptions = {method: 'get'};
+
+        await client.getPropertyValues<string>(groupName, objectType, targetId);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+});

--- a/app/client/rest/properties.ts
+++ b/app/client/rest/properties.ts
@@ -5,6 +5,7 @@ import type ClientBase from './base';
 
 export interface ClientPropertiesMix {
     getPropertyValues: <T>(groupName: string, objectType: string, targetId: string, groupLabel?: RequestGroupLabel) => Promise<Array<PropertyValue<T>>>;
+    getPropertyFields: (groupName: string, objectType: string, targetType: string, groupLabel?: RequestGroupLabel) => Promise<PropertyField[]>;
 }
 
 const ClientProperties = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
@@ -14,6 +15,14 @@ const ClientProperties = <TBase extends Constructor<ClientBase>>(superclass: TBa
             url,
             {method: 'get', groupLabel},
         ) as unknown as Promise<Array<PropertyValue<T>>>;
+    };
+
+    getPropertyFields = async (groupName: string, objectType: string, targetType: string, groupLabel?: RequestGroupLabel) => {
+        const url = `${this.urlVersion}/properties/groups/${groupName}/${objectType}/fields?target_type=${targetType}`;
+        return this.doFetch(
+            url,
+            {method: 'get', groupLabel},
+        ) as unknown as Promise<PropertyField[]>;
     };
 };
 

--- a/app/client/rest/properties.ts
+++ b/app/client/rest/properties.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type ClientBase from './base';
+
+export interface ClientPropertiesMix {
+    getPropertyValues: <T>(groupName: string, objectType: string, targetId: string, groupLabel?: RequestGroupLabel) => Promise<Array<PropertyValue<T>>>;
+}
+
+const ClientProperties = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
+    getPropertyValues = async <T>(groupName: string, objectType: string, targetId: string, groupLabel?: RequestGroupLabel) => {
+        const url = `${this.urlVersion}/properties/groups/${groupName}/${objectType}/values/${targetId}`;
+        return this.doFetch(
+            url,
+            {method: 'get', groupLabel},
+        ) as unknown as Promise<Array<PropertyValue<T>>>;
+    };
+};
+
+export default ClientProperties;

--- a/app/components/channel_actions/favorite_box/favorite_box.tsx
+++ b/app/components/channel_actions/favorite_box/favorite_box.tsx
@@ -15,11 +15,12 @@ type Props = {
     channelId: string;
     containerStyle?: StyleProp<ViewStyle>;
     isFavorited: boolean;
+    isManaged?: boolean;
     showSnackBar?: boolean;
     testID?: string;
 }
 
-const FavoriteBox = ({channelId, containerStyle, isFavorited, showSnackBar = false, testID}: Props) => {
+const FavoriteBox = ({channelId, containerStyle, isFavorited, isManaged = false, showSnackBar = false, testID}: Props) => {
     const intl = useIntl();
     const serverUrl = useServerUrl();
 
@@ -29,6 +30,10 @@ const FavoriteBox = ({channelId, containerStyle, isFavorited, showSnackBar = fal
     }, [serverUrl, channelId, showSnackBar]);
 
     const favoriteActionTestId = isFavorited ? `${testID}.unfavorite.action` : `${testID}.favorite.action`;
+
+    if (isManaged) {
+        return null;
+    }
 
     return (
         <OptionBox

--- a/app/components/channel_actions/favorite_box/index.ts
+++ b/app/components/channel_actions/favorite_box/index.ts
@@ -4,7 +4,7 @@
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
 import {combineLatestWith, switchMap} from 'rxjs/operators';
 
-import {observeIsChannelFavorited} from '@queries/servers/categories';
+import {observeIsChannelFavorited, observeIsChannelInManagedCategory} from '@queries/servers/categories';
 import {observeChannel} from '@queries/servers/channel';
 import {observeCurrentTeamId} from '@queries/servers/system';
 
@@ -24,8 +24,14 @@ const enhanced = withObservables(['channelId'], ({channelId, database}: OwnProps
         switchMap(([c, tId]) => observeIsChannelFavorited(database, c?.teamId || tId, channelId)),
     );
 
+    const isManaged = channel.pipe(
+        combineLatestWith(currentTeamId),
+        switchMap(([c, tId]) => observeIsChannelInManagedCategory(database, c?.teamId || tId, channelId)),
+    );
+
     return {
         isFavorited,
+        isManaged,
     };
 });
 

--- a/app/constants/categories.ts
+++ b/app/constants/categories.ts
@@ -9,6 +9,7 @@ export const UNREADS_CATEGORY = 'unreads';
 /** Prefix for locally synthesized sidebar categories (managed channel groupings). Not server UUIDs. */
 export const MANAGED_LOCAL_CATEGORY_PREFIX = 'mm_managed:';
 export const MANAGED_CHANNEL_CATEGORIES_GROUP = 'managed_channel_categories';
+export const MANAGED_CHANNEL_CATEGORIES_FIELD = 'category_name';
 
 export default {
     CHANNELS_CATEGORY,

--- a/app/constants/categories.ts
+++ b/app/constants/categories.ts
@@ -6,6 +6,10 @@ export const DMS_CATEGORY = 'direct_messages';
 export const FAVORITES_CATEGORY = 'favorites';
 export const UNREADS_CATEGORY = 'unreads';
 
+/** Prefix for locally synthesized sidebar categories (managed channel groupings). Not server UUIDs. */
+export const MANAGED_LOCAL_CATEGORY_PREFIX = 'mm_managed:';
+export const MANAGED_CHANNEL_CATEGORIES_GROUP = 'managed_channel_categories';
+
 export default {
     CHANNELS_CATEGORY,
     DMS_CATEGORY,

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -103,6 +103,7 @@ const WebsocketEvents = {
     SCHEDULED_POST_UPDATED: 'scheduled_post_updated',
     SCHEDULED_POST_DELETED: 'scheduled_post_deleted',
     CUSTOM_PROFILE_ATTRIBUTES_VALUES_UPDATED: 'custom_profile_attributes_values_updated',
+    PROPERTY_VALUES_UPDATED: 'property_values_updated',
     CUSTOM_PROFILE_ATTRIBUTES_FIELD_UPDATED: 'custom_profile_attributes_field_updated',
     CUSTOM_PROFILE_ATTRIBUTES_FIELD_CREATED: 'custom_profile_attributes_field_created',
     CUSTOM_PROFILE_ATTRIBUTES_FIELD_DELETED: 'custom_profile_attributes_field_deleted',

--- a/app/helpers/sidebar/managed_categories_merge.ts
+++ b/app/helpers/sidebar/managed_categories_merge.ts
@@ -83,9 +83,9 @@ export async function fetchManagedCategoryPropertyIds(serverUrl: string) {
             return undefined;
         }
 
-        const ids = {groupId: field.group_id, fieldId: field.id};
-        EphemeralStore.setManagedCategoryPropertyIds(serverUrl, ids);
-        return ids;
+        const managedCategoryPropertyIds = {groupId: field.group_id, fieldId: field.id};
+        EphemeralStore.setManagedCategoryPropertyIds(serverUrl, managedCategoryPropertyIds);
+        return managedCategoryPropertyIds;
     } catch (error) {
         logDebug('[fetchManagedCategoryPropertyIds]', error);
         return undefined;

--- a/app/helpers/sidebar/managed_categories_merge.ts
+++ b/app/helpers/sidebar/managed_categories_merge.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
+import {getCategoryById} from '@queries/servers/categories';
+
+import type {Database} from '@nozbe/watermelondb';
+
+export function makeManagedCategoryId(teamId: string, displayName: string): string {
+    return `${MANAGED_LOCAL_CATEGORY_PREFIX}${teamId}:${displayName}`;
+}
+
+export async function mergeManagedMappingsIntoSidebarCategories(
+    database: Database,
+    teamId: string,
+    serverCategories: CategoryWithChannels[],
+    mappings: Record<string, string>,
+): Promise<CategoryWithChannels[]> {
+    const managedChannelIds = new Set(Object.keys(mappings));
+    if (managedChannelIds.size === 0) {
+        return serverCategories;
+    }
+
+    const stripped = serverCategories.map((cat) => ({
+        ...cat,
+        channel_ids: cat.channel_ids.filter((id) => !managedChannelIds.has(id)),
+    }));
+
+    const byName = new Map<string, string[]>();
+    for (const [chId, name] of Object.entries(mappings)) {
+        if (!name) {
+            continue;
+        }
+        const list = byName.get(name) ?? [];
+        list.push(chId);
+        byName.set(name, list);
+    }
+
+    const names = [...byName.keys()].sort((a, b) => a.localeCompare(b, undefined, {numeric: true}));
+    const managedCategories = await Promise.all(names.map(async (name, i) => {
+        const channelIds = [...(byName.get(name) ?? [])].sort((a, b) => a.localeCompare(b, undefined, {numeric: true}));
+        const id = makeManagedCategoryId(teamId, name);
+        const existing = await getCategoryById(database, id);
+        return {
+            id,
+            team_id: teamId,
+            display_name: name,
+            sort_order: (-1000 + i) * 10,
+            sorting: 'alpha' as CategorySorting,
+            type: 'custom' as CategoryType,
+            muted: false,
+            collapsed: existing?.collapsed ?? false,
+            channel_ids: channelIds,
+        };
+    }));
+
+    return [...managedCategories, ...stripped];
+}

--- a/app/helpers/sidebar/managed_categories_merge.ts
+++ b/app/helpers/sidebar/managed_categories_merge.ts
@@ -1,13 +1,20 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
-import {getCategoryById} from '@queries/servers/categories';
+import {MANAGED_CHANNEL_CATEGORIES_FIELD, MANAGED_CHANNEL_CATEGORIES_GROUP, MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
+import NetworkManager from '@managers/network_manager';
+import {queryCategoriesByTeamIds} from '@queries/servers/categories';
+import EphemeralStore from '@store/ephemeral_store';
+import {logDebug} from '@utils/log';
 
 import type {Database} from '@nozbe/watermelondb';
 
 export function makeManagedCategoryId(teamId: string, displayName: string): string {
     return `${MANAGED_LOCAL_CATEGORY_PREFIX}${teamId}:${displayName}`;
+}
+
+export function computeManagedSortOrder(index: number): number {
+    return (-1000 + index) * 10;
 }
 
 export async function mergeManagedMappingsIntoSidebarCategories(
@@ -21,11 +28,6 @@ export async function mergeManagedMappingsIntoSidebarCategories(
         return serverCategories;
     }
 
-    const stripped = serverCategories.map((cat) => ({
-        ...cat,
-        channel_ids: cat.channel_ids.filter((id) => !managedChannelIds.has(id)),
-    }));
-
     const byName = new Map<string, string[]>();
     for (const [chId, name] of Object.entries(mappings)) {
         if (!name) {
@@ -37,22 +39,55 @@ export async function mergeManagedMappingsIntoSidebarCategories(
     }
 
     const names = [...byName.keys()].sort((a, b) => a.localeCompare(b, undefined, {numeric: true}));
-    const managedCategories = await Promise.all(names.map(async (name, i) => {
+
+    const allLocalCategories = await queryCategoriesByTeamIds(database, [teamId]).fetch();
+    const collapsedById = new Map<string, boolean>();
+    for (const cat of allLocalCategories) {
+        collapsedById.set(cat.id, cat.collapsed);
+    }
+
+    const managedCategories = names.map((name, i) => {
         const channelIds = [...(byName.get(name) ?? [])].sort((a, b) => a.localeCompare(b, undefined, {numeric: true}));
         const id = makeManagedCategoryId(teamId, name);
-        const existing = await getCategoryById(database, id);
         return {
             id,
             team_id: teamId,
             display_name: name,
-            sort_order: (-1000 + i) * 10,
+            sort_order: computeManagedSortOrder(i),
             sorting: 'alpha' as CategorySorting,
             type: 'custom' as CategoryType,
             muted: false,
-            collapsed: existing?.collapsed ?? false,
+            collapsed: collapsedById.get(id) ?? false,
             channel_ids: channelIds,
         };
-    }));
+    });
 
-    return [...managedCategories, ...stripped];
+    return [...managedCategories, ...serverCategories];
+}
+
+export async function fetchManagedCategoryPropertyIds(serverUrl: string) {
+    const cached = EphemeralStore.getManagedCategoryPropertyIds(serverUrl);
+    if (cached) {
+        return cached;
+    }
+
+    try {
+        const client = NetworkManager.getClient(serverUrl);
+        const fields = await client.getPropertyFields(MANAGED_CHANNEL_CATEGORIES_GROUP, 'channel', 'system');
+        if (fields.length === 0) {
+            return undefined;
+        }
+
+        const field = fields.find((f) => f.name === MANAGED_CHANNEL_CATEGORIES_FIELD);
+        if (!field) {
+            return undefined;
+        }
+
+        const ids = {groupId: field.group_id, fieldId: field.id};
+        EphemeralStore.setManagedCategoryPropertyIds(serverUrl, ids);
+        return ids;
+    } catch (error) {
+        logDebug('[fetchManagedCategoryPropertyIds]', error);
+        return undefined;
+    }
 }

--- a/app/queries/servers/categories.ts
+++ b/app/queries/servers/categories.ts
@@ -74,7 +74,9 @@ export async function prepareCategoriesAndCategoriesChannels(operator: ServerDat
                     }
                 } else {
                     for (const cc of localCategoryChannels) {
-                        flattenedModels.push(cc.prepareDestroyPermanently());
+                        if (!teamIdToChannelIds.get(localCategory.teamId)?.has(cc.channelId)) {
+                            flattenedModels.push(cc.prepareDestroyPermanently());
+                        }
                     }
                     flattenedModels.push(localCategory.prepareDestroyPermanently());
                 }
@@ -100,9 +102,10 @@ export async function prepareCategoryChannels(
         const categoryChannels: CategoryChannel[] = [];
 
         categories?.forEach((category) => {
+            const isManaged = category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX);
             category.channel_ids.forEach((channelId, index) => {
                 categoryChannels.push({
-                    id: makeCategoryChannelId(category.team_id, channelId),
+                    id: isManaged ? getManagedCategoryChannelId(category.team_id, channelId) : makeCategoryChannelId(category.team_id, channelId),
                     category_id: category.id,
                     channel_id: channelId,
                     sort_order: index,
@@ -145,6 +148,25 @@ export const getChannelCategory = async (database: Database, teamId: string, cha
     return undefined;
 };
 
+export const getManagedCategoryChannelId = (teamId: string, channelId: string) => {
+    return `${MANAGED_LOCAL_CATEGORY_PREFIX}${makeCategoryChannelId(teamId, channelId)}`;
+};
+
+export const getManagedCategoryChannelById = async (database: Database, teamId: string, channelId: string) => {
+    try {
+        return await database.get<CategoryChannelModel>(CATEGORY_CHANNEL).find(getManagedCategoryChannelId(teamId, channelId));
+    } catch {
+        return undefined;
+    }
+};
+
+export const getManagedCategoryForChannel = async (database: Database, teamId: string, channelId: string) => {
+    const result = await database.get<CategoryModel>(CATEGORY).query(
+        Q.on(CATEGORY_CHANNEL, Q.where('id', getManagedCategoryChannelId(teamId, channelId))),
+    ).fetch();
+    return result.length ? result[0] : undefined;
+};
+
 export const getIsChannelFavorited = async (database: Database, teamId: string, channelId: string) => {
     const result = await queryChannelCategory(database, teamId, channelId).fetch();
     if (result.length > 0) {
@@ -162,8 +184,10 @@ export const observeIsChannelFavorited = (database: Database, teamId: string, ch
 };
 
 export const observeIsChannelInManagedCategory = (database: Database, teamId: string, channelId: string) => {
-    return queryChannelCategory(database, teamId, channelId).observe().pipe(
-        map((result) => (result.length ? result[0].id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX) : false)),
+    return database.get<CategoryModel>(CATEGORY).query(
+        Q.on(CATEGORY_CHANNEL, Q.where('id', getManagedCategoryChannelId(teamId, channelId))),
+    ).observe().pipe(
+        map((result) => result.length > 0),
         distinctUntilChanged(),
     );
 };

--- a/app/queries/servers/categories.ts
+++ b/app/queries/servers/categories.ts
@@ -3,9 +3,9 @@
 
 import {Database, Model, Q, Query} from '@nozbe/watermelondb';
 import {of as of$} from 'rxjs';
-import {switchMap, distinctUntilChanged} from 'rxjs/operators';
+import {map, switchMap, distinctUntilChanged} from 'rxjs/operators';
 
-import {FAVORITES_CATEGORY} from '@constants/categories';
+import {FAVORITES_CATEGORY, MANAGED_LOCAL_CATEGORY_PREFIX} from '@constants/categories';
 import {MM_TABLES} from '@constants/database';
 import {makeCategoryChannelId} from '@utils/categories';
 import {pluckUnique} from '@utils/helpers';
@@ -157,6 +157,13 @@ export const getIsChannelFavorited = async (database: Database, teamId: string, 
 export const observeIsChannelFavorited = (database: Database, teamId: string, channelId: string) => {
     return queryChannelCategory(database, teamId, channelId).observe().pipe(
         switchMap((result) => (result.length ? of$(result[0].type === FAVORITES_CATEGORY) : of$(false))),
+        distinctUntilChanged(),
+    );
+};
+
+export const observeIsChannelInManagedCategory = (database: Database, teamId: string, channelId: string) => {
+    return queryChannelCategory(database, teamId, channelId).observe().pipe(
+        map((result) => (result.length ? result[0].id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX) : false)),
         distinctUntilChanged(),
     );
 };

--- a/app/screens/home/channel_list/categories_list/categories/helpers/observe_flattened_categories.ts
+++ b/app/screens/home/channel_list/categories_list/categories/helpers/observe_flattened_categories.ts
@@ -5,7 +5,7 @@ import {of as of$, combineLatest, type Observable} from 'rxjs';
 import {switchMap, map, distinctUntilChanged} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
-import {DMS_CATEGORY, UNREADS_CATEGORY} from '@constants/categories';
+import {DMS_CATEGORY, MANAGED_LOCAL_CATEGORY_PREFIX, UNREADS_CATEGORY} from '@constants/categories';
 import {getSidebarPreferenceAsBool} from '@helpers/api/preference';
 import {filterAndSortMyChannels, makeChannelsMap} from '@helpers/database';
 import {queryCategoriesByTeamIds} from '@queries/servers/categories';
@@ -29,10 +29,6 @@ import type CategoryModel from '@typings/database/models/servers/category';
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type MyChannelModel from '@typings/database/models/servers/my_channel';
 import type PreferenceModel from '@typings/database/models/servers/preference';
-
-const filterUnreads = (channels: ChannelModel[], unreadIds: Set<string>) => {
-    return channels.filter((c) => !unreadIds.has(c.id));
-};
 
 const observeCategoryChannels = (category: CategoryModel, myChannels: Observable<MyChannelModel[]>) => {
     const channels = category.channels.observeWithColumns(['create_at', 'display_name']);
@@ -195,6 +191,54 @@ const observeFlattenedUnreads = (
     );
 };
 
+const processCategoriesData = (categoriesData: CategoryData[], unreadsOnTopValue: boolean): FlattenedCategoriesData => {
+    const filtered = filterManagedDuplicates(categoriesData);
+
+    const unreadChannelIds = new Set<string>();
+    for (const catData of filtered) {
+        for (const ch of catData.allUnreadChannels) {
+            unreadChannelIds.add(ch.id);
+        }
+    }
+
+    let processed = filtered;
+    if (unreadsOnTopValue) {
+        processed = filtered.map((catData) => ({
+            ...catData,
+            sortedChannels: catData.sortedChannels.filter((ch) => !catData.unreadIds.has(ch.id)),
+        }));
+    }
+
+    const items = flattenCategories(processed, unreadsOnTopValue);
+    return {items, unreadChannelIds};
+};
+
+const filterManagedDuplicates = (categoriesData: CategoryData[]): CategoryData[] => {
+    const managedChannelIds = new Set<string>();
+    for (const catData of categoriesData) {
+        if (catData.category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
+            for (const ch of catData.sortedChannels) {
+                managedChannelIds.add(ch.id);
+            }
+        }
+    }
+
+    if (managedChannelIds.size === 0) {
+        return categoriesData;
+    }
+
+    return categoriesData.map((catData) => {
+        if (catData.category.id.startsWith(MANAGED_LOCAL_CATEGORY_PREFIX)) {
+            return catData;
+        }
+        const channels = catData.sortedChannels.filter((ch) => !managedChannelIds.has(ch.id));
+        if (channels.length === catData.sortedChannels.length) {
+            return catData;
+        }
+        return {...catData, sortedChannels: channels};
+    });
+};
+
 // Observable for normal mode - categories with headers and grouped channels
 const observeFlattenedCategoriesNormal = (
     categories: CategoryModel[],
@@ -218,27 +262,7 @@ const observeFlattenedCategoriesNormal = (
     );
 
     return combineLatest([combineLatest(categoryDataObservables), unreadsOnTop]).pipe(
-        map(([categoriesData, unreadsOnTopValue]) => {
-            // Collect all unread channel IDs and process categories in one pass
-            const unreadChannelIds = new Set<string>();
-            const processedCategoriesData: CategoryData[] = categoriesData.map((catData) => {
-                // Add all unread channels from this category to the set
-                for (const channel of catData.allUnreadChannels) {
-                    unreadChannelIds.add(channel.id);
-                }
-
-                if (unreadsOnTopValue) {
-                    return {
-                        ...catData,
-                        sortedChannels: filterUnreads(catData.sortedChannels, catData.unreadIds),
-                    };
-                }
-                return catData;
-            });
-
-            const items = flattenCategories(processedCategoriesData, unreadsOnTopValue);
-            return {items, unreadChannelIds};
-        }),
+        map(([categoriesData, unreadsOnTopValue]) => processCategoriesData(categoriesData, unreadsOnTopValue)),
         distinctUntilChanged((prev, curr) => {
             if (prev.items.length !== curr.items.length) {
                 return false;

--- a/app/store/ephemeral_store.ts
+++ b/app/store/ephemeral_store.ts
@@ -50,6 +50,8 @@ class EphemeralStoreSingleton {
     // It is cleared any time the connection with the server is lost.
     private channelPlaybooksSynced: {[serverUrl: string]: Set<string>} = {};
 
+    private managedCategoryPropertyIds: {[serverUrl: string]: {groupId: string; fieldId: string} | undefined} = {};
+
     // Track how many translations are being executed at the same time on the channel.
     // We limit this to avoid overwhelming the device.
     private runningTranslations = new Set<string>();
@@ -322,6 +324,18 @@ class EphemeralStoreSingleton {
 
     clearChannelPlaybooksSynced = (serverUrl: string) => {
         delete this.channelPlaybooksSynced[serverUrl];
+    };
+
+    getManagedCategoryPropertyIds = (serverUrl: string) => {
+        return this.managedCategoryPropertyIds[serverUrl];
+    };
+
+    setManagedCategoryPropertyIds = (serverUrl: string, ids: {groupId: string; fieldId: string}) => {
+        this.managedCategoryPropertyIds[serverUrl] = ids;
+    };
+
+    clearManagedCategoryPropertyIds = (serverUrl: string) => {
+        delete this.managedCategoryPropertyIds[serverUrl];
     };
 
     // Ephemeral control for rejected files

--- a/types/api/config.d.ts
+++ b/types/api/config.d.ts
@@ -74,6 +74,7 @@ interface ClientConfig {
     EnableLatex: string;
     EnableLdap: string;
     EnableLinkPreviews: string;
+    EnableManagedChannelCategories?: string;
     EnablePermalinkPreviews: string;
     EnableMarketplace: string;
     EnableMetrics: string;

--- a/types/api/properties.d.ts
+++ b/types/api/properties.d.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+type PropertyValue<T = unknown> = {
+    id: string;
+    target_id: string;
+    target_type: string;
+    group_id: string;
+    field_id: string;
+    value: T;
+    create_at: number;
+    update_at: number;
+    delete_at: number;
+};
+
+type PropertyValuesUpdatedData = {
+    object_type?: string;
+    target_id?: string;
+    channel_id?: string;
+    group_name?: string;
+    field_name?: string;
+    name?: string;
+    values?: string | Record<string, unknown>;
+    delete_at?: number;
+};

--- a/types/api/properties.d.ts
+++ b/types/api/properties.d.ts
@@ -13,13 +13,20 @@ type PropertyValue<T = unknown> = {
     delete_at: number;
 };
 
+type PropertyField = {
+    id: string;
+    group_id: string;
+    name: string;
+    type: string;
+    target_type: string;
+    create_at: number;
+    update_at: number;
+    delete_at: number;
+};
+
 type PropertyValuesUpdatedData = {
     object_type?: string;
     target_id?: string;
-    channel_id?: string;
-    group_name?: string;
-    field_name?: string;
-    name?: string;
-    values?: string | Record<string, unknown>;
-    delete_at?: number;
+    field_id?: string;
+    values: string;
 };


### PR DESCRIPTION
#### Summary
Server-side managed channel categories (see https://github.com/mattermost/mattermost/pull/35935) allow admins to assign channels to named categories that users cannot modify. This PR adds mobile client support.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68255

#### Screenshots
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/752575d2-3675-4267-8b44-6b2e9719cbff" />

#### Release Note
```release-note
Added mobile support for admin-managed sidebar channel categories.
```