### PR TITLE
Fix crash on android caused by keyboard controller

### DIFF
--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -4,7 +4,6 @@
 import React, {type ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {Platform, type StyleProp, View, type ViewStyle, TouchableHighlight, type LayoutChangeEvent} from 'react-native';
-import {KeyboardController} from 'react-native-keyboard-controller';
 
 import {removePost} from '@actions/local/post';
 import {showPermalink} from '@actions/remote/permalink';
@@ -28,6 +27,7 @@ import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {navigateBack, navigateToScreen} from '@screens/navigation';
 import {isBoRPost, isUnrevealedBoRPost} from '@utils/bor';
 import {hasJumboEmojiOnly} from '@utils/emoji/helpers';
+import {dismissKeyboard} from '@utils/keyboard';
 import {fromAutoResponder, isFromWebhook, isPostFailed, isPostPendingOrFailed, isSystemMessage} from '@utils/post';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 
@@ -233,7 +233,7 @@ const Post = ({
 
         pressDetected.current = true;
 
-        KeyboardController.dismiss();
+        dismissKeyboard();
 
         if (post) {
             setTimeout(handlePostPress, 300);

--- a/patches/react-native-keyboard-controller+1.21.10.patch
+++ b/patches/react-native-keyboard-controller+1.21.10.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-keyboard-controller/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt b/node_modules/react-native-keyboard-controller/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+index 8bffcae..cdb9a3a 100644
+--- a/node_modules/react-native-keyboard-controller/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
++++ b/node_modules/react-native-keyboard-controller/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+@@ -54,7 +54,7 @@ class KeyboardControllerModuleImpl(
+             view.clearFocus()
+           }
+         }
+-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !animated) {
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !animated && !controller.isInsetAnimationInProgress()) {
+           controller.startControlRequest(view) { insetsController ->
+             insetsController.finish(false)
+ 


### PR DESCRIPTION
#### Summary
Fixes com.reactnativekeyboardcontroller.interactive.KeyboardAnimationController.startControlRequest throws an IllegalStateException if the inset animation is already in progress, this PR patches the library in order to gate the startControlRequest checking if is currently being animated

#### Ticket Link
[Play report](https://play.google.com/console/u/1/developers/7231322553409637977/app/4975058447662511733/vitals/crashes/21ddfcd509039848400983d4dc2d28e7/details?days=28&versionCode=6000775%2C2000775&isUserPerceived=true)

#### Release Note
```release-note
Fixed a random crash that occurred while using the keyboard
```