### PR TITLE
fix: push notification navigation delay and stale in-app avatar

### DIFF
--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -96,7 +96,7 @@ export async function switchToChannel(serverUrl: string, channelId: string, team
                     }
                     DeviceEventEmitter.emit(NavigationConstants.NAVIGATION_HOME, Screens.CHANNEL);
                 } else {
-                    await NavigationStore.waitUntilScreenHasLoaded(Screens.HOME);
+                    await NavigationStore.waitUntilScreenHasLoaded(Screens.CHANNEL_LIST);
                     await dismissAllRoutesAndPopToScreen(Screens.CHANNEL);
                 }
 

--- a/app/actions/local/thread.ts
+++ b/app/actions/local/thread.ts
@@ -87,7 +87,7 @@ export const switchToThread = async (serverUrl: string, rootId: string, isFromNo
             }
 
             await navigateToRoot();
-            await NavigationStore.waitUntilScreenIsTop(Screens.HOME);
+            await NavigationStore.waitUntilScreenIsTop(Screens.CHANNEL_LIST);
             if (currentTeamId !== teamId && isTabletDevice) {
                 DeviceEventEmitter.emit(Navigation.NAVIGATION_HOME, Screens.GLOBAL_THREADS);
             }

--- a/app/screens/in_app_notification/icon.tsx
+++ b/app/screens/in_app_notification/icon.tsx
@@ -86,7 +86,7 @@ const NotificationIcon = ({author, enablePostIconOverride, fromWebhook, override
     );
 };
 
-const enhanced = withObservables([], ({database, senderId}: WithDatabaseArgs & {senderId: string}) => {
+const enhanced = withObservables(['senderId'], ({database, senderId}: WithDatabaseArgs & {senderId: string}) => {
     const author = observeUser(database, senderId);
 
     return {

--- a/app/store/navigation_store.ts
+++ b/app/store/navigation_store.ts
@@ -98,7 +98,7 @@ class NavigationStoreSingleton {
             setTimeout(() => {
                 subscription.unsubscribe();
                 resolve();
-            }, 3000);
+            }, 1000);
         });
     }
 
@@ -120,7 +120,7 @@ class NavigationStoreSingleton {
             setTimeout(() => {
                 subscription.unsubscribe();
                 resolve();
-            }, 30000);
+            }, 1000);
         });
     }
 
@@ -141,7 +141,7 @@ class NavigationStoreSingleton {
             setTimeout(() => {
                 subscription.unsubscribe();
                 resolve();
-            }, 3000);
+            }, 1000);
         });
     }
 


### PR DESCRIPTION
#### Summary
This was already fixed once: commit 00805cc1c / 72fb6aa33 ("Fix opening push notifications after migration (#9779)") removed waitUntilScreenIsTop entirely and switched both call sites to Screens.CHANNEL_LIST + waitUntilScreenHasLoaded.

Then commit 3acf3bec7 ("fix: app bugs surfaced by Detox RF migration (#9789)") reverted it, because it cherry-picked changes from an older migrate_RF_to_detox branch that predated the #9779 fix — reintroducing waitUntilScreenIsTop(Screens.HOME) in both files. That regression is present on HEAD right now

#### Ticket Link
reported here https://hub.mattermost.com/private-core/pl/a43q7tyy1bftin8opsxqng9eje

#### Release Note
```release-note
NONE
```
