### PR TITLE
DDIL Improvement Proposal

### DIFF
--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -12,6 +12,9 @@ import {fetchChannelStats} from '@actions/remote/channel';
 import {ActionType, General, Post, ServerErrors} from '@constants';
 import DatabaseManager from '@database/manager';
 import {filterPostsInOrderedArray} from '@helpers/api/post';
+
+// DDIL: Import sync priority derivation for outbound message ordering
+// import {deriveSyncPriority} from '@utils/sync_priority';
 import {getNeededAtMentionedUsernames} from '@helpers/api/user';
 import NetworkManager from '@managers/network_manager';
 import {getMyChannel, prepareMissingChannelsForAllTeams, queryAllMyChannel} from '@queries/servers/channel';
@@ -140,6 +143,18 @@ export async function createPost(serverUrl: string, post: Partial<Post>, files: 
 
     const isCRTEnabled = await getIsCRTEnabled(database);
 
+    // DDIL: Assign sync priority at write time so the reconnect flush
+    // can order failed posts by urgency. This reads existing signals
+    // (PostPriorityType, channel type, @mentions) — see deriveSyncPriority().
+    //
+    // To wire in:
+    //   const channel = await getChannelById(database, newPost.channel_id);
+    //   const priority = deriveSyncPriority(newPost, channel?.type ?? General.OPEN_CHANNEL);
+    //
+    // Then include `sync_priority: priority` in both the initial write (line ~139)
+    // and the error post below. Keeping it commented until the team reviews
+    // the priority tiers.
+
     let created;
     try {
         created = await client.createPost({...newPost, create_at: 0});
@@ -150,8 +165,10 @@ export async function createPost(serverUrl: string, post: Partial<Post>, files: 
             id: pendingPostId,
             props: {
                 ...newPost.props,
-                failed: true,
+                failed: true,    // DDIL: Keep props.failed for backward compat with UI reads
             },
+            // DDIL: When `failed` column is live, also set:
+            // failed: true,
             update_at: Date.now(),
         };
 
@@ -277,6 +294,8 @@ export const retryFailedPost = async (serverUrl: string, post: PostModel) => {
                     ...p.props,
                     failed: true,
                 };
+                // DDIL: When `failed` column is live, also set:
+                // p.failed = true;
             });
             await operator.batchRecords([post], 'retryFailedPost - error update');
         }
@@ -1199,3 +1218,106 @@ export async function unacknowledgePost(serverUrl: string, postId: string) {
         EphemeralStore.unsetUnacknowledgingPost(postId);
     }
 }
