### PR TITLE
Fix opening push notifications after migration

### DIFF
--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -96,7 +96,7 @@ export async function switchToChannel(serverUrl: string, channelId: string, team
                     }
                     DeviceEventEmitter.emit(NavigationConstants.NAVIGATION_HOME, Screens.CHANNEL);
                 } else {
-                    await NavigationStore.waitUntilScreenHasLoaded(Screens.HOME);
+                    await NavigationStore.waitUntilScreenHasLoaded(Screens.CHANNEL_LIST);
                     await dismissAllRoutesAndPopToScreen(Screens.CHANNEL);
                 }
 

--- a/app/actions/local/thread.test.ts
+++ b/app/actions/local/thread.test.ts
@@ -39,7 +39,6 @@ jest.mock('@store/navigation_store', () => {
         ...original,
         NavigationStore: {
             ...original.NavigationStore,
-            waitUntilScreenIsTop: jest.fn(() => Promise.resolve()),
             waitUntilScreenHasLoaded: jest.fn(() => Promise.resolve()),
             getScreensInStack: jest.fn(() => []),
             getRootRouteInfo: jest.fn(() => {

--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -87,7 +87,7 @@ export const switchToThread = async (serverUrl: string, rootId: string, isFromNo
             }
 
             await navigateToRoot();
-            await NavigationStore.waitUntilScreenIsTop(Screens.HOME);
+            await NavigationStore.waitUntilScreenHasLoaded(Screens.CHANNEL_LIST);
             if (currentTeamId !== teamId && isTabletDevice) {
                 DeviceEventEmitter.emit(Navigation.NAVIGATION_HOME, Screens.GLOBAL_THREADS);
             }

--- a/app/actions/remote/entry/notification.test.ts
+++ b/app/actions/remote/entry/notification.test.ts
@@ -51,7 +51,7 @@ describe('Performance metrics are set correctly', () => {
             console.log(`POST ${url} not registered in the mock`);
             return {status: 404, ok: false};
         });
-        mockedNavigationStore.waitUntilScreenIsTop.mockImplementation(() => Promise.resolve());
+        mockedNavigationStore.waitUntilScreenHasLoaded.mockImplementation(() => Promise.resolve());
 
         // There are no problems when running the tests for this file alone without this line
         // but for some reason, when running several tests together, it fails if we don't add this.

--- a/app/store/navigation_store.test.ts
+++ b/app/store/navigation_store.test.ts
@@ -322,31 +322,12 @@ describe('NavigationStore', () => {
             expect(NavigationStore.isScreenInStack(Screens.ABOUT)).toBe(true);
         });
 
-        it('should resolve waitUntilScreenIsTop when screen becomes visible', async () => {
-            const navState1 = createNavigationState([
-                {key: `${Screens.CHANNEL}-1`, name: Screens.CHANNEL},
-            ]);
-            NavigationStore.updateFromNavigationState(navState1);
-
-            const promise = NavigationStore.waitUntilScreenIsTop(Screens.ABOUT);
-
-            const navState2 = createNavigationState([
-                {key: `${Screens.CHANNEL}-1`, name: Screens.CHANNEL},
-                {key: `${Screens.ABOUT}-2`, name: Screens.ABOUT},
-            ]);
-            NavigationStore.updateFromNavigationState(navState2);
-
-            await promise;
-            expect(NavigationStore.getVisibleScreen()).toBe(Screens.ABOUT);
-        });
-
         it('should resolve immediately if screen is already top', async () => {
             const navState = createNavigationState([
                 {key: `${Screens.ABOUT}-1`, name: Screens.ABOUT},
             ]);
             NavigationStore.updateFromNavigationState(navState);
 
-            await NavigationStore.waitUntilScreenIsTop(Screens.ABOUT);
             expect(NavigationStore.getVisibleScreen()).toBe(Screens.ABOUT);
         });
 

--- a/app/store/navigation_store.ts
+++ b/app/store/navigation_store.ts
@@ -102,28 +102,6 @@ class NavigationStoreSingleton {
         });
     }
 
-    waitUntilScreenIsTop(screenId: AvailableScreens): Promise<void> {
-        return new Promise<void>((resolve) => {
-            if (this.getVisibleScreen() === screenId) {
-                resolve();
-                return;
-            }
-
-            const subscription = this.state$.subscribe((state) => {
-                const topScreen = state.screenStack[state.screenStack.length - 1];
-                if (topScreen === screenId) {
-                    subscription.unsubscribe();
-                    resolve();
-                }
-            });
-
-            setTimeout(() => {
-                subscription.unsubscribe();
-                resolve();
-            }, 30000);
-        });
-    }
-
     waitUntilScreensIsRemoved(screenId: AvailableScreens): Promise<void> {
         return new Promise<void>((resolve) => {
             if (!this.isScreenInStack(screenId)) {


### PR DESCRIPTION
#### Summary
This PR fixes an issue where opening a push notification would not take the user to the channel or thread.

this started to happen after the expo-router migration.

#### Ticket Link
N/A


#### Release Note
```release-note
NONE
```
