### PR TITLE
fix(android): misaligned CustomStatusEmoji in channel header on android

### DIFF
--- a/app/screens/channel/header/header.tsx
+++ b/app/screens/channel/header/header.tsx
@@ -66,12 +66,12 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     customStatusContainer: {
         flexDirection: 'row',
         height: 15,
+        alignItems: 'center',
         left: Platform.select({ios: undefined, default: -2}),
         marginTop: Platform.select({ios: undefined, default: 1}),
     },
     customStatusEmoji: {
         marginRight: 5,
-        marginTop: Platform.select({ios: undefined, default: -2}),
     },
     customStatusText: {
         alignItems: 'center',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
fix the android specific alignment issue of CustomStatusEmoji with text in Channel header by removing Platform specific negative margin which was pushing custom status emoji to the top

negative margin introduced in  #7342

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
Android api 37 emulator

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
| Before | After |
|--------|--------|
| <img width="423" height="241" alt="before" src="https://github.com/user-attachments/assets/805f7b11-b58e-417e-8cfe-5e38199fd87e" /> | <img width="428" height="273" alt="after" src="https://github.com/user-attachments/assets/a6e35614-30f6-4396-9d8c-aeb7fc756758" /> | 

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixed a UI issue where custom status appears misaligned in the channel header
```
