### PR TITLE
[MM-69124] Remove temporary device-verification logs

### DIFF
--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -262,12 +262,6 @@ class PushNotificationsSingleton {
         }
         const notification = convertToNotificationData(incoming, false);
 
-        // TEMP (device verification, remove before merge — MM-69124): grep MMLogs
-        // for "onNotificationReceivedBackground". A "processing" line followed by a
-        // "processed" line (no truncation between) means the DB work finished before
-        // completion, i.e. the fix held.
-        logDebug('onNotificationReceivedBackground: processing', notification.payload?.ack_id);
-
         // Wait until the notification is fully processed (including its DB
         // read/write) before signaling completion. iOS keeps the app alive
         // until the fetch completion handler is called; calling it early lets
@@ -277,9 +271,6 @@ class PushNotificationsSingleton {
         // including failures, for the same reason.
         try {
             await this.processNotification(notification);
-
-            // TEMP (device verification, remove before merge — MM-69124)
-            logDebug('onNotificationReceivedBackground: processed → completion(NEW_DATA)');
             completion(NotificationBackgroundFetchResult.NEW_DATA);
         } catch (error) {
             logWarning('onNotificationReceivedBackground', error);

--- a/ios/Mattermost/AppDelegate.swift
+++ b/ios/Mattermost/AppDelegate.swift
@@ -295,14 +295,10 @@ class AppDelegate: ExpoAppDelegate, OrientationLockable {
         databaseLockBackgroundTask = UIApplication.shared.beginBackgroundTask(withName: "MMDatabaseLockProtection") { [weak self] in
             self?.endDatabaseLockProtection()
         }
-        // TEMP (device verification, remove before merge): grep MMLogs for "MMDatabaseLockProtection".
-        TurboLogger.write(level: .info, message: "MMDatabaseLockProtection: begin taskId \(databaseLockBackgroundTask.rawValue)")
     }
 
     private func endDatabaseLockProtection() {
         guard databaseLockBackgroundTask != .invalid else { return }
-        // TEMP (device verification, remove before merge)
-        TurboLogger.write(level: .info, message: "MMDatabaseLockProtection: end taskId \(databaseLockBackgroundTask.rawValue)")
         UIApplication.shared.endBackgroundTask(databaseLockBackgroundTask)
         databaseLockBackgroundTask = .invalid
     }


### PR DESCRIPTION
#### Summary

Removes the temporary device-verification logs added in #9819 for the iOS background DB-lock mitigation (RUNNINGBOARD `0xdead10cc`). These were explicitly marked `TEMP (... remove before merge)` and were only intended to help debug the fix on-device during beta. This is the follow-up tracked by MM-69124.

Removed:
- **`app/init/push_notifications.ts`** — the two `logDebug` lines in `onNotificationReceivedBackground` (`"processing"` / `"processed → completion(NEW_DATA)"`).
- **`ios/Mattermost/AppDelegate.swift`** — the two `TurboLogger.write` lines (`"MMDatabaseLockProtection: begin/end taskId …"`).

The actual mitigation logic — awaiting `processNotification` before calling the completion handler, and the `beginBackgroundTask`/`endBackgroundTask` assertion — and its permanent explanatory comments are left unchanged. The `logDebug`/`logWarning` imports are still used elsewhere, so no imports were removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69124

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Release Note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRyDmGqoCbsAJquzgLHDvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRyDmGqoCbsAJquzgLHDvK)_