### PR TITLE
Simplify iOS dependency install: remove "-m1" script variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ When testing features that require mobile device interaction:
 ```bash
 # Setup
 npm run pod-install           # iOS CocoaPods
-npm run ios-gems              # Ruby gems for iOS (or ios-gems-m1 for M1 Macs)
+npm run ios-gems              # Ruby gems for iOS
 
 # Development
 npm start                     # Start Metro bundler

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ When testing features that require mobile device interaction:
 
 ```bash
 # Setup
-npm run pod-install           # iOS CocoaPods (or pod-install-m1 for M1 Macs)
+npm run pod-install           # iOS CocoaPods
 npm run ios-gems              # Ruby gems for iOS (or ios-gems-m1 for M1 Macs)
 
 # Development

--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "i18n-extract": "npm run mmjstool -- i18n extract-mobile",
     "ios": "react-native run-ios",
     "ios-gems": "bundle install",
-    "ios-gems-m1": "arch -arm64 bundle install",
     "intune:disable": "./scripts/intune-disable.sh",
     "intune:enable": "INTUNE_ENABLED=1 npm run intune:link && INTUNE_ENABLED=1 npm run pod-install",
     "intune:init": "./scripts/intune-init.sh",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "lint": "eslint --ignore-pattern .gitignore --ignore-pattern node_modules --quiet .",
     "mmjstool": "mmjstool",
     "pod-install": "cd ios && RCT_NEW_ARCH_ENABLED=1 pod install",
-    "pod-install-m1": "cd ios && RCT_NEW_ARCH_ENABLED=1 arch -x86_64 pod install",
     "postinstall": "patch-package && ./scripts/postinstall.sh",
     "prepare": "husky",
     "preinstall": "./scripts/preinstall.sh && npx solidarity",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -48,7 +48,7 @@ function installGemsAndPodsM1() {
     echo "Installing Gems"
     npm run ios-gems-m1
     echo "Getting Cocoapods dependencies"
-    npm run pod-install-m1
+    npm run pod-install
 }
 
 function setup() {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -44,13 +44,6 @@ function installGemsAndPods() {
     npm run pod-install
 }
 
-function installGemsAndPodsM1() {
-    echo "Installing Gems"
-    npm run ios-gems-m1
-    echo "Getting Cocoapods dependencies"
-    npm run pod-install
-}
-
 function setup() {
     if [[ -z "$SKIP_SETUP" ]]; then
         npm run clean || exit 1
@@ -61,11 +54,7 @@ function setup() {
         node node_modules/\@sentry/cli/scripts/install.js || exit 1
 
         if [[ "$1" == "ios"* ]]; then
-          if [[ $(uname -p) == 'arm' ]]; then
-            installGemsAndPodsM1 || exit 1
-          else
-            installGemsAndPods || exit 1
-          fi
+          installGemsAndPods || exit 1
         fi
 
         ASSETS=$(node scripts/generate-assets.js)

--- a/scripts/intune-init.sh
+++ b/scripts/intune-init.sh
@@ -34,11 +34,7 @@ npm run intune:link
 
 # Install pods with Intune
 echo "📦 Installing iOS dependencies with Intune..."
-if [[ $(uname -p) == 'arm' ]]; then
-    INTUNE_ENABLED=1 npm run pod-install-m1
-else
-    INTUNE_ENABLED=1 npm run pod-install
-fi
+INTUNE_ENABLED=1 npm run pod-install
 
 echo ""
 echo "✅ Intune development environment ready!"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  if [ "$INTUNE_ENABLED" = "1" ]; then
+  if [ "${INTUNE_ENABLED:-}" = "1" ]; then
     echo "🔐 INTUNE_ENABLED detected"
     npm run intune:init
   else

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,23 +1,12 @@
 #!/usr/bin/env bash
 
-function installPods() {
-    echo "Getting Cocoapods dependencies"
-    npm run pod-install
-}
-
-function installPodsM1() {
-    echo "Getting Cocoapods dependencies"
-    npm run pod-install-m1
-}
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
   if [ "$INTUNE_ENABLED" = "1" ]; then
     echo "🔐 INTUNE_ENABLED detected"
     npm run intune:init
-  elif [[ $(uname -p) == 'arm' ]]; then
-    installPodsM1
   else
-    installPods
+    echo "Getting Cocoapods dependencies"
+    npm run pod-install
   fi
 fi
 

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -2,12 +2,7 @@
 
 function cocoapods() {
     echo "Installing Cocoapods"
-    if [[ $(uname -p) == 'arm' ]]; then
-      npm run ios-gems-m1 &> /dev/null || exit 1
-    else
-      npm run ios-gems &> /dev/null  || exit 1
-    fi
-    
+    npm run ios-gems &> /dev/null || exit 1
 }
 
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
#### Summary

Removes the `pod-install-m1` and `ios-gems-m1` npm scripts, leaving a single `pod-install` and `ios-gems` that work on both Apple Silicon and Intel. With the current toolchain (CocoaPods 1.16.1), `pod install` and `bundle install` both run natively on Apple Silicon -- as the arm64 CI runners (`macos-15`/`macos-14`/`macos-26`) already do, and as verified locally -- so the Rosetta/arch workarounds are no longer needed.

#### Ticket Link
None.

#### Checklist
- [x] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: macOS 15 (Apple Silicon) — verified `npm run pod-install` and `npm run ios-gems` resolve dependencies natively.

#### Screenshots
None — no UI changes.

#### Release Note
```release-note
NONE
```