+
+// =============================================================================
+// DDIL: Auto-retry failed posts on reconnect, ordered by sync priority
+// =============================================================================
+//
+// This is the missing outbound leg of doReconnect().
+//
+// Current state: When connectivity restores, doReconnect() fetches inbound data
+// (config, channels, posts) but does nothing about locally-queued failed posts.
+// They sit with props.failed=true until the user manually taps "Retry" on each.
+//
+// Proposed: After inbound sync completes, query for failed posts ordered by
+// sync_priority (URGENT first), and flush them — with bandwidth awareness via
+// the existing NetworkPerformanceManager.
+//
+// OPEN QUESTIONS (commented inline — these need team input):
+//
+// 1. NetworkPerformanceManager resets to 'normal' on app foreground (see
+//    cleanupOnAppStateChange in network_performance_manager.ts). So
+//    getCurrentPerformanceState() at flush start will almost always return
+//    'normal' — even on a marginal satellite link. The bandwidth gate in
+//    retryFailedPosts() effectively never triggers.
+//
+//    Option A — Subscribe to observable during flush:
+//      Instead of polling once, subscribe to observePerformanceState() and
+//      react if state degrades mid-flush. If state flips to 'slow' after
+//      sending 3 of 10 posts, pause and only continue with URGENT tier.
+//      Pro: Most accurate, uses real-time data.
+//      Con: More complex control flow, flush becomes stateful.
+//
+//    Option B — Warm-up window before flushing:
+//      After reconnect, wait for NetworkPerformanceManager to accumulate its
+//      minimum 4 requests (from the inbound sync that just ran) before
+//      flushing non-urgent posts. URGENT posts flush immediately regardless.
+//      Pro: Simple, piggybacks on inbound sync traffic for measurement.
+//      Con: Adds latency to NORMAL/DEFERRED posts (probably a few seconds).
+//
+//    Option C — User-controlled DDIL mode toggle:
+//      A toggle in settings that forces priority-only flushing regardless of
+//      what the manager reports. The operator in the field knows their link
+//      quality better than any heuristic.
+//      Pro: Zero false positives/negatives, user has full control.
+//      Con: Requires the user to know about and remember to toggle it.
+//
+// 2. Starvation: If URGENT posts keep arriving, NORMAL posts wait forever.
+//    Simple fix: promote NORMAL→URGENT after N deferrals or X minutes.
+//    Not implemented until we know if this is a real-world concern.
+//
+// 3. The 150ms inter-send delay is a placeholder. On a satellite link this
+//    might need to be higher. On LTE it's probably unnecessary. Could be
+//    adaptive based on NetworkPerformanceManager latency stats.
+
+// import {Q} from '@nozbe/watermelondb';
+// import NetworkPerformanceManager from '@managers/network_performance_manager';
+// import {SyncPriority} from '@utils/sync_priority';
+// import {logInfo} from '@utils/log';
+//
+// const RETRY_INTER_SEND_DELAY_MS = 150;
+//
+// export async function retryFailedPosts(serverUrl: string): Promise<void> {
+//     const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+//
+//     // Use the manager that already exists — no new detection infra needed
+//     const networkState = NetworkPerformanceManager
+//         .getCurrentPerformanceState(serverUrl);
+//     const isBandwidthConstrained = networkState === 'slow';
+//
+//     // Efficient query — only possible because `failed` is now an indexed column
+//     // instead of buried in a JSON blob.
+//     const failedPosts = await database
+//         .get<PostModel>(MM_TABLES.SERVER.POST)
+//         .query(
+//             Q.where('failed', true),
+//             Q.sortBy('sync_priority', Q.asc),  // 0 (URGENT) before 1 before 2
+//             Q.sortBy('create_at', Q.asc),       // oldest first within each tier
+//         )
+//         .fetch();
+//
+//     if (!failedPosts.length) {
+//         return;
+//     }
+//
+//     logInfo(`[DDIL] Retrying ${failedPosts.length} failed posts, network: ${networkState}`);
+//
+//     for (const post of failedPosts) {
+//         // Under constrained bandwidth: only send URGENT (tier 0).
+//         // NORMAL and DEFERRED wait for the next reconnect window or
+//         // until the network recovers to 'normal'.
+//         if (isBandwidthConstrained && post.syncPriority > SyncPriority.URGENT) {
+//             logDebug(`[DDIL] Deferring post ${post.id} (priority ${post.syncPriority})`);
+//             continue;
+//         }
+//
+//         // Reuse the existing retry path — it handles thread creation,
+//         // lastPostAt updates, and all the edge cases.
+//         await retryFailedPost(serverUrl, post);
+//
+//         // Small pause between sends on a recovering connection.
+//         // Prevents overwhelming a marginal link with a burst.
+//         await new Promise((resolve) => setTimeout(resolve, RETRY_INTER_SEND_DELAY_MS));
+//     }
+// }
+

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -88,6 +88,16 @@ async function doReconnect(serverUrl: string, groupLabel?: BaseRequestGroupLabel
 
     await fetchPostDataIfNeeded(serverUrl, groupLabel);
 
+    // DDIL: After inbound sync, flush outbound failed posts in priority order.
+    // This is the missing outbound leg — currently failed posts sit until
+    // the user manually taps Retry on each one.
+    //
+    // Placement rationale: After fetchPostDataIfNeeded (so the user sees
+    // the latest inbound state) but before deferredAppEntryActions (so
+    // outbound messages don't compete with deferred background fetches).
+    //
+    // await retryFailedPosts(serverUrl);
+
     const {id: currentUserId, locale: currentUserLocale} = (await getCurrentUser(database))!;
     const license = await getLicense(database);
     const config = await getConfig(database);

--- a/app/database/migration/server/index.ts
+++ b/app/database/migration/server/index.ts
@@ -28,6 +28,30 @@ const {AI_BOT, AI_THREAD} = AGENTS_TABLES;
 
 export default schemaMigrations({migrations: [
     {
+        // DDIL: Add indexed `failed` column and `sync_priority` to Post table.
+        // This is an additive migration — no existing data affected, low rollback risk.
+        // Existing posts will have failed=null and sync_priority=null (both isOptional).
+        //
+        // WHY: `props.failed` lives inside a JSON blob today, meaning you can't query
+        // for failed posts without loading every post and deserializing props in JS.
+        // After a long blackout with many queued messages, that's a real bottleneck.
+        // Moving `failed` to a real indexed column enables:
+        //   Q.where('failed', true)  — fast, indexed lookup
+        //
+        // `sync_priority` enables priority-ordered retry on reconnect:
+        //   Q.sortBy('sync_priority', Q.asc), Q.sortBy('create_at', Q.asc)
+        toVersion: 20,
+        steps: [
+            addColumns({
+                table: POST,
+                columns: [
+                    {name: 'failed', type: 'boolean', isOptional: true},
+                    {name: 'sync_priority', type: 'number', isOptional: true},
+                ],
+            }),
+        ],
+    },
+    {
         toVersion: 19,
         steps: [
             createTable({

--- a/app/database/models/server/post.ts
+++ b/app/database/models/server/post.ts
@@ -101,6 +101,15 @@ export default class PostModel extends Model implements PostModelInterface {
     /** props : Additional attributes for this props */
     @json('props', safeParseJSON) props!: any;
 
+    // DDIL: Indexed failure state — replaces the buried `props.failed` JSON flag.
+    // Enables efficient querying: Q.where('failed', true)
+    @field('failed') failed!: boolean;
+
+    // DDIL: Priority tier for outbound sync ordering on reconnect.
+    // See SyncPriority enum in app/utils/sync_priority.ts
+    // 0 = URGENT, 1 = NORMAL, 2 = DEFERRED
+    @field('sync_priority') syncPriority!: number;
+
     // A draft can be associated with this post for as long as this post is a parent post
     @lazy drafts = this.collections.get<DraftModel>(DRAFT).query(Q.on(POST, 'id', this.id));
 

--- a/app/database/schema/server/index.ts
+++ b/app/database/schema/server/index.ts
@@ -46,7 +46,7 @@ import {
 } from './table_schemas';
 
 export const serverSchema: AppSchema = appSchema({
-    version: 19,
+    version: 20,
     tables: [
         AiBotSchema,
         AiThreadSchema,

--- a/app/database/schema/server/table_schemas/post.ts
+++ b/app/database/schema/server/table_schemas/post.ts
@@ -26,6 +26,18 @@ export default tableSchema({
         {name: 'type', type: 'string', isIndexed: true},
         {name: 'update_at', type: 'number'},
         {name: 'user_id', type: 'string', isIndexed: true},
+
+        // DDIL: Move failure state out of the `props` JSON blob so we can
+        // query for failed posts without deserializing every row.
+        // Currently `props.failed = true` is invisible to WatermelonDB indexes.
+        {name: 'failed', type: 'boolean', isOptional: true, isIndexed: true},
+
+        // DDIL: Sync priority tier assigned at write time.
+        // 0 = URGENT (DMs, @mentions, user-flagged urgent)
+        // 1 = NORMAL (standard channel messages)
+        // 2 = DEFERRED (file-heavy posts, read receipts)
+        // Enables ORDER BY sync_priority ASC, create_at ASC on reconnect flush.
+        {name: 'sync_priority', type: 'number', isOptional: true},
     ],
 });
 

--- a/app/utils/post/index.ts
+++ b/app/utils/post/index.ts
@@ -57,6 +57,12 @@ export function isPostEphemeral(post: PostModel): boolean {
 }
 
 export function isPostFailed(post: PostModel): boolean {
+    // DDIL: Once the `failed` column migration is fully wired in, this can
+    // simplify to:
+    //   return post.failed || ((post.pendingPostId === post.id) && (Date.now() > post.updateAt + POST_TIME_TO_FAIL));
+    //
+    // The props.failed check stays for backward compat with posts written
+    // before the migration (they'll have failed=null, props.failed=true).
     return Boolean(post.props?.failed) || ((post.pendingPostId === post.id) && (Date.now() > post.updateAt + POST_TIME_TO_FAIL));
 }
 

--- a/app/utils/sync_priority.ts
+++ b/app/utils/sync_priority.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// DDIL Outbound Message Prioritization
+//
+// Assigns a sync tier to outgoing posts at write time so that when connectivity
+// restores after a blackout, the retry flush can send the most critical messages
+// first — especially under constrained bandwidth.
+//
+// The signals read here already exist in the codebase:
+//   - PostPriorityType (urgent/important) from app/constants/post.ts
+//   - Channel type (DM, GM, public, private) from app/constants/general.ts
+//   - @mention patterns from the message body
+//
+// None of these signals are currently used in the send/retry path.
+
+import {General} from '@constants';
+import {PostPriorityType} from '@constants/post';
+
+// Ordered tiers — lower number = higher priority in the retry queue.
+// Using a const object + companion type instead of enum for tree-shaking.
+export const SyncPriority = {
+    URGENT: 0,   // DMs, @mentions, user-flagged urgent
+    NORMAL: 1,   // Standard channel messages
+    DEFERRED: 2, // File-only posts, low-signal content
+} as const;
+
+export type SyncPriority = typeof SyncPriority[keyof typeof SyncPriority];
+
+// Matches @username mentions but NOT @channel, @here, @all (broadcast mentions).
+// Those reach everyone and aren't person-specific urgent signals.
+const DIRECT_MENTION_REGEX = /\B@[a-z0-9._-]+/i;
+const BROADCAST_MENTIONS = new Set(['@channel', '@here', '@all']);
+
+function containsDirectUserMention(message: string): boolean {
+    const matches = message.match(DIRECT_MENTION_REGEX);
+    if (!matches) {
+        return false;
+    }
+    return matches.some((m) => !BROADCAST_MENTIONS.has(m.toLowerCase()));
+}
+
+/**
+ * Derives the sync priority for an outbound post based on existing signals.
+ *
+ * Called at post creation time. The result is written to `post.sync_priority`
+ * and used by retryFailedPosts() to order the reconnect flush.
+ *
+ * @param post - The post being created (needs message, metadata, file_ids)
+ * @param channelType - The channel's type (D, G, O, P)
+ */
+export function deriveSyncPriority(
+    post: Pick<Post, 'message' | 'metadata' | 'file_ids'>,
+    channelType: string,
+): SyncPriority {
+    // User explicitly marked this post as urgent — respect that signal
+    if (post.metadata?.priority?.priority === PostPriorityType.URGENT) {
+        return SyncPriority.URGENT;
+    }
+
+    // DMs are inherently urgent in a DDIL context — direct person-to-person
+    if (channelType === General.DM_CHANNEL) {
+        return SyncPriority.URGENT;
+    }
+
+    // @mention to a specific user (not a broadcast)
+    if (containsDirectUserMention(post.message)) {
+        return SyncPriority.URGENT;
+    }
+
+    // DECISION POINT: Should GM (group message) channels be URGENT?
+    // Argument for: GMs are small-group, high-signal conversations
+    // Argument against: Some GMs are used as lightweight channels
+    // Currently: NORMAL — but this is worth discussing with the team
+    // if (channelType === General.GM_CHANNEL) {
+    //     return SyncPriority.URGENT;
+    // }
+
+    // Posts with file attachments — the message text is the critical payload,
+    // but if the post is file-only (empty message), it can wait.
+    // DECISION POINT: Should we split file uploads from their parent post?
+    // That's a bigger change — keeping them atomic for now.
+    if (post.file_ids?.length && !post.message.trim()) {
+        return SyncPriority.DEFERRED;
+    }
+
+    return SyncPriority.NORMAL;
+}

--- a/docs/Proposals/DDIL_Reliability_proposal.md
+++ b/docs/Proposals/DDIL_Reliability_proposal.md
@@ -1,0 +1,431 @@
+# DDIL Reliability: Outbound Message Prioritization
+
+**Prepared by:** Kyle Venenga  
+**Date:** April 2026  
+**Repo:** `mattermost/mattermost-mobile`  
+**Key files:** `app/actions/remote/post.ts` · `app/actions/websocket/index.ts` · `app/managers/network_performance_manager.ts` · `app/database/models/server/post.ts` · `types/api/posts.d.ts`
+
+---
+
+## What I was looking at
+
+Jesse mentioned the conversation we had about reliability in degraded network environments, specifically what Artemis II probably had to do after coming back around the moon and reestablishing contact with Earth. The question that stuck with me: when you have a narrow bandwidth window and a backlog of queued messages, what goes first?
+
+I cloned the repo and spent a while tracing the send path end-to-end before writing anything down.
+
+---
+
+## What I found
+
+### 1. `failed` state lives in an unindexed JSON blob
+
+In `app/database/models/server/post.ts`, the Post model stores failure state inside the `props` JSON column:
+
+```typescript
+// Current — in post.ts
+@json('props', safeParseJSON) props!: any;
+// failed is set as props.failed = true
+```
+
+There's no way to efficiently query for failed posts. No index, no column, just a key buried in a JSON string. To find all failed posts you'd have to load every post and deserialize `props` in JavaScript. After a long blackout with a bunch of queued messages, that's going to hurt.
+
+### 2. The reconnect path handles incoming data but ignores outbound
+
+`doReconnect()` in `app/actions/websocket/index.ts` does solid work orchestrating the inbound sync:
+
+```typescript
+// Immediate (blocking)
+const entryData = await entry(serverUrl, currentTeamId, currentChannelId, ...);
+
+// Screen-aware post fetch
+await fetchPostDataIfNeeded(serverUrl, groupLabel);
+
+// Deferred (non-blocking)
+await deferredAppEntryActions(serverUrl, ...);
+```
+
+The two-tier structure here is well thought out. But the outbound side is just... empty. Failed posts sit there with `props.failed = true` until the user taps retry on each one individually. No automatic flush after reconnect.
+
+### 3. `NetworkPerformanceManager` exists but nothing reads it in the send path
+
+`app/managers/network_performance_manager.ts` already tracks request latency: sliding window of 20 requests, 70% threshold to flip to "slow." It has a clean observable:
+
+```typescript
+NetworkPerformanceManager.observePerformanceState(serverUrl);
+// Returns Observable<'normal' | 'slow'>
+
+NetworkPerformanceManager.getCurrentPerformanceState(serverUrl);
+// Returns 'normal' | 'slow' synchronously
+```
+
+This drives the connection banner in the UI, but nobody reads it when deciding what to send. The infrastructure is there, just not wired up.
+
+### 4. `PostPriorityType` exists but only affects how things look
+
+From `app/constants/post.ts`:
+
+```typescript
+export enum PostPriorityType {
+  STANDARD = "",
+  URGENT = "urgent",
+  IMPORTANT = "important",
+}
+```
+
+Red/blue styling, persistent notifications, display stuff. When messages queue up offline and connectivity comes back, they all flush in creation order regardless of this flag. The signal is right there, we're just not using it.
+
+---
+
+## Current flow
+
+```
+User taps send
+      |
+      v
+createPost() in app/actions/remote/post.ts
+      |
+      v
+Write to WatermelonDB immediately          <-- offline-first, this is correct
+(pending_post_id = userId:timestamp)
+      |
+      v
+client.createPost(), HTTP POST to server
+      |
+      |-- success --> handlePosts with server-assigned ID
+      |               batchRecords(models, 'createPost - success')
+      |
+      |-- failure --> errorPost with props.failed = true
+      |               batchRecords(models, 'createPost - failure')
+      |
+      |-- hung for 10s --> isPostFailed() catches it at render time:
+                           pendingPostId === id && Date.now() > updateAt + 10000
+                           (no explicit timeout, the UI just decides it's dead)
+
+      Either way, failed post sits there until user manually taps Retry.
+```
+
+```
+Network restores
+      |
+      v
+WebsocketManager detects via NetInfo
+      |
+      v
+doReconnect()
+      |-- entry()                    config, teams, channels        [handled]
+      |-- fetchPostDataIfNeeded()    posts for visible screen      [handled]
+      |-- deferredAppEntryActions()  background sync               [handled]
+      |
+      x   retryFailedPosts()        outbound failed messages       [missing]
+```
+
+---
+
+## Proposed changes
+
+Three changes, each building on the last.
+
+---
+
+### Change 1: Move `failed` to a proper indexed column
+
+This is the prerequisite. Can't do anything useful without being able to query failed posts efficiently.
+
+One thing to think about: the UI currently reads `props.failed` to show the failure indicator. We're adding a new column, not removing the old one, so both need to stay in sync during the transition. `isPostFailed()` in `app/utils/post/index.ts` should check both: the new column for new posts, `props.failed` for backward compat with posts written before the migration.
+
+**Migration** (additive, no existing data affected):
+
+```typescript
+// app/database/migration/server/index.ts, toVersion: 20
+{
+    toVersion: 20,
+    steps: [
+        addColumns({
+            table: MM_TABLES.SERVER.POST,
+            columns: [
+                {name: 'failed', type: 'boolean', isOptional: true},
+                {name: 'sync_priority', type: 'number', isOptional: true},
+            ],
+        }),
+    ],
+},
+```
+
+**Schema** - add both columns (with `failed` indexed) in `app/database/schema/server/table_schemas/post.ts`:
+
+```typescript
+{name: 'failed', type: 'boolean', isOptional: true, isIndexed: true},
+{name: 'sync_priority', type: 'number', isOptional: true},
+```
+
+**Bump schema version** to 20 in `app/database/schema/server/index.ts`.
+
+**Model update** - two new fields in `app/database/models/server/post.ts`:
+
+```typescript
+@field('failed') failed!: boolean;
+@field('sync_priority') syncPriority!: number;
+```
+
+**Type update** - add optional fields to the `Post` API type in `types/api/posts.d.ts`:
+
+```typescript
+failed?: boolean;
+sync_priority?: number;
+```
+
+These are optional because server-originated posts won't carry them. They only matter for locally-created outbound posts.
+
+**Type update** - add fields to the `PostModel` interface in `types/database/models/servers/post.ts`:
+
+```typescript
+failed: boolean;
+syncPriority: number;
+```
+
+**Write path update** - in the `createPost` and `retryFailedPost` catch blocks, set both:
+
+```typescript
+// Keep props.failed for backward compat with UI reads
+props: { ...post.props, failed: true },
+// New indexed column
+// failed: true,
+```
+
+That's it for Change 1. The model is richer, queries are fast, nothing behavioral changes.
+
+---
+
+### Change 2: Priority assignment at write time
+
+New utility: `app/utils/sync_priority.ts`
+
+Reads signals that already exist (`PostPriorityType`, channel type, @mention patterns) and assigns a sync tier. Uses a const object with companion type (not an enum) for tree-shaking, per project convention.
+
+```typescript
+import { General } from "@constants";
+import { PostPriorityType } from "@constants/post";
+
+export const SyncPriority = {
+  URGENT: 0, // DMs, @mentions, user-flagged urgent
+  NORMAL: 1, // Standard channel messages
+  DEFERRED: 2, // File-only posts (no message text), low-signal content
+} as const;
+
+export type SyncPriority = (typeof SyncPriority)[keyof typeof SyncPriority];
+
+const DIRECT_MENTION_REGEX = /\B@[a-z0-9._-]+/i;
+const BROADCAST_MENTIONS = new Set(["@channel", "@here", "@all"]);
+
+function containsDirectUserMention(message: string): boolean {
+  const matches = message.match(DIRECT_MENTION_REGEX);
+  if (!matches) {
+    return false;
+  }
+  return matches.some((m) => !BROADCAST_MENTIONS.has(m.toLowerCase()));
+}
+
+export function deriveSyncPriority(
+  post: Pick<Post, "message" | "metadata" | "file_ids">,
+  channelType: string,
+): SyncPriority {
+  // User explicitly flagged this as urgent, respect it
+  if (post.metadata?.priority?.priority === PostPriorityType.URGENT) {
+    return SyncPriority.URGENT;
+  }
+
+  // DMs are inherently urgent, direct person-to-person
+  if (channelType === General.DM_CHANNEL) {
+    return SyncPriority.URGENT;
+  }
+
+  // @mention targeting a specific person (not @channel/@here/@all)
+  if (containsDirectUserMention(post.message)) {
+    return SyncPriority.URGENT;
+  }
+
+  // File-only posts with no message body can wait
+  if (post.file_ids?.length && !post.message.trim()) {
+    return SyncPriority.DEFERRED;
+  }
+
+  return SyncPriority.NORMAL;
+}
+```
+
+Call `deriveSyncPriority()` at post creation time and write the result to `sync_priority` alongside the pending post.
+
+Note: posts with files AND a message body stay NORMAL, not DEFERRED. Only truly empty file-only posts get deprioritized. Felt wrong to defer a message just because someone attached a screenshot.
+
+---
+
+### Change 3: Auto-retry on reconnect, priority-ordered
+
+New function at the bottom of `app/actions/remote/post.ts`:
+
+```typescript
+import { Q } from "@nozbe/watermelondb";
+import NetworkPerformanceManager from "@managers/network_performance_manager";
+import { SyncPriority } from "@utils/sync_priority";
+
+const RETRY_INTER_SEND_DELAY_MS = 150;
+
+export async function retryFailedPosts(serverUrl: string): Promise<void> {
+  const { database } = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+
+  // Read the existing performance manager, no new detection infra
+  const networkState =
+    NetworkPerformanceManager.getCurrentPerformanceState(serverUrl);
+  const isBandwidthConstrained = networkState === "slow";
+
+  // Fast indexed query, only works because failed is a real column now
+  const failedPosts = await database
+    .get<PostModel>(MM_TABLES.SERVER.POST)
+    .query(
+      Q.where("failed", true),
+      Q.sortBy("sync_priority", Q.asc), // 0 (URGENT) first
+      Q.sortBy("create_at", Q.asc), // oldest first within tier
+    )
+    .fetch();
+
+  if (!failedPosts.length) {
+    return;
+  }
+
+  logInfo(
+    `[DDIL] Retrying ${failedPosts.length} failed posts, network: ${networkState}`,
+  );
+
+  for (const post of failedPosts) {
+    // On a slow link: only flush URGENT, everything else waits
+    if (isBandwidthConstrained && post.syncPriority > SyncPriority.URGENT) {
+      logDebug(
+        `[DDIL] Deferring post ${post.id} (priority ${post.syncPriority})`,
+      );
+      continue;
+    }
+
+    // Use the existing single-post retry. It handles thread creation,
+    // lastPostAt updates, and the auto-delete edge cases (deleted root,
+    // read-only town square, plugin dismissal).
+    await retryFailedPost(serverUrl, post);
+
+    // Pace sends on a recovering connection
+    await new Promise((resolve) =>
+      setTimeout(resolve, RETRY_INTER_SEND_DELAY_MS),
+    );
+  }
+}
+```
+
+Wire into `doReconnect()` in `app/actions/websocket/index.ts`. One line, placed after inbound sync but before deferred actions:
+
+```typescript
+await fetchPostDataIfNeeded(serverUrl, groupLabel);
+await retryFailedPosts(serverUrl);          // <-- add this
+await deferredAppEntryActions(serverUrl, ...);
+```
+
+The placement matters: user sees fresh inbound messages first, then their queued outbound messages start flushing, then background sync continues.
+
+---
+
+## Proposed flow (after changes)
+
+```
+Network restores
+      |
+      v
+WebsocketManager --> doReconnect()
+      |
+      |-- entry(): config, teams, channels
+      |-- fetchPostDataIfNeeded(): visible channel posts
+      |-- retryFailedPosts()  <-- NEW
+      |       |
+      |       |-- query: WHERE failed = true
+      |       |         ORDER BY sync_priority ASC, create_at ASC
+      |       |
+      |       |-- check NetworkPerformanceManager
+      |       |         if 'slow': only flush URGENT (priority 0)
+      |       |         if 'normal': flush all tiers
+      |       |
+      |       +-- retryFailedPost() for each, 150ms between sends
+      |
+      +-- deferredAppEntryActions()
+```
+
+**The Artemis/DDIL scenario, solved:**
+
+A field operator goes offline for 8 minutes and queues:
+
+1. Status update to team channel - priority 1 (NORMAL)
+2. 5MB aerial photo, no caption - priority 2 (DEFERRED)
+3. DM to CO: "RTB, weather closing in" - priority 0 (URGENT)
+4. Follow-up DM: "Window is 20 min" - priority 0 (URGENT)
+
+Connection restores. `NetworkPerformanceManager` reports `slow`. The flush sends 3 and 4 first, the CO gets the RTB call. Items 1 and 2 wait for the next window or for the link to improve.
+
+---
+
+## Open questions (want your input)
+
+### 1. The `NetworkPerformanceManager` reset problem
+
+When the app comes back to foreground after a blackout, `network_performance_manager.ts` resets all servers to `'normal'`:
+
+```typescript
+private cleanupOnAppStateChange = () => {
+    Object.keys(this.performanceSubjects).forEach((serverUrl) => {
+        this.performanceSubjects[serverUrl].next('normal');
+    });
+};
+```
+
+So `getCurrentPerformanceState()` at the start of `retryFailedPosts()` will almost always say "normal", even if you're connecting through a satellite with 2-second latency. The bandwidth gate basically never triggers.
+
+Three ways to deal with this:
+
+**Option A - Subscribe to the observable during the flush**  
+Instead of checking once and getting a stale "normal", subscribe to `observePerformanceState()` and react if state degrades while we're mid-flush. Say we've sent 3 of 10 posts and the state flips to "slow", pause there and only continue with URGENT posts.
+
+- Pro: Most accurate, reacts to real conditions in real time.
+- Con: More complex control flow. The flush becomes stateful, it needs to track where it paused and what's left.
+
+**Option B - Wait for the warm-up window**  
+The inbound sync (`entry()`, `fetchPostDataIfNeeded()`) generates several HTTP requests before we even get to `retryFailedPosts()`. Let the performance manager accumulate its minimum 4 data points from those requests before flushing non-urgent posts. URGENT posts could still flush immediately.
+
+- Pro: Simple, piggybacks on traffic that's already happening.
+- Con: Adds a few seconds of latency to NORMAL/DEFERRED posts. Might not even be noticeable since inbound sync takes time anyway.
+
+**Option C - Let the user decide**  
+A toggle somewhere in settings: "DDIL mode" or "Priority-only sync." When it's on, only URGENT posts flush regardless of what the performance manager thinks. The person in the field knows their connection better than any algorithm.
+
+- Pro: No false positives or negatives. Full user control.
+- Con: Requires the user to know about it and remember to toggle it. Most users won't.
+
+I lean toward C as the most honest approach for real DDIL deployments, but I'm not sure. This feels like a decision that should come from people who've actually shipped to those environments.
+
+### 2. Starvation
+
+If URGENT messages keep getting generated, NORMAL posts could wait indefinitely. Standard priority queue problem. A simple fix would be promoting any NORMAL post to URGENT after it's been deferred N times or waited longer than X minutes. Didn't build it because I don't know if this actually happens in practice. Seems worth asking before adding the complexity.
+
+### 3. The inter-send delay
+
+The 150ms pause between retried posts is a guess. The idea is to avoid hammering a fragile recovering connection with a burst of requests, but the right number depends entirely on the link. On LTE 150ms is probably unnecessary. On a satellite connection it might need to be 500ms+.
+
+Options: a fixed conservative number, adaptive based on the latency stats the performance manager already has, or just limiting concurrency instead of adding delays (send 3 at a time instead of one-at-a-time-with-pauses).
+
+### 4. File attachment splitting
+
+Right now a post with an attachment is one atomic thing. In an ideal DDIL world you'd send the message text immediately and queue the file upload separately. But that means splitting one outbox entry into two linked entries, which is a bigger structural change. Keeping it out of scope here but worth circling back to.
+
+---
+
+## What this doesn't change
+
+- **The offline-first write path.** Messages still hit WatermelonDB immediately and show up in the UI. This only changes what happens to failed posts when connectivity comes back.
+- **Deduplication.** The `pending_post_id` matching and operator upsert logic stays the same.
+- **The WatermelonDB sync contract.** Everything here is application-layer.
+- **Server behavior.** The server just receives posts in a different order. It doesn't need to know or care about the prioritization.
+
+_Happy to dig into any of this further on the call. Looking forward to it._

--- a/types/api/posts.d.ts
+++ b/types/api/posts.d.ts
@@ -134,6 +134,15 @@ type Post = {
     user_activity_posts?: Post[];
     state?: 'DELETED';
     prev_post_id?: string;
+
+    // DDIL: Indexed failure state — replaces the buried props.failed JSON flag.
+    // Optional because server-originated posts won't have this field.
+    failed?: boolean;
+
+    // DDIL: Outbound sync priority tier (0=URGENT, 1=NORMAL, 2=DEFERRED).
+    // Assigned at write time by deriveSyncPriority(), used by retryFailedPosts()
+    // to order the reconnect flush.
+    sync_priority?: number;
 };
 
 type PostProps = {

--- a/types/database/models/servers/post.ts
+++ b/types/database/models/servers/post.ts
@@ -73,6 +73,12 @@ declare class PostModel extends Model {
     /** props : Additional attributes for this props */
     props: Record<string, unknown> | null;
 
+    /** failed : Whether this post failed to send (DDIL — indexed for efficient querying) */
+    failed: boolean;
+
+    /** syncPriority : Outbound sync tier (0=URGENT, 1=NORMAL, 2=DEFERRED) */
+    syncPriority: number;
+
     /** drafts  : Every draft associated with this Post */
     drafts: Query<DraftModel>;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

A general proposal to improve DDIL. General improvements suggest adding a failed state at the root Post object for easier querying of failed to send posts. The proposal suggests re-trying to send messages upon re-connection based message priority determined at post creation. The proposal raises engineering questions about topics such as on-ramp traffic light buffer timing for sending retries, how to avoid starving posts, and how to handle network monitoring upon re-connection. 


Draft proposal - not intended for merge in current form.
This is a discussion document outlining observations from reading the 
send path and three proposed changes for improving DDIL reliability.
Intended as a starting point for conversation with the team.

#### Release Note
No release note needed - draft proposal only, not intended for merge.
