### PR TITLE
Fix blank CallScreen / dead mic toggle: wait for ws.sessionID in waitForPeerConnection

### DIFF
--- a/app/products/calls/connection/connection.test.ts
+++ b/app/products/calls/connection/connection.test.ts
@@ -604,4 +604,53 @@ describe('newConnection', () => {
         await expect(res).resolves.toBe('sessionID');
         jest.useRealTimers();
     });
+
+    it('waitForPeerConnection does not resolve with empty sessionID when peer connects before WS register', async () => {
+        // Simulate the race where WebRTC peer connects (e.g. via direct host candidate)
+        // before the Calls WS register completes and populates ws.sessionID.
+        // The promise must NOT resolve with an empty sessionID — it should keep waiting
+        // (and time out if the register never arrives).
+
+        // eslint-disable-next-line
+        // @ts-ignore
+        RTCPeer.mockImplementation(() => {
+            return {
+                getStats: jest.fn(),
+                on: jest.fn(),
+                connected: true,
+            };
+        });
+
+        // eslint-disable-next-line
+        // @ts-ignore
+        WebSocketClient.mockImplementation(() => ({
+            initialize: jest.fn(),
+            on: (event: string, handler: any) => {
+                if (event === 'join') {
+                    handler();
+                }
+            },
+            send: jest.fn(),
+            sessionID: '',
+        }));
+
+        const connection = await newConnection(
+            'http://localhost:8065',
+            'channelID',
+            () => {},
+            () => {},
+            true,
+        );
+        expect(connection).toBeDefined();
+
+        await Promise.resolve();
+
+        jest.useFakeTimers();
+
+        const res = connection.waitForPeerConnection();
+        jest.runAllTimers();
+
+        await expect(res).rejects.toEqual('timed out waiting for peer connection');
+        jest.useRealTimers();
+    });
 });

--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -464,7 +464,12 @@ export async function newConnection(
                 return;
             }
             setTimeout(() => {
-                if (peer?.connected) {
+                // Wait for both the WebRTC peer connection AND the Calls WS register
+                // (which populates ws.sessionID). Without the sessionID guard, a fast
+                // ICE path (direct host candidate) can beat the WS register and resolve
+                // with an empty sessionID, leaving downstream state (currentCall.mySessionId,
+                // mute toggles) effectively blank. See issue #9709.
+                if (peer?.connected && ws.sessionID) {
                     rtcMonitor?.start();
                     callback(ws.sessionID);
                 } else {


### PR DESCRIPTION
#### Summary

`waitForPeerConnection` in `app/products/calls/connection/connection.ts` resolved as soon as `peer?.connected` became true and returned `ws.sessionID` verbatim. When WebRTC ICE completes before the Calls plugin WebSocket register event — common on fast networks with a working direct host candidate (no TURN relay) — `ws.sessionID` is still an empty string at that moment. The promise resolves with `""`, downstream `setCurrentCallConnected(channelId, "")` leaves `currentCall.mySessionId = ""`, `currentCall.sessions[""] === undefined`, and `call_screen.tsx:659` bails out with `return null` → blank CallScreen. The same empty `mySessionId` makes `muteMyself()` / `unmuteMyself()` post an action with no session identifier, so the mic toggle silently does nothing.

This PR guards the resolution on both conditions: the promise now waits until `peer?.connected && ws.sessionID` (non-empty) before invoking the callback, which preserves the existing timeout semantics via the retry path.

Also adds a unit test for the race: `peer.connected === true` with `ws.sessionID === ''` must NOT resolve — it must keep polling and ultimately time out.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-mobile/issues/9709

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information

Repro observed on Samsung SM-S938B (Android 16), Mattermost Mobile 2.39.0+6000743. Fix is platform-agnostic (pure logic in shared TS).

#### Screenshots

N/A — no UI changes; internal logic only.

#### Release Note

Fix blank call screen and unresponsive mute toggle when joining a call on fast networks: `waitForPeerConnection` now waits for the WebSocket register to populate `sessionID` before resolving, avoiding an empty `mySessionId` in client state.