### PR TITLE
resumes slide animation after stopping due to modal system dialog showing

### DIFF
--- a/app/components/keyboard_aware_post_draft_container.tsx
+++ b/app/components/keyboard_aware_post_draft_container.tsx
@@ -12,7 +12,6 @@ import {Events} from '@constants';
 import {isEdgeToEdge} from '@constants/device';
 import {useKeyboardState} from '@context/keyboard_state';
 import useDidMount from '@hooks/did_mount';
-import {DEFAULT_POST_INPUT_HEIGHT} from '@hooks/use_keyboard_state_context';
 import {dismissKeyboard} from '@utils/keyboard';
 
 // Use KeyboardGestureArea on iOS and Android 35+ (with edge-to-edge)
@@ -182,7 +181,6 @@ export const KeyboardAwarePostDraftContainer = ({
     return (
         <Wrapper
             {...wrapperProps}
-            offset={DEFAULT_POST_INPUT_HEIGHT} // KeyboardGestureArea has a bug on iOS that changing the offset causes the input to translate, see: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1365
             enableSwipeToDismiss={false} // this applies only to Android
         >
             <View style={styles.gestureArea}>

--- a/app/hooks/screen_transition_animation.test.ts
+++ b/app/hooks/screen_transition_animation.test.ts
@@ -198,7 +198,8 @@ describe('useScreenTransitionAnimation', () => {
 
             sharedValue.value = 150;
 
-            capturedAppStateCallback!('background');
+            expect(capturedAppStateCallback).toBeDefined();
+            capturedAppStateCallback?.('background');
 
             expect(mockCancelAnimation).toHaveBeenCalledWith(sharedValue);
         });
@@ -209,10 +210,11 @@ describe('useScreenTransitionAnimation', () => {
             focusEffectCallback();
 
             sharedValue.value = 150;
-            capturedAppStateCallback!('background');
+            expect(capturedAppStateCallback).toBeDefined();
+            capturedAppStateCallback?.('background');
             mockWithTiming.mockClear();
 
-            capturedAppStateCallback!('active');
+            capturedAppStateCallback?.('active');
 
             expect(mockWithTiming).toHaveBeenCalledWith(0, {duration: expect.any(Number)});
         });
@@ -225,7 +227,8 @@ describe('useScreenTransitionAnimation', () => {
             sharedValue.value = 0;
             mockWithTiming.mockClear();
 
-            capturedAppStateCallback!('active');
+            expect(capturedAppStateCallback).toBeDefined();
+            capturedAppStateCallback?.('active');
 
             expect(mockWithTiming).not.toHaveBeenCalled();
         });

--- a/app/hooks/screen_transition_animation.test.ts
+++ b/app/hooks/screen_transition_animation.test.ts
@@ -219,7 +219,7 @@ describe('useScreenTransitionAnimation', () => {
             expect(mockWithTiming).toHaveBeenCalledWith(0, {duration: expect.any(Number)});
         });
 
-        it('does not restart animation when app returns to active with the screen already at rest', () => {
+        it('does restart animation even when app returns to active with the screen already at rest', () => {
             renderHook(() => useScreenTransitionAnimation(true));
             const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
             focusEffectCallback();
@@ -230,7 +230,7 @@ describe('useScreenTransitionAnimation', () => {
             expect(capturedAppStateCallback).toBeDefined();
             capturedAppStateCallback?.('active');
 
-            expect(mockWithTiming).not.toHaveBeenCalled();
+            expect(mockWithTiming).toHaveBeenCalled();
         });
 
         it('removes AppState listener on blur', () => {

--- a/app/hooks/screen_transition_animation.test.ts
+++ b/app/hooks/screen_transition_animation.test.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {renderHook} from '@testing-library/react-native';
-import {Platform} from 'react-native';
+import {AppState, Platform} from 'react-native';
 
 import {useScreenTransitionAnimation} from './screen_transition_animation';
 
@@ -11,6 +11,7 @@ const mockUseReducedMotion = jest.fn();
 const mockUseSharedValue = jest.fn();
 const mockUseAnimatedStyle = jest.fn();
 const mockWithTiming = jest.fn();
+const mockCancelAnimation = jest.fn();
 const mockUseWindowDimensions = jest.fn();
 
 jest.mock('expo-router', () => ({
@@ -18,6 +19,7 @@ jest.mock('expo-router', () => ({
 }));
 
 jest.mock('react-native-reanimated', () => ({
+    cancelAnimation: (sv: {value: number}) => mockCancelAnimation(sv),
     useReducedMotion: () => mockUseReducedMotion(),
     useSharedValue: (value: number) => mockUseSharedValue(value),
     useAnimatedStyle: (callback: () => any) => mockUseAnimatedStyle(callback),
@@ -30,12 +32,17 @@ jest.mock('./device', () => ({
 
 describe('useScreenTransitionAnimation', () => {
     let sharedValue: {value: number};
+    let mockSubRemove: jest.Mock;
+    let capturedAppStateCallback: ((state: string) => void) | undefined;
 
     beforeEach(() => {
         jest.clearAllMocks();
 
         // Setup default mock implementations
         sharedValue = {value: 0};
+        mockSubRemove = jest.fn();
+        capturedAppStateCallback = undefined;
+
         mockUseSharedValue.mockReturnValue(sharedValue);
         mockUseAnimatedStyle.mockImplementation((callback) => {
             const style = callback();
@@ -44,6 +51,15 @@ describe('useScreenTransitionAnimation', () => {
         mockWithTiming.mockImplementation((value) => value);
         mockUseReducedMotion.mockReturnValue(false);
         mockUseWindowDimensions.mockReturnValue({width: 375, height: 812});
+
+        jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, callback) => {
+            capturedAppStateCallback = callback as (state: string) => void;
+            return {remove: mockSubRemove} as any;
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     describe('initialization', () => {
@@ -87,8 +103,10 @@ describe('useScreenTransitionAnimation', () => {
             // Get the callback that was passed to useAnimatedStyle
             const animatedStyleCallback = mockUseAnimatedStyle.mock.calls[0][0];
             const style = animatedStyleCallback();
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            focusEffectCallback();
 
-            expect(mockWithTiming).toHaveBeenCalledWith(sharedValue.value, {duration: 250});
+            expect(mockWithTiming).toHaveBeenCalledWith(0, {duration: 250});
             expect(style).toHaveProperty('transform');
         });
 
@@ -100,8 +118,10 @@ describe('useScreenTransitionAnimation', () => {
             // Get the callback that was passed to useAnimatedStyle
             const animatedStyleCallback = mockUseAnimatedStyle.mock.calls[0][0];
             const style = animatedStyleCallback();
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            focusEffectCallback();
 
-            expect(mockWithTiming).toHaveBeenCalledWith(sharedValue.value, {duration: 350});
+            expect(mockWithTiming).toHaveBeenCalledWith(0, {duration: 350});
             expect(style).toHaveProperty('transform');
         });
 
@@ -167,6 +187,57 @@ describe('useScreenTransitionAnimation', () => {
             cleanup();
 
             expect(sharedValue.value).toBe(0);
+        });
+    });
+
+    describe('AppState resume', () => {
+        it('cancels the in-flight animation when going to background so it does not race to completion', () => {
+            renderHook(() => useScreenTransitionAnimation(true));
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            focusEffectCallback();
+
+            sharedValue.value = 150;
+
+            capturedAppStateCallback!('background');
+
+            expect(mockCancelAnimation).toHaveBeenCalledWith(sharedValue);
+        });
+
+        it('resumes the slide-in animation on active when the value is still mid-flight', () => {
+            renderHook(() => useScreenTransitionAnimation(true));
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            focusEffectCallback();
+
+            sharedValue.value = 150;
+            capturedAppStateCallback!('background');
+            mockWithTiming.mockClear();
+
+            capturedAppStateCallback!('active');
+
+            expect(mockWithTiming).toHaveBeenCalledWith(0, {duration: expect.any(Number)});
+        });
+
+        it('does not restart animation when app returns to active with the screen already at rest', () => {
+            renderHook(() => useScreenTransitionAnimation(true));
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            focusEffectCallback();
+
+            sharedValue.value = 0;
+            mockWithTiming.mockClear();
+
+            capturedAppStateCallback!('active');
+
+            expect(mockWithTiming).not.toHaveBeenCalled();
+        });
+
+        it('removes AppState listener on blur', () => {
+            renderHook(() => useScreenTransitionAnimation(true));
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            const cleanup = focusEffectCallback();
+
+            cleanup();
+
+            expect(mockSubRemove).toHaveBeenCalled();
         });
     });
 
@@ -282,8 +353,8 @@ describe('useScreenTransitionAnimation', () => {
 
             renderHook(() => useScreenTransitionAnimation(true));
 
-            const animatedStyleCallback = mockUseAnimatedStyle.mock.calls[0][0];
-            animatedStyleCallback();
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            focusEffectCallback();
 
             expect(mockWithTiming).toHaveBeenCalledWith(
                 expect.any(Number),
@@ -296,8 +367,8 @@ describe('useScreenTransitionAnimation', () => {
 
             renderHook(() => useScreenTransitionAnimation(true));
 
-            const animatedStyleCallback = mockUseAnimatedStyle.mock.calls[0][0];
-            animatedStyleCallback();
+            const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0];
+            focusEffectCallback();
 
             expect(mockWithTiming).toHaveBeenCalledWith(
                 expect.any(Number),

--- a/app/hooks/screen_transition_animation.ts
+++ b/app/hooks/screen_transition_animation.ts
@@ -40,10 +40,10 @@ export const useScreenTransitionAnimation = (animated: boolean = true) => {
                     // Freeze the animation at its current value so the UI thread doesn't
                     // race to completion while the app is backgrounded.
                     cancelAnimation(translateX);
-                } else if (state === 'active' && translateX.value !== 0) {
-                    translateX.value = latestRef.current.shouldAnimate
-                        ? withTiming(0, {duration: animationDuration})
-                        : 0;
+                } else if (state === 'active') {
+                    cancelAnimation(translateX);
+                    translateX.value = latestRef.current.width;
+                    translateX.value = latestRef.current.shouldAnimate ? withTiming(0, {duration: animationDuration}) : 0;
                 }
             });
 

--- a/app/hooks/screen_transition_animation.ts
+++ b/app/hooks/screen_transition_animation.ts
@@ -3,8 +3,8 @@
 
 import {useFocusEffect} from 'expo-router';
 import {useCallback, useEffect, useRef} from 'react';
-import {Platform} from 'react-native';
-import {useReducedMotion, useSharedValue, useAnimatedStyle, withTiming} from 'react-native-reanimated';
+import {AppState, Platform} from 'react-native';
+import {cancelAnimation, useReducedMotion, useSharedValue, useAnimatedStyle, withTiming} from 'react-native-reanimated';
 
 import {useWindowDimensions} from './device';
 
@@ -17,6 +17,7 @@ export const useScreenTransitionAnimation = (animated: boolean = true) => {
     const reducedMotion = useReducedMotion();
     const shouldAnimate = animated && !reducedMotion;
     const translateX = useSharedValue(shouldAnimate ? width : 0);
+    const animationDuration = Platform.OS === 'android' ? 250 : 350;
 
     // Keep a ref so the useFocusEffect cleanup always reads the latest values
     // without adding them as dependencies (which would re-trigger cleanup on rotation/motion changes)
@@ -25,26 +26,33 @@ export const useScreenTransitionAnimation = (animated: boolean = true) => {
         latestRef.current = {width, shouldAnimate};
     }, [width, shouldAnimate]);
 
-    const animatedStyle = useAnimatedStyle(() => {
-        const duration = Platform.OS === 'android' ? 250 : 350;
-        return {
-            transform: [{translateX: withTiming(translateX.value, {duration})}],
-        };
-    }, []);
+    const animatedStyle = useAnimatedStyle(() => ({
+        transform: [{translateX: translateX.value}],
+    }), []);
 
-    // Use focus effect to handle screen appearing (similar to componentDidAppear)
     useFocusEffect(
         useCallback(() => {
-            // Screen is focused (appeared)
-            translateX.value = 0;
+            const {shouldAnimate: sa} = latestRef.current;
+            translateX.value = sa ? withTiming(0, {duration: animationDuration}) : 0;
+
+            const sub = AppState.addEventListener('change', (state) => {
+                if (state === 'inactive' || state === 'background') {
+                    // Freeze the animation at its current value so the UI thread doesn't
+                    // race to completion while the app is backgrounded.
+                    cancelAnimation(translateX);
+                } else if (state === 'active' && translateX.value !== 0) {
+                    translateX.value = latestRef.current.shouldAnimate
+                        ? withTiming(0, {duration: animationDuration})
+                        : 0;
+                }
+            });
 
             return () => {
-                // Screen is blurred (disappeared)
-                const {width: w, shouldAnimate: sa} = latestRef.current;
-                translateX.value = sa ? -w : 0;
+                sub.remove();
+                const {width: w, shouldAnimate: saBlur} = latestRef.current;
+                translateX.value = saBlur ? withTiming(-w, {duration: animationDuration}) : 0;
             };
-
-        }, [translateX]),
+        }, [translateX, animationDuration]),
     );
 
     useEffect(() => {

--- a/app/hooks/screen_transition_animation.ts
+++ b/app/hooks/screen_transition_animation.ts
@@ -42,6 +42,7 @@ export const useScreenTransitionAnimation = (animated: boolean = true) => {
                     cancelAnimation(translateX);
                 } else if (state === 'active') {
                     cancelAnimation(translateX);
+                    translateX.value = latestRef.current.width;
                     translateX.value = latestRef.current.shouldAnimate ? withTiming(0, {duration: animationDuration}) : 0;
                 }
             });

--- a/app/hooks/screen_transition_animation.ts
+++ b/app/hooks/screen_transition_animation.ts
@@ -42,7 +42,6 @@ export const useScreenTransitionAnimation = (animated: boolean = true) => {
                     cancelAnimation(translateX);
                 } else if (state === 'active') {
                     cancelAnimation(translateX);
-                    translateX.value = latestRef.current.width;
                     translateX.value = latestRef.current.shouldAnimate ? withTiming(0, {duration: animationDuration}) : 0;
                 }
             });

--- a/app/keyboard/state_machine/transitions/keyboard_open.test.ts
+++ b/app/keyboard/state_machine/transitions/keyboard_open.test.ts
@@ -112,8 +112,37 @@ describe('keyboardOpenTransitions', () => {
         });
     });
 
-    describe('[3] KEYBOARD_OPEN → KEYBOARD_EVENT_END → KEYBOARD_OPEN (isRotating guard)', () => {
+    describe('[3] KEYBOARD_OPEN → KEYBOARD_EVENT_START → KEYBOARD_OPEN', () => {
         const t = keyboardOpenTransitions[3];
+
+        it('should have correct from/event/to', () => {
+            expect(t.from).toBe(InputContainerStateType.KEYBOARD_OPEN);
+            expect(t.event).toBe(StateMachineEventType.KEYBOARD_EVENT_START);
+            expect(t.to).toBe(InputContainerStateType.KEYBOARD_OPEN);
+        });
+
+        it('action calls calculateKeyboardUpdates with event.height when rawHeight is defined', () => {
+            const snapshot = makeSnapshot();
+            const event = makeEvent({type: StateMachineEventType.KEYBOARD_EVENT_START, height: 280, rawHeight: 330});
+            t.action!(snapshot, event);
+            expect(calculateKeyboardUpdates).toHaveBeenCalledWith(snapshot, 280, 330);
+        });
+
+        it('action falls back to snapshot.keyboardEventHeight when event.height is undefined', () => {
+            const snapshot = makeSnapshot({keyboardEventHeight: 300});
+            const event = makeEvent({type: StateMachineEventType.KEYBOARD_EVENT_START, height: undefined, rawHeight: 330});
+            t.action!(snapshot, event);
+            expect(calculateKeyboardUpdates).toHaveBeenCalledWith(snapshot, 300, 330);
+        });
+
+        it('action returns undefined when rawHeight is undefined', () => {
+            const result = t.action!(makeSnapshot(), makeEvent({type: StateMachineEventType.KEYBOARD_EVENT_START, height: 280, rawHeight: undefined}));
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('[4] KEYBOARD_OPEN → KEYBOARD_EVENT_END → KEYBOARD_OPEN (isRotating guard)', () => {
+        const t = keyboardOpenTransitions[4];
 
         it('should have correct from/event/to', () => {
             expect(t.from).toBe(InputContainerStateType.KEYBOARD_OPEN);

--- a/app/keyboard/state_machine/transitions/keyboard_open.ts
+++ b/app/keyboard/state_machine/transitions/keyboard_open.ts
@@ -58,6 +58,22 @@ export const keyboardOpenTransitions: StateTransition[] = [
     },
     {
         from: InputContainerStateType.KEYBOARD_OPEN,
+        event: StateMachineEventType.KEYBOARD_EVENT_START,
+        to: InputContainerStateType.KEYBOARD_OPEN,
+        action: (snapshot: StateSnapshot, event: StateEvent): ActionUpdates | void => {
+            'worklet';
+
+            const height = event.height ?? snapshot.keyboardEventHeight;
+
+            if (event.rawHeight !== undefined) {
+                return calculateKeyboardUpdates(snapshot, height, event.rawHeight);
+            }
+
+            return undefined;
+        },
+    },
+    {
+        from: InputContainerStateType.KEYBOARD_OPEN,
         event: StateMachineEventType.KEYBOARD_EVENT_END,
         to: InputContainerStateType.KEYBOARD_OPEN,
         guard: (_: StateSnapshot, event: StateEvent): boolean => {

--- a/app/keyboard/state_machine/transitions/keyboard_open.ts
+++ b/app/keyboard/state_machine/transitions/keyboard_open.ts
@@ -12,6 +12,18 @@ import {
     type StateEvent,
 } from '@keyboard/state_machine/types';
 
+const moveStartAction = (snapshot: StateSnapshot, event: StateEvent): ActionUpdates | undefined => {
+    'worklet';
+
+    const height = event.height ?? snapshot.keyboardEventHeight;
+
+    if (event.rawHeight !== undefined) {
+        return calculateKeyboardUpdates(snapshot, height, event.rawHeight);
+    }
+
+    return undefined;
+};
+
 export const keyboardOpenTransitions: StateTransition[] = [
     {
         from: InputContainerStateType.KEYBOARD_OPEN,
@@ -44,33 +56,13 @@ export const keyboardOpenTransitions: StateTransition[] = [
         from: InputContainerStateType.KEYBOARD_OPEN,
         event: StateMachineEventType.KEYBOARD_EVENT_MOVE,
         to: InputContainerStateType.KEYBOARD_OPEN,
-        action: (snapshot: StateSnapshot, event: StateEvent): ActionUpdates | void => {
-            'worklet';
-
-            const height = event.height ?? snapshot.keyboardEventHeight;
-
-            if (event.rawHeight !== undefined) {
-                return calculateKeyboardUpdates(snapshot, height, event.rawHeight);
-            }
-
-            return undefined;
-        },
+        action: moveStartAction,
     },
     {
         from: InputContainerStateType.KEYBOARD_OPEN,
         event: StateMachineEventType.KEYBOARD_EVENT_START,
         to: InputContainerStateType.KEYBOARD_OPEN,
-        action: (snapshot: StateSnapshot, event: StateEvent): ActionUpdates | void => {
-            'worklet';
-
-            const height = event.height ?? snapshot.keyboardEventHeight;
-
-            if (event.rawHeight !== undefined) {
-                return calculateKeyboardUpdates(snapshot, height, event.rawHeight);
-            }
-
-            return undefined;
-        },
+        action: moveStartAction,
     },
     {
         from: InputContainerStateType.KEYBOARD_OPEN,

--- a/app/managers/session_manager.ts
+++ b/app/managers/session_manager.ts
@@ -153,7 +153,9 @@ export class SessionManagerSingleton {
                 }
                 const launchRoute = await determineRouteFromLaunchProps({launchType, serverUrl, displayName});
 
-                router.replace({pathname: launchRoute.route, params: launchRoute.params});
+                requestAnimationFrame(() => {
+                    router.replace({pathname: launchRoute.route, params: launchRoute.params});
+                });
             }
         } finally {
             this.terminatingSessionUrl.delete(serverUrl);

--- a/app/routes/+native-intent.ts
+++ b/app/routes/+native-intent.ts
@@ -55,7 +55,15 @@ export const addEventListener = () => {
 /**
  * Optional: Redirect system paths if needed
  * We don't need custom redirection, so just return the path as-is
+ *
+ * Exception: SSO callback URLs (mmauth://, mmauthbeta://) are consumed by the
+ * SSO screen's own Linking listener. If they reach expo-router they resolve to
+ * an unregistered route. Returning null keeps the app on its current path.
  */
 export function redirectSystemPath(options: {path: string; initial: boolean}) {
+    if (options.path?.startsWith(Sso.REDIRECT_URL_SCHEME) ||
+        options.path?.startsWith(Sso.REDIRECT_URL_SCHEME_DEV)) {
+        return null;
+    }
     return options.path;
 }

--- a/app/screens/server/index.tsx
+++ b/app/screens/server/index.tsx
@@ -172,9 +172,14 @@ const Server = ({
             return false;
         });
 
-        PushNotifications.registerIfNeeded();
+        const registerTimeout = setTimeout(() => {
+            PushNotifications.registerIfNeeded();
+        }, 500);
 
-        return () => backHandler.remove();
+        return () => {
+            backHandler.remove();
+            clearTimeout(registerTimeout);
+        };
     });
 
     const displayLogin = (serverUrl: string, config: ClientConfig, license: ClientLicense) => {

--- a/app/screens/sso/index.tsx
+++ b/app/screens/sso/index.tsx
@@ -112,24 +112,6 @@ const SSO = ({
         setLoginError(errorMessage);
     }, [intl]);
 
-    const doSSOLogin = async (bearerToken: string, csrfToken: string) => {
-        const result: LoginActionResponse = await ssoLogin(serverUrl, serverDisplayName, config.DiagnosticId!, bearerToken, csrfToken, serverPreauthSecret);
-        if (result?.error && result.failed) {
-            onLoadEndError(result.error);
-            return;
-        }
-        goToHome(result.error);
-    };
-
-    const doSSOCodeExchange = async (loginCode: string, samlChallenge: {codeVerifier: string; state: string}) => {
-        const result: LoginActionResponse = await ssoLoginWithCodeExchange(serverUrl, serverDisplayName, config.DiagnosticId!, loginCode, samlChallenge, serverPreauthSecret);
-        if (result?.error && result.failed) {
-            onLoadEndError(result.error);
-            return;
-        }
-        goToHome(result.error);
-    };
-
     const goToHome = useCallback((error?: unknown) => {
         const hasError = launchError || Boolean(error);
         navigateToScreen(Screens.HOME, {extra, launchError: hasError, launchType, serverUrl}, true);
@@ -150,6 +132,24 @@ const SSO = ({
         goToHome();
         return true;
     }, [serverUrl, serverDisplayName, config.DiagnosticId, config.IntuneScope, goToHome, onLoadEndError]);
+
+    const doSSOLogin = useCallback(async (bearerToken: string, csrfToken: string) => {
+        const result: LoginActionResponse = await ssoLogin(serverUrl, serverDisplayName, config.DiagnosticId!, bearerToken, csrfToken, serverPreauthSecret);
+        if (result?.error && result.failed) {
+            onLoadEndError(result.error);
+            return;
+        }
+        goToHome(result.error);
+    }, [config.DiagnosticId, goToHome, onLoadEndError, serverDisplayName, serverPreauthSecret, serverUrl]);
+
+    const doSSOCodeExchange = useCallback(async (loginCode: string, samlChallenge: {codeVerifier: string; state: string}) => {
+        const result: LoginActionResponse = await ssoLoginWithCodeExchange(serverUrl, serverDisplayName, config.DiagnosticId!, loginCode, samlChallenge, serverPreauthSecret);
+        if (result?.error && result.failed) {
+            onLoadEndError(result.error);
+            return;
+        }
+        goToHome(result.error);
+    }, [config.DiagnosticId, goToHome, onLoadEndError, serverDisplayName, serverPreauthSecret, serverUrl]);
 
     const animatedStyles = useScreenTransitionAnimation(!isModal);
 

--- a/app/screens/sso/sso_authentication.tsx
+++ b/app/screens/sso/sso_authentication.tsx
@@ -101,7 +101,7 @@ const SSOAuthentication = ({doSSOLogin, doSSOCodeExchange, loginError, loginUrl,
                 setLoginSuccess(true);
                 doSSOLogin(bearerToken, csrfToken);
             }
-        } else if (Platform.OS === 'ios' || result.type === 'dismiss') {
+        } else if (Platform.OS === 'ios') {
             setError(
                 intl.formatMessage({
                     id: 'mobile.oauth.failed_to_login',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-mobile",
-      "version": "2.40.0",
+      "version": "2.41.0",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {


### PR DESCRIPTION
#### Summary
On a fresh install a permission system dialog shows during slide in animation for the select server screen. When the user dismisses the dialog the animation does not complete leaving the app on an inconsistent state.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68981

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on:
- Android Pixel 6A running Android 16
- Android emulator running Android 11 & 15
- iOS simulator running iOS 26.1

#### Release Note
```release-note
NONE
```
