### PR TITLE
Fix Submit button missing from interactive dialog header

### DIFF
--- a/app/screens/apps_form/apps_form_component.test.tsx
+++ b/app/screens/apps_form/apps_form_component.test.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import DatabaseManager from '@database/manager';
+import {renderWithEverything} from '@test/intl-test-helper';
+
+import AppsFormComponent from './apps_form_component';
+
+import type {Database} from '@nozbe/watermelondb';
+
+jest.mock('@screens/navigation', () => ({
+    navigateBack: jest.fn(),
+}));
+
+jest.mock('@actions/remote/command', () => ({
+    handleGotoLocation: jest.fn(),
+}));
+
+jest.mock('./apps_form_field', () => {
+    const MockField = () => null;
+    return {
+        __esModule: true,
+        default: MockField,
+    };
+});
+
+const mockSetOptions = jest.fn();
+jest.mock('expo-router', () => ({
+    useNavigation: jest.fn(() => ({
+        setOptions: mockSetOptions,
+        addListener: jest.fn(() => jest.fn()),
+    })),
+}));
+
+const serverUrl = 'http://localhost:8065';
+
+function getProps(form: Partial<AppForm> = {}) {
+    return {
+        form: {
+            title: 'Test',
+            fields: [],
+            ...form,
+        } as AppForm,
+        submit: jest.fn().mockResolvedValue({data: {type: 'ok'}}),
+        performLookupCall: jest.fn(),
+        refreshOnSelect: jest.fn(),
+    };
+}
+
+function lastHeaderRight(): undefined | (() => React.ReactElement<{text: string; disabled: boolean; testID: string}>) {
+    const lastCall = mockSetOptions.mock.calls[mockSetOptions.mock.calls.length - 1];
+    return lastCall?.[0]?.headerRight;
+}
+
+describe('AppsFormComponent navigation header', () => {
+    let database: Database;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await DatabaseManager.init([serverUrl]);
+        database = DatabaseManager.getServerDatabaseAndOperator(serverUrl).database;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('installs header Submit when the form has no submit_buttons field', () => {
+        renderWithEverything(<AppsFormComponent {...getProps()}/>, {database, serverUrl});
+
+        const headerRight = lastHeaderRight();
+        expect(headerRight).toBeDefined();
+
+        const button = headerRight!();
+        expect(button.props.testID).toBe('interactive_dialog.submit.button');
+        expect(button.props.text).toBe('Submit');
+        expect(button.props.disabled).toBe(false);
+    });
+
+    it('clears header Submit when submit_buttons field has options (inline buttons render)', () => {
+        const form: Partial<AppForm> = {
+            submit_buttons: 'action',
+            fields: [{
+                name: 'action',
+                type: 'static_select',
+                options: [
+                    {label: 'Approve', value: 'approve'},
+                    {label: 'Reject', value: 'reject'},
+                ],
+            }] as AppField[],
+        };
+
+        renderWithEverything(<AppsFormComponent {...getProps(form)}/>, {database, serverUrl});
+
+        const lastCall = mockSetOptions.mock.calls[mockSetOptions.mock.calls.length - 1];
+        expect(lastCall[0]).toEqual({headerRight: undefined});
+    });
+
+    it('keeps header Submit when submit_buttons field has no options (inline buttons render nothing)', () => {
+        const form: Partial<AppForm> = {
+            submit_buttons: 'action',
+            fields: [{
+                name: 'action',
+                type: 'static_select',
+                options: [],
+            }] as AppField[],
+        };
+
+        renderWithEverything(<AppsFormComponent {...getProps(form)}/>, {database, serverUrl});
+
+        const headerRight = lastHeaderRight();
+        expect(headerRight).toBeDefined();
+        expect(headerRight!().props.testID).toBe('interactive_dialog.submit.button');
+    });
+
+    it('honors form.submit_label as the header button text', () => {
+        renderWithEverything(
+            <AppsFormComponent {...getProps({submit_label: 'Triage'})}/>,
+            {database, serverUrl},
+        );
+
+        const headerRight = lastHeaderRight();
+        expect(headerRight!().props.text).toBe('Triage');
+    });
+});

