### PR TITLE
Pass channel_id on AI rewrite requests for MBE plugin gating

### DIFF
--- a/app/components/post_draft/draft_input/draft_input.tsx
+++ b/app/components/post_draft/draft_input/draft_input.tsx
@@ -251,6 +251,7 @@ function DraftInput({
                     <View style={style.actionsContainer}>
                         <QuickActions
                             testID={quickActionsTestID}
+                            channelId={channelId}
                             fileCount={files.length}
                             addFiles={addFiles}
                             updateValue={updateValue}

--- a/app/components/post_draft/quick_actions/quick_actions.test.tsx
+++ b/app/components/post_draft/quick_actions/quick_actions.test.tsx
@@ -18,6 +18,7 @@ describe('Quick Actions', () => {
         updatePostBoRStatus: jest.fn(),
         testID: 'test-quick-actions',
         canUploadFiles: true,
+        channelId: 'channel-id',
         fileCount: 0,
         isAgentsEnabled: true,
         isPostPriorityEnabled: true,

--- a/app/components/post_draft/quick_actions/quick_actions.tsx
+++ b/app/components/post_draft/quick_actions/quick_actions.tsx
@@ -18,6 +18,7 @@ import type {AvailableScreens} from '@typings/screens/navigation';
 type Props = {
     testID?: string;
     canUploadFiles: boolean;
+    channelId: string;
     fileCount: number;
     isAgentsEnabled: boolean;
     isPostPriorityEnabled: boolean;
@@ -54,6 +55,7 @@ const style = StyleSheet.create({
 export default function QuickActions({
     testID,
     canUploadFiles,
+    channelId,
     value,
     fileCount,
     isAgentsEnabled,
@@ -127,6 +129,7 @@ export default function QuickActions({
             {isAgentsEnabled && (
                 <AIRewriteAction
                     testID={aiRewriteActionTestID}
+                    channelId={channelId}
                     value={value}
                     updateValue={updateValue}
                 />

--- a/app/products/agents/actions/remote/agents.test.ts
+++ b/app/products/agents/actions/remote/agents.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import NetworkManager from '@managers/network_manager';
+import {getFullErrorMessage} from '@utils/errors';
+import {logError} from '@utils/log';
+
+import {rewriteMessage} from './agents';
+
+import type {RewriteAction} from '@agents/types';
+
+jest.mock('@managers/network_manager');
+jest.mock('@utils/errors');
+jest.mock('@utils/log');
+jest.mock('@agents/store', () => ({
+    rewriteStore: {setAgents: jest.fn()},
+}));
+
+const serverUrl = 'https://test.mattermost.com';
+
+const mockClient = {
+    getRewrittenMessage: jest.fn(),
+};
+
+beforeAll(() => {
+    jest.mocked(NetworkManager.getClient).mockReturnValue(mockClient as any);
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('rewriteMessage', () => {
+    const action: RewriteAction = 'improve_writing';
+
+    it('should forward channelId to client.getRewrittenMessage', async () => {
+        mockClient.getRewrittenMessage.mockResolvedValue('rewritten text');
+
+        const result = await rewriteMessage(serverUrl, 'hello', 'channel-abc', action, 'a prompt', 'agent-1');
+
+        expect(mockClient.getRewrittenMessage).toHaveBeenCalledTimes(1);
+        expect(mockClient.getRewrittenMessage).toHaveBeenCalledWith('hello', 'channel-abc', action, 'a prompt', 'agent-1');
+        expect(result).toEqual({rewrittenText: 'rewritten text'});
+    });
+
+    it('should forward an empty channelId unchanged so the client decides whether to omit channel_id', async () => {
+        mockClient.getRewrittenMessage.mockResolvedValue('rewritten text');
+
+        await rewriteMessage(serverUrl, 'hello', '', action, undefined, undefined);
+
+        expect(mockClient.getRewrittenMessage).toHaveBeenCalledWith('hello', '', action, undefined, undefined);
+    });
+
+    it('should return error and log on failure', async () => {
+        const error = new Error('Network error');
+        const errorMessage = 'Network error occurred';
+        mockClient.getRewrittenMessage.mockRejectedValue(error);
+        jest.mocked(getFullErrorMessage).mockReturnValue(errorMessage);
+
+        const result = await rewriteMessage(serverUrl, 'hello', 'channel-abc', action, undefined, undefined);
+
+        expect(logError).toHaveBeenCalledWith('[rewriteMessage]', error);
+        expect(getFullErrorMessage).toHaveBeenCalledWith(error);
+        expect(result).toEqual({error: errorMessage});
+    });
+});

--- a/app/products/agents/actions/remote/agents.ts
+++ b/app/products/agents/actions/remote/agents.ts
@@ -39,13 +39,14 @@ export const fetchAgents = async (serverUrl: string) => {
 export async function rewriteMessage(
     serverUrl: string,
     message: string,
+    channelId: string,
     action: RewriteAction,
     customPrompt: string | undefined,
     agentId: string | undefined,
 ): Promise<{rewrittenText?: string; error?: unknown}> {
     try {
         const client = NetworkManager.getClient(serverUrl);
-        const rewrittenText = await client.getRewrittenMessage(message, action, customPrompt, agentId);
+        const rewrittenText = await client.getRewrittenMessage(message, channelId, action, customPrompt, agentId);
         return {rewrittenText};
     } catch (error) {
         logError('[rewriteMessage]', error);

--- a/app/products/agents/client/rest.test.ts
+++ b/app/products/agents/client/rest.test.ts
@@ -86,4 +86,55 @@ describe('ClientAgents', () => {
             );
         });
     });
+
+    describe('getRewrittenMessage', () => {
+        beforeEach(() => {
+            mockDoFetch.mockResolvedValue({rewritten_text: 'rewritten'});
+        });
+
+        it('should include channel_id in body when channelId is non-empty', async () => {
+            await client.getRewrittenMessage('hello', 'channel-123', 'rephrase', 'prompt', 'agent-1');
+
+            expect(mockDoFetch).toHaveBeenCalledTimes(1);
+            const [, options] = mockDoFetch.mock.calls[0];
+            expect(options.body).toEqual({
+                agent_id: 'agent-1',
+                message: 'hello',
+                channel_id: 'channel-123',
+                action: 'rephrase',
+                custom_prompt: 'prompt',
+            });
+            expect(options.body).toHaveProperty('channel_id', 'channel-123');
+        });
+
+        it('should omit channel_id from body when channelId is an empty string', async () => {
+            await client.getRewrittenMessage('hello', '', 'rephrase', undefined, undefined);
+
+            expect(mockDoFetch).toHaveBeenCalledTimes(1);
+            const [, options] = mockDoFetch.mock.calls[0];
+            expect(options.body).not.toHaveProperty('channel_id');
+            expect(options.body).toEqual({
+                agent_id: undefined,
+                message: 'hello',
+                action: 'rephrase',
+                custom_prompt: undefined,
+            });
+        });
+
+        it('should return rewritten_text from the response', async () => {
+            mockDoFetch.mockResolvedValue({rewritten_text: 'the new text'});
+
+            const result = await client.getRewrittenMessage('hello', 'channel-123');
+
+            expect(result).toBe('the new text');
+        });
+
+        it('should return raw response when rewritten_text is undefined', async () => {
+            mockDoFetch.mockResolvedValue('plain text response');
+
+            const result = await client.getRewrittenMessage('hello', 'channel-123');
+
+            expect(result).toBe('plain text response');
+        });
+    });
 });

--- a/app/products/agents/client/rest.ts
+++ b/app/products/agents/client/rest.ts
@@ -25,7 +25,7 @@ export interface ClientAgentsMix {
     submitToolResult: (postId: string, acceptedToolIds: string[]) => Promise<void>;
 
     // Rewrite methods
-    getRewrittenMessage: (message: string, action?: string, customPrompt?: string, agentId?: string) => Promise<string>;
+    getRewrittenMessage: (message: string, channelId: string, action?: string, customPrompt?: string, agentId?: string) => Promise<string>;
     getAgentsStatus: () => Promise<AgentsStatusResponse>;
 }
 
@@ -136,10 +136,11 @@ const ClientAgents = (superclass: any) => class extends superclass {
     // Rewrite Methods
     // =========================================================================
 
-    getRewrittenMessage = async (message: string, action?: string, customPrompt?: string, agentId?: string): Promise<string> => {
+    getRewrittenMessage = async (message: string, channelId: string, action?: string, customPrompt?: string, agentId?: string): Promise<string> => {
         const body: RewriteRequest = {
             agent_id: agentId,
             message,
+            ...(channelId ? {channel_id: channelId} : {}),
             action,
             custom_prompt: customPrompt,
         };

--- a/app/products/agents/components/ai_rewrite_action/index.tsx
+++ b/app/products/agents/components/ai_rewrite_action/index.tsx
@@ -19,6 +19,7 @@ const ICON_SIZE = 24;
 type Props = {
     testID?: string;
     disabled?: boolean;
+    channelId: string;
     value: string;
     updateValue: (value: string | ((prevValue: string) => string)) => void;
 }
@@ -34,6 +35,7 @@ const styles = {
 export default function AIRewriteAction({
     testID,
     disabled = false,
+    channelId,
     value,
     updateValue,
 }: Props) {
@@ -53,11 +55,12 @@ export default function AIRewriteAction({
             title,
             props: {
                 closeButtonId: 'close-ai-rewrite',
+                channelId,
                 originalMessage: value,
                 updateValue,
             },
         });
-    }, [intl, isTablet, theme, value, updateValue]);
+    }, [intl, isTablet, theme, channelId, value, updateValue]);
 
     const isDisabled = disabled || isProcessing;
     const actionTestID = isDisabled ? `${testID}.disabled` : testID;

--- a/app/products/agents/hooks/use_rewrite.ts
+++ b/app/products/agents/hooks/use_rewrite.ts
@@ -14,6 +14,7 @@ const TIMEOUT_MS = 30000; // 30 seconds
 type StartRewriteCallback = (
     serverUrl: string,
     message: string,
+    channelId: string,
     action: RewriteAction,
     customPrompt: string | undefined,
     agentId: string | undefined,
@@ -59,6 +60,7 @@ export const useRewrite = (): UseRewriteReturn => {
     const startRewrite = useCallback((
         serverUrl: string,
         message: string,
+        channelId: string,
         action: RewriteAction,
         customPrompt: string | undefined,
         agentId: string | undefined,
@@ -82,7 +84,7 @@ export const useRewrite = (): UseRewriteReturn => {
 
         const runRewrite = async () => {
             try {
-                const rewritePromise = rewriteMessage(serverUrl, message, action, customPrompt, agentId);
+                const rewritePromise = rewriteMessage(serverUrl, message, channelId, action, customPrompt, agentId);
                 currentPromiseRef.current = rewritePromise;
 
                 const result = await Promise.race([rewritePromise, timeoutPromise]);

--- a/app/products/agents/screens/rewrite_options/index.tsx
+++ b/app/products/agents/screens/rewrite_options/index.tsx
@@ -83,6 +83,7 @@ const messages = defineMessages({
 type Props = {
     closeButtonId: string;
     componentId: AvailableScreens;
+    channelId: string;
     originalMessage: string;
     updateValue: (value: string | ((prevValue: string) => string)) => void;
 };
@@ -141,6 +142,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
 const RewriteOptions = ({
     closeButtonId,
     componentId,
+    channelId,
     originalMessage,
     updateValue,
 }: Props) => {
@@ -204,6 +206,7 @@ const RewriteOptions = ({
             startRewrite(
                 serverUrl,
                 messageToProcess,
+                channelId,
                 action,
                 prompt,
                 agentId,
@@ -222,7 +225,7 @@ const RewriteOptions = ({
             // Still try to start the rewrite even if sheet close failed
             triggerRewrite();
         }
-    }, [originalMessage, serverUrl, closeBottomSheet, selectedAgent, startRewrite, handleRewriteSuccess, handleRewriteError]);
+    }, [originalMessage, channelId, serverUrl, closeBottomSheet, selectedAgent, startRewrite, handleRewriteSuccess, handleRewriteError]);
 
     // Determine if we're in generation mode (empty original message means user wants to generate new content)
     const isInGenerationMode = !originalMessage || !originalMessage.trim();

--- a/app/products/agents/types/api.ts
+++ b/app/products/agents/types/api.ts
@@ -52,6 +52,7 @@ export type AgentsStatusResponse = {
 export type RewriteRequest = {
     agent_id?: string;
     message: string;
+    channel_id?: string;
     action?: string;
     custom_prompt?: string;
 };

--- a/app/screens/edit_post/edit_post_input/edit_post_input.tsx
+++ b/app/screens/edit_post/edit_post_input/edit_post_input.tsx
@@ -136,6 +136,7 @@ const EditPostInput = ({
                     />
                     <QuickActions
                         testID='edit_post.quick_actions'
+                        channelId={post.channelId}
                         fileCount={postFiles.length}
                         addFiles={addFiles}
                         updateValue={updateValue}


### PR DESCRIPTION
#### Summary

Simply:
We need the `channelId` when the `/posts/rewrite` endpoint is hit.  Why? So the Message-Based Encryption (MBE) plugin can say "no AI rewrites in MBE channels".

More detail: 
Thread `channelId` from the post draft input through the AI Rewrite call chain so the request body sent to `POST /posts/rewrite` carries `channel_id`. Mattermost servers running the Message-Based Encryption (MBE) tech-preview plugin use this field to identify the channel and decide whether to allow the rewrite — the plugin refuses AI rewrites on encrypted channels (since shipping plaintext to an external LLM provider would defeat the encryption guarantee).

The field is optional on the server side (`omitempty`); servers without the MBE plugin and older servers ignore it.

#### Ticket Link

Server PR: https://github.com/mattermost/mattermost/pull/36407

#### Backwards compatibility

- **Old mobile + MBE-enabled server**: AI Rewrite is rejected on every channel because the plugin cannot identify the channel and must fail closed.  (only for servers that have the Message-Based Encryption tech preview enabled)
- **New mobile + MBE-enabled server**: AI Rewrite works on non-encrypted channels, is rejected only on MBE-encrypted channels.
- **New mobile + non-MBE server**: unchanged — the extra field is silently ignored.

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information

Verified via `npm run check`. No UI changes; no device-specific behavior.

#### Release Note

```release-note
Pass channel ID on AI rewrite requests so servers using the Message-Based Encryption tech-preview plugin can gate AI rewrites by channel.
```