### PR TITLE
fix(MM-69538): Android thread scroll to root post header

### DIFF
--- a/app/components/post_list/android_thread_scroll.test.ts
+++ b/app/components/post_list/android_thread_scroll.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Platform} from 'react-native';
+
+import {Screens} from '@constants';
+
+import {isAndroidThreadRootPost, isAndroidThreadScreen} from './android_thread_scroll';
+
+describe('android_thread_scroll', () => {
+    const originalOS = Platform.OS;
+
+    afterEach(() => {
+        Object.defineProperty(Platform, 'OS', {value: originalOS});
+    });
+
+    it('should identify Android thread screens only', () => {
+        Object.defineProperty(Platform, 'OS', {value: 'android'});
+        expect(isAndroidThreadScreen(Screens.THREAD)).toBe(true);
+        expect(isAndroidThreadScreen(Screens.CHANNEL)).toBe(false);
+
+        Object.defineProperty(Platform, 'OS', {value: 'ios'});
+        expect(isAndroidThreadScreen(Screens.THREAD)).toBe(false);
+    });
+
+    it('should identify Android thread root posts by root id or reply state', () => {
+        Object.defineProperty(Platform, 'OS', {value: 'android'});
+
+        expect(isAndroidThreadRootPost({
+            location: Screens.THREAD,
+            postId: 'root-post-id',
+            rootId: 'root-post-id',
+        })).toBe(true);
+
+        expect(isAndroidThreadRootPost({
+            location: Screens.THREAD,
+            postId: 'reply-post-id',
+            rootId: 'root-post-id',
+        })).toBe(false);
+
+        expect(isAndroidThreadRootPost({
+            location: Screens.THREAD,
+            isReplyPost: false,
+        })).toBe(true);
+
+        expect(isAndroidThreadRootPost({
+            location: Screens.THREAD,
+            isReplyPost: true,
+        })).toBe(false);
+    });
+});

--- a/app/components/post_list/android_thread_scroll.ts
+++ b/app/components/post_list/android_thread_scroll.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Platform} from 'react-native';
+
+import {Screens} from '@constants';
+
+import type {AvailableScreens} from '@typings/screens/navigation';
+
+export const isAndroidThreadScreen = (location: AvailableScreens) => (
+    Platform.OS === 'android' && location === Screens.THREAD
+);
+
+type AndroidThreadRootPostArgs = {
+    location: AvailableScreens;
+    postId?: string;
+    rootId?: string;
+    isReplyPost?: boolean;
+};
+
+export const isAndroidThreadRootPost = ({
+    location,
+    postId,
+    rootId,
+    isReplyPost,
+}: AndroidThreadRootPostArgs) => {
+    if (!isAndroidThreadScreen(location)) {
+        return false;
+    }
+
+    if (postId !== undefined && rootId !== undefined) {
+        return postId === rootId;
+    }
+
+    return !isReplyPost;
+};

--- a/app/components/post_list/post/body/message/message.tsx
+++ b/app/components/post_list/post/body/message/message.tsx
@@ -8,6 +8,7 @@ import Animated from 'react-native-reanimated';
 
 import Markdown from '@components/markdown';
 import {isChannelMentions} from '@components/markdown/channel_mention/channel_mention';
+import {isAndroidThreadRootPost} from '@components/post_list/android_thread_scroll';
 import {Screens} from '@constants';
 import {usePostConfig} from '@context/post_config';
 import {useShowMoreAnimatedStyle} from '@hooks/show_more';
