### PR TITLE
[MM-65820] Keep users in archived channels when server omits ExperimentalViewArchivedChannels

### DIFF
--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -18,7 +18,7 @@ import NetworkManager from '@managers/network_manager';
 import {getActiveServer} from '@queries/app/servers';
 import {prepareMyChannelsForTeam, getChannelById, getChannelByName, getMyChannel, getChannelInfo, queryMyChannelSettingsByIds, getMembersCountByChannelsId, deleteChannelMembership, queryChannelsById} from '@queries/servers/channel';
 import {queryDisplayNamePreferences} from '@queries/servers/preference';
-import {getCommonSystemValues, getConfig, getCurrentChannelId, getCurrentTeamId, getCurrentUserId, getLicense, setCurrentChannelId, setCurrentTeamAndChannelId} from '@queries/servers/system';
+import {canViewArchivedChannels, getCommonSystemValues, getConfig, getCurrentChannelId, getCurrentTeamId, getCurrentUserId, getLicense, setCurrentChannelId, setCurrentTeamAndChannelId} from '@queries/servers/system';
 import {getNthLastChannelFromTeam, getMyTeamById, getTeamByName, queryMyTeams, removeChannelFromTeamHistory, getTeamById} from '@queries/servers/team';
 import {getIsCRTEnabled} from '@queries/servers/thread';
 import {getCurrentUser} from '@queries/servers/user';
