### PR TITLE
Fix passing number strings through screen params

### DIFF
--- a/app/screens/navigation.test.ts
+++ b/app/screens/navigation.test.ts
@@ -8,6 +8,7 @@ import {Events, Navigation, Screens} from '@constants';
 import BottomSheetStore from '@store/bottom_sheet_store';
 import CallbackStore from '@store/callback_store';
 import {NavigationStore} from '@store/navigation_store';
+import {safeParseJSON} from '@utils/helpers';
 import {logError} from '@utils/log';
 
 import {
@@ -62,11 +63,23 @@ describe('navigation', () => {
     });
 
     describe('propsToParams', () => {
-        it('should convert string props to params unchanged', () => {
+        it('should JSON-encode string props to preserve type on round-trip', () => {
             const props = {name: 'test', id: '123'};
             const result = propsToParams(props);
 
-            expect(result).toEqual({name: 'test', id: '123'});
+            expect(result).toEqual({name: '"test"', id: '"123"'});
+        });
+
+        it('should preserve numeric strings through params round-trip', () => {
+            const props = {loginId: '123456789', password: '654321'};
+            const params = propsToParams(props);
+
+            const decoded = Object.keys(params).reduce((acc, key) => {
+                acc[key] = safeParseJSON(params[key]);
+                return acc;
+            }, {} as Record<string, unknown>);
+
+            expect(decoded).toEqual({loginId: '123456789', password: '654321'});
         });
 
         it('should convert non-string props to JSON strings', () => {
@@ -106,7 +119,7 @@ describe('navigation', () => {
             const result = propsToParams(props);
 
             expect(result).toEqual({
-                string: 'value',
+                string: '"value"',
                 number: '123',
                 boolean: 'false',
                 object: '{"nested":true}',
@@ -120,8 +133,8 @@ describe('navigation', () => {
             updateParams(props);
 
             expect(router.setParams).toHaveBeenCalledWith({
-                theme: 'dark',
-                userId: '123',
+                theme: '"dark"',
+                userId: '"123"',
             });
         });
 
@@ -147,7 +160,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(unauthenticated)/login',
-                params: {serverUrl: 'https://example.com'},
+                params: {serverUrl: '"https://example.com"'},
             });
         });
 
@@ -156,7 +169,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(add-server)/login',
-                params: {isModal: 'true', serverUrl: 'https://example.com'},
+                params: {isModal: 'true', serverUrl: '"https://example.com"'},
             });
         });
 
@@ -174,7 +187,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(bottom_sheet)/generic_bottom_sheet',
-                params: {content: 'test'},
+                params: {content: '"test"'},
             });
         });
 
@@ -183,7 +196,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(settings)',
-                params: {section: 'display'},
+                params: {section: '"display"'},
             });
         });
 
@@ -192,7 +205,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(authenticated)/channel',
-                params: {channelId: 'abc123'},
+                params: {channelId: '"abc123"'},
             });
         });
 
@@ -201,7 +214,7 @@ describe('navigation', () => {
 
             expect(router.replace).toHaveBeenCalledWith({
                 pathname: '/(unauthenticated)/login',
-                params: {serverUrl: 'https://example.com'},
+                params: {serverUrl: '"https://example.com"'},
             });
             expect(router.push).not.toHaveBeenCalled();
         });
@@ -235,7 +248,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/base/account',
-                params: {section: 'profile'},
+                params: {section: '"profile"'},
             });
         });
 
@@ -244,7 +257,7 @@ describe('navigation', () => {
 
             expect(router.replace).toHaveBeenCalledWith({
                 pathname: '/base/account',
-                params: {section: 'profile'},
+                params: {section: '"profile"'},
             });
             expect(router.push).not.toHaveBeenCalled();
         });
@@ -422,7 +435,7 @@ describe('navigation', () => {
             await dismissAllRoutesAndPopToScreen(Screens.CHANNEL, {channelId: 'abc'});
 
             expect(router.dismissTo).toHaveBeenCalledWith('/(authenticated)/channel');
-            expect(router.setParams).toHaveBeenCalledWith({channelId: 'abc'});
+            expect(router.setParams).toHaveBeenCalledWith({channelId: '"abc"'});
         });
 
         it('should reset to root and push when screen is not in stack', async () => {
@@ -433,7 +446,7 @@ describe('navigation', () => {
             expect(router.dismissTo).toHaveBeenCalledWith('/(authenticated)/(home)/channel_list');
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(authenticated)/channel',
-                params: {channelId: 'abc'},
+                params: {channelId: '"abc"'},
             });
         });
 
@@ -467,7 +480,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(settings)/settings_display',
-                params: {theme: 'dark'},
+                params: {theme: '"dark"'},
             });
         });
 
@@ -487,7 +500,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(channel_info)/channel_notification_preferences',
-                params: {channelId: 'ch123'},
+                params: {channelId: '"ch123"'},
             });
         });
 

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -15,7 +15,7 @@ import type {AvailableScreens} from '@typings/screens/navigation';
 
 export function propsToParams(props: any): Record<string, string> {
     return Object.keys(props || {}).reduce((params, key) => {
-        params[key] = typeof props[key] === 'string' ? props[key] : JSON.stringify(props[key]);
+        params[key] = JSON.stringify(props[key]);
         return params;
     }, {} as Record<string, string>);
 }

--- a/app/utils/navigation/index.test.ts
+++ b/app/utils/navigation/index.test.ts
@@ -113,10 +113,10 @@ describe('Navigation utils', () => {
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/pdf_viewer',
                 params: {
-                    title: 'document.pdf',
+                    title: '"document.pdf"',
                     allowPdfLinkNavigation: 'false',
-                    fileId: 'file123',
-                    filePath: '/path/to/document.pdf',
+                    fileId: '"file123"',
+                    filePath: '"/path/to/document.pdf"',
                 },
             });
         });
@@ -135,10 +135,10 @@ describe('Navigation utils', () => {
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/pdf_viewer',
                 params: {
-                    title: 'report.pdf',
+                    title: '"report.pdf"',
                     allowPdfLinkNavigation: 'false',
-                    fileId: 'file456',
-                    filePath: '/path/to/report.pdf',
+                    fileId: '"file456"',
+                    filePath: '"/path/to/report.pdf"',
                 },
             });
         });
@@ -156,10 +156,10 @@ describe('Navigation utils', () => {
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/pdf_viewer',
                 params: {
-                    title: 'image.pdf',
+                    title: '"image.pdf"',
                     allowPdfLinkNavigation: 'false',
-                    fileId: 'gallery123',
-                    filePath: '/gallery/image.pdf',
+                    fileId: '"gallery123"',
+                    filePath: '"/gallery/image.pdf"',
                 },
             });
         });
@@ -173,7 +173,7 @@ describe('Navigation utils', () => {
             expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.BLUR_AND_DISMISS_KEYBOARD);
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(bottom_sheet)/user_profile',
-                params: {userId: 'user123', username: 'johndoe'},
+                params: {userId: '"user123"', username: '"johndoe"'},
             });
         });
     });


### PR DESCRIPTION
#### Summary
When passing params through screens, we may end up in the situation where a string is made up of only numbers. In that case, the way we were handling the parameters, turn them into numbers, instead of keeping them as strings.

This can cause issues in login, when the id only contains numbers. The server received a number expecting a string, and fallback to the default empty string.

Using stringify for all values add a bit more of noise to the strings (the surrounding `"`), but deals with this issue.

#### Ticket Link
NONE

#### Release Note
```release-note
Fix issue when login with numeric only ids.
```
