### PR TITLE
fix: prevent channel appearing empty after push notification race with deleted post

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
@@ -61,7 +61,10 @@ internal fun DatabaseHelper.handleMyChannel(db: WMDatabase, myChannel: ReadableM
             // deleted-only batch may produce an older create_at — clamp against the stored value.
             val channelId = myChannel.getString("id") ?: ""
             val existingLastFetchedAt = find(db, "MyChannel", channelId)?.let {
-                try { it.getDouble("last_fetched_at") } catch (e: Exception) { 0.0 }
+                try { it.getDouble("last_fetched_at") } catch (e: Exception) {
+                    e.printStackTrace()
+                    0.0
+                }
             } ?: 0.0
             val clampedLastFetchedAt = maxOf(existingLastFetchedAt, computedLastFetchedAt)
             if (clampedLastFetchedAt > 0) {

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
@@ -45,7 +45,7 @@ internal fun DatabaseHelper.handleMyChannel(db: WMDatabase, myChannel: ReadableM
         if (postsData != null && !receivingThreads) {
             val posts = ReadableMapUtils.toJSONObject(postsData.getMap("posts")).toMap()
             val postList = posts.toList()
-            val lastFetchedAt = postList.fold(0.0) { acc, next ->
+            val computedLastFetchedAt = postList.fold(0.0) { acc, next ->
                 val post = next.second as Map<*, *>
                 val createAt = post["create_at"] as Double
                 val updateAt = post["update_at"] as Double
@@ -57,7 +57,16 @@ internal fun DatabaseHelper.handleMyChannel(db: WMDatabase, myChannel: ReadableM
 
                 maxOf(value, acc)
             }
-            json.put("last_fetched_at", lastFetchedAt)
+            // Ensure monotonicity: never regress the cursor. An empty batch produces 0 and a
+            // deleted-only batch may produce an older create_at — clamp against the stored value.
+            val channelId = myChannel.getString("id") ?: ""
+            val existingLastFetchedAt = find(db, "MyChannel", channelId)?.let {
+                try { it.getDouble("last_fetched_at") } catch (e: Exception) { 0.0 }
+            } ?: 0.0
+            val clampedLastFetchedAt = maxOf(existingLastFetchedAt, computedLastFetchedAt)
+            if (clampedLastFetchedAt > 0) {
+                json.put("last_fetched_at", clampedLastFetchedAt)
+            }
         }
 
         if (exists) {

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
@@ -50,7 +50,10 @@ internal fun DatabaseHelper.handleMyChannel(db: WMDatabase, myChannel: ReadableM
                 val createAt = post["create_at"] as Double
                 val updateAt = post["update_at"] as Double
                 val deleteAt = post["delete_at"] as Double
-                val value = maxOf(createAt, updateAt, deleteAt)
+                // For deleted posts, use only createAt — the server sets updateAt = deleteAt = T_del
+                // on deletion, so including either would advance last_fetched_at to "now" and cause
+                // subsequent fetchPostsSince calls to return 0 posts, making the channel appear empty.
+                val value = if (deleteAt > 0) createAt else maxOf(createAt, updateAt)
 
                 maxOf(value, acc)
             }

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Channel.kt
@@ -216,19 +216,36 @@ fun updateMyChannel(db: WMDatabase, myChanel: JSONObject) {
         val isUnread = try { myChanel.getBoolean("is_unread") } catch (e: JSONException) { false }
         val lastPostAt = try { myChanel.getDouble("last_post_at") } catch (e: JSONException) { 0 }
         val lastViewedAt = try { myChanel.getDouble("last_viewed_at") } catch (e: JSONException) { 0 }
-        val lastFetchedAt = try { myChanel.getDouble("last_fetched_at") } catch (e: JSONException) { 0 }
 
-        db.execute(
-                """
-                    UPDATE MyChannel SET message_count=?, mentions_count=?, is_unread=?, 
-                    last_post_at=?, last_viewed_at=?, last_fetched_at=?, _status = 'updated' 
-                    WHERE id=?
-                    """,
-                arrayOf(
-                        msgCount, mentionsCount, isUnread,
-                        lastPostAt, lastViewedAt, lastFetchedAt, id
-                )
-        )
+        // Only write last_fetched_at when the caller explicitly set it in the JSON.
+        // Falling back to 0 on a missing key and writing it unconditionally would regress
+        // the cursor (e.g. when postsData == null or receivingThreads == true).
+        if (myChanel.has("last_fetched_at")) {
+            val lastFetchedAt = myChanel.getDouble("last_fetched_at")
+            db.execute(
+                    """
+                        UPDATE MyChannel SET message_count=?, mentions_count=?, is_unread=?,
+                        last_post_at=?, last_viewed_at=?, last_fetched_at=?, _status = 'updated'
+                        WHERE id=?
+                        """,
+                    arrayOf(
+                            msgCount, mentionsCount, isUnread,
+                            lastPostAt, lastViewedAt, lastFetchedAt, id
+                    )
+            )
+        } else {
+            db.execute(
+                    """
+                        UPDATE MyChannel SET message_count=?, mentions_count=?, is_unread=?,
+                        last_post_at=?, last_viewed_at=?, _status = 'updated'
+                        WHERE id=?
+                        """,
+                    arrayOf(
+                            msgCount, mentionsCount, isUnread,
+                            lastPostAt, lastViewedAt, id
+                    )
+            )
+        }
     } catch (e: Exception) {
         e.printStackTrace()
     }

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/Post.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/Post.kt
@@ -247,7 +247,7 @@ fun DatabaseHelper.handlePosts(db: WMDatabase, postsData: ReadableMap?, channelI
                 }
             }
 
-            if (!receivingThreads) {
+            if (!receivingThreads && posts.isNotEmpty()) {
                 handlePostsInChannel(db, channelId, earliest, latest)
             }
             handlePostsInThread(db, postsInThread)

--- a/app/utils/post/index.ts
+++ b/app/utils/post/index.ts
@@ -103,7 +103,12 @@ export const processPostsFetched = (data: PostResponse) => {
 
 export const getLastFetchedAtFromPosts = (posts?: Post[]) => {
     return posts?.reduce((timestamp: number, p) => {
-        const maxTimestamp = Math.max(p.create_at, p.update_at, p.delete_at);
+        // For deleted posts, use only create_at — the server sets update_at = delete_at = T_del
+        // when deleting, so including either would advance last_fetched_at to "now" and
+        // cause all subsequent fetchPostsSince calls to return 0 posts, making the channel appear empty.
+        const maxTimestamp = p.delete_at > 0
+            ? p.create_at
+            : Math.max(p.create_at, p.update_at);
         return Math.max(maxTimestamp, timestamp);
     }, 0) || 0;
 };

--- a/ios/Gekidou/Sources/Gekidou/PushNotification/PushNotification+FetchData.swift
+++ b/ios/Gekidou/Sources/Gekidou/PushNotification/PushNotification+FetchData.swift
@@ -215,7 +215,10 @@ extension PushNotification {
                         var lastFetchedAt: Double = 0
                         if let postResponse = data.posts, !receivingThreads {
                             let posts = Array(postResponse.posts.values)
-                            if let fetchedAt = posts.map({max($0.createAt, $0.updateAt, $0.deleteAt)}).max() {
+                            // For deleted posts, use only createAt — the server sets updateAt = deleteAt = T_del
+                            // on deletion, so including either would set last_fetched_at to "now" and cause
+                            // subsequent fetchPostsSince calls to return 0 posts, making the channel appear empty.
+                            if let fetchedAt = posts.map({ $0.deleteAt > 0 ? $0.createAt : max($0.createAt, $0.updateAt) }).max() {
                                 lastFetchedAt = fetchedAt
                             }
                         }

--- a/ios/Gekidou/Sources/Gekidou/Storage/Database+Channels.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database+Channels.swift
@@ -231,14 +231,26 @@ extension Database {
         let isUnread = messageCount > 0
         
         if hasThread(db, threadId: myChannel.id) {
-            let updateQuery = myChannelTable.where(idCol == myChannel.id)
-                .update(
-                    messageCountCol <- messageCount,
-                    mentionsCol <- mentionsCount,
-                    isUnreadCol <- isUnreadCol,
-                    lastPostAtCol <- lastPostAt,
-                    lastFetchedAtCol <- lastFetchedAt
-                )
+            // Read the current last_fetched_at to ensure monotonicity:
+            // never regress the cursor backwards (e.g. when a deleted-only fetch computes
+            // an older create_at, or an empty fetch computes 0).
+            let existingLastFetchedAt: Double
+            if let row = try? db.pluck(myChannelTable.where(idCol == myChannel.id)) {
+                existingLastFetchedAt = (try? row.get(lastFetchedAtCol)) ?? 0
+            } else {
+                existingLastFetchedAt = 0
+            }
+
+            var updateSetters: [Setter] = [
+                messageCountCol <- messageCount,
+                mentionsCol <- mentionsCount,
+                isUnreadCol <- isUnread,
+                lastPostAtCol <- lastPostAt,
+            ]
+            if lastFetchedAt > existingLastFetchedAt {
+                updateSetters.append(lastFetchedAtCol <- lastFetchedAt)
+            }
+            let updateQuery = myChannelTable.where(idCol == myChannel.id).update(updateSetters)
             let _ = try db.run(updateQuery)
         } else {
             let rolesCol = Expression<String>("roles")

--- a/ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift
+++ b/ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift
@@ -110,8 +110,13 @@ extension Database {
         let sortedAndNotDeletedPosts = sortedChainedPosts.filter({$0.deleteAt == 0})
 
         if (!receivingThreads) {
-            if let first = sortedAndNotDeletedPosts.first,
-               let last = sortedAndNotDeletedPosts.last {
+            // Use non-deleted posts for the range when available; fall back to all posts
+            // (including deleted) so that a PostsInChannel record is always created.
+            // Without this, a notification race where the only fetched post is already deleted
+            // leaves PostsInChannel empty, which makes the channel appear completely empty in the UI.
+            let postsForRange = sortedAndNotDeletedPosts.isEmpty ? sortedChainedPosts : sortedAndNotDeletedPosts
+            if let first = postsForRange.first,
+               let last = postsForRange.last {
                 let earliest = first.createAt
                 let latest = last.createAt
                 try handlePostsInChannel(db, channelId, earliest, latest)


### PR DESCRIPTION
#### Summary

We did experience the following issue multiple times already across our userbase and I've asked Claude to help debug it and this is what it came up with (sounds logical to me too).
Unfortunately, we were not yet able to properly reproduce the issue so I cannot confirm if the fix really helps, it's also very difficult to get the self compiled version rolled out to all our users, so I'd like to discuss the change here to see if you think it makes sense to apply it even though we're unable to reproduce it properly.

When a post is created and deleted before Gekidou fetches it, the background extension computes last_fetched_at = T_del ≈ now (using delete_at in the max formula). All subsequent fetchPostsSince(T_del) calls return 0 posts, storePostsForChannel is never called, PostsInChannel stays empty, and the channel appears completely empty in the UI indefinitely.

Fix across all layers:
- Use only create_at for deleted posts in getLastFetchedAtFromPosts (TS), Gekidou PushNotification+FetchData (iOS) and handleMyChannel (Android), since the server sets update_at = delete_at = T_del on deletion
- Always create a PostsInChannel record in Gekidou Database+Posts even when all fetched posts are deleted, falling back to the deleted posts for range
- Guard handlePostsInChannel in Android Post.kt to avoid writing a {0,0} chunk when the posts map is empty


```release-note
fix: prevent channel appearing empty after push notification race with deleted post
```
