### PR TITLE
MM-68482: Dismiss keyboard when opening app from push notification

### DIFF
--- a/app/actions/remote/entry/notification.test.ts
+++ b/app/actions/remote/entry/notification.test.ts
@@ -17,6 +17,11 @@ import type ServerDataOperator from '@database/operator/server_data_operator';
 jest.mock('@managers/performance_metrics_manager');
 jest.mock('@store/navigation_store');
 
+const mockDismissKeyboard = jest.fn();
+jest.mock('@utils/keyboard', () => ({
+    dismissKeyboard: (...args: unknown[]) => mockDismissKeyboard(...args),
+}));
+
 const mockedNavigationStore = jest.mocked(NavigationStore);
 
 describe('Performance metrics are set correctly', () => {
@@ -97,6 +102,7 @@ describe('Performance metrics are set correctly', () => {
             version: '', // Version is not checked at this level
         });
 
+        expect(mockDismissKeyboard).toHaveBeenCalled();
         expect(PerformanceMetricsManager.setLoadTarget).toHaveBeenCalledWith('CHANNEL');
     });
 

--- a/app/actions/remote/entry/notification.ts
+++ b/app/actions/remote/entry/notification.ts
@@ -17,6 +17,7 @@ import {getMyTeamById} from '@queries/servers/team';
 import {getIsCRTEnabled} from '@queries/servers/thread';
 import EphemeralStore from '@store/ephemeral_store';
 import {isErrorWithStatusCode} from '@utils/errors';
+import {dismissKeyboard} from '@utils/keyboard';
 import {emitNotificationError} from '@utils/notification';
 import {setThemeDefaults, updateThemeIfNeeded} from '@utils/theme';
 
@@ -33,6 +34,9 @@ export async function pushNotificationEntry(serverUrl: string, notification: Not
     if (!operator) {
         return {error: `${serverUrl} database not found`};
     }
+
+    // Cold start from push: ensure keyboard is not stuck over the channel after navigation
+    await dismissKeyboard();
 
     PerformanceMetricsManager.startTimeToInteraction();
 

--- a/app/actions/remote/notifications.test.ts
+++ b/app/actions/remote/notifications.test.ts
@@ -70,6 +70,11 @@ const throwFunc = (e?: string) => {
     throw Error(e == null ? 'error' : e);
 };
 
+const mockDismissKeyboard = jest.fn();
+jest.mock('@utils/keyboard', () => ({
+    dismissKeyboard: (...args: unknown[]) => mockDismissKeyboard(...args),
+}));
+
 let mockEmitNotificationError: jest.Mock;
 jest.mock('@utils/notification', () => {
     const original = jest.requireActual('@utils/notification');
@@ -198,6 +203,7 @@ describe('notifications', () => {
         const result = await openNotification(serverUrl, {payload: {...notificationData, team_id: ''}} as NotificationWithData) as {error?: unknown};
         expect(result).toBeDefined();
         expect(result.error).toBeUndefined();
+        expect(mockDismissKeyboard).toHaveBeenCalled();
     });
 });
 

--- a/app/actions/remote/notifications.ts
+++ b/app/actions/remote/notifications.ts
@@ -19,6 +19,7 @@ import {getCurrentTeamId} from '@queries/servers/system';
 import {getMyTeamById, prepareMyTeams} from '@queries/servers/team';
 import {getIsCRTEnabled} from '@queries/servers/thread';
 import EphemeralStore from '@store/ephemeral_store';
+import {dismissKeyboard} from '@utils/keyboard';
 import {logWarning} from '@utils/log';
 import {emitNotificationError} from '@utils/notification';
 import {processPostsFetched} from '@utils/post';
@@ -223,6 +224,9 @@ export const openNotification = async (serverUrl: string, notification: Notifica
     }
 
     EphemeralStore.setNotificationTapped(true);
+
+    // Dismiss keyboard before switching channel/thread (e.g. iOS resume from push can leave draft focused)
+    await dismissKeyboard();
 
     const channelId = notification.payload!.channel_id!;
     const rootId = notification.payload!.root_id!;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes [MM-68482](https://mattermost.atlassian.net/browse/MM-68482): on iOS, the keyboard could stay open after opening the app from a push notification, blocking the channel view until restart.

## Root cause
[#9602](https://github.com/mattermost/mattermost-mobile/pull/9602) replaced `Keyboard.dismiss()` with `KeyboardController.dismiss()` (`dismissKeyboard`) only in paths that open the user profile bottom sheet. **Push notification navigation** (`pushNotificationEntry` on cold start and `openNotification` when tapping a notification from the background) never dismissed the keyboard before switching channel/thread, so a previously focused post draft could leave the keyboard in a bad state after resume.

## Fix
- `pushNotificationEntry`: await `dismissKeyboard()` after DB validation, before navigation/metrics.
- `openNotification`: await `dismissKeyboard()` after marking the notification tapped, before channel/thread switch.

https://github.com/mattermost/mattermost-mobile/issues/9705
 [MM-68482](https://mattermost.atlassian.net/browse/MM-68482)
## Tests
- Extended unit tests to assert `dismissKeyboard` is invoked in the happy paths.

## How to reproduce (manual)
1. iOS device or simulator, logged in.
2. Open a channel, focus the message draft so the keyboard is visible.
3. Background the app (home button / swipe up).
4. Send yourself a message push for another channel (or same channel).
5. Tap the notification to open the app.

**Before:** Keyboard sometimes remained stuck and obscured content.  
**After:** Keyboard is dismissed before navigating to the notification target.

Note: `npm run tsc` currently reports a pre-existing error in `navigation.ts` (`androidIgnoreTouchInside`); unchanged by this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ea988f8-120d-4a9d-a3da-8a4f420158c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ea988f8-120d-4a9d-a3da-8a4f420158c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[MM-68482]: https://mattermost.atlassian.net/browse/MM-68482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Release Note

```release-note
Fix issue with keyboard stuck after opening from a push notification in iOS
```