### PR TITLE
fix: save videos to correct gallery folder when mime type is generic

### DIFF
--- a/.hermes/plans/mm-26590-return-key-go.md
+++ b/.hermes/plans/mm-26590-return-key-go.md
@@ -1,0 +1,29 @@
+# Spec: Change "Join" to "Go" on Sign-in Page Keyboard (Issue #26590)
+
+## Issue Summary
+On iOS, the return/enter key on the on-screen keyboard shows "Join" when users are typing their password on the login screen. It should show "Go" instead.
+
+## Root Cause
+In `/home/ubuntu/dev/workspace/projects/mattermost-mobile/app/screens/login/form.tsx` at line 390, the password input has:
+```tsx
+returnKeyType='join'
+```
+
+The React Native `returnKeyType` prop accepts different values per platform. For iOS, 'join' displays "Join" on the keyboard, while 'go' displays "Go".
+
+## Fix Scope
+Single file change: `app/screens/login/form.tsx`
+- Line 390: Change `returnKeyType='join'` to `returnKeyType='go'`
+
+This affects only the password field on the login screen.
+
+## Acceptance Criteria
+- [ ] On iOS: Password field shows "Go" on keyboard return key
+- [ ] On Android: Password field shows "Go" on keyboard return key (Android also supports 'go')
+- [ ] No regression on other screens using returnKeyType
+- [ ] Screenshots provided for both platforms
+
+## Testing
+- Manual test on iOS simulator and Android emulator
+- Verify keyboard shows "Go" on password field
+- Verify login functionality still works (pressing "Go" triggers login)

--- a/app/screens/gallery/footer/download_with_action/index.tsx
+++ b/app/screens/gallery/footer/download_with_action/index.tsx
@@ -24,7 +24,7 @@ import {useTheme} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
 import {alertFailedToOpenDocument, alertOnlyPDFSupported} from '@utils/document';
 import {getFullErrorMessage} from '@utils/errors';
-import {deleteFile, fileExists, getLocalFilePathFromFile, hasWriteStoragePermission, isPdf, pathWithPrefix} from '@utils/file';
+import {deleteFile, fileExists, getLocalFilePathFromFile, hasWriteStoragePermission, isImage, isPdf, isVideo, pathWithPrefix} from '@utils/file';
 import {galleryItemToFileInfo} from '@utils/gallery';
 import {logDebug} from '@utils/log';
 import {previewPdf} from '@utils/navigation';
@@ -206,10 +206,11 @@ const DownloadWithAction = ({action, enableSecureFilePreview, item, onShareCallb
         }
     };
 
-    const saveImageOrVideo = async (path: string) => {
+    const saveImageOrVideo = async (path: string, actualType?: string) => {
         if (mounted.current) {
             try {
-                const cameraType = item.type === 'avatar' ? 'image' : item.type;
+                const resolvedType = actualType || item.type;
+                const cameraType = resolvedType === 'avatar' ? 'image' : resolvedType;
                 await CameraRoll.saveAsset(path, {
                     type: cameraType === 'image' ? 'photo' : 'video',
                     album: applicationName || '',
@@ -231,12 +232,18 @@ const DownloadWithAction = ({action, enableSecureFilePreview, item, onShareCallb
             const hasPermission = await hasWriteStoragePermission(intl);
 
             if (hasPermission) {
-                switch (item.type) {
+                // Re-check actual file type from mime_type/extension, since
+                // servers may send generic mime types like application/octet-stream
+                // for videos, causing them to be misclassified as 'file'.
+                const fileInfo = galleryItemToFileInfo(item);
+                const actualType = isVideo(fileInfo) ? 'video' : (isImage(fileInfo) ? 'image' : item.type);
+
+                switch (actualType) {
                     case 'file':
                         saveFile(path);
                         break;
                     default:
-                        saveImageOrVideo(path);
+                        saveImageOrVideo(path, actualType);
                         break;
                 }
             }

--- a/app/screens/gallery/footer/download_with_action/index.tsx
+++ b/app/screens/gallery/footer/download_with_action/index.tsx
@@ -82,6 +82,7 @@ const DownloadWithAction = ({action, enableSecureFilePreview, item, onShareCallb
     const [showToast, setShowToast] = useState<boolean|undefined>();
     const [error, setError] = useState('');
     const [saved, setSaved] = useState(false);
+    const [savedType, setSavedType] = useState<string>();
     const [progress, setProgress] = useState(0);
     const mounted = useRef(false);
     const downloadPromise = useRef<ProgressPromise<ClientResponse> | undefined>(undefined);
@@ -111,7 +112,7 @@ const DownloadWithAction = ({action, enableSecureFilePreview, item, onShareCallb
         iconName = 'check';
         toastStyle = styles.fileSaved;
 
-        switch (item.type) {
+        switch (savedType || item.type) {
             case 'image':
             case 'avatar':
                 message = intl.formatMessage({id: 'gallery.image_saved', defaultMessage: 'Image saved'});
@@ -216,6 +217,7 @@ const DownloadWithAction = ({action, enableSecureFilePreview, item, onShareCallb
                     album: applicationName || '',
                 });
                 setSaved(true);
+                setSavedType(resolvedType);
                 if (item.type !== 'avatar') {
                     updateLocalFilePath(serverUrl, item.id, path);
                 }
@@ -236,7 +238,12 @@ const DownloadWithAction = ({action, enableSecureFilePreview, item, onShareCallb
                 // servers may send generic mime types like application/octet-stream
                 // for videos, causing them to be misclassified as 'file'.
                 const fileInfo = galleryItemToFileInfo(item);
-                const actualType = isVideo(fileInfo) ? 'video' : (isImage(fileInfo) ? 'image' : item.type);
+                let actualType = item.type;
+                if (isVideo(fileInfo)) {
+                    actualType = 'video';
+                } else if (isImage(fileInfo)) {
+                    actualType = 'image';
+                }
 
                 switch (actualType) {
                     case 'file':


### PR DESCRIPTION
## Summary
Fixes videos being saved to the wrong folder (Downloads instead of Gallery) when the server sends a generic mime type like `application/octet-stream`.

## Problem
Servers often send video files with generic mime types (`application/octet-stream`, `application/postscript`) instead of the correct `video/mp4` etc. The `isVideo()` check in `fileToGalleryItem` only matches exact mime types from `SUPPORTED_VIDEO_FORMAT`, so these files were classified as `'file'` and routed to `saveFile()` (Downloads) instead of `saveImageOrVideo()` (CameraRoll/Gallery).

## Fix
In `save()`, re-check the actual file type using `isVideo()`/`isImage()` with the full `FileInfo` (which also checks file extension, not just mime type) before routing. This ensures videos with generic mime types but valid extensions are properly saved to the gallery.

Resolves #25559

## Release Notes
```release-note
FIX: Videos with generic mime types are now correctly saved to the device gallery instead of Downloads.
```