### PR TITLE
Fix: skip JSON.stringify for string screen params

### DIFF
--- a/app/screens/navigation.test.ts
+++ b/app/screens/navigation.test.ts
@@ -8,7 +8,6 @@ import {Events, Navigation, Screens} from '@constants';
 import BottomSheetStore from '@store/bottom_sheet_store';
 import CallbackStore from '@store/callback_store';
 import {NavigationStore} from '@store/navigation_store';
-import {safeParseJSON} from '@utils/helpers';
 import {logError} from '@utils/log';
 
 import {
@@ -63,23 +62,11 @@ describe('navigation', () => {
     });
 
     describe('propsToParams', () => {
-        it('should JSON-encode string props to preserve type on round-trip', () => {
+        it('should convert string props to params unchanged', () => {
             const props = {name: 'test', id: '123'};
             const result = propsToParams(props);
 
-            expect(result).toEqual({name: '"test"', id: '"123"'});
-        });
-
-        it('should preserve numeric strings through params round-trip', () => {
-            const props = {loginId: '123456789', password: '654321'};
-            const params = propsToParams(props);
-
-            const decoded = Object.keys(params).reduce((acc, key) => {
-                acc[key] = safeParseJSON(params[key]);
-                return acc;
-            }, {} as Record<string, unknown>);
-
-            expect(decoded).toEqual({loginId: '123456789', password: '654321'});
+            expect(result).toEqual({name: 'test', id: '123'});
         });
 
         it('should convert non-string props to JSON strings', () => {
@@ -119,7 +106,7 @@ describe('navigation', () => {
             const result = propsToParams(props);
 
             expect(result).toEqual({
-                string: '"value"',
+                string: 'value',
                 number: '123',
                 boolean: 'false',
                 object: '{"nested":true}',
@@ -133,8 +120,8 @@ describe('navigation', () => {
             updateParams(props);
 
             expect(router.setParams).toHaveBeenCalledWith({
-                theme: '"dark"',
-                userId: '"123"',
+                theme: 'dark',
+                userId: '123',
             });
         });
 
@@ -160,7 +147,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(unauthenticated)/login',
-                params: {serverUrl: '"https://example.com"'},
+                params: {serverUrl: 'https://example.com'},
             });
         });
 
@@ -169,7 +156,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(add-server)/login',
-                params: {isModal: 'true', serverUrl: '"https://example.com"'},
+                params: {isModal: 'true', serverUrl: 'https://example.com'},
             });
         });
 
@@ -187,7 +174,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(bottom_sheet)/generic_bottom_sheet',
-                params: {content: '"test"'},
+                params: {content: 'test'},
             });
         });
 
@@ -196,7 +183,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(settings)',
-                params: {section: '"display"'},
+                params: {section: 'display'},
             });
         });
 
@@ -205,7 +192,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(authenticated)/channel',
-                params: {channelId: '"abc123"'},
+                params: {channelId: 'abc123'},
             });
         });
 
@@ -214,7 +201,7 @@ describe('navigation', () => {
 
             expect(router.replace).toHaveBeenCalledWith({
                 pathname: '/(unauthenticated)/login',
-                params: {serverUrl: '"https://example.com"'},
+                params: {serverUrl: 'https://example.com'},
             });
             expect(router.push).not.toHaveBeenCalled();
         });
@@ -248,7 +235,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/base/account',
-                params: {section: '"profile"'},
+                params: {section: 'profile'},
             });
         });
 
@@ -257,7 +244,7 @@ describe('navigation', () => {
 
             expect(router.replace).toHaveBeenCalledWith({
                 pathname: '/base/account',
-                params: {section: '"profile"'},
+                params: {section: 'profile'},
             });
             expect(router.push).not.toHaveBeenCalled();
         });
@@ -435,7 +422,7 @@ describe('navigation', () => {
             await dismissAllRoutesAndPopToScreen(Screens.CHANNEL, {channelId: 'abc'});
 
             expect(router.dismissTo).toHaveBeenCalledWith('/(authenticated)/channel');
-            expect(router.setParams).toHaveBeenCalledWith({channelId: '"abc"'});
+            expect(router.setParams).toHaveBeenCalledWith({channelId: 'abc'});
         });
 
         it('should reset to root and push when screen is not in stack', async () => {
@@ -446,7 +433,7 @@ describe('navigation', () => {
             expect(router.dismissTo).toHaveBeenCalledWith('/(authenticated)/(home)/channel_list');
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(authenticated)/channel',
-                params: {channelId: '"abc"'},
+                params: {channelId: 'abc'},
             });
         });
 
