### PR TITLE
Fix agents/bots flooding /invite and at-mention autocomplete

### DIFF
--- a/app/components/autocomplete/at_mention/at_mention.tsx
+++ b/app/components/autocomplete/at_mention/at_mention.tsx
@@ -12,6 +12,7 @@ import SpecialMentionItem from '@components/autocomplete/special_mention_item';
 import {AT_MENTION_REGEX, AT_MENTION_SEARCH_REGEX} from '@constants/autocomplete';
 import {useServerUrl} from '@context/server';
 import {useDebounce} from '@hooks/utils';
+import {filterProfilesMatchingTerm} from '@utils/user';
 
 import {SECTION_KEY_AGENTS, SECTION_KEY_GROUPS, SECTION_KEY_SPECIAL, emptyGroupList, emptySectionList, emptyUserlList} from './constants';
 import {checkSpecialMentions, filterResults, getAllUsers, getMatchTermForAtMention, keyExtractor, makeSections, searchGroups, sortReceivedUsers} from './utils';
@@ -103,10 +104,13 @@ const AtMention = ({
             const usersOnly = receivedUsers.users.filter((u) => !agentIds.has(u.id));
             const outOfChannelOnly = receivedUsers.out_of_channel?.filter((u) => !agentIds.has(u.id));
 
+            // Server returns all agents regardless of term; filter client-side.
+            const filteredAgents = filterProfilesMatchingTerm(receivedAgents, term);
+
             const [sortedMembers, sortedOutOfChannel] = await sortReceivedUsers(sUrl, term, usersOnly, outOfChannelOnly);
             setUsersInChannel(sortedMembers.length ? sortedMembers : emptyUserlList);
             setUsersOutOfChannel(sortedOutOfChannel.length ? sortedOutOfChannel : emptyUserlList);
-            setAgents(receivedAgents.length ? receivedAgents : emptyUserlList);
+            setAgents(filteredAgents.length ? filteredAgents : emptyUserlList);
         }
 
         setLoading(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The `/api/v4/users/autocomplete` endpoint returns all AI plugin agents regardless of the typed term. The webapp already handles this in [`at_mention_provider.tsx`](https://github.com/mattermost/mattermost/blob/master/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx) by running its `filterProfile` over `data.agents`. This PR mirrors that on mobile by reusing the existing `filterProfilesMatchingTerm` util, which already encodes the same `getSuggestionsSplitByMultiple` + `AUTOCOMPLETE_SPLIT_CHARACTERS` logic the webapp uses.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-68616

#### Release Note

```release-note
Fixed an issue on mobile where AI agents/bots flooded the at-mention and /invite autocomplete results regardless of the typed username.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd4c0739-b9ef-485e-89a8-941468ff1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd4c0739-b9ef-485e-89a8-941468ff1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

