### PR TITLE
fix: hardware Enter key not sending messages in channel on iPad

### DIFF
--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -310,7 +310,7 @@ export default function PostInput({
         if (rootId) {
             sourceScreen = Screens.THREAD;
         } else if (isTablet) {
-            sourceScreen = Screens.HOME;
+            sourceScreen = Screens.CHANNEL_LIST;
         }
         if (currentScreen === sourceScreen) {
             sendMessage();
@@ -322,7 +322,7 @@ export default function PostInput({
         if (rootId) {
             sourceScreen = Screens.THREAD;
         } else if (isTablet) {
-            sourceScreen = Screens.HOME;
+            sourceScreen = Screens.CHANNEL_LIST;
         }
 
         if (currentScreen === sourceScreen) {


### PR DESCRIPTION
#### Summary
On tablet split-view, the channel screen is rendered inline within the channel_list route rather than being pushed as its own CHANNEL route, so the resolved current screen is Screens.CHANNEL_LIST, not Screens.HOME. The hardware keyboard Enter/Shift+Enter handlers were comparing against Screens.HOME, so the condition never matched and Enter silently did nothing when composing in a channel on iPad. Thread replies worked because THREAD is always a real pushed route.

#### Ticket Link
(https://github.com/mattermost/mattermost-mobile/issues/9868)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [x] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: ios26

#### Screenshots
N/A

#### Release Note
* Fixed enter is not working on channel

```release-note
Fixed enter is not working on channel
```