### PR TITLE
Mobile: Quick fixes for docs label automation

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -1,7 +1,10 @@
 name: Documentation Impact Review
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
 concurrency:
   group: ${{ format('docs-impact-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
@@ -12,7 +15,7 @@ permissions:
   id-token: write
 jobs:
   docs-impact-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
     runs-on: ubuntu-24.04
     env:
       HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}


### PR DESCRIPTION
Applying same fixes from https://github.com/mattermost/mattermost/pull/36185 to mobile.

Fixes the following issues:
 - Don't run the ci check on release branches. Only run it on master/main branch.
 - Skip analyzing docs impact for PRs opened by ``unified-ci-app`` bot.

```release-note
NONE
```
