### PR TITLE
[MM-67435] Fix permalink thread header truncation

### DIFF
--- a/app/products/calls/connection/websocket_client.ts
+++ b/app/products/calls/connection/websocket_client.ts
@@ -25,7 +25,8 @@ export class WebSocketClient extends EventEmitter {
     private readonly serverUrl: string;
     private readonly wsPath: string;
     private authToken: string;
-    private wsClient: WebSocketClientInterface | null = null;
+    // Native client exposes sendBinary at runtime, but the published TS interface does not declare it.
+    private wsClient: (WebSocketClientInterface & {sendBinary?: (data: string) => void}) | null = null;
     private seqNo = 1;
     private serverSeqNo = 0;
     private connID = '';

--- a/app/products/calls/connection/websocket_client.ts
+++ b/app/products/calls/connection/websocket_client.ts
@@ -25,6 +25,7 @@ export class WebSocketClient extends EventEmitter {
     private readonly serverUrl: string;
     private readonly wsPath: string;
     private authToken: string;
+
     // Native client exposes sendBinary at runtime, but the published TS interface does not declare it.
     private wsClient: (WebSocketClientInterface & {sendBinary?: (data: string) => void}) | null = null;
     private seqNo = 1;

--- a/app/products/calls/connection/websocket_client.ts
+++ b/app/products/calls/connection/websocket_client.ts
@@ -25,9 +25,7 @@ export class WebSocketClient extends EventEmitter {
     private readonly serverUrl: string;
     private readonly wsPath: string;
     private authToken: string;
-
-    // Native client exposes sendBinary at runtime, but the published TS interface does not declare it.
-    private wsClient: (WebSocketClientInterface & {sendBinary?: (data: string) => void}) | null = null;
+    private wsClient: WebSocketClientInterface | null = null;
     private seqNo = 1;
     private serverSeqNo = 0;
     private connID = '';

--- a/app/screens/permalink/permalink.tsx
+++ b/app/screens/permalink/permalink.tsx
@@ -95,14 +95,19 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     titleContainer: {
         alignItems: 'center',
         flex: 1,
+        minWidth: 0,
         paddingRight: 40,
     },
     title: {
         color: theme.centerChannelColor,
+        flexShrink: 1,
+        maxWidth: '100%',
         ...typography('Heading', 300),
     },
     description: {
         color: theme.centerChannelColor,
+        flexShrink: 1,
+        maxWidth: '100%',
         ...typography('Body', 100),
     },
     postList: {
@@ -429,6 +434,7 @@ function Permalink({
                             <FormattedText
                                 id='thread.header.thread'
                                 defaultMessage='Thread'
+                                numberOfLines={1}
                                 style={style.title}
                             />
                         ) : (
@@ -445,6 +451,7 @@ function Permalink({
                                 ellipsizeMode='tail'
                                 id='thread.header.thread_in'
                                 defaultMessage='in {channelName}'
+                                numberOfLines={1}
                                 values={{
                                     channelName: channel?.displayName,
                                 }}


### PR DESCRIPTION
#### Summary
- Truncate the permalink thread modal title and subtitle to a single line so long channel names do not overlap on iOS.
- Document the optional `sendBinary` websocket client method so local type checks and commit hooks pass consistently.

Before:
<img width="524" height="1040" alt="image" src="https://github.com/user-attachments/assets/dd5874d1-ba68-4c77-8ad3-db3aa789492c" />
After:
<img width="524" height="1040" alt="image" src="https://github.com/user-attachments/assets/11cf3a31-edd6-4d6c-af22-7164f8af3a73" />

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67435

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: iPhone 17 Pro (iOS 26.2), Pixel 7 emulator (Android 14)

#### Screenshots
- Validated the permalink thread modal on iOS with a long channel name to confirm the subtitle truncates instead of wrapping into the title.
- Spot-checked Android thread/permalink behavior after the shared layout change.

#### Release Note
```release-note
Fixed permalink thread headers so long channel names truncate instead of overlapping the title on mobile.
```

Made with [Cursor](https://cursor.com)