### PR TITLE
[MM-69092] Ios bg task db lock

### DIFF
--- a/app/actions/remote/notifications.ts
+++ b/app/actions/remote/notifications.ts
@@ -19,6 +19,7 @@ import {getCurrentTeamId} from '@queries/servers/system';
 import {getMyTeamById, prepareMyTeams} from '@queries/servers/team';
 import {getIsCRTEnabled} from '@queries/servers/thread';
 import EphemeralStore from '@store/ephemeral_store';
+import {runWithBackgroundTask} from '@utils/background_task';
 import {logWarning} from '@utils/log';
 import {emitNotificationError} from '@utils/notification';
 import {processPostsFetched} from '@utils/post';
@@ -203,7 +204,7 @@ export const backgroundNotification = async (serverUrl: string, notification: No
             }
 
             if (models.length) {
-                await operator.batchRecords(models, 'backgroundNotification');
+                await runWithBackgroundTask('backgroundNotification', () => operator.batchRecords(models, 'backgroundNotification'));
             }
             return {models};
         }

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -36,6 +36,7 @@ import {getCurrentUser} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
 import {NavigationStore} from '@store/navigation_store';
 import {setTeamLoading} from '@store/team_load_store';
+import {runWithBackgroundTask} from '@utils/background_task';
 import {isTablet} from '@utils/helpers';
 import {logDebug, logInfo} from '@utils/log';
 
@@ -80,7 +81,7 @@ async function doReconnect(serverUrl: string, groupLabel?: BaseRequestGroupLabel
 
         const dt = Date.now();
         if (models?.length) {
-            await operator.batchRecords(models, 'doReconnect');
+            await runWithBackgroundTask('doReconnect', () => operator.batchRecords(models, 'doReconnect'));
         }
 
         logInfo('WEBSOCKET RECONNECT MODELS BATCHING TOOK', `${Date.now() - dt}ms`);

--- a/app/utils/background_task.test.ts
+++ b/app/utils/background_task.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import RNUtils from '@mattermost/rnutils';
+
+import {runWithBackgroundTask} from './background_task';
+
+jest.mock('@mattermost/rnutils', () => ({
+    __esModule: true,
+    default: {
+        beginBackgroundTask: jest.fn(),
+        endBackgroundTask: jest.fn(),
+    },
+}));
+
+const mockedRNUtils = jest.mocked(RNUtils);
+
+describe('runWithBackgroundTask', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('brackets the task with a background-task assertion and returns its result', async () => {
+        mockedRNUtils.beginBackgroundTask.mockReturnValue(7);
+        const task = jest.fn().mockResolvedValue('done');
+
+        const result = await runWithBackgroundTask('test', task);
+
+        expect(result).toBe('done');
+        expect(mockedRNUtils.beginBackgroundTask).toHaveBeenCalledTimes(1);
+        expect(task).toHaveBeenCalledTimes(1);
+        expect(mockedRNUtils.endBackgroundTask).toHaveBeenCalledWith(7);
+    });
+
+    it('ends the background task even when the work throws', async () => {
+        mockedRNUtils.beginBackgroundTask.mockReturnValue(7);
+        const error = new Error('boom');
+
+        await expect(runWithBackgroundTask('test', () => Promise.reject(error))).rejects.toThrow(error);
+
+        expect(mockedRNUtils.endBackgroundTask).toHaveBeenCalledWith(7);
+    });
+
+    it('still runs the work and does not end a task when begin fails', async () => {
+        mockedRNUtils.beginBackgroundTask.mockImplementation(() => {
+            throw new Error('no native module');
+        });
+        const task = jest.fn().mockResolvedValue('done');
+
+        const result = await runWithBackgroundTask('test', task);
+
+        expect(result).toBe('done');
+        expect(task).toHaveBeenCalledTimes(1);
+        expect(mockedRNUtils.endBackgroundTask).not.toHaveBeenCalled();
+    });
+
+    it('does not end a task when begin returns the invalid sentinel (e.g. Android no-op)', async () => {
+        mockedRNUtils.beginBackgroundTask.mockReturnValue(-1);
+        const task = jest.fn().mockResolvedValue('done');
+
+        await runWithBackgroundTask('test', task);
+
+        expect(task).toHaveBeenCalledTimes(1);
+        expect(mockedRNUtils.endBackgroundTask).not.toHaveBeenCalled();
+    });
+});

