### PR TITLE
Hide agents sidebar entry in release-2.41 (cherry-pick #9734)

### DIFF
--- a/app/screens/home/channel_list/categories_list/categories_list.tsx
+++ b/app/screens/home/channel_list/categories_list/categories_list.tsx
@@ -6,7 +6,6 @@ import {DeviceEventEmitter, FlatList, useWindowDimensions} from 'react-native';
 import Animated, {useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import {SafeAreaView, type Edge} from 'react-native-safe-area-context';
 
-import AgentsButton from '@agents/components/agents_button';
 import DraftsButton from '@components/drafts_buttton';
 import ThreadsButton from '@components/threads_button';
 import {Events, Screens} from '@constants';
@@ -44,7 +43,6 @@ type ChannelListProps = {
     scheduledPostHasError: boolean;
     lastChannelId?: ScreenType;
     scheduledPostsEnabled?: boolean;
-    agentsEnabled?: boolean;
     showPlaybooksButton?: boolean;
 };
 
@@ -64,7 +62,6 @@ const CategoriesList = ({
     scheduledPostHasError,
     lastChannelId,
     scheduledPostsEnabled,
-    agentsEnabled,
     showPlaybooksButton,
 }: ChannelListProps) => {
     const theme = useTheme();
@@ -135,18 +132,6 @@ const CategoriesList = ({
         return null;
     }, [activeScreen, draftsCount, isTablet, scheduledPostCount, scheduledPostHasError, scheduledPostsEnabled]);
 
-    const agentsButtonComponent = useMemo(() => {
-        if (!agentsEnabled) {
-            return null;
-        }
-
-        return (
-            <AgentsButton
-                shouldHighlightActive={activeScreen === Screens.AGENT_CHAT}
-            />
-        );
-    }, [agentsEnabled, activeScreen]);
-
     const playbooksButtonComponent = useMemo(() => {
         if (!showPlaybooksButton) {
             return null;
@@ -165,7 +150,7 @@ const CategoriesList = ({
             return (<LoadChannelsError/>);
         }
 
-        const components = [threadButtonComponent, draftsButtonComponent, agentsButtonComponent, playbooksButtonComponent,
+        const components = [threadButtonComponent, draftsButtonComponent, playbooksButtonComponent,
             <Categories
                 key='categories'
                 isTablet={isTablet}
@@ -186,7 +171,7 @@ const CategoriesList = ({
                 />
             </SafeAreaView>
         );
-    }, [agentsButtonComponent, draftsButtonComponent, hasChannels, isTablet, playbooksButtonComponent, styles.flex, threadButtonComponent]);
+    }, [draftsButtonComponent, hasChannels, isTablet, playbooksButtonComponent, styles.flex, threadButtonComponent]);
 
     return (
         <Animated.View style={[styles.container, tabletStyle]}>

--- a/app/screens/home/channel_list/categories_list/index.tsx
+++ b/app/screens/home/channel_list/categories_list/index.tsx
@@ -5,7 +5,6 @@ import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
 import {combineLatest, of} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {observeIsAgentsEnabled} from '@agents/database/queries/version';
 import {observeHasRunningPlaybookRunsInTeam} from '@playbooks/database/queries/run';
 import {observeIsPlaybooksEnabled} from '@playbooks/database/queries/version';
 import {observeDraftCount} from '@queries/servers/drafts';
@@ -30,7 +29,6 @@ const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
         switchMap((scheduledPosts) => of(hasScheduledPostError(scheduledPosts))),
     );
     const scheduledPostsEnabled = observeScheduledPostEnabled(database);
-    const agentsEnabled = observeIsAgentsEnabled(database);
     const showPlaybooksButton = currentTeamId.pipe(
         switchMap((teamId) => combineLatest([
             observeIsPlaybooksEnabled(database),
@@ -45,7 +43,6 @@ const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
         scheduledPostCount,
         scheduledPostHasError,
         scheduledPostsEnabled,
-        agentsEnabled,
         showPlaybooksButton,
     };
 });


### PR DESCRIPTION
#### Summary
Cherry-pick of #9734 onto the `release-2.41` branch.

Removes the Agents sidebar for release-2.41 because of a conflict between this release and the upcoming agents v2. Sidebar support will be exclusive to Agents V2.

This change removes the `AgentsButton` from the channel list sidebar and drops the now-unused `agentsEnabled` observable plumbing in `categories_list`.

A conflict in `categories_list.tsx` was resolved by keeping the `FlatList` rendering structure already present on `release-2.41` while removing the agents button entry from the components list and dropping `agentsButtonComponent` from the `useMemo` deps.

#### Ticket Link
NONE

#### Checklist
- [x] Has UI changes

#### Device Information
Same as #9734 — verified the `categories_list` test suite continues to pass.

#### Screenshots
N/A — sidebar entry is removed, no new UI.

#### Release Note
```release-note
NONE
```