### PR TITLE
[MM-69722] Add file provider to manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,15 @@
         <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
         <meta-data android:name="android.content.APP_RESTRICTIONS"
                    android:resource="@xml/app_restrictions" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_viewer_provider_paths" />
+        </provider>
       <activity
         android:name=".MainActivity"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"


### PR DESCRIPTION
#### Summary
Download logs and download files (no images nor videos, only files) from the gallery was not working. This was due to using a non defined authority to access them.

The research implies that this problem has been there forever, which is unexpected. Adding this provider to the manifest fix the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-69722

#### Release Note
```release-note
Fix issue on android where it was not possible to download logs or files from the gallery
```