--- a/app/screens/apps_form/apps_form_component.test.tsx
+++ b/app/screens/apps_form/apps_form_component.test.tsx
@@ -73,10 +73,10 @@ describe('AppsFormComponent navigation header', () => {
         const headerRight = lastHeaderRight();
         expect(headerRight).toBeDefined();
 
-        const button = headerRight!();
-        expect(button.props.testID).toBe('interactive_dialog.submit.button');
-        expect(button.props.text).toBe('Submit');
-        expect(button.props.disabled).toBe(false);
+        const button = headerRight?.();
+        expect(button?.props.testID).toBe('interactive_dialog.submit.button');
+        expect(button?.props.text).toBe('Submit');
+        expect(button?.props.disabled).toBe(false);
     });
 
     it('clears header Submit when submit_buttons field has options (inline buttons render)', () => {
@@ -112,7 +112,7 @@ describe('AppsFormComponent navigation header', () => {
 
         const headerRight = lastHeaderRight();
         expect(headerRight).toBeDefined();
-        expect(headerRight!().props.testID).toBe('interactive_dialog.submit.button');
+        expect(headerRight?.().props.testID).toBe('interactive_dialog.submit.button');
     });
 
     it('honors form.submit_label as the header button text', () => {
@@ -122,6 +122,6 @@ describe('AppsFormComponent navigation header', () => {
         );
 
         const headerRight = lastHeaderRight();
-        expect(headerRight!().props.text).toBe('Triage');
+        expect(headerRight?.().props.text).toBe('Triage');
     });
 });

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -393,10 +393,12 @@ function AppsFormComponent({
 
     useEffect(() => {
         // Header Submit is the default submission affordance. When the form
-        // declares a custom submit_buttons field, the inline buttons rendered
-        // at the bottom of the form replace the header Submit so the user
-        // picks an explicit button value.
-        if (submitButtons) {
+        // declares a custom submit_buttons field with at least one option, the
+        // inline buttons rendered at the bottom of the form replace the header
+        // Submit so the user picks an explicit button value. If the field has
+        // no options (nothing renders inline), keep the header Submit so the
+        // form remains submittable.
+        if (submitButtons?.options?.length) {
             navigation.setOptions({headerRight: undefined});
             return;
         }

--- a/app/screens/apps_form/apps_form_component.tsx
+++ b/app/screens/apps_form/apps_form_component.tsx
@@ -392,19 +392,25 @@ function AppsFormComponent({
     }, [form, values, performLookupCall, intl]);
 
     useEffect(() => {
+        // Header Submit is the default submission affordance. When the form
+        // declares a custom submit_buttons field, the inline buttons rendered
+        // at the bottom of the form replace the header Submit so the user
+        // picks an explicit button value.
         if (submitButtons) {
-            navigation.setOptions({
-                headerRight: () => (
-                    <NavigationButton
-                        onPress={handleSubmit}
-                        disabled={submitting}
-                        testID='interactive_dialog.submit.button'
-                        text={intl.formatMessage({id: 'interactive_dialog.submit', defaultMessage: 'Submit'})}
-                    />
-                ),
-            });
+            navigation.setOptions({headerRight: undefined});
+            return;
         }
-    }, [handleSubmit, intl, navigation, submitButtons, submitting]);
+        navigation.setOptions({
+            headerRight: () => (
+                <NavigationButton
+                    onPress={handleSubmit}
+                    disabled={submitting}
+                    testID='interactive_dialog.submit.button'
+                    text={form.submit_label || intl.formatMessage({id: 'interactive_dialog.submit', defaultMessage: 'Submit'})}
+                />
+            ),
+        });
+    }, [form.submit_label, handleSubmit, intl, navigation, submitButtons, submitting]);
 
     // Cleanup on unmount to prevent memory leaks
     useEffect(() => {


### PR DESCRIPTION
## Summary

- Restores the header Submit button on interactive dialogs (regressed in #9402, the RNN→Expo Router migration).
- The original RNN code returned `undefined` for the right-button when the form had a custom `submit_buttons` field, otherwise built a default Submit. The migration accidentally inverted the gate, so the header Submit only appears for the (rare) custom-buttons case and never for a standard `/dialog` invocation.
- Also restores honoring `form.submit_label` so dialogs that set a custom label (e.g. `"Triage"`, `"Approve"`) render that label instead of the hardcoded `"Submit"` — the legacy `InteractiveDialog` path already does this; AppsForm is now back in parity.
- Added unit tests to prevent future regressions.

## Test plan

- [ ] `/dialog` slash command on a test server → header Submit appears and submits successfully.
- [ ] A dialog with `submit_label: "Triage"` → header button reads "Triage", not "Submit".
- [ ] A dialog with a custom `submit_buttons` field (e.g. Approve / Reject) → header has no Submit; inline bottom buttons handle the submission as before.
- [ ] Existing interactive dialog tests (`dialog_conversion.test.ts`) still pass.

## Related

- Original regression introduced in b6fc85385 ("Migrate from RNN to Expo router", #9402).
- Surfaced while QA-ing inline action buttons; affects any current production dialog flow that relies on the default Submit.

#### Release Note
```release-note
NONE
```
