### PR TITLE
fix: wrong copy code button color inside CodeScreen causing accessibility issues

### DIFF
--- a/app/screens/code/index.tsx
+++ b/app/screens/code/index.tsx
@@ -47,13 +47,13 @@ const CodeScreen = ({code, language, textStyle}: CodeScreenProps) => {
                 <NavigationButton
                     iconName='content-copy'
                     iconSize={24}
-                    color={theme.centerChannelColor}
+                    color={theme.sidebarHeaderTextColor}
                     onPress={copyToClipboard}
                     testID='copy-code'
                 />
             ),
         });
-    }, [copyToClipboard, navigation, theme.centerChannelColor]);
+    }, [copyToClipboard, navigation, theme.sidebarHeaderTextColor]);
 
     return (
         <View style={styles.flex}>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Fixed the copy button color in CodeScreen header not changing by setting `headerTintColor` directly in `navigation.setOptions()`. The global `headerTintColor` from the authenticated layout was overriding any color prop on the NavigationButton component.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
iPhone 17 PRO Simulator iOS 26.0

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

### Sapphire

| Before | After |
|--------|--------|
| <img width="464" height="259" alt="before copy" src="https://github.com/user-attachments/assets/2c8e08f9-d666-4c58-a8ae-d3ae1754b80b" /> | <img width="467" height="285" alt="Sapphire" src="https://github.com/user-attachments/assets/9348bc9f-129f-4490-9399-a8609bf9e646" /> | 

### Denim

| Before | After |
|--------|--------|
| <img width="490" height="279" alt="denim before" src="https://github.com/user-attachments/assets/8c974931-cae2-4867-a49d-b1c6e3107456" /> | <img width="459" height="254" alt="Denim" src="https://github.com/user-attachments/assets/5ab1c004-1536-491e-a31d-458157dd7b3f" /> |

### Quartz

| Before | After |
|--------|--------|
| <img width="461" height="274" alt="quartz before" src="https://github.com/user-attachments/assets/b697617f-0d03-4f85-9d69-11f47c274a35" /> | <img width="464" height="268" alt="Quartz" src="https://github.com/user-attachments/assets/49976e7b-344e-4fdb-b94c-a1e87fd94e01" /> |

### Onyx

| Before | After |
|--------|--------|
| <img width="459" height="318" alt="onyx before" src="https://github.com/user-attachments/assets/8e681c86-8ebf-479c-8345-15dfe442ae79" /> | <img width="464" height="311" alt="Onyx" src="https://github.com/user-attachments/assets/e09b5596-2e27-467b-a35d-2ef9cda8f18b" /> |

### Indigo

| Before | After |
|--------|--------|
| <img width="467" height="276" alt="indigo before" src="https://github.com/user-attachments/assets/5fdb1023-cea8-422a-bc7f-29da76d13ba6" /> | <img width="461" height="259" alt="indigo" src="https://github.com/user-attachments/assets/39d2b8b8-6fb8-4640-8679-4c1fc7f35cae" /> |

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
fix: copy code button color with header button theming across Sapphire and Denim themes
```
