### PR TITLE
[MM-69123] mitigate background lock of the DB

### DIFF
--- a/app/init/push_notifications.test.ts
+++ b/app/init/push_notifications.test.ts
@@ -366,6 +366,36 @@ describe('PushNotifications', () => {
             expect(processSpy).toHaveBeenCalled();
             expect(completion).toHaveBeenCalledWith('new-data');
         });
+
+        it('should not signal completion until processing (and its DB write) has finished', async () => {
+            const notification = {
+                payload: {
+                    verified: 'true',
+                    channel_id: 'channel1',
+                },
+            };
+            const completion = jest.fn();
+
+            // Control when processing resolves so we can assert the ordering:
+            // completion must not be called while the DB write is still in
+            // flight, or iOS can re-suspend the app while the App Group SQLite
+            // lock is held (RUNNINGBOARD 0xdead10cc).
+            let resolveProcessing: () => void = () => {};
+            const processing = new Promise<void>((resolve) => {
+                resolveProcessing = resolve;
+            });
+            jest.spyOn(pushNotifications, 'processNotification').mockReturnValueOnce(processing);
+
+            const handled = pushNotifications.onNotificationReceivedBackground(notification as any, completion);
+
+            await Promise.resolve();
+            expect(completion).not.toHaveBeenCalled();
+
+            resolveProcessing();
+            await handled;
+
+            expect(completion).toHaveBeenCalledWith('new-data');
+        });
     });
 
     describe('onNotificationReceivedForeground', () => {

--- a/app/init/push_notifications.test.ts
+++ b/app/init/push_notifications.test.ts
@@ -349,6 +349,7 @@ describe('PushNotifications', () => {
             await pushNotifications.onNotificationReceivedBackground(notification as any, completion);
 
             expect(processSpy).not.toHaveBeenCalled();
+            expect(completion).toHaveBeenCalledWith('no-data');
         });
 
         it('should process verified notification', async () => {
@@ -395,6 +396,21 @@ describe('PushNotifications', () => {
             await handled;
 
             expect(completion).toHaveBeenCalledWith('new-data');
+        });
+
+        it('should still signal completion (FAILED) when processing rejects', async () => {
+            const notification = {
+                payload: {
+                    verified: 'true',
+                    channel_id: 'channel1',
+                },
+            };
+            const completion = jest.fn();
+            jest.spyOn(pushNotifications, 'processNotification').mockRejectedValueOnce(new Error('boom'));
+
+            await pushNotifications.onNotificationReceivedBackground(notification as any, completion);
+
+            expect(completion).toHaveBeenCalledWith('failed');
         });
     });
 

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -33,7 +33,7 @@ import InAppNotificationStore from '@store/in_app_notification_store';
 import {NavigationStore} from '@store/navigation_store';
 import {isBetaApp} from '@utils/general';
 import {isMainActivity, isTablet} from '@utils/helpers';
-import {logDebug, logInfo} from '@utils/log';
+import {logDebug, logInfo, logWarning} from '@utils/log';
 import {convertToNotificationData} from '@utils/notification';
 
 const messages = defineMessages({
@@ -250,6 +250,10 @@ class PushNotificationsSingleton {
     onNotificationReceivedBackground = async (incoming: Notification, completion: (response: NotificationBackgroundFetchResult) => void) => {
         if (incoming.payload.verified === 'false') {
             logDebug('not handling background notification because it was not verified, ackId=', incoming.payload.ackId);
+
+            // Always finish the iOS background completion handler, or the OS
+            // keeps the app awake until it times out and then terminates it.
+            completion(NotificationBackgroundFetchResult.NO_DATA);
             return;
         }
         const notification = convertToNotificationData(incoming, false);
@@ -259,10 +263,15 @@ class PushNotificationsSingleton {
         // until the fetch completion handler is called; calling it early lets
         // the OS re-suspend the app while a WatermelonDB statement still holds
         // the shared App Group SQLite lock, which triggers a RUNNINGBOARD
-        // 0xdead10cc termination.
-        await this.processNotification(notification);
-
-        completion(NotificationBackgroundFetchResult.NEW_DATA);
+        // 0xdead10cc termination. completion() must run on every path,
+        // including failures, for the same reason.
+        try {
+            await this.processNotification(notification);
+            completion(NotificationBackgroundFetchResult.NEW_DATA);
+        } catch (error) {
+            logWarning('onNotificationReceivedBackground', error);
+            completion(NotificationBackgroundFetchResult.FAILED);
+        }
     };
 
     // This triggers when the app was in the foreground (Android and iOS)

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -258,6 +258,12 @@ class PushNotificationsSingleton {
         }
         const notification = convertToNotificationData(incoming, false);
 
+        // TEMP (device verification, remove before merge — MM-69124): grep MMLogs
+        // for "onNotificationReceivedBackground". A "processing" line followed by a
+        // "processed" line (no truncation between) means the DB work finished before
+        // completion, i.e. the fix held.
+        logDebug('onNotificationReceivedBackground: processing', notification.payload?.ack_id);
+
         // Wait until the notification is fully processed (including its DB
         // read/write) before signaling completion. iOS keeps the app alive
         // until the fetch completion handler is called; calling it early lets
@@ -267,6 +273,9 @@ class PushNotificationsSingleton {
         // including failures, for the same reason.
         try {
             await this.processNotification(notification);
+
+            // TEMP (device verification, remove before merge — MM-69124)
+            logDebug('onNotificationReceivedBackground: processed → completion(NEW_DATA)');
             completion(NotificationBackgroundFetchResult.NEW_DATA);
         } catch (error) {
             logWarning('onNotificationReceivedBackground', error);

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -124,10 +124,10 @@ class PushNotificationsSingleton {
                             unread_replies: 0,
                             last_viewed_at: Date.now(),
                         };
-                        updateThread(serverUrl, payload.root_id, data);
+                        await updateThread(serverUrl, payload.root_id, data);
                     }
                 } else {
-                    markChannelAsViewed(serverUrl, payload.channel_id);
+                    await markChannelAsViewed(serverUrl, payload.channel_id);
                 }
             }
         }
@@ -194,7 +194,9 @@ class PushNotificationsSingleton {
                 // Handle notification tapped
                 openNotification(serverUrl, notification);
             } else {
-                backgroundNotification(serverUrl, notification);
+                // Awaited so the caller can keep the app alive until the DB write
+                // completes (see onNotificationReceivedBackground).
+                await backgroundNotification(serverUrl, notification);
             }
         }
     };
@@ -219,13 +221,13 @@ class PushNotificationsSingleton {
         if (payload) {
             switch (payload.type) {
                 case PushNotification.NOTIFICATION_TYPE.CLEAR:
-                    this.handleClearNotification(notification);
+                    await this.handleClearNotification(notification);
                     break;
                 case PushNotification.NOTIFICATION_TYPE.MESSAGE:
-                    this.handleMessageNotification(notification);
+                    await this.handleMessageNotification(notification);
                     break;
                 case PushNotification.NOTIFICATION_TYPE.SESSION:
-                    this.handleSessionNotification(notification);
+                    await this.handleSessionNotification(notification);
                     break;
             }
         }
@@ -251,7 +253,14 @@ class PushNotificationsSingleton {
             return;
         }
         const notification = convertToNotificationData(incoming, false);
-        this.processNotification(notification);
+
+        // Wait until the notification is fully processed (including its DB
+        // read/write) before signaling completion. iOS keeps the app alive
+        // until the fetch completion handler is called; calling it early lets
+        // the OS re-suspend the app while a WatermelonDB statement still holds
+        // the shared App Group SQLite lock, which triggers a RUNNINGBOARD
+        // 0xdead10cc termination.
+        await this.processNotification(notification);
 
         completion(NotificationBackgroundFetchResult.NEW_DATA);
     };

--- a/ios/Mattermost/AppDelegate.swift
+++ b/ios/Mattermost/AppDelegate.swift
@@ -289,10 +289,14 @@ class AppDelegate: ExpoAppDelegate, OrientationLockable {
         databaseLockBackgroundTask = UIApplication.shared.beginBackgroundTask(withName: "MMDatabaseLockProtection") { [weak self] in
             self?.endDatabaseLockProtection()
         }
+        // TEMP (device verification, remove before merge): grep MMLogs for "MMDatabaseLockProtection".
+        TurboLogger.write(level: .info, message: "MMDatabaseLockProtection: begin taskId \(databaseLockBackgroundTask.rawValue)")
     }
 
     private func endDatabaseLockProtection() {
         guard databaseLockBackgroundTask != .invalid else { return }
+        // TEMP (device verification, remove before merge)
+        TurboLogger.write(level: .info, message: "MMDatabaseLockProtection: end taskId \(databaseLockBackgroundTask.rawValue)")
         UIApplication.shared.endBackgroundTask(databaseLockBackgroundTask)
         databaseLockBackgroundTask = .invalid
     }

--- a/ios/Mattermost/AppDelegate.swift
+++ b/ios/Mattermost/AppDelegate.swift
@@ -33,6 +33,14 @@ class AppDelegate: ExpoAppDelegate, OrientationLockable {
     var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
     var reactNativeFactory: RCTReactNativeFactory?
 
+    // Background-task assertion held across the background transition so any
+    // in-flight WatermelonDB operation (read or write) can finish and release
+    // the shared App Group SQLite lock before the OS suspends the app. Without
+    // it, iOS terminates the app with RUNNINGBOARD 0xdead10cc when it suspends
+    // while a SQLite statement still holds the lock. Only touched from main-
+    // thread lifecycle callbacks and the (also main-thread) expiration handler.
+    private var databaseLockBackgroundTask: UIBackgroundTaskIdentifier = .invalid
+
     override func application(
         _ application: UIApplication,
         handleEventsForBackgroundURLSession identifier: String,
@@ -248,6 +256,7 @@ class AppDelegate: ExpoAppDelegate, OrientationLockable {
     override func applicationDidBecomeActive(_ application: UIApplication) {
         super.applicationDidBecomeActive(application)
         GekidouWrapper.default.setPreference("true", forKey: "ApplicationIsForeground")
+        endDatabaseLockProtection()
     }
 
     override func applicationWillResignActive(_ application: UIApplication) {
@@ -258,12 +267,34 @@ class AppDelegate: ExpoAppDelegate, OrientationLockable {
     override func applicationDidEnterBackground(_ application: UIApplication) {
         super.applicationDidEnterBackground(application)
         GekidouWrapper.default.setPreference("false", forKey: "ApplicationIsForeground")
+        beginDatabaseLockProtection()
     }
 
     override func applicationWillTerminate(_ application: UIApplication) {
         super.applicationWillTerminate(application)
         GekidouWrapper.default.setPreference("false", forKey: "ApplicationIsForeground")
         GekidouWrapper.default.setPreference("false", forKey: "ApplicationIsRunning")
+        endDatabaseLockProtection()
+    }
+
+    // MARK: - Database lock protection (prevents RUNNINGBOARD 0xdead10cc)
+
+    // Keeps the app from being suspended while a WatermelonDB statement still
+    // holds the shared App Group SQLite lock. Begun when entering the
+    // background; released when returning to the foreground or when the OS
+    // background-execution time expires (whichever comes first), by which point
+    // any in-flight DB read/write has finished and released the lock.
+    private func beginDatabaseLockProtection() {
+        guard databaseLockBackgroundTask == .invalid else { return }
+        databaseLockBackgroundTask = UIApplication.shared.beginBackgroundTask(withName: "MMDatabaseLockProtection") { [weak self] in
+            self?.endDatabaseLockProtection()
+        }
+    }
+
+    private func endDatabaseLockProtection() {
+        guard databaseLockBackgroundTask != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(databaseLockBackgroundTask)
+        databaseLockBackgroundTask = .invalid
     }
 
     // MARK: - Orientation


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This mitigates iOS RUNNINGBOARD 0xdead10cc kills caused by the app being suspended while WatermelonDB still holds a lock on the shared App Group SQLite database.

 The fix adds a UIApplication background-task assertion when the app enters background, and releases it when the app becomes active again, terminates, or the OS  background time expires. This gives in-flight WatermelonDB reads and writes time to finish and release the shared SQLite lock before iOS suspends the process.

The crash logs this targets all show EXC_CRASH (SIGKILL) with RUNNINGBOARD 0xdead10cc, with active WatermelonDB query or batchJSON work in SQLite at the time of termination. This covers both read and write paths, instead of only wrapping individual write call sites.

**Note**: this is a mitigation, not a guarantee. If a database operation exceeds the OS-granted background time, iOS can still terminate the app. 

there are some logs that we might want to remove before releasing, otherwise they might be useful to debug while in beta. See [MM-69124](https://mattermost.atlassian.net/browse/MM-69124)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69123
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: iphone 13 Pro

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```


[MM-69124]: https://mattermost.atlassian.net/browse/MM-69124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