### PR TITLE
Fix early user name truncation on Android in post header and user profile

### DIFF
--- a/app/components/post_list/post/header/display_name/index.tsx
+++ b/app/components/post_list/post/header/display_name/index.tsx
@@ -8,6 +8,7 @@ import CustomStatusEmoji from '@components/custom_status/custom_status_emoji';
 import FormattedText from '@components/formatted_text';
 import {usePreventDoubleTap} from '@hooks/utils';
 import {openUserProfile} from '@utils/navigation';
+import {nonBreakingString} from '@utils/strings';
 import {makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 
@@ -112,7 +113,7 @@ const HeaderDisplayName = ({
                         numberOfLines={1}
                         testID='post_header.display_name'
                     >
-                        {displayName}
+                        {nonBreakingString(displayName)}
                     </Text>
                 </View>
                 {showCustomStatusEmoji && (

--- a/app/screens/user_profile/title/index.tsx
+++ b/app/screens/user_profile/title/index.tsx
@@ -14,6 +14,7 @@ import {useIsTablet} from '@hooks/device';
 import {useGalleryItem} from '@hooks/gallery';
 import {openGalleryAtIndex} from '@utils/gallery';
 import {urlSafeBase64Encode} from '@utils/security';
+import {nonBreakingString} from '@utils/strings';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 import {displayUsername} from '@utils/user';
@@ -172,7 +173,7 @@ const UserProfileTitle = ({
                         style={styles.displayName}
                         testID='user_profile.display_name'
                     >
-                        {`${prefix}${displayName}`}
+                        {nonBreakingString(`${prefix}${displayName}`)}
                     </Text>
                     {!hideUsername &&
                     <Text


### PR DESCRIPTION
## Summary

Display names that contain a space (e.g. `Jordan Taylor-Anderson`) were truncated **far too early on Android** — collapsing all the way down to `Jorda...` — while rendering correctly on iOS (`Jordan Taylor-...` at the intended max width).

Repro devices: a wide Android phone vs. a narrower iPhone. The Android device is actually the *wider* of the two, which rules out a space/density problem and points squarely at a measurement bug.

### Root cause

There is **no JS-level string slicing** of names — `displayUsername()` returns the full name. All truncation is done by React Native's `<Text numberOfLines={1} ellipsizeMode="tail">` constrained by its flex container.

On Android, a single-line `<Text numberOfLines={1}>` inside a flex container measures its available width against the **first whitespace-delimited token** (`Jordan`), then the ellipsis eats into it → `Jorda...`. iOS measures against the full available width regardless of word boundaries, so it truncates correctly at the container edge.

### Fix

Wrap the display name in `nonBreakingString()` (replaces spaces with `\xa0`) so the name is treated as a single unbreakable token and measured against the real container width. This matches the existing, proven pattern already used for the same purpose in `user_item`, `channel_body`, and `chips`.

Two components are affected (both shown in the bug reports):

- `app/components/post_list/post/header/display_name/index.tsx` — post/thread author name
- `app/screens/user_profile/title/index.tsx` — user profile bottom sheet title

## Test plan

- [ ] Android: open a thread/channel with a user whose display name has a space + a long surname; confirm the post header shows the name clipped at the 60% cap (e.g. `Jordan Taylor-...`) instead of `Jorda...`.
- [ ] Android: open that user's profile bottom sheet; confirm the title shows the full name (or a correctly-clipped name) instead of an over-truncated one.
- [ ] iOS: confirm no regression — names still truncate at the same point as before.

> Note: the change was developed in an environment without the native toolchain, so it has not been verified on a device/emulator yet. CI is expected to confirm lint/types. `npm run tsc` reports 10 pre-existing errors that are identical with and without this change, and none are in the two edited files.

https://claude.ai/code/session_016fHLeCk7uwdHapQbdWX2xK