### PR TITLE
server DB migration to add persistence flag needed by ephemeral mode …

### DIFF
--- a/app/database/manager/__mocks__/index.ts
+++ b/app/database/manager/__mocks__/index.ts
@@ -29,7 +29,7 @@ import {urlSafeBase64Encode} from '@utils/security';
 import {removeProtocol} from '@utils/url';
 
 import type {AppDatabase, CreateServerDatabaseArgs, Models, RegisterServerDatabaseArgs, ServerDatabase, ServerDatabases} from '@typings/database/database';
-import type ServerModel from '@typings/database/models/app/servers';
+import type {default as ServerModel, PersistenceFlag} from '@typings/database/models/app/servers';
 
 const {SERVERS} = MM_TABLES.APP;
 const APP_DATABASE = 'app';
@@ -192,6 +192,18 @@ class DatabaseManagerSingleton {
             await appDatabase.write(async () => {
                 await server?.update((record) => {
                     record.displayName = displayName;
+                });
+            });
+        }
+    };
+
+    public updatePersistenceFlag = async (serverUrl: string, persistenceFlag: PersistenceFlag) => {
+        const appDatabase = this.appDatabase?.database;
+        if (appDatabase) {
+            const server = await this.getServer(serverUrl);
+            await appDatabase.write(async () => {
+                await server?.update((record) => {
+                    record.persistenceFlag = persistenceFlag;
                 });
             });
         }

--- a/app/database/manager/index.ts
+++ b/app/database/manager/index.ts
@@ -34,6 +34,7 @@ import {urlSafeBase64Encode} from '@utils/security';
 import {removeProtocol} from '@utils/url';
 
 import type {AppDatabase, CreateServerDatabaseArgs, RegisterServerDatabaseArgs, Models, ServerDatabase, ServerDatabases} from '@typings/database/database';
+import type {PersistenceFlag} from '@typings/database/models/app/servers';
 
 const {SERVERS} = MM_TABLES.APP;
 const APP_DATABASE = 'app';
@@ -249,6 +250,18 @@ class DatabaseManagerSingleton {
             await appDatabase.write(async () => {
                 await server?.update((record) => {
                     record.displayName = displayName;
+                });
+            });
+        }
+    };
+
+    public updatePersistenceFlag = async (serverUrl: string, persistenceFlag: PersistenceFlag) => {
+        const appDatabase = this.appDatabase?.database;
+        if (appDatabase) {
+            const server = await getServer(serverUrl);
+            await appDatabase.write(async () => {
+                await server?.update((record) => {
+                    record.persistenceFlag = persistenceFlag;
                 });
             });
         }

--- a/app/database/manager/test.ts
+++ b/app/database/manager/test.ts
@@ -94,4 +94,23 @@ describe('*** Database Manager tests ***', () => {
         const serverUrl = await DatabaseManager.getServerUrlFromIdentifier('appv3');
         expect(serverUrl).toBe('https://appv3.mattermost.com');
     });
+
+    it('=> updatePersistenceFlag persists the flag on the matching server record', async () => {
+        expect.assertions(2);
+
+        const targetUrl = 'https://appv3.mattermost.com';
+        const fetchServer = async () => {
+            const servers = await DatabaseManager.appDatabase?.database.collections.
+                get<ServersModel>(SERVERS).query(Q.where('url', targetUrl)).fetch();
+            return servers?.[0];
+        };
+
+        const before = await fetchServer();
+        expect(before?.persistenceFlag).toBe('');
+
+        await DatabaseManager.updatePersistenceFlag(targetUrl, 'wiped');
+
+        const after = await fetchServer();
+        expect(after?.persistenceFlag).toBe('wiped');
+    });
 });

--- a/app/database/migration/app/index.ts
+++ b/app/database/migration/app/index.ts
@@ -1,9 +1,25 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {schemaMigrations} from '@nozbe/watermelondb/Schema/migrations';
+import {addColumns, schemaMigrations} from '@nozbe/watermelondb/Schema/migrations';
+
+import {MM_TABLES} from '@constants/database';
 
 // NOTE : To implement migration, please follow this document
 // https://nozbe.github.io/WatermelonDB/Advanced/Migrations.html
 
-export default schemaMigrations({migrations: []});
+const {SERVERS} = MM_TABLES.APP;
+
+export default schemaMigrations({migrations: [
+    {
+        toVersion: 2,
+        steps: [
+            addColumns({
+                table: SERVERS,
+                columns: [
+                    {name: 'persistence_flag', type: 'string'},
+                ],
+            }),
+        ],
+    },
+]});

