### PR TITLE
[MM-69363] Fix clipped "No more unreads" empty state

### DIFF
--- a/app/screens/home/channel_list/categories_list/categories/categories.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/categories.tsx
@@ -3,7 +3,7 @@
 
 import {FlashList, type FlashListRef, type ListRenderItem, type ViewToken} from '@shopify/flash-list';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {DeviceEventEmitter, View, type LayoutChangeEvent} from 'react-native';
+import {DeviceEventEmitter, View} from 'react-native';
 
 import {fetchDirectChannelsInfo, switchToChannelById} from '@actions/remote/channel';
 import ChannelItem from '@components/channel_item';
@@ -32,6 +32,7 @@ type Props = {
     unreadChannelIds: Set<string>;
     onlyUnreads: boolean;
     isTablet: boolean;
+    listHeight: number;
 };
 
 const ESTIMATED_ITEM_SIZE = 42;
@@ -59,7 +60,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     },
 }));
 
-const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet}: Props) => {
+const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, listHeight}: Props) => {
     const theme = useTheme();
     const styles = getStyleSheet(theme);
     const listRef = useRef<FlashListRef<FlattenedItem> | null>(null);
@@ -67,7 +68,6 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet}: P
     const switchingTeam = useTeamSwitch();
     const [initialLoad, setInitialLoad] = useState(flattenedItems.length === 0);
     const [isChannelScreenActive, setChannelScreenActive] = useState(true);
-    const [listHeight, setListHeight] = useState(0);
     const [hasUnreadsAbove, setHasUnreadsAbove] = useState(false);
     const [hasUnreadsBelow, setHasUnreadsBelow] = useState(false);
 
@@ -128,11 +128,6 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet}: P
             />
         );
     }, [styles, onChannelSwitch, isChannelScreenActive]);
-
-    const onListLayout = useCallback((event: LayoutChangeEvent) => {
-        const {height} = event.nativeEvent.layout;
-        setListHeight(height);
-    }, []);
 
     const onViewableItemsChanged = useCallback(({viewableItems}: {viewableItems: Array<ViewToken<FlattenedItem>>}) => {
         if (!viewableItems.length || !unreadChannelIds.size) {
@@ -235,7 +230,6 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet}: P
                     showsHorizontalScrollIndicator={false}
                     showsVerticalScrollIndicator={false}
                     ListEmptyComponent={ListEmptyComponent}
-                    onLayout={onListLayout}
                     onViewableItemsChanged={onViewableItemsChanged}
                     viewabilityConfig={VIEWABILITY_CONFIG}
                 />

--- a/app/screens/home/channel_list/categories_list/categories_list.tsx
+++ b/app/screens/home/channel_list/categories_list/categories_list.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useMemo, useRef, useState} from 'react';
-import {DeviceEventEmitter, FlatList, useWindowDimensions} from 'react-native';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {DeviceEventEmitter, FlatList, useWindowDimensions, type LayoutChangeEvent} from 'react-native';
 import Animated, {useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import {SafeAreaView, type Edge} from 'react-native-safe-area-context';
 
 import {handleTeamChange} from '@actions/remote/team';
 import AgentsButton from '@agents/components/agents_button';
+import {ROW_HEIGHT} from '@components/channel_item/channel_item';
 import DraftsButton from '@components/drafts_buttton';
 import Loading from '@components/loading';
 import ThreadsButton from '@components/threads_button';
@@ -82,6 +83,7 @@ const CategoriesList = ({
     const isTeamLoading = useTeamsLoading(serverUrl);
     const tabletWidth = useSharedValue(isTablet ? getTabletWidth(moreThanOneTeam) : 0);
     const [activeScreen, setActiveScreen] = useState<ScreenType>(isTablet && lastChannelId ? lastChannelId : Screens.CHANNEL);
+    const [listHeight, setListHeight] = useState(0);
 
     const healedRef = useRef(false);
     useEffect(() => {
@@ -194,6 +196,14 @@ const CategoriesList = ({
         );
     }, [activeScreen, isTablet, lastChannelId, showPlaybooksButton]);
 
+    const onListLayout = useCallback((event: LayoutChangeEvent) => {
+        const {height} = event.nativeEvent.layout;
+        const items = [threadButtonComponent, draftsButtonComponent, agentsButtonComponent, playbooksButtonComponent].reduce((result, item) => {
+            return result + (Boolean(item) ? 1 : 0);
+        }, 0);
+        setListHeight(height - (items * ROW_HEIGHT));
+    }, [threadButtonComponent, draftsButtonComponent, agentsButtonComponent, playbooksButtonComponent]);
+
     const content = useMemo(() => {
         if (!hasChannels) {
             if (isTeamLoading) {
@@ -211,6 +221,7 @@ const CategoriesList = ({
             <Categories
                 key='categories'
                 isTablet={isTablet}
+                listHeight={listHeight}
             />,
         ];
 
@@ -225,10 +236,11 @@ const CategoriesList = ({
                     renderItem={({item}) => item}
                     nestedScrollEnabled={true}
                     style={styles.flex}
+                    onLayout={onListLayout}
                 />
             </SafeAreaView>
         );
-    }, [agentsButtonComponent, draftsButtonComponent, hasChannels, isTablet, isTeamLoading, playbooksButtonComponent, styles.flex, threadButtonComponent]);
+    }, [agentsButtonComponent, draftsButtonComponent, hasChannels, isTablet, isTeamLoading, listHeight, onListLayout, playbooksButtonComponent, styles.flex, threadButtonComponent]);
 
     return (
         <Animated.View style={[styles.container, tabletStyle]}>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

The empty-state wrapper was sized to a height measured from the inner FlashList's own onLayout. When the unread filter is active and there are zero unread channels the list has no items, so that measurement is a self-referential loop that collapses to ~0 and clips the empty state.

Measure the available height from the outer FlatList instead (which is not derived from the empty state) and subtract the visible header buttons, then pass it down to Categories for the empty-state height.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-69363](https://mattermost.atlassian.net/browse/MM-69363)
#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: iosSim

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
<img width="1206" height="2622" alt="01_channel_list" src="https://github.com/user-attachments/assets/1f5970f9-1b6c-4e60-80b9-b7800a14826d" />
<img width="1206" height="2622" alt="03_empty_state_full" src="https://github.com/user-attachments/assets/8c9d8f8b-8c6d-4edf-8055-fcde696ffbc0" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```


[MM-69363]: https://mattermost.atlassian.net/browse/MM-69363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