### PR TITLE
Ignore @mattermost/calls-native in notice file generation

### DIFF
--- a/build/notice-file/config.yaml
+++ b/build/notice-file/config.yaml
@@ -11,6 +11,7 @@ search:
 additionalDependencies: []
 includeDevDependencies: false
 ignoreDependencies:
+- "@mattermost/calls-native"
 - "@mattermost/hardware-keyboard"
 - "@mattermost/rnshare"
 - "@mattermost/rnutils"


### PR DESCRIPTION
#### Summary
The package is a local file dependency and is not published to npm, which caused notice-file-generator to fail with a 404.

#### Ticket Link
Details in DM.

#### Release Note

```release-note
NONE
```
