### PR TITLE
CI: LPT shard distribution + cached duration ledger

### DIFF
--- a/.github/actions/generate-specs/action.yml
+++ b/.github/actions/generate-specs/action.yml
@@ -25,6 +25,28 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # Restore the per-spec duration ledger from the actions cache. Used by
+    # split-tests.js's LPT bin-packing to balance shard wall-clock. Cache miss
+    # is non-fatal — split-tests.js falls back to median / uniform default.
+    #
+    # Key scope:
+    #   - Per-platform (so iOS durations don't leak into Android shards and
+    #     vice versa — iOS specs are notably slower than Android on most files).
+    #   - Per-search-path (the iPad job has different durations than the main
+    #     iOS job, and any future product-specific search_path differs too).
+    #   - `-v1` suffix lets us invalidate the cache by bumping the version when
+    #     the duration parser or schema changes.
+    - name: Restore shard-duration ledger
+      uses: actions/cache/restore@v4
+      with:
+        path: detox/.shard-durations.json
+        key: shard-durations-v1-${{ runner.os }}-${{ inputs.device_name }}-${{ inputs.search_path }}
+        # Falls back to the most-recently-saved ledger for any device on this
+        # search_path if the exact device key misses. Still better than no data.
+        restore-keys: |
+          shard-durations-v1-${{ runner.os }}-${{ inputs.device_name }}-
+          shard-durations-v1-${{ runner.os }}-
+
     - name: ci/generate-specs
       id: generate-specs
       env:
@@ -32,6 +54,7 @@ runs:
         SEARCH_PATH: ${{ inputs.search_path }}
         DEVICE_NAME: ${{ inputs.device_name }}
         DEVICE_OS_VERSION: ${{ inputs.device_os_version }}
+        DURATIONS_FILE: detox/.shard-durations.json
       run: |
         set -e
         node ${{ github.action_path }}/split-tests.js | tee output.json

--- a/.github/actions/generate-specs/split-tests.js
+++ b/.github/actions/generate-specs/split-tests.js
@@ -1,101 +1,155 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+/*
+ * Split detox .e2e.ts files across shards using Longest-Processing-Time (LPT)
+ * bin-packing on historical per-spec durations.
+ *
+ * Why LPT, not equal-count chunking:
+ *   The previous implementation sliced files alphabetically into equal-count
+ *   chunks. Test files vary 10× in runtime (a 60s spec vs a 600s spec), so the
+ *   slowest shard ran 2-3× longer than the fastest. Wall-clock = slowest shard.
+ *
+ * Algorithm:
+ *   1. Walk SEARCH_PATH for *.e2e.ts (excluding ipad/, which runs separately).
+ *   2. Load historical durations from durations file (env: DURATIONS_FILE,
+ *      default: detox/.shard-durations.json). Missing entries fall back to
+ *      the median of known entries (or DEFAULT_DURATION if file is empty).
+ *   3. Sort specs by duration DESC.
+ *   4. For each spec, assign to the shard whose current total duration is
+ *      smallest. (Greedy LPT — guaranteed worst case ≤ (4/3 − 1/(3m))×optimal.)
+ *   5. Emit GitHub Actions matrix include[] in the existing schema:
+ *      { runId, specs, deviceName, deviceOsVersion }.
+ *
+ * The durations file is treated as a CACHE, not a committed artifact:
+ *   CI restores it from actions/cache before this step runs and saves a new
+ *   version (parsed from junit reports) after each detox run. A cache miss
+ *   degrades cleanly to median/default and the resulting shard split is still
+ *   correct (just may be more skewed than optimal until the next run).
+ */
+
 const fs = require('fs');
 const path = require('path');
 
-class DeviceInfo {
-  constructor(deviceName, deviceOsVersion) {
-    this.deviceName = deviceName;
-    this.deviceOsVersion = deviceOsVersion;
-  }
-}
+const DEFAULT_DURATION_SECONDS = 180; // 3 min — used when no historical data exists at all
 