@@ -122,6 +123,41 @@ const Message = ({
         message = getPostTranslatedMessage(post.message, translation);
     }
 
+    const isAndroidThreadRoot = isAndroidThreadRootPost({location, isReplyPost});
+
+    const markdown = (
+        <Markdown
+            allowInlineActions={allowInlineActions}
+            baseTextStyle={style.message}
+            channelId={post.channelId}
+            channelMentions={channelMentions}
+            imagesMetadata={imagesMetadata}
+            isEdited={isEdited}
+            isReplyPost={isReplyPost}
+            isSearchResult={location === Screens.SEARCH}
+            layoutWidth={layoutWidth}
+            location={location}
+            postId={post.id}
+            value={message}
+            mentionKeys={mentionKeys}
+            highlightKeys={highlightKeys}
+            searchPatterns={searchPatterns}
+            theme={theme}
+            isUnsafeLinksPost={Boolean(post.props?.unsafe_links && post.props.unsafe_links !== '')}
+        />
+    );
+
+    if (isAndroidThreadRoot) {
+        return (
+            <View
+                style={[style.messageContainer, isPendingOrFailed && style.pendingPost]}
+                collapsable={false}
+            >
+                {markdown}
+            </View>
+        );
+    }
+
     return (
         <>
             <Animated.View style={animatedStyle}>
@@ -135,25 +171,7 @@ const Message = ({
                         style={[style.messageContainer, (isReplyPost && style.reply), (isPendingOrFailed && style.pendingPost)]}
                         onLayout={onLayout}
                     >
-                        <Markdown
-                            allowInlineActions={allowInlineActions}
-                            baseTextStyle={style.message}
-                            channelId={post.channelId}
-                            channelMentions={channelMentions}
-                            imagesMetadata={imagesMetadata}
-                            isEdited={isEdited}
-                            isReplyPost={isReplyPost}
-                            isSearchResult={location === Screens.SEARCH}
-                            layoutWidth={layoutWidth}
-                            location={location}
-                            postId={post.id}
-                            value={message}
-                            mentionKeys={mentionKeys}
-                            highlightKeys={highlightKeys}
-                            searchPatterns={searchPatterns}
-                            theme={theme}
-                            isUnsafeLinksPost={Boolean(post.props?.unsafe_links && post.props.unsafe_links !== '')}
-                        />
+                        {markdown}
                     </View>
                 </ScrollView>
             </Animated.View>

--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -12,6 +12,7 @@ import AgentPost from '@agents/components/agent_post';
 import {isAgentPost} from '@agents/utils';
 import CallsCustomMessage from '@calls/components/calls_custom_message';
 import {isCallsCustomMessage} from '@calls/utils';
+import {isAndroidThreadRootPost} from '@components/post_list/android_thread_scroll';
 import UnrevealedBurnOnReadPost from '@components/post_list/post/burn_on_read/unrevealed';
 import SystemAvatar from '@components/system_avatar';
 import SystemHeader from '@components/system_header';
@@ -295,8 +296,6 @@ const Post = ({
     const highlightSaved = isSaved && !skipSavedHeader;
     const hightlightPinned = post.isPinned && !skipPinnedHeader;
     const itemTestID = `${testID}.${post.id}`;
-    const rightColumnStyle: StyleProp<ViewStyle> = [styles.rightColumn, (Boolean(post.rootId) && isLastReply && styles.rightColumnPadding)];
-    const pendingPostStyle: StyleProp<ViewStyle> | undefined = isPendingOrFailed ? styles.pendingPost : undefined;
 
     let highlightedStyle: StyleProp<ViewStyle>;
     if (highlight) {
@@ -304,6 +303,15 @@ const Post = ({
     } else if ((highlightSaved || hightlightPinned) && highlightPinnedOrSaved) {
         highlightedStyle = styles.highlightPinnedOrSaved;
     }
+
+    const isAndroidThreadRoot = isAndroidThreadRootPost({location, postId: post.id, rootId});
+    const postContainerStyle = [
+        isAndroidThreadRoot ? {overflow: 'hidden' as const} : styles.postStyle,
+        style,
+        highlightedStyle,
+    ];
+    const rightColumnStyle: StyleProp<ViewStyle> = [styles.rightColumn, (Boolean(post.rootId) && isLastReply && styles.rightColumnPadding)];
+    const pendingPostStyle: StyleProp<ViewStyle> | undefined = isPendingOrFailed ? styles.pendingPost : undefined;
 
     let header: ReactNode;
     let postAvatar: ReactNode;
@@ -446,8 +454,9 @@ const Post = ({
     return (
         <View
             testID={testID}
-            style={[styles.postStyle, style, highlightedStyle]}
+            style={postContainerStyle}
             onLayout={onLayout}
+            collapsable={isAndroidThreadRoot ? false : undefined}
         >
             <TouchableHighlight
                 testID={itemTestID}

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -423,4 +423,60 @@ describe('components/post_list/PostList', () => {
 
         expect(fetchPostsSpy).not.toHaveBeenCalled();
     });
+
+    it('includes thread root post in list data on Android thread screen', () => {
+        const originalOS = Platform.OS;
+        Object.defineProperty(Platform, 'OS', {value: 'android'});
+
+        const rootPost = mockPostModel({id: 'root-post-id', createAt: 2000});
+        const replies = Array.from({length: 12}, (_, index) => mockPostModel({
+            id: `reply-${index}`,
+            createAt: 1000 + index,
+            rootId: 'root-post-id',
+        }));
+        const props = {
+            ...baseProps,
+            location: Screens.THREAD,
+            rootId: rootPost.id,
+            posts: [...replies, rootPost],
+        };
+        const {getByTestId} = renderWithEverything(
+            <PostList {...props}/>,
+            {database, serverUrl},
+        );
+        const flatList = getByTestId('post_list.flat_list');
+
+        expect(flatList.props.data.some((item: {type: string; value: {currentPost: {id: string}}}) => {
+            return item.type === 'post' && item.value.currentPost.id === rootPost.id;
+        })).toBe(true);
+        expect(flatList.props.data.some((item: {type: string}) => item.type === 'thread-overview')).toBe(true);
+
+        Object.defineProperty(Platform, 'OS', {value: originalOS});
+    });
+
+    it('merges contentContainerStyle on Android thread', () => {
+        const originalOS = Platform.OS;
+        Object.defineProperty(Platform, 'OS', {value: 'android'});
+
+        const props = {
+            ...baseProps,
+            location: Screens.THREAD,
+            rootId: 'root-post-id',
+            contentContainerStyle: {marginTop: 10},
+        };
+        const {getByTestId} = renderWithEverything(
+            <PostList {...props}/>,
+            {database, serverUrl},
+        );
+        const flatList = getByTestId('post_list.flat_list');
+
+        expect(flatList.props.contentContainerStyle).toEqual(
+            expect.arrayContaining([
+                {marginTop: 10},
+                expect.objectContaining({marginTop: 0}),
+            ]),
+        );
+
+        Object.defineProperty(Platform, 'OS', {value: originalOS});
+    });
 });

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {type ReactElement, useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {DeviceEventEmitter, type ListRenderItemInfo, Platform, type StyleProp, StyleSheet, type ViewStyle, type NativeSyntheticEvent, type NativeScrollEvent, type ViewToken} from 'react-native';
+import {DeviceEventEmitter, type ListRenderItemInfo, Platform, type StyleProp, StyleSheet, type ViewStyle, type NativeSyntheticEvent, type NativeScrollEvent, type ViewToken, useWindowDimensions} from 'react-native';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import {KeyboardState, useAnimatedKeyboard, useKeyboardState as useControllerKeyboardState} from 'react-native-keyboard-controller';
 import Animated, {scrollTo, useAnimatedProps, useAnimatedReaction, useAnimatedStyle, type AnimatedStyle} from 'react-native-reanimated';
@@ -30,6 +30,7 @@ import PostListPerformance from '@utils/performance/post_list_performance';
 import {getDateForDateLine, preparePostList} from '@utils/post_list';
 import {getTimezone} from '@utils/user';
 
+import {isAndroidThreadScreen} from './android_thread_scroll';
 import {INITIAL_BATCH_TO_RENDER, SCROLL_POSITION_CONFIG, VIEWABILITY_CONFIG} from './config';
 import MoreMessages from './more_messages';
 import ScrollToEndView from './scroll_to_end_view';
@@ -93,6 +94,7 @@ const PostList = ({
     appsEnabled,
     mmBlocksEnabled,
     channelId,
+    contentContainerStyle,
     currentUser,
     customEmojiNames,
     disablePullToRefresh,
@@ -119,6 +121,7 @@ const PostList = ({
     const {panGesture: emojiPickerGesture} = useInputAccessoryViewGesture();
     const insets = useSafeAreaInsets();
     const defaultHeaderHeight = useDefaultHeaderHeight();
+    const {height: windowHeight} = useWindowDimensions();
 
     // Derive values from currentUser
     const currentUserId = currentUser.id;
@@ -200,7 +203,7 @@ const PostList = ({
 
     // Progressive loading: start with 10 items, then add the rest after initial render
     // The remaining posts are loaded in trackInitialRenderMetrics when viewable items are detected
-    const [showAllPosts, setShowAllPosts] = useState(false);
+    const [showAllPosts, setShowAllPosts] = useState(isAndroidThreadScreen(location));
 
     const {orderedPosts, initialIndex} = useMemo(() => {
         const result = preparePostList(posts, lastViewedAt, showNewMessageLine, currentUserId, currentUsername, shouldShowJoinLeaveMessages, currentTimezone, location === Screens.THREAD, savedPostIds);
@@ -208,7 +211,9 @@ const PostList = ({
 
         let postsToShow = result;
         if (!showAllPosts) {
-            postsToShow = result.slice(0, INITIAL_BATCH_TO_RENDER);
+            // Thread root post lives at the end of the ordered list (visual top when inverted).
+            // Keep the tail so the root post is measured in the initial batch on Android.
+            postsToShow = isAndroidThreadScreen(location)? result.slice(-INITIAL_BATCH_TO_RENDER): result.slice(0, INITIAL_BATCH_TO_RENDER);
         }
 
         return {
@@ -255,7 +260,7 @@ const PostList = ({
         initialRenderTracked.current = false;
 
         // Reset showAllPosts when channel/thread changes to enable progressive loading for new channel
-        setShowAllPosts(false);
+        setShowAllPosts(isAndroidThreadScreen(location));
 
         return () => {
             // Print summary when switching away from this channel/thread
@@ -523,9 +528,15 @@ const PostList = ({
         [isKeyboardVisible],
     );
 
-    const contentContainerStyleWithMargin = useMemo(() => ({
-        marginTop: location === Screens.PERMALINK || !isEdgeToEdge ? 0 : postInputContainerHeight + emojiPickerPadding,
-    }), [location, emojiPickerPadding, postInputContainerHeight]);
+    const isAndroidThread = isAndroidThreadScreen(location);
+
+    const contentContainerStyleWithMargin = useMemo(() => [
+        contentContainerStyle,
+        {
+            marginTop: location === Screens.PERMALINK || !isEdgeToEdge ? 0 : postInputContainerHeight + emojiPickerPadding,
+            ...(isAndroidThread && {paddingBottom: windowHeight}),
+        },
+    ], [contentContainerStyle, isAndroidThread, location, emojiPickerPadding, postInputContainerHeight, windowHeight]);
 
     const animatedProps = useAnimatedProps(
         () => {
@@ -583,8 +594,8 @@ const PostList = ({
                             inverted={true}
                             refreshing={refreshing}
                             onRefresh={onRefresh}
-                            maintainVisibleContentPosition={SCROLL_POSITION_CONFIG}
-                            removeClippedSubviews={true}
+                            maintainVisibleContentPosition={isAndroidThread ? undefined : SCROLL_POSITION_CONFIG}
+                            removeClippedSubviews={!isAndroidThread}
                             style={styles.flex}
                             windowSize={10}
                         />


### PR DESCRIPTION
#### Summary
Fixes an Android-only bug where the thread view could not scroll far enough to reveal the root post header (avatar, username, timestamp) after browsing replies. The root post body appeared at the top of the list while the header remained clipped below the "replies" separator.

Changes apply only to Android thread screens:
- Add extra inverted-list scroll padding so the full root post can be brought into view
- Include the root post in the initial progressive-loading batch (tail slice)
- Skip nested scroll/max-height clipping on thread root posts to improve cell measurement
- Centralize Android thread detection in `android_thread_scroll.ts`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69538

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Pixel 7 emulator (Android 14)

#### Screenshots
Verified via mobile MCP: after scrolling through replies and back to top, root post header (nickmisasi, 10:28 AM) with full 84px avatar appears above the "12 replies" separator.

#### Release Note
```release-note
Fixed an issue on Android where the thread view could not scroll to the top of the root post, leaving the post header and avatar obscured.
```

Made with [Cursor](https://cursor.com)