### PR TITLE
[MM-69455] Fix channel bookmark taps with React Native New Architecture

### DIFF
--- a/app/components/channel_bookmarks/channel_bookmark/bookmark_document.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/bookmark_document.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Button} from '@rneui/base';
 import React, {useCallback, useRef} from 'react';
-import {StyleSheet, View} from 'react-native';
+import {Pressable, StyleSheet, View} from 'react-native';
 
 import Document, {type DocumentRef} from '@components/document';
 import ProgressBar from '@components/progress_bar';
@@ -24,11 +23,10 @@ type Props = {
 }
 
 const styles = StyleSheet.create({
-    container: {
+    pressable: {
         flexDirection: 'row',
         paddingVertical: 6,
     },
-    button: {backgroundColor: 'transparent'},
     progress: {
         justifyContent: 'flex-end',
     },
@@ -53,11 +51,10 @@ const BookmarkDocument = ({bookmark, canDownloadFiles, enableSecureFilePreview, 
             downloadAndPreviewFile={toggleDownloadAndPreview}
             ref={document}
         >
-            <Button
-                buttonStyle={styles.button}
+            <Pressable
+                style={({pressed}) => [styles.pressable, pressed && {opacity: 0.72}]}
                 onPress={handlePress}
                 onLongPress={onLongPress}
-                containerStyle={styles.container}
             >
                 <BookmarkDetails
                     bookmark={bookmark}
@@ -72,7 +69,7 @@ const BookmarkDocument = ({bookmark, canDownloadFiles, enableSecureFilePreview, 
                         }
                     </View>
                 </BookmarkDetails>
-            </Button>
+            </Pressable>
         </Document>
     );
 };

--- a/app/components/channel_bookmarks/channel_bookmark/bookmark_document.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/bookmark_document.tsx
@@ -52,6 +52,7 @@ const BookmarkDocument = ({bookmark, canDownloadFiles, enableSecureFilePreview, 
             ref={document}
         >
             <Pressable
+                accessibilityRole='button'
                 style={({pressed}) => [styles.pressable, pressed && {opacity: 0.72}]}
                 onPress={handlePress}
                 onLongPress={onLongPress}

--- a/app/components/channel_bookmarks/channel_bookmark/channel_bookmark.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/channel_bookmark.tsx
@@ -2,10 +2,9 @@
 // See LICENSE.txt for license information.
 
 import {useManagedConfig} from '@mattermost/react-native-emm';
-import {Button} from '@rneui/base';
 import React, {useCallback, useMemo} from 'react';
 import {useIntl} from 'react-intl';
-import {StyleSheet} from 'react-native';
+import {Pressable, StyleSheet} from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import {ITEM_HEIGHT} from '@components/option_item';
@@ -39,14 +38,11 @@ type Props = {
 }
 
 const styles = StyleSheet.create({
-    container: {
+    pressable: {
         alignItems: 'center',
         flexDirection: 'row',
         paddingVertical: 6,
         height: 48,
-    },
-    button: {
-        backgroundColor: 'transparent',
         paddingHorizontal: 0,
     },
 });
@@ -63,12 +59,12 @@ const ChannelBookmark = ({
 
     const handlePress = useCallback(() => {
         if (bookmark.linkUrl) {
-            openLink(bookmark.linkUrl, siteURL, serverUrl, intl);
+            openLink(bookmark.linkUrl, serverUrl, siteURL, intl);
             return;
         }
 
         onPress?.(index || 0);
-    }, [bookmark, index, intl, onPress, serverUrl, siteURL]);
+    }, [bookmark.linkUrl, index, intl, onPress, serverUrl, siteURL]);
 
     const handleLongPress = useCallback(() => {
         const canShare = !enableSecureFilePreview && (canDownloadFiles || bookmark.type === 'link');
@@ -110,9 +106,8 @@ const ChannelBookmark = ({
             ref={ref}
             testID={`channel_bookmark.${bookmark.id}`}
         >
-            <Button
-                containerStyle={styles.container}
-                buttonStyle={styles.button}
+            <Pressable
+                style={({pressed}) => [styles.pressable, pressed && {opacity: 0.72}]}
                 onPress={onGestureEvent}
                 onLongPress={handleLongPress}
             >
@@ -120,7 +115,7 @@ const ChannelBookmark = ({
                     bookmark={bookmark}
                     file={file}
                 />
-            </Button>
+            </Pressable>
         </Animated.View>
     );
 };

--- a/app/components/channel_bookmarks/channel_bookmark/channel_bookmark.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/channel_bookmark.tsx
@@ -63,7 +63,7 @@ const ChannelBookmark = ({
             return;
         }
 
-        onPress?.(index || 0);
+        onPress?.(index ?? 0);
     }, [bookmark.linkUrl, index, intl, onPress, serverUrl, siteURL]);
 
     const handleLongPress = useCallback(() => {
@@ -87,7 +87,7 @@ const ChannelBookmark = ({
         bottomSheet(renderContent, snapPoints);
     }, [bookmark, canCopyPublicLink, canDeleteBookmarks, canDownloadFiles, canEditBookmarks, enableSecureFilePreview, file]);
 
-    const {onGestureEvent, ref} = useGalleryItem(galleryIdentifier, index || 0, handlePress);
+    const {onGestureEvent, ref} = useGalleryItem(galleryIdentifier, index ?? 0, handlePress);
 
     if (isDocumentFile) {
         return (
@@ -107,6 +107,7 @@ const ChannelBookmark = ({
             testID={`channel_bookmark.${bookmark.id}`}
         >
             <Pressable
+                accessibilityRole='button'
                 style={({pressed}) => [styles.pressable, pressed && {opacity: 0.72}]}
                 onPress={onGestureEvent}
                 onLongPress={handleLongPress}

--- a/app/hooks/gallery.test.ts
+++ b/app/hooks/gallery.test.ts
@@ -87,7 +87,7 @@ describe('gallery hooks', () => {
         expect(mockWithTiming).not.toHaveBeenCalled();
     });
 
-    test('useGalleryItem', async () => {
+    test('useGalleryItem', () => {
         const identifier = 'test';
         const index = 0;
         const onPress = jest.fn();
@@ -111,11 +111,10 @@ describe('gallery hooks', () => {
         });
 
         expect(gallery.sharedValues.activeIndex.value).toBe(index);
-        await Promise.resolve();
         expect(onPress).toHaveBeenCalledWith(identifier, index);
     });
 
-    test('useGalleryItem updates activeIndex when onGestureEvent is triggered', async () => {
+    test('useGalleryItem updates activeIndex when onGestureEvent is triggered', () => {
         const identifier = 'test';
         const index = 0;
         const onPress = jest.fn();
@@ -138,7 +137,6 @@ describe('gallery hooks', () => {
         });
 
         expect(gallery.sharedValues.activeIndex.value).toBe(index);
-        await Promise.resolve();
         expect(onPress).toHaveBeenCalledWith(identifier, index);
     });
 });

--- a/app/hooks/gallery.test.ts
+++ b/app/hooks/gallery.test.ts
@@ -6,7 +6,7 @@ import {useSharedValue} from 'react-native-reanimated';
 
 import {useGallery} from '@context/gallery';
 
-import {useGalleryControls, useGalleryItem, diff} from './gallery';
+import {useGalleryControls, useGalleryItem, diff, type DiffContext} from './gallery';
 
 import type {DefaultStyle} from 'react-native-reanimated/lib/typescript/hook/commonTypes';
 
@@ -33,19 +33,19 @@ jest.mock('react-native', () => ({
 
 describe('gallery hooks', () => {
     test('diff', () => {
-        const context = {} as {___diffs?: any};
+        const context = {} as DiffContext;
         const name = 'test';
         const value = 10;
 
         const result = diff(context, name, value);
 
         expect(result).toBe(0);
-        expect(context.___diffs[name].stash).toBe(0);
-        expect(context.___diffs[name].prev).toBe(value);
+        expect(context.___diffs![name].stash).toBe(0);
+        expect(context.___diffs![name].prev).toBe(value);
     });
 
     test('diff should return 0 for the same value', () => {
-        const context = {} as {___diffs?: any};
+        const context = {} as DiffContext;
         const name = 'test';
         const value = 10;
 
@@ -53,8 +53,8 @@ describe('gallery hooks', () => {
         const result = diff(context, name, value);
 
         expect(result).toBe(0);
-        expect(context.___diffs[name].stash).toBe(0);
-        expect(context.___diffs[name].prev).toBe(value);
+        expect(context.___diffs![name].stash).toBe(0);
+        expect(context.___diffs![name].prev).toBe(value);
     });
 
     test('useGalleryControls', () => {
@@ -87,7 +87,7 @@ describe('gallery hooks', () => {
         expect(mockWithTiming).not.toHaveBeenCalled();
     });
 
-    test('useGalleryItem', () => {
+    test('useGalleryItem', async () => {
         const identifier = 'test';
         const index = 0;
         const onPress = jest.fn();
@@ -111,10 +111,11 @@ describe('gallery hooks', () => {
         });
 
         expect(gallery.sharedValues.activeIndex.value).toBe(index);
+        await Promise.resolve();
         expect(onPress).toHaveBeenCalledWith(identifier, index);
     });
 
-    test('useGalleryItem updates activeIndex when onGestureEvent is triggered', () => {
+    test('useGalleryItem updates activeIndex when onGestureEvent is triggered', async () => {
         const identifier = 'test';
         const index = 0;
         const onPress = jest.fn();
@@ -137,6 +138,7 @@ describe('gallery hooks', () => {
         });
 
         expect(gallery.sharedValues.activeIndex.value).toBe(index);
+        await Promise.resolve();
         expect(onPress).toHaveBeenCalledWith(identifier, index);
     });
 });

--- a/app/hooks/gallery.ts
+++ b/app/hooks/gallery.ts
@@ -7,7 +7,6 @@ import {
     useSharedValue,
     withTiming, type WithTimingConfig,
 } from 'react-native-reanimated';
-import {scheduleOnRN} from 'react-native-worklets';
 
 import {useGallery} from '@context/gallery';
 
@@ -113,13 +112,13 @@ export function useGalleryItem(
         gallery.registerItem(index, ref);
     });
 
-    const onGestureEvent = () => {
-        'worklet';
-
+    // Invoked from the JS thread as a Touchable/Button onPress, so it must be a
+    // plain callback. A 'worklet' here is not reliably executed as a press
+    // handler under the new architecture, which silently breaks gallery taps.
+    const onGestureEvent = useCallback(() => {
         activeIndex.value = index;
-
-        scheduleOnRN(onPress, identifier, index);
-    };
+        onPress(identifier, index);
+    }, [activeIndex, index, identifier, onPress]);
 
     return {
         ref,

--- a/app/hooks/gallery.ts
+++ b/app/hooks/gallery.ts
@@ -7,12 +7,22 @@ import {
     useSharedValue,
     withTiming, type WithTimingConfig,
 } from 'react-native-reanimated';
+import {scheduleOnRN} from 'react-native-worklets';
 
 import {useGallery} from '@context/gallery';
 
 import useDidMount from './did_mount';
 
-export function diff(context: any, name: string, value: any) {
+interface DiffEntry {
+    stash: number;
+    prev: number | null;
+}
+
+export interface DiffContext {
+    ___diffs?: Record<string, DiffEntry>;
+}
+
+export function diff(context: DiffContext, name: string, value: number) {
     'worklet';
 
     if (!context.___diffs) {
@@ -112,13 +122,13 @@ export function useGalleryItem(
         gallery.registerItem(index, ref);
     });
 
-    // Invoked from the JS thread as a Touchable/Button onPress, so it must be a
-    // plain callback. A 'worklet' here is not reliably executed as a press
-    // handler under the new architecture, which silently breaks gallery taps.
-    const onGestureEvent = useCallback(() => {
+    const onGestureEvent = () => {
+        'worklet';
+
         activeIndex.value = index;
-        onPress(identifier, index);
-    }, [activeIndex, index, identifier, onPress]);
+
+        scheduleOnRN(onPress, identifier, index);
+    };
 
     return {
         ref,

--- a/detox/e2e/support/server_api/channel_bookmark.ts
+++ b/detox/e2e/support/server_api/channel_bookmark.ts
@@ -4,6 +4,24 @@
 import client from './client';
 import {getResponseFromError} from './common';
 
+export const apiCreateChannelBookmarkFile = async (baseUrl: string, channelId: string, displayName: string, fileId: string): Promise<any> => {
+    try {
+        const response = await client.post(
+            `${baseUrl}/api/v4/channels/${channelId}/bookmarks`,
+            {
+                channel_id: channelId,
+                display_name: displayName,
+                file_id: fileId,
+                type: 'file',
+            },
+        );
+
+        return {bookmark: response.data};
+    } catch (err) {
+        return getResponseFromError(err);
+    }
+};
+
 export const apiCreateChannelBookmarkLink = async (baseUrl: string, channelId: string, displayName: string, linkUrl: string): Promise<any> => {
     try {
         const response = await client.post(
@@ -56,6 +74,7 @@ export const apiIsBookmarksAvailable = async (baseUrl: string, channelId: string
 };
 
 export const ChannelBookmark = {
+    apiCreateChannelBookmarkFile,
     apiCreateChannelBookmarkLink,
     apiGetChannelBookmarks,
     apiDeleteChannelBookmark,

--- a/detox/e2e/test/products/channels/channels/channel_bookmarks.e2e.ts
+++ b/detox/e2e/test/products/channels/channels/channel_bookmarks.e2e.ts
@@ -395,7 +395,7 @@ describe('Channels - Channel Bookmarks', () => {
         await ChannelScreen.back();
     });
 
-    it('MM-69455 - should open file preview on tap and options sheet on long press for channel bookmarks', async () => {
+    it('MM-T69455_1 - should open file preview on tap and options sheet on long press for channel bookmarks', async () => {
         const getHeaderBookmark = (bookmarkId: string) => element(
             by.
                 id(`channel_bookmark.${bookmarkId}`).

--- a/detox/e2e/test/products/channels/channels/channel_bookmarks.e2e.ts
+++ b/detox/e2e/test/products/channels/channels/channel_bookmarks.e2e.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import path from 'path';
+
 // *******************************************************************
 // - [#] indicates a test step (e.g. # Go to a screen)
 // - [*] indicates an assertion (e.g. * Check the title)
@@ -10,6 +12,7 @@
 import {
     ChannelBookmark,
     Channel,
+    Post,
     Setup,
     System,
 } from '@support/server_api';
@@ -37,7 +40,10 @@ describe('Channels - Channel Bookmarks', () => {
     let channelT5607: any;
     let channelT5609: any;
     let channelT5610: any;
+    let channelT69455: any;
     let bookmarkT5610: any;
+    let bookmarkFileT69455: any;
+    let bookmarkLinkT69455: any;
 
     const createChannel = async () => {
         const {channel} = await Channel.apiCreateChannel(siteOneUrl, {
@@ -110,6 +116,7 @@ describe('Channels - Channel Bookmarks', () => {
         channelT5607 = await createChannel();
         channelT5609 = await createChannel();
         channelT5610 = await createChannel();
+        channelT69455 = await createChannel();
 
         // ── Pre-create bookmarks ──────────────────────────────────────────────
         const {bookmark: bT5610} = await ChannelBookmark.apiCreateChannelBookmarkLink(
@@ -129,6 +136,30 @@ describe('Channels - Channel Bookmarks', () => {
         await ChannelBookmark.apiCreateChannelBookmarkLink(
             siteOneUrl, channelT5609.id, 'Banner Test Bookmark', 'https://mattermost.com',
         );
+
+        const {bookmark: linkT69455} = await ChannelBookmark.apiCreateChannelBookmarkLink(
+            siteOneUrl, channelT69455.id, 'Tap Link Bookmark', 'https://mattermost.com',
+        );
+        if (!linkT69455?.id) {
+            throw new Error('[beforeAll] Failed to create bookmarkLinkT69455');
+        }
+        bookmarkLinkT69455 = linkT69455;
+
+        const {fileId, error: uploadError} = await Post.apiUploadFileToChannel(
+            siteOneUrl,
+            channelT69455.id,
+            path.resolve(__dirname, '../../../../support/fixtures/image.png'),
+        );
+        if (uploadError || !fileId) {
+            throw new Error(`[beforeAll] Failed to upload file bookmark attachment: ${JSON.stringify(uploadError)}`);
+        }
+        const {bookmark: fileT69455} = await ChannelBookmark.apiCreateChannelBookmarkFile(
+            siteOneUrl, channelT69455.id, 'Tap File Bookmark', fileId,
+        );
+        if (!fileT69455?.id) {
+            throw new Error('[beforeAll] Failed to create bookmarkFileT69455');
+        }
+        bookmarkFileT69455 = fileT69455;
 
         // ── Single login + reload to sync all API-created data ────────────────
         await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
@@ -359,6 +390,62 @@ describe('Channels - Channel Bookmarks', () => {
                     withAncestor(by.id('channel_header.bookmarks.list')),
             ),
         ).toBeVisible();
+
+        // # Go back to channel list
+        await ChannelScreen.back();
+    });
+
+    it('MM-69455 - should open file preview on tap and options sheet on long press for channel bookmarks', async () => {
+        const getHeaderBookmark = (bookmarkId: string) => element(
+            by.
+                id(`channel_bookmark.${bookmarkId}`).
+                withAncestor(by.id('channel_header.bookmarks.list')),
+        );
+
+        const dismissGallery = async () => {
+            if (isAndroid()) {
+                await device.pressBack();
+            } else {
+                await element(by.id('gallery.header.close.button')).atIndex(0).tap();
+            }
+            await waitFor(element(by.id('gallery.header.close.button'))).not.toExist().withTimeout(timeouts.TEN_SEC);
+        };
+
+        // # Navigate to the channel with link and file bookmarks
+        await openChannel(channelT69455);
+
+        const fileBookmarkEl = getHeaderBookmark(bookmarkFileT69455.id);
+        const linkBookmarkEl = getHeaderBookmark(bookmarkLinkT69455.id);
+
+        await waitFor(fileBookmarkEl).toExist().withTimeout(timeouts.TEN_SEC);
+        await waitFor(linkBookmarkEl).toExist().withTimeout(timeouts.TEN_SEC);
+
+        // # Tap the file bookmark
+        await fileBookmarkEl.tap();
+
+        // * Verify file preview gallery opens (tap must reach the gallery press handler)
+        const galleryCloseButton = element(by.id('gallery.header.close.button'));
+        await waitFor(galleryCloseButton).toExist().withTimeout(timeouts.TEN_SEC);
+
+        // # Dismiss the gallery
+        await dismissGallery();
+
+        // # Tap the link bookmark
+        await linkBookmarkEl.tap();
+        await wait(timeouts.ONE_SEC);
+
+        // * Verify tap does not open the bookmark options bottom sheet
+        await expect(ChannelBookmarkScreen.editOption).not.toBeVisible();
+
+        // # Long press the link bookmark to open options
+        await linkBookmarkEl.longPress();
+
+        // * Verify long press opens the bookmark options bottom sheet
+        await expect(ChannelBookmarkScreen.editOption).toBeVisible();
+
+        if (isAndroid()) {
+            await device.pressBack();
+        }
 
         // # Go back to channel list
         await ChannelScreen.back();


### PR DESCRIPTION
## Summary

**Root cause:** `useGalleryItem` (`app/hooks/gallery.ts`) returned `onGestureEvent` as a Reanimated worklet and wired it to React Native `onPress` handlers (including `channel_bookmark.tsx`). Worklets are intended for Reanimated and react-native-gesture-handler contexts — not as direct `onPress` callbacks. With [React Native's New Architecture](https://reactnative.dev/architecture/landing-page) enabled in this app, that worklet was silently never invoked on tap, so file/image bookmarks did not open the gallery and link navigation did not run. Long-press still worked because it uses a separate plain JS callback.

**Fix:** Replace the worklet with a plain JS `useCallback` in `useGalleryItem`. Also fix swapped `openLink(serverUrl, siteURL)` arguments for link bookmarks and replace `@rneui` `Button` with `Pressable` on bookmark components.

**Note:** `bookmark_document.tsx` does not use `useGalleryItem`; its only change is `Button` → `Pressable` for document-type bookmarks (PDF, etc.).

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69455

## Test plan

**This PR (bookmarks):**
- [x] Manual: tap file bookmark → gallery/preview opens
- [x] Manual: tap link bookmark → URL opens (not options sheet)
- [x] Manual: long-press link bookmark → options sheet
- [ ] Detox: `MM-69455` in `channel_bookmarks.e2e.ts` (iOS + Android)

**Follow-up — other `useGalleryItem` consumers (fixed by the hook change, not modified in this PR):**

| Area | Component | Manual check |
|------|-----------|--------------|
| Post inline image | `image_preview.tsx` | Tap → gallery |
| OpenGraph image | `opengraph_image/index.tsx` | Tap → gallery |
| Attachment image | `attachment_image/index.tsx` | Tap → gallery |
| Markdown image | `markdown_image/index.tsx` | Tap → gallery |
| File thumbnail | `files/file.tsx` | Tap → preview |
| Draft upload | `upload_item_wrapper.tsx` | Tap → gallery |
| Profile avatar | `user_profile/title/index.tsx` | Tap → gallery |
| Document bookmark | `bookmark_document.tsx` | Tap → PDF preview (separate code path) |

**Detox candidates for follow-up:** post image tap → gallery; file attachment tap → gallery.

**Out of scope (worklets used correctly in gesture/Reanimated contexts):** emoji picker dismiss drag, keyboard scroll compensation, in-gallery pinch/pan.

#### Release Note
```release-note
None
```