### PR TITLE
Fix CRT-off consecutive reply bar 1px offset and vertical overlap.

### DIFF
--- a/app/components/post_list/post/body/body.tsx
+++ b/app/components/post_list/post/body/body.tsx
@@ -13,7 +13,7 @@ import {Screens} from '@constants';
 import StatusUpdatePost from '@playbooks/components/status_update_post';
 import {PLAYBOOKS_UPDATE_STATUS_POST_TYPE} from '@playbooks/constants/plugin';
 import {isEdited as postEdited, isPostFailed, hasInteractivePostContent} from '@utils/post';
-import {makeStyleSheetFromTheme} from '@utils/theme';
+import {blendColors, makeStyleSheetFromTheme} from '@utils/theme';
 
 import Acknowledgements from './acknowledgements';
 import AddMembers from './add_members';
@@ -64,8 +64,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         messageContainer: {width: '100%'},
         replyBar: {
-            backgroundColor: theme.centerChannelColor,
-            opacity: 0.1,
+            backgroundColor: blendColors(theme.centerChannelBg, theme.centerChannelColor, 0.1),
             marginLeft: 1,
             marginRight: 7,
             width: 3,

--- a/app/components/post_list/post/post.tsx
+++ b/app/components/post_list/post/post.tsx
@@ -3,7 +3,7 @@
 
 import React, {type ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
-import {Platform, type StyleProp, View, type ViewStyle, TouchableHighlight, type LayoutChangeEvent} from 'react-native';
+import {type StyleProp, View, type ViewStyle, TouchableHighlight, type LayoutChangeEvent} from 'react-native';
 
 import {removePost} from '@actions/local/post';
 import {showPermalink} from '@actions/remote/permalink';
@@ -17,6 +17,7 @@ import SystemAvatar from '@components/system_avatar';
 import SystemHeader from '@components/system_header';
 import {Screens} from '@constants';
 import {POST_TIME_TO_FAIL} from '@constants/post';
+import {PROFILE_PICTURE_SIZE} from '@constants/view';
 import {useKeyboardState} from '@context/keyboard_state';
 import {usePostConfig} from '@context/post_config';
 import {useServerUrl} from '@context/server';
@@ -93,7 +94,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         consecutivePostContainer: {
             marginBottom: 10,
             marginRight: 10,
-            marginLeft: Platform.select({ios: 34, android: 33}),
+            marginLeft: PROFILE_PICTURE_SIZE,
             marginTop: 10,
         },
         container: {flexDirection: 'row'},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- When Collapsed Reply Threads is off, consecutive same-user thread replies replace the avatar with a spacer
- That spacer used `marginLeft: 34/33` instead of the avatar width (`PROFILE_PICTURE_SIZE` = 32), shifting the reply bar by 1–2px
- Align the consecutive-post spacer to `PROFILE_PICTURE_SIZE` so reply bars line up with the first reply

## Root cause
In `app/components/post_list/post/post.tsx`, `consecutivePostContainer.marginLeft` was `Platform.select({ios: 34, android: 33})` while a normal avatar column is 32px wide. Webhook icon buffers (which those values appear to mirror) never apply on the consecutive path because `areConsecutivePosts` excludes webhooks.

## Testing
- tested on android emulator:

Horizontal line issue before: 

<img width="270" height="317" alt="image" src="https://github.com/user-attachments/assets/57b1ded9-150e-4732-8e7c-2472893aaddd" />

vertical line issue before:

<img width="187" height="165" alt="image" src="https://github.com/user-attachments/assets/4d8a770b-26e2-4b6b-b7ec-0e8291597a05" />

vertical line issue after:

<img width="251" height="309" alt="image" src="https://github.com/user-attachments/assets/bd96f246-d3b7-4420-8297-13775aaec382" />


```release-note
Fixed a 1-2px offset in consecutive threaded replies when CRT view is disabled.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54c32d27-094a-4e3d-a907-ea0f7052ca9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54c32d27-094a-4e3d-a907-ea0f7052ca9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

