### PR TITLE
Route through usePropsFromParams for remaining stragglers

### DIFF
--- a/app/routes/(authenticated)/code.test.tsx
+++ b/app/routes/(authenticated)/code.test.tsx
@@ -33,7 +33,8 @@ jest.mock('react-syntax-highlighter/create-element', () => ({
 }));
 
 // Mock expo-router with just the exports the route + screen use, so each test
-// can feed the route its params via useLocalSearchParams.
+// can feed the route its params via useLocalSearchParams. Values match what
+// propsToParams produces in production: JSON-encoded strings.
 const mockUseLocalSearchParams = jest.fn();
 jest.mock('expo-router', () => ({
     useLocalSearchParams: () => mockUseLocalSearchParams(),
@@ -52,10 +53,10 @@ describe('CodeRoute (MM-69330)', () => {
     });
 
     // Regression: tapping a code block whose text happens to be valid JSON
-    // (e.g. "42", "{...}", "true") crashed the app. `usePropsFromParams` ran
-    // `safeParseJSON` over every param, so `code` was parsed from a string into
-    // a number/object/boolean. `Highlighter` then called `code.split('\n')` on a
-    // non-string value, throwing "code.split is not a function".
+    // (e.g. "42", "{...}", "true") used to crash the Highlighter because
+    // `safeParseJSON` coerced the string into a number/object/boolean.
+    // Now that propsToParams always JSON-encodes on the send side, decoding
+    // '"42"' with safeParseJSON produces the string '42', preserving type.
     it.each([
         ['a bare number', '42'],
         ['a JSON object', '{"hello": "world"}'],
@@ -63,10 +64,10 @@ describe('CodeRoute (MM-69330)', () => {
         ['a boolean literal', 'true'],
     ])('renders without crashing when the code block content is %s', (_label, code) => {
         mockUseLocalSearchParams.mockReturnValue({
-            code,
-            language: 'json',
-            textStyle: '{}',
-            title: 'Code',
+            code: JSON.stringify(code),
+            language: JSON.stringify('json'),
+            textStyle: JSON.stringify({}),
+            title: JSON.stringify('Code'),
         });
 
         const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);
@@ -78,10 +79,10 @@ describe('CodeRoute (MM-69330)', () => {
     it('renders plain (non-JSON) code without crashing', () => {
         const code = 'const greeting = "hello";';
         mockUseLocalSearchParams.mockReturnValue({
-            code,
-            language: 'javascript',
-            textStyle: '{}',
-            title: 'Code',
+            code: JSON.stringify(code),
+            language: JSON.stringify('javascript'),
+            textStyle: JSON.stringify({}),
+            title: JSON.stringify('Code'),
         });
 
         const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);

--- a/app/routes/(authenticated)/code.tsx
+++ b/app/routes/(authenticated)/code.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
-
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
 import {usePropsFromParams} from '@hooks/props_from_params';
@@ -10,12 +8,7 @@ import CodeScreen, {type CodeScreenProps} from '@screens/code';
 
 export default function CodeRoute() {
     const theme = useTheme();
-
-    // `code` is read directly so it is never run through safeParseJSON: a code
-    // block whose text is valid JSON (e.g. "42", "{...}") would otherwise be
-    // coerced to a non-string and crash the Highlighter (MM-69330).
-    const {code} = useLocalSearchParams<{code: string}>();
-    const {title, ...props} = usePropsFromParams<Omit<CodeScreenProps, 'code'> & {title: string}>();
+    const {code, title, ...props} = usePropsFromParams<CodeScreenProps & {title: string}>();
 
     useNavigationHeader({
         showWhenPushed: true,

--- a/app/routes/(authenticated)/thread.tsx
+++ b/app/routes/(authenticated)/thread.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams, useNavigation} from 'expo-router';
+import {useNavigation} from 'expo-router';
 import {useCallback, useEffect} from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 
@@ -9,6 +9,7 @@ import Header from '@components/navigation_header/header';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useDefaultHeaderHeight} from '@hooks/header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import ThreadScreen from '@screens/thread';
 
 import type {NativeStackHeaderProps} from '@react-navigation/native-stack';
@@ -30,7 +31,7 @@ export default function ThreadRoute() {
     const intl = useIntl();
     const serverUrl = useServerUrl();
     const defaultHeight = useDefaultHeaderHeight();
-    const {channelName, rootId, title: routeTitle} = useLocalSearchParams<{channelName: string; rootId: string; title?: string}>();
+    const {channelName, rootId, title: routeTitle} = usePropsFromParams<{channelName: string; rootId: string; title?: string}>();
 
     const title = routeTitle || intl.formatMessage(threadMessages.thread);
     const subtitle = channelName ? intl.formatMessage(threadMessages.threadIn, {channelName}) : undefined;

--- a/app/routes/(modals)/(settings)/about.tsx
+++ b/app/routes/(modals)/(settings)/about.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
-
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import SettingsAboutScreen from '@screens/settings/about';
 
 type Props = {
@@ -12,7 +11,7 @@ type Props = {
 };
 
 export default function SettingsAboutRoute() {
-    const {headerTitle} = useLocalSearchParams<Props>();
+    const {headerTitle} = usePropsFromParams<Props>();
     const theme = useTheme();
 
     useNavigationHeader({

--- a/app/routes/(modals)/(settings)/settings_display_timezone_select.tsx
+++ b/app/routes/(modals)/(settings)/settings_display_timezone_select.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
 import {useIntl} from 'react-intl';
 
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import SettingsDisplayTimezoneSelectScreen from '@screens/settings/display_timezone_select';
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export default function SettingsDisplayTimezoneSelectRoute() {
-    const {currentTimezone} = useLocalSearchParams<Props>();
+    const {currentTimezone} = usePropsFromParams<Props>();
     const intl = useIntl();
     const theme = useTheme();
 


### PR DESCRIPTION
## Summary

Four route files still consume `useLocalSearchParams` directly, bypassing the `safeParseJSON` decode that every other route already uses via `usePropsFromParams`. Combined with `propsToParams` unconditionally JSON-encoding every prop (introduced in #9931), that means their string params arrive with literal quote characters embedded (e.g. `rootId` `abc123` → `"abc123"`).

This PR migrates the four holdouts so every route decodes what the send side encoded — closing the symmetry.

### Files migrated

| File | Symptom before this PR |
|---|---|
| `app/routes/(authenticated)/thread.tsx` | `rootId` misses in `observePost`, `rootPost` stays `undefined`, `ThreadContent` never renders. User sees a blank thread with subtitle `in "channel name"` (literal quotes). Fixed by hotfix #9948 for release, this closes the loop on main. |
| `app/routes/(authenticated)/code.tsx` | Code viewer renders content with outer quotes and escaped inner quotes/backslashes. The MM-69330 workaround (bypassing the hook to keep `code` as a string) is obsolete now that `propsToParams` always JSON-encodes: `safeParseJSON('"42"')` returns the string `'42'`, not the number `42`. |
| `app/routes/(modals)/(settings)/about.tsx` | `headerTitle` displayed in the nav header includes literal quotes. |
| `app/routes/(modals)/(settings)/settings_display_timezone_select.tsx` | `currentTimezone` compared against the DB value fails to match; user's current timezone is not highlighted in the selector. |

### Test changes

`code.test.tsx` previously fed the route raw string params (`{code: '42', ...}`) to simulate the pre-#9931 world. This PR updates it to feed JSON-encoded params (`{code: '"42"', ...}`), which is what `propsToParams` actually produces in production. The MM-69330 regression coverage still exercises the same scenario: a code block whose content is valid JSON must reach the viewer as a string.

All 20 tests in `code.test.tsx` + `props_from_params.test.ts` pass; TypeScript is clean.

### Blast radius

`useLocalSearchParams` is no longer called by any route file in the app. The only remaining callers are the hook implementation itself (`app/hooks/props_from_params.ts`) and jest.mock declarations in test files.

## Test plan

- [x] `npm run tsc` clean.
- [x] `code.test.tsx` + `props_from_params.test.ts` green (20 tests).
- [ ] Manually verified on Android debug build: open a thread — root post + replies + draft render, subtitle has no literal quote characters.
- [ ] Manually verified on Android debug build: tap a code block whose content is `42` — the viewer displays `42`, not `"42"`.
- [ ] Manually verified on Android debug build: open Settings → About — the header title shows correctly without literal quotes.
- [ ] Manually verified on Android debug build: open Settings → Display → Timezone — the current timezone is preselected/highlighted.

Made with [Cursor](https://cursor.com)