### PR TITLE
[69330] codeblock crash on tap

### DIFF
--- a/app/routes/(authenticated)/code.test.tsx
+++ b/app/routes/(authenticated)/code.test.tsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import CodeRoute from './code';
+
+// react-syntax-highlighter pulls in ESM-only deps (refractor/hastscript) that
+// jest doesn't transform, and it's not the code under test here. Stub it with a
+// passthrough that renders the highlighted `code` as plain text. The crash this
+// test targets happens in our own Highlighter (getMaximumLineLength -> code.split)
+// before this component is ever rendered, so stubbing it does not hide the bug.
+jest.mock('react-syntax-highlighter', () => {
+    const {Text: RNText} = require('react-native');
+    return {
+        __esModule: true,
+        default: ({children}: {children: React.ReactNode}) => <RNText>{children}</RNText>,
+    };
+});
+
+jest.mock('react-syntax-highlighter/dist/cjs/styles/hljs', () => ({
+    githubGist: {hljs: {}},
+    monokai: {hljs: {}},
+    solarizedDark: {hljs: {}},
+    solarizedLight: {hljs: {}},
+}));
+
+// ESM-only submodule imported transitively by the syntax_highlight renderer.
+jest.mock('react-syntax-highlighter/create-element', () => ({
+    createStyleObject: jest.fn(() => ({})),
+}));
+
+// Mock expo-router with just the exports the route + screen use, so each test
+// can feed the route its params via useLocalSearchParams.
+const mockUseLocalSearchParams = jest.fn();
+jest.mock('expo-router', () => ({
+    useLocalSearchParams: () => mockUseLocalSearchParams(),
+    useNavigation: () => ({
+        setOptions: jest.fn(),
+        addListener: jest.fn(() => jest.fn()),
+    }),
+    useRouter: () => ({
+        canGoBack: jest.fn(() => true),
+    }),
+}));
+
+describe('CodeRoute (MM-69330)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // Regression: tapping a code block whose text happens to be valid JSON
+    // (e.g. "42", "{...}", "true") crashed the app. `usePropsFromParams` ran
+    // `safeParseJSON` over every param, so `code` was parsed from a string into
+    // a number/object/boolean. `Highlighter` then called `code.split('\n')` on a
+    // non-string value, throwing "code.split is not a function".
+    it.each([
+        ['a bare number', '42'],
+        ['a JSON object', '{"hello": "world"}'],
+        ['a JSON array', '[1, 2, 3]'],
+        ['a boolean literal', 'true'],
+    ])('renders without crashing when the code block content is %s', (_label, code) => {
+        mockUseLocalSearchParams.mockReturnValue({
+            code,
+            language: 'json',
+            textStyle: '{}',
+            title: 'Code',
+        });
+
+        const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);
+
+        // The raw code text must reach the viewer verbatim, as a string.
+        expect(getByText(code)).toBeTruthy();
+    });
+
+    it('renders plain (non-JSON) code without crashing', () => {
+        const code = 'const greeting = "hello";';
+        mockUseLocalSearchParams.mockReturnValue({
+            code,
+            language: 'javascript',
+            textStyle: '{}',
+            title: 'Code',
+        });
+
+        const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);
+
+        expect(getByText(code)).toBeTruthy();
+    });
+});

--- a/app/routes/(authenticated)/code.tsx
+++ b/app/routes/(authenticated)/code.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {useLocalSearchParams} from 'expo-router';
+
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
 import {usePropsFromParams} from '@hooks/props_from_params';
@@ -8,7 +10,12 @@ import CodeScreen, {type CodeScreenProps} from '@screens/code';
 
 export default function CodeRoute() {
     const theme = useTheme();
-    const {title, ...props} = usePropsFromParams<CodeScreenProps & {title: string}>();
+
+    // `code` is read directly so it is never run through safeParseJSON: a code
+    // block whose text is valid JSON (e.g. "42", "{...}") would otherwise be
+    // coerced to a non-string and crash the Highlighter (MM-69330).
+    const {code} = useLocalSearchParams<{code: string}>();
+    const {title, ...props} = usePropsFromParams<Omit<CodeScreenProps, 'code'> & {title: string}>();
 
     useNavigationHeader({
         showWhenPushed: true,
@@ -18,5 +25,10 @@ export default function CodeRoute() {
         },
     });
 
-    return (<CodeScreen {...props}/>);
+    return (
+        <CodeScreen
+            {...props}
+            code={code}
+        />
+    );
 }


### PR DESCRIPTION
#### Summary


Fixes MM-69330 — tapping a code block crashes the app (regression in v2.41, worked in v2.40).

`CodeRoute` (`app/routes/(authenticated)/code.tsx`) read **every** route param through
`usePropsFromParams`, which runs `safeParseJSON` over each value. A code block whose text
happens to be valid JSON — e.g. `42`, `{"a":1}`, `[1,2,3]`, `true` — was therefore coerced
from a string into a number/object/boolean. `CodeScreen` passed that to the `Highlighter`,
whose `getMaximumLineLength` calls `code.split('\n')` on a non-string value, throwing
`TypeError: code.split is not a function` — the `Highlighter → CodeScreen → CodeRoute`
crash in the ticket's stack trace.

Plain code (not JSON-parseable) was unaffected, which is why this slipped through.

## Fix

Read `code` directly via `useLocalSearchParams` so it stays a raw string and never hits
`safeParseJSON`. `usePropsFromParams` is kept for the remaining props (`textStyle` is a real
object param that still needs JSON parsing).

## Tests

Added `app/routes/(authenticated)/code.test.tsx`: renders the real
`CodeRoute → CodeScreen → Highlighter` with controlled params (stubbing only the third-party
`react-syntax-highlighter`, since the crash is in our own code that runs before it renders).
Covers four JSON-parseable code-block contents plus a plain-code control.

- Fails against the buggy route (4× `code.split is not a function`).
- Passes with this fix (5/5).
- `eslint` clean; full `tsc --noEmit` reports 0 errors.

## Follow-up (not in this PR)

The root cause is an asymmetry in the navigation plumbing: `propsToParams`
(`app/screens/navigation.ts`) passes strings through raw while JSON-stringifying non-strings,
but `usePropsFromParams` runs `safeParseJSON` on everything. So **any** JSON-shaped string
param can be silently coerced — `code` is just the first field where it reaches a hard crash.
Other call sites that pass free-text strings (e.g. `agents_rewrite_options.originalMessage`,
channel `displayName`s) carry the same latent risk. Recommend a separate PR to make
encode/decode symmetric (always stringify ↔ always parse). 

Suggested options for doing this:

1 — Symmetric matched pair (recommended)

Producer always JSON.stringify (including strings); consumer always JSON.parse. Then '42' → '"42"' → '42' (stays a string); everything round-trips losslessly.
- Smallest core change: two one-line edits (the two functions above).
- Most principled: kills the entire bug class, types stop lying.

2 — Explicit parse intent (lower blast radius, more verbose)

Leave the producer; give the consumer a per-key opt-out: usePropsFromParams<T>({raw: ['code']}). Each route with a free-text string field declares it raw.
- No producer change, but requires per-route judgment and touches every affected call site.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-69330


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: iosSim

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
