### PR TITLE
prevent crash when reaction emoji is removed while ReactionsScreen is…

### DIFF
--- a/app/screens/reactions/emoji_bar/index.tsx
+++ b/app/screens/reactions/emoji_bar/index.tsx
@@ -36,6 +36,10 @@ const EmojiBar = ({emojiSelected, reactionsByName, setIndex, sortedReactions}: P
     const listRef = useRef<FlatList<string>>(null);
 
     const scrollToIndex = (index: number, animated = false) => {
+        if (index < 0 || !listRef?.current) {
+            return;
+        }
+
         listRef.current?.scrollToIndex({
             animated,
             index,

--- a/app/screens/reactions/reactions.tsx
+++ b/app/screens/reactions/reactions.tsx
@@ -32,7 +32,7 @@ function getSortedReactions(reactions: ReactionModel[] | undefined, prevSortedRe
 
 const Reactions = ({initialEmoji, location, reactions}: Props) => {
     const [sortedReactions, setSortedReactions] = useState(Array.from(new Set(reactions?.map((r) => getEmojiFirstAlias(r.emojiName)))));
-    const [index, setIndex] = useState(sortedReactions.indexOf(initialEmoji));
+    const [index, setIndex] = useState(() => Math.max(0, sortedReactions.indexOf(initialEmoji)));
 
     const reactionsByName = useMemo(() => {
         return reactions?.reduce((acc, reaction) => {
@@ -54,7 +54,7 @@ const Reactions = ({initialEmoji, location, reactions}: Props) => {
 
     const renderContent = useCallback(() => {
         const emojiAlias = sortedReactions[index];
-        if (!reactionsByName) {
+        if (!emojiAlias || !reactionsByName) {
             return null;
         }
 

--- a/detox/e2e/test/products/channels/messaging/emojis_and_reactions.e2e.ts
+++ b/detox/e2e/test/products/channels/messaging/emojis_and_reactions.e2e.ts
@@ -352,7 +352,7 @@ describe('Messaging - Emojis and Reactions', () => {
             // * Verify the screen survives the emoji removal without crashing
             await waitFor(
                 element(by.id('reaction.emoji.fire').withAncestor(by.id(ReactionsScreen.testID.reactionsScreen))),
-            ).not.toBeVisible().withTimeout(timeouts.TEN_SEC);
+            ).not.toExist().withTimeout(timeouts.TEN_SEC);
             await expect(ReactionsScreen.reactionsScreen).toExist();
         } finally {
             await device.enableSynchronization();

--- a/detox/e2e/test/products/channels/messaging/emojis_and_reactions.e2e.ts
+++ b/detox/e2e/test/products/channels/messaging/emojis_and_reactions.e2e.ts
@@ -314,4 +314,52 @@ describe('Messaging - Emojis and Reactions', () => {
         // # Go back to channel list screen
         await ChannelScreen.back();
     });
+
+    it('MM-66558 - should not crash when the selected emoji is removed while ReactionsScreen is open', async () => {
+        // # Set up a second user and add a 'fire' reaction via API
+        const {user: otherUser} = await User.apiCreateUser(siteOneUrl);
+        await Team.apiAddUserToTeam(siteOneUrl, otherUser.id, testTeam.id);
+        await Channel.apiAddUserToChannel(siteOneUrl, otherUser.id, testChannel.id);
+
+        const message = `Message ${getRandomId()}`;
+        await Post.apiCreatePost(siteOneUrl, {channelId: testChannel.id, message});
+        const {post} = await Post.apiGetLastPostInChannel(siteOneUrl, testChannel.id);
+
+        await User.apiLogin(siteOneUrl, {username: otherUser.newUser.username, password: otherUser.newUser.password});
+        await client.post(`${siteOneUrl}/api/v4/reactions`, {
+            user_id: otherUser.id,
+            post_id: post.id,
+            emoji_name: 'fire',
+            create_at: 0,
+        });
+        await User.apiLogin(siteOneUrl, {username: testUser.username, password: testUser.password});
+
+        // # Open the channel and long-press the fire reaction to open ReactionsScreen
+        await ChannelScreen.open(channelsCategory, testChannel.name);
+        const fireReaction = element(by.id('reaction.emoji.fire').withAncestor(by.id(`channel.post_list.post.${post.id}`)));
+        await waitFor(fireReaction).toExist().withTimeout(timeouts.TEN_SEC);
+
+        await device.disableSynchronization();
+        try {
+            await fireReaction.longPress();
+            await waitFor(ReactionsScreen.reactionsScreen).toExist().withTimeout(timeouts.TEN_SEC);
+
+            // # Remove the 'fire' reaction via API while ReactionsScreen is open
+            await User.apiLogin(siteOneUrl, {username: otherUser.newUser.username, password: otherUser.newUser.password});
+            await client.delete(`${siteOneUrl}/api/v4/users/${otherUser.id}/posts/${post.id}/reactions/fire`);
+            await User.apiLogin(siteOneUrl, {username: testUser.username, password: testUser.password});
+
+            // * Verify the screen survives the emoji removal without crashing
+            await waitFor(
+                element(by.id('reaction.emoji.fire').withAncestor(by.id(ReactionsScreen.testID.reactionsScreen))),
+            ).not.toBeVisible().withTimeout(timeouts.TEN_SEC);
+            await expect(ReactionsScreen.reactionsScreen).toExist();
+        } finally {
+            await device.enableSynchronization();
+        }
+
+        // # Go back to channel list screen
+        await ReactionsScreen.close();
+        await ChannelScreen.back();
+    });
 });


### PR DESCRIPTION
#### Summary
Original issue shows an index out of range error and according to screenshot it seems to be happening in the post list screen. After test and code review there is a guard already added in post_list some months ago that should be covering this crash committed months after issue report:

```
    const scrollToIndex = useCallback((index: number, animated = true, applyOffset = true) => {
        if (index < 0 || !listRef?.current) {
            return;
        }
       ....
    }
```

After reviewing other scrollToIndex similar code locations, there is a **crash also happening when showing emoji reactions list** bottom sheet for a post.
This fix covers and tests also that particular scenario and makes sure all other scrollToIndex calls are guarded for out of range indexing.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66558

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Android 16 & iOS 26.1 emulators

#### Release Note
```release-note
fixes crash while showing emoji reaction list
```
