### PR TITLE
fetch roles during entry to avoid UI observing inconsistent channel s…

### DIFF
--- a/app/actions/remote/entry/common.test.ts
+++ b/app/actions/remote/entry/common.test.ts
@@ -6,6 +6,7 @@ import {RESULTS} from 'react-native-permissions';
 
 import {handleKickFromChannel, fetchMyChannelsForTeam} from '@actions/remote/channel';
 import {fetchMyPreferences} from '@actions/remote/preference';
+import {fetchRoles} from '@actions/remote/role';
 import {fetchConfigAndLicense} from '@actions/remote/systems';
 import {fetchMyTeams, handleKickFromTeam} from '@actions/remote/team';
 import {fetchMe} from '@actions/remote/user';
@@ -25,6 +26,7 @@ import {entry, setExtraSessionProps, verifyPushProxy, entryInitialChannelId, han
 jest.mock('@actions/remote/channel');
 jest.mock('@actions/remote/scheduled_post');
 jest.mock('@actions/remote/preference');
+jest.mock('@actions/remote/role');
 jest.mock('@actions/remote/systems');
 jest.mock('@actions/remote/team');
 jest.mock('@actions/remote/user');
@@ -129,6 +131,7 @@ describe('actions/remote/entry/common', () => {
                 meData: mockUser,
                 isCRTEnabled: false,
             });
+            expect(fetchRoles).toHaveBeenCalled();
 
             expect(result).toEqual(expect.objectContaining({
                 initialChannelId: '',

--- a/app/actions/remote/entry/common.ts
+++ b/app/actions/remote/entry/common.ts
@@ -7,6 +7,7 @@ import {RESULTS, checkNotifications} from 'react-native-permissions';
 import {deletePostsForChannel, deletePostsForChannelsWithAutotranslation} from '@actions/local/channel';
 import {fetchChannelById, fetchMyChannelsForTeam, handleKickFromChannel, type MyChannelsRequest} from '@actions/remote/channel';
 import {type MyPreferencesRequest, fetchMyPreferences} from '@actions/remote/preference';
+import {fetchRoles} from '@actions/remote/role';
 import {fetchConfigAndLicense, fetchDataRetentionPolicy} from '@actions/remote/systems';
 import {fetchMyTeams, handleKickFromTeam, type MyTeamsRequest} from '@actions/remote/team';
 import {fetchMe, type MyUserRequest} from '@actions/remote/user';
@@ -183,10 +184,14 @@ const entryRest = async (serverUrl: string, teamId?: string, channelId?: string,
 
         await handleAutotranslationChanges(serverUrl, meData, chData);
 
-        const modelPromises = await prepareEntryModels({operator, teamData: initialTeamData, chData, prefData, meData, isCRTEnabled});
-        const models = (await Promise.all(modelPromises)).flat();
-        logDebug('Process models on entry', groupLabel, models.length, `${Date.now() - dt}ms`);
+        const [models] = await Promise.all([
+            prepareEntryModels({operator, teamData: initialTeamData, chData, prefData, meData, isCRTEnabled}).
+                then((proms) => Promise.all(proms)).
+                then((results) => results.flat()),
+            fetchRoles(serverUrl, teamData.memberships, chData?.memberships, meData?.user, false, false, groupLabel),
+        ]);
 
+        logDebug('Process models on entry', groupLabel, models.length, `${Date.now() - dt}ms`);
         return {models, initialChannelId, initialTeamId, prefData, teamData, chData, meData, gmConverted};
     } catch (error) {
         logError('entryRest', groupLabel, error);


### PR DESCRIPTION
#### Summary
Fetch roles during entry action alongside with channels when needed to avoid UI observing inconsistent channel states and showing channels as read only incorrectly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67855

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: Android 16 and iOS 26.1 emulators

#### Release Note
```release-note
fixes showing channels as read only on bad network conditions
```
