### PR TITLE
Update supported ESR version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mattermost Mobile v2
 
-- **Minimum Server versions:** Current ESR version (10.11.0+)
+- **Minimum Server versions:** Current ESR version (11.7.0+)
 - **Supported iOS versions:** 16.0+
 - **Supported Android versions:** 7.0+
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ If your app is working properly, you should see a grey “Connecting…” bar t
 If you are seeing this message all the time, and your internet connection seems fine: 
 
 Ask your server administrator if the server uses NGINX or another webserver as a reverse proxy. If so, they should check that it is configured correctly for [supporting the websocket connection for APIv4 endpoints](https://docs.mattermost.com/install/install-ubuntu-1604.html#configuring-nginx-as-a-proxy-for-mattermost-server). 
+

--- a/README.md
+++ b/README.md
@@ -70,4 +70,3 @@ If your app is working properly, you should see a grey “Connecting…” bar t
 If you are seeing this message all the time, and your internet connection seems fine: 
 
 Ask your server administrator if the server uses NGINX or another webserver as a reverse proxy. If so, they should check that it is configured correctly for [supporting the websocket connection for APIv4 endpoints](https://docs.mattermost.com/install/install-ubuntu-1604.html#configuring-nginx-as-a-proxy-for-mattermost-server). 
-

--- a/app/constants/supported_server.ts
+++ b/app/constants/supported_server.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export const MIN_REQUIRED_VERSION = '9.11.0';
-export const FULL_VERSION = '10.11.0';
-export const MAJOR_VERSION = 10;
-export const MIN_VERSION = 11;
+export const MIN_REQUIRED_VERSION = '10.11.0';
+export const FULL_VERSION = '11.7.0';
+export const MAJOR_VERSION = 11;
+export const MIN_VERSION = 7;
 export const PATCH_VERSION = 0;
 
 export default {

--- a/app/constants/supported_server.ts
+++ b/app/constants/supported_server.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export const MIN_REQUIRED_VERSION = '10.11.0';
+export const MIN_REQUIRED_VERSION = '9.11.0';
 export const FULL_VERSION = '11.7.0';
 export const MAJOR_VERSION = 11;
 export const MIN_VERSION = 7;

--- a/app/managers/global_event_handler.test.ts
+++ b/app/managers/global_event_handler.test.ts
@@ -6,6 +6,7 @@ import {Alert, DeviceEventEmitter} from 'react-native';
 import {switchToChannelById} from '@actions/remote/channel';
 import {batchTeamThreadSync} from '@actions/remote/thread';
 import {Events, Device} from '@constants';
+import {FULL_VERSION} from '@constants/supported_server';
 import DatabaseManager from '@database/manager';
 import {getServerCredentials} from '@init/credentials';
 import {getActiveServerUrl} from '@queries/app/servers';
@@ -40,7 +41,8 @@ describe('GlobalEventHandler', () => {
 
     describe('onServerVersionChanged', () => {
         it('should not show alert when version meets minimum requirement', async () => {
-            await GlobalEventHandler.onServerVersionChanged({serverUrl: 'http://server.com', serverVersion: '10.0.0'});
+            // Use the current supported full version so this test survives future minimum-version bumps
+            await GlobalEventHandler.onServerVersionChanged({serverUrl: 'http://server.com', serverVersion: FULL_VERSION});
             expect(Alert.alert).not.toHaveBeenCalled();
         });
 

--- a/app/managers/global_event_handler.test.ts
+++ b/app/managers/global_event_handler.test.ts
@@ -6,7 +6,6 @@ import {Alert, DeviceEventEmitter} from 'react-native';
 import {switchToChannelById} from '@actions/remote/channel';
 import {batchTeamThreadSync} from '@actions/remote/thread';
 import {Events, Device} from '@constants';
-import {FULL_VERSION} from '@constants/supported_server';
 import DatabaseManager from '@database/manager';
 import {getServerCredentials} from '@init/credentials';
 import {getActiveServerUrl} from '@queries/app/servers';
@@ -41,8 +40,7 @@ describe('GlobalEventHandler', () => {
 
     describe('onServerVersionChanged', () => {
         it('should not show alert when version meets minimum requirement', async () => {
-            // Use the current supported full version so this test survives future minimum-version bumps
-            await GlobalEventHandler.onServerVersionChanged({serverUrl: 'http://server.com', serverVersion: FULL_VERSION});
+            await GlobalEventHandler.onServerVersionChanged({serverUrl: 'http://server.com', serverVersion: '10.0.0'});
             expect(Alert.alert).not.toHaveBeenCalled();
         });
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Requires Mattermost Server v10.11.0+. Older servers may not be able to connect or have unexpected behavior.
+Requires Mattermost Server v11.7.0+. Older servers may not be able to connect or have unexpected behavior.
 
 -------
 

--- a/fastlane/metadata/changelog
+++ b/fastlane/metadata/changelog
@@ -1,4 +1,4 @@
-This version is compatible with Mattermost servers v10.11.0+.
+This version is compatible with Mattermost servers v11.7.0+.
 
 Please see [changelog](https://docs.mattermost.com/administration/mobile-changelog.html) for full release notes. If you're interested in helping beta test upcoming versions before they are released, please see our [documentation](https://github.com/mattermost/mattermost-mobile#testing).
 


### PR DESCRIPTION
QA Test Steps:
1. Connect to a server with a version lower than ESR (e.g. v10.10). Expected: Prompt to upgrade the server is received.
2. Connect to a server with a version equal to ESR (v10.11). Expected: Prompt to upgrade the server is not received.
3. Connect to a server with a version greater than ESR (e.g. v10.12). Expected: Prompt to upgrade the server is not received.

```release-note
Updated minimum supported version to v11.7.0.
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfEWUrN4ixMD9oQGDc4DK8)_