### PR TITLE
Automated cherry pick of #9849

### DIFF
--- a/app/routes/(authenticated)/code.test.tsx
+++ b/app/routes/(authenticated)/code.test.tsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import CodeRoute from './code';
+
+// react-syntax-highlighter pulls in ESM-only deps (refractor/hastscript) that
+// jest doesn't transform, and it's not the code under test here. Stub it with a
+// passthrough that renders the highlighted `code` as plain text. The crash this
+// test targets happens in our own Highlighter (getMaximumLineLength -> code.split)
+// before this component is ever rendered, so stubbing it does not hide the bug.
+jest.mock('react-syntax-highlighter', () => {
+    const {Text: RNText} = require('react-native');
+    return {
+        __esModule: true,
+        default: ({children}: {children: React.ReactNode}) => <RNText>{children}</RNText>,
+    };
+});
+
+jest.mock('react-syntax-highlighter/dist/cjs/styles/hljs', () => ({
+    githubGist: {hljs: {}},
+    monokai: {hljs: {}},
+    solarizedDark: {hljs: {}},
+    solarizedLight: {hljs: {}},
+}));
+
+// ESM-only submodule imported transitively by the syntax_highlight renderer.
+jest.mock('react-syntax-highlighter/create-element', () => ({
+    createStyleObject: jest.fn(() => ({})),
+}));
+
+// Mock expo-router with just the exports the route + screen use, so each test
+// can feed the route its params via useLocalSearchParams.
+const mockUseLocalSearchParams = jest.fn();
+jest.mock('expo-router', () => ({
+    useLocalSearchParams: () => mockUseLocalSearchParams(),
+    useNavigation: () => ({
+        setOptions: jest.fn(),
+        addListener: jest.fn(() => jest.fn()),
+    }),
+    useRouter: () => ({
+        canGoBack: jest.fn(() => true),
+    }),
+}));
+
+describe('CodeRoute (MM-69330)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // Regression: tapping a code block whose text happens to be valid JSON
+    // (e.g. "42", "{...}", "true") crashed the app. `usePropsFromParams` ran
+    // `safeParseJSON` over every param, so `code` was parsed from a string into
+    // a number/object/boolean. `Highlighter` then called `code.split('\n')` on a
+    // non-string value, throwing "code.split is not a function".
+    it.each([
+        ['a bare number', '42'],
+        ['a JSON object', '{"hello": "world"}'],
+        ['a JSON array', '[1, 2, 3]'],
+        ['a boolean literal', 'true'],
+    ])('renders without crashing when the code block content is %s', (_label, code) => {
+        mockUseLocalSearchParams.mockReturnValue({
+            code,
+            language: 'json',
+            textStyle: '{}',
+            title: 'Code',
+        });
+
+        const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);
+
+        // The raw code text must reach the viewer verbatim, as a string.
+        expect(getByText(code)).toBeTruthy();
+    });
+
+    it('renders plain (non-JSON) code without crashing', () => {
+        const code = 'const greeting = "hello";';
+        mockUseLocalSearchParams.mockReturnValue({
+            code,
+            language: 'javascript',
+            textStyle: '{}',
+            title: 'Code',
+        });
+
+        const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);
+
+        expect(getByText(code)).toBeTruthy();
+    });
+});

--- a/app/routes/(authenticated)/code.tsx
+++ b/app/routes/(authenticated)/code.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {useLocalSearchParams} from 'expo-router';
+
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
 import {usePropsFromParams} from '@hooks/props_from_params';
@@ -8,7 +10,12 @@ import CodeScreen, {type CodeScreenProps} from '@screens/code';
 
 export default function CodeRoute() {
     const theme = useTheme();
-    const {title, ...props} = usePropsFromParams<CodeScreenProps & {title: string}>();
+
+    // `code` is read directly so it is never run through safeParseJSON: a code
+    // block whose text is valid JSON (e.g. "42", "{...}") would otherwise be
+    // coerced to a non-string and crash the Highlighter (MM-69330).
+    const {code} = useLocalSearchParams<{code: string}>();
+    const {title, ...props} = usePropsFromParams<Omit<CodeScreenProps, 'code'> & {title: string}>();
 
     useNavigationHeader({
         showWhenPushed: true,
@@ -18,5 +25,10 @@ export default function CodeRoute() {
         },
     });
 
-    return (<CodeScreen {...props}/>);
+    return (
+        <CodeScreen
+            {...props}
+            code={code}
+        />
+    );
 }


### PR DESCRIPTION
Cherry pick of #9849 on release-2.41.

/cc  @Willyfrog

```release-note
NONE
```