### PR TITLE
Revert "MM-68171 - Show team sidebar when other teams are available to join (#9658)"

### DIFF
--- a/app/components/team_sidebar/team_sidebar.tsx
+++ b/app/components/team_sidebar/team_sidebar.tsx
@@ -37,8 +37,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
 });
 
 export default function TeamSidebar({iconPad, canJoinOtherTeams, hasMoreThanOneTeam}: Props) {
-    const shouldShowSidebar = hasMoreThanOneTeam || canJoinOtherTeams;
-    const initialWidth = shouldShowSidebar ? TEAM_SIDEBAR_WIDTH : 0;
+    const initialWidth = hasMoreThanOneTeam ? TEAM_SIDEBAR_WIDTH : 0;
     const width = useSharedValue(initialWidth);
     const marginTop = useSharedValue(iconPad ? 44 : 0);
     const theme = useTheme();
@@ -62,11 +61,11 @@ export default function TeamSidebar({iconPad, canJoinOtherTeams, hasMoreThanOneT
     }, [iconPad]);
 
     useEffect(() => {
-        width.value = shouldShowSidebar ? TEAM_SIDEBAR_WIDTH : 0;
+        width.value = hasMoreThanOneTeam ? TEAM_SIDEBAR_WIDTH : 0;
 
-    // width is a stable reanimated shared value ref
+    // Update the shared value only when the hasMoreThanOneTeam changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [shouldShowSidebar]);
+    }, [hasMoreThanOneTeam]);
 
     return (
         <Animated.View style={[styles.container, transform]}>

--- a/app/screens/home/channel_list/channel_list.test.tsx
+++ b/app/screens/home/channel_list/channel_list.test.tsx
@@ -33,7 +33,6 @@ jest.mock('@screens/navigation', () => ({
 
 function getBaseProps(): ComponentProps<typeof ChannelListScreen> {
     return {
-        canJoinOtherTeams: false,
         hasChannels: true,
         hasCurrentUser: true,
         hasMoreThanOneTeam: true,
@@ -107,36 +106,6 @@ describe('watermark overlay', () => {
         rerender(<ChannelListScreen {...{...props, isWatermarkEnabled: false}}/>);
         await waitFor(() => {
             expect(dismissWatermarkOverlay).toHaveBeenCalledTimes(1);
-        });
-    });
-});
-
-describe('team sidebar visibility', () => {
-    let database: Database;
-    const serverUrl = 'http://www.someserverurl.com';
-
-    beforeAll(async () => {
-        const server = await TestHelper.setupServerDatabase(serverUrl);
-        database = server.database;
-    });
-
-    it('should render when canJoinOtherTeams is true and user has only one team', async () => {
-        const props = getBaseProps();
-        props.canJoinOtherTeams = true;
-        props.hasMoreThanOneTeam = false;
-        const {getByTestId} = renderWithEverything(<ChannelListScreen {...props}/>, {database, serverUrl});
-        await waitFor(() => {
-            expect(getByTestId('channel_list.screen')).toBeTruthy();
-        });
-    });
-
-    it('should render when canJoinOtherTeams is false and user has only one team', async () => {
-        const props = getBaseProps();
-        props.canJoinOtherTeams = false;
-        props.hasMoreThanOneTeam = false;
-        const {getByTestId} = renderWithEverything(<ChannelListScreen {...props}/>, {database, serverUrl});
-        await waitFor(() => {
-            expect(getByTestId('channel_list.screen')).toBeTruthy();
         });
     });
 });

--- a/app/screens/home/channel_list/channel_list.tsx
+++ b/app/screens/home/channel_list/channel_list.tsx
@@ -32,7 +32,6 @@ import Servers from './servers';
 import type {LaunchType} from '@typings/launch';
 
 type ChannelProps = {
-    canJoinOtherTeams: boolean;
     hasChannels: boolean;
     isCRTEnabled: boolean;
     hasTeams: boolean;
@@ -211,7 +210,7 @@ const ChannelListScreen = (props: ChannelProps) => {
                             hasMoreThanOneTeam={props.hasMoreThanOneTeam}
                         />
                         <CategoriesList
-                            iconPad={canAddOtherServers && !props.hasMoreThanOneTeam && !props.canJoinOtherTeams}
+                            iconPad={canAddOtherServers && !props.hasMoreThanOneTeam}
                             isCRTEnabled={props.isCRTEnabled}
                             moreThanOneTeam={props.hasMoreThanOneTeam}
                             hasChannels={props.hasChannels}

--- a/app/screens/home/channel_list/index.ts
+++ b/app/screens/home/channel_list/index.ts
@@ -6,24 +6,18 @@ import {of as of$} from 'rxjs';
 import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
 import {observeIncomingCalls} from '@calls/state';
-import {withServerUrl} from '@context/server';
 import {queryAllMyChannelsForTeam} from '@queries/servers/channel';
 import {observeConfigBooleanValue, observeCurrentTeamId, observeCurrentUserId, observeLicense} from '@queries/servers/system';
 import {queryMyTeams} from '@queries/servers/team';
 import {observeShowToS} from '@queries/servers/terms_of_service';
 import {observeIsCRTEnabled} from '@queries/servers/thread';
 import {observeCurrentUser} from '@queries/servers/user';
-import EphemeralStore from '@store/ephemeral_store';
 
 import ChannelsList from './channel_list';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
 
-type EnhanceProps = WithDatabaseArgs & {
-    serverUrl?: string;
-}
-
-const enhanced = withObservables([], ({database, serverUrl}: EnhanceProps) => {
+const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const isLicensed = observeLicense(database).pipe(
         switchMap((lcs) => (lcs ? of$(lcs.IsLicensed === 'true') : of$(false))),
     );
@@ -59,8 +53,7 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhanceProps) => {
             distinctUntilChanged(),
         ),
         showIncomingCalls,
-        canJoinOtherTeams: EphemeralStore.observeCanJoinOtherTeams(serverUrl || ''),
     };
 });
 
-export default withDatabase(withServerUrl(enhanced(ChannelsList)));
+export default withDatabase(enhanced(ChannelsList));


### PR DESCRIPTION
## Summary

Reverts #9658 per design team feedback ([MM-68171](https://mattermost.atlassian.net/browse/MM-68171) discussion).

The original fix made the team sidebar visible whenever the user could join another team, even when they were a member of only one team. After review, design prefers a different approach: hide the sidebar in the single-team case (matching the prior behavior) and surface "Join Another Team" / "Leave team" via a bottom-sheet menu accessed from the channel list header instead.

## Replacement

The replacement PR adds a chevron affordance next to the team name in the channel list header that opens a bottom-sheet team menu. That work lives in a separate PR so this revert can land independently if the menu PR isn't ready by code freeze.

- Replacement PR: _to be filed immediately after this one_

## Regression note

Landing this revert without the replacement reintroduces the original [MM-68171](https://mattermost.atlassian.net/browse/MM-68171) bug: a user who is a member of only one team but has permission to join others will have no path to discover/join those teams from the channel list. Per design team direction, this is acceptable as a fallback if the replacement can't ship in time — they prefer the original behavior over the always-visible-sidebar UX.

## Test Plan

- [ ] Single-team user with joinable teams: team sidebar is hidden (back to original behavior; no "+" button visible)
- [ ] Single-team user without joinable teams: team sidebar is hidden (unchanged)
- [ ] Multi-team user (2+ teams): team sidebar is visible (unchanged)
- [ ] `npm run tsc` passes
- [ ] `npm test -- channel_list` passes

[MM-68171]: https://mattermost.atlassian.net/browse/MM-68171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MM-68171]: https://mattermost.atlassian.net/browse/MM-68171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