### PR TITLE
Reorder build targets

### DIFF
--- a/ios/Mattermost.xcodeproj/xcshareddata/xcschemes/Mattermost.xcscheme
+++ b/ios/Mattermost.xcodeproj/xcshareddata/xcschemes/Mattermost.xcscheme
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7ACAA9BE580DD31A5CB9D97C45D9492D"
-               BuildableName = "React.framework"
-               BlueprintName = "React-Core"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "Mattermost.app"
+               BlueprintName = "Mattermost"
+               ReferencedContainer = "container:Mattermost.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
@@ -28,10 +28,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-               BuildableName = "Mattermost.app"
-               BlueprintName = "Mattermost"
-               ReferencedContainer = "container:Mattermost.xcodeproj">
+               BlueprintIdentifier = "7ACAA9BE580DD31A5CB9D97C45D9492D"
+               BuildableName = "React.framework"
+               BlueprintName = "React-Core"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry


### PR DESCRIPTION
#### Summary
RN tooling broke and it is choosing the wrong target to install into the ios device/sim

by rearranging the targets until the fix is included, the app builds again.

<img width="2044" height="896" alt="CleanShot 2026-06-03 at 14 36 31@2x" src="https://github.com/user-attachments/assets/809773af-82b1-4658-af09-ffe31f6d486f" />


#### Ticket Link

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
