### PR TITLE
feat(drafts): Phase 2 — API DTOs, REST client, normalization, capability

### DIFF
--- a/app/client/rest/base.ts
+++ b/app/client/rest/base.ts
@@ -223,6 +223,22 @@ export default class ClientBase extends ClientTracking {
         return `${this.getPostsRoute()}/schedule`;
     }
 
+    getDraftsRoute() {
+        return `${this.urlVersion}/drafts`;
+    }
+
+    getUserTeamDraftsRoute(userId: string, teamId: string) {
+        return `${this.getUserRoute(userId)}/teams/${teamId}/drafts`;
+    }
+
+    getUserChannelDraftsRoute(userId: string, channelId: string) {
+        return `${this.getUserRoute(userId)}/channels/${channelId}/drafts`;
+    }
+
+    getUserThreadDraftRoute(userId: string, channelId: string, rootId: string) {
+        return `${this.getUserChannelDraftsRoute(userId, channelId)}/${rootId}`;
+    }
+
     getUserCustomProfileAttributesRoute(userId: string) {
         return `${this.getUsersRoute()}/${userId}/custom_profile_attributes`;
     }

--- a/app/client/rest/drafts.test.ts
+++ b/app/client/rest/drafts.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import TestHelper from '@test/test_helper';
+
+import type ClientBase from './base';
+import type {ClientDraftsMix} from './drafts';
+
+describe('ClientDrafts', () => {
+    let client: ClientDraftsMix & ClientBase;
+    const draft: DraftUpsertRequest = {
+        channel_id: 'channel_id',
+        root_id: '',
+        message: 'draft message',
+        type: '',
+        props: {},
+        file_ids: [],
+    };
+
+    beforeAll(() => {
+        client = TestHelper.createClient();
+        client.doFetch = jest.fn();
+    });
+
+    test('getDrafts', async () => {
+        const teamId = 'team_id';
+        const groupLabel = 'WebSocket Reconnect';
+        const expectedUrl = client.getUserTeamDraftsRoute('me', teamId);
+        const expectedOptions = {
+            method: 'get',
+            groupLabel,
+        };
+
+        await client.getDrafts(teamId, groupLabel);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    test('upsertDraft', async () => {
+        await client.upsertDraft(draft, 'connection_id');
+
+        const expectedUrl = client.getDraftsRoute();
+        const expectedOptions = {
+            method: 'post',
+            body: draft,
+            headers: {'Connection-Id': 'connection_id'},
+        };
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    test('upsertDraft without connection ID', async () => {
+        await client.upsertDraft(draft);
+
+        const expectedUrl = client.getDraftsRoute();
+        const expectedOptions = {
+            method: 'post',
+            body: draft,
+            headers: {},
+        };
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    test('deleteDraft for a channel draft (empty rootId) hits the channel route', async () => {
+        const channelId = 'channel_id';
+        const connectionId = 'connection_id';
+        const expectedUrl = client.getUserChannelDraftsRoute('me', channelId);
+        const expectedOptions = {
+            method: 'delete',
+            headers: {'Connection-Id': connectionId},
+        };
+
+        await client.deleteDraft(channelId, '', connectionId);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    test('deleteDraft for a thread draft (non-empty rootId) hits the thread route', async () => {
+        const channelId = 'channel_id';
+        const rootId = 'root_id';
+        const expectedUrl = client.getUserThreadDraftRoute('me', channelId, rootId);
+        const expectedOptions = {
+            method: 'delete',
+            headers: {},
+        };
+
+        await client.deleteDraft(channelId, rootId);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+});

--- a/app/client/rest/drafts.ts
+++ b/app/client/rest/drafts.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type ClientBase from './base';
+
+export interface ClientDraftsMix {
+    getDrafts(teamId: string, groupLabel?: RequestGroupLabel): Promise<DraftApi[]>;
+    upsertDraft(draft: DraftUpsertRequest, connectionId?: string): Promise<DraftApi>;
+    deleteDraft(channelId: string, rootId?: string, connectionId?: string): Promise<DraftApi>;
+}
+
+const ClientDrafts = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
+    getDrafts = (teamId: string, groupLabel?: RequestGroupLabel) => {
+        return this.doFetch(
+            this.getUserTeamDraftsRoute('me', teamId),
+            {method: 'get', groupLabel},
+        );
+    };
+
+    upsertDraft = (draft: DraftUpsertRequest, connectionId?: string) => {
+        const headers: Record<string, string> = {};
+        if (connectionId) {
+            headers['Connection-Id'] = connectionId;
+        }
+        return this.doFetch(
+            this.getDraftsRoute(),
+            {
+                method: 'post',
+                body: draft,
+                headers,
+            },
+        );
+    };
+
+    deleteDraft = (channelId: string, rootId = '', connectionId?: string) => {
+        const headers: Record<string, string> = {};
+        if (connectionId) {
+            headers['Connection-Id'] = connectionId;
+        }
+        const route = rootId ? this.getUserThreadDraftRoute('me', channelId, rootId) : this.getUserChannelDraftsRoute('me', channelId);
+        return this.doFetch(
+            route,
+            {
+                method: 'delete',
+                headers,
+            },
+        );
+    };
+};
+
+export default ClientDrafts;

--- a/app/client/rest/index.ts
+++ b/app/client/rest/index.ts
@@ -14,6 +14,7 @@ import ClientChannelBookmarks, {type ClientChannelBookmarksMix} from './channel_
 import ClientChannels, {type ClientChannelsMix} from './channels';
 import {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID} from './constants';
 import ClientCustomAttributes, {type ClientCustomAttributesMix} from './custom_profile_attributes';
+import ClientDrafts, {type ClientDraftsMix} from './drafts';
 import ClientEmojis, {type ClientEmojisMix} from './emojis';
 import ClientFiles, {type ClientFilesMix} from './files';
 import ClientGeneral, {type ClientGeneralMix} from './general';
@@ -54,6 +55,7 @@ interface Client extends ClientBase,
     ClientPluginsMix,
     ClientNPSMix,
     ClientCustomAttributesMix,
+    ClientDraftsMix,
     ClientPlaybooksMix
 {
     setClientCredentials: (token: string, preauthSecret?: string) => void;
@@ -83,7 +85,7 @@ class Client extends mix(ClientBase).with(
     ClientPlugins,
     ClientNPS,
     ClientCustomAttributes,
-    ClientScheduledPost,
+    ClientDrafts,
     ClientPlaybooks,
 ) {
     // eslint-disable-next-line no-useless-constructor

--- a/app/constants/preferences.ts
+++ b/app/constants/preferences.ts
@@ -63,6 +63,7 @@ const Preferences = {
     ADVANCED_FILTER_JOIN_LEAVE: 'join_leave',
     ADVANCED_CODE_BLOCK_ON_CTRL_ENTER: 'code_block_ctrl_enter',
     ADVANCED_SEND_ON_CTRL_ENTER: 'send_on_ctrl_enter',
+    ADVANCED_SYNC_DRAFTS: 'sync_drafts',
     ATTACH_APP_LOGS: 'attach_app_logs',
     THEMES: {
         denim: {

--- a/app/queries/servers/drafts.ts
+++ b/app/queries/servers/drafts.ts
@@ -2,10 +2,14 @@
 // See LICENSE.txt for license information.
 
 import {Database, Q} from '@nozbe/watermelondb';
-import {of as of$, switchMap} from 'rxjs';
+import {combineLatest, distinctUntilChanged, of as of$, switchMap} from 'rxjs';
 
+import {Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import DraftModel from '@typings/database/models/servers/draft';
+
+import {queryPreferencesByCategoryAndName} from './preference';
+import {getConfigBooleanValue, observeConfigBooleanValue} from './system';
 
 import type Model from '@nozbe/watermelondb/Model';
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
@@ -21,6 +25,55 @@ const {SERVER: {DRAFT, DRAFT_OUTBOX, CHANNEL}} = MM_TABLES;
  */
 export const buildDraftOutboxId = (channelId: string, rootId = '') => {
     return `${channelId}-${rootId || 'root'}`;
+};
+
+/**
+ * isDraftSyncPreferenceEnabled: the advanced setting gate. Synchronization stays enabled
+ * when the `advanced_settings/sync_drafts` preference is absent (opt-out defaults to on)
+ * and is only disabled when the preference is explicitly set to 'false'.
+ */
+const isDraftSyncPreferenceEnabled = (value: string | undefined) => {
+    return value !== 'false';
+};
+
+/**
+ * getIsDraftSyncEnabled: draft synchronization is enabled ONLY when BOTH the server config
+ * `AllowSyncedDrafts` is 'true' AND the user's `advanced_settings/sync_drafts` preference is
+ * not explicitly 'false'. There is deliberately no server-version gate: drafts predate the
+ * minimum supported server.
+ */
+export const getIsDraftSyncEnabled = async (database: Database) => {
+    const allowed = await getConfigBooleanValue(database, 'AllowSyncedDrafts');
+    if (!allowed) {
+        return false;
+    }
+
+    const prefs = await queryPreferencesByCategoryAndName(
+        database,
+        Preferences.CATEGORIES.ADVANCED_SETTINGS,
+        Preferences.ADVANCED_SYNC_DRAFTS,
+    ).fetch();
+
+    return isDraftSyncPreferenceEnabled(prefs[0]?.value);
+};
+
+/**
+ * observeIsDraftSyncEnabled: reactive form of getIsDraftSyncEnabled. Emits true only when
+ * the `AllowSyncedDrafts` config is 'true' AND the `advanced_settings/sync_drafts` preference
+ * is not explicitly 'false'.
+ */
+export const observeIsDraftSyncEnabled = (database: Database) => {
+    const allowed = observeConfigBooleanValue(database, 'AllowSyncedDrafts');
+    const preference = queryPreferencesByCategoryAndName(
+        database,
+        Preferences.CATEGORIES.ADVANCED_SETTINGS,
+        Preferences.ADVANCED_SYNC_DRAFTS,
+    ).observeWithColumns(['value']);
+
+    return combineLatest([allowed, preference]).pipe(
+        switchMap(([isAllowed, prefs]) => of$(isAllowed && isDraftSyncPreferenceEnabled(prefs[0]?.value))),
+        distinctUntilChanged(),
+    );
 };
 
 export const getDraft = async (database: Database, channelId: string, rootId = '') => {

--- a/app/utils/draft/sync.test.ts
+++ b/app/utils/draft/sync.test.ts
@@ -1,0 +1,200 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import TestHelper from '@test/test_helper';
+
+import {buildDraftUpsertRequest, isSyncableDraft, normalizeServerDraft, reconstructDraftBoRConfig} from './sync';
+
+const baseServerDraft: DraftApi = {
+    create_at: 100,
+    update_at: 200,
+    delete_at: 0,
+    user_id: 'user_id',
+    channel_id: 'channel_id',
+    root_id: '',
+    message: 'server message',
+    type: '',
+    props: {from_webhook: 'true'},
+    file_ids: ['file1', 'file2'],
+};
+
+describe('normalizeServerDraft (server -> mobile)', () => {
+    it('should map update_at to serverUpdateAt, pass props through, and copy file_ids exactly', () => {
+        const result = normalizeServerDraft(baseServerDraft);
+
+        expect(result.channelId).toBe('channel_id');
+        expect(result.rootId).toBe('');
+        expect(result.message).toBe('server message');
+        expect(result.serverUpdateAt).toBe(200);
+        expect(result.props).toEqual({from_webhook: 'true'});
+        expect(result.fileIds).toEqual(['file1', 'file2']);
+        expect(result.fileIds).toHaveLength(2);
+    });
+
+    it('should copy file_ids exactly even when metadata.files is missing, and default files to empty', () => {
+        const result = normalizeServerDraft(baseServerDraft);
+
+        expect(result.fileIds).toEqual(['file1', 'file2']);
+        expect(result.files).toEqual([]);
+        expect(result.files).toHaveLength(0);
+    });
+
+    it('should hydrate files from metadata.files', () => {
+        const file1 = TestHelper.fakeFileInfo({id: 'file1'});
+        const file2 = TestHelper.fakeFileInfo({id: 'file2'});
+        const serverDraft: DraftApi = {
+            ...baseServerDraft,
+            metadata: {files: [file1, file2]},
+        };
+
+        const result = normalizeServerDraft(serverDraft);
+
+        expect(result.files).toEqual([file1, file2]);
+        expect(result.files).toHaveLength(2);
+    });
+
+    it('should map priority into metadata.priority', () => {
+        const priority: PostPriority = {priority: 'urgent', requested_ack: true};
+        const serverDraft: DraftApi = {...baseServerDraft, priority};
+
+        const result = normalizeServerDraft(serverDraft);
+
+        expect(result.metadata?.priority).toEqual(priority);
+    });
+
+    it('should leave metadata undefined when there is no priority or borConfig', () => {
+        const result = normalizeServerDraft(baseServerDraft);
+
+        expect(result.metadata).toBeUndefined();
+    });
+
+    it('should reconstruct borConfig for a burn_on_read draft when durations are valid', () => {
+        const serverDraft: DraftApi = {...baseServerDraft, type: 'burn_on_read'};
+
+        const result = normalizeServerDraft(serverDraft, {borDurationSeconds: 30, borMaximumTimeToLiveSeconds: 300});
+
+        expect(result.type).toBe('burn_on_read');
+        expect(result.metadata?.borConfig).toEqual({
+            enabled: true,
+            borDurationSeconds: 30,
+            borMaximumTimeToLiveSeconds: 300,
+        });
+    });
+
+    it('should not set an enabled borConfig for a burn_on_read draft when durations are missing (fail closed)', () => {
+        const serverDraft: DraftApi = {...baseServerDraft, type: 'burn_on_read'};
+
+        const result = normalizeServerDraft(serverDraft);
+
+        expect(result.metadata?.borConfig).toBeUndefined();
+    });
+});
+
+describe('isSyncableDraft', () => {
+    const draft = {
+        channelId: 'channel_id',
+        rootId: '',
+        type: '' as PostTypesUserCreatable,
+        props: null,
+        fileIds: [],
+    };
+
+    it('should be true when the draft has message content', () => {
+        expect(isSyncableDraft({...draft, message: 'hello'})).toBe(true);
+    });
+
+    it('should be false for an empty message even with attachments and priority', () => {
+        const emptyDraft = {
+            ...draft,
+            message: '',
+            fileIds: ['file1'],
+            metadata: {priority: {priority: 'urgent'} as PostPriority},
+        };
+
+        expect(isSyncableDraft(emptyDraft)).toBe(false);
+    });
+});
+
+describe('buildDraftUpsertRequest (mobile -> server)', () => {
+    it('should send only the allowed fields, with file_ids from fileIds and priority from metadata', () => {
+        const draft = {
+            channelId: 'channel_id',
+            rootId: 'root_id',
+            message: 'draft message',
+            type: '' as PostTypesUserCreatable,
+            props: {from_webhook: 'true'},
+            fileIds: ['file1'],
+            metadata: {priority: {priority: 'important'} as PostPriority},
+        };
+
+        const request = buildDraftUpsertRequest(draft);
+
+        expect(request).toEqual({
+            channel_id: 'channel_id',
+            root_id: 'root_id',
+            message: 'draft message',
+            type: '',
+            props: {from_webhook: 'true'},
+            file_ids: ['file1'],
+            priority: {priority: 'important'},
+        });
+    });
+
+    it('should never serialize local-only file fields', () => {
+        const draft = {
+            channelId: 'channel_id',
+            rootId: '',
+            message: 'draft message',
+            type: '' as PostTypesUserCreatable,
+            props: null,
+            fileIds: ['file1'],
+            metadata: {
+                files: [TestHelper.fakeFileInfo({id: 'file1', localPath: '/tmp/x', clientId: 'c1', bytesRead: 5, failed: true})],
+            },
+        };
+
+        const request = buildDraftUpsertRequest(draft);
+
+        const serialized = JSON.stringify(request);
+        expect(serialized).not.toContain('localPath');
+        expect(serialized).not.toContain('clientId');
+        expect(serialized).not.toContain('bytesRead');
+        expect(serialized).not.toContain('failed');
+        expect(request?.file_ids).toEqual(['file1']);
+    });
+
+    it('should return null for an empty message so it never POSTs', () => {
+        const draft = {
+            channelId: 'channel_id',
+            rootId: '',
+            message: '',
+            type: '' as PostTypesUserCreatable,
+            props: null,
+            fileIds: [],
+        };
+
+        expect(buildDraftUpsertRequest(draft)).toBeNull();
+    });
+});
+
+describe('reconstructDraftBoRConfig', () => {
+    it('should return an enabled config for a burn_on_read type with valid durations', () => {
+        expect(reconstructDraftBoRConfig('burn_on_read', {borDurationSeconds: 30, borMaximumTimeToLiveSeconds: 300})).toEqual({
+            enabled: true,
+            borDurationSeconds: 30,
+            borMaximumTimeToLiveSeconds: 300,
+        });
+    });
+
+    it('should return null (fail closed) for a burn_on_read type when durations are missing', () => {
+        expect(reconstructDraftBoRConfig('burn_on_read', undefined)).toBeNull();
+    });
+
+    it('should return null (fail closed) for a burn_on_read type when durations are not positive', () => {
+        expect(reconstructDraftBoRConfig('burn_on_read', {borDurationSeconds: 0, borMaximumTimeToLiveSeconds: 300})).toBeNull();
+    });
+
+    it('should return null for a non burn_on_read type', () => {
+        expect(reconstructDraftBoRConfig('', {borDurationSeconds: 30, borMaximumTimeToLiveSeconds: 300})).toBeNull();
+    });
+});

--- a/app/utils/draft/sync.ts
+++ b/app/utils/draft/sync.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {PostTypes} from '@constants/post';
+
+// DraftLike is the minimal set of fields the pure sync helpers read from a Draft.
+// A WatermelonDB DraftModel instance satisfies this shape, as does a plain object
+// built from one, which keeps these functions free of any database dependency.
+type DraftLike = {
+    channelId: string;
+    rootId: string;
+    message: string;
+    type: PostTypesUserCreatable | null;
+    props: DraftProps | null;
+    fileIds: string[];
+    metadata?: PostMetadata;
+};
+
+// NormalizedDraft is the persistence-ready shape produced from a server DraftApi.
+// It uses the DraftModel property names so a later phase can assign the values
+// directly onto a prepared record. It intentionally never carries a record id or
+// a local update_at; the caller stamps update_at when content actually changes.
+type NormalizedDraft = {
+    channelId: string;
+    rootId: string;
+    message: string;
+    serverUpdateAt: number;
+    type: PostTypesUserCreatable | null;
+    props: DraftProps;
+    fileIds: string[];
+    files: FileInfo[];
+    metadata?: PostMetadata;
+};
+
+type BoRDurations = {
+    borDurationSeconds: number;
+    borMaximumTimeToLiveSeconds: number;
+};
+
+/**
+ * reconstructDraftBoRConfig: pure, fail-closed reconstruction of a draft's burn-on-read
+ * config. The duration values live in server config (not in draft props) so the caller
+ * passes them in. Returns null when the draft is not a burn-on-read draft, and also null
+ * (fail closed) when it is a burn-on-read draft but valid positive durations are not
+ * available — never fabricate durations.
+ */
+export const reconstructDraftBoRConfig = (
+    serverType: string | null | undefined,
+    durations: BoRDurations | undefined,
+): PostBoRConfig | null => {
+    if (serverType !== PostTypes.BURN_ON_READ) {
+        return null;
+    }
+
+    if (!durations || durations.borDurationSeconds <= 0 || durations.borMaximumTimeToLiveSeconds <= 0) {
+        return null;
+    }
+
+    return {
+        enabled: true,
+        borDurationSeconds: durations.borDurationSeconds,
+        borMaximumTimeToLiveSeconds: durations.borMaximumTimeToLiveSeconds,
+    };
+};
+
+/**
+ * isSyncableDraft: a draft is only syncable when it has message content. Empty-message
+ * drafts (attachment-only, priority-only, burn-on-read-only, type/props-only) are never
+ * synced because the server treats an empty-message upsert as a delete.
+ */
+export const isSyncableDraft = (draft: DraftLike): boolean => {
+    return draft.message.length > 0;
+};
+
+/**
+ * buildDraftUpsertRequest: build the server POST body from a local draft. Sends ONLY the
+ * server-owned fields; local-only file fields (localPath, clientId, bytesRead, failed,
+ * upload progress) and local-only draft fields (record id, server_update_at) are never
+ * serialized. Returns null for a non-syncable (empty message) draft so callers cannot
+ * accidentally POST an empty draft that the server would interpret as a delete.
+ */
+export const buildDraftUpsertRequest = (draft: DraftLike): DraftUpsertRequest | null => {
+    if (!isSyncableDraft(draft)) {
+        return null;
+    }
+
+    const request: DraftUpsertRequest = {
+        channel_id: draft.channelId,
+        root_id: draft.rootId,
+        message: draft.message,
+        type: draft.type ?? '',
+        props: draft.props ?? {},
+        file_ids: draft.fileIds ?? [],
+    };
+
+    const priority = draft.metadata?.priority;
+    if (priority) {
+        request.priority = priority;
+    }
+
+    return request;
+};
+
+/**
+ * normalizeServerDraft: map a server DraftApi into a persistence-ready NormalizedDraft.
+ * Server update_at is captured as server_update_at (an observation hint) and never as the
+ * local update_at. file_ids are copied exactly, even when metadata.files is unavailable, so
+ * attachment IDs are never lost and local paths are never invented. Priority and burn-on-read
+ * config are reconstructed into metadata; burn-on-read fails closed when durations are missing.
+ */
+export const normalizeServerDraft = (
+    serverDraft: DraftApi,
+    durations?: BoRDurations,
+): NormalizedDraft => {
+    const metadata: PostMetadata = {};
+
+    if (serverDraft.priority) {
+        metadata.priority = serverDraft.priority;
+    }
+
+    const borConfig = reconstructDraftBoRConfig(serverDraft.type, durations);
+    if (borConfig) {
+        metadata.borConfig = borConfig;
+    }
+
+    return {
+        channelId: serverDraft.channel_id,
+        rootId: serverDraft.root_id,
+        message: serverDraft.message,
+        serverUpdateAt: serverDraft.update_at,
+        type: serverDraft.type === PostTypes.BURN_ON_READ ? PostTypes.BURN_ON_READ : '',
+        props: serverDraft.props ?? {},
+        fileIds: serverDraft.file_ids ?? [],
+        files: serverDraft.metadata?.files ?? [],
+        metadata: Object.keys(metadata).length ? metadata : undefined,
+    };
+};

--- a/types/api/config.d.ts
+++ b/types/api/config.d.ts
@@ -8,6 +8,7 @@ interface ClientConfig {
     AllowEditPost: string;
     AllowedThemes: string;
     AllowDownloadLogs: string;
+    AllowSyncedDrafts: string;
     AndroidAppDownloadLink: string;
     AndroidLatestVersion: string;
     AndroidMinVersion: string;

--- a/types/api/drafts.d.ts
+++ b/types/api/drafts.d.ts
@@ -4,3 +4,33 @@
 // DraftProps carries server draft props round-tripped by mobile even when mobile
 // does not interpret them. Absent props normalize to an empty object.
 type DraftProps = Record<string, unknown>;
+
+// DraftApi is the server Draft JSON shape (server model.Draft) as returned by the
+// drafts REST endpoints. It is the wire representation, distinct from the local
+// WatermelonDB Draft model.
+type DraftApi = {
+    create_at: number;
+    update_at: number;
+    delete_at: number;
+    user_id: string;
+    channel_id: string;
+    root_id: string;
+    message: string;
+    type: PostType;
+    props: DraftProps;
+    file_ids: string[];
+    metadata?: PostMetadata;
+    priority?: PostPriority;
+};
+
+// DraftUpsertRequest is the POST body accepted by the server drafts endpoint.
+// Only these fields are ever sent from mobile; local-only fields are never serialized.
+type DraftUpsertRequest = {
+    channel_id: string;
+    root_id: string;
+    message: string;
+    type: PostType;
+    props: DraftProps;
+    file_ids: string[];
+    priority?: PostPriority;
+};


### PR DESCRIPTION
## Summary

Phase 2 of synchronized drafts: the **client, mapping, and capability layer**. Everything here is intentionally **unwired** — no coordinator, no workers, no lifecycle/trigger hooks. Stacked on the Phase 1 branch (#9961); retarget to `main` once Phase 1 merges.

### Changes
- **DTOs** — `types/api/drafts.d.ts` gains `DraftApi` (server response) and `DraftUpsertRequest` (POST body); `types/api/config.d.ts` gains `AllowSyncedDrafts`.
- **REST client** — `client/rest/base.ts` draft route helpers; new `ClientDrafts` mixin (`getDrafts`, `upsertDraft`, `deleteDraft` — channel vs thread by `rootId`, `Connection-Id` on POST/DELETE), mixed into `client/rest/index.ts` (also removes a pre-existing duplicate `ClientScheduledPost` entry in the `.with()` list).
- **Normalization** (`utils/draft/sync.ts`, pure) — server→mobile (`update_at`→`server_update_at`, never a local `update_at`; priority; props passthrough; **exact** `file_ids`; files from `metadata.files`); mobile→server (only `channel_id`/`root_id`/`message`/`type`/`props`/`file_ids`/`priority`; **returns `null` for empty message** so it never POSTs — the server treats empty as delete). **Fail-closed Burn-on-Read**: durations come from server config, not props; missing/invalid durations → no `enabled` borConfig.
- **Capability** — `getIsDraftSyncEnabled`/`observeIsDraftSyncEnabled`: enabled iff `AllowSyncedDrafts === 'true'` **and** the `advanced_settings/sync_drafts` preference isn't `'false'` (absent = enabled). No server-version gate (drafts predate the minimum supported server).

### Tests (69 passing across the touched suites)
- Client: correct GET/POST/channel-DELETE/thread-DELETE URLs + methods; `Connection-Id` present/absent.
- Sync: field mapping, exact `file_ids` copy (incl. missing `metadata.files`), priority, props passthrough, empty-message → not syncable / never POSTs, no local file-field serialization, BoR reconstruct (valid) and fail-closed (missing/non-positive durations, non-BoR).

### Checks
- `npm run tsc` — clean
- `eslint --quiet` on all changed files — clean
- Jest — 5 suites / 69 tests pass (new client + sync suites + scheduled_post / post-handler / drafts-query regression neighbors)

### Exit criteria met
Client and mapping/capability methods complete but not connected to any lifecycle path; no regressions in existing draft tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)