### PR TITLE
[MM-69723, MM-69705] Version-gate ChannelBookmarks and CustomProfileAttributes for flag removal

### DIFF
--- a/app/actions/remote/channel_bookmark.test.ts
+++ b/app/actions/remote/channel_bookmark.test.ts
@@ -99,6 +99,7 @@ describe('channel bookmarks', () => {
         expect(result).toBeDefined();
         expect(result.bookmarks).toBeDefined();
         expect(result.bookmarks?.length).toBe(0);
+        expect(mockClient.getChannelBookmarksForChannel).not.toHaveBeenCalled();
     });
 
     it('createChannelBookmark - handle not found database', async () => {

--- a/app/actions/remote/channel_bookmark.ts
+++ b/app/actions/remote/channel_bookmark.ts
@@ -5,7 +5,8 @@ import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import websocketManager from '@managers/websocket_manager';
 import {getBookmarksSince, getChannelBookmarkById} from '@queries/servers/channel_bookmark';
-import {getConfigValue, getLicense} from '@queries/servers/system';
+import {getChannelBookmarksEnabled} from '@queries/servers/features';
+import {getLicense} from '@queries/servers/system';
 import {getFullErrorMessage} from '@utils/errors';
 import {logError} from '@utils/log';
 
@@ -16,7 +17,7 @@ export async function fetchChannelBookmarks(serverUrl: string, channelId: string
         const client = NetworkManager.getClient(serverUrl);
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
 
-        const bookmarksEnabled = (await getConfigValue(database, 'FeatureFlagChannelBookmarks')) === 'true';
+        const bookmarksEnabled = await getChannelBookmarksEnabled(database);
         const isLicensed = (await getLicense(database))?.IsLicensed === 'true';
 
         if (!bookmarksEnabled || !isLicensed) {

--- a/app/actions/remote/channel_bookmark.ts
+++ b/app/actions/remote/channel_bookmark.ts
@@ -6,7 +6,6 @@ import NetworkManager from '@managers/network_manager';
 import websocketManager from '@managers/websocket_manager';
 import {getBookmarksSince, getChannelBookmarkById} from '@queries/servers/channel_bookmark';
 import {getChannelBookmarksEnabled} from '@queries/servers/features';
-import {getLicense} from '@queries/servers/system';
 import {getFullErrorMessage} from '@utils/errors';
 import {logError} from '@utils/log';
 
@@ -18,9 +17,8 @@ export async function fetchChannelBookmarks(serverUrl: string, channelId: string
         const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
 
         const bookmarksEnabled = await getChannelBookmarksEnabled(database);
-        const isLicensed = (await getLicense(database))?.IsLicensed === 'true';
 
-        if (!bookmarksEnabled || !isLicensed) {
+        if (!bookmarksEnabled) {
             return {bookmarks: []};
         }
 

--- a/app/constants/versions.ts
+++ b/app/constants/versions.ts
@@ -3,6 +3,14 @@
 
 export const GM_AS_DM_VERSION = [9, 1, 0];
 
+// Server version where a promoted feature flag is removed from the client config (MM-69218). Mobile
+// treats the feature as always-on at or after this version, and honors the flag on older servers that
+// still send it (see @queries/servers/features). One constant per flag so the pattern is easy to copy;
+// each must track its own server-side removal release, and the compat shim can be deleted once
+// MIN_REQUIRED_VERSION reaches it (guarded by a test in features.test.ts).
+export const CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION = [11, 10, 0];
+export const CUSTOM_PROFILE_ATTRIBUTES_FLAG_REMOVED_VERSION = [11, 10, 0];
+
 export const OS_VERSION = {
     ANDROID: 'android',
     IOS: 'ios',

--- a/app/queries/servers/features.test.ts
+++ b/app/queries/servers/features.test.ts
@@ -3,6 +3,7 @@
 
 import {firstValueFrom} from 'rxjs';
 
+import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import {MIN_REQUIRED_VERSION} from '@constants/supported_server';
 import {CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, CUSTOM_PROFILE_ATTRIBUTES_FLAG_REMOVED_VERSION} from '@constants/versions';
 import DatabaseManager from '@database/manager';
@@ -23,11 +24,20 @@ const setConfigs = (configs: Array<{id: string; value: string}>) => operator.han
     prepareRecordsOnly: false,
 });
 
+const setLicensed = (isLicensed: boolean) => operator.handleSystem({
+    systems: [{id: SYSTEM_IDENTIFIERS.LICENSE, value: {IsLicensed: isLicensed ? 'true' : 'false'}}],
+    prepareRecordsOnly: false,
+});
+
 beforeEach(async () => {
     await DatabaseManager.init([serverUrl]);
     const serverDatabaseAndOperator = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
     database = serverDatabaseAndOperator.database;
     operator = serverDatabaseAndOperator.operator;
+
+    // Channel bookmarks also gate on license; hold it licensed so the shared matrix below isolates the
+    // version/flag behavior. The unlicensed case is covered separately.
+    await setLicensed(true);
 });
 
 afterEach(async () => {
@@ -65,8 +75,19 @@ describe.each([
     });
 });
 
+// Channel bookmarks additionally gate on license, unlike the other promoted flags. Both variants apply
+// the same gate so UI and fetch paths stay consistent.
+describe('ChannelBookmarks license gate', () => {
+    it('disables both variants on an unlicensed server even when the feature is otherwise enabled', async () => {
+        await setConfigs([{id: 'Version', value: CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION.join('.')}]);
+        await setLicensed(false);
+        expect(await firstValueFrom(observeChannelBookmarksEnabled(database))).toBe(false);
+        expect(await getChannelBookmarksEnabled(database)).toBe(false);
+    });
+});
+
 // getChannelBookmarksEnabled is the async variant used by the channel bookmark action; confirm it applies
-// the same gate as the observe helper.
+// the same version gate as the observe helper.
 describe('getChannelBookmarksEnabled (async variant)', () => {
     it('applies the version gate', async () => {
         await setConfigs([{id: 'Version', value: '10.0.0'}]);

--- a/app/queries/servers/features.test.ts
+++ b/app/queries/servers/features.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {firstValueFrom} from 'rxjs';
+
+import {MIN_REQUIRED_VERSION} from '@constants/supported_server';
+import {CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, CUSTOM_PROFILE_ATTRIBUTES_FLAG_REMOVED_VERSION} from '@constants/versions';
+import DatabaseManager from '@database/manager';
+import {isMinimumServerVersion} from '@utils/helpers';
+
+import {getChannelBookmarksEnabled, observeChannelBookmarksEnabled, observeCustomProfileAttributesEnabled} from './features';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+import type {Database} from '@nozbe/watermelondb';
+
+const serverUrl = 'baseHandler.test.com';
+let database: Database;
+let operator: ServerDataOperator;
+
+const setConfigs = (configs: Array<{id: string; value: string}>) => operator.handleConfigs({
+    configs,
+    configsToDelete: [],
+    prepareRecordsOnly: false,
+});
+
+beforeEach(async () => {
+    await DatabaseManager.init([serverUrl]);
+    const serverDatabaseAndOperator = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+    database = serverDatabaseAndOperator.database;
+    operator = serverDatabaseAndOperator.operator;
+});
+
+afterEach(async () => {
+    await DatabaseManager.destroyServerDatabase(serverUrl);
+});
+
+// The version-gate behavior is shared across the promoted-flag helpers, so run the same matrix for each
+// flag through its observe* helper. Flags differ only in their config key and removal version.
+describe.each([
+    {name: 'ChannelBookmarks', flag: 'FeatureFlagChannelBookmarks', removedVersion: CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, observeEnabled: observeChannelBookmarksEnabled},
+    {name: 'CustomProfileAttributes', flag: 'FeatureFlagCustomProfileAttributes', removedVersion: CUSTOM_PROFILE_ATTRIBUTES_FLAG_REMOVED_VERSION, observeEnabled: observeCustomProfileAttributesEnabled},
+])('$name feature-flag compatibility', ({flag, removedVersion, observeEnabled}) => {
+    const atRemoval = removedVersion.join('.');
+    const olderServer = '10.0.0';
+
+    it('is enabled once the flag is removed, even though it is no longer sent', async () => {
+        await setConfigs([{id: 'Version', value: atRemoval}]);
+        expect(await firstValueFrom(observeEnabled(database))).toBe(true);
+    });
+
+    it('honors the flag on older servers that still send it', async () => {
+        await setConfigs([{id: 'Version', value: olderServer}, {id: flag, value: 'true'}]);
+        expect(await firstValueFrom(observeEnabled(database))).toBe(true);
+    });
+
+    it('is disabled on older servers that do not enable the flag', async () => {
+        await setConfigs([{id: 'Version', value: olderServer}]);
+        expect(await firstValueFrom(observeEnabled(database))).toBe(false);
+    });
+
+    // Once MIN_REQUIRED_VERSION reaches the removal version, every supported server has the flag gone, the
+    // gate is always true, and this shim is dead code — delete the helper, constant, and call sites then.
+    it('shim is still needed: min supported server predates flag removal', () => {
+        expect(isMinimumServerVersion(MIN_REQUIRED_VERSION, ...removedVersion)).toBe(false);
+    });
+});
+
+// getChannelBookmarksEnabled is the async variant used by the channel bookmark action; confirm it applies
+// the same gate as the observe helper.
+describe('getChannelBookmarksEnabled (async variant)', () => {
+    it('applies the version gate', async () => {
+        await setConfigs([{id: 'Version', value: '10.0.0'}]);
+        expect(await getChannelBookmarksEnabled(database)).toBe(false);
+
+        await setConfigs([{id: 'Version', value: CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION.join('.')}]);
+        expect(await getChannelBookmarksEnabled(database)).toBe(true);
+    });
+});

--- a/app/queries/servers/features.ts
+++ b/app/queries/servers/features.ts
@@ -1,13 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {combineLatest, of as of$} from 'rxjs';
+import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
-import {GM_AS_DM_VERSION} from '@constants/versions';
+import {CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, CUSTOM_PROFILE_ATTRIBUTES_FLAG_REMOVED_VERSION, GM_AS_DM_VERSION} from '@constants/versions';
 import {isMinimumServerVersion} from '@utils/helpers';
 
-import {observeConfigValue} from './system';
+import {getConfigValue, observeConfigValue} from './system';
 
 import type {Database} from '@nozbe/watermelondb';
 
@@ -15,4 +15,46 @@ export const observeHasGMasDMFeature = (database: Database) => {
     return observeConfigValue(database, 'Version').pipe(
         switchMap((v) => of$(isMinimumServerVersion(v, ...GM_AS_DM_VERSION))),
     );
+};
+
+// A feature flag (MM-69218) is eventually removed from the client config, at which point the server
+// stops sending it. `removedVersion` is the server version where that happens: at or above it the flag is
+// gone and the feature takes its retired value `defaultValue` — true for a flag promoted to default-on,
+// false for a flag retired while still default-off. Below that version the flag is still sent (or the
+// feature predates it entirely), so honor the flag value.
+const isFeatureFlagEnabled = (version: string | undefined, flag: string | undefined, removedVersion: number[], defaultValue: boolean): boolean => {
+    if (isMinimumServerVersion(version, ...removedVersion)) {
+        return defaultValue;
+    }
+    return flag === 'true';
+};
+
+const observeFeatureFlagWithVersion = (database: Database, flag: keyof ClientConfig, removedVersion: number[], defaultValue: boolean) => {
+    return combineLatest([
+        observeConfigValue(database, 'Version'),
+        observeConfigValue(database, flag),
+    ]).pipe(
+        switchMap(([version, value]) => of$(isFeatureFlagEnabled(version, value, removedVersion, defaultValue))),
+        distinctUntilChanged(),
+    );
+};
+
+const getFeatureFlagWithVersion = async (database: Database, flag: keyof ClientConfig, removedVersion: number[], defaultValue: boolean) => {
+    const [version, value] = await Promise.all([
+        getConfigValue(database, 'Version'),
+        getConfigValue(database, flag),
+    ]);
+    return isFeatureFlagEnabled(version, value, removedVersion, defaultValue);
+};
+
+export const observeChannelBookmarksEnabled = (database: Database) => {
+    return observeFeatureFlagWithVersion(database, 'FeatureFlagChannelBookmarks', CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, true);
+};
+
+export const getChannelBookmarksEnabled = (database: Database) => {
+    return getFeatureFlagWithVersion(database, 'FeatureFlagChannelBookmarks', CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, true);
+};
+
+export const observeCustomProfileAttributesEnabled = (database: Database) => {
+    return observeFeatureFlagWithVersion(database, 'FeatureFlagCustomProfileAttributes', CUSTOM_PROFILE_ATTRIBUTES_FLAG_REMOVED_VERSION, true);
 };

--- a/app/queries/servers/features.ts
+++ b/app/queries/servers/features.ts
@@ -7,7 +7,7 @@ import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 import {CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, CUSTOM_PROFILE_ATTRIBUTES_FLAG_REMOVED_VERSION, GM_AS_DM_VERSION} from '@constants/versions';
 import {isMinimumServerVersion} from '@utils/helpers';
 
-import {getConfigValue, observeConfigValue} from './system';
+import {getConfigValue, getLicense, observeConfigValue, observeLicense} from './system';
 
 import type {Database} from '@nozbe/watermelondb';
 
@@ -47,12 +47,24 @@ const getFeatureFlagWithVersion = async (database: Database, flag: keyof ClientC
     return isFeatureFlagEnabled(version, value, removedVersion, defaultValue);
 };
 
+// Channel bookmarks additionally require a license, so both the observable and async variants include
+// the license gate and stay consistent across UI and fetch paths.
 export const observeChannelBookmarksEnabled = (database: Database) => {
-    return observeFeatureFlagWithVersion(database, 'FeatureFlagChannelBookmarks', CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, true);
+    return combineLatest([
+        observeFeatureFlagWithVersion(database, 'FeatureFlagChannelBookmarks', CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, true),
+        observeLicense(database),
+    ]).pipe(
+        switchMap(([enabled, license]) => of$(enabled && license?.IsLicensed === 'true')),
+        distinctUntilChanged(),
+    );
 };
 
-export const getChannelBookmarksEnabled = (database: Database) => {
-    return getFeatureFlagWithVersion(database, 'FeatureFlagChannelBookmarks', CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, true);
+export const getChannelBookmarksEnabled = async (database: Database) => {
+    const [enabled, license] = await Promise.all([
+        getFeatureFlagWithVersion(database, 'FeatureFlagChannelBookmarks', CHANNEL_BOOKMARKS_FLAG_REMOVED_VERSION, true),
+        getLicense(database),
+    ]);
+    return enabled && license?.IsLicensed === 'true';
 };
 
 export const observeCustomProfileAttributesEnabled = (database: Database) => {

--- a/app/screens/channel/header/index.ts
+++ b/app/screens/channel/header/index.ts
@@ -11,6 +11,7 @@ import {queryPlaybookRunsPerChannel} from '@playbooks/database/queries/run';
 import {observeIsPlaybooksEnabled} from '@playbooks/database/queries/version';
 import {observeChannel, observeChannelInfo, observeIsChannelAutotranslated} from '@queries/servers/channel';
 import {observeCanAddBookmarks, queryBookmarks} from '@queries/servers/channel_bookmark';
+import {observeChannelBookmarksEnabled} from '@queries/servers/features';
 import {observeConfigBooleanValue, observeCurrentTeamId, observeCurrentUserId} from '@queries/servers/system';
 import {observeIsUserLanguageSupportedByAutotranslation, observeUser} from '@queries/servers/user';
 import {
@@ -94,7 +95,7 @@ const enhanced = withObservables(['channelId'], ({channelId, database}: OwnProps
         distinctUntilChanged(),
     );
 
-    const isBookmarksEnabled = observeConfigBooleanValue(database, 'FeatureFlagChannelBookmarks');
+    const isBookmarksEnabled = observeChannelBookmarksEnabled(database);
     const canAddBookmarks = observeCanAddBookmarks(database, channelId);
 
     const activeRuns = isPlaybooksEnabled.pipe(

--- a/app/screens/channel/index.tsx
+++ b/app/screens/channel/index.tsx
@@ -10,11 +10,10 @@ import {Preferences} from '@constants';
 import {withServerUrl} from '@context/server';
 import {observeCurrentChannel} from '@queries/servers/channel';
 import {queryBookmarks} from '@queries/servers/channel_bookmark';
-import {observeHasGMasDMFeature} from '@queries/servers/features';
+import {observeChannelBookmarksEnabled, observeHasGMasDMFeature} from '@queries/servers/features';
 import {queryPreferencesByCategoryAndName} from '@queries/servers/preference';
 import {observeScheduledPostCountForChannel} from '@queries/servers/scheduled_post';
 import {
-    observeConfigBooleanValue,
     observeCurrentChannelId,
     observeCurrentUserId,
 } from '@queries/servers/system';
@@ -35,7 +34,7 @@ const enhanced = withObservables([], ({database, serverUrl}: EnhanceProps) => {
     const channelType = observeCurrentChannel(database).pipe(switchMap((c) => of$(c?.type)));
     const currentUserId = observeCurrentUserId(database);
     const hasGMasDMFeature = observeHasGMasDMFeature(database);
-    const isBookmarksEnabled = observeConfigBooleanValue(database, 'FeatureFlagChannelBookmarks');
+    const isBookmarksEnabled = observeChannelBookmarksEnabled(database);
     const hasBookmarks = (count: number) => of$(count > 0);
     const includeBookmarkBar = channelId.pipe(
         combineLatestWith(isBookmarksEnabled),

--- a/app/screens/channel_info/index.ts
+++ b/app/screens/channel_info/index.ts
@@ -12,9 +12,9 @@ import {withServerUrl} from '@context/server';
 import {observeIsPlaybooksEnabled} from '@playbooks/database/queries/version';
 import {observeChannelAutotranslation, observeCurrentChannel} from '@queries/servers/channel';
 import {observeCanAddBookmarks} from '@queries/servers/channel_bookmark';
+import {observeChannelBookmarksEnabled} from '@queries/servers/features';
 import {observeCanManageChannelAutotranslations, observeCanManageChannelMembers, observeCanManageChannelSettings, observePermissionForChannel, observePermissionForTeam} from '@queries/servers/role';
 import {
-    observeConfigBooleanValue,
     observeConfigValue,
     observeCurrentChannelId,
     observeCurrentTeamId,
@@ -241,7 +241,7 @@ const enhanced = withObservables([], ({serverUrl, database}: Props) => {
         distinctUntilChanged(),
     );
 
-    const isBookmarksEnabled = observeConfigBooleanValue(database, 'FeatureFlagChannelBookmarks');
+    const isBookmarksEnabled = observeChannelBookmarksEnabled(database);
 
     const canAddBookmarks = channelId.pipe(
         switchMap((cId) => {

--- a/app/screens/edit_profile/index.ts
+++ b/app/screens/edit_profile/index.ts
@@ -6,6 +6,7 @@ import {of as of$, combineLatest} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observeCustomProfileAttributesByUserId, observeCustomProfileFields} from '@queries/servers/custom_profile';
+import {observeCustomProfileAttributesEnabled} from '@queries/servers/features';
 import {observeConfigBooleanValue} from '@queries/servers/system';
 import {observeCurrentUser} from '@queries/servers/user';
 import {sortCustomProfileAttributes, convertToAttributesMap, convertProfileAttributesToCustomAttributes} from '@utils/user';
@@ -26,7 +27,7 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const samlLastNameAttributeSet = observeConfigBooleanValue(database, 'SamlLastNameAttributeSet');
     const samlNicknameAttributeSet = observeConfigBooleanValue(database, 'SamlNicknameAttributeSet');
     const samlPositionAttributeSet = observeConfigBooleanValue(database, 'SamlPositionAttributeSet');
-    const customAttributesEnabled = observeConfigBooleanValue(database, 'FeatureFlagCustomProfileAttributes');
+    const customAttributesEnabled = observeCustomProfileAttributesEnabled(database);
 
     const rawCustomAttributes = currentUser.pipe(
         switchMap((u) => (u ? observeCustomProfileAttributesByUserId(database, u.id) : of$([]))),
@@ -65,7 +66,7 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
             switchMap(([ldap, saml]) => of$(ldap || saml)),
         ),
         lockedPicture: observeConfigBooleanValue(database, 'LdapPictureAttributeSet'),
-        enableCustomAttributes: observeConfigBooleanValue(database, 'FeatureFlagCustomProfileAttributes'),
+        enableCustomAttributes: observeCustomProfileAttributesEnabled(database),
         userCustomAttributes: rawCustomAttributes,
         customFields,
         customAttributesSet: formattedCustomAttributes,

--- a/app/screens/user_profile/index.ts
+++ b/app/screens/user_profile/index.ts
@@ -9,6 +9,7 @@ import {General, Permissions, Preferences} from '@constants';
 import {getDisplayNamePreferenceAsBool} from '@helpers/api/preference';
 import {observeChannel} from '@queries/servers/channel';
 import {observeCustomProfileAttributesByUserId, observeCustomProfileFields} from '@queries/servers/custom_profile';
+import {observeCustomProfileAttributesEnabled} from '@queries/servers/features';
 import {queryDisplayNamePreferences} from '@queries/servers/preference';
 import {observeCanManageChannelMembers, observePermissionForChannel} from '@queries/servers/role';
 import {observeConfigBooleanValue, observeCurrentTeamId, observeCurrentUserId} from '@queries/servers/system';
@@ -67,7 +68,7 @@ const enhanced = withObservables([], ({channelId, database, userId}: EnhancedPro
         observeWithColumns(['value']);
     const isMilitaryTime = preferences.pipe(map((prefs) => getDisplayNamePreferenceAsBool(prefs, Preferences.USE_MILITARY_TIME)));
     const isCustomStatusEnabled = observeConfigBooleanValue(database, 'EnableCustomUserStatuses');
-    const enableCustomAttributes = observeConfigBooleanValue(database, 'FeatureFlagCustomProfileAttributes');
+    const enableCustomAttributes = observeCustomProfileAttributesEnabled(database);
 
     // Custom profile attributes
     const rawCustomAttributes = observeCustomProfileAttributesByUserId(database, userId);


### PR DESCRIPTION
#### Summary
We're deleting feature flags, and need to special case a few for mobile. 
- **ChannelBookmarks** — shipped v9.8. A missing flag hides the bookmark bar and skips the bookmarks fetch.
- **CustomProfileAttributes** — shipped v10.6. A missing flag disables CPA in edit-profile and user-profile.

A new framework for handling versions and defaults is added to streamline this going forward. A test also verifies when the min server version exceeds any of these so we can remove even the shim.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69723
Fixes: https://mattermost.atlassian.net/browse/MM-69705

#### Checklist

- [x] Added or updated unit tests (required for all new features)

#### Device Information

Not device-tested — logic-only change covered by unit tests (`app/queries/servers/features.test.ts`, 8 cases across the version-gate matrix; existing `channel_bookmark` tests still pass).

#### Release Note

```release-note
Kept Channel Bookmarks and Custom Profile Attributes working against server versions that no longer send the corresponding feature flags.
```