@@ -480,7 +467,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(settings)/settings_display',
-                params: {theme: '"dark"'},
+                params: {theme: 'dark'},
             });
         });
 
@@ -500,7 +487,7 @@ describe('navigation', () => {
 
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/(channel_info)/channel_notification_preferences',
-                params: {channelId: '"ch123"'},
+                params: {channelId: 'ch123'},
             });
         });
 

--- a/app/screens/navigation.ts
+++ b/app/screens/navigation.ts
@@ -15,7 +15,7 @@ import type {AvailableScreens} from '@typings/screens/navigation';
 
 export function propsToParams(props: any): Record<string, string> {
     return Object.keys(props || {}).reduce((params, key) => {
-        params[key] = JSON.stringify(props[key]);
+        params[key] = typeof props[key] === 'string' ? props[key] : JSON.stringify(props[key]);
         return params;
     }, {} as Record<string, string>);
 }

--- a/app/utils/navigation/index.test.ts
+++ b/app/utils/navigation/index.test.ts
@@ -113,10 +113,10 @@ describe('Navigation utils', () => {
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/pdf_viewer',
                 params: {
-                    title: '"document.pdf"',
+                    title: 'document.pdf',
                     allowPdfLinkNavigation: 'false',
-                    fileId: '"file123"',
-                    filePath: '"/path/to/document.pdf"',
+                    fileId: 'file123',
+                    filePath: '/path/to/document.pdf',
                 },
             });
         });
@@ -135,10 +135,10 @@ describe('Navigation utils', () => {
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/pdf_viewer',
                 params: {
-                    title: '"report.pdf"',
+                    title: 'report.pdf',
                     allowPdfLinkNavigation: 'false',
-                    fileId: '"file456"',
-                    filePath: '"/path/to/report.pdf"',
+                    fileId: 'file456',
+                    filePath: '/path/to/report.pdf',
                 },
             });
         });
@@ -156,10 +156,10 @@ describe('Navigation utils', () => {
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(modals)/pdf_viewer',
                 params: {
-                    title: '"image.pdf"',
+                    title: 'image.pdf',
                     allowPdfLinkNavigation: 'false',
-                    fileId: '"gallery123"',
-                    filePath: '"/gallery/image.pdf"',
+                    fileId: 'gallery123',
+                    filePath: '/gallery/image.pdf',
                 },
             });
         });
@@ -173,7 +173,7 @@ describe('Navigation utils', () => {
             expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.BLUR_AND_DISMISS_KEYBOARD);
             expect(router.push).toHaveBeenCalledWith({
                 pathname: '/(bottom_sheet)/user_profile',
-                params: {userId: '"user123"', username: '"johndoe"'},
+                params: {userId: 'user123', username: 'johndoe'},
             });
         });
     });


### PR DESCRIPTION
## Summary

Restores the string-pass-through in `propsToParams` that #9931 removed. When every param value (including strings) is `JSON.stringify`'d, `expo-router` consumers that read `useLocalSearchParams` as raw strings end up with literally-quoted values (e.g. `rootId` `abc123` -> `"abc123"`), which breaks the receiving screen.

### Impact

The thread screen goes completely blank after opening any thread:
- The extra-quoted `rootId` misses in `observePost` → `rootPost` is `undefined` → `<ThreadContent>` is never rendered → no root post, no reply list, no post draft.
- The header subtitle shows `in "channel-name"` (literal quote characters), which is the visual fingerprint of the JSON-encoded value flowing through unchanged.

Screenshots of the broken state (v2.42.1):

<!-- The bug reporter had three screenshots showing this: attach if needed -->

### What this PR does

Reverts:
- The one-line change in `app/screens/navigation.ts`.
- The companion test expectation changes in `app/screens/navigation.test.ts` and `app/utils/navigation/index.test.ts`.

### Follow-up

The numeric-string-round-trip issue #9931 was addressing is real, but should be fixed on the receive side (decoding via `safeParseJSON` in a helper wrapper around `useLocalSearchParams`) rather than by JSON-encoding every string on the send side without an audit of all route consumers. A follow-up PR will introduce that helper and migrate the routes.

## Test plan

- [ ] `npm run tsc` passes.
- [ ] `npm test -- app/screens/navigation.test.ts app/utils/navigation/index.test.ts` passes.
- [ ] Manually verified on Android: build the APK from this branch, install, open any thread — root post + replies + post draft all render, and the header subtitle no longer has surrounding quote characters.

Made with [Cursor](https://cursor.com)