--- a/app/utils/background_task.ts
+++ b/app/utils/background_task.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import RNUtils from '@mattermost/rnutils';
+
+import {logDebug} from '@utils/log';
+
+const INVALID_TASK_ID = -1;
+
+/**
+ * Runs `task` while holding an iOS background-task assertion, asking the OS for
+ * extra execution time so an in-flight operation can finish before the app is
+ * suspended. This prevents 0xdead10cc terminations, where iOS kills the app for
+ * holding a lock on a file in the shared App Group container (e.g. the
+ * WatermelonDB SQLite write lock) at suspension.
+ *
+ * Best-effort: if the native call is unavailable or throws, the task still runs.
+ * The background task is a no-op on Android (the platform has no equivalent
+ * suspension lock-kill).
+ *
+ * @param name label used for log traceability
+ * @param task the async work to protect
+ */
+export async function runWithBackgroundTask<T>(name: string, task: () => Promise<T>): Promise<T> {
+    let taskId = INVALID_TASK_ID;
+    try {
+        taskId = RNUtils.beginBackgroundTask();
+    } catch (e) {
+        logDebug('runWithBackgroundTask: failed to begin background task', name, e);
+    }
+
+    try {
+        return await task();
+    } finally {
+        if (taskId !== INVALID_TASK_ID) {
+            try {
+                RNUtils.endBackgroundTask(taskId);
+            } catch (e) {
+                logDebug('runWithBackgroundTask: failed to end background task', name, e);
+            }
+        }
+    }
+}

--- a/app/utils/background_task.ts
+++ b/app/utils/background_task.ts
@@ -29,6 +29,10 @@ export async function runWithBackgroundTask<T>(name: string, task: () => Promise
         logDebug('runWithBackgroundTask: failed to begin background task', name, e);
     }
 
+    // TEMP (device verification, remove before merge): confirms the background
+    // task actually wrapped the write. Grep MMLogs for "runWithBackgroundTask".
+    logDebug('runWithBackgroundTask: begin', name, 'taskId', taskId);
+
     try {
         return await task();
     } finally {
@@ -39,5 +43,8 @@ export async function runWithBackgroundTask<T>(name: string, task: () => Promise
                 logDebug('runWithBackgroundTask: failed to end background task', name, e);
             }
         }
+
+        // TEMP (device verification, remove before merge)
+        logDebug('runWithBackgroundTask: end', name, 'taskId', taskId);
     }
 }

--- a/libraries/@mattermost/rnutils/android/src/main/java/com/mattermost/rnutils/RNUtilsModuleImpl.kt
+++ b/libraries/@mattermost/rnutils/android/src/main/java/com/mattermost/rnutils/RNUtilsModuleImpl.kt
@@ -171,6 +171,14 @@ class RNUtilsModuleImpl(private val reactContext: ReactApplicationContext): Life
         return map
     }
 
+    // iOS-only background-task assertion to avoid 0xdead10cc during DB writes.
+    // Android has no equivalent suspension lock-kill, so these are no-ops.
+    fun beginBackgroundTask(): Double = -1.0
+
+    fun endBackgroundTask(taskId: Double) {
+        // No-op on Android
+    }
+
     fun unlockOrientation() {
         val activity = reactContext.currentActivity ?: return
         activity.runOnUiThread {

--- a/libraries/@mattermost/rnutils/android/src/newarch/RNUtilsModule.kt
+++ b/libraries/@mattermost/rnutils/android/src/newarch/RNUtilsModule.kt
@@ -33,6 +33,9 @@ class RNUtilsModule(val reactContext: ReactApplicationContext) : NativeRNUtilsSp
     override fun setHasRegisteredLoad() = implementation.setHasRegisteredLoad()
     override fun getHasRegisteredLoad(): WritableMap = implementation.getHasRegisteredLoad()
 
+    override fun beginBackgroundTask(): Double = implementation.beginBackgroundTask()
+    override fun endBackgroundTask(taskId: Double) = implementation.endBackgroundTask(taskId)
+
     override fun unlockOrientation() {
         implementation.unlockOrientation()
     }

--- a/libraries/@mattermost/rnutils/android/src/oldarch/RNUtilsModule.kt
+++ b/libraries/@mattermost/rnutils/android/src/oldarch/RNUtilsModule.kt
@@ -56,6 +56,16 @@ class RNUtilsModule(context: ReactApplicationContext) :
         return implementation.getHasRegisteredLoad()
     }
 
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    fun beginBackgroundTask(): Double {
+        return implementation.beginBackgroundTask()
+    }
+
+    @ReactMethod
+    fun endBackgroundTask(taskId: Double) {
+        implementation.endBackgroundTask(taskId)
+    }
+
     @ReactMethod
     fun unlockOrientation() {
         implementation.unlockOrientation()

--- a/libraries/@mattermost/rnutils/ios/RNUtils.mm
+++ b/libraries/@mattermost/rnutils/ios/RNUtils.mm
@@ -84,6 +84,14 @@ RCT_REMAP_METHOD(setHasRegisteredLoad, setLoad) {
     [wrapper setHasRegisteredLoad];
 }
 
+RCT_REMAP_BLOCKING_SYNCHRONOUS_METHOD(beginBackgroundTask, NSNumber*, beginBgTask) {
+    return [wrapper beginBackgroundTask];
+}
+
+RCT_REMAP_METHOD(endBackgroundTask, taskId:(double)taskId) {
+    [wrapper endBackgroundTask:@(taskId)];
+}
+
 RCT_REMAP_METHOD(unlockOrientation, unlock) {
     [wrapper unlockOrientation];
 }
@@ -194,6 +202,14 @@ RCT_EXPORT_METHOD(createZipFile:(NSArray<NSString *> *)paths
 
 - (void)setHasRegisteredLoad {
     [wrapper setHasRegisteredLoad];
+}
+
+- (NSNumber *)beginBackgroundTask {
+    return [wrapper beginBackgroundTask];
+}
+
+- (void)endBackgroundTask:(double)taskId {
+    [wrapper endBackgroundTask:@(taskId)];
 }
 
 - (void)lockPortrait {

--- a/libraries/@mattermost/rnutils/ios/RNUtilsWrapper.swift
+++ b/libraries/@mattermost/rnutils/ios/RNUtilsWrapper.swift
@@ -381,6 +381,30 @@ import React
             ]
         }
     }
+
+    // Requests extra background execution time so an in-flight operation (e.g. a
+    // WatermelonDB write holding the App Group SQLite lock) can complete and
+    // release the lock before the app suspends, preventing 0xdead10cc kills.
+    // `beginBackgroundTask`/`endBackgroundTask` are documented as safe to call
+    // from any thread, so we don't hop to the main queue (which may be blocked).
+    @objc public func beginBackgroundTask() -> NSNumber {
+        var taskId: UIBackgroundTaskIdentifier = .invalid
+        taskId = UIApplication.shared.beginBackgroundTask(withName: "MMDatabaseWrite") {
+            // Expiration handler: must end the task or the OS terminates the app.
+            if taskId != .invalid {
+                UIApplication.shared.endBackgroundTask(taskId)
+                taskId = .invalid
+            }
+        }
+        return NSNumber(value: taskId.rawValue)
+    }
+
+    @objc public func endBackgroundTask(_ taskId: NSNumber) {
+        let identifier = UIBackgroundTaskIdentifier(rawValue: taskId.intValue)
+        if identifier != .invalid {
+            UIApplication.shared.endBackgroundTask(identifier)
+        }
+    }
 }
 
 

