### PR TITLE
fix: failed to install React-Core.framework using npm run ios

### DIFF
--- a/patches/@react-native-community+cli-platform-apple+20.1.3.patch
+++ b/patches/@react-native-community+cli-platform-apple+20.1.3.patch
@@ -1,11 +1,12 @@
 diff --git a/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js b/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js
-index df09405..2c81e5d 100644
+index df09405..0efb061 100644
 --- a/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js
 +++ b/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js
-@@ -48,7 +48,7 @@ async function getBuildSettings(xcodeProject, mode, buildOutput, scheme, target)
+@@ -47,8 +47,7 @@ async function getBuildSettings(xcodeProject, mode, buildOutput, scheme, target)
+       selectedTarget = target;
      }
    }
-   const targetIndex = applicationTargets.indexOf(selectedTarget);
+-  const targetIndex = applicationTargets.indexOf(selectedTarget);
 -  return settings[targetIndex].buildSettings;
 +  return settings.find(s => s.target === selectedTarget).buildSettings;
  }

--- a/patches/@react-native-community+cli-platform-apple+20.1.3.patch
+++ b/patches/@react-native-community+cli-platform-apple+20.1.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js b/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js
+index df09405..2c81e5d 100644
+--- a/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js
++++ b/node_modules/@react-native-community/cli-platform-apple/build/commands/runCommand/getBuildSettings.js
+@@ -48,7 +48,7 @@ async function getBuildSettings(xcodeProject, mode, buildOutput, scheme, target)
+     }
+   }
+   const targetIndex = applicationTargets.indexOf(selectedTarget);
+-  return settings[targetIndex].buildSettings;
++  return settings.find(s => s.target === selectedTarget).buildSettings;
+ }
+ function getPlatformName(buildOutput) {
+   // Xcode can sometimes escape `=` with a backslash or put the value in quotes


### PR DESCRIPTION
#### Summary

Added a `patch-package` patch for `@react-native-community/cli-platform-apple`
to fix an issue where the iOS app was failing to install and launch on the
simulator.

When building the Mattermost Mobile app, Xcode generates multiple build targets.
The `React-Core` `.framework` target was appearing before the `Mattermost` `.app`
target in the raw build settings output:

```js
[
  { target: "React-Core", WRAPPER_EXTENSION: "framework" },  // index 0
  { target: "Mattermost", WRAPPER_EXTENSION: "app" },        // index 1
]
```

The CLI filters `applicationTargets` to only `.app` targets correctly, but then
uses the filtered index to look up build settings in the original unfiltered
array, returning `React-Core` settings instead of `Mattermost`:

```js
const targetIndex = applicationTargets.indexOf(selectedTarget); // returns 0
return settings[targetIndex].buildSettings; // settings[0] is React-Core, not Mattermost
```

The patch fixes this by looking up the correct target directly from the
`settings` array by target name:

```js
return settings.find(s => s.target === selectedTarget).buildSettings;
```

#### Ticket Link

N/A

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information

This PR was tested on: iPhone 16 Simulator, iOS 26.2

#### Release Note

```release-note
Fixed iOS simulator launching React.framework instead of Mattermost.app after a successful build by patching @react-native-community/cli-platform-apple to return correct build settings for the selected target.
```