### PR TITLE
Route through usePropsFromParams for remaining stragglers (#9949) (release-2.42)

### DIFF
--- a/app/routes/(authenticated)/code.test.tsx
+++ b/app/routes/(authenticated)/code.test.tsx
@@ -33,7 +33,8 @@ jest.mock('react-syntax-highlighter/create-element', () => ({
 }));
 
 // Mock expo-router with just the exports the route + screen use, so each test
-// can feed the route its params via useLocalSearchParams.
+// can feed the route its params via useLocalSearchParams. Values match what
+// propsToParams produces in production: JSON-encoded strings.
 const mockUseLocalSearchParams = jest.fn();
 jest.mock('expo-router', () => ({
     useLocalSearchParams: () => mockUseLocalSearchParams(),
@@ -52,10 +53,10 @@ describe('CodeRoute (MM-69330)', () => {
     });
 
     // Regression: tapping a code block whose text happens to be valid JSON
-    // (e.g. "42", "{...}", "true") crashed the app. `usePropsFromParams` ran
-    // `safeParseJSON` over every param, so `code` was parsed from a string into
-    // a number/object/boolean. `Highlighter` then called `code.split('\n')` on a
-    // non-string value, throwing "code.split is not a function".
+    // (e.g. "42", "{...}", "true") used to crash the Highlighter because
+    // `safeParseJSON` coerced the string into a number/object/boolean.
+    // Now that propsToParams always JSON-encodes on the send side, decoding
+    // '"42"' with safeParseJSON produces the string '42', preserving type.
     it.each([
         ['a bare number', '42'],
         ['a JSON object', '{"hello": "world"}'],
@@ -63,10 +64,10 @@ describe('CodeRoute (MM-69330)', () => {
         ['a boolean literal', 'true'],
     ])('renders without crashing when the code block content is %s', (_label, code) => {
         mockUseLocalSearchParams.mockReturnValue({
-            code,
-            language: 'json',
-            textStyle: '{}',
-            title: 'Code',
+            code: JSON.stringify(code),
+            language: JSON.stringify('json'),
+            textStyle: JSON.stringify({}),
+            title: JSON.stringify('Code'),
         });
 
         const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);
@@ -78,10 +79,10 @@ describe('CodeRoute (MM-69330)', () => {
     it('renders plain (non-JSON) code without crashing', () => {
         const code = 'const greeting = "hello";';
         mockUseLocalSearchParams.mockReturnValue({
-            code,
-            language: 'javascript',
-            textStyle: '{}',
-            title: 'Code',
+            code: JSON.stringify(code),
+            language: JSON.stringify('javascript'),
+            textStyle: JSON.stringify({}),
+            title: JSON.stringify('Code'),
         });
 
         const {getByText} = renderWithIntlAndTheme(<CodeRoute/>);

--- a/app/routes/(authenticated)/code.tsx
+++ b/app/routes/(authenticated)/code.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
-
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
 import {usePropsFromParams} from '@hooks/props_from_params';
@@ -10,12 +8,7 @@ import CodeScreen, {type CodeScreenProps} from '@screens/code';
 
 export default function CodeRoute() {
     const theme = useTheme();
-
-    // `code` is read directly so it is never run through safeParseJSON: a code
-    // block whose text is valid JSON (e.g. "42", "{...}") would otherwise be
-    // coerced to a non-string and crash the Highlighter (MM-69330).
-    const {code} = useLocalSearchParams<{code: string}>();
-    const {title, ...props} = usePropsFromParams<Omit<CodeScreenProps, 'code'> & {title: string}>();
+    const {code, title, ...props} = usePropsFromParams<CodeScreenProps & {title: string}>();
 
     useNavigationHeader({
         showWhenPushed: true,

--- a/app/routes/(authenticated)/thread.tsx
+++ b/app/routes/(authenticated)/thread.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams, useNavigation} from 'expo-router';
+import {useNavigation} from 'expo-router';
 import {useCallback, useEffect} from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 import {Platform} from 'react-native';
@@ -10,6 +10,7 @@ import NavigationButton from '@components/navigation_button';
 import NavigationHeaderTitle from '@components/navigation_header_title';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import ThreadScreen from '@screens/thread';
 
 const threadMessages = defineMessages({
@@ -28,7 +29,7 @@ export default function ThreadRoute() {
     const theme = useTheme();
     const intl = useIntl();
     const serverUrl = useServerUrl();
-    const {channelName, rootId, title: routeTitle} = useLocalSearchParams<{channelName: string; rootId: string; title?: string}>();
+    const {channelName, rootId, title: routeTitle} = usePropsFromParams<{channelName: string; rootId: string; title?: string}>();
 
     const title = routeTitle || intl.formatMessage(threadMessages.thread);
     const subtitle = channelName ? intl.formatMessage(threadMessages.threadIn, {channelName}) : undefined;

--- a/app/routes/(modals)/(settings)/about.tsx
+++ b/app/routes/(modals)/(settings)/about.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
-
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import SettingsAboutScreen from '@screens/settings/about';
 
 type Props = {
@@ -12,7 +11,7 @@ type Props = {
 };
 
 export default function SettingsAboutRoute() {
-    const {headerTitle} = useLocalSearchParams<Props>();
+    const {headerTitle} = usePropsFromParams<Props>();
     const theme = useTheme();
 
     useNavigationHeader({

--- a/app/routes/(modals)/(settings)/settings_display_timezone_select.tsx
+++ b/app/routes/(modals)/(settings)/settings_display_timezone_select.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useLocalSearchParams} from 'expo-router';
 import {useIntl} from 'react-intl';
 
 import {useTheme} from '@context/theme';
 import {getHeaderOptions, useNavigationHeader} from '@hooks/navigation_header';
+import {usePropsFromParams} from '@hooks/props_from_params';
 import SettingsDisplayTimezoneSelectScreen from '@screens/settings/display_timezone_select';
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export default function SettingsDisplayTimezoneSelectRoute() {
-    const {currentTimezone} = useLocalSearchParams<Props>();
+    const {currentTimezone} = usePropsFromParams<Props>();
     const intl = useIntl();
     const theme = useTheme();
 


### PR DESCRIPTION
Cherry-pick of #9949 (9a40cad) onto `release-2.42` for the v2.42.2 hotfix.

Fixes MM-69330: threads (and three other routes — code viewer, About, timezone picker) appeared blank / corrupted after #9931 changed `propsToParams` to unconditionally `JSON.stringify` every param. Those four routes were still consuming `useLocalSearchParams` directly instead of the decoding `usePropsFromParams` hook, so their string params arrived with literal quote characters embedded (e.g. `rootId "abc123"` → `'"abc123"'`), breaking DB lookups and rendering.

Migrating all four routes to `usePropsFromParams` closes the symmetry: every param is JSON-encoded on send and JSON-decoded on receive.

## Conflict resolution note

`thread.tsx` had a trivial conflict because a later `main`-only feature commit (`e18fc6921`, MM-68208 banners) added a `useDefaultHeaderHeight` import + call. That commit was never cherry-picked to `release-2.42`, so this cherry-pick keeps `thread.tsx` on `release-2.42` as it was in v2.42.1, changing only:

- `useLocalSearchParams` → `usePropsFromParams` in the import from `expo-router` / `@hooks/props_from_params`
- the hook call itself

Everything else applies cleanly.

## Release note

```release-note
Fixed an issue where threads appeared blank when opened, and other screens (code viewer, About, timezone picker) received corrupted parameters.
```

Cherry-picked from #9949 (9a40cad748965717fe089456c0c192006d0396eb).

Made with [Cursor](https://cursor.com)