### PR TITLE
fixes audio devices not showing on android audio selector during a call

### DIFF
--- a/app/products/calls/connection/connection.test.ts
+++ b/app/products/calls/connection/connection.test.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 import {RTCMonitor, RTCPeer, parseRTCStats} from '@mattermost/calls/lib';
 import {zlibSync, strToU8} from 'fflate';
-import {Platform} from 'react-native';
+import {DeviceEventEmitter, Platform} from 'react-native';
 import InCallManager from 'react-native-incall-manager';
 
 import NetworkManager from '@managers/network_manager';
@@ -179,6 +179,34 @@ describe('newConnection', () => {
         expect(openHandler).toBeDefined();
         openHandler!('originalConnID', 'prevConnID', true);
         expect(wsSend).toHaveBeenCalledWith('reconnect', {channelID: 'channelID', originalConnID: 'originalConnID', prevConnID: 'prevConnID'});
+    });
+
+    it('registers the audio device changed listener before starting InCallManager', async () => {
+        // eslint-disable-next-line
+        // @ts-ignore
+        WebSocketClient.mockImplementation(() => ({
+            initialize: jest.fn(),
+            on: jest.fn(),
+            send: jest.fn(),
+        }));
+
+        await newConnection(
+            'http://localhost:8065',
+            'channelID',
+            () => {},
+            () => {},
+            false,
+            mockIntl,
+        );
+
+        const addListenerMock = DeviceEventEmitter.addListener as jest.Mock;
+        const audioListenerCallIndex = addListenerMock.mock.calls.findIndex(([eventType]) => eventType === 'onAudioDeviceChanged');
+        expect(audioListenerCallIndex).not.toBe(-1);
+
+        const audioListenerCallOrder = addListenerMock.mock.invocationCallOrder[audioListenerCallIndex];
+        const startCallOrder = (InCallManager.start as jest.Mock).mock.invocationCallOrder[0];
+
+        expect(audioListenerCallOrder).toBeLessThan(startCallOrder);
     });
 
     it('mute/unmute', async () => {

--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -139,6 +139,7 @@ export async function newConnection(
     } catch (err) {
         InCallManager.stop();
         audioDeviceChanged?.remove();
+
         // Rethrows the error, to be caught by the caller.
         throw err;
     }

--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -103,7 +103,7 @@ export async function newConnection(
         }
     }
 
-    // audio device changed listener is added before InCallManager start to listens to the first audio device change event.
+    // audio device changed listener is added before InCallManager.start() to listen for the first audio device change event.
     let btInitialized = false;
     let speakerInitialized = false;
     if (Platform.OS === 'android') {
@@ -134,8 +134,14 @@ export async function newConnection(
     InCallManager.start();
     InCallManager.stopProximitySensor();
 
-    // Throws an error, to be caught by caller.
-    await ws.initialize();
+    try {
+        await ws.initialize();
+    } catch (err) {
+        InCallManager.stop();
+        audioDeviceChanged?.remove();
+        // Rethrows the error, to be caught by the caller.
+        throw err;
+    }
 
     if (hasMicPermission) {
         initializeVoiceTrack();

--- a/app/products/calls/connection/connection.ts
+++ b/app/products/calls/connection/connection.ts
@@ -103,6 +103,32 @@ export async function newConnection(
         }
     }
 
+    // audio device changed listener is added before InCallManager start to listens to the first audio device change event.
+    let btInitialized = false;
+    let speakerInitialized = false;
+    if (Platform.OS === 'android') {
+        audioDeviceChanged = DeviceEventEmitter.addListener('onAudioDeviceChanged', (data: AudioDeviceInfoRaw) => {
+            const info: AudioDeviceInfo = {
+                availableAudioDeviceList: JSON.parse(data.availableAudioDeviceList),
+                selectedAudioDevice: data.selectedAudioDevice,
+            };
+            setAudioDeviceInfo(info);
+            logDebug('calls: AudioDeviceChanged, info:', info);
+
+            // Auto switch to bluetooth the first time we connect to bluetooth, but not after.
+            if (!btInitialized) {
+                if (info.availableAudioDeviceList.includes(AudioDevice.Bluetooth)) {
+                    setPreferredAudioRoute(AudioDevice.Bluetooth);
+                    btInitialized = true;
+                } else if (!speakerInitialized) {
+                    // If we don't have bluetooth available, default to speakerphone on.
+                    setPreferredAudioRoute(AudioDevice.Speakerphone);
+                    speakerInitialized = true;
+                }
+            }
+        });
+    }
+
     const ws = new WebSocketClient(serverUrl, client.getWebSocketUrl(), credentials?.token);
 
     InCallManager.start();
@@ -330,31 +356,7 @@ export async function newConnection(
             }
         }
 
-        let btInitialized = false;
-        let speakerInitialized = false;
-
         if (Platform.OS === 'android') {
-            audioDeviceChanged = DeviceEventEmitter.addListener('onAudioDeviceChanged', (data: AudioDeviceInfoRaw) => {
-                const info: AudioDeviceInfo = {
-                    availableAudioDeviceList: JSON.parse(data.availableAudioDeviceList),
-                    selectedAudioDevice: data.selectedAudioDevice,
-                };
-                setAudioDeviceInfo(info);
-                logDebug('calls: AudioDeviceChanged, info:', info);
-
-                // Auto switch to bluetooth the first time we connect to bluetooth, but not after.
-                if (!btInitialized) {
-                    if (info.availableAudioDeviceList.includes(AudioDevice.Bluetooth)) {
-                        setPreferredAudioRoute(AudioDevice.Bluetooth);
-                        btInitialized = true;
-                    } else if (!speakerInitialized) {
-                        // If we don't have bluetooth available, default to speakerphone on.
-                        setPreferredAudioRoute(AudioDevice.Speakerphone);
-                        speakerInitialized = true;
-                    }
-                }
-            });
-
             // To allow us to use microphone in the background
             foregroundServiceStart(intl);
         }


### PR DESCRIPTION
#### Summary
Audio device selector is not properly initialized when a call start on an Android device and shows a blank bottom sheet.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69440

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: Android Pixel 6A running Android 17

#### Release Note
```release-note
fixes audio selector for calls on Android devices
```
