### PR TITLE
SEC-10094 feat(workflow): PR test analysis

### DIFF
--- a/.github/workflows/pr-test-analysis-override.yml
+++ b/.github/workflows/pr-test-analysis-override.yml
@@ -1,0 +1,34 @@
+---
+name: PR Test Analysis Override
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: test-analyzer-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  override:
+    permissions:
+      statuses: write
+      pull-requests: read
+      contents: read
+      issues: write
+    if: >-
+      github.repository == 'mattermost/mattermost-mobile' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/test-analysis-override') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    # Pin to a commit SHA once the reusable workflow is stable. Using @main during initial rollout.
+    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis-override.yml@main
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      target_repo: mattermost/mattermost-mobile
+      comment_body: ${{ github.event.comment.body }}
+      comment_id: ${{ github.event.comment.id }}
+      sender: ${{ github.event.comment.user.login }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      WEBHOOK_URL: ${{ secrets.WEBHOOK_URL_TEST_PR_ANALYSIS_HUB }}

--- a/.github/workflows/pr-test-analysis.yml
+++ b/.github/workflows/pr-test-analysis.yml
@@ -1,0 +1,48 @@
+---
+name: PR Test Analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+      - 'release-*'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to analyze'
+        required: true
+        type: number
+      claude_model:
+        description: 'Claude model to use (default: claude-sonnet-4-6)'
+        required: false
+        type: string
+
+concurrency:
+  group: test-analyzer-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+      id-token: write
+    # pull_request: skip drafts and forks (drafts are not ready for analysis;
+    # fork runs do not receive this repo's Actions secrets).
+    # workflow_dispatch: always allowed — runs in this repo with secrets, so you can pass a fork PR number manually.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == 'mattermost/mattermost-mobile')
+    # Pin to a commit SHA once the reusable workflow is stable. Using @main during initial rollout.
+    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      target_repo: mattermost/mattermost-mobile
+      claude_model: ${{ inputs.claude_model || vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      WEBHOOK_URL: ${{ secrets.WEBHOOK_URL_TEST_PR_ANALYSIS_HUB }}


### PR DESCRIPTION
#### Summary
Per rollout plan - https://hub.mattermost.com/private-core/pl/gt5hkzyrfiduze6rq3bta91www

- Add PR Test Analysis workflow that uses AI to evaluate test coverage adequacy on pull requests targeting `main` and `release-*` branches
- Add PR Test Analysis Override workflow that allows authorized users to override a failing test analysis status via `/test-analysis-override <reason>` comment
- Both workflows delegate to reusable workflows in [mattermost-test-automation-toolkit](https://github.com/mattermost/mattermost-test-automation-toolkit), following the same pattern as [mattermost/mattermost](https://github.com/mattermost/mattermost)

#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-10094

#### Release Note
```release-note
NONE
```
