### PR TITLE
feat(e2e): trigger E2E on push to main/release and record Zephyr results for non-PR runs

### DIFF
--- a/.github/workflows/e2e-detox-pr.yml
+++ b/.github/workflows/e2e-detox-pr.yml
@@ -159,6 +159,7 @@ jobs:
     uses: ./.github/workflows/e2e-ios-template.yml
     with:
       run-type: ${{ inputs.run_type || 'PR' }}
+      record_tests_in_zephyr: ${{ (inputs.run_type == 'RELEASE' || inputs.run_type == 'NIGHTLY' || inputs.run_type == 'MASTER') && 'true' || 'false' }}
       MOBILE_VERSION: ${{ inputs.MOBILE_VERSION }}
       MM_TEST_SERVER_URL: ${{ inputs.SITE_1_URL }}
       MM_TEST_SERVER_URL_2: ${{ inputs.SITE_2_URL }}
@@ -174,6 +175,7 @@ jobs:
     with:
       run-android-tests: true
       run-type: ${{ inputs.run_type || 'PR' }}
+      record_tests_in_zephyr: ${{ (inputs.run_type == 'RELEASE' || inputs.run_type == 'NIGHTLY' || inputs.run_type == 'MASTER') && 'true' || 'false' }}
       MOBILE_VERSION: ${{ inputs.MOBILE_VERSION }}
       MM_TEST_SERVER_URL: ${{ inputs.SITE_1_URL }}
       MM_TEST_SERVER_URL_2: ${{ inputs.SITE_2_URL }}

--- a/.github/workflows/e2e-detox-pr.yml
+++ b/.github/workflows/e2e-detox-pr.yml
@@ -37,7 +37,7 @@ on:
         required: false
         type: string
       run_type:
-        description: "Run type for test reporting (PR/RELEASE/NIGHTLY). Defaults to PR."
+        description: "Run type for test reporting (PR/RELEASE/NIGHTLY/MASTER). Defaults to PR."
         required: false
         default: "PR"
         type: string

--- a/.github/workflows/e2e-nightly-trigger.yml
+++ b/.github/workflows/e2e-nightly-trigger.yml
@@ -5,6 +5,10 @@ name: E2E Nightly Trigger
 # instances, and dispatches e2e-detox-pr.yml with the instance URLs.
 # When e2e-detox-pr.yml completes, Matterwick destroys the provisioned instances.
 on:
+  push:
+    branches:
+      - main
+      - 'release-*'
   schedule:
     - cron: "0 0 * * *" # Every day at midnight UTC
 


### PR DESCRIPTION
## Summary
- **`e2e-nightly-trigger.yml`**: adds `push` triggers for `main` and `release-*` branches so matterwick provisions dedicated cloud servers and dispatches `e2e-detox-pr.yml` on every push — not just on the nightly schedule
- **`e2e-detox-pr.yml`**: passes `record_tests_in_zephyr: true` to the iOS and Android template workflows when `run_type` is `RELEASE`, `NIGHTLY`, or `MASTER`, restoring the Zephyr recording behaviour that previously lived in the now-retired `e2e-detox-release.yml` and `e2e-detox-scheduled.yml`

## How it fits together
| Trigger | `run_type` matterwick sends | `record_tests_in_zephyr` |
|---|---|---|
| PR label (`E2E/Run-*`) | _(empty, defaults to `PR`)_ | `false` |
| Push to `main` | `MASTER` | `true` |
| Push to `release-*` | `RELEASE` | `true` |
| Nightly schedule | `NIGHTLY` | `true` |

```release-note
NONE
```
🤖 Generated with [Claude Code](https://claude.com/claude-code)