### PR TITLE
fix: SeText heading markdown rendering differently from web version

### DIFF
--- a/patches/commonmark+0.31.2-0.patch
+++ b/patches/commonmark+0.31.2-0.patch
@@ -1,0 +1,71 @@
+diff --git a/node_modules/commonmark/lib/blocks.js b/node_modules/commonmark/lib/blocks.js
+index c25b1c4..af3509d 100644
+--- a/node_modules/commonmark/lib/blocks.js
++++ b/node_modules/commonmark/lib/blocks.js
+@@ -701,7 +701,7 @@ var blockStarts = [
+                 .match(reSetextHeadingLine))
+         ) {
+             parser.closeUnmatchedBlocks();
+-            // resolve reference link definitiosn
++            // resolve reference link definitions
+             var pos;
+             while (
+                 peek(container._string_content, 0) === C_OPEN_BRACKET &&
+@@ -710,15 +710,52 @@ var blockStarts = [
+                     parser.refmap
+                 ))
+             ) {
+-                container._string_content = container._string_content.slice(
+-                    pos
+-                );
++                container._string_content = container._string_content.slice(pos);
+             }
+             if (container._string_content.length > 0) {
++                // Split accumulated paragraph text into lines. addLine() always
++                // appends a trailing "\n", so drop the empty string that
++                // produces after split.
++                var lines = container._string_content.split("\n");
++                if (lines[lines.length - 1] === "") {
++                    lines.pop();
++                }
++
++                // Only the LAST line becomes the setext heading.
++                var headingLine = lines.pop();
++                var remainingLines = lines; // everything before the last line
++
+                 var heading = new Node("heading", container.sourcepos);
+                 heading.level = match[0][0] === "=" ? 1 : 2;
+-                heading._string_content = container._string_content;
+-                container.insertAfter(heading);
++                heading._string_content = headingLine;
++
++                if (remainingLines.length > 0) {
++                    // Keep preceding lines as their own paragraph, placed
++                    // right before the heading.
++                    var remainingContent = remainingLines.join("\n") + "\n";
++                    var paragraphEndLine =
++                        container.sourcepos[0][0] + remainingLines.length - 1;
++                    var paragraphEndCol =
++                        remainingLines[remainingLines.length - 1].length;
++
++                    var remainingParagraph = new Node("paragraph", [
++                        container.sourcepos[0],
++                        [paragraphEndLine, paragraphEndCol]
++                    ]);
++                    remainingParagraph._string_content = remainingContent;
++
++                    heading._sourcepos = [
++                        [paragraphEndLine + 1, container.sourcepos[0][1]],
++                        container.sourcepos[1]
++                    ];
++
++                    container.insertAfter(remainingParagraph);
++                    remainingParagraph.insertAfter(heading);
++                } else {
++                    // Only one line in the paragraph — behaves as before.
++                    container.insertAfter(heading);
++                }
++
+                 container.unlink();
+                 parser.tip = heading;
+                 parser.advanceOffset(


### PR DESCRIPTION
#### Summary

This PR fixes a Markdown rendering inconsistency where **setext headings** (headings created by underlining a line with `---` or `===`) were being rendered differently in the mobile app compared to the web app.

**Issue**

Given input like:

```
text 1
text 2
text 3
---
text 4
```

The mobile parser (based on `commonmark`) follows the strict CommonMark spec, which states that a setext underline converts the **entire preceding paragraph** into a heading — not just the line directly above the underline. Since `text 1`, `text 2`, and `text 3` have no blank lines between them, the parser treats them as a single paragraph node, and that whole block becomes the heading. `text 4` is left as a separate paragraph.

This does not match the web app's behavior, where only `text 3` (the line immediately preceding the `---`) becomes the heading, and `text 1` / `text 2` remain a normal paragraph.

**Root cause**

In `blocks.js`, the setext heading block-start handler assigns the *entire* accumulated paragraph string (`container._string_content`, which includes all prior lines) directly to the new heading node:

```javascript
heading._string_content = container._string_content;
```

Because `container._string_content` contains every line collected in the paragraph so far (`"text 1\ntext 2\ntext 3\n"`), all of it gets wrapped in the heading, rather than isolating just the final line.

**Fix**

- Split `container._string_content` into individual lines and drop the trailing empty entry produced by the final line break.
- Pop off only the **last line** and use it as the heading's content, so the heading now reflects only the line directly above the setext underline.
- If any lines remain before the last one, rebuild them into a new `paragraph` node (with recalculated `sourcepos`) and insert it into the tree immediately before the heading, preserving them as normal paragraph text instead of discarding them.
- If the original paragraph only had one line, behavior is unchanged (heading is created directly from it, no extra paragraph node needed).

**Follow-up fix during testing**

An initial version of the patch attempted to reassign the heading's `sourcepos` directly:

```javascript
heading.sourcepos = [...]; // TypeError: Cannot assign to property 'sourcepos' which has only a getter
```

This threw a runtime error because `sourcepos` on `Node` is a getter-only property (backed internally by `_sourcepos`). The fix was updated to assign to the internal field instead:

```javascript
heading._sourcepos = [...];
```

This resolves the crash while keeping the source position metadata accurate for the newly split heading and paragraph nodes.

#### Ticket Link
<!-- Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX -->

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!-- If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible). -->
### Web
<img width="398" height="253" alt="image" src="https://github.com/user-attachments/assets/bf92e2ce-ed7c-4a83-99e1-9f6b302548ac" />

### Before
<img width="480" height="307" alt="image" src="https://github.com/user-attachments/assets/dd44ad84-34f1-405a-9589-128e2f647f1e" />


### After
<img width="492" height="361" alt="image" src="https://github.com/user-attachments/assets/31d135d5-9641-4104-a1d9-41d5324e6d4a" />


#### Release Note
```release-note
Fixed setext-style Markdown headings (underlined with --- or ===) incorrectly converting all preceding paragraph lines into the heading instead of only the line directly above the underline, to match web app behavior.
```

---