--- a/app/database/models/app/servers.ts
+++ b/app/database/models/app/servers.ts
@@ -6,7 +6,7 @@ import {field} from '@nozbe/watermelondb/decorators';
 
 import {MM_TABLES} from '@constants/database';
 
-import type ServersModelInterface from '@typings/database/models/app/servers';
+import type {default as ServersModelInterface, PersistenceFlag} from '@typings/database/models/app/servers';
 
 const {SERVERS} = MM_TABLES.APP;
 
@@ -32,4 +32,7 @@ export default class ServersModel extends Model implements ServersModelInterface
 
     /** identifier: Determines the installation identifier of a server */
     @field('identifier') identifier!: string;
+
+    /** persistence_flag: Marker for non-default persistence behavior on this server's local database */
+    @field('persistence_flag') persistenceFlag!: PersistenceFlag;
 }

--- a/app/database/schema/app/index.ts
+++ b/app/database/schema/app/index.ts
@@ -8,7 +8,7 @@ import {MM_TABLES} from '@constants/database';
 const {INFO, GLOBAL, SERVERS} = MM_TABLES.APP;
 
 export const schema: AppSchema = appSchema({
-    version: 1,
+    version: 2,
     tables: [
         tableSchema({
             name: INFO,
@@ -32,6 +32,7 @@ export const schema: AppSchema = appSchema({
                 {name: 'identifier', type: 'string', isIndexed: true},
                 {name: 'last_active_at', type: 'number', isIndexed: true},
                 {name: 'url', type: 'string', isIndexed: true},
+                {name: 'persistence_flag', type: 'string'},
             ],
         }),
     ],

--- a/app/database/schema/app/table_schemas/servers.ts
+++ b/app/database/schema/app/table_schemas/servers.ts
@@ -15,6 +15,7 @@ export default tableSchema({
         {name: 'url', type: 'string', isIndexed: true},
         {name: 'last_active_at', type: 'number', isIndexed: true},
         {name: 'identifier', type: 'string', isIndexed: true},
+        {name: 'persistence_flag', type: 'string'},
     ],
 });
 

--- a/app/database/schema/app/test.ts
+++ b/app/database/schema/app/test.ts
@@ -10,7 +10,7 @@ const {INFO, GLOBAL, SERVERS} = MM_TABLES.APP;
 describe('*** Test schema for APP database ***', () => {
     it('=> The APP SCHEMA should strictly match', () => {
         expect(schema).toEqual({
-            version: 1,
+            version: 2,
             tables: {
                 [INFO]: {
                     name: INFO,
@@ -42,6 +42,7 @@ describe('*** Test schema for APP database ***', () => {
                         identifier: {name: 'identifier', type: 'string', isIndexed: true},
                         last_active_at: {name: 'last_active_at', type: 'number', isIndexed: true},
                         url: {name: 'url', type: 'string', isIndexed: true},
+                        persistence_flag: {name: 'persistence_flag', type: 'string'},
                     },
                     columnArray: [
                         {name: 'db_path', type: 'string'},
@@ -49,6 +50,7 @@ describe('*** Test schema for APP database ***', () => {
                         {name: 'identifier', type: 'string', isIndexed: true},
                         {name: 'last_active_at', type: 'number', isIndexed: true},
                         {name: 'url', type: 'string', isIndexed: true},
+                        {name: 'persistence_flag', type: 'string'},
                     ],
                 },
             },

--- a/app/queries/app/servers.test.ts
+++ b/app/queries/app/servers.test.ts
@@ -9,7 +9,7 @@ import DatabaseManager from '@database/manager';
 import {getConfigValue} from '@queries/servers/system';
 import {isMinimumServerVersion} from '@utils/helpers';
 
-import {queryServerDisplayName, queryAllActiveServers, getServer, getAllServers, getActiveServer, getActiveServerUrl, getServerByIdentifier, getServerByDisplayName, getServerDisplayName, observeServerDisplayName, observeAllActiveServers, areAllServersSupported} from './servers';
+import {queryServerDisplayName, queryAllActiveServers, getServer, getAllServers, getActiveServer, getActiveServerUrl, getServerByIdentifier, getServerByDisplayName, getServerDisplayName, getWipedServers, observeServerDisplayName, observeAllActiveServers, areAllServersSupported} from './servers';
 
 jest.mock('@database/manager', () => ({
     getAppDatabaseAndOperator: jest.fn(),
@@ -140,6 +140,26 @@ describe('Servers Queries', () => {
         mockServerModel.query.mockReturnValueOnce({fetch: jest.fn().mockResolvedValue(servers)} as any);
         const result = await getActiveServerUrl();
         expect(result).toEqual('https://example2.com');
+    });
+
+    test('getWipedServers should query for rows where persistence_flag = wiped', async () => {
+        const wipedServers = [{url: 'https://wiped.test', persistenceFlag: 'wiped'}];
+        mockServerModel.query.mockReturnValueOnce({fetch: jest.fn().mockResolvedValue(wipedServers)} as any);
+
+        const result = await getWipedServers();
+
+        expect(mockDatabase.get).toHaveBeenCalledWith(SERVERS);
+        expect(mockServerModel.query).toHaveBeenCalledWith(Q.where('persistence_flag', 'wiped'));
+        expect(result).toEqual(wipedServers);
+    });
+
+    it('getWipedServers should return an empty array if there is an error', async () => {
+        mockedGetAppDatabaseAndOperator.mockImplementationOnce(() => {
+            throw new Error('Error');
+        });
+
+        const result = await getWipedServers();
+        expect(result).toEqual([]);
     });
 
     test('getServerByIdentifier should return a server by identifier', async () => {

--- a/app/queries/app/servers.ts
+++ b/app/queries/app/servers.ts
@@ -72,6 +72,15 @@ export const getActiveServerUrl = async () => {
     return server?.url || '';
 };
 
+export const getWipedServers = async () => {
+    try {
+        const {database} = DatabaseManager.getAppDatabaseAndOperator();
+        return database.get<ServerModel>(SERVERS).query(Q.where('persistence_flag', 'wiped')).fetch();
+    } catch {
+        return [];
+    }
+};
+
 export const getServerByIdentifier = async (identifier: string) => {
     try {
         const {database} = DatabaseManager.getAppDatabaseAndOperator();

--- a/docs/database/app_database/app-database.md
+++ b/docs/database/app_database/app-database.md
@@ -1,4 +1,4 @@
-# App Database - Schema Version 1
+# App Database - Schema Version 2
 # Please bump the version by 1, any time the schema changes.
 # Also, include the migration plan under app/database/migration/server,
 # update all models, relationships and types.
@@ -28,3 +28,4 @@ display_name string
 url string INDEX
 last_active_at number INDEX
 identifier string INDEX
+persistence_flag string

--- a/types/database/models/app/servers.ts
+++ b/types/database/models/app/servers.ts
@@ -4,6 +4,13 @@
 import type {Model} from '@nozbe/watermelondb';
 
 /**
+ * Marks a server's local database as being in a non-default persistence state
+ * - 'wiped': database has been wiped and is awaiting recovery on next reconnection.
+ * - 'zero-persistence': server runs with the no persistence on disk.
+ */
+export type PersistenceFlag = '' | 'wiped' | 'zero-persistence';
+
+/**
  * The Server model will help us to identify the various servers a user will log in; in the context of
  * multi-server support system.  The db_path field will hold the App-Groups file-path
  */
@@ -25,6 +32,9 @@ declare class ServersModel extends Model {
 
     /** diagnostic_id: Determines the installation identifier of a server */
     identifier: string;
+
+    /** persistence_flag: Marker for non-default persistence behavior on this server's local database */
+    persistenceFlag: PersistenceFlag;
 }
 
 export default ServersModel;

--- a/types/database/models/app/servers.ts
+++ b/types/database/models/app/servers.ts
@@ -6,7 +6,7 @@ import type {Model} from '@nozbe/watermelondb';
 /**
  * Marks a server's local database as being in a non-default persistence state
  * - 'wiped': database has been wiped and is awaiting recovery on next reconnection.
- * - 'zero-persistence': server runs with the no persistence on disk.
+ * - 'zero-persistence': server runs with no persistence on disk.
  */
 export type PersistenceFlag = '' | 'wiped' | 'zero-persistence';
 


### PR DESCRIPTION
#### Summary
Adding persistence flag to app database in order to support Mobile Ephemeral Mode different features

When **Mobile Ephemeral Mode** (MEM) is enabled by an admin, database persistence using SQLite for a particular server is not always the case. For MVF, MEM features will need to support:

- Zero Persistence mode setup by an admin: the app won't persist anything on a disk backed database and only in-memory ephemeral persistence can be used. We will flag the server to be on `zero-persistence` mode to make the app behave as so.
- Offline wiping being setup for a particular server: in such a case, when the app is considered to be offline after a certain period of time the server database is completely wiped. To enforce it during app restarts and to show proper blocking UI we flag the server persistence mode as `wiped`.

To accommodate these two local persistence new modes and make the UI react accordingly, a new flag is now added to the app database (since server database may not exist) with different enumerated values depending on server mandated settings as described above.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68290

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Release Note
```release-note
NONE
```
