### PR TITLE
Fix intune autolink path

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+const path = require('path');
+
 // eslint-disable-next-line no-process-env
 const intuneEnabled = process.env.INTUNE_ENABLED === '1' || process.env.INTUNE_ENABLED === 'true';
 
@@ -9,7 +11,7 @@ const dependencies = {};
 // Conditionally add Intune dependency when enabled
 if (intuneEnabled) {
     dependencies['@mattermost/intune'] = {
-        root: './libraries/@mattermost/intune',
+        root: path.resolve(__dirname, 'libraries/@mattermost/intune'),
     };
 }
 


### PR DESCRIPTION
#### Summary
Fix the intune autolink by using the full path instead of relative.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
