### PR TITLE
Add explicit iOS Simulator destination to fix xcodebuild destination resolution

### DIFF
--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -18,6 +18,10 @@ runs:
       with:
         xcode-version: '26.1'
 
+    - name: ci/install-ios-simulator-runtime
+      shell: bash
+      run: xcodebuild -downloadPlatform iOS
+
     - name: ci/prepare-mobile-build
       uses: ./.github/actions/prepare-mobile-build
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -469,7 +469,7 @@ platform :ios do
     UI.message("Building for #{build_arch} architecture on #{host_arch} host")
 
     build_ios_unsigned_or_simulator(
-      more_xc_args: "-sdk iphonesimulator -arch #{build_arch}",
+      more_xc_args: "-sdk iphonesimulator -destination 'generic/platform=iOS Simulator'",
       rel_build_dir: "Release-iphonesimulator",
       output_file: output_file,
     )


### PR DESCRIPTION
#### Summary

The E2E `build-ios-simulator` job has been failing during the `xcodebuild` simulator build with:

```
xcodebuild: error: Found no destinations for the scheme 'Mattermost' and action build.
```

and, on an earlier run, the underlying:

```
error: No simulator runtime version from ["23C54", "23E254a", "23F77"]
       available to use with iphonesimulator SDK version 23B77
```

The simulator lane invokes `xcodebuild ... -sdk iphonesimulator -arch <arch>` with **no `-destination`**, so xcodebuild must auto-resolve a concrete device+runtime pair — which fails when the runner's installed simulator runtimes don't line up with the SDK shipped by the pinned Xcode.

This adds an explicit `-destination 'generic/platform=iOS Simulator'` to the simulator build so xcodebuild targets the simulator platform generically instead of resolving a specific device/runtime.

This is a prototype to validate the fix in CI — if a generic destination still can't resolve a runtime, the alternative is bumping the pinned Xcode version (`.github/actions/prepare-ios-build/action.yaml`) or installing the matching simulator runtime on the runner.

#### Ticket Link

NONE

#### Checklist

- [ ] Has UI changes
- [x] Have run E2E tests by adding label `E2E/Run-iOS`.

#### Device Information

CI iOS Simulator (GitHub Actions runner).

#### Release Note

```release-note
NONE
```