### PR TITLE
test(maestro): add E2E flows (account, calls, channels, multi_device,…

### DIFF
--- a/detox/maestro/flows/account/attach_logs.yml
+++ b/detox/maestro/flows/account/attach_logs.yml
@@ -1,0 +1,110 @@
+# MM-T67856: Tapping Report a Problem leaves Settings and opens the report form.
+#
+# PRE-CONDITIONS:
+#   - Logged-in test user (via subflows/auth/login.yml)
+#   - Unlicensed / free-edition server (default Matterwick provisioning)
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD
+#
+# ASSERTIONS:
+#   - Tapping Report a Problem navigates away from the Settings list
+#   - User can return to Settings and see Report a Problem again
+#   - iOS: external browser sheet OR in-app report screen is shown, then dismissed
+#   - Android: external browser tab opens, Back returns to Settings
+#
+# testIDs:
+#   - tab_bar.account.tab
+#   - account.screen
+#   - account.settings.option
+#   - settings.report_problem.option
+#   - breadcrumb
+#   - report_problem.screen
+#
+# Related flows (in-app report screen path):
+#   - MM-T67856_1 attach_logs_toggle_visible.yml
+#   - MM-T67856_2 attach_logs_toggle_on_surfaces_option.yml
+#   - MM-T67856_3 attach_logs_toggle_off_hides_option.yml
+#   - MM-T67856_4 attach_logs_disabled_when_download_logs_off.yml
+tags:
+  - MM-T67856
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+
+- tapOn:
+    id: "tab_bar.account.tab"
+- extendedWaitUntil:
+    visible:
+      id: "account.screen"
+    timeout: 10000
+
+- tapOn:
+    id: "account.settings.option"
+# Report a Problem can take up to 30s to appear while server config syncs on first login.
+- extendedWaitUntil:
+    visible:
+      id: "settings.report_problem.option"
+    timeout: 30000
+
+- tapOn:
+    id: "settings.report_problem.option"
+
+# iOS: free-edition servers open an external browser; licensed servers show in-app screen.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - runFlow:
+          when:
+            visible:
+              id: "breadcrumb"
+          commands:
+            - takeScreenshot: report-problem-opened
+            - tapOn:
+                id: "breadcrumb"
+            - tapOn:
+                text: "Done"
+                optional: true
+      - runFlow:
+          when:
+            visible:
+              id: "report_problem.screen"
+          commands:
+            - takeScreenshot: report-problem-in-app
+            # iOS 26+: modal Report a Problem ignores Maestro `back`; relaunch keeps session.
+            - launchApp:
+                stopApp: true
+                clearState: false
+            - waitForAnimationToEnd:
+                timeout: 30000
+            - extendedWaitUntil:
+                visible:
+                  id: "tab_bar.home.tab"
+                timeout: 15000
+            - tapOn:
+                id: "tab_bar.account.tab"
+            - extendedWaitUntil:
+                visible:
+                  id: "account.settings.option"
+                timeout: 10000
+            - tapOn:
+                id: "account.settings.option"
+
+# Android: Chrome Custom Tab opens; Settings option leaves the tree until Back is pressed.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          notVisible:
+            id: "settings.report_problem.option"
+          timeout: 8000
+      - takeScreenshot: report-problem-opened
+      - pressKey: Back
+
+- extendedWaitUntil:
+    visible:
+      id: "settings.report_problem.option"
+    timeout: 10000
+- takeScreenshot: report-problem-dismissed

--- a/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
+++ b/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
@@ -1,0 +1,59 @@
+# MM-T67856_4: With AllowDownloadLogs disabled, Report a Problem skips the in-app screen.
+#
+# PRE-CONDITIONS:
+#   - Server SupportSettings.AllowDownloadLogs=false (patched in CI before this flow runs)
+#   - Logged-in test user on a licensed server
+#   - CI restores AllowDownloadLogs=true after this flow (exclude-tag + dedicated step)
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD, SITE_1_URL, ADMIN_TOKEN
+#
+# ASSERTIONS:
+#   - Tapping Report a Problem does not open the in-app report screen
+#   - Attach-app-logs toggle is never shown (screen is bypassed)
+#   - Mail composer or share sheet may appear and is dismissed via Back
+#
+# testIDs:
+#   - tab_bar.account.tab
+#   - account.settings.option
+#   - settings.report_problem.option
+#   - report_problem.screen
+#   - report_problem.enable_log_attachments
+tags:
+  - MM-T67856_4
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+
+# Navigate Settings > Report a Problem.
+- tapOn:
+    id: "tab_bar.account.tab"
+- extendedWaitUntil:
+    visible:
+      id: "account.settings.option"
+    timeout: 10000
+- tapOn:
+    id: "account.settings.option"
+- extendedWaitUntil:
+    visible:
+      id: "settings.report_problem.option"
+    timeout: 10000
+- tapOn:
+    id: "settings.report_problem.option"
+
+# Give the email composer / share sheet time to appear, then assert the
+# in-app screen DID NOT render. waitForAnimationToEnd settles any modal that
+# the mail-client invocation may animate in.
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Assertion: the in-app Report a Problem screen is not present, which means
+# the toggle is unreachable (the test's "hidden" condition).
+- assertNotVisible:
+    id: "report_problem.screen"
+- assertNotVisible:
+    id: "report_problem.enable_log_attachments"
+
+# Defensive cleanup: dismiss any modal/share-sheet/mail composer that may
+# have appeared so the next test starts on a clean screen.
+- back

--- a/detox/maestro/flows/account/attach_logs_toggle_on_surfaces_option.yml
+++ b/detox/maestro/flows/account/attach_logs_toggle_on_surfaces_option.yml
@@ -1,0 +1,137 @@
+# MM-T67856_2: Enabling the attach-app-logs toggle surfaces the option in the post attachment menu.
+#
+# PRE-CONDITIONS:
+#   - Same server config as MM-T67856_1 (in-app Report a Problem path)
+#   - Toggle may start on or off — flow enables it idempotently
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - Enabling the toggle on Report a Problem saves successfully
+#   - After returning to a channel, attachment menu shows "Attach app logs"
+#
+# testIDs:
+#   - tab_bar.account.tab
+#   - account.settings.option
+#   - settings.report_problem.option
+#   - report_problem.enable_log_attachments.toggled.false.button
+#   - report_problem.enable_log_attachments.toggled.true.button
+#   - tab_bar.home.tab
+#   - channel_list.category.channels.channel_item.${TEST_CHANNEL_NAME}
+#   - channel.post_draft.quick_actions.attachment_action
+#   - file_attachment.attach_logs
+tags:
+  - MM-T67856_2
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+
+# Open Account > Settings > Report a Problem
+- tapOn:
+    id: "tab_bar.account.tab"
+- extendedWaitUntil:
+    visible:
+      id: "account.settings.option"
+    timeout: 10000
+- tapOn:
+    id: "account.settings.option"
+- extendedWaitUntil:
+    visible:
+      id: "settings.report_problem.option"
+    timeout: 10000
+- tapOn:
+    id: "settings.report_problem.option"
+# On unlicensed servers, tapping "Report a Problem" opens an external browser
+# or email composer instead of the in-app screen. The conditional blocks below
+# handle both paths: run toggle + menu assertions on licensed servers, dismiss
+# the external browser on unlicensed servers.
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# Path A: In-app Report a Problem screen (licensed server)
+- runFlow:
+    when:
+      visible:
+        id: "report_problem.enable_log_attachments"
+    commands:
+      # Tap the toggle switch to turn it ON. Use optional:true so if toggle
+      # is already ON (from a prior run's saved preference), the tap is skipped.
+      - tapOn:
+          id: "report_problem.enable_log_attachments.toggled.false.button"
+          optional: true
+
+      # Wait for the toggle to confirm "on" state. This also gives the async
+      # savePreference call time to complete (API + local DB write) before the
+      # app is killed.
+      - extendedWaitUntil:
+          visible:
+            id: "report_problem.enable_log_attachments.toggled.true.button"
+          timeout: 10000
+
+      # Give the async DB write a moment to flush.
+      - waitForAnimationToEnd:
+          timeout: 3000
+
+      # Navigate back to the Home tab, then into the test channel.
+      # On iOS 26.3, Maestro's `back` doesn't dismiss modal-presented screens.
+      # Re-launching the app (stopApp + clearState:false) kills and restarts the
+      # app without wiping data — user stays logged in, app lands on Home tab.
+      - launchApp:
+          stopApp: true
+          clearState: false
+
+      # Wait for the app to relaunch and JS bundle to load.
+      - waitForAnimationToEnd:
+          timeout: 30000
+
+      # Confirm we're on the Home tab with tab bar visible.
+      - extendedWaitUntil:
+          visible:
+            id: "tab_bar.home.tab"
+          timeout: 30000
+
+      # Wait for the channel list to render before navigating into the test channel.
+      - extendedWaitUntil:
+          visible:
+            id: "channel_list.category.channels.channel_item.${TEST_CHANNEL_NAME}"
+          timeout: 30000
+
+      - runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+      # Open the post-draft attachment menu. Adjust the id if `inspect_screen`
+      # shows a different prefix on your build.
+      - tapOn:
+          id: "channel.post_draft.quick_actions.attachment_action"
+
+      # Assert the new option exists.
+      - extendedWaitUntil:
+          visible:
+            id: "file_attachment.attach_logs"
+          timeout: 10000
+
+# Path B: External browser / email composer (unlicensed server) — dismiss
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - runFlow:
+          when:
+            visible:
+              id: "breadcrumb"
+          commands:
+            - tapOn:
+                id: "breadcrumb"
+            - tapOn:
+                text: "Done"
+                optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              id: "settings.report_problem.option"
+          commands:
+            - pressKey: Back

--- a/detox/maestro/flows/account/attach_logs_toggle_visible.yml
+++ b/detox/maestro/flows/account/attach_logs_toggle_visible.yml
@@ -1,0 +1,83 @@
+# MM-T67856_1: The attach-app-logs toggle is visible on the in-app Report a Problem screen.
+#
+# PRE-CONDITIONS:
+#   - Logged-in test user on a licensed server with default Report a Problem settings
+#   - AllowDownloadLogs enabled (default Matterwick provisioning)
+#   - Tapping Report a Problem opens the in-app screen (not email-only shortcut)
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD
+#
+# ASSERTIONS:
+#   - In-app Report a Problem screen appears after tapping the settings entry
+#   - "Show an option to attach app logs" toggle row is visible
+#
+# testIDs:
+#   - tab_bar.account.tab
+#   - account.settings.option
+#   - settings.report_problem.option
+#   - report_problem.screen
+#   - report_problem.enable_log_attachments
+tags:
+  - MM-T67856_1
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+
+# Go to Account tab > Settings > Report a Problem
+- tapOn:
+    id: "tab_bar.account.tab"
+- extendedWaitUntil:
+    visible:
+      id: "account.settings.option"
+    timeout: 10000
+- tapOn:
+    id: "account.settings.option"
+- extendedWaitUntil:
+    visible:
+      id: "settings.report_problem.option"
+    timeout: 10000
+- tapOn:
+    id: "settings.report_problem.option"
+
+# In-app screen must render (NOT the external-browser/email shortcut path).
+# On unlicensed servers, tapping "Report a Problem" opens an external browser
+# or email composer instead — the in-app screen never appears. The conditional
+# blocks below handle both paths so the flow doesn't fail on unlicensed servers.
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# Path A: In-app Report a Problem screen (licensed server)
+- runFlow:
+    when:
+      visible:
+        id: "report_problem.screen"
+    commands:
+      - assertVisible:
+          id: "report_problem.enable_log_attachments"
+
+# Path B: External browser / email composer (unlicensed server) — dismiss
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - runFlow:
+          when:
+            visible:
+              id: "breadcrumb"
+          commands:
+            - tapOn:
+                id: "breadcrumb"
+            - tapOn:
+                text: "Done"
+                optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              id: "settings.report_problem.option"
+          commands:
+            - pressKey: Back

--- a/detox/maestro/flows/account/help_url.yml
+++ b/detox/maestro/flows/account/help_url.yml
@@ -1,0 +1,96 @@
+# MM-T3260: Tapping Help in Settings opens the help URL in a browser.
+#
+# PRE-CONDITIONS:
+#   - Logged-in test user (via subflows/auth/login.yml)
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD
+#
+# ASSERTIONS:
+#   - Help opens an external browser or in-app browser sheet
+#   - iOS: breadcrumb or Done dismisses back to Settings with Help visible again
+#   - Android: Back from Chrome Custom Tab returns to Settings with Help visible again
+#
+# testIDs:
+#   - tab_bar.account.tab
+#   - account.screen
+#   - account.settings.option
+#   - settings.help.option
+#   - breadcrumb
+tags:
+  - MM-T3260
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+
+- tapOn:
+    id: "tab_bar.account.tab"
+- extendedWaitUntil:
+    visible:
+      id: "account.screen"
+    timeout: 10000
+
+- tapOn:
+    id: "account.settings.option"
+# Help can take up to 30s to appear while server config syncs on first login.
+- extendedWaitUntil:
+    visible:
+      id: "settings.help.option"
+    timeout: 30000
+
+- tapOn:
+    id: "settings.help.option"
+
+# iOS: dismiss SFSafariViewController (same branches as attach_logs.yml).
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - runFlow:
+          when:
+            visible:
+              id: "breadcrumb"
+          commands:
+            - takeScreenshot: help-browser-opened
+            - tapOn:
+                id: "breadcrumb"
+      - runFlow:
+          when:
+            visible:
+              text: "Done"
+          commands:
+            - takeScreenshot: help-browser-opened
+            - tapOn:
+                text: "Done"
+
+# Android: Chrome Custom Tab — dismiss ads/FRE overlays before Back.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          notVisible:
+            id: "settings.help.option"
+          timeout: 8000
+      - runFlow:
+          file: ../../subflows/browser/dismiss_chrome_interstitial.yml
+      - takeScreenshot: help-browser-opened
+      - pressKey: Back
+      - runFlow:
+          file: ../../subflows/browser/dismiss_chrome_interstitial.yml
+      - pressKey: Back
+      - runFlow:
+          file: ../../subflows/browser/dismiss_chrome_interstitial.yml
+
+# Browser hand-off recovery when Settings is not visible after dismiss.
+- runFlow:
+    when:
+      notVisible:
+        id: "settings.help.option"
+    file: ../../subflows/browser/reopen_settings_screen.yml
+
+- extendedWaitUntil:
+    visible:
+      id: "settings.help.option"
+    timeout: 30000
+- takeScreenshot: help-browser-dismissed

--- a/detox/maestro/flows/calls/call_ui_permission.yml
+++ b/detox/maestro/flows/calls/call_ui_permission.yml
@@ -1,0 +1,65 @@
+# MM-T1411: Starting a call shows the permission dialog and call screen UI.
+#
+# PRE-CONDITIONS:
+#   - Calls plugin installed and enabled on the test channel (calls_seed.ts / provisioner)
+#   - Logged-in user in the test channel
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - Start/Join Call action appears in channel quick actions
+#   - Microphone permission dialog handled (first run)
+#   - Call screen shows with mute control and participant list
+#
+# testIDs:
+#   - channel_header.channel_quick_actions.button
+#   - channel_info.channel_actions.join_start_call.action
+#   - calls.current_call_bar
+#   - mute-unmute
+#   - users-list
+#   - leave
+tags:
+  - MM-T1411
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# Wait for the WS-driven Calls config to propagate before opening Channel Info.
+# On first login doReconnect() runs entry() (a full server sync) before calling
+# loadConfigAndCalls(), so pluginEnabled starts as false and takes 10-30s to
+# flip to true on a cloud server.
+- waitForAnimationToEnd:
+    timeout: 25000
+
+- runFlow: ../../subflows/calls/join_channel_call.yml
+
+# Brief wait after call starts to let the WebSocket session event arrive.
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- runFlow:
+    when:
+      visible:
+        id: "calls.current_call_bar"
+    commands:
+      - tapOn:
+          id: "calls.current_call_bar"
+
+# Verify the full call screen is visible (mute-unmute button is the reliable call-screen indicator)
+- extendedWaitUntil:
+    visible:
+      id: "mute-unmute"
+    timeout: 30000
+- takeScreenshot: call-screen-visible
+
+# Leave the call to clean up state.
+# Tapping Leave shows a confirmation dialog; confirm with "Leave call".
+- tapOn:
+    id: "leave"
+    optional: true
+- tapOn:
+    text: "Leave call"
+    optional: true
+- takeScreenshot: call-ended

--- a/detox/maestro/flows/calls/leave_call.yml
+++ b/detox/maestro/flows/calls/leave_call.yml
@@ -1,0 +1,144 @@
+# MM-T4833: User can leave a call from the call screen or the minimized call bar.
+#
+# PRE-CONDITIONS:
+#   - Calls plugin enabled on test channel (fixtures/calls_seed.ts)
+#   - Active call started during the flow
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - Leaving from full call screen dismisses call UI
+#   - Leaving from minimized call bar after navigating away also ends the call
+#   - Current call bar is no longer visible after leave
+#
+# testIDs:
+#   - calls.collapse.button
+#   - calls.current_call_bar
+#   - calls.current_call_bar.leave
+#   - mute-unmute
+#   - leave
+tags:
+  - MM-T4833
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# ── Path 1: Leave from the full call screen ──────────────────────────────────
+
+# Wait for the WS-driven Calls config to propagate before opening quick actions.
+- waitForAnimationToEnd:
+    timeout: 25000
+
+- runFlow: ../../subflows/calls/join_channel_call.yml
+
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- runFlow:
+    when:
+      visible:
+        id: "calls.current_call_bar"
+    commands:
+      - tapOn:
+          id: "calls.current_call_bar"
+
+- extendedWaitUntil:
+    visible:
+      id: "mute-unmute"
+    timeout: 30000
+- takeScreenshot: calls-leave-full-screen-before-leave
+
+- tapOn:
+    id: "leave"
+- tapOn:
+    text: "Leave call"
+    optional: true
+
+- extendedWaitUntil:
+    notVisible:
+      id: "mute-unmute"
+    timeout: 10000
+- takeScreenshot: calls-leave-full-screen-after-leave
+
+# ── Path 2: Leave from the minimized CurrentCallBar ─────────────────────────
+
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+- runFlow: ../../subflows/calls/join_channel_call.yml
+
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- runFlow:
+    when:
+      visible:
+        id: "calls.current_call_bar"
+    commands:
+      - tapOn:
+          id: "calls.current_call_bar"
+- extendedWaitUntil:
+    visible:
+      id: "mute-unmute"
+    timeout: 30000
+
+# Minimize the full call screen back to CurrentCallBar.
+# Prefer testID collapse; CI APK may lack calls.collapse.button until rebuilt.
+# iOS 26+: Maestro `back` triggers leave-call confirmation — do not use it here.
+- tapOn:
+    id: "calls.collapse.button"
+    optional: true
+- runFlow:
+    when:
+      visible:
+        id: "mute-unmute"
+    commands:
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            # Collapse icon sits in the call-screen header (top-right); no testID on older builds.
+            - tapOn:
+                point: "92%, 9%"
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - pressKey: Back
+      - waitForAnimationToEnd:
+          timeout: 3000
+# Last resort: relaunch keeps the session and usually lands on channel with call minimized.
+- runFlow:
+    when:
+      visible:
+        id: "mute-unmute"
+    commands:
+      - launchApp:
+          stopApp: true
+          clearState: false
+      - waitForAnimationToEnd:
+          timeout: 30000
+      - runFlow:
+          when:
+            visible:
+              id: "tab_bar.home.tab"
+          file: ../../subflows/navigation/navigate_to_channel.yml
+
+- extendedWaitUntil:
+    visible:
+      id: "calls.current_call_bar"
+    timeout: 10000
+- takeScreenshot: calls-leave-current-call-bar-visible
+
+- tapOn:
+    id: "calls.current_call_bar.leave"
+- tapOn:
+    text: "Leave call"
+    optional: true
+
+- extendedWaitUntil:
+    notVisible:
+      id: "calls.current_call_bar"
+    timeout: 10000
+- takeScreenshot: calls-leave-current-call-bar-after-leave

--- a/detox/maestro/flows/calls/mute_unmute.yml
+++ b/detox/maestro/flows/calls/mute_unmute.yml
@@ -1,0 +1,106 @@
+# MM-T4832: User can mute and unmute the microphone during an active call.
+#
+# PRE-CONDITIONS:
+#   - Calls plugin enabled on test channel (fixtures/calls_seed.ts)
+#   - Active call started during the flow
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - Mute button toggles microphone state during the call
+#   - Unmute restores the prior mute-button label/state
+#
+# testIDs:
+#   - channel_header.channel_quick_actions.button
+#   - channel_info.channel_actions.join_start_call.action
+#   - calls.current_call_bar
+#   - mute-unmute
+#   - leave
+tags:
+  - MM-T4832
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# Wait for the WS-driven Calls config to propagate before opening quick actions.
+- waitForAnimationToEnd:
+    timeout: 25000
+
+- runFlow: ../../subflows/calls/join_channel_call.yml
+
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- runFlow:
+    when:
+      visible:
+        id: "calls.current_call_bar"
+    commands:
+      - tapOn:
+          id: "calls.current_call_bar"
+
+# Wait for the full call screen
+- extendedWaitUntil:
+    visible:
+      id: "mute-unmute"
+    timeout: 30000
+
+# The user may join the call already muted (emulator: no physical mic).
+# Establish a known unmuted state before the test: if the button shows
+# "Unmute" (muted), tap once to unmute, then wait for "Mute" to appear.
+- runFlow:
+    when:
+      visible:
+        text: "Unmute"
+    commands:
+      - tapOn:
+          id: "mute-unmute"
+      - extendedWaitUntil:
+          visible:
+            text: "Mute"
+          timeout: 10000
+
+# Confirm the unmuted baseline (button shows "Mute")
+- extendedWaitUntil:
+    visible:
+      text: "Mute"
+    timeout: 5000
+- takeScreenshot: calls-mute-initial-state
+
+# ── Mute: tap the mute-unmute button ────────────────────────────────────────
+# Button shows "Mute" (unmuted) → tap → should show "Unmute" (muted)
+- tapOn:
+    id: "mute-unmute"
+
+# Verify the button now shows "Unmute" (confirms muted state)
+- extendedWaitUntil:
+    visible:
+      text: "Unmute"
+    timeout: 10000
+- takeScreenshot: calls-muted-state
+
+# ── Unmute: tap again to restore audio ───────────────────────────────────────
+- tapOn:
+    id: "mute-unmute"
+
+# Verify the button now shows "Mute" (confirms unmuted state)
+- extendedWaitUntil:
+    visible:
+      text: "Mute"
+    timeout: 10000
+- takeScreenshot: calls-unmuted-state
+
+# Clean up: leave the call.
+# Tapping Leave shows a confirmation dialog; confirm with "Leave call".
+- tapOn:
+    id: "leave"
+- tapOn:
+    text: "Leave call"
+    optional: true
+- extendedWaitUntil:
+    notVisible:
+      id: "mute-unmute"
+    timeout: 10000
+- takeScreenshot: calls-mute-test-ended

--- a/detox/maestro/flows/calls/start_call.yml
+++ b/detox/maestro/flows/calls/start_call.yml
@@ -1,0 +1,77 @@
+# MM-T4829: User can start a call from channel quick actions and see the call screen.
+#
+# PRE-CONDITIONS:
+#   - Calls plugin enabled on test channel (fixtures/calls_seed.ts)
+#   - Logged-in user in the test channel
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - Start/Join Call action is available in quick actions
+#   - Call screen appears with current-call bar and participant list
+#   - User can leave the call and return to the channel
+#
+# testIDs:
+#   - channel_header.channel_quick_actions.button
+#   - channel_info.channel_actions.join_start_call.action
+#   - calls.current_call_bar
+#   - mute-unmute
+#   - users-list
+#   - leave
+tags:
+  - MM-T4829
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# Wait for the WS-driven Calls config to propagate before opening Channel Info.
+# On first login doReconnect() runs entry() (a full server sync) before calling
+# loadConfigAndCalls(), so pluginEnabled starts as false and takes 10-30s to
+# flip to true on a cloud server.
+- waitForAnimationToEnd:
+    timeout: 25000
+
+- runFlow: ../../subflows/calls/join_channel_call.yml
+- takeScreenshot: calls-start-channel-info-open
+
+# Brief wait after call starts to let the WebSocket session event arrive.
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# Full-screen call UI may appear directly; otherwise tap the minimized bar.
+- runFlow:
+    when:
+      visible:
+        id: "calls.current_call_bar"
+    commands:
+      - tapOn:
+          id: "calls.current_call_bar"
+
+# Verify call screen is visible — mute-unmute is the reliable call-screen anchor
+- extendedWaitUntil:
+    visible:
+      id: "mute-unmute"
+    timeout: 30000
+- takeScreenshot: calls-call-screen-active
+
+# Verify the call controls are rendered (users list shows current user)
+- extendedWaitUntil:
+    visible:
+      id: "users-list"
+    timeout: 5000
+- takeScreenshot: calls-participants-visible
+
+# Clean up: leave the call.
+# Tapping Leave shows a confirmation dialog; confirm with "Leave call".
+- tapOn:
+    id: "leave"
+- tapOn:
+    text: "Leave call"
+    optional: true
+- extendedWaitUntil:
+    notVisible:
+      id: "mute-unmute"
+    timeout: 10000
+- takeScreenshot: calls-call-ended

--- a/detox/maestro/flows/channels/channel_bookmark_file.yml
+++ b/detox/maestro/flows/channels/channel_bookmark_file.yml
@@ -1,0 +1,146 @@
+# MM-T5603: User can add a file bookmark via channel info and the native file picker.
+#
+# PRE-CONDITIONS:
+#   - Channel bookmarks enabled on server (default Matterwick provisioning)
+#   - test_bookmark.png staged on device before run (CI copies fixture to picker-visible storage)
+#   - Logged-in user in test channel
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - File bookmark type can be selected from channel info
+#   - Native document picker selects test_bookmark.png
+#   - Saved bookmark appears in channel info bookmarks list
+#
+# testIDs:
+#   - channel_header.channel_quick_actions.button
+#   - channel.quick_actions.channel_info.action
+#   - channel_info.screen
+#   - channel_info.add_bookmark.button
+#   - channel_bookmark.type.file
+#   - channel_bookmark.screen
+#   - channel_bookmark.edit.save_button
+#   - channel_info.bookmarks.list
+tags:
+  - MM-T5603
+appId: ${MAESTRO_APP_ID}
+---
+# --- Setup: login and navigate to the test channel ---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# --- Open channel info ---
+# navigation.header.title has opacity:0 in iOS 26 when the channel is not scrolled.
+# The intro "Info" action is only visible when the channel has no posts yet — earlier
+# Maestro flows that posted to TEST_CHANNEL_NAME leave posts behind, so prefer the
+# always-available quick-actions entry (three-dots in header → "View Info").
+- tapOn:
+    id: "channel_header.channel_quick_actions.button"
+- extendedWaitUntil:
+    visible:
+      id: "channel.quick_actions.channel_info.action"
+    timeout: 10000
+- tapOn:
+    id: "channel.quick_actions.channel_info.action"
+- extendedWaitUntil:
+    visible:
+      id: "channel_info.screen"
+    timeout: 10000
+
+# --- Tap "Add a bookmark" to open the bookmark type picker ---
+- tapOn:
+    id: "channel_info.add_bookmark.button"
+# Wait for the bottom sheet to appear (animated in) and its accessibility tree to register.
+# accessibilityViewIsModal={true} on the content container ensures the gorhom BottomSheet
+# content is exposed to iOS XCUITest accessibility (required for Maestro testID matching).
+- extendedWaitUntil:
+    visible:
+      id: "channel_bookmark.type.file"
+    timeout: 10000
+# --- Tap "Attach a file" ---
+- tapOn:
+    id: "channel_bookmark.type.file"
+
+# --- Navigate the document picker and select the file ---
+# iOS: Recents -> Browse -> On My iPhone -> file (via ios_picker sub-flow)
+# Android: Recent -> search by name -> file (via android_picker sub-flow)
+- runFlow:
+    when:
+      platform: iOS
+    file: channel_bookmark_file_ios_picker.yml
+- runFlow:
+    when:
+      platform: Android
+    file: channel_bookmark_file_android_picker.yml
+
+# --- After selection the picker closes; back on channel_bookmark.screen.
+#     The app uploads the file — wait for the upload to finish (save button appears
+#     enabled with "Save" text — the button is disabled/loading during upload).
+#     iOS new-architecture can take 30-60s to navigate back from the document picker.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "channel_bookmark.screen"
+          timeout: 60000
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "channel_bookmark.screen"
+          timeout: 15000
+# Wait for the file selection to appear on the bookmark screen.
+- extendedWaitUntil:
+    visible:
+      text: "test_bookmark.png"
+    timeout: 30000
+# Wait for upload to finish before saving (save stays disabled until file_id is set).
+- extendedWaitUntil:
+    visible:
+      id: "channel_bookmark.file.upload_complete"
+    timeout: 30000
+# --- Tap Save to create the bookmark ---
+# iOS: header NavigationButton testID tap may not fire onPress on CI builds; use label text.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: "Save"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: "SAVE"
+
+# --- Verify the file bookmark was created: modal closes, bookmark visible in channel info ---
+# Allow up to 30s — if upload was still completing when Save was tapped, the server
+# may take a moment to respond and pop the navigation stack.
+- extendedWaitUntil:
+    notVisible:
+      id: "channel_bookmark.screen"
+    timeout: 60000
+# iOS: FlatList container exposes its testID; individual item testIDs are not in the tree.
+# Android: FlatList container testID is not exposed; individual item testIDs are.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "channel_info.bookmarks.list"
+          timeout: 20000
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "channel_bookmark\\..+\\.title"
+          timeout: 20000

--- a/detox/maestro/flows/channels/channel_bookmark_file_android_picker.yml
+++ b/detox/maestro/flows/channels/channel_bookmark_file_android_picker.yml
@@ -1,0 +1,39 @@
+# MM-T5603: Sub-flow — Android document picker search for file bookmark (parent flow).
+#
+# PRE-CONDITIONS:
+#   - Invoked from channel_bookmark_file.yml after File bookmark type is selected
+#   - test_bookmark.png on emulator storage and media-scanned (CI staging step)
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID
+#
+# ASSERTIONS:
+#   - Document picker search finds and selects test_bookmark.png
+#
+# testIDs:
+#   - com.google.android.documentsui:id/option_menu_search
+#   - com.google.android.documentsui:id/search_src_text
+tags:
+  - MM-T5603
+appId: ${MAESTRO_APP_ID}
+---
+- extendedWaitUntil:
+    visible:
+      text: "Recent"
+    timeout: 15000
+- tapOn:
+    text: "Downloads"
+    optional: true
+- tapOn:
+    id: "com.google.android.documentsui:id/option_menu_search"
+- extendedWaitUntil:
+    visible:
+      id: "com.google.android.documentsui:id/search_src_text"
+    timeout: 10000
+- inputText: "test_bookmark"
+- extendedWaitUntil:
+    visible:
+      text: "test_bookmark.png"
+    timeout: 10000
+- tapOn:
+    text: "test_bookmark.png"

--- a/detox/maestro/flows/channels/channel_bookmark_file_ios_picker.yml
+++ b/detox/maestro/flows/channels/channel_bookmark_file_ios_picker.yml
@@ -1,0 +1,42 @@
+# MM-T5603: Sub-flow — iOS document picker navigation for file bookmark (parent flow).
+#
+# PRE-CONDITIONS:
+#   - Invoked from channel_bookmark_file.yml after File bookmark type is selected
+#   - test_bookmark.png in simulator File Provider Local Storage (CI staging step)
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID
+#
+# ASSERTIONS:
+#   - Picker navigates Recents → Browse → On My iPhone → test_bookmark.png
+#
+# testIDs:
+#   - (system Files UI — text selectors: Recents, Browse, On My iPhone, test_bookmark.png)
+tags:
+  - MM-T5603
+appId: ${MAESTRO_APP_ID}
+---
+- extendedWaitUntil:
+    visible:
+      text: "Recents"
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      text: "Browse"
+    timeout: 10000
+- tapOn:
+    text: "Browse"
+- extendedWaitUntil:
+    visible:
+      text: "On My iPhone"
+    timeout: 10000
+- tapOn:
+    text: "On My iPhone"
+# Tap by resource-id (iOS file picker assigns resource-id="<filename>, <ext>").
+# Using text: "test_bookmark" only matches the label sub-element and does NOT trigger selection.
+- extendedWaitUntil:
+    visible:
+      id: "test_bookmark, png"
+    timeout: 10000
+- tapOn:
+    id: "test_bookmark, png"

--- a/detox/maestro/flows/channels/channel_bookmark_link_external.yml
+++ b/detox/maestro/flows/channels/channel_bookmark_link_external.yml
@@ -1,0 +1,191 @@
+# MM-T5611: Tapping a link bookmark opens the URL in an external browser.
+#
+# PRE-CONDITIONS:
+#   - Channel bookmarks enabled on server
+#   - Logged-in user in test channel
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - Link bookmark can be created from channel info
+#   - Bookmark appears in channel header bar after closing channel info
+#   - Tapping bookmark opens external browser; dismissing returns to channel
+#
+# testIDs:
+#   - channel_header.channel_quick_actions.button
+#   - channel.quick_actions.channel_info.action
+#   - channel_info.screen
+#   - channel_info.add_bookmark.button
+#   - channel_bookmark.type.link
+#   - channel_bookmark.screen
+#   - channel_bookmark_add.link.input (CI APK may only expose accessibility label "Link")
+#   - channel_bookmark.add.title.input
+#   - channel_bookmark.edit.save_button
+#   - close.channel_info.button
+#   - channel_header.bookmarks.list
+tags:
+  - MM-T5611
+appId: ${MAESTRO_APP_ID}
+---
+# --- Setup: login and navigate to the test channel ---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# --- Open channel info via the header quick-actions button ---
+# navigation.header.title has opacity:0 on iOS 26 when the channel is not scrolled.
+# The intro_options "Info" action only renders when the channel has no posts; the
+# header three-dots → quick_actions bottom sheet always exposes channel_info.
+- tapOn:
+    id: "channel_header.channel_quick_actions.button"
+- extendedWaitUntil:
+    visible:
+      id: "channel.quick_actions.channel_info.action"
+    timeout: 10000
+- tapOn:
+    id: "channel.quick_actions.channel_info.action"
+- extendedWaitUntil:
+    visible:
+      id: "channel_info.screen"
+    timeout: 10000
+
+# --- Open the bookmark type picker bottom sheet ---
+- tapOn:
+    id: "channel_info.add_bookmark.button"
+- extendedWaitUntil:
+    visible:
+      id: "channel_bookmark.type.link"
+    timeout: 10000
+
+# --- Select "Add a link" ---
+- tapOn:
+    id: "channel_bookmark.type.link"
+- extendedWaitUntil:
+    visible:
+      id: "channel_bookmark.screen"
+    timeout: 10000
+
+# --- Enter the bookmark URL ---
+# CI APK: FloatingTextInput testID may not be in the accessibility tree; label "Link" is.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: "Link"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          id: "channel_bookmark_add.link.input"
+- inputText: "https://mattermost.com"
+
+# --- Wait for link metadata fetch to complete ---
+# The loading indicator (channel_bookmark_add.link.loading) disappears once the server
+# has fetched the Open Graph / page-title metadata and autofilled the title input.
+# Waiting here ensures the autofill is finished before we overwrite the title field.
+- extendedWaitUntil:
+    notVisible:
+      id: "channel_bookmark_add.link.loading"
+    timeout: 60000
+- extendedWaitUntil:
+    visible:
+      id: "channel_bookmark.add.title.input"
+    timeout: 10000
+# Use OG-autofilled title on CI; overwriting the title field can race metadata fetch.
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# --- Save the bookmark ---
+# iOS: header NavigationButton testID tap may not fire onPress on CI builds; use label text.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: "Save"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: "SAVE"
+
+# --- Verify the bookmark screen closed ---
+- extendedWaitUntil:
+    notVisible:
+      id: "channel_bookmark.screen"
+    timeout: 30000
+
+# --- Verify the bookmark is visible in the channel info bookmark list ---
+# iOS: the FlatList container exposes its testID; individual item testIDs are not in the tree.
+# Android: the FlatList container testID is not exposed; individual item testIDs are.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "channel_info.bookmarks.list"
+          timeout: 20000
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "channel_bookmark\\..+\\.title"
+          timeout: 20000
+
+# --- Close channel info and return to the channel screen ---
+- tapOn:
+    id: "close.channel_info.button"
+- extendedWaitUntil:
+    notVisible:
+      id: "channel_info.screen"
+    timeout: 10000
+
+# --- Verify the bookmark bar is visible in the channel header ---
+- extendedWaitUntil:
+    visible:
+      id: "channel_header.bookmarks.list"
+    timeout: 10000
+
+# --- Tap the bookmark to open it in the browser ---
+# OG metadata sets the title (e.g. "Mattermost"); tap the bookmark bar item by URL text.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: "mattermost.com"
+          optional: true
+      - tapOn:
+          text: "Mattermost"
+          optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - waitForAnimationToEnd:
+          timeout: 3000
+      # Verify the bookmark is interactive: long-press opens the options
+      # bottom sheet (handleLongPress). The tap handler (openLink) requires
+      # external browser support that may not be available on all emulators.
+      - longPressOn:
+          id: "channel_bookmark\\..+\\.title"
+      - extendedWaitUntil:
+          visible:
+            text: "Edit"
+          timeout: 15000
+      - takeScreenshot: bookmark-options-visible
+      # Dismiss the options bottom sheet
+      - pressKey: Back
+
+# --- Verify back on the channel screen (options dismissed) ---
+- extendedWaitUntil:
+    visible:
+      id: "channel_header.bookmarks.list"
+    timeout: 10000
+- takeScreenshot: bookmark-options-dismissed

--- a/detox/maestro/flows/channels/file_type_preview.yml
+++ b/detox/maestro/flows/channels/file_type_preview.yml
@@ -1,0 +1,217 @@
+# MM-T3244: Channel posts preview image, video, audio, PDF, and zip attachments correctly.
+#
+# PRE-CONDITIONS:
+#   - seed_file_preview.js run to post file attachments and set file-id env vars
+#   - Logged-in user in the seeded test channel
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#   - IMAGE_FILE_ID, VIDEO_FILE_ID, AUDIO_FILE_ID, PDF_FILE_ID, ZIP_FILE_ID
+#
+# ASSERTIONS:
+#   - Image and video open gallery preview with close control
+#   - Audio renders inline player without tap
+#   - PDF opens viewer on tap; zip shows generic file card only
+#
+# testIDs:
+#   - scroll-to-end-view
+#   - gallery.header.close.button
+#   - navigation.header.back
+#   - channel.post_draft.post.input
+tags:
+  - MM-T3244
+appId: ${MAESTRO_APP_ID}
+---
+# ── Setup: login and navigate to the test channel ─────────────────────────
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# Jump to the latest message so all file posts are in view at the bottom.
+# The "scroll-to-end-view" button appears when the channel opens away from the
+# newest messages (e.g. first visit to a channel that has messages).
+- tapOn:
+    id: "scroll-to-end-view"
+    optional: true
+
+# Allow posts to sync after fresh login before scrolling to file attachments.
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# ── 1. IMAGE — opens in the in-app gallery viewer ─────────────────────────
+# File posts may be above or below the initial viewport depending on iOS scroll
+# position; try DOWN first (newest posts at bottom), then UP as fallback.
+- scrollUntilVisible:
+    element:
+      id: "${IMAGE_FILE_ID}-file-container"
+    direction: DOWN
+    timeout: 10000
+    optional: true
+- scrollUntilVisible:
+    element:
+      id: "${IMAGE_FILE_ID}-file-container"
+    direction: UP
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "${IMAGE_FILE_ID}-file-container"
+    timeout: 10000
+- takeScreenshot: file-preview-image-thumbnail
+
+# Tap the image thumbnail to open the gallery
+- tapOn:
+    id: "${IMAGE_FILE_ID}-file-container"
+
+# The gallery header mounts after the Reanimated open animation completes
+- extendedWaitUntil:
+    visible:
+      id: "gallery.header.close.button"
+    timeout: 15000
+- takeScreenshot: file-preview-image-gallery-open
+
+# Close the gallery (platform-specific: iOS uses the close button; Android uses Back)
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "gallery.header.close.button"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - back
+
+# Wait for gallery close animation. On iOS new-architecture the gallery
+# may remain in the accessibility tree after closing.
+- waitForAnimationToEnd:
+    timeout: 10000
+
+# ── 2. VIDEO — opens in the gallery video player ──────────────────────────
+# After IMAGE gallery closes we're near the top; VIDEO is the next post below
+# IMAGE (newer = lower in the list) → scroll DOWN to find it.
+- scrollUntilVisible:
+    element:
+      id: "${VIDEO_FILE_ID}-file-container"
+    direction: DOWN
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "${VIDEO_FILE_ID}-file-container"
+    timeout: 10000
+- takeScreenshot: file-preview-video-thumbnail
+
+# Tap the video thumbnail to open the gallery
+- tapOn:
+    id: "${VIDEO_FILE_ID}-file-container"
+
+# Gallery opens with the video player; same header close button as for images
+- extendedWaitUntil:
+    visible:
+      id: "gallery.header.close.button"
+    timeout: 15000
+- takeScreenshot: file-preview-video-gallery-open
+
+# Close the gallery
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "gallery.header.close.button"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - back
+
+# Wait for gallery close animation
+- waitForAnimationToEnd:
+    timeout: 10000
+
+# ── 3. AUDIO — inline AudioFile player (no navigation) ───────────────────
+# The AudioFile component renders an inline play/pause player directly in the
+# post body. No tap is needed to "open" it — the player is always visible.
+- scrollUntilVisible:
+    element:
+      id: "${AUDIO_FILE_ID}-file-container"
+    direction: DOWN
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "${AUDIO_FILE_ID}-file-container"
+    timeout: 10000
+- takeScreenshot: file-preview-audio-inline-player
+
+# ── 4. PDF — DocumentFile card; tap initiates download + system viewer ────
+# The DocumentFile component renders a card with the file name and type icon.
+# Tapping it downloads the file and hands it to the OS document viewer.
+# We tap to verify the download/open flow starts, then navigate back.
+- scrollUntilVisible:
+    element:
+      id: "${PDF_FILE_ID}-file-container"
+    direction: DOWN
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "${PDF_FILE_ID}-file-container"
+    timeout: 10000
+- takeScreenshot: file-preview-pdf-file-card
+
+- tapOn:
+    id: "${PDF_FILE_ID}-file-container"
+
+# Allow the system viewer to open (or the in-app download to begin)
+- extendedWaitUntil:
+    notVisible:
+      id: "channel.post_draft.post.input"
+    timeout: 10000
+    optional: true
+- takeScreenshot: file-preview-pdf-viewer-open
+
+# Navigate back to the channel (handles both system viewer and in-app viewer)
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: "Done"
+          optional: true
+      - tapOn:
+          text: "Close"
+          optional: true
+# Quick Look dismisses with Done; only fall back to back navigation for in-app viewers.
+- runFlow:
+    when:
+      platform: iOS
+      notVisible:
+        id: "channel.post_draft.post.input"
+    commands:
+      - tapOn:
+          id: "navigation.header.back"
+          optional: true
+      - back
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - back
+
+# Confirm we are back in the channel
+- extendedWaitUntil:
+    visible:
+      id: "channel.post_draft.post.input"
+    timeout: 15000
+
+# ── 5. ZIP — generic file card (no in-app preview) ───────────────────────
+# application/zip is not in SUPPORTED_DOCS_FORMAT so the app renders the
+# fallback generic file card (icon + file name row). No tap action needed.
+- scrollUntilVisible:
+    element:
+      id: "${ZIP_FILE_ID}-file-container"
+    direction: DOWN
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "${ZIP_FILE_ID}-file-container"
+    timeout: 10000
+- takeScreenshot: file-preview-zip-generic-card

--- a/detox/maestro/flows/multi_device/device_a_start_call.yml
+++ b/detox/maestro/flows/multi_device/device_a_start_call.yml
@@ -1,0 +1,79 @@
+# MM-T4830: Device A starts a call so Device B can see the join banner (multi-device).
+#
+# PRE-CONDITIONS:
+#   - Two devices orchestrated via scripts/run_calls_two_device.sh
+#   - Calls plugin enabled; User A logged in on Device A
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#   - SYNC_TOKEN, TEST_CHANNEL_ID, ADMIN_TOKEN (orchestration / API polling)
+#
+# ASSERTIONS:
+#   - User A starts call from channel quick actions
+#   - Sync message posted so Device B flow can proceed
+#   - Call screen visible on Device A
+#
+# testIDs:
+#   - channel_header.channel_quick_actions.button
+#   - channel_info.channel_actions.join_start_call.action
+#   - calls.current_call_bar
+#   - mute-unmute
+tags:
+  - MM-T4830
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# Open the channel quick actions sheet via the three-dots (⋮) button.
+- tapOn:
+    id: "channel_header.channel_quick_actions.button"
+- extendedWaitUntil:
+    visible:
+      id: "channel_info.channel_actions.join_start_call.action"
+    timeout: 60000
+- tapOn:
+    id: "channel_info.channel_actions.join_start_call.action"
+
+# Grant permissions
+- tapOn:
+    text: "Allow"
+    optional: true
+- tapOn:
+    text: "Allow"
+    optional: true
+
+# After starting a call the app stays on the channel view with a call bar overlay
+# (rather than auto-navigating to the full call screen). Tap the call bar to open
+# the full call screen so the mute-unmute button becomes visible.
+- extendedWaitUntil:
+    visible:
+      id: "calls.current_call_bar"
+    timeout: 15000
+- tapOn:
+    id: "calls.current_call_bar"
+
+# Verify call screen — User A is now the sole active participant
+- extendedWaitUntil:
+    visible:
+      id: "mute-unmute"
+    timeout: 15000
+- takeScreenshot: calls-device-a-call-active
+
+# Post the sync token to the channel so Device B is unblocked to join.
+# Device B polls the API (via fixtures/poll_for_message.ts) and starts
+# its flow only after this message appears.
+- tapOn:
+    id: "navigation.header.back"
+    optional: true
+- back
+
+# Verify the call bar is visible on the channel view (User A is still in the call).
+# After this screenshot Device A's flow exits. The Mattermost app continues running
+# and User A remains in the call — the call stays active on the server. Device B can
+# then log in and join the call independently.
+- extendedWaitUntil:
+    visible:
+      id: "calls.current_call_bar"
+    timeout: 15000
+- takeScreenshot: calls-device-a-call-bar-visible

--- a/detox/maestro/flows/multi_device/device_b_join_call.yml
+++ b/detox/maestro/flows/multi_device/device_b_join_call.yml
@@ -1,0 +1,71 @@
+# MM-T4831: Device B sees the join banner and joins User A's active call (multi-device).
+#
+# PRE-CONDITIONS:
+#   - Device A has started a call (device_a_start_call.yml completed)
+#   - User B logged in on Device B in the same channel
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#
+# ASSERTIONS:
+#   - Join call banner appears in channel
+#   - Tapping Join opens call screen with mute control and participant list
+#
+# testIDs:
+#   - calls.join_call_banner.join
+#   - calls.current_call_bar
+#   - mute-unmute
+#   - users-list
+tags:
+  - MM-T4831
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# The JoinCallBanner should appear at the top of the channel since Device A
+# started a call while Device B was logged in.
+- extendedWaitUntil:
+    visible:
+      id: "calls.join_call_banner.join"
+    timeout: 120000
+- takeScreenshot: calls-device-b-join-banner-visible
+
+# Grant microphone permission before tapping Join (system dialog appears after tap)
+- tapOn:
+    id: "calls.join_call_banner.join"
+
+# Grant permissions
+- tapOn:
+    text: "Allow"
+    optional: true
+- tapOn:
+    text: "Allow"
+    optional: true
+
+# Joining keeps the app on the channel view with a call bar overlay (same as starting
+# a call). Tap the call bar to open the full call screen so mute-unmute is accessible.
+- extendedWaitUntil:
+    visible:
+      id: "calls.current_call_bar"
+    timeout: 15000
+- tapOn:
+    id: "calls.current_call_bar"
+
+# Verify Device B is now on the call screen
+- extendedWaitUntil:
+    visible:
+      id: "mute-unmute"
+    timeout: 15000
+- takeScreenshot: calls-device-b-joined-call
+
+# Verify participants list shows both users (users-list renders one card per participant)
+- extendedWaitUntil:
+    visible:
+      id: "users-list"
+    timeout: 5000
+- takeScreenshot: calls-device-b-participants-visible
+
+# Leave intentionally omitted here for two-device orchestration:
+# device_a_verify_joined.yml runs on Device A while Device B is still on the call
+# screen, showing both participants. device_b_leave_call.yml handles cleanup after.

--- a/detox/maestro/flows/multi_device/user_a_sends_message.yml
+++ b/detox/maestro/flows/multi_device/user_a_sends_message.yml
@@ -1,0 +1,36 @@
+# MM-T3055: Device A sends a sync message for Device B to receive (multi-device).
+#
+# PRE-CONDITIONS:
+#   - Two devices orchestrated via scripts/run_two_device.sh
+#   - User A logged in on Device A in the test channel
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#   - SYNC_TOKEN (unique token embedded in message text)
+#
+# ASSERTIONS:
+#   - Message containing SYNC_TOKEN is sent and visible on Device A
+#
+# testIDs:
+#   - channel.post_draft.post.input
+#   - channel.post_draft.send_action.send.button
+tags:
+  - MM-T3055
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# Type and send a message containing SYNC_TOKEN so Device B can detect it via API
+- tapOn:
+    id: "channel.post_draft.post.input"
+- inputText: "MM-T3055 sync test message ${SYNC_TOKEN}"
+- tapOn:
+    id: "channel.post_draft.send_action.send.button"
+
+# Verify the message appeared in the channel on this device
+- extendedWaitUntil:
+    visible:
+      text: "MM-T3055 sync test message ${SYNC_TOKEN}"
+    timeout: 10000
+- takeScreenshot: user-a-sent-message

--- a/detox/maestro/flows/multi_device/user_b_receives_message.yml
+++ b/detox/maestro/flows/multi_device/user_b_receives_message.yml
@@ -1,0 +1,31 @@
+# MM-T3056: Device B receives the message sent by Device A (multi-device).
+#
+# PRE-CONDITIONS:
+#   - user_a_sends_message.yml completed on Device A
+#   - User B logged in on Device B; API poll waits for server delivery
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, SITE_1_URL, TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_CHANNEL_NAME
+#   - SYNC_TOKEN, TEST_CHANNEL_ID, ADMIN_TOKEN
+#
+# ASSERTIONS:
+#   - Message with SYNC_TOKEN is visible on Device B's channel screen
+#
+# testIDs:
+#   - channel message text containing SYNC_TOKEN (assertVisible by text)
+tags:
+  - MM-T3056
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: ../../subflows/auth/login.yml
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
+
+# Poll the Mattermost API until the message from Device A appears
+# This ensures Device B does not assert before the message is delivered
+- runScript: ../../fixtures/poll_for_message.ts
+
+# Verify the message from Device A is visible on Device B's screen
+- assertVisible:
+    text: "MM-T3055 sync test message ${SYNC_TOKEN}"
+    timeout: 30000
+- takeScreenshot: user-b-received-message

--- a/detox/maestro/flows/timezone/clock_display.yml
+++ b/detox/maestro/flows/timezone/clock_display.yml
@@ -1,0 +1,89 @@
+# MM-T1325: Timezone display settings reflect the device timezone after app restart.
+#
+# PRE-CONDITIONS:
+#   - CI: run_ci_batches.sh sets emulator/sim TZ to SIMULATOR_TIMEZONE (default America/New_York)
+#   - Local: use scripts/run_timezone_test.sh to set device TZ and EXPECTED_TIMEZONE_REGION
+#
+# REQUIRED ENV VARS:
+#   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD
+#   - EXPECTED_TIMEZONE_REGION — set by CI/local wrapper (e.g. "New York" for America/New_York)
+#   - SIMULATOR_TIMEZONE — IANA id (CI/local wrapper; default America/New_York)
+#
+# ASSERTIONS:
+#   - With EXPECTED_TIMEZONE_REGION: description shows that region label
+#   - Without EXPECTED_TIMEZONE_REGION (bare local maestro test): automatic TZ on, label not "Off"
+#
+# testIDs:
+#   - tab_bar.account.tab
+#   - account.screen
+#   - account.settings.option
+#   - settings.display.option
+#   - display_settings.screen
+#   - display_settings.timezone.option
+#   - timezone_display_settings.screen
+#   - timezone_display_settings.automatic.option
+#   - timezone_display_settings.automatic.option.description
+tags:
+  - MM-T1325
+appId: ${MAESTRO_APP_ID}
+env:
+  SIMULATOR_TIMEZONE: ${SIMULATOR_TIMEZONE || "America/New_York"}
+  EXPECTED_TIMEZONE_REGION: ${EXPECTED_TIMEZONE_REGION || ""}
+---
+# Step 1: Login (login.yml clearState:true relaunch picks up CI TZ from launchctl setenv).
+- runFlow: ../../subflows/auth/login.yml
+
+# Step 2: Open Account settings
+- tapOn:
+    id: "tab_bar.account.tab"
+- extendedWaitUntil:
+    visible:
+      id: "account.screen"
+    timeout: 10000
+
+# Step 3: Open Settings
+- tapOn:
+    id: "account.settings.option"
+- extendedWaitUntil:
+    visible:
+      id: "settings.display.option"
+    timeout: 10000
+
+# Step 4: Open Display settings
+- tapOn:
+    id: "settings.display.option"
+- extendedWaitUntil:
+    visible:
+      id: "display_settings.screen"
+    timeout: 10000
+
+# Step 5: Open Timezone settings
+- tapOn:
+    id: "display_settings.timezone.option"
+- extendedWaitUntil:
+    visible:
+      id: "timezone_display_settings.screen"
+    timeout: 10000
+
+# Step 6: Enable automatic timezone if needed; assert region label.
+- assertVisible:
+    id: "timezone_display_settings.automatic.option"
+- runFlow:
+    when:
+      visible:
+        text: "Off"
+    commands:
+      - tapOn:
+          id: "timezone_display_settings.automatic.option"
+- waitForAnimationToEnd:
+    timeout: 3000
+# CI and run_timezone_test.sh pass EXPECTED_TIMEZONE_REGION; bare local runs use weaker check.
+- runFlow:
+    when:
+      true: ${EXPECTED_TIMEZONE_REGION != ""}
+    file: ../../subflows/timezone/assert_timezone_region_label.yml
+- runFlow:
+    when:
+      true: ${EXPECTED_TIMEZONE_REGION == ""}
+    file: ../../subflows/timezone/assert_timezone_region_local.yml
+- takeScreenshot: timezone-settings-visible


### PR DESCRIPTION
**Summary**: Maestro flow definitions under detox/maestro/flows/, composing the subflows/fixtures from the framework PR.

Split form main PR https://github.com/mattermost/mattermost-mobile/pull/9788
```release-note
NONE
```
