### PR TITLE
MM-68575: Use server getMyTeams for canJoinOtherTeams check

### DIFF
--- a/app/actions/remote/team.test.ts
+++ b/app/actions/remote/team.test.ts
@@ -422,6 +422,27 @@ describe('teams', () => {
             expect(mockClient.getMyTeams).toHaveBeenCalledWith(groupLabel);
             expect(mockClient.getTeams).toHaveBeenCalledWith(0, PER_PAGE_DEFAULT, false, groupLabel);
         });
+
+        it('should set canJoin false when getMyTeams fails', async () => {
+            const err = new Error('network unavailable');
+            (mockClient.getMyTeams as jest.Mock).mockRejectedValue(err);
+
+            const result = await updateCanJoinTeams(serverUrl) as {error: unknown};
+
+            expect(result?.error).toBeDefined();
+            expect(setCanJoinSpy).toHaveBeenCalledWith(serverUrl, false);
+        });
+
+        it('should set canJoin false when getTeams fails', async () => {
+            const err = new Error('server timeout');
+            (mockClient.getMyTeams as jest.Mock).mockResolvedValue([activeTeam('t1')]);
+            (mockClient.getTeams as jest.Mock).mockRejectedValue(err);
+
+            const result = await updateCanJoinTeams(serverUrl) as {error: unknown};
+
+            expect(result?.error).toBeDefined();
+            expect(setCanJoinSpy).toHaveBeenCalledWith(serverUrl, false);
+        });
     });
 
     it('fetchTeamsThreads - handle not found database', async () => {

--- a/app/actions/remote/team.test.ts
+++ b/app/actions/remote/team.test.ts
@@ -3,10 +3,12 @@
 
 /* eslint-disable max-lines */
 
+import {PER_PAGE_DEFAULT} from '@client/rest/constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {getActiveServerUrl} from '@queries/app/servers';
+import EphemeralStore from '@store/ephemeral_store';
 
 import {fetchScheduledPosts} from './scheduled_post';
 import {
@@ -367,6 +369,59 @@ describe('teams', () => {
     it('updateCanJoinTeams - base case', async () => {
         const result = await updateCanJoinTeams(serverUrl);
         expect(result).toBeDefined();
+    });
+
+    describe('updateCanJoinTeams server membership (MM-68575)', () => {
+        let setCanJoinSpy: jest.SpiedFunction<typeof EphemeralStore.setCanJoinOtherTeams>;
+
+        const activeTeam = (id: string): Team => ({id, name: id, delete_at: 0} as Team);
+
+        beforeEach(() => {
+            setCanJoinSpy = jest.spyOn(EphemeralStore, 'setCanJoinOtherTeams');
+        });
+
+        afterEach(() => {
+            setCanJoinSpy.mockRestore();
+            mockClient.getMyTeams.mockImplementation(() => [{id: teamId, name: 'team1'}]);
+            mockClient.getTeams.mockImplementation(() => [{id: teamId, name: 'team1'}]);
+        });
+
+        it('should set canJoin false when getMyTeams lists full membership while getTeams returns all server teams', async () => {
+            (mockClient.getMyTeams as jest.Mock).mockResolvedValue([
+                activeTeam('t1'),
+                activeTeam('t2'),
+                activeTeam('t3'),
+            ]);
+            (mockClient.getTeams as jest.Mock).mockResolvedValue([
+                activeTeam('t1'),
+                activeTeam('t2'),
+                activeTeam('t3'),
+            ]);
+
+            await updateCanJoinTeams(serverUrl);
+
+            expect(setCanJoinSpy).toHaveBeenCalledWith(serverUrl, false);
+        });
+
+        it('should set canJoin true when an active server team is not in getMyTeams', async () => {
+            (mockClient.getMyTeams as jest.Mock).mockResolvedValue([activeTeam('t1')]);
+            (mockClient.getTeams as jest.Mock).mockResolvedValue([activeTeam('t1'), activeTeam('t2')]);
+
+            await updateCanJoinTeams(serverUrl);
+
+            expect(setCanJoinSpy).toHaveBeenCalledWith(serverUrl, true);
+        });
+
+        it('should pass groupLabel to getMyTeams and getTeams', async () => {
+            const groupLabel = 'Cold Start Deferred' as RequestGroupLabel;
+            (mockClient.getMyTeams as jest.Mock).mockResolvedValue([activeTeam('t1')]);
+            (mockClient.getTeams as jest.Mock).mockResolvedValue([activeTeam('t1')]);
+
+            await updateCanJoinTeams(serverUrl, groupLabel);
+
+            expect(mockClient.getMyTeams).toHaveBeenCalledWith(groupLabel);
+            expect(mockClient.getTeams).toHaveBeenCalledWith(0, PER_PAGE_DEFAULT, false, groupLabel);
+        });
     });
 
     it('fetchTeamsThreads - handle not found database', async () => {

--- a/app/actions/remote/team.test.ts
+++ b/app/actions/remote/team.test.ts
@@ -361,11 +361,6 @@ describe('teams', () => {
         expect(result.hasMore).toBeFalsy();
     });
 
-    it('updateCanJoinTeams - handle not found database', async () => {
-        const result = await updateCanJoinTeams('foo') as {error: unknown};
-        expect(result?.error).toBeDefined();
-    });
-
     it('updateCanJoinTeams - base case', async () => {
         const result = await updateCanJoinTeams(serverUrl);
         expect(result).toBeDefined();
@@ -423,17 +418,17 @@ describe('teams', () => {
             expect(mockClient.getTeams).toHaveBeenCalledWith(0, PER_PAGE_DEFAULT, false, groupLabel);
         });
 
-        it('should set canJoin false when getMyTeams fails', async () => {
+        it('should preserve the last known canJoin value when getMyTeams fails', async () => {
             const err = new Error('network unavailable');
             (mockClient.getMyTeams as jest.Mock).mockRejectedValue(err);
 
             const result = await updateCanJoinTeams(serverUrl) as {error: unknown};
 
             expect(result?.error).toBeDefined();
-            expect(setCanJoinSpy).toHaveBeenCalledWith(serverUrl, false);
+            expect(setCanJoinSpy).not.toHaveBeenCalled();
         });
 
-        it('should set canJoin false when getTeams fails', async () => {
+        it('should preserve the last known canJoin value when getTeams fails', async () => {
             const err = new Error('server timeout');
             (mockClient.getMyTeams as jest.Mock).mockResolvedValue([activeTeam('t1')]);
             (mockClient.getTeams as jest.Mock).mockRejectedValue(err);
@@ -441,7 +436,7 @@ describe('teams', () => {
             const result = await updateCanJoinTeams(serverUrl) as {error: unknown};
 
             expect(result?.error).toBeDefined();
-            expect(setCanJoinSpy).toHaveBeenCalledWith(serverUrl, false);
+            expect(setCanJoinSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/app/actions/remote/team.ts
+++ b/app/actions/remote/team.ts
@@ -15,7 +15,7 @@ import {getActiveServerUrl} from '@queries/app/servers';
 import {prepareCategoriesAndCategoriesChannels} from '@queries/servers/categories';
 import {prepareMyChannelsForTeam, getDefaultChannelForTeam} from '@queries/servers/channel';
 import {prepareCommonSystemValues, getCurrentTeamId, getCurrentUserId} from '@queries/servers/system';
-import {addTeamToTeamHistory, prepareDeleteTeam, prepareMyTeams, getNthLastChannelFromTeam, queryTeamsById, getLastTeam, getTeamById, removeTeamFromTeamHistory, queryMyTeams} from '@queries/servers/team';
+import {addTeamToTeamHistory, prepareDeleteTeam, prepareMyTeams, getNthLastChannelFromTeam, queryTeamsById, getLastTeam, getTeamById, removeTeamFromTeamHistory} from '@queries/servers/team';
 import {navigateToRoot} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {setTeamLoading} from '@store/team_load_store';
@@ -324,9 +324,9 @@ export async function fetchTeamsForComponent(
 export const updateCanJoinTeams = async (serverUrl: string, groupLabel?: RequestGroupLabel) => {
     try {
         const client = NetworkManager.getClient(serverUrl);
-        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        DatabaseManager.getServerDatabaseAndOperator(serverUrl);
 
-        const myTeams = await queryMyTeams(database).fetch();
+        const myTeams = await client.getMyTeams(groupLabel);
         const myTeamsIds = new Set(myTeams.map((m) => m.id));
 
         const canJoin = await recCanJoinTeams(client, myTeamsIds, 0, groupLabel);

--- a/app/actions/remote/team.ts
+++ b/app/actions/remote/team.ts
@@ -324,7 +324,6 @@ export async function fetchTeamsForComponent(
 export const updateCanJoinTeams = async (serverUrl: string, groupLabel?: RequestGroupLabel) => {
     try {
         const client = NetworkManager.getClient(serverUrl);
-        DatabaseManager.getServerDatabaseAndOperator(serverUrl);
 
         const myTeams = await client.getMyTeams(groupLabel);
         const myTeamsIds = new Set(myTeams.map((m) => m.id));
@@ -334,8 +333,11 @@ export const updateCanJoinTeams = async (serverUrl: string, groupLabel?: Request
         EphemeralStore.setCanJoinOtherTeams(serverUrl, canJoin);
         return {};
     } catch (error) {
+        // Preserve the last known value on transient failures so a spotty
+        // connection doesn't hide the Join Team affordance for users who can
+        // legitimately join. The ephemeral store defaults to false, so this
+        // only retains a previously-computed value.
         logDebug('error on updateCanJoinTeams', getFullErrorMessage(error));
-        EphemeralStore.setCanJoinOtherTeams(serverUrl, false);
         forceLogoutIfNecessary(serverUrl, error);
         return {error};
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

`updateCanJoinTeams` compared paginated `getTeams()` against local `queryMyTeams()`, which could lag sync. For system admins, `getTeams()` returns every server team, so incomplete local membership made "join another team" appear until something (e.g. a websocket team event) recomputed the flag.

Membership for this check is now taken from `client.getMyTeams(groupLabel)` (same `groupLabel` as `getTeams`). Existing `recCanJoinTeams` pagination and error handling are unchanged.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-68575

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information

This PR was tested on: Automated only (`npm run tsc`, `npm test -- app/actions/remote/team.test.ts`). No manual device verification for this change.

#### Screenshots

N/A — no direct UI/layout changes in this PR.

#### Release Note

```release-note
Fixed an issue where system admins could briefly see a join-team affordance when there were no additional teams to join, due to local team membership lagging behind server state.
```
