### PR TITLE
Fix darker seam between consecutive reply bars when CRT is off

### DIFF
--- a/app/components/post_list/post/body/body.tsx
+++ b/app/components/post_list/post/body/body.tsx
@@ -13,7 +13,7 @@ import {Screens} from '@constants';
 import StatusUpdatePost from '@playbooks/components/status_update_post';
 import {PLAYBOOKS_UPDATE_STATUS_POST_TYPE} from '@playbooks/constants/plugin';
 import {isEdited as postEdited, isPostFailed, hasInteractivePostContent} from '@utils/post';
-import {makeStyleSheetFromTheme} from '@utils/theme';
+import {blendColors, makeStyleSheetFromTheme} from '@utils/theme';
 
 import Acknowledgements from './acknowledgements';
 import AddMembers from './add_members';
@@ -64,8 +64,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
         },
         messageContainer: {width: '100%'},
         replyBar: {
-            backgroundColor: theme.centerChannelColor,
-            opacity: 0.1,
+            backgroundColor: blendColors(theme.centerChannelBg, theme.centerChannelColor, 0.1),
             marginLeft: 1,
             marginRight: 7,
             width: 3,


### PR DESCRIPTION
## Summary
- Found while testing #bfcb86116 (the consecutive reply-bar horizontal offset fix) on an Android emulator: zooming into two consecutive same-thread replies (CRT off) showed a single device-pixel row that's visibly darker than the rest of the reply bar, right at the seam between the two posts.
- Root cause: each reply's `replyBar` view (`app/components/post_list/post/body/body.tsx`) is translucent (`opacity: 0.1`) and adjacent bars are laid out with zero gap so they read as one continuous line. At non-integer device pixel ratios, Yoga rounds each bar's box independently, so the two boxes can overlap by 1 native pixel — two translucent layers compositing there blend to a darker line.
- Fix: bake the blend against `theme.centerChannelBg` into an opaque `backgroundColor` via the existing `blendColors` util, instead of using the `opacity` style prop. Since the bar is now a solid color, an accidental 1px overlap between two bars just draws the same color twice — no visible seam.

## Test plan
- [x] Verified via `mobile-mcp` against a running Android emulator (Pixel 3a API 33): created consecutive thread replies with CRT off, sampled raw pixel values down the reply-bar column before/after the fix.
  - Before: `(236,237,238)` bar color with one row of `(219,221,223)` at the seam (visibly darker).
  - After: uniform `(235,236,237)` bar color across the full span, no darker row.
- [x] `npm run tsc` — clean
- [x] `npm run fix` (eslint) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)