### PR TITLE
Prevent deleting downloaded files when preview fails for unsupported MIME types

### DIFF
--- a/app/hooks/files.ts
+++ b/app/hooks/files.ts
@@ -167,12 +167,12 @@ export const useDownloadFileAndPreview = (enableSecureFilePreview: boolean) => {
             }).then(() => {
                 setDownloading(false);
                 setProgress(0);
-            }).catch(() => {
+                       }).catch(() => {
                 alertFailedToOpenDocument(file, intl);
 
-                if (path) {
-                    deleteFile(path);
-                }
+                // Do not delete downloaded files if opening fails.
+                // Unsupported MIME types may not be previewable,
+                // but the downloaded file should still remain available.
             }).finally(() => {
                 onDonePreviewingFile();
             });


### PR DESCRIPTION
## Summary

This PR prevents downloaded files from being deleted when previewing/opening fails for unsupported MIME types on Android.

Previously, when `FileViewer.open()` failed for unsupported file types such as `.gpx` or `.bin`, the downloaded file was immediately deleted in the catch block. This resulted in the download appearing to fail silently from the user's perspective.

The deletion logic has been removed so the downloaded file remains available even if preview/opening is unsupported.

## Ticket Link

Fixes https://github.com/mattermost/mattermost-mobile/issues/9474

## Related Changes

* Removed cleanup deletion logic from the `FileViewer.open()` failure handler in `app/hooks/files.ts`
* Preserved downloaded files when preview/opening fails for unsupported MIME types

## Testing

Code-path investigation and logic verification were performed based on the issue reproduction flow and existing file preview behavior.

I was not able to fully run the Android environment locally due to SDK setup limitations, so additional device-side verification may still be helpful.

```release-note
Fixed an issue where downloaded unsupported MIME type files could be deleted when preview failed on Android.
```