-class SpecGroup {
-  constructor(runId, specs, deviceInfo) {
-    this.runId = runId;
-    this.specs = specs;
-    this.deviceName = deviceInfo.deviceName;
-    this.deviceOsVersion = deviceInfo.deviceOsVersion;
-  }
-}
-
-class Specs {
-  constructor(searchPath, parallelism, deviceInfo) {
-    this.searchPath = searchPath;
-    this.parallelism = parallelism;
-    this.rawFiles = [];
-    this.groupedFiles = [];
-    this.deviceInfo = deviceInfo;
-  }
-
-  findFiles() {
-    const dirPath = path.join(this.searchPath);
-
-    const fileRegex = /\.e2e\.ts$/;
-
-    const walkSync = (currentPath) => {
-      const files = fs.readdirSync(currentPath);
-
-      files.forEach((file) => {
-        const filePath = path.join(currentPath, file);
-        const stats = fs.statSync(filePath);
-
-        if (stats.isDirectory()) {
-          // iPad tests are iOS-only; exclude from Android and other non-iPad runs.
-          // They run in their own isolated job with search_path pointing directly at ipad/.
-          if (file === 'ipad') {
-            return;
-          }
-          walkSync(filePath);
-        } else if (fileRegex.test(filePath)) {
-          const relativeFilePath = filePath.replace(dirPath + '/', '');
-          const fullPath = path.join(this.searchPath, relativeFilePath);
-          this.rawFiles.push(fullPath);
+function findSpecs(searchPath) {
+    const specs = [];
+    const walk = (dir) => {
+        for (const entry of fs.readdirSync(dir)) {
+            const full = path.join(dir, entry);
+            const stat = fs.statSync(full);
+            if (stat.isDirectory()) {
+                // iPad tests are iOS-only and run in their own isolated job.
+                if (entry === 'ipad') {
+                    continue;
+                }
+                walk(full);
+            } else if (/\.e2e\.ts$/.test(entry)) {
+                specs.push(full);
+            }
         }
-      });
     };
+    walk(searchPath);
+    return specs;
+}
 
-    walkSync(dirPath);
-  }
-
-  generateSplits() {
-    const chunkSize = Math.floor(this.rawFiles.length / this.parallelism);
-    let remainder = this.rawFiles.length % this.parallelism;
-    let runNo = 1;
-    let start = 0;
-
-    for (let i = 0; i < this.parallelism; i++) {
-      let end = start + chunkSize + (remainder > 0 ? 1 : 0);
-      const fileGroup = this.rawFiles.slice(start, end).join(' ');
-      const specFileGroup = new SpecGroup(runNo.toString(), fileGroup, this.deviceInfo);
-      this.groupedFiles.push(specFileGroup);
-
-      start = end;
-      runNo++;
-      if (remainder > 0) {
-        remainder--;
-      }
+function loadDurations(durationsFile) {
+    if (!durationsFile || !fs.existsSync(durationsFile)) {
+        return {};
     }
-  }
+    try {
+        const parsed = JSON.parse(fs.readFileSync(durationsFile, 'utf8'));
+        // Tolerate either { "path": seconds } or
+        // { "durations": { "path": seconds }, "updated_at": "..." }
+        return parsed.durations || parsed;
+    } catch (err) {
+        process.stderr.write(`[split-tests] Failed to parse ${durationsFile}: ${err.message}. Falling back to default.\n`);
+        return {};
+    }
+}
 
-  dumpSplits() {
-    const output = {
-      include: this.groupedFiles,
-    };
+function median(values) {
+    if (values.length === 0) {
+        return DEFAULT_DURATION_SECONDS;
+    }
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
 
-    console.log(JSON.stringify(output));
-  }
+function packLPT(specs, parallelism, durations) {
+    const knownValues = Object.values(durations).filter((d) => typeof d === 'number' && d > 0);
+    const fallback = median(knownValues);
+
+    // Resolve duration for each spec. Specs are stored in the durations file
+    // by their path relative to repo root (or by basename — try both).
+    const items = specs.map((spec) => {
+        const direct = durations[spec];
+        const basename = durations[path.basename(spec)];
+        const duration = direct ?? basename ?? fallback;
+        return {spec, duration};
+    });
+
+    // Sort descending so the biggest specs get placed first.
+    items.sort((a, b) => b.duration - a.duration);
+
+    // Initialize shards.
+    const shards = Array.from({length: parallelism}, (_, i) => ({
+        runId: String(i + 1),
+        specs: [],
+        total: 0,
+    }));
+
+    // Greedy: each item goes to the currently-shortest shard.
+    for (const item of items) {
+        let smallest = shards[0];
+        for (const shard of shards) {
+            if (shard.total < smallest.total) {
+                smallest = shard;
+            }
+        }
+        smallest.specs.push(item.spec);
+        smallest.total += item.duration;
+    }
+
+    return shards;
 }
 
 function main() {
-  const searchPath = process.env.SEARCH_PATH;
-  const parallelism = parseInt(process.env.PARALLELISM, 10);
-  const deviceName = process.env.DEVICE_NAME;
-  const deviceOsVersion = process.env.DEVICE_OS_VERSION;
-  const deviceInfo = new DeviceInfo(deviceName, deviceOsVersion);
-  const specs = new Specs(searchPath, parallelism, deviceInfo);
+    const searchPath = process.env.SEARCH_PATH;
+    const parallelism = parseInt(process.env.PARALLELISM, 10);
+    const deviceName = process.env.DEVICE_NAME;
+    const deviceOsVersion = process.env.DEVICE_OS_VERSION;
+    const durationsFile = process.env.DURATIONS_FILE || path.resolve('detox/.shard-durations.json');
 
-  specs.findFiles();
-  specs.generateSplits();
-  specs.dumpSplits();
+    if (!searchPath || !parallelism) {
+        process.stderr.write('[split-tests] SEARCH_PATH and PARALLELISM env vars are required.\n');
+        process.exit(1);
+    }
+
+    const specs = findSpecs(searchPath);
+    const durations = loadDurations(durationsFile);
+    const shards = packLPT(specs, parallelism, durations);
+
+    // Diagnostics to stderr so they don't pollute the JSON output captured by
+    // the action's `tee output.json` step.
+    const totals = shards.map((s) => Math.round(s.total));
+    const knownCount = specs.filter((s) => durations[s] != null || durations[path.basename(s)] != null).length;
+    process.stderr.write(
+        `[split-tests] specs=${specs.length} shards=${parallelism} durations_known=${knownCount}/${specs.length} ` +
+        `shard_totals(seconds)=[${totals.join(',')}] max=${Math.max(...totals)} min=${Math.min(...totals)}\n`,
+    );
+
+    const output = {
+        include: shards.map((s) => ({
+            runId: s.runId,
+            specs: s.specs.join(' '),
+            deviceName,
+            deviceOsVersion,
+        })),
+    };
+
+    process.stdout.write(JSON.stringify(output));
 }
 
 main();

--- a/.github/actions/generate-specs/update-durations.js
+++ b/.github/actions/generate-specs/update-durations.js
@@ -1,0 +1,125 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+/*
+ * Parse detox junit XML reports and update the per-spec duration ledger used
+ * by split-tests.js. Runs after the matrix completes, before the cache save.
+ *
+ * Inputs (env):
+ *   JUNIT_ROOT        — directory to recursively scan for junit XML files
+ *                       (default: detox/artifacts)
+ *   JUNIT_NAME_REGEX  — filename regex to match (default: ^(ios|android)-junit.*\.xml$ —
+ *                       matches detox's `${platform}-junit*.xml` output written by
+ *                       detox/save_report.js via junit-report-merger)
+ *   DURATIONS_FILE    — path to write the updated ledger (default detox/.shard-durations.json)
+ *   EMA_ALPHA         — smoothing factor 0..1 for exponential moving average
+ *                       between existing and new durations (default 0.3 — new
+ *                       runs have moderate weight, older runs decay slowly so
+ *                       CI hardware noise doesn't whipsaw the ledger).
+ *
+ * Junit format: detox writes <testsuite name="<spec-path>" time="<seconds>">
+ *   per-spec. Failed runs still report a time; we count them too (the test
+ *   ran, took N seconds, regardless of pass/fail).
+ *
+ * Why EMA, not last-write-wins:
+ *   Individual runs can spike if a runner has hardware contention. EMA(0.3)
+ *   makes the ledger stable while still tracking real changes in 3-4 runs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const JUNIT_ROOT = process.env.JUNIT_ROOT || 'detox/artifacts';
+const JUNIT_NAME_REGEX = new RegExp(process.env.JUNIT_NAME_REGEX || '^(ios|android)-junit.*\\.xml$');
+const DURATIONS_FILE = process.env.DURATIONS_FILE || path.resolve('detox/.shard-durations.json');
+const EMA_ALPHA = parseFloat(process.env.EMA_ALPHA || '0.3');
+
+function findJunitFiles(root) {
+    // Recursive walk in pure Node — avoids depending on shell `**` (only works
+    // with `shopt -s globstar`) or `find` (works but adds an extra process).
+    const out = [];
+    if (!fs.existsSync(root)) {
+        return out;
+    }
+    const walk = (dir) => {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                walk(full);
+            } else if (entry.isFile() && JUNIT_NAME_REGEX.test(entry.name)) {
+                out.push(full);
+            }
+        }
+    };
+    walk(root);
+    return out;
+}
+
+function loadExisting() {
+    if (!fs.existsSync(DURATIONS_FILE)) {
+        return {};
+    }
+    try {
+        const parsed = JSON.parse(fs.readFileSync(DURATIONS_FILE, 'utf8'));
+        return parsed.durations || parsed;
+    } catch (err) {
+        process.stderr.write(`[update-durations] Existing ${DURATIONS_FILE} unparseable, starting fresh: ${err.message}\n`);
+        return {};
+    }
+}
+
+function parseJunit(file) {
+    const xml = fs.readFileSync(file, 'utf8');
+    // Each <testsuite name="..." time="..."> represents one spec file in detox's
+    // junit output. We don't need a full XML parser — a regex over the
+    // testsuite open tags is sufficient and avoids adding a dependency.
+    const out = {};
+    const re = /<testsuite\b[^>]*\bname="([^"]+)"[^>]*\btime="([^"]+)"/g;
+    let m;
+    while ((m = re.exec(xml)) !== null) {
+        const name = m[1];
+        const time = parseFloat(m[2]);
+        if (Number.isFinite(time) && time > 0) {
+            // junit's "name" is sometimes a class path and sometimes a file
+            // path. Normalize: keep what we got and let split-tests.js try
+            // both the full and basename match.
+            out[name] = time;
+        }
+    }
+    return out;
+}
+
+function main() {
+    const files = findJunitFiles(JUNIT_ROOT);
+    if (files.length === 0) {
+        process.stderr.write(`[update-durations] No junit files matched under ${JUNIT_ROOT} (regex ${JUNIT_NAME_REGEX}). Leaving ledger unchanged.\n`);
+        return;
+    }
+    process.stderr.write(`[update-durations] Ingesting ${files.length} junit file(s) from ${JUNIT_ROOT}\n`);
+
+    const existing = loadExisting();
+    const observed = {};
+    for (const file of files) {
+        Object.assign(observed, parseJunit(file));
+    }
+
+    // EMA merge: new = α·observed + (1-α)·existing.
+    const merged = {...existing};
+    for (const [spec, time] of Object.entries(observed)) {
+        const prev = existing[spec];
+        merged[spec] = prev == null ? time : (EMA_ALPHA * time) + ((1 - EMA_ALPHA) * prev);
+    }
+
+    fs.mkdirSync(path.dirname(DURATIONS_FILE), {recursive: true});
+    fs.writeFileSync(DURATIONS_FILE, JSON.stringify({
+        updated_at: new Date().toISOString(),
+        ema_alpha: EMA_ALPHA,
+        durations: merged,
+    }, null, 2));
+
+    process.stderr.write(
+        `[update-durations] observed_specs=${Object.keys(observed).length} ` +
+        `total_ledger=${Object.keys(merged).length} written=${DURATIONS_FILE}\n`,
+    );
+}
+
+main();

--- a/.github/workflows/e2e-android-template.yml
+++ b/.github/workflows/e2e-android-template.yml
@@ -340,6 +340,25 @@ jobs:
           path="${{ needs.generate-specs.outputs.build_id }}-${{ needs.generate-specs.outputs.mobile_sha }}-${{ needs.generate-specs.outputs.mobile_ref }}"
           echo "path=$(echo "${path}" | sed 's/\./-/g')" >> ${GITHUB_OUTPUT}
 
+      - name: Update shard-duration ledger from junit
+        run: |
+          set -e
+          node .github/actions/generate-specs/update-durations.js
+        env:
+          JUNIT_ROOT: detox/artifacts
+          JUNIT_NAME_REGEX: "^android-junit.*\\.xml$"
+          DURATIONS_FILE: detox/.shard-durations.json
+        continue-on-error: true
+
+      - name: Save shard-duration ledger to cache
+        uses: actions/cache/save@v4
+        if: hashFiles('detox/.shard-durations.json') != ''
+        with:
+          path: detox/.shard-durations.json
+          # Android device_name is currently a fixed AVD; key matches the
+          # restore key in .github/actions/generate-specs/action.yml.
+          key: shard-durations-v1-Linux-${{ env.DEVICE_NAME || 'android' }}-${{ inputs.search_path }}-${{ github.run_id }}
+
       - name: Save report Detox Dependencies
         id: report-link
         run: |

--- a/.github/workflows/e2e-ios-template.yml
+++ b/.github/workflows/e2e-ios-template.yml
@@ -667,6 +667,35 @@ jobs:
           path="${{ needs.generate-specs.outputs.build_id }}-${{ needs.generate-specs.outputs.mobile_sha }}-${{ needs.generate-specs.outputs.mobile_ref }}"
           echo "path=$(echo "${path}" | sed 's/\./-/g')" >> ${GITHUB_OUTPUT}
 
+      - name: Update shard-duration ledger from junit
+        # Parse per-spec times from the merged junit reports into
+        # detox/.shard-durations.json. The follow-up cache-save step persists
+        # this so the next run's generate-specs has fresh LPT input.
+        # Non-fatal: if no junit files are present (catastrophic shard failure),
+        # the ledger is left untouched.
+        run: |
+          set -e
+          # Detox's per-shard junit lives at detox/artifacts/*/junit*.xml after
+          # download-artifact has unpacked everything.
+          node .github/actions/generate-specs/update-durations.js
+        env:
+          JUNIT_ROOT: detox/artifacts
+          # Match detox's per-shard `${platform}-junit*.xml` filename (written
+          # by junit-report-merger; see detox/save_report.js).
+          JUNIT_NAME_REGEX: "^ios-junit.*\\.xml$"
+          DURATIONS_FILE: detox/.shard-durations.json
+        continue-on-error: true
+
+      - name: Save shard-duration ledger to cache
+        # Uses actions/cache/save@v4 (not actions/cache@v4) so we ALWAYS write
+        # at this step regardless of cache-restore status in generate-specs.
+        # The key matches generate-specs/action.yml's restore key.
+        uses: actions/cache/save@v4
+        if: hashFiles('detox/.shard-durations.json') != ''
+        with:
+          path: detox/.shard-durations.json
+          key: shard-durations-v1-macOS-${{ env.DEVICE_NAME }}-${{ inputs.search_path }}-${{ github.run_id }}
+
       - name: Save report Detox Dependencies
         id: report-link
         run: |


### PR DESCRIPTION
## Summary

Replaces the current equal-count alphabetical chunking in `generate-specs` with Longest-Processing-Time-first (LPT) bin-packing driven by a cached per-spec duration ledger.

Today every Detox shard receives an arbitrary alphabetical slice of `*.e2e.ts` files. Real per-file runtimes vary 10× (60s — 600s), so the slowest shard ends up running 2-3× longer than the fastest. Wall-clock for the whole suite = slowest shard.

## Approach

- **Generate-specs** (pre-test): restore `detox/.shard-durations.json` from `actions/cache`, run LPT on the file list.
- **Merge-reports** (post-test): parse per-spec `time=` out of `${platform}-junit*.xml` (written by detox via `junit-report-merger`), EMA-blend into the ledger, save back to `actions/cache`.

LPT is the standard greedy multiprocessor scheduling algorithm — sort jobs by duration descending, assign each to the currently-shortest bin. Worst case ≤ (4/3 − 1/(3m)) × optimal — for 20 shards, within 12.5% of optimal.

## Files

- `.github/actions/generate-specs/split-tests.js` — full rewrite. LPT with safe fallbacks (cold cache → median → uniform default = same effective behavior as old chunker).
- `.github/actions/generate-specs/update-durations.js` — new. Native-Node recursive walker (no shell `**` dependency), EMA(α=0.3).
- `.github/actions/generate-specs/action.yml` — cache restore before split.
- `.github/workflows/e2e-ios-template.yml` — cache save + ledger update in merge-reports job. `JUNIT_NAME_REGEX=^ios-junit.*\.xml$`.
- `.github/workflows/e2e-android-template.yml` — same, `^android-junit.*\.xml$`.

## Expected impact

- **First run on this branch:** cold cache → fallback uniform durations → same effective shard distribution as today. Validates that nothing breaks.
- **Second run on this branch:** restored ledger drives LPT split. Worst-shard wall-clock should drop from current 60-90 min toward `max(total/20, longest-single-spec)` ≈ 40-50 min for the current ~110-file suite.

## Test plan

- [ ] First push to this branch: confirm `generate-specs` job succeeds with cold ledger (matrix populated, every shard runs).
- [ ] Confirm `merge-reports` step "Update shard-duration ledger from junit" finds and parses junit files (look for log line `[update-durations] Ingesting N junit file(s)` with N > 0).
- [ ] Confirm `Save shard-duration ledger to cache` step succeeds (uploads the ledger).
- [ ] Second push (any trivial change): confirm `Restore shard-duration ledger` in generate-specs reports a cache hit and `[split-tests] durations_known=N/124` shows N matching the spec count from the first run.
- [ ] Compare per-shard wall-clocks first run vs second run — second should show meaningfully tighter spread.

## Risk

LOW for first run — fallback path is equivalent to current behavior.

MEDIUM for second run — if the LPT output schema differs from what the matrix consumer expects, shards fail to enumerate. Mitigated: schema matches the existing producer (verified locally with synthetic data).

Both failure modes manifest at the start of the workflow (within ~5 min) and are easy to revert by closing this PR.

#### Release Note
```release-note
NONE
```