### PR TITLE
Hide agents sidebar entry in release-2.40

### DIFF
--- a/app/screens/home/channel_list/categories_list/categories_list.tsx
+++ b/app/screens/home/channel_list/categories_list/categories_list.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import AgentsButton from '@agents/components/agents_button';
 import React, {useEffect, useMemo, useState} from 'react';
 import {DeviceEventEmitter, useWindowDimensions} from 'react-native';
 import Animated, {useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
@@ -39,7 +38,6 @@ type ChannelListProps = {
     scheduledPostHasError: boolean;
     lastChannelId?: string;
     scheduledPostsEnabled?: boolean;
-    agentsEnabled?: boolean;
     showPlaybooksButton?: boolean;
 };
 
@@ -59,7 +57,6 @@ const CategoriesList = ({
     scheduledPostHasError,
     lastChannelId,
     scheduledPostsEnabled,
-    agentsEnabled,
     showPlaybooksButton,
 }: ChannelListProps) => {
     const theme = useTheme();
@@ -130,18 +127,6 @@ const CategoriesList = ({
         return null;
     }, [activeScreen, draftsCount, isTablet, scheduledPostCount, scheduledPostHasError, scheduledPostsEnabled]);
 
-    const agentsButtonComponent = useMemo(() => {
-        if (!agentsEnabled) {
-            return null;
-        }
-
-        return (
-            <AgentsButton
-                shouldHighlightActive={activeScreen === AGENTS}
-            />
-        );
-    }, [agentsEnabled, activeScreen]);
-
     const playbooksButtonComponent = useMemo(() => {
         if (!showPlaybooksButton) {
             return null;
@@ -162,12 +147,11 @@ const CategoriesList = ({
                 <SubHeader/>
                 {threadButtonComponent}
                 {draftsButtonComponent}
-                {agentsButtonComponent}
                 {playbooksButtonComponent}
                 <Categories isTablet={isTablet}/>
             </>
         );
-    }, [agentsButtonComponent, draftsButtonComponent, hasChannels, isTablet, playbooksButtonComponent, threadButtonComponent]);
+    }, [draftsButtonComponent, hasChannels, isTablet, playbooksButtonComponent, threadButtonComponent]);
 
     return (
         <Animated.View style={[styles.container, tabletStyle]}>

--- a/app/screens/home/channel_list/categories_list/index.tsx
+++ b/app/screens/home/channel_list/categories_list/index.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {observeIsAgentsEnabled} from '@agents/database/queries/version';
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
 import {combineLatest, of} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
@@ -30,7 +29,6 @@ const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
         switchMap((scheduledPosts) => of(hasScheduledPostError(scheduledPosts))),
     );
     const scheduledPostsEnabled = observeScheduledPostEnabled(database);
-    const agentsEnabled = observeIsAgentsEnabled(database);
     const showPlaybooksButton = currentTeamId.pipe(
         switchMap((teamId) => combineLatest([
             observeIsPlaybooksEnabled(database),
@@ -45,7 +43,6 @@ const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
         scheduledPostCount,
         scheduledPostHasError,
         scheduledPostsEnabled,
-        agentsEnabled,
         showPlaybooksButton,
     };
 });


### PR DESCRIPTION
#### Summary
This PR removes the Agents sidebar fore release-2.40 because of a conflict between this release and the upcoming agents v2. Sidebar support will now be exclusive to Agents V2.

The Agents sidebar entry was added in release-2.40 (#9318) but did not ship in release-2.39. Since the sidebar entry is the only entry point to the agents UI, removing it makes the feature inaccessible while leaving the underlying agents code intact.

This change removes the `AgentsButton` from the channel list sidebar and drops the now-unused `agentsEnabled` observable plumbing in `categories_list`.

#### Ticket Link
NONE

#### Checklist
- [x] Has UI changes

#### Device Information
This PR was tested by running the existing `categories_list` test suite (all 48 tests pass).

#### Screenshots
N/A — sidebar entry is removed, no new UI.

#### Release Note
```release-note
NONE
```