@@ -1385,10 +1385,9 @@ export const archiveChannel = async (serverUrl: string, channelId: string) => {
         EphemeralStore.addArchivingChannel(channelId);
         const client = NetworkManager.getClient(serverUrl);
         const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const config = await getConfig(database);
         const channelBeforeArchive = await getChannelById(database, channelId);
         await client.deleteChannel(channelId);
-        if (config?.ExperimentalViewArchivedChannels === 'true') {
+        if (await canViewArchivedChannels(database)) {
             await setChannelDeleteAt(serverUrl, channelId, Date.now());
         } else {
             removeCurrentUserFromChannel(serverUrl, channelId);

--- a/app/actions/remote/search.ts
+++ b/app/actions/remote/search.ts
@@ -7,7 +7,7 @@ import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {prepareMissingChannelsForAllTeams} from '@queries/servers/channel';
-import {getConfigValue, getCurrentTeamId} from '@queries/servers/system';
+import {canViewArchivedChannels, getCurrentTeamId} from '@queries/servers/system';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
 import {getCurrentUser} from '@queries/servers/user';
 import {getFullErrorMessage} from '@utils/errors';
@@ -58,14 +58,14 @@ export const searchPosts = async (serverUrl: string, teamId: string, params: Pos
     try {
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const client = NetworkManager.getClient(serverUrl);
-        const viewArchivedChannels = await getConfigValue(database, 'ExperimentalViewArchivedChannels');
+        const viewArchivedChannels = await canViewArchivedChannels(database);
         const user = await getCurrentUser(database);
         const timezoneOffset = getUtcOffsetForTimeZone(getUserTimezone(user)) * 60;
 
         let postsArray: Post[] = [];
         const data = await client.searchPostsWithParams(teamId, {
             ...params,
-            include_deleted_channels: Boolean(viewArchivedChannels),
+            include_deleted_channels: viewArchivedChannels,
             time_zone_offset: timezoneOffset,
         });
 

--- a/app/actions/websocket/channel.test.ts
+++ b/app/actions/websocket/channel.test.ts
@@ -13,7 +13,7 @@ import {getCurrentCall} from '@calls/state';
 import {General} from '@constants';
 import DatabaseManager from '@database/manager';
 import {deleteChannelMembership, getChannelById, getCurrentChannel, prepareMyChannelsForTeam} from '@queries/servers/channel';
-import {setCurrentTeamId, getCurrentChannelId, getCurrentTeamId, getConfig} from '@queries/servers/system';
+import {setCurrentTeamId, getCurrentChannelId, getCurrentTeamId, canViewArchivedChannels} from '@queries/servers/system';
 import {getCurrentUser, getTeammateNameDisplay, getUserById} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
 
@@ -583,7 +583,7 @@ describe('WebSocket Channel Actions', () => {
             (EphemeralStore.isArchivingChannel as jest.Mock).mockReturnValueOnce(false);
             (getCurrentUser as jest.Mock).mockResolvedValue({id: userId, isGuest: false});
             (getCurrentChannel as jest.Mock).mockResolvedValue({id: channelId});
-            (getConfig as jest.Mock).mockResolvedValue({ExperimentalViewArchivedChannels: 'false'});
+            (canViewArchivedChannels as jest.Mock).mockResolvedValue(false);
 
             await handleChannelDeletedEvent(serverUrl, msg);
 
@@ -605,7 +605,7 @@ describe('WebSocket Channel Actions', () => {
             (EphemeralStore.isArchivingChannel as jest.Mock).mockReturnValueOnce(false);
             (getCurrentUser as jest.Mock).mockResolvedValue({id: userId, isGuest: true});
             (getCurrentChannel as jest.Mock).mockResolvedValue({id: channelId});
-            (getConfig as jest.Mock).mockResolvedValue({ExperimentalViewArchivedChannels: 'false'});
+            (canViewArchivedChannels as jest.Mock).mockResolvedValue(false);
 
             await handleChannelDeletedEvent(serverUrl, msg);
 
@@ -615,12 +615,12 @@ describe('WebSocket Channel Actions', () => {
             expect(removeCurrentUserFromChannel).toHaveBeenCalledWith(serverUrl, channelId);
         });
 
-        it('should handle channel deleted event with ExperimentalViewArchivedChannels enabled', async () => {
+        it('should keep the user in the channel when archived channels are viewable', async () => {
             (EphemeralStore.isLeavingChannel as jest.Mock).mockReturnValueOnce(false);
             (EphemeralStore.isArchivingChannel as jest.Mock).mockReturnValueOnce(false);
             (getCurrentUser as jest.Mock).mockResolvedValue({id: userId, isGuest: false});
             (getCurrentChannel as jest.Mock).mockResolvedValue({id: channelId});
-            (getConfig as jest.Mock).mockResolvedValue({ExperimentalViewArchivedChannels: 'true'});
+            (canViewArchivedChannels as jest.Mock).mockResolvedValue(true);
 
             await handleChannelDeletedEvent(serverUrl, msg);
 

--- a/app/actions/websocket/channel.ts
+++ b/app/actions/websocket/channel.ts
@@ -18,7 +18,7 @@ import {getCurrentCall} from '@calls/state';
 import {Events, General} from '@constants';
 import DatabaseManager from '@database/manager';
 import {deleteChannelMembership, getChannelById, prepareMyChannelsForTeam, getCurrentChannel} from '@queries/servers/channel';
-import {getConfig, getCurrentChannelId, getCurrentTeamId, setCurrentTeamId} from '@queries/servers/system';
+import {canViewArchivedChannels, getCurrentChannelId, getCurrentTeamId, setCurrentTeamId} from '@queries/servers/system';
 import {getCurrentUser, getTeammateNameDisplay, getUserById} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
 import MyChannelModel from '@typings/database/models/servers/my_channel';
@@ -447,9 +447,8 @@ export async function handleChannelDeletedEvent(serverUrl: string, msg: WebSocke
         }
 
         const currentChannel = await getCurrentChannel(database);
-        const config = await getConfig(database);
 
-        if (config?.ExperimentalViewArchivedChannels !== 'true') {
+        if (!(await canViewArchivedChannels(database))) {
             if (currentChannel && currentChannel.id === channelId) {
                 await handleKickFromChannel(serverUrl, channelId, Events.CHANNEL_ARCHIVED);
             }

--- a/app/queries/servers/system.test.ts
+++ b/app/queries/servers/system.test.ts
@@ -20,6 +20,7 @@ import {
     observeCurrentChannelId, observeCurrentTeamId, observeCurrentUserId, observeGlobalThreadsTab,
     observePushVerificationStatus, observeConfig, observeConfigValue, observeMaxFileCount,
     observeIsCustomStatusExpirySupported, observeConfigBooleanValue, observeConfigIntValue,
+    canViewArchivedChannels, observeCanViewArchivedChannels,
     observeLicense, observeAllowedThemesKeys, observeOnlyUnreads,
     observeIsFreeEdition, observeIsMinimumLicenseTier, observeReportAProblemMetadata,
 } from './system';
@@ -671,6 +672,34 @@ describe('system observe functions', () => {
     it('observeConfigBooleanValue emits true when config is "true"', async () => {
         await operator.handleConfigs({configs: [{id: 'EnableCustomEmoji', value: 'true'}], configsToDelete: [], prepareRecordsOnly: false});
         expect(await firstValueFrom(observeConfigBooleanValue(database, 'EnableCustomEmoji'))).toBe(true);
+    });
+
+    it('canViewArchivedChannels resolves true when ExperimentalViewArchivedChannels is absent', async () => {
+        expect(await canViewArchivedChannels(database)).toBe(true);
+    });
+
+    it('canViewArchivedChannels resolves true when ExperimentalViewArchivedChannels is "true"', async () => {
+        await operator.handleConfigs({configs: [{id: 'ExperimentalViewArchivedChannels', value: 'true'}], configsToDelete: [], prepareRecordsOnly: false});
+        expect(await canViewArchivedChannels(database)).toBe(true);
+    });
+
+    it('canViewArchivedChannels resolves false when ExperimentalViewArchivedChannels is "false"', async () => {
+        await operator.handleConfigs({configs: [{id: 'ExperimentalViewArchivedChannels', value: 'false'}], configsToDelete: [], prepareRecordsOnly: false});
+        expect(await canViewArchivedChannels(database)).toBe(false);
+    });
+
+    it('observeCanViewArchivedChannels emits true when ExperimentalViewArchivedChannels is absent', async () => {
+        expect(await firstValueFrom(observeCanViewArchivedChannels(database))).toBe(true);
+    });
+
+    it('observeCanViewArchivedChannels emits true when ExperimentalViewArchivedChannels is "true"', async () => {
+        await operator.handleConfigs({configs: [{id: 'ExperimentalViewArchivedChannels', value: 'true'}], configsToDelete: [], prepareRecordsOnly: false});
+        expect(await firstValueFrom(observeCanViewArchivedChannels(database))).toBe(true);
+    });
+
+    it('observeCanViewArchivedChannels emits false when ExperimentalViewArchivedChannels is "false"', async () => {
+        await operator.handleConfigs({configs: [{id: 'ExperimentalViewArchivedChannels', value: 'false'}], configsToDelete: [], prepareRecordsOnly: false});
+        expect(await firstValueFrom(observeCanViewArchivedChannels(database))).toBe(false);
     });
 
     it('observeConfigIntValue emits defaultValue when not set', async () => {

--- a/app/queries/servers/system.ts
+++ b/app/queries/servers/system.ts
@@ -287,6 +287,26 @@ export const observeConfigIntValue = (database: Database, key: keyof ClientConfi
     );
 };
 
+// The deprecated ExperimentalViewArchivedChannels setting was the last gate on viewing archived
+// channels. It is always enabled on servers newer than v10.11, which stopped sending it in the client
+// config, so an absent value means the feature is on. Supported older servers (down to v5.26.2) still
+// send it and may have explicitly disabled it, so only an explicit 'false' turns archived channels off.
+//
+// TODO: once we drop support for servers <= v10.11 the field is never sent, so these helpers and all of
+// their callers can be removed and archived channels treated as always viewable.
+const archivedChannelsViewable = (value?: string) => value !== 'false';
+
+export const canViewArchivedChannels = async (database: Database) => {
+    return archivedChannelsViewable(await getConfigValue(database, 'ExperimentalViewArchivedChannels'));
+};
+
+export const observeCanViewArchivedChannels = (database: Database) => {
+    return observeConfigValue(database, 'ExperimentalViewArchivedChannels').pipe(
+        switchMap((value) => of$(archivedChannelsViewable(value))),
+        distinctUntilChanged(),
+    );
+};
+
 export const observeLicense = (database: Database): Observable<ClientLicense | undefined> => {
     return querySystemValue(database, SYSTEM_IDENTIFIERS.LICENSE).observe().pipe(
         switchMap((result) => (result.length ? result[0].observe() : of$({value: undefined}))),

--- a/app/screens/browse_channels/index.ts
+++ b/app/screens/browse_channels/index.ts
@@ -8,7 +8,7 @@ import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 import {Permissions} from '@constants';
 import {queryAllMyChannel} from '@queries/servers/channel';
 import {observePermissionForTeam} from '@queries/servers/role';
-import {observeConfigBooleanValue} from '@queries/servers/system';
+import {observeCanViewArchivedChannels, observeConfigBooleanValue} from '@queries/servers/system';
 import {observeCurrentTeam} from '@queries/servers/team';
 import {observeCurrentUser} from '@queries/servers/user';
 
@@ -18,7 +18,7 @@ import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const sharedChannelsEnabled = observeConfigBooleanValue(database, 'ExperimentalSharedChannels');
-    const canShowArchivedChannels = observeConfigBooleanValue(database, 'ExperimentalViewArchivedChannels');
+    const canShowArchivedChannels = observeCanViewArchivedChannels(database);
 
     const currentTeam = observeCurrentTeam(database);
     const currentUser = observeCurrentUser(database);

--- a/app/screens/channel_settings/archive/index.ts
+++ b/app/screens/channel_settings/archive/index.ts
@@ -6,7 +6,7 @@ import {of as of$} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observeChannel} from '@queries/servers/channel';
-import {observeConfigBooleanValue} from '@queries/servers/system';
+import {observeCanViewArchivedChannels} from '@queries/servers/system';
 
 import Archive from './archive';
 
@@ -18,7 +18,7 @@ type Props = WithDatabaseArgs & {
 
 const enhanced = withObservables(['channelId'], ({channelId, database}: Props) => {
     const channel = observeChannel(database, channelId);
-    const canViewArchivedChannels = observeConfigBooleanValue(database, 'ExperimentalViewArchivedChannels');
+    const canViewArchivedChannels = observeCanViewArchivedChannels(database);
 
     return {
         canViewArchivedChannels,

--- a/app/screens/home/channel_list/categories_list/categories/header/index.ts
+++ b/app/screens/home/channel_list/categories_list/categories/header/index.ts
@@ -5,14 +5,14 @@ import {withObservables} from '@nozbe/watermelondb/react';
 import {combineLatestWith} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {observeConfigBooleanValue, observeCurrentChannelId} from '@queries/servers/system';
+import {observeCanViewArchivedChannels, observeCurrentChannelId} from '@queries/servers/system';
 
 import CategoryHeader from './header';
 
 import type CategoryModel from '@typings/database/models/servers/category';
 
 const enhanced = withObservables(['category'], ({category}: {category: CategoryModel}) => {
-    const canViewArchived = observeConfigBooleanValue(category.database, 'ExperimentalViewArchivedChannels');
+    const canViewArchived = observeCanViewArchivedChannels(category.database);
     const currentChannelId = observeCurrentChannelId(category.database);
 
     return {


### PR DESCRIPTION
#### Summary

In v11, I deprecated `ExperimentalViewArchivedChannels` without considering mobile. This created a set of issues when archiving channels from the mobile app. Since v10.11 is about to rotate out of support, let's just harden the mobile app against this field being missing (and we can eventually jettison it altogether).

Introduce a central helper `canViewArchivedChannels` / `observeCanViewArchivedChannels` that default `true` unless the config explicitly shows otherwise. The server enforces actual channel access regardless.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-65820

#### Checklist

- [x] Added or updated unit tests (required for all new features)

#### Device Information

This PR was tested on: iOS Simulator

#### Release Note

```release-note
Fixed an issue where archiving a channel redirected you to the channel list instead of keeping you in the archived channel.
```