--- a/libraries/@mattermost/rnutils/src/NativeRNUtils.ts
+++ b/libraries/@mattermost/rnutils/src/NativeRNUtils.ts
@@ -62,6 +62,13 @@ export interface Spec extends TurboModule {
     getHasRegisteredLoad: () => HasRegisteredLoadResponse;
     setHasRegisteredLoad: () => void;
 
+    // iOS only: request extra background execution time so an in-flight write
+    // (e.g. the App Group SQLite write lock) can finish before suspension and
+    // avoid a 0xdead10cc termination. Returns a task id to pass back to
+    // endBackgroundTask. No-op on Android (returns -1).
+    beginBackgroundTask: () => number;
+    endBackgroundTask: (taskId: number) => void;
+
     deleteDatabaseDirectory: (databaseName: string, shouldRemoveDirectory: boolean) => DatabaseOperationResult;
     renameDatabase: (databaseName: string, newDatabaseName: string) => DatabaseOperationResult;
     deleteEntitiesFile: () => boolean;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -260,6 +260,8 @@ jest.doMock('react-native', () => {
             isRunningInSplitView: jest.fn().mockReturnValue({isSplit: false, isTablet: false}),
             getHasRegisteredLoad: jest.fn().mockReturnValue({hasRegisteredLoad: false}),
             setHasRegisteredLoad: jest.fn(),
+            beginBackgroundTask: jest.fn().mockReturnValue(-1),
+            endBackgroundTask: jest.fn(),
 
             getDeliveredNotifications: jest.fn().mockResolvedValue([]),
             removeChannelNotifications: jest.fn().mockImplementation(),


### PR DESCRIPTION
#### Summary
From the investigation with Claude:

result: The crash is 0xdead10cc — iOS kills the app for holding the App Group SQLite lock while being suspended; the JS thread is mid-WatermelonDB write while the main thread is blocked on WebSocketWrapper.swift:202. Same root cause produces both "crashes" and "notifications not delivered." It's a regression from the post-2.40 RNN→Expo Router migration (#9402).

 @mattermost/react-native-network-client 1.9.3 → 1.10.0 — its WebSocketWrapper.didReceive runs on the main dispatch queue (confirmed by the stack) and calls error.localizedDescription / nsError?.description, which do synchronous bundle I/O. WS errors (errorCode 61/57 = connection refused/not connected) are common during backgrounding/flaky networks → main thread stalls.
 
 there are 2 commits in the PR, the last one is to be removed if I get to confirm the fix is working
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69092
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
