### PR TITLE
fix(ios): make rnnc Alamofire patch idempotent (addresses #9789 review)

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -121,37 +121,14 @@ post_install do |installer|
 
   end
 
-    # react-native-network-client's prepare_command applies Alamofire+5.9.1.diff,
-    # which inserts an `allHeaders` / `sizeString` block for uncompressed content
-    # length support. Alamofire 5.10.x incorporated this natively, so the patch
-    # creates a duplicate `let allHeaders` declaration in the same function scope.
-    # Xcode 26 / Swift 6 treats duplicate `let` in the same scope as a hard error.
-    # Remove the first (patch-inserted) copy; the native one at the bottom remains.
-    alamofire_delegate = File.join(installer.sandbox.root, 'Alamofire/Source/Core/SessionDelegate.swift')
-    if File.exist?(alamofire_delegate)
-      content = File.read(alamofire_delegate)
-      patch_marker = '// [PATCHED] removed duplicate allHeaders redeclaration'
-      unless content.include?(patch_marker)
-        if content.scan('let allHeaders = (downloadRequest.response)').length >= 2
-          patched = content.sub(
-            "        let allHeaders = (downloadRequest.response)?.allHeaderFields as? NSDictionary ?? NSDictionary()\n" \
-            "        let sizeString = (allHeaders[\"X-Uncompressed-Content-Length\"] ?? allHeaders[\"x-uncompressed-content-length\"]) as? String\n" \
-            "        if (sizeString != nil) {\n" \
-            "            let size = Int64(sizeString!)\n" \
-            "            downloadRequest.updateDownloadProgress(bytesWritten: bytesWritten,\n" \
-            "                                               totalBytesExpectedToWrite: size!)\n" \
-            "            return\n" \
-            "        }\n\n",
-            "        #{patch_marker}\n"
-          )
-          if patched != content
-            File.chmod(0644, alamofire_delegate)
-            File.write(alamofire_delegate, patched)
-            Pod::UI.puts 'Patched Alamofire/SessionDelegate.swift: removed duplicate allHeaders block (>= 5.10.x compatibility).'
-          end
-        end
-      end
-    end
+    # NOTE: The Alamofire duplicate-`allHeaders` workaround that used to live here
+    # has moved upstream into @mattermost/react-native-network-client via
+    # patch-package (patches/@mattermost+react-native-network-client+1.10.0.patch).
+    # That patch makes rnnc's own `ios/patches/apply_patches.rb` idempotent so it
+    # no longer double-applies its bundled Alamofire diff, which was the actual
+    # source of the duplicate `let allHeaders` (Swift 6 / Xcode 26 hard error) —
+    # NOT native Alamofire. Fixing it at the source means every rnnc consumer
+    # benefits and the consuming app's Podfile stays clean.
 
     # ensure stdlib is embedded for Gekidou to work correctly in extensions
     %w[NotificationService MattermostShare].each do |ext_name|

--- a/patches/@mattermost+react-native-network-client+1.10.0.patch
+++ b/patches/@mattermost+react-native-network-client+1.10.0.patch
@@ -1,12 +1,17 @@
 diff --git a/node_modules/@mattermost/react-native-network-client/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt b/node_modules/@mattermost/react-native-network-client/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
-index b8df3e0..60b5087 100644
+index 472d7b4..60b5087 100644
 --- a/node_modules/@mattermost/react-native-network-client/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
 +++ b/node_modules/@mattermost/react-native-network-client/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
-@@ -551,7 +551,14 @@ internal class NetworkClient(private val context: Context, private val baseUrl:
+@@ -551,12 +551,14 @@ internal class NetworkClient(private val context: Context, private val baseUrl:
          chain: Array<X509Certificate>? = null,
          cause: CertificateException? = null
      ) {
--        val host = URI(baseUrlString).host
+-        // Prefer the host from HttpUrl (non-null by contract). Fall back to URI parsing
+-        // and then to the raw baseUrlString so the message never contains "null" and
+-        // emittedCertErrorHosts.add() never gets a null key (#9789).
+-        val host = baseUrl?.host
+-            ?: runCatching { URI(baseUrlString).host }.getOrNull()
+-            ?: baseUrlString
 +        // java.net.URI parses authority more strictly than okhttp3.HttpUrl; for some
 +        // valid baseUrlStrings (notably wss:// schemes or hostnames containing chars
 +        // URI rejects) `URI(...).host` returns null. Adding null to MutableSet<String>
@@ -18,3 +23,69 @@ index b8df3e0..60b5087 100644
          // Emit only once per client instance — retries would otherwise flood the JS layer (#7658).
          if (!emittedCertErrorHosts.add(host)) return
  
+diff --git a/node_modules/@mattermost/react-native-network-client/ios/patches/apply_patches.rb b/node_modules/@mattermost/react-native-network-client/ios/patches/apply_patches.rb
+index 7951108..99ceebf 100644
+--- a/node_modules/@mattermost/react-native-network-client/ios/patches/apply_patches.rb
++++ b/node_modules/@mattermost/react-native-network-client/ios/patches/apply_patches.rb
+@@ -7,6 +7,45 @@ module Pod
+             return Dir["ios/patches/*.diff"]
+         end
+         
++        # Returns true if the patch's added lines are already present in the
++        # target file. `git apply --check` can report a patch as appliable even
++        # when it has already been applied, because an inserted hunk may re-match
++        # its own trailing context at a new offset (the Alamofire diff inserts a
++        # block that itself ends in `downloadRequest.updateDownloadProgress(...)`,
++        # which re-matches the hunk context). Applying a second time duplicates
++        # the inserted lines — e.g. a second `let allHeaders` — which Swift 6 /
++        # Xcode 26 reject as a hard "invalid redeclaration" error.
++        #
++        # This is a content-based idempotency guard. It only consults the FIRST
++        # target file in the diff (every patch here touches a single file) and is
++        # wrapped so any parsing failure falls through to the normal apply path —
++        # it can only ADD a skip, never block a legitimate first application.
++        def patch_additions_present?(file, repo_root, directory_arg)
++            diff = File.read(file)
++            target_rel = diff[/^\+\+\+\sb\/(.+?)\s*$/, 1]
++            return false unless target_rel
++
++            # `-p2` strips the 2 leading path components (e.g. "b/Pods/"); the
++            # remainder is resolved relative to --directory (the Pods dir).
++            stripped = target_rel.split('/')[2..]&.join('/')
++            return false if stripped.nil? || stripped.empty?
++
++            target = File.join(repo_root, directory_arg, stripped)
++            return false unless File.exist?(target)
++
++            added = diff.each_line
++                        .select { |l| l.start_with?('+') && !l.start_with?('+++') }
++                        .map { |l| l[1..].to_s.strip }
++                        .reject(&:empty?)
++            return false if added.empty?
++
++            signature = added.max_by(&:length)
++            File.read(target).include?(signature)
++        rescue StandardError => e
++            Pod::UI.warn "Idempotency check skipped for #{file}: #{e}"
++            false
++        end
++
+         def apply_patch(file)
+             repo_root = `git rev-parse --show-toplevel`.strip
+             directory_arg = Dir.glob(Pathname(repo_root).join("**/**/Pods")).first.sub("#{repo_root}/", "")
+@@ -22,6 +61,15 @@ module Pod
+ 
+                 can_apply = system("git apply --check #{base_args}")
+                 if can_apply
++                    # Guard against re-applying a patch whose additions are already
++                    # present (git can still report it appliable — see comment on
++                    # patch_additions_present?). Prevents duplicate declarations
++                    # that break the Swift 6 / Xcode 26 build.
++                    if patch_additions_present?(file, repo_root, directory_arg)
++                        Pod::UI.puts "Skipping #{file} (additions already present)"
++                        next
++                    end
++
+                     did_apply = system("git apply #{base_args}")
+                     if did_apply
+                         Pod::UI.puts "Successfully applied #{file}"


### PR DESCRIPTION
## Summary

Addresses @larkox's review comment on #9789:

> `ios/Podfile` … Shouldn't this be fixed in `react-native-network-client`?

**Yes — and this PR does that.** It targets the #9789 branch
(`rf-split/app-bugfixes-and-tests`) so it can be merged in to resolve the
comment.

## Root cause (the old Podfile comment was wrong)

`X-Uncompressed-Content-Length` is a **Mattermost server header**, not native
Alamofire — it's also handled in the Android `DownloadProgressInterceptor`.
rnnc's podspec `prepare_command` runs `ios/patches/apply_patches.rb`, which
applies `Alamofire+5.11.2.diff`, inserting an `allHeaders`/`sizeString` block.

Under some pod-install conditions the diff applies **twice**: the inserted
block ends in `downloadRequest.updateDownloadProgress(...)`, which re-matches
the hunk's trailing context, so `git apply --check` still reports the patch
appliable. The second application produces a duplicate `let allHeaders`, which
Swift 6 / Xcode 26 reject as *"invalid redeclaration"*.

## Fix (in rnnc, via patch-package)

`patches/@mattermost+react-native-network-client+1.10.0.patch` now also patches
`apply_patches.rb` with a **content-based idempotency guard**: after the
existing `git apply --check`, if the patch's added lines are already present in
the target, skip. This only triggers in the double-apply case (git says
appliable **and** additions present); a pristine first apply is unaffected.
Wrapped defensively so any parse failure falls through to the normal apply path.

Removed the consumer-side `ios/Podfile` `post_install` workaround that stripped
the duplicate after the fact; left a note pointing at the patch. Net behavior is
unchanged (single `allHeaders` block) — the fix just lives at the source now, so
every rnnc consumer benefits and the app Podfile stays clean.

## Verification

- Ruby syntax checked: `apply_patches.rb` + `ios/Podfile` both `Syntax OK`.
- `patch-package` regenerated scoped to only `NetworkClient.kt` +
  `apply_patches.rb` (no stray Android `build/` artifacts).
- **Needs the iOS build job** (pod install → xcodebuild) here to confirm
  end-to-end — a full local iOS build wasn't run.

## Merge plan

Merge this into `rf-split/app-bugfixes-and-tests` (#9789); the Podfile
workaround is removed here as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)