### PR TITLE
Fix Android crash: view created after ViewController destroyed (MM-68032)

### DIFF
--- a/patches/react-native-navigation+7.45.0.patch
+++ b/patches/react-native-navigation+7.45.0.patch
@@ -412,6 +412,40 @@ index 7f1a2e0..c8b3d91 100644
          } else {
              children.remove(child);
          }
+diff --git a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/statusbar/StatusBarPresenter.kt b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/statusbar/StatusBarPresenter.kt
+index 0000000..0000000 100644
+--- a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/statusbar/StatusBarPresenter.kt
++++ b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/statusbar/StatusBarPresenter.kt
+@@ -120,7 +120,7 @@ class StatusBarPresenter private constructor(
+ 
+     private fun setStatusBarVisible(viewController: ViewController<*>, visible: Bool) {
+         val window = window.get() ?: return
+-        val view = if (viewController.view != null) viewController.view else window.decorView
++        val view = viewController.getExistingViewOnly() ?: window.decorView
+         if (visible.isFalse) {
+             hideStatusBar(window, view)
+         } else {
+diff --git a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java
+index 0000000..0000000 100644
+--- a/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java
++++ b/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java
+@@ -242,6 +242,16 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
+         return view;
+     }
+ 
++    /**
++     * Returns the view only if it already exists; does not create one.
++     * Kotlin {@code viewController.view} maps to {@link #getView()}, which can recreate views
++     * during activity teardown and crash with "Tried to create view after it has already been destroyed".
++     */
++    @Nullable
++    public T getExistingViewOnly() {
++        return view;
++    }
++
+     public void detachView() {
+         if (view == null || view.getParent() == null) return;
+         ((ViewManager) view.getParent()).removeView(view);
 diff --git a/node_modules/react-native-navigation/lib/ios/RNNComponentViewController.m b/node_modules/react-native-navigation/lib/ios/RNNComponentViewController.m
 index fc482a6..9406bbf 100644
 --- a/node_modules/react-native-navigation/lib/ios/RNNComponentViewController.m


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Fixes a high-volume Android production crash (`RuntimeException: Tried to create view after it has already been destroyed`) seen when destroying `MainActivity`, with the stack going through react-native-navigation status bar handling.

**Root cause:** In `StatusBarPresenter.setStatusBarVisible`, Kotlin `viewController.view` resolves to the Java **getter** `getView()`, not the backing field. During teardown that can call `getView()` on a controller whose view was already torn down and `isDestroyed` is true, which throws the exact message from Sentry.

**Fix:** Add `ViewController.getExistingViewOnly()` (returns the field without creating a view) and use it from `StatusBarPresenter` so status bar visibility uses either the existing view or `window.decorView`, never `getView()` implicitly.

Change is applied via the existing `patches/react-native-navigation+7.45.0.patch`.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-68032

Sentry: https://mattermost-mr.sentry.io/issues/6640793436/

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information

This PR was tested on: not run (native Android patch; `npm run tsc` passed)

#### Screenshots

N/A

#### Release Note

```release-note
Fixed an Android crash when closing the app related to status bar handling during activity destroy.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d18c294a-b290-472c-92da-c9cc52655939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d18c294a-b290-472c-92da-c9cc52655939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

