### PR TITLE
[MM-67999] Bump react-native-network-client to 1.9.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1456,7 +1456,7 @@ PODS:
     - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
-  - react-native-network-client (1.9.2):
+  - react-native-network-client (1.9.3):
     - Alamofire (~> 5.10.2)
     - DoubleConversion
     - glog
@@ -2678,7 +2678,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: 1279ed5533ab248197e8a05f928f3d826fe5a31e
   react-native-keyboard-controller: 0aff65ca209dae10cd0ac7c9c2404baabb625d42
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-network-client: 58074d41410fbbdf84d9e4808e5d0e8852112fb4
+  react-native-network-client: da2a1edbad0dfdf90a38194e2d1e34c37dc3d93b
   react-native-notifications: 3bafa1237ae8a47569a84801f17d80242fe9f6a5
   react-native-paste-input: c8fdbe9366a5d93a503848ba19fc335ae532c63b
   react-native-performance: 125a96c145e29918b55b45ce25cbba54f1e24dcd
@@ -2746,6 +2746,6 @@ SPEC CHECKSUMS:
   WatermelonDB: 4c846c8cb94eef3cba90fa034d15310163226703
   Yoga: 2b02f3f767761bb4ffd25b1bb56fd264be57bd6b
 
-PODFILE CHECKSUM: 65f5721fd74a068496007fbab16c3a07600ac04f
+PODFILE CHECKSUM: c91489514ecbd67a0fcd5317589e9cd96db89d21
 
 COCOAPODS: 1.16.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@mattermost/compass-icons": "0.1.53",
         "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
         "@mattermost/react-native-emm": "1.6.2",
-        "@mattermost/react-native-network-client": "1.9.2",
+        "@mattermost/react-native-network-client": "1.9.3",
         "@mattermost/react-native-paste-input": "0.8.1",
         "@mattermost/react-native-turbo-log": "0.6.0",
         "@mattermost/rnshare": "file:./libraries/@mattermost/rnshare",
@@ -4669,9 +4669,9 @@
       }
     },
     "node_modules/@mattermost/react-native-network-client": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.9.2.tgz",
-      "integrity": "sha512-ykljf4U5jYApXrfkZMhDjyLIchrq/jWxh0eZQxtykXcInHR/wwRerC4jDCBKLKat4TiZK2lG7QZThZFjkEbdlw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@mattermost/react-native-network-client/-/react-native-network-client-1.9.3.tgz",
+      "integrity": "sha512-pEL1zRyM/IfposOizLVugOX/bJJJ1+LDg6/mMfQGxNUspYyXzmhoh3IRaeS2XV54fjzJX8Q5cvrNlo8haKlUfA==",
       "license": "MIT",
       "dependencies": {
         "validator": "13.15.23",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@mattermost/compass-icons": "0.1.53",
     "@mattermost/hardware-keyboard": "file:./libraries/@mattermost/hardware-keyboard",
     "@mattermost/react-native-emm": "1.6.2",
-    "@mattermost/react-native-network-client": "1.9.2",
+    "@mattermost/react-native-network-client": "1.9.3",
     "@mattermost/react-native-paste-input": "0.8.1",
     "@mattermost/react-native-turbo-log": "0.6.0",
     "@mattermost/rnshare": "file:./libraries/@mattermost/rnshare",


### PR DESCRIPTION
#### Summary

Upgrade the network library to handle the race condition.

includes the fix in https://github.com/mattermost/react-native-network-client/pull/163

#### Ticket Link
[MM-67999](https://mattermost.atlassian.net/browse/MM-67999)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: ios sim and android emulator

```release-note
NONE
```

[MM-67999]: https://mattermost.atlassian.net/browse/MM-67999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