### PR TITLE
Fix threads not loading after route parameter serialization change

### DIFF
--- a/app/components/markdown/markdown_code_block/index.test.tsx
+++ b/app/components/markdown/markdown_code_block/index.test.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fireEvent} from '@testing-library/react-native';
+import React from 'react';
+
+import {Preferences, Screens} from '@constants';
+import {navigateToScreen} from '@screens/navigation';
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import MarkdownCodeBlock from './index';
+
+jest.mock('@components/syntax_highlight', () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+}));
+
+jest.mock('@screens/navigation', () => ({
+    bottomSheet: jest.fn(),
+    dismissBottomSheet: jest.fn(),
+    navigateToScreen: jest.fn(),
+}));
+
+describe('MarkdownCodeBlock', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(global, 'requestAnimationFrame').mockImplementation((callback) => {
+            callback(0);
+            return 0;
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should mark code params as internally serialized', () => {
+        const code = '"hello"';
+        const {getByTestId} = renderWithIntlAndTheme(
+            <MarkdownCodeBlock
+                content={code}
+                language='json'
+                textStyle={{}}
+                theme={Preferences.THEMES.denim}
+            />,
+        );
+
+        fireEvent.press(getByTestId('markdown_code_block'));
+
+        expect(navigateToScreen).toHaveBeenCalledWith(Screens.CODE, expect.objectContaining({
+            code,
+            codeIsSerialized: true,
+        }));
+    });
+});

--- a/app/components/markdown/markdown_code_block/index.tsx
+++ b/app/components/markdown/markdown_code_block/index.tsx
@@ -100,6 +100,7 @@ const MarkdownCodeBlock = ({language = '', content, textStyle, theme}: MarkdownC
 
         const passProps = {
             code: content,
+            codeIsSerialized: true,
             language: getHighlightLanguageFromNameOrAlias(language),
             textStyle,
             title,
@@ -226,4 +227,3 @@ const MarkdownCodeBlock = ({language = '', content, textStyle, theme}: MarkdownC
 };
 
 export default MarkdownCodeBlock;
-

--- a/app/hooks/props_from_params.test.ts
+++ b/app/hooks/props_from_params.test.ts
@@ -173,6 +173,36 @@ describe('usePropsFromParams', () => {
         });
     });
 
+    it.each(['42', 'true', '{"key":"value"}', '[1,2,3]', '"hello"'])(
+        'should preserve the raw string param %s when the route requires a string',
+        (code) => {
+            mockUseLocalSearchParams.mockReturnValue({code});
+
+            const {result} = renderHook(() => usePropsFromParams<{code: string}>({
+                preserveStringParams: ['code'],
+            }));
+
+            expect(result.current).toEqual({code});
+        },
+    );
+
+    it.each(['hello', '"hello"'])(
+        'should decode the internally serialized string param %s exactly once',
+        (code) => {
+            mockUseLocalSearchParams.mockReturnValue({
+                code: JSON.stringify(code),
+                codeIsSerialized: 'true',
+            });
+
+            const {result} = renderHook(() => usePropsFromParams<{code: string}>({
+                encodedStringParamsMarker: 'codeIsSerialized',
+                preserveStringParams: ['code'],
+            }));
+
+            expect(result.current).toEqual({code});
+        },
+    );
+
     it('should handle complex nested objects', () => {
         mockUseLocalSearchParams.mockReturnValue({
             config: '{"user":{"id":"123","profile":{"name":"John","age":30}},"settings":{"theme":"dark"}}',

--- a/app/hooks/props_from_params.ts
+++ b/app/hooks/props_from_params.ts
@@ -5,14 +5,25 @@ import {useLocalSearchParams} from 'expo-router';
 
 import {safeParseJSON} from '@utils/helpers';
 
-export function usePropsFromParams<T>(): T {
+type PropsFromParamsOptions<T> = {
+    encodedStringParamsMarker?: string;
+    preserveStringParams?: Array<keyof T>;
+};
+
+export function usePropsFromParams<T>({encodedStringParamsMarker, preserveStringParams = []}: PropsFromParamsOptions<T> = {}): T {
     const params = useLocalSearchParams();
+    const stringParams = new Set(preserveStringParams.map(String));
+    const hasEncodedStringParams = Boolean(encodedStringParamsMarker && params[encodedStringParamsMarker] === 'true');
 
     // Convert URL params to props format that existing screen expects
     const props = {} as T;
     Object.keys(params).forEach((key) => {
+        if (key === encodedStringParamsMarker) {
+            return;
+        }
+
         const value = safeParseJSON(params[key]);
-        (props as Record<string, unknown>)[key] = value;
+        (props as Record<string, unknown>)[key] = stringParams.has(key) && !hasEncodedStringParams ? params[key] : value;
     });
 
     return props;

--- a/app/routes/(authenticated)/code.test.tsx
+++ b/app/routes/(authenticated)/code.test.tsx
@@ -61,6 +61,7 @@ describe('CodeRoute (MM-69330)', () => {
         ['a JSON object', '{"hello": "world"}'],
         ['a JSON array', '[1, 2, 3]'],
         ['a boolean literal', 'true'],
+        ['a JSON string literal', '"hello"'],
     ])('renders without crashing when the code block content is %s', (_label, code) => {
         mockUseLocalSearchParams.mockReturnValue({
             code,
@@ -82,6 +83,21 @@ describe('CodeRoute (MM-69330)', () => {
             language: 'javascript',
             textStyle: '{}',
             title: 'Code',
+        });
+
+        const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);
+
+        expect(getByText(code)).toBeTruthy();
+    });
+
+    it('removes the serializer layer without changing JSON-looking code', () => {
+        const code = '{"hello":"world"}';
+        mockUseLocalSearchParams.mockReturnValue({
+            code: JSON.stringify(code),
+            codeIsSerialized: 'true',
+            language: JSON.stringify('json'),
+            textStyle: JSON.stringify({}),
+            title: JSON.stringify('Code'),
         });
 
         const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);

--- a/app/routes/(authenticated)/code.tsx
+++ b/app/routes/(authenticated)/code.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
-
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
 import {usePropsFromParams} from '@hooks/props_from_params';
@@ -11,11 +9,10 @@ import CodeScreen, {type CodeScreenProps} from '@screens/code';
 export default function CodeRoute() {
     const theme = useTheme();
 
-    // `code` is read directly so it is never run through safeParseJSON: a code
-    // block whose text is valid JSON (e.g. "42", "{...}") would otherwise be
-    // coerced to a non-string and crash the Highlighter (MM-69330).
-    const {code} = useLocalSearchParams<{code: string}>();
-    const {title, ...props} = usePropsFromParams<Omit<CodeScreenProps, 'code'> & {title: string}>();
+    const {title, ...props} = usePropsFromParams<CodeScreenProps & {title: string}>({
+        encodedStringParamsMarker: 'codeIsSerialized',
+        preserveStringParams: ['code'],
+    });
 
     useNavigationHeader({
         showWhenPushed: true,
@@ -28,7 +25,6 @@ export default function CodeRoute() {
     return (
         <CodeScreen
             {...props}
-            code={code}
         />
     );
 }

--- a/app/routes/(authenticated)/thread.test.tsx
+++ b/app/routes/(authenticated)/thread.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import ThreadScreen from '@screens/thread';
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import ThreadRoute from './thread';
+
+const mockUseLocalSearchParams = jest.fn();
+const mockSetOptions = jest.fn();
+
+jest.mock('expo-router', () => ({
+    useLocalSearchParams: () => mockUseLocalSearchParams(),
+    useNavigation: () => ({
+        goBack: jest.fn(),
+        setOptions: mockSetOptions,
+    }),
+}));
+
+jest.mock('@context/server', () => ({
+    useServerUrl: () => 'https://example.com',
+}));
+
+jest.mock('@hooks/header', () => ({
+    useDefaultHeaderHeight: () => 44,
+}));
+
+jest.mock('@screens/thread', () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+}));
+
+describe('ThreadRoute', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should decode the serialized root post ID before rendering the thread', () => {
+        mockUseLocalSearchParams.mockReturnValue({
+            channelName: '"Town Square"',
+            rootId: '"6mjyxw4i3j8m9d7q2r5h"',
+        });
+
+        renderWithIntlAndTheme(<ThreadRoute/>);
+
+        expect(jest.mocked(ThreadScreen).mock.calls[0][0]).toEqual(expect.objectContaining({
+            rootId: '6mjyxw4i3j8m9d7q2r5h',
+            serverUrl: 'https://example.com',
+        }));
+    });
+});

--- a/app/routes/(authenticated)/thread.tsx
+++ b/app/routes/(authenticated)/thread.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams, useNavigation} from 'expo-router';
+import {useNavigation} from 'expo-router';
 import {useCallback, useEffect} from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 
@@ -9,6 +9,7 @@ import Header from '@components/navigation_header/header';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useDefaultHeaderHeight} from '@hooks/header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import ThreadScreen from '@screens/thread';
 
 import type {NativeStackHeaderProps} from '@react-navigation/native-stack';
@@ -30,7 +31,7 @@ export default function ThreadRoute() {
     const intl = useIntl();
     const serverUrl = useServerUrl();
     const defaultHeight = useDefaultHeaderHeight();
-    const {channelName, rootId, title: routeTitle} = useLocalSearchParams<{channelName: string; rootId: string; title?: string}>();
+    const {channelName, rootId, title: routeTitle} = usePropsFromParams<{channelName: string; rootId: string; title?: string}>();
 
     const title = routeTitle || intl.formatMessage(threadMessages.thread);
     const subtitle = channelName ? intl.formatMessage(threadMessages.threadIn, {channelName}) : undefined;

--- a/app/routes/(modals)/(settings)/about.test.tsx
+++ b/app/routes/(modals)/(settings)/about.test.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {useNavigationHeader} from '@hooks/navigation_header';
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import SettingsAboutRoute from './about';
+
+const mockUseLocalSearchParams = jest.fn();
+
+jest.mock('expo-router', () => ({
+    useLocalSearchParams: () => mockUseLocalSearchParams(),
+}));
+
+jest.mock('@hooks/navigation_header', () => ({
+    getHeaderOptions: jest.fn(() => ({})),
+    useNavigationHeader: jest.fn(),
+}));
+
+jest.mock('@screens/settings/about', () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+}));
+
+describe('SettingsAboutRoute', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should decode the serialized header title', () => {
+        mockUseLocalSearchParams.mockReturnValue({
+            headerTitle: '"About Mattermost"',
+        });
+
+        renderWithIntlAndTheme(<SettingsAboutRoute/>);
+
+        expect(jest.mocked(useNavigationHeader)).toHaveBeenCalledWith(expect.objectContaining({
+            headerOptions: expect.objectContaining({
+                headerTitle: 'About Mattermost',
+            }),
+        }));
+    });
+});

--- a/app/routes/(modals)/(settings)/about.tsx
+++ b/app/routes/(modals)/(settings)/about.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
-
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import SettingsAboutScreen from '@screens/settings/about';
 
 type Props = {
@@ -12,7 +11,7 @@ type Props = {
 };
 
 export default function SettingsAboutRoute() {
-    const {headerTitle} = useLocalSearchParams<Props>();
+    const {headerTitle} = usePropsFromParams<Props>();
     const theme = useTheme();
 
     useNavigationHeader({

--- a/app/routes/(modals)/(settings)/settings_display_timezone_select.test.tsx
+++ b/app/routes/(modals)/(settings)/settings_display_timezone_select.test.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import SettingsDisplayTimezoneSelectScreen from '@screens/settings/display_timezone_select';
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import SettingsDisplayTimezoneSelectRoute from './settings_display_timezone_select';
+
+const mockUseLocalSearchParams = jest.fn();
+
+jest.mock('expo-router', () => ({
+    useLocalSearchParams: () => mockUseLocalSearchParams(),
+}));
+
+jest.mock('@hooks/navigation_header', () => ({
+    getHeaderOptions: jest.fn(() => ({})),
+    useNavigationHeader: jest.fn(),
+}));
+
+jest.mock('@screens/settings/display_timezone_select', () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+}));
+
+describe('SettingsDisplayTimezoneSelectRoute', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should decode the serialized current timezone', () => {
+        mockUseLocalSearchParams.mockReturnValue({
+            currentTimezone: '"Europe/Warsaw"',
+        });
+
+        renderWithIntlAndTheme(<SettingsDisplayTimezoneSelectRoute/>);
+
+        expect(jest.mocked(SettingsDisplayTimezoneSelectScreen).mock.calls[0][0]).toEqual(expect.objectContaining({
+            currentTimezone: 'Europe/Warsaw',
+        }));
+    });
+});

--- a/app/routes/(modals)/(settings)/settings_display_timezone_select.tsx
+++ b/app/routes/(modals)/(settings)/settings_display_timezone_select.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
 import {useIntl} from 'react-intl';
 
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import SettingsDisplayTimezoneSelectScreen from '@screens/settings/display_timezone_select';
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export default function SettingsDisplayTimezoneSelectRoute() {
-    const {currentTimezone} = useLocalSearchParams<Props>();
+    const {currentTimezone} = usePropsFromParams<Props>();
     const intl = useIntl();
     const theme = useTheme();
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
The https://github.com/mattermost/mattermost-mobile/pull/9931 PR introduced a regression in thread rendering, as complained about in https://github.com/mattermost/mattermost-mobile/issues/9943 https://github.com/mattermost/mattermost-mobile/issues/9945 https://github.com/mattermost/mattermost-mobile/issues/9946

Instead of reverting this change, this PR fixes routes that were reading JSON-serialized navigation parameters without decoding them. The main issue was that some routes still accessed `useLocalSearchParams()` directly and as a result thread post IDs included literal quotation marks when passed to the database query.

This PR:
- retains the global JSON serializer and its numeric-string login fix
- migrates the thread, About, timezone and code-viewer routes to the centralized `usePropsFromParams()` decoder
- extends `usePropsFromParams()` so routes can explicitly preserve parameters as strings
- marks internally navigated code-viewer parameters so they are decoded exactly once
- preserves raw/deep-linked code snippets byte-for-byte, including values that look like
  JSON such as `42`, `true`, objects, arrays, and quoted strings
- adds a bunch of regression tests

As this is my first contribution, please be gentle - I tried to copy the conventions you use to the best of my abilities.

#### Ticket Link
N/A

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [x] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on Android 15/API 35 x86_64 emulator against a live MM instance.

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note

```
-->

```release-note
Fixed thread rendering after route parameter serialization change
```
