### PR TITLE
[MM-69455] Fix channel bookmark taps with React Native New Architecture (cherry-pick #9904)

### DIFF
--- a/app/components/channel_bookmarks/channel_bookmark/bookmark_document.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/bookmark_document.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Button} from '@rneui/base';
 import React, {useCallback, useRef} from 'react';
-import {StyleSheet, View} from 'react-native';
+import {Pressable, StyleSheet, View} from 'react-native';
 
 import Document, {type DocumentRef} from '@components/document';
 import ProgressBar from '@components/progress_bar';
@@ -24,11 +23,10 @@ type Props = {
 }
 
 const styles = StyleSheet.create({
-    container: {
+    pressable: {
         flexDirection: 'row',
         paddingVertical: 6,
     },
-    button: {backgroundColor: 'transparent'},
     progress: {
         justifyContent: 'flex-end',
     },
@@ -53,11 +51,11 @@ const BookmarkDocument = ({bookmark, canDownloadFiles, enableSecureFilePreview, 
             downloadAndPreviewFile={toggleDownloadAndPreview}
             ref={document}
         >
-            <Button
-                buttonStyle={styles.button}
+            <Pressable
+                accessibilityRole='button'
+                style={({pressed}) => [styles.pressable, pressed && {opacity: 0.72}]}
                 onPress={handlePress}
                 onLongPress={onLongPress}
-                containerStyle={styles.container}
             >
                 <BookmarkDetails
                     bookmark={bookmark}
@@ -72,7 +70,7 @@ const BookmarkDocument = ({bookmark, canDownloadFiles, enableSecureFilePreview, 
                         }
                     </View>
                 </BookmarkDetails>
-            </Button>
+            </Pressable>
         </Document>
     );
 };

--- a/app/components/channel_bookmarks/channel_bookmark/channel_bookmark.tsx
+++ b/app/components/channel_bookmarks/channel_bookmark/channel_bookmark.tsx
@@ -2,10 +2,9 @@
 // See LICENSE.txt for license information.
 
 import {useManagedConfig} from '@mattermost/react-native-emm';
-import {Button} from '@rneui/base';
 import React, {useCallback, useMemo} from 'react';
 import {useIntl} from 'react-intl';
-import {StyleSheet} from 'react-native';
+import {Pressable, StyleSheet} from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import {ITEM_HEIGHT} from '@components/option_item';
@@ -39,14 +38,11 @@ type Props = {
 }
 
 const styles = StyleSheet.create({
-    container: {
+    pressable: {
         alignItems: 'center',
         flexDirection: 'row',
         paddingVertical: 6,
         height: 48,
-    },
-    button: {
-        backgroundColor: 'transparent',
         paddingHorizontal: 0,
     },
 });
@@ -63,12 +59,12 @@ const ChannelBookmark = ({
 
     const handlePress = useCallback(() => {
         if (bookmark.linkUrl) {
-            openLink(bookmark.linkUrl, siteURL, serverUrl, intl);
+            openLink(bookmark.linkUrl, serverUrl, siteURL, intl);
             return;
         }
 
-        onPress?.(index || 0);
-    }, [bookmark, index, intl, onPress, serverUrl, siteURL]);
+        onPress?.(index ?? 0);
+    }, [bookmark.linkUrl, index, intl, onPress, serverUrl, siteURL]);
 
     const handleLongPress = useCallback(() => {
         const canShare = !enableSecureFilePreview && (canDownloadFiles || bookmark.type === 'link');
@@ -91,7 +87,7 @@ const ChannelBookmark = ({
         bottomSheet(renderContent, snapPoints);
     }, [bookmark, canCopyPublicLink, canDeleteBookmarks, canDownloadFiles, canEditBookmarks, enableSecureFilePreview, file]);
 
-    const {onGestureEvent, ref} = useGalleryItem(galleryIdentifier, index || 0, handlePress);
+    const {onGestureEvent, ref} = useGalleryItem(galleryIdentifier, index ?? 0, handlePress);
 
     if (isDocumentFile) {
         return (
@@ -106,10 +102,13 @@ const ChannelBookmark = ({
     }
 
     return (
-        <Animated.View ref={ref}>
-            <Button
-                containerStyle={styles.container}
-                buttonStyle={styles.button}
+        <Animated.View
+            ref={ref}
+            testID={`channel_bookmark.${bookmark.id}`}
+        >
+            <Pressable
+                accessibilityRole='button'
+                style={({pressed}) => [styles.pressable, pressed && {opacity: 0.72}]}
                 onPress={onGestureEvent}
                 onLongPress={handleLongPress}
             >
@@ -117,7 +116,7 @@ const ChannelBookmark = ({
                     bookmark={bookmark}
                     file={file}
                 />
-            </Button>
+            </Pressable>
         </Animated.View>
     );
 };


### PR DESCRIPTION
#### Summary
Cherry-pick of #9904 to `release-2.42`.

`useGalleryItem` (`app/hooks/gallery.ts`) returned `onGestureEvent` as a Reanimated worklet wired to React Native `onPress` handlers. With the New Architecture enabled, that worklet was silently never invoked on tap, so file/image bookmark taps failed to open the gallery and link navigation did not run. The fix replaces the worklet with a plain JS `useCallback`, fixes swapped `openLink` arguments for link bookmarks, and replaces the `@rneui` `Button` with `Pressable` on the bookmark components.

**Cherry-pick note:** The two Detox files from the original PR (`detox/e2e/support/server_api/channel_bookmark.ts` and `detox/e2e/test/products/channels/channels/channel_bookmarks.e2e.ts`) do not exist on `release-2.42`, so they were dropped. This PR contains only the source fix (`channel_bookmark.tsx`, `bookmark_document.tsx`, `gallery.ts`, `gallery.test.ts`). A content conflict in `channel_bookmark.tsx` (Button → Pressable) was resolved in favor of the fix.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-69455

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: iOS Simulator (via original PR #9904)

#### Screenshots
N/A

#### Release Note
```release-note
None
```