### PR TITLE
Exclude webhook posts from thread reply highlight check

### DIFF
--- a/app/components/post_list/post/index.ts
+++ b/app/components/post_list/post/index.ts
@@ -15,7 +15,7 @@ import {observeThreadById} from '@queries/servers/thread';
 import {observeUser} from '@queries/servers/user';
 import {isBoRPost} from '@utils/bor';
 import {fileModelsToFileInfo} from '@utils/file';
-import {areConsecutivePosts, isPostEphemeral} from '@utils/post';
+import {areConsecutivePosts, isFromWebhook, isPostEphemeral} from '@utils/post';
 
 import Post from './post';
 
@@ -35,12 +35,12 @@ type PropsInput = WithDatabaseArgs & {
 }
 
 function observeShouldHighlightReplyBar(database: Database, currentUser: UserModel, post: PostModel, postsInThread: PostsInThreadModel) {
-    const myPostsCount = queryPostsBetween(database, postsInThread.earliest, postsInThread.latest, null, currentUser.id, '', post.rootId || post.id).observeCount();
+    const myPosts = queryPostsBetween(database, postsInThread.earliest, postsInThread.latest, null, currentUser.id, '', post.rootId || post.id).observe();
     const root = observePost(database, post.rootId);
 
-    return combineLatest([myPostsCount, root]).pipe(
-        switchMap(([mpc, r]) => {
-            const threadRepliedToByCurrentUser = mpc > 0;
+    return combineLatest([myPosts, root]).pipe(
+        switchMap(([posts, r]) => {
+            const threadRepliedToByCurrentUser = posts.some((p) => !isFromWebhook(p));
             let threadCreatedByCurrentUser = false;
             if (r?.userId === currentUser.id) {
                 threadCreatedByCurrentUser = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incorrect thread reply-bar highlighting when a webhook posts under the current user's ID in a thread.

When checking whether the current user has participated in a thread, webhook posts are now excluded from the reply count. This matches the web app fix in `makeIsPostCommentMention`.

## Changes

- In `observeShouldHighlightReplyBar`, switch from `observeCount()` to fetching posts and filtering out webhook posts via `isFromWebhook()` before determining `threadRepliedToByCurrentUser`.

## Release Note

```release-note
Threads started by webhooks no longer highlight if you own the webhook.
```

## Test plan

- [x] `npm run tsc`
- [x] `npm run fix`
- [x] `npm test -- app/utils/post/index.test.ts`
- [ ] Manual: With CRT disabled and comment notifications set to "any", verify that a webhook post under your user ID in a thread does not cause subsequent replies to show the highlight bar
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbead4ee-f9d4-411f-898e-af1f0bfe52c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbead4ee-f9d4-411f-898e-af1f0bfe52c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

