### PR TITLE
Fix shared value lifecycle in useKeyboardEvents

### DIFF
--- a/app/hooks/use_keyboard_events/index.test.ts
+++ b/app/hooks/use_keyboard_events/index.test.ts
@@ -19,13 +19,14 @@ jest.mock('react-native-keyboard-controller', () => ({
     useReanimatedFocusedInput: jest.fn(() => ({input: {value: null}})),
 }));
 
-// makeMutable must return a proper {value} object so the isRotating/wasRotating
-// shared values work when handler bodies execute synchronously in Jest.
-jest.mock('react-native-reanimated', () => ({
-    ...jest.requireActual('react-native-reanimated'),
-    makeMutable: <T>(init: T) => ({value: init}),
-    useSharedValue: <T>(init: T) => ({value: init}),
-}));
+jest.mock('react-native-reanimated', () => {
+    const ReactModule: typeof import('react') = require('react');
+
+    return {
+        ...jest.requireActual('react-native-reanimated'),
+        useSharedValue: <T, >(init: T) => ReactModule.useRef({value: init}).current,
+    };
+});
 
 type KeyboardEvent = {height: number; progress: number; target?: number | null};
 
@@ -278,6 +279,26 @@ describe('useKeyboardEvents', () => {
             handlers.onStart({height: 0, progress: 0, target: 1});
 
             // onEnd with height=0 — rotation is in progress, should suppress the END event
+            handlers.onEnd({height: 0, progress: 0, target: 1});
+
+            expect(ctx.processEvent).not.toHaveBeenCalledWith(
+                expect.objectContaining({type: StateMachineEventType.KEYBOARD_EVENT_END}),
+            );
+        });
+
+        it('should preserve rotation state across rerenders', () => {
+            const ctx = makeContext({currentStateValue: InputContainerStateType.KEYBOARD_OPEN});
+            let handlers: Record<string, (e: KeyboardEvent) => void> = {};
+            jest.mocked(useKeyboardHandler).mockImplementation((updatedHandlers) => {
+                handlers = updatedHandlers as typeof handlers;
+            });
+            const {rerender} = renderHook(
+                ({inputTag}) => useKeyboardEvents(ctx as never, inputTag),
+                {initialProps: {inputTag: 1}},
+            );
+
+            handlers.onStart({height: 0, progress: 0, target: 1});
+            rerender({inputTag: 1});
             handlers.onEnd({height: 0, progress: 0, target: 1});
 
             expect(ctx.processEvent).not.toHaveBeenCalledWith(

--- a/app/hooks/use_keyboard_events/index.ts
+++ b/app/hooks/use_keyboard_events/index.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {useKeyboardHandler, useReanimatedFocusedInput} from 'react-native-keyboard-controller';
-import {makeMutable, useSharedValue} from 'react-native-reanimated';
+import {useSharedValue} from 'react-native-reanimated';
 
 import {isAndroidEdgeToEdge} from '@constants/device';
 import {StateMachineEventType, InputContainerStateType} from '@keyboard';
@@ -10,7 +10,7 @@ import {StateMachineEventType, InputContainerStateType} from '@keyboard';
 import type {KeyboardStateContextReturn} from '@hooks/use_keyboard_state_context';
 
 export function useKeyboardEvents(context: KeyboardStateContextReturn, inputTag: number | null) {
-    const isRotating = makeMutable(false);
+    const isRotating = useSharedValue(false);
     const wasRotating = useSharedValue(false);
 
     // Destructure to avoid passing context object into worklets


### PR DESCRIPTION
### Summary

`useKeyboardEvents` created `isRotating` with `makeMutable(false)` directly in the hook body. Reanimated creates a new mutable value on every render in that usage, which can discard in-progress rotation state when `KeyboardStateProvider` rerenders between keyboard callbacks and causes unnecessary native allocation churn.

This switches `isRotating` to `useSharedValue(false)`, matching the existing `wasRotating` state directly below it. The shared value now keeps a stable identity across renders while retaining the same `.value` API and worklet behavior.

The regression test rerenders the hook between rotation start and end events and verifies that the rotation state is preserved.

Introduced in #9402.

### Related

This PR does not fix the native heap-corruption race tracked in #9726 and fixed upstream by [software-mansion/react-native-reanimated#9790](https://github.com/software-mansion/react-native-reanimated/pull/9790). It only removes one app-side source of unnecessary shared-value allocation and finalization churn.

### Testing

- Keyboard hook tests pass (21 tests).
- TypeScript and ESLint pass.
- Full Jest passes except for the existing Windows Intl Korean AM snapshot mismatch (`오전` versus `AM`).

```release-note
Fixed keyboard rotation handling when the message input rerenders.
```