### PR TITLE
feat(drafts): Phase 3 — atomic local intent, deletion origins, composer guards, manager shell

### DIFF
--- a/app/actions/local/draft.test.ts
+++ b/app/actions/local/draft.test.ts
@@ -1,13 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Q, type Database} from '@nozbe/watermelondb';
 import {DeviceEventEmitter} from 'react-native';
 
 import {Navigation, Screens} from '@constants';
-import {SYSTEM_IDENTIFIERS} from '@constants/database';
+import {MM_TABLES, SYSTEM_IDENTIFIERS} from '@constants/database';
 import {DRAFT_SCREEN_TAB_DRAFTS, DRAFT_SCREEN_TAB_SCHEDULED_POSTS} from '@constants/draft';
 import {PostTypes} from '@constants/post';
 import DatabaseManager from '@database/manager';
+import {getDraft, getDraftOutbox} from '@queries/servers/drafts';
 import {dismissAllRoutesAndPopToScreen} from '@screens/navigation';
 import {NavigationStore} from '@store/navigation_store';
 import {isTablet} from '@utils/helpers';
@@ -28,6 +30,7 @@ import type ServerDataOperator from '@database/operator/server_data_operator';
 import type DraftModel from '@typings/database/models/servers/draft';
 
 let operator: ServerDataOperator | undefined;
+let database: Database;
 const serverUrl = 'baseHandler.test.com';
 const channelId = 'id1';
 const teamId = 'tId1';
@@ -72,6 +75,7 @@ describe('draft actions', () => {
     beforeEach(async () => {
         await DatabaseManager.init([serverUrl]);
         operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
+        database = DatabaseManager.serverDatabases[serverUrl]!.database;
     });
 
     afterEach(async () => {
@@ -80,12 +84,12 @@ describe('draft actions', () => {
 
     describe('updateDraftFile', () => {
         it('handle not found database', async () => {
-            const {error} = await updateDraftFile('foo', channelId, '', fileInfo, false);
+            const {error} = await updateDraftFile('foo', channelId, '', fileInfo);
             expect(error).toBeTruthy();
         });
 
         it('handle no draft', async () => {
-            const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo, false);
+            const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo);
             expect(error).toBeTruthy();
             expect(error).toBe('no draft');
         });
@@ -93,7 +97,7 @@ describe('draft actions', () => {
         it('handle no file', async () => {
             await operator?.handleDraft({drafts: [draft], prepareRecordsOnly: false});
 
-            const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo, false);
+            const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo);
             expect(error).toBeTruthy();
             expect(error).toBe('file not found');
         });
@@ -111,12 +115,12 @@ describe('draft actions', () => {
 
     describe('removeDraftFile', () => {
         it('handle not found database', async () => {
-            const {error} = await removeDraftFile('foo', channelId, '', '', false);
+            const {error} = await removeDraftFile('foo', channelId, '', '');
             expect(error).toBeTruthy();
         });
 
         it('handle no draft', async () => {
-            const {error} = await removeDraftFile(serverUrl, channelId, '', 'clientid', false);
+            const {error} = await removeDraftFile(serverUrl, channelId, '', 'clientid');
             expect(error).toBeTruthy();
             expect(error).toBe('no draft');
         });
@@ -124,7 +128,7 @@ describe('draft actions', () => {
         it('handle no file', async () => {
             await operator?.handleDraft({drafts: [draft], prepareRecordsOnly: false});
 
-            const {error} = await removeDraftFile(serverUrl, channelId, '', 'clientid', false);
+            const {error} = await removeDraftFile(serverUrl, channelId, '', 'clientid');
             expect(error).toBeTruthy();
             expect(error).toBe('file not found');
         });
@@ -140,7 +144,7 @@ describe('draft actions', () => {
         it('remove draft file, no message', async () => {
             await operator?.handleDraft({drafts: [{channel_id: channel.id, files: [fileInfo], root_id: '', update_at: Date.now()}], prepareRecordsOnly: false});
 
-            const {draft: draftModel, error} = await removeDraftFile(serverUrl, channelId, '', 'clientid', false);
+            const {draft: draftModel, error} = await removeDraftFile(serverUrl, channelId, '', 'clientid');
             expect(error).toBeUndefined();
             expect(draftModel).toBeDefined();
         });
@@ -148,21 +152,27 @@ describe('draft actions', () => {
 
     describe('updateDraftMessage', () => {
         it('handle not found database', async () => {
-            const result = await updateDraftMessage('foo', channelId, '', 'newmessage', false) as {draft: unknown; error: unknown};
+            const result = await updateDraftMessage('foo', channelId, '', 'newmessage') as {draft: unknown; error: unknown};
             expect(result.error).toBeDefined();
             expect(result.draft).toBeUndefined();
         });
 
         it('update draft message, blank message, no draft', async () => {
-            const result = await updateDraftMessage(serverUrl, channelId, '', '', false) as {draft: unknown; error: unknown};
+            const result = await updateDraftMessage(serverUrl, channelId, '', '') as {draft: unknown; error: unknown};
             expect(result.error).toBeUndefined();
             expect(result.draft).toBeUndefined();
         });
 
         it('update draft message, no draft', async () => {
-            const models = await updateDraftMessage(serverUrl, channelId, '', 'newmessage', false) as DraftModel[];
-            expect(models).toBeDefined();
-            expect(models?.length).toBe(1);
+            const result = await updateDraftMessage(serverUrl, channelId, '', 'newmessage') as {draft: DraftModel; error: unknown};
+            expect(result.error).toBeUndefined();
+            expect(result.draft).toBeDefined();
+            expect(result.draft.message).toBe('newmessage');
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('upsert');
+            expect(outbox?.generation).toBe(1);
+            expect(outbox?.status).toBe('pending');
         });
 
         it('update draft message', async () => {
@@ -177,7 +187,7 @@ describe('draft actions', () => {
         it('update draft message, same message', async () => {
             await operator?.handleDraft({drafts: [{...draft, files: [fileInfo]}], prepareRecordsOnly: false});
 
-            const result = await updateDraftMessage(serverUrl, channelId, '', 'test', false) as {draft: DraftModel; error: unknown};
+            const result = await updateDraftMessage(serverUrl, channelId, '', 'test') as {draft: DraftModel; error: unknown};
             expect(result.error).toBeUndefined();
             expect(result.draft).toBeDefined();
             expect(result.draft.message).toBe('test');
@@ -186,7 +196,7 @@ describe('draft actions', () => {
         it('update draft message, no file', async () => {
             await operator?.handleDraft({drafts: [{channel_id: channel.id, files: [], root_id: '', update_at: Date.now()}], prepareRecordsOnly: false});
 
-            const result = await updateDraftMessage(serverUrl, channelId, '', 'newmessage', false) as {draft: DraftModel; error: unknown};
+            const result = await updateDraftMessage(serverUrl, channelId, '', 'newmessage') as {draft: DraftModel; error: unknown};
             expect(result.error).toBeUndefined();
             expect(result.draft).toBeDefined();
             expect(result.draft.message).toBe('newmessage');
@@ -195,15 +205,16 @@ describe('draft actions', () => {
 
     describe('addFilesToDraft', () => {
         it('handle not found database', async () => {
-            const result = await addFilesToDraft('foo', channelId, '', [], false) as {draft: unknown; error: unknown};
+            const result = await addFilesToDraft('foo', channelId, '', []) as {draft: unknown; error: unknown};
             expect(result.error).toBeDefined();
             expect(result.draft).toBeUndefined();
         });
 
         it('add draft files, no draft', async () => {
-            const models = await addFilesToDraft(serverUrl, channelId, '', [fileInfo], false) as DraftModel[];
-            expect(models).toBeDefined();
-            expect(models?.length).toBe(1);
+            const result = await addFilesToDraft(serverUrl, channelId, '', [fileInfo]) as {draft: DraftModel; error: unknown};
+            expect(result.error).toBeUndefined();
+            expect(result.draft).toBeDefined();
+            expect(result.draft.files.length).toBe(1);
         });
 
         it('add draft files', async () => {
@@ -258,10 +269,16 @@ describe('draft actions', () => {
         });
 
         it('handle no draft', async () => {
-            const models = await updateDraftPriority(serverUrl, channelId, '', postPriority) as DraftModel[];
-            expect(models).toBeDefined();
-            expect(models.length).toBe(1);
-            expect(models[0].metadata?.priority?.priority).toBe(postPriority.priority);
+            const result = await updateDraftPriority(serverUrl, channelId, '', postPriority) as {draft: DraftModel; error: unknown};
+            expect(result.error).toBeUndefined();
+            expect(result.draft).toBeDefined();
+            expect(result.draft.metadata?.priority?.priority).toBe(postPriority.priority);
+
+            // Priority-only draft with an empty message is unsyncable: it is parked, never pending.
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('upsert');
+            expect(outbox?.status).toBe('blocked');
+            expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
         });
 
         it('update draft priority', async () => {
@@ -271,6 +288,150 @@ describe('draft actions', () => {
             expect(result.error).toBeUndefined();
             expect(result.draft).toBeDefined();
             expect(result.draft.metadata?.priority?.priority).toBe(postPriority.priority);
+        });
+    });
+
+    describe('draft outbox synchronization intents', () => {
+        const {DRAFT, DRAFT_OUTBOX} = MM_TABLES.SERVER;
+        const uploadingFile = {clientId: 'up1', localPath: 'path1'} as FileInfo;
+        const completedFile = {id: 'srvid1', clientId: 'up1', localPath: 'path1'} as FileInfo;
+
+        const countOutbox = async () => {
+            const rows = await database.get(DRAFT_OUTBOX).query(Q.where('channel_id', channelId)).fetch();
+            return rows.length;
+        };
+
+        it('creates one Draft and one pending upsert outbox on the first non-empty edit', async () => {
+            await updateDraftMessage(serverUrl, channelId, '', 'hello');
+
+            const drafts = await database.get(DRAFT).query(Q.where('channel_id', channelId)).fetch();
+            expect(drafts.length).toBe(1);
+            expect(await countOutbox()).toBe(1);
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('upsert');
+            expect(outbox?.generation).toBe(1);
+            expect(outbox?.status).toBe('pending');
+            expect(outbox?.attemptCount).toBe(0);
+        });
+
+        it('coalesces repeated edits into a single outbox with an incrementing generation', async () => {
+            await updateDraftMessage(serverUrl, channelId, '', 'a');
+            await updateDraftMessage(serverUrl, channelId, '', 'b');
+            await updateDraftMessage(serverUrl, channelId, '', 'c');
+
+            expect(await countOutbox()).toBe(1);
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('upsert');
+            expect(outbox?.generation).toBe(3);
+            expect(outbox?.status).toBe('pending');
+        });
+
+        it('removeDraft destroys the draft and queues a non-keepLocal delete with a fingerprint', async () => {
+            await operator?.handleDraft({drafts: [draft], prepareRecordsOnly: false});
+
+            await removeDraft(serverUrl, channelId);
+
+            expect(await getDraft(database, channelId, '')).toBeUndefined();
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('delete');
+            expect(outbox?.keepLocal).toBe(false);
+            expect(typeof outbox?.deletedFingerprint).toBe('string');
+            expect(outbox?.deletedFingerprint?.length).toBeGreaterThan(0);
+        });
+
+        it('clears a synchronized draft to a keepLocal delete while retaining the visible attachment', async () => {
+            await database.write(async () => {
+                await database.get<DraftModel>(DRAFT).create((d) => {
+                    d.channelId = channelId;
+                    d.rootId = '';
+                    d.message = 'server text';
+                    d.updateAt = 1;
+                    d.serverUpdateAt = 500;
+                    d.files = [fileInfo];
+                    d.fileIds = ['fileid'];
+                });
+            });
+
+            await updateDraftMessage(serverUrl, channelId, '', '');
+
+            const retained = await getDraft(database, channelId, '');
+            expect(retained).toBeDefined();
+            expect(retained?.message).toBe('');
+            expect(retained?.files.length).toBe(1);
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('delete');
+            expect(outbox?.keepLocal).toBe(true);
+            expect(outbox?.deletedFingerprint?.length).toBeGreaterThan(0);
+        });
+
+        it('parks an attachment-only draft that was never server-backed instead of enqueuing a delete', async () => {
+            // fileInfo carries a server id, so the attachment is completed but the message is empty.
+            await addFilesToDraft(serverUrl, channelId, '', [fileInfo]);
+
+            const retained = await getDraft(database, channelId, '');
+            expect(retained).toBeDefined();
+            expect(retained?.files.length).toBe(1);
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('upsert');
+            expect(outbox?.status).toBe('blocked');
+            expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
+        });
+
+        it('protects an in-progress upload with waiting_for_upload, then parks it on completion when empty', async () => {
+            await addFilesToDraft(serverUrl, channelId, '', [uploadingFile]);
+
+            let outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe('waiting_for_upload');
+            expect(outbox?.operation).toBe('upsert');
+
+            await updateDraftFile(serverUrl, channelId, '', completedFile);
+
+            const retained = await getDraft(database, channelId, '');
+            expect(retained?.fileIds).toEqual(['srvid1']);
+
+            // Upload finished but the message is still empty, so it cannot POST -> parked.
+            outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe('blocked');
+            expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
+            expect(await countOutbox()).toBe(1);
+        });
+
+        it('flips a pending delete back to a reset pending upsert on a genuine edit', async () => {
+            await updateDraftMessage(serverUrl, channelId, '', 'hello');
+            await removeDraft(serverUrl, channelId);
+
+            const deleteOutbox = await getDraftOutbox(database, channelId, '');
+            expect(deleteOutbox?.operation).toBe('delete');
+
+            await updateDraftMessage(serverUrl, channelId, '', 'world');
+
+            const draftAfter = await getDraft(database, channelId, '');
+            expect(draftAfter?.message).toBe('world');
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe('upsert');
+            expect(outbox?.status).toBe('pending');
+            expect(outbox?.generation).toBe(3);
+            expect(outbox?.deletedFingerprint).toBeNull();
+            expect(outbox?.keepLocal).toBe(false);
+            expect(outbox?.attemptCount).toBe(0);
+            expect(await countOutbox()).toBe(1);
+        });
+
+        it('does not create an outbox row for device-local markdown image metadata', async () => {
+            await operator?.handleDraft({drafts: [draft], prepareRecordsOnly: false});
+
+            await updateDraftMarkdownImageMetadata({
+                serverUrl,
+                channelId,
+                rootId: '',
+                imageMetadata: {image1: {height: 1, width: 1, format: 'png', frame_count: 1}},
+            });
+
+            expect(await countOutbox()).toBe(0);
         });
     });
 
@@ -435,6 +596,7 @@ describe('updateDraftBoRConfig', () => {
     beforeEach(async () => {
         await DatabaseManager.init([serverUrl]);
         operator = DatabaseManager.serverDatabases[serverUrl]?.operator;
+        database = DatabaseManager.serverDatabases[serverUrl]!.database;
     });
 
     afterEach(async () => {
@@ -447,12 +609,17 @@ describe('updateDraftBoRConfig', () => {
     });
 
     it('handle no draft', async () => {
-        const models = await updateDraftBoRConfig(serverUrl, channelId, '', postBoRConfig) as DraftModel[];
-        expect(models).toBeDefined();
-        expect(models.length).toBe(1);
-        expect(models[0].metadata?.borConfig?.enabled).toBe(postBoRConfig.enabled);
-        expect(models[0].metadata?.borConfig?.borDurationSeconds).toBe(postBoRConfig.borDurationSeconds);
-        expect(models[0].type).toBe(PostTypes.BURN_ON_READ);
+        const result = await updateDraftBoRConfig(serverUrl, channelId, '', postBoRConfig) as {draft: DraftModel; error: unknown};
+        expect(result.error).toBeUndefined();
+        expect(result.draft).toBeDefined();
+        expect(result.draft.metadata?.borConfig?.enabled).toBe(postBoRConfig.enabled);
+        expect(result.draft.metadata?.borConfig?.borDurationSeconds).toBe(postBoRConfig.borDurationSeconds);
+        expect(result.draft.type).toBe(PostTypes.BURN_ON_READ);
+
+        // Burn-on-read-only draft with an empty message is unsyncable: parked, never pending.
+        const outbox = await getDraftOutbox(database, channelId, '');
+        expect(outbox?.status).toBe('blocked');
+        expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
     });
 
     it('update draft BoR config with enabled true', async () => {

--- a/app/actions/local/draft.ts
+++ b/app/actions/local/draft.ts
@@ -5,13 +5,17 @@ import {Image} from 'expo-image';
 import {DeviceEventEmitter} from 'react-native';
 
 import {Navigation, Screens} from '@constants';
+import {MM_TABLES} from '@constants/database';
+import {DraftOutboxOperation, DraftOutboxStatus, type DraftScreenTab} from '@constants/draft';
 import {PostTypes} from '@constants/post';
 import DatabaseManager from '@database/manager';
-import {getDraft} from '@queries/servers/drafts';
+import {getChannelById} from '@queries/servers/channel';
+import {mutateDraftAndOutbox, prepareDraftOutbox, type OutboxIntent} from '@queries/servers/drafts';
 import {getCurrentTeamId, setCurrentTeamAndChannelId} from '@queries/servers/system';
 import {addChannelToTeamHistory} from '@queries/servers/team';
 import {dismissAllRoutesAndPopToScreen} from '@screens/navigation';
 import {NavigationStore} from '@store/navigation_store';
+import {draftContentFingerprint} from '@utils/draft/sync';
 import {getExtensionFromMime} from '@utils/file';
 import {isTablet} from '@utils/helpers';
 import {logError} from '@utils/log';
@@ -19,8 +23,91 @@ import {removeImageProxyForKey} from '@utils/markdown';
 import {urlSafeBase64Encode} from '@utils/security';
 import {isParsableUrl} from '@utils/url';
 
-import type {DraftScreenTab} from '@constants/draft';
-import type {Model} from '@nozbe/watermelondb';
+import type {Database, Model} from '@nozbe/watermelondb';
+import type DraftModel from '@typings/database/models/servers/draft';
+import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+
+const {SERVER: {DRAFT}} = MM_TABLES;
+
+/**
+ * resolveTeamScope: the team scope stamped onto a new/updated DraftOutbox row for a channel.
+ * DM/GM channels already carry an empty teamId, and a missing channel falls back to '' too.
+ */
+const resolveTeamScope = async (database: Database, channelId: string): Promise<string> => {
+    const channel = await getChannelById(database, channelId);
+    return channel?.teamId ?? '';
+};
+
+/**
+ * fingerprintDraft: fingerprint the current server-visible content of a Draft so a queued DELETE
+ * can later distinguish a stale replica echo from genuinely new content.
+ */
+const fingerprintDraft = (draft: DraftModel): string => {
+    return draftContentFingerprint({
+        message: draft.message,
+        type: draft.type,
+        props: draft.props,
+        fileIds: draft.fileIds ?? [],
+        priority: draft.metadata?.priority,
+    });
+};
+
+/**
+ * prepareEmptyTransition: shared handling for a Draft whose visible content just became empty
+ * (message '' and, for the caller to decide, possibly no files). Produces the Draft + DraftOutbox
+ * records for the three empty branches:
+ *  - potentiallyDispatched: the draft may exist on the server, so enqueue a DELETE (keepLocal when
+ *    local-only content such as attachments remains) and either retain the visible draft (message
+ *    cleared) or destroy it.
+ *  - not dispatched but local content remains: park a blocked/unsyncable_empty outbox and retain
+ *    the visible draft; never enqueue a delete for something the server never saw.
+ *  - not dispatched and nothing local worth keeping: destroy the draft and drop any outbox row.
+ */
+const prepareEmptyTransition = async (
+    database: Database,
+    channelId: string,
+    rootId: string,
+    draft: DraftModel,
+    outbox: DraftOutboxModel | undefined,
+    hasLocalContent: boolean,
+): Promise<Model[]> => {
+    const teamId = await resolveTeamScope(database, channelId);
+    const potentiallyDispatched = (outbox != null && outbox.operation === DraftOutboxOperation.Upsert) || ((draft.serverUpdateAt ?? 0) > 0);
+
+    if (potentiallyDispatched) {
+        const deletedFingerprint = fingerprintDraft(draft);
+        const models: Model[] = [];
+        if (hasLocalContent) {
+            models.push(draft.prepareUpdate((d) => {
+                d.message = '';
+                d.updateAt = Date.now();
+            }));
+        } else {
+            models.push(draft.prepareDestroyPermanently());
+        }
+        models.push(...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, {
+            type: 'delete',
+            keepLocal: hasLocalContent,
+            deletedFingerprint,
+        }));
+        return models;
+    }
+
+    if (hasLocalContent) {
+        return [
+            draft.prepareUpdate((d) => {
+                d.message = '';
+                d.updateAt = Date.now();
+            }),
+            ...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, {type: 'park'}),
+        ];
+    }
+
+    return [
+        draft.prepareDestroyPermanently(),
+        ...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, {type: 'remove'}),
+    ];
+};
 
 type goToScreenParams = {
     initialTab?: DraftScreenTab;
@@ -73,140 +160,250 @@ export const switchToGlobalDrafts = async (serverUrl: string, teamId?: string, i
     }
 };
 
-export async function updateDraftFile(serverUrl: string, channelId: string, rootId: string, file: FileInfo, prepareRecordsOnly = false) {
+export async function updateDraftFile(serverUrl: string, channelId: string, rootId: string, file: FileInfo) {
     try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (!draft) {
-            return {error: 'no draft'};
-        }
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        let result: DraftModel | undefined;
+        let earlyError: string | undefined;
 
-        const i = draft.files.findIndex((v) => v.clientId === file.clientId);
-        if (i === -1) {
-            return {error: 'file not found'};
-        }
+        await mutateDraftAndOutbox(database, channelId, rootId, async ({draft, outbox}) => {
+            if (!draft) {
+                earlyError = 'no draft';
+                return [];
+            }
 
-        // We create a new list to make sure we re-render the draft input.
-        const newFiles = [...draft.files];
-        newFiles[i] = file;
-        draft.prepareUpdate((d) => {
-            d.files = newFiles;
-            d.updateAt = Date.now();
+            const i = draft.files.findIndex((v) => v.clientId === file.clientId);
+            if (i === -1) {
+                earlyError = 'file not found';
+                return [];
+            }
+
+            result = draft;
+
+            // We create a new list to make sure we re-render the draft input.
+            const newFiles = [...draft.files];
+            newFiles[i] = file;
+
+            const existingFileIds = draft.fileIds ?? [];
+            const completedId = file.id;
+
+            if (completedId && !existingFileIds.includes(completedId)) {
+                // Upload finished: the attachment now has a portable server id. Persist it, then
+                // coalesce a pending upsert when the draft can POST (message present) or park it as
+                // unsyncable_empty when the message is still empty (attachments alone never POST).
+                const newFileIds = [...existingFileIds, completedId];
+                const teamId = await resolveTeamScope(database, channelId);
+                const intent: OutboxIntent = draft.message.length > 0 ? {type: 'upsert'} : {type: 'park'};
+                return [
+                    draft.prepareUpdate((d) => {
+                        d.files = newFiles;
+                        d.fileIds = newFileIds;
+                        d.updateAt = Date.now();
+                    }),
+                    ...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, intent),
+                ];
+            }
+
+            // Progress-only, device-local change: update the visible files but do not bump the
+            // portable generation or disturb an existing waiting_for_upload outbox.
+            return [draft.prepareUpdate((d) => {
+                d.files = newFiles;
+                d.updateAt = Date.now();
+            })];
         });
 
-        if (!prepareRecordsOnly) {
-            await operator.batchRecords([draft], 'updateDraftFile');
+        if (earlyError) {
+            return {error: earlyError};
         }
 
-        return {draft};
+        return {draft: result};
     } catch (error) {
         logError('Failed updateDraftFile', error);
         return {error};
     }
 }
 
-export async function removeDraftFile(serverUrl: string, channelId: string, rootId: string, clientId: string, prepareRecordsOnly = false) {
+export async function removeDraftFile(serverUrl: string, channelId: string, rootId: string, clientId: string) {
     try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (!draft) {
-            return {error: 'no draft'};
-        }
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        let result: DraftModel | undefined;
+        let earlyError: string | undefined;
 
-        const i = draft.files.findIndex((v) => v.clientId === clientId);
-        if (i === -1) {
-            return {error: 'file not found'};
-        }
+        await mutateDraftAndOutbox(database, channelId, rootId, async ({draft, outbox}) => {
+            if (!draft) {
+                earlyError = 'no draft';
+                return [];
+            }
 
-        if (draft.files.length === 1 && !draft.message) {
-            draft.prepareDestroyPermanently();
-        } else {
-            draft.prepareUpdate((d) => {
-                d.files = draft.files.filter((v, index) => index !== i);
+            const i = draft.files.findIndex((v) => v.clientId === clientId);
+            if (i === -1) {
+                earlyError = 'file not found';
+                return [];
+            }
+
+            result = draft;
+
+            const removed = draft.files[i];
+            const newFiles = draft.files.filter((v, index) => index !== i);
+            const existingFileIds = draft.fileIds ?? [];
+            const newFileIds = removed.id ? existingFileIds.filter((id) => id !== removed.id) : existingFileIds;
+            const portableChanged = newFileIds.length !== existingFileIds.length;
+
+            // Removing the last file with no message empties the draft: run the shared transition.
+            if (newFiles.length === 0 && !draft.message) {
+                return prepareEmptyTransition(database, channelId, rootId, draft, outbox, false);
+            }
+
+            const models: Model[] = [draft.prepareUpdate((d) => {
+                d.files = newFiles;
+                if (removed.id) {
+                    d.fileIds = newFileIds;
+                }
                 d.updateAt = Date.now();
-            });
+            })];
+
+            if (portableChanged) {
+                // A completed (portable) attachment was removed -> portable content changed. It can
+                // sync when the message can POST, otherwise it stays parked as unsyncable_empty.
+                const teamId = await resolveTeamScope(database, channelId);
+                const intent: OutboxIntent = draft.message.length > 0 ? {type: 'upsert'} : {type: 'park'};
+                models.push(...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, intent));
+            } else if (
+                outbox &&
+                draft.message.length === 0 &&
+                newFileIds.length === 0 &&
+                (outbox.status === DraftOutboxStatus.WaitingForUpload || outbox.status === DraftOutboxStatus.BlockedUpload)
+            ) {
+                // Removed a still-uploading/failed attachment and nothing portable remains: there is
+                // nothing to POST, so drop the outbox row rather than leaving a stale upload intent.
+                const teamId = await resolveTeamScope(database, channelId);
+                models.push(...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, {type: 'remove'}));
+            }
+
+            return models;
+        });
+
+        if (earlyError) {
+            return {error: earlyError};
         }
 
-        if (!prepareRecordsOnly) {
-            await operator.batchRecords([draft], 'removeDraftFile');
-        }
-
-        return {draft};
+        return {draft: result};
     } catch (error) {
         logError('Failed removeDraftFile', error);
         return {error};
     }
 }
 
-export async function updateDraftMessage(serverUrl: string, channelId: string, rootId: string, message: string, prepareRecordsOnly = false) {
+export async function updateDraftMessage(serverUrl: string, channelId: string, rootId: string, message: string) {
     try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (!draft) {
-            if (!message) {
-                return {};
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        let result: DraftModel | undefined;
+
+        await mutateDraftAndOutbox(database, channelId, rootId, async ({draft, outbox}) => {
+            if (!draft) {
+                if (!message) {
+                    return [];
+                }
+
+                // First content edit for this key: create the visible draft and a pending upsert.
+                const teamId = await resolveTeamScope(database, channelId);
+                const created = database.collections.get<DraftModel>(DRAFT).prepareCreate((d) => {
+                    d.channelId = channelId;
+                    d.rootId = rootId;
+                    d.message = message;
+                    d.updateAt = Date.now();
+                    d.files = [];
+                    d.fileIds = [];
+                });
+                result = created;
+                return [created, ...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, {type: 'upsert'})];
             }
 
-            const newDraft: Draft = {
-                channel_id: channelId,
-                root_id: rootId,
-                message,
-                update_at: Date.now(),
-            };
+            result = draft;
 
-            return operator.handleDraft({drafts: [newDraft], prepareRecordsOnly});
-        }
+            if (draft.message === message) {
+                // No content change (covers the empty-stays-empty stale-cleanup no-op too).
+                return [];
+            }
 
-        if (draft.message === message) {
-            return {draft};
-        }
+            if (message) {
+                // A genuine content edit; coalesce a pending upsert (flips a delete/blocked back to pending).
+                const teamId = await resolveTeamScope(database, channelId);
+                return [
+                    draft.prepareUpdate((d) => {
+                        d.message = message;
+                        d.updateAt = Date.now();
+                    }),
+                    ...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, {type: 'upsert'}),
+                ];
+            }
 
-        if (draft.files.length === 0 && !message) {
-            draft.prepareDestroyPermanently();
-        } else {
-            draft.prepareUpdate((d) => {
-                d.message = message;
-                d.updateAt = Date.now();
-            });
-        }
+            // Message cleared to empty: attachment-only content stays visible, everything else empties.
+            const hasLocalContent = draft.files.length > 0;
+            return prepareEmptyTransition(database, channelId, rootId, draft, outbox, hasLocalContent);
+        });
 
-        if (!prepareRecordsOnly) {
-            await operator.batchRecords([draft], 'updateDraftMessage');
-        }
-
-        return {draft};
+        return {draft: result};
     } catch (error) {
         logError('Failed updateDraftMessage', error);
         return {error};
     }
 }
 
-export async function addFilesToDraft(serverUrl: string, channelId: string, rootId: string, files: FileInfo[], prepareRecordsOnly = false) {
+export async function addFilesToDraft(serverUrl: string, channelId: string, rootId: string, files: FileInfo[]) {
     try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (!draft) {
-            const newDraft: Draft = {
-                channel_id: channelId,
-                root_id: rootId,
-                files,
-                message: '',
-                update_at: Date.now(),
-            };
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        let result: DraftModel | undefined;
 
-            return operator.handleDraft({drafts: [newDraft], prepareRecordsOnly});
-        }
+        await mutateDraftAndOutbox(database, channelId, rootId, async ({draft, outbox}) => {
+            const teamId = await resolveTeamScope(database, channelId);
 
-        draft.prepareUpdate((d) => {
-            d.files = [...draft.files, ...files];
-            d.updateAt = Date.now();
+            // Newly-added attachments usually have no server id yet; capture any that already do.
+            const addedCompletedIds = files.filter((f): f is FileInfo & {id: string} => Boolean(f.id)).map((f) => f.id);
+
+            const message = draft?.message ?? '';
+            const existingFileIds = draft?.fileIds ?? [];
+            const newFileIds = Array.from(new Set([...existingFileIds, ...addedCompletedIds]));
+
+            const models: Model[] = [];
+            if (draft) {
+                result = draft;
+                models.push(draft.prepareUpdate((d) => {
+                    d.files = [...draft.files, ...files];
+                    d.fileIds = newFileIds;
+                    d.updateAt = Date.now();
+                }));
+            } else {
+                const created = database.collections.get<DraftModel>(DRAFT).prepareCreate((d) => {
+                    d.channelId = channelId;
+                    d.rootId = rootId;
+                    d.message = '';
+                    d.updateAt = Date.now();
+                    d.files = files;
+                    d.fileIds = newFileIds;
+                });
+                result = created;
+                models.push(created);
+            }
+
+            // An empty message can never POST, so attachments alone are never a pending upsert:
+            //  - message present -> pending upsert (portable).
+            //  - empty message but a completed (server-backed) attachment -> parked unsyncable_empty.
+            //  - empty message with only in-progress uploads -> waiting_for_upload to protect them.
+            let intent: OutboxIntent;
+            if (message.length > 0) {
+                intent = {type: 'upsert'};
+            } else if (newFileIds.length > 0) {
+                intent = {type: 'park'};
+            } else {
+                intent = {type: 'waitingForUpload'};
+            }
+            models.push(...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, intent));
+
+            return models;
         });
 
-        if (!prepareRecordsOnly) {
-            await operator.batchRecords([draft], 'addFilesToDraft');
-        }
-
-        return {draft};
+        return {draft: result};
     } catch (error) {
         logError('Failed addFilesToDraft', error);
         return {error};
@@ -216,97 +413,131 @@ export async function addFilesToDraft(serverUrl: string, channelId: string, root
 export const removeDraft = async (serverUrl: string, channelId: string, rootId = '') => {
     try {
         const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (draft) {
-            await database.write(async () => {
-                await draft.destroyPermanently();
-            });
-        }
+        let result: DraftModel | undefined;
 
-        return {draft};
+        await mutateDraftAndOutbox(database, channelId, rootId, async ({draft, outbox}) => {
+            if (!draft) {
+                return [];
+            }
+
+            result = draft;
+
+            // Explicit user delete: fingerprint the current content, remove the visible draft, and
+            // queue a non-keepLocal DELETE so the server representation is removed too.
+            const deletedFingerprint = fingerprintDraft(draft);
+            const teamId = await resolveTeamScope(database, channelId);
+            return [
+                draft.prepareDestroyPermanently(),
+                ...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, {
+                    type: 'delete',
+                    keepLocal: false,
+                    deletedFingerprint,
+                }),
+            ];
+        });
+
+        return {draft: result};
     } catch (error) {
         logError('Failed removeDraft', error);
         return {error};
     }
 };
 
-export async function updateDraftPriority(serverUrl: string, channelId: string, rootId: string, postPriority: PostPriority, prepareRecordsOnly = false) {
+export async function updateDraftPriority(serverUrl: string, channelId: string, rootId: string, postPriority: PostPriority) {
     try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (!draft) {
-            const newDraft: Draft = {
-                channel_id: channelId,
-                root_id: rootId,
-                metadata: {
-                    priority: postPriority,
-                },
-                update_at: Date.now(),
-            };
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        let result: DraftModel | undefined;
 
-            return operator.handleDraft({drafts: [newDraft], prepareRecordsOnly});
-        }
+        await mutateDraftAndOutbox(database, channelId, rootId, async ({draft, outbox}) => {
+            const teamId = await resolveTeamScope(database, channelId);
 
-        draft.prepareUpdate((d) => {
-            d.metadata = {
-                ...d.metadata,
-                priority: postPriority,
-            };
-            d.updateAt = Date.now();
+            let message: string;
+            const models: Model[] = [];
+            if (draft) {
+                result = draft;
+                message = draft.message;
+                models.push(draft.prepareUpdate((d) => {
+                    d.metadata = {
+                        ...d.metadata,
+                        priority: postPriority,
+                    };
+                    d.updateAt = Date.now();
+                }));
+            } else {
+                const created = database.collections.get<DraftModel>(DRAFT).prepareCreate((d) => {
+                    d.channelId = channelId;
+                    d.rootId = rootId;
+                    d.message = '';
+                    d.updateAt = Date.now();
+                    d.files = [];
+                    d.fileIds = [];
+                    d.metadata = {priority: postPriority};
+                });
+                result = created;
+                models.push(created);
+                message = '';
+            }
+
+            // Priority is portable metadata, but an empty message can never POST: keep it parked
+            // as unsyncable until a genuine message edit flips it to a pending upsert.
+            const intent = message.length > 0 ? {type: 'upsert'} as const : {type: 'park'} as const;
+            models.push(...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, intent));
+            return models;
         });
 
-        if (!prepareRecordsOnly) {
-            await operator.batchRecords([draft], 'updateDraftPriority');
-        }
-
-        return {draft};
+        return {draft: result};
     } catch (error) {
         logError('Failed updateDraftPriority', error);
         return {error};
     }
 }
 
-export async function updateDraftBoRConfig(serverUrl: string, channelId: string, rootId: string, postBoRConfig: PostBoRConfig, prepareRecordsOnly = false) {
+export async function updateDraftBoRConfig(serverUrl: string, channelId: string, rootId: string, postBoRConfig: PostBoRConfig) {
     try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (!draft) {
-            const newDraft: Draft = {
-                channel_id: channelId,
-                root_id: rootId,
-                update_at: Date.now(),
-                metadata: {
-                    borConfig: postBoRConfig,
-                },
-            };
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        let result: DraftModel | undefined;
+        const draftType = postBoRConfig.enabled ? PostTypes.BURN_ON_READ : '';
 
-            if (postBoRConfig.enabled) {
-                newDraft.type = PostTypes.BURN_ON_READ;
+        await mutateDraftAndOutbox(database, channelId, rootId, async ({draft, outbox}) => {
+            const teamId = await resolveTeamScope(database, channelId);
+
+            let message: string;
+            const models: Model[] = [];
+            if (draft) {
+                result = draft;
+                message = draft.message;
+                models.push(draft.prepareUpdate((d) => {
+                    d.metadata = {
+                        ...d.metadata,
+                        borConfig: postBoRConfig,
+                    };
+                    d.type = draftType;
+                    d.updateAt = Date.now();
+                }));
             } else {
-                newDraft.type = '';
+                const created = database.collections.get<DraftModel>(DRAFT).prepareCreate((d) => {
+                    d.channelId = channelId;
+                    d.rootId = rootId;
+                    d.message = '';
+                    d.updateAt = Date.now();
+                    d.files = [];
+                    d.fileIds = [];
+                    d.metadata = {borConfig: postBoRConfig};
+                    d.type = draftType;
+                });
+                result = created;
+                models.push(created);
+                message = '';
             }
 
-            return operator.handleDraft({drafts: [newDraft], prepareRecordsOnly});
-        }
-
-        draft?.prepareUpdate((d) => {
-            d.metadata = {
-                ...d.metadata,
-                borConfig: postBoRConfig,
-            };
-
-            if (postBoRConfig.enabled) {
-                d.type = PostTypes.BURN_ON_READ;
-            } else {
-                d.type = '';
-            }
+            // Burn-on-read is portable metadata, but an empty message can never POST: park it as
+            // unsyncable until a genuine message edit flips it to a pending upsert.
+            const intent = message.length > 0 ? {type: 'upsert'} as const : {type: 'park'} as const;
+            models.push(...prepareDraftOutbox(database, channelId, rootId, teamId, outbox, intent));
+            return models;
         });
 
-        if (!prepareRecordsOnly) {
-            await operator.batchRecords([draft], 'updateDraftBoRConfig');
-        }
-
-        return {draft};
+        return {draft: result};
     } catch (error) {
         logError('Failed updateDraftBoRConfig', error);
         return {error};
@@ -318,30 +549,34 @@ export async function updateDraftMarkdownImageMetadata({
     channelId,
     rootId,
     imageMetadata,
-    prepareRecordsOnly = false,
 }: {
     serverUrl: string;
     channelId: string;
     rootId: string;
     imageMetadata: Dictionary<PostImage | undefined>;
-    prepareRecordsOnly?: boolean;
 }) {
     try {
-        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        const draft = await getDraft(database, channelId, rootId);
-        if (draft) {
-            draft.prepareUpdate((d) => {
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        let result: DraftModel | undefined;
+
+        // Markdown image dimensions are device-local render hints, not portable content: update
+        // the visible draft only, never touching the DraftOutbox row or the portable generation.
+        await mutateDraftAndOutbox(database, channelId, rootId, ({draft}) => {
+            if (!draft) {
+                return [];
+            }
+
+            result = draft;
+            return [draft.prepareUpdate((d) => {
                 d.metadata = {
                     ...d.metadata,
                     images: imageMetadata,
                 };
                 d.updateAt = Date.now();
-            });
-            if (!prepareRecordsOnly) {
-                await operator.batchRecords([draft], 'updateDraftImageMetadata');
-            }
-        }
-        return {draft};
+            })];
+        });
+
+        return {draft: result};
     } catch (error) {
         logError('Failed updateDraftMarkdownImageMetadata', error);
         return {error};

--- a/app/actions/local/post.test.ts
+++ b/app/actions/local/post.test.ts
@@ -2,8 +2,9 @@
 // See LICENSE.txt for license information.
 
 import {ActionType, Post} from '@constants';
-import {SYSTEM_IDENTIFIERS} from '@constants/database';
+import {MM_TABLES, SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
+import {buildDraftOutboxId, getDraft, getDraftOutbox} from '@queries/servers/drafts';
 import {getPostById} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {COMBINED_USER_ACTIVITY} from '@utils/post_list';
@@ -23,6 +24,10 @@ import {
 } from './post';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
+import type DraftModel from '@typings/database/models/servers/draft';
+import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+
+const {DRAFT, DRAFT_OUTBOX} = MM_TABLES.SERVER;
 
 const serverUrl = 'baseHandler.test.com';
 let operator: ServerDataOperator;
@@ -338,6 +343,102 @@ describe('deletePosts', () => {
 
         const {error} = await deletePosts(serverUrl, [post.id, 'id2']);
         expect(error).toBeDefined();
+    });
+});
+
+describe('draft deletion-origin routing', () => {
+    const seedReplyDraft = async (rootId: string) => {
+        await operator.database.write(async () => {
+            await operator.database.get<DraftModel>(DRAFT).create((d) => {
+                d.channelId = channelId;
+                d.rootId = rootId;
+                d.message = 'a reply draft';
+                d.updateAt = 1;
+            });
+        }, 'seed-reply-draft');
+    };
+
+    const seedOutbox = async (rootId: string) => {
+        await operator.database.write(async () => {
+            await operator.database.get<DraftOutboxModel>(DRAFT_OUTBOX).create((o) => {
+                o._raw.id = buildDraftOutboxId(channelId, rootId);
+                o.channelId = channelId;
+                o.rootId = rootId;
+                o.teamId = 'team1';
+                o.operation = 'upsert';
+                o.generation = 1;
+                o.keepLocal = false;
+                o.attemptCount = 0;
+                o.nextAttemptAt = 0;
+                o.status = 'pending';
+            });
+        }, 'seed-outbox');
+    };
+
+    it('confirmed post deletion removes a CLEAN reply draft and enqueues no delete outbox row', async () => {
+        const rootPost = TestHelper.fakePost({id: 'cleanrootpostid', channel_id: channelId});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [rootPost.id],
+            posts: [rootPost],
+            prepareRecordsOnly: false,
+        });
+        await seedReplyDraft(rootPost.id);
+
+        const {error} = await removePost(serverUrl, rootPost);
+        expect(error).toBeUndefined();
+
+        // The post is gone and the clean reply draft under it was removed...
+        expect(await getPostById(operator.database, rootPost.id)).toBeUndefined();
+        expect(await getDraft(operator.database, channelId, rootPost.id)).toBeUndefined();
+
+        // ...but server cleanup owns the deletion, so no DraftOutbox row was created.
+        expect(await getDraftOutbox(operator.database, channelId, rootPost.id)).toBeUndefined();
+    });
+
+    it('confirmed post deletion preserves a DIRTY reply draft and its outbox (local-wins)', async () => {
+        const rootPost = TestHelper.fakePost({id: 'dirtyrootpostid', channel_id: channelId});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [rootPost.id],
+            posts: [rootPost],
+            prepareRecordsOnly: false,
+        });
+        await seedReplyDraft(rootPost.id);
+        await seedOutbox(rootPost.id);
+
+        const {error} = await removePost(serverUrl, rootPost);
+        expect(error).toBeUndefined();
+
+        expect(await getDraft(operator.database, channelId, rootPost.id)).toBeDefined();
+        expect(await getDraftOutbox(operator.database, channelId, rootPost.id)).toBeDefined();
+    });
+
+    it('cache eviction via deletePosts emits no Draft deletion and preserves drafts + outbox', async () => {
+        const rootId = 'cacheevictionrootid';
+        await seedReplyDraft(rootId);
+        await seedOutbox(rootId);
+
+        // The LokiJS test adapter's unsafeExecute only accepts { loki }, not { sqls }, so we
+        // intercept it to both bypass the invariant and capture the emitted SQL statements.
+        let capturedSqls: Array<[string, unknown[]]> = [];
+        const spy = jest.spyOn(operator.database.adapter, 'unsafeExecute').
+            mockImplementation((operations) => {
+                capturedSqls = (operations as {sqls: Array<[string, unknown[]]>}).sqls;
+                return Promise.resolve();
+            });
+
+        const {error} = await deletePosts(serverUrl, [rootId]);
+        expect(error).toBe(false);
+
+        // No emitted statement targets the Draft table (DraftOutbox is a different table name).
+        expect(capturedSqls.some(([sql]) => (/from\s+Draft\b/i).test(sql))).toBe(false);
+
+        spy.mockRestore();
+
+        // The draft and its outbox intent survive cache eviction.
+        expect(await getDraft(operator.database, channelId, rootId)).toBeDefined();
+        expect(await getDraftOutbox(operator.database, channelId, rootId)).toBeDefined();
     });
 });
 

--- a/app/actions/local/post.ts
+++ b/app/actions/local/post.ts
@@ -5,6 +5,7 @@ import {fetchPostAuthors} from '@actions/remote/post';
 import {ActionType, Post} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import DatabaseManager from '@database/manager';
+import {prepareDeleteCleanReplyDrafts} from '@queries/servers/drafts';
 import {countUsersFromMentions, getPostById, prepareDeletePost, queryPostsById} from '@queries/servers/post';
 import {getCurrentUserId} from '@queries/servers/system';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
@@ -21,7 +22,7 @@ import type MyChannelModel from '@typings/database/models/servers/my_channel';
 import type PostModel from '@typings/database/models/servers/post';
 import type UserModel from '@typings/database/models/servers/user';
 
-const {SERVER: {DRAFT, FILE, POST, POSTS_IN_THREAD, REACTION, THREAD, THREAD_PARTICIPANT, THREADS_IN_TEAM}} = MM_TABLES;
+const {SERVER: {FILE, POST, POSTS_IN_THREAD, REACTION, THREAD, THREAD_PARTICIPANT, THREADS_IN_TEAM}} = MM_TABLES;
 
 export const sendAddToChannelEphemeralPost = async (serverUrl: string, user: UserModel, addedUsernames: string[], messages: string[], channeId: string, postRootId = '') => {
     try {
@@ -120,6 +121,11 @@ export const sendEphemeralPost = async (serverUrl: string, message: string, chan
 async function preparePostDeletion(database: Database, post: PostModel | Post) {
     const removeModels: Model[] = [];
 
+    // Root ids whose confirmed deletion may also remove a CLEAN reply draft. This is the
+    // confirmed server post deletion origin: server cleanup owns the deletion, so we remove
+    // clean reply drafts WITHOUT enqueuing a DELETE outbox row (see prepareDeleteCleanReplyDrafts).
+    const deletedRootIds: string[] = [];
+
     if (post.type === Post.POST_TYPES.COMBINED_USER_ACTIVITY) {
         const systemPostIds = getPostIdsForCombinedUserActivityPost(post.id);
         for await (const id of systemPostIds) {
@@ -129,13 +135,18 @@ async function preparePostDeletion(database: Database, post: PostModel | Post) {
                 removeModels.push(...preparedPost);
             }
         }
+        deletedRootIds.push(...systemPostIds);
     } else {
         const postModel = await getPostById(database, post.id);
         if (postModel) {
             const preparedPost = await prepareDeletePost(postModel);
             removeModels.push(...preparedPost);
         }
+        deletedRootIds.push(post.id);
     }
+
+    const cleanDraftModels = await prepareDeleteCleanReplyDrafts(database, deletedRootIds);
+    removeModels.push(...cleanDraftModels);
 
     return removeModels;
 }
@@ -398,8 +409,12 @@ export async function deletePosts(serverUrl: string, postIds: string[]) {
                     [`DELETE FROM ${POST} where id IN (${postsFormatted})`, []],
                     [`DELETE FROM ${REACTION} where post_id IN (${postsFormatted})`, []],
                     [`DELETE FROM ${FILE} where post_id IN (${postsFormatted})`, []],
-                    [`DELETE FROM ${DRAFT} where root_id IN (${postsFormatted})`, []],
 
+                    // Deliberately do NOT delete drafts here. deletePosts is a cache-eviction /
+                    // data-retention origin (it removes posts to reclaim space, not because they
+                    // were deleted on the server), so it must PRESERVE both the Draft and its
+                    // durable DraftOutbox sync intent. Confirmed server post deletions remove
+                    // clean reply drafts explicitly via preparePostDeletion instead.
                     [`DELETE FROM ${POSTS_IN_THREAD} where root_id IN (${postsFormatted})`, []],
 
                     [`DELETE FROM ${THREAD} where id IN (${postsFormatted})`, []],

--- a/app/components/post_draft/draft_handler/draft_handler.tsx
+++ b/app/components/post_draft/draft_handler/draft_handler.tsx
@@ -10,6 +10,7 @@ import useFileUploadError from '@hooks/file_upload_error';
 import DraftEditPostUploadManager from '@managers/draft_upload_manager';
 import {fileMaxWarning, fileSizeWarning, getUploadErrorMessage, uploadDisabledWarning} from '@utils/file';
 
+import {buildEditorKey, invalidateEditor} from '../editor_guard';
 import SendHandler from '../send_handler';
 
 import type {ErrorHandlers} from '@typings/components/upload_error_handlers';
@@ -68,6 +69,10 @@ export default function DraftHandler(props: Props) {
 
     const clearDraft = useCallback(() => {
         removeDraft(serverUrl, channelId, rootId);
+
+        // Send/Delete resurrection guard: invalidate the editor generation so a
+        // still-pending lifecycle save cannot recreate the just-cleared draft.
+        invalidateEditor(buildEditorKey(serverUrl, channelId, rootId));
         updateValue('');
     }, [serverUrl, channelId, rootId, updateValue]);
 

--- a/app/components/post_draft/editor_guard.test.ts
+++ b/app/components/post_draft/editor_guard.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    buildEditorKey,
+    captureEditorGeneration,
+    clearEditor,
+    invalidateEditor,
+    isEditorGenerationStale,
+    markEditorEdited,
+    markEditorSaved,
+    resetEditorBaseline,
+    shouldSaveEditor,
+} from './editor_guard';
+
+describe('editor_guard', () => {
+    const serverUrl = 'https://server.com';
+    const channelId = 'channel-id';
+    const rootId = '';
+
+    let key: string;
+
+    beforeEach(() => {
+        key = buildEditorKey(serverUrl, channelId, rootId);
+
+        // Ensure a fresh entry for each test.
+        clearEditor(key);
+    });
+
+    it('should build a composite key from serverUrl, channelId and rootId', () => {
+        expect(buildEditorKey('a', 'b', 'c')).toBe('a:b:c');
+    });
+
+    it('should default to clean, non-stale state on first access', () => {
+        expect(shouldSaveEditor(key)).toBe(false);
+        expect(captureEditorGeneration(key)).toBe(0);
+    });
+
+    it('should make shouldSaveEditor true after a genuine edit', () => {
+        markEditorEdited(key);
+        expect(shouldSaveEditor(key)).toBe(true);
+    });
+
+    it('should clear dirty flag and set baseline after markEditorSaved', () => {
+        markEditorEdited(key);
+        markEditorSaved(key, 'saved value');
+        expect(shouldSaveEditor(key)).toBe(false);
+    });
+
+    it('should clear dirty flag without signalling an edit on resetEditorBaseline', () => {
+        markEditorEdited(key);
+        resetEditorBaseline(key, 'external value');
+        expect(shouldSaveEditor(key)).toBe(false);
+    });
+
+    it('should bump generation and clear dirty flag on invalidateEditor', () => {
+        markEditorEdited(key);
+        const before = captureEditorGeneration(key);
+
+        invalidateEditor(key);
+
+        expect(captureEditorGeneration(key)).toBe(before + 1);
+
+        // Resurrection guard: a subsequent lifecycle save must be a no-op.
+        expect(shouldSaveEditor(key)).toBe(false);
+    });
+
+    it('should make a captured generation stale after invalidateEditor', () => {
+        const captured = captureEditorGeneration(key);
+        expect(isEditorGenerationStale(key, captured)).toBe(false);
+
+        invalidateEditor(key);
+
+        expect(isEditorGenerationStale(key, captured)).toBe(true);
+    });
+
+    it('should treat a captured generation as stale when the key is absent', () => {
+        const captured = captureEditorGeneration(key);
+        clearEditor(key);
+        expect(isEditorGenerationStale(key, captured)).toBe(true);
+    });
+
+    it('should remove state on clearEditor so a fresh entry is created afterwards', () => {
+        markEditorEdited(key);
+        invalidateEditor(key);
+        expect(captureEditorGeneration(key)).toBe(1);
+
+        clearEditor(key);
+
+        // Fresh entry: generation reset to 0, clean.
+        expect(captureEditorGeneration(key)).toBe(0);
+        expect(shouldSaveEditor(key)).toBe(false);
+    });
+
+    it('should keep distinct keys independent', () => {
+        const otherKey = buildEditorKey(serverUrl, 'other-channel', rootId);
+        clearEditor(otherKey);
+
+        markEditorEdited(key);
+        invalidateEditor(key);
+
+        expect(shouldSaveEditor(otherKey)).toBe(false);
+        expect(captureEditorGeneration(otherKey)).toBe(0);
+
+        markEditorEdited(otherKey);
+        expect(shouldSaveEditor(otherKey)).toBe(true);
+        expect(shouldSaveEditor(key)).toBe(false);
+
+        clearEditor(otherKey);
+    });
+});

--- a/app/components/post_draft/editor_guard.ts
+++ b/app/components/post_draft/editor_guard.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Per-composer race guard registry.
+//
+// Local Draft edits/deletes are routed through a durable outbox. Once a Send or
+// Delete clears the draft, a still-pending blur / app-background / unmount save
+// can re-run a draft update with stale editor text, resurrecting the draft and
+// coalescing an upsert over the durable DELETE. This module tracks, per composer
+// key, whether the editor holds a genuine unsaved user edit and a monotonically
+// increasing generation that Send/Delete bump so late lifecycle saves become
+// no-ops (both via `shouldSaveEditor` and via the captured-generation staleness
+// check).
+
+type EditorGuardState = {
+
+    // Bumped on every Send/Delete. Lifecycle saves capture the generation before
+    // the async write and discard their result if it changed in the meantime.
+    generation: number;
+
+    // True only after a genuine user keystroke; cleared once saved or when an
+    // external/remote value change updates the baseline.
+    hasUnsavedEdit: boolean;
+
+    // Last value known to be persisted (or externally provided). Kept for
+    // completeness/debugging and to reason about clean-vs-dirty state.
+    baseline: string;
+};
+
+const registry = new Map<string, EditorGuardState>();
+
+/**
+ * Build the registry key shared by the save site and the invalidation sites.
+ */
+export function buildEditorKey(serverUrl: string, channelId: string, rootId: string): string {
+    return `${serverUrl}:${channelId}:${rootId}`;
+}
+
+/**
+ * Lazily create (generation:0, hasUnsavedEdit:false, baseline:'') and return the
+ * state for a key.
+ */
+function getOrCreate(key: string): EditorGuardState {
+    let state = registry.get(key);
+    if (!state) {
+        state = {generation: 0, hasUnsavedEdit: false, baseline: ''};
+        registry.set(key, state);
+    }
+    return state;
+}
+
+/**
+ * Mark the editor dirty in response to a genuine user edit.
+ */
+export function markEditorEdited(key: string): void {
+    getOrCreate(key).hasUnsavedEdit = true;
+}
+
+/**
+ * Record a successful save: clear the dirty flag and advance the baseline.
+ */
+export function markEditorSaved(key: string, value: string): void {
+    const state = getOrCreate(key);
+    state.hasUnsavedEdit = false;
+    state.baseline = value;
+}
+
+/**
+ * Update the baseline from an EXTERNAL/remote value change (channel switch,
+ * clearDraft, remote update). Marks the editor clean but does NOT signal a
+ * user edit, so a later untouched blur/unmount will not resave stale text.
+ */
+export function resetEditorBaseline(key: string, value: string): void {
+    const state = getOrCreate(key);
+    state.hasUnsavedEdit = false;
+    state.baseline = value;
+}
+
+/**
+ * Invalidate the editor on Send/Delete: bump the generation (so captured
+ * generations become stale) and clear the dirty flag (so a subsequent lifecycle
+ * save is a no-op and cannot resurrect the draft).
+ */
+export function invalidateEditor(key: string): void {
+    const state = getOrCreate(key);
+    state.generation += 1;
+    state.hasUnsavedEdit = false;
+}
+
+/**
+ * Whether a lifecycle save should proceed (true only when there is a genuine
+ * unsaved user edit).
+ */
+export function shouldSaveEditor(key: string): boolean {
+    return getOrCreate(key).hasUnsavedEdit;
+}
+
+/**
+ * Capture the current generation for a later staleness check.
+ */
+export function captureEditorGeneration(key: string): number {
+    return getOrCreate(key).generation;
+}
+
+/**
+ * Whether the generation changed since it was captured (or the key is absent).
+ */
+export function isEditorGenerationStale(key: string, captured: number): boolean {
+    const state = registry.get(key);
+    if (!state) {
+        return true;
+    }
+    return state.generation !== captured;
+}
+
+/**
+ * Remove the entry entirely (call on unmount). A subsequent access lazily
+ * recreates a fresh entry.
+ */
+export function clearEditor(key: string): void {
+    registry.delete(key);
+}

--- a/app/components/post_draft/post_input/post_input.tsx
+++ b/app/components/post_draft/post_input/post_input.tsx
@@ -13,7 +13,6 @@ import {
 import {useAnimatedKeyboard} from 'react-native-keyboard-controller';
 import Animated, {cancelAnimation, Easing, useAnimatedStyle, useSharedValue, withRepeat, withTiming} from 'react-native-reanimated';
 
-import {updateDraftMessage} from '@actions/local/draft';
 import {userTyping} from '@actions/websocket/users';
 import {useRewrite} from '@agents/hooks';
 import {Events, Screens} from '@constants';
@@ -26,6 +25,17 @@ import {useCurrentScreen} from '@store/navigation_store';
 import {handleDraftUpdate} from '@utils/draft';
 import {extractFileInfo} from '@utils/file';
 import {changeOpacity, makeStyleSheetFromTheme, getKeyboardAppearanceFromTheme} from '@utils/theme';
+
+import {
+    buildEditorKey,
+    captureEditorGeneration,
+    clearEditor,
+    isEditorGenerationStale,
+    markEditorEdited,
+    markEditorSaved,
+    resetEditorBaseline,
+    shouldSaveEditor,
+} from '../editor_guard';
 
 import type {AvailableScreens} from '@typings/screens/navigation';
 
@@ -196,15 +206,33 @@ export default function PostInput({
         };
     }, [isProcessing, pulseOpacity]);
 
-    const onBlur = useCallback(() => {
+    const editorKey = useMemo(() => buildEditorKey(serverUrl, channelId, rootId), [serverUrl, channelId, rootId]);
+
+    // Guarded lifecycle save: only persists when the editor holds a genuine
+    // unsaved edit, and discards the write (via isStillValid) if a Send/Delete
+    // invalidated the editor generation while the save was in flight. Prevents
+    // a stale blur/background/unmount save from resurrecting a cleared draft.
+    // The editor_guard functions are module-level (stable) and intentionally
+    // omitted from the deps.
+    const guardedSave = useCallback((val: string) => {
+        if (!shouldSaveEditor(editorKey)) {
+            return;
+        }
+        const gen = captureEditorGeneration(editorKey);
         handleDraftUpdate({
             serverUrl,
             channelId,
             rootId,
-            value,
+            value: val,
+            isStillValid: () => !isEditorGenerationStale(editorKey, gen),
         });
+        markEditorSaved(editorKey, val);
+    }, [editorKey, serverUrl, channelId, rootId]);
+
+    const onBlur = useCallback(() => {
+        guardedSave(value);
         setIsFocused(false);
-    }, [serverUrl, channelId, rootId, value, setIsFocused]);
+    }, [guardedSave, value, setIsFocused]);
 
     const onFocus = useCallback(() => {
         // On edge-to-edge Android, ignore focus events when emoji search is focused.
@@ -273,6 +301,7 @@ export default function PostInput({
     const handleTextChange = useCallback((newValue: string) => {
         updateValue(newValue);
         lastNativeValue.current = newValue;
+        markEditorEdited(editorKey);
 
         checkMessageLength(newValue);
 
@@ -287,6 +316,7 @@ export default function PostInput({
         }
     }, [
         updateValue,
+        editorKey,
         checkMessageLength,
         timeBetweenUserTypingUpdatesMilliseconds,
         membersInChannel,
@@ -338,11 +368,11 @@ export default function PostInput({
 
     const onAppStateChange = useCallback((appState: AppStateStatus) => {
         if (appState !== 'active' && previousAppState.current === 'active') {
-            updateDraftMessage(serverUrl, channelId, rootId, value);
+            guardedSave(value);
         }
 
         previousAppState.current = appState;
-    }, [serverUrl, channelId, rootId, value]);
+    }, [guardedSave, value]);
 
     useEffect(() => {
         const listener = AppState.addEventListener('change', onAppStateChange);
@@ -364,12 +394,14 @@ export default function PostInput({
         });
         return () => {
             listener.remove();
-            updateDraftMessage(serverUrl, channelId, rootId, lastNativeValue.current); // safe draft on unmount
+            guardedSave(lastNativeValue.current); // guarded draft save on unmount (no-op when clean or invalidated)
+            clearEditor(editorKey);
         };
 
     // - updateValue and updateCursorPosition are stable setState/hook functions
     // - inputRef is a ref (stable reference, doesn't need to be in deps)
     // - serverUrl, value, lastNativeValue are either stable or we want their latest values when event fires
+    // - guardedSave and editorKey are stable per composer; the guard functions are module-level
     // - We need to recreate the listener when channelId/rootId changes to check the correct source screen
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [updateValue, channelId, rootId, inputRef]);
@@ -377,8 +409,13 @@ export default function PostInput({
     useEffect(() => {
         if (value !== lastNativeValue.current) {
             lastNativeValue.current = value;
+
+            // An EXTERNAL value change (channel switch, clearDraft, or a remote
+            // update) updates the guard baseline and marks the editor clean, so a
+            // later untouched blur/unmount does NOT resave stale text.
+            resetEditorBaseline(editorKey, value);
         }
-    }, [value]);
+    }, [value, editorKey]);
 
     const events = useMemo(() => ({
         onEnterPressed: handleHardwareEnterPress,

--- a/app/constants/draft.ts
+++ b/app/constants/draft.ts
@@ -32,3 +32,25 @@ export const DraftOutboxStatus = {
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type DraftOutboxStatus = typeof DraftOutboxStatus[keyof typeof DraftOutboxStatus];
+
+// Draft sync retry-timer timing (used by DraftSyncManager).
+// DRAFT_SYNC_RETRY_BASE_MS: base delay for the first backoff step.
+export const DRAFT_SYNC_RETRY_BASE_MS = 1_000;
+
+// DRAFT_SYNC_RETRY_MAX_MS: ceiling for the exponential backoff delay.
+export const DRAFT_SYNC_RETRY_MAX_MS = 300_000;
+
+// DRAFT_SYNC_RETRY_JITTER: fractional (+/-) jitter applied to each backoff delay.
+export const DRAFT_SYNC_RETRY_JITTER = 0.2;
+
+// DRAFT_ABSENCE_CONFIRMATION_DELAY_MS: grace period before confirming a draft is absent on the server.
+export const DRAFT_ABSENCE_CONFIRMATION_DELAY_MS = 5_000;
+
+// DRAFT_SYNC_RECONCILIATION_DEADLINE_MS: deadline for a baseline reconciliation pass to complete.
+export const DRAFT_SYNC_RECONCILIATION_DEADLINE_MS = 30_000;
+
+// DRAFT_SYNC_SNAPSHOT_STALE_MS: age after which a cached reconciliation snapshot is considered stale.
+export const DRAFT_SYNC_SNAPSHOT_STALE_MS = 300_000;
+
+// MAX_DRAFT_SYNC_EVENT_BUFFER: hard cap on buffered inbound WebSocket events per server.
+export const MAX_DRAFT_SYNC_EVENT_BUFFER = 1_000;

--- a/app/hooks/handle_send_message.test.tsx
+++ b/app/hooks/handle_send_message.test.tsx
@@ -13,11 +13,13 @@ import {createPost} from '@actions/remote/post';
 import {createScheduledPost} from '@actions/remote/scheduled_post';
 import {handleCallsSlashCommand} from '@calls/actions';
 import {Events, Screens} from '@constants';
+import {MESSAGE_TYPE} from '@constants/snack_bar';
 import {useServerUrl} from '@context/server';
 import DatabaseManager from '@database/manager';
 import DraftUploadManager from '@managers/draft_upload_manager';
 import {getPostById} from '@queries/servers/post';
 import * as DraftUtils from '@utils/draft';
+import {showSnackBar} from '@utils/snack_bar';
 
 import {useHandleSendMessage} from './handle_send_message';
 
@@ -690,5 +692,54 @@ describe('useHandleSendMessage', () => {
         );
         expect(defaultProps.clearDraft).toHaveBeenCalled();
         expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.POST_LIST_SCROLL_TO_BOTTOM, Screens.CHANNEL);
+    });
+
+    it('should fail closed for a BoR send with invalid durations without creating a post or clearing the draft', async () => {
+        const props = {
+            ...defaultProps,
+            postBoRConfig: {
+                enabled: true,
+                borDurationSeconds: 0,
+                borMaximumTimeToLiveSeconds: 3600,
+            } as PostBoRConfig,
+        };
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            await result.current.handleSendMessage();
+        });
+
+        expect(createPost).not.toHaveBeenCalled();
+        expect(createScheduledPost).not.toHaveBeenCalled();
+        expect(props.clearDraft).not.toHaveBeenCalled();
+        expect(showSnackBar).toHaveBeenCalledTimes(1);
+        expect(jest.mocked(showSnackBar).mock.calls[0][0]).toEqual(
+            expect.objectContaining({type: MESSAGE_TYPE.ERROR}),
+        );
+    });
+
+    it('should fail closed for a scheduled BoR send with invalid durations without creating a scheduled post', async () => {
+        const schedulingInfo = {
+            scheduled_at: 1234567890,
+            timezone: 'UTC',
+        };
+        const props = {
+            ...defaultProps,
+            postBoRConfig: {
+                enabled: true,
+                borDurationSeconds: 60,
+                borMaximumTimeToLiveSeconds: 0,
+            } as PostBoRConfig,
+        };
+        const {result} = renderHook(() => useHandleSendMessage(props), {wrapper});
+
+        await act(async () => {
+            await result.current.handleSendMessage(schedulingInfo);
+        });
+
+        expect(createScheduledPost).not.toHaveBeenCalled();
+        expect(createPost).not.toHaveBeenCalled();
+        expect(props.clearDraft).not.toHaveBeenCalled();
+        expect(showSnackBar).toHaveBeenCalledTimes(1);
     });
 });

--- a/app/hooks/handle_send_message.ts
+++ b/app/hooks/handle_send_message.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
-import {useIntl} from 'react-intl';
+import {defineMessages, useIntl} from 'react-intl';
 import {DeviceEventEmitter} from 'react-native';
 
 import {getChannelTimezones} from '@actions/remote/channel';
@@ -26,6 +26,13 @@ import {showSnackBar} from '@utils/snack_bar';
 import {confirmOutOfOfficeDisabled} from '@utils/user';
 
 import type CustomEmojiModel from '@typings/database/models/servers/custom_emoji';
+
+const messages = defineMessages({
+    burnOnReadSendFailed: {
+        id: 'mobile.burn_on_read.send_failed',
+        defaultMessage: 'This burn-on-read message can\'t be sent right now. Your draft has been saved.',
+    },
+});
 
 export type CreateResponse = {
     data?: boolean;
@@ -133,6 +140,19 @@ export const useHandleSendMessage = ({
             post.type = 'burn_on_read';
         }
 
+        // Fail-closed: a burn-on-read send whose config can't be reconstructed
+        // must NOT fall through to a plain (non-burning) post. Abort without
+        // creating the post and without clearing the draft (which stays saved).
+        if (postBoRConfig?.enabled && (!postBoRConfig || postBoRConfig.borDurationSeconds <= 0 || postBoRConfig.borMaximumTimeToLiveSeconds <= 0)) {
+            showSnackBar({
+                barType: SNACK_BAR_TYPE.CREATE_POST_ERROR,
+                customMessage: intl.formatMessage(messages.burnOnReadSendFailed),
+                type: MESSAGE_TYPE.ERROR,
+            });
+            setSendingMessage(false);
+            return;
+        }
+
         let response: CreateResponse;
         if (schedulingInfo) {
             response = await createScheduledPost(serverUrl, scheduledPostFromPost(post, schedulingInfo, postPriority, postFiles));
@@ -185,7 +205,7 @@ export const useHandleSendMessage = ({
 
         setSendingMessage(false);
         DeviceEventEmitter.emit(Events.POST_LIST_SCROLL_TO_BOTTOM, rootId ? Screens.THREAD : Screens.CHANNEL);
-    }, [files, currentUserId, channelId, rootId, value, postPriority, postBoRConfig?.enabled, isFromDraftView, serverUrl, intl, canPost, channelIsArchived, channelIsReadOnly, deactivatedChannel, clearDraft, onPostCreated]);
+    }, [files, currentUserId, channelId, rootId, value, postPriority, postBoRConfig, isFromDraftView, serverUrl, intl, canPost, channelIsArchived, channelIsReadOnly, deactivatedChannel, clearDraft, onPostCreated]);
 
     const showSendToAllOrChannelOrHereAlert = useCallback((calculatedMembersCount: number, atHere: boolean, schedulingInfo?: SchedulingInfo) => {
         const notifyAllMessage = DraftUtils.buildChannelWideMentionMessage(intl, calculatedMembersCount, channelTimezoneCount, atHere);

--- a/app/managers/draft_sync_manager/index.test.ts
+++ b/app/managers/draft_sync_manager/index.test.ts
@@ -1,0 +1,233 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Q, type Database} from '@nozbe/watermelondb';
+
+import {MM_TABLES} from '@constants/database';
+import {DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+import {buildDraftOutboxId} from '@queries/servers/drafts';
+import {advanceTimers, disableFakeTimers, enableFakeTimers} from '@test/timer_helpers';
+import * as log from '@utils/log';
+
+import {exportedForTesting, default as DraftSyncManagerDefault} from './index';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+
+const {DRAFT_OUTBOX} = MM_TABLES.SERVER;
+const {DraftSyncManagerSingleton} = exportedForTesting;
+const SERVER_URL = 'draft.sync.manager.test.com';
+
+const CHANNEL_ID = 'channelidchannelidchannelid0';
+const ROOT_ID = '';
+
+// Narrow view onto the manager's private per-server state for assertions that would otherwise
+// need bespoke test hooks (buffer length, epoch). Typed to avoid `any`.
+type ManagerInternals = {
+    eventBuffers: Record<string, WebSocketMessage[]>;
+    lifecycleEpoch: Record<string, number>;
+};
+
+const internals = (manager: InstanceType<typeof DraftSyncManagerSingleton>) =>
+    manager as unknown as ManagerInternals;
+
+const fakeEvent = (): WebSocketMessage => ({
+    event: 'draft_created',
+    data: {},
+    broadcast: {} as WebsocketBroadcast,
+    seq: 0,
+});
+
+describe('DraftSyncManager (Phase 3 shell)', () => {
+    let database: Database;
+    let operator: ServerDataOperator;
+    let manager: InstanceType<typeof DraftSyncManagerSingleton>;
+
+    const setSyncConfig = async (value: 'true' | 'false') => {
+        await operator.handleConfigs({
+            configs: [{id: 'AllowSyncedDrafts', value}],
+            configsToDelete: [],
+            prepareRecordsOnly: false,
+        });
+    };
+
+    const createOutbox = async (status: DraftOutboxStatus, nextAttemptAt: number, channelId = CHANNEL_ID, rootId = ROOT_ID) => {
+        await database.write(async (writer) => {
+            const record = database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).prepareCreate((o) => {
+                o._raw.id = buildDraftOutboxId(channelId, rootId);
+                o.channelId = channelId;
+                o.rootId = rootId;
+                o.teamId = 'team1';
+                o.operation = 'upsert';
+                o.generation = 1;
+                o.attemptCount = 0;
+                o.nextAttemptAt = nextAttemptAt;
+                o.keepLocal = false;
+                o.status = status;
+                o.lastErrorCode = null;
+                o.deletedFingerprint = null;
+            });
+            await writer.batch(record);
+        });
+    };
+
+    beforeEach(async () => {
+        enableFakeTimers();
+        await DatabaseManager.init([SERVER_URL]);
+        database = DatabaseManager.serverDatabases[SERVER_URL]!.database;
+        operator = DatabaseManager.serverDatabases[SERVER_URL]!.operator;
+        manager = new DraftSyncManagerSingleton();
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        await DatabaseManager.destroyServerDatabase(SERVER_URL);
+        disableFakeTimers();
+    });
+
+    it('does not import or use the network client (sanity guard for the no-network constraint)', () => {
+        // The manager module must never reach for a client in Phase 3.
+        const getClientSpy = jest.spyOn(NetworkManager, 'getClient');
+        manager.initialize(SERVER_URL);
+        expect(getClientSpy).not.toHaveBeenCalled();
+    });
+
+    it('initialize reads capability and schedules a retry timer when an eligible outbox row exists and sync is enabled', async () => {
+        await setSyncConfig('true');
+        await createOutbox(DraftOutboxStatus.Pending, 0);
+
+        await manager.initialize(SERVER_URL);
+
+        expect(jest.getTimerCount()).toBe(1);
+    });
+
+    it('initialize schedules no timer when sync is disabled even with an eligible outbox row', async () => {
+        // No AllowSyncedDrafts config -> capability disabled.
+        await createOutbox(DraftOutboxStatus.Pending, 0);
+
+        await manager.initialize(SERVER_URL);
+
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('does not schedule a timer for rows that are not retry-eligible', async () => {
+        await setSyncConfig('true');
+        await createOutbox(DraftOutboxStatus.Blocked, 0);
+
+        await manager.initialize(SERVER_URL);
+
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('the retry timer firing performs no network call and reschedules itself', async () => {
+        await setSyncConfig('true');
+        await createOutbox(DraftOutboxStatus.Pending, 0);
+
+        const getClientSpy = jest.spyOn(NetworkManager, 'getClient');
+        const querySpy = jest.spyOn(database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX), 'query');
+
+        await manager.initialize(SERVER_URL);
+        expect(jest.getTimerCount()).toBe(1);
+
+        querySpy.mockClear();
+
+        // Fire the heartbeat. It must re-query the outbox and reschedule (row still eligible)
+        // without ever touching the network.
+        await advanceTimers(1);
+
+        expect(getClientSpy).not.toHaveBeenCalled();
+        expect(querySpy).toHaveBeenCalledTimes(1);
+        expect(jest.getTimerCount()).toBe(1);
+    });
+
+    it('invalidate synchronously increments the epoch, cancels the timer and clears the event buffer', async () => {
+        await setSyncConfig('true');
+        await createOutbox(DraftOutboxStatus.Pending, 0);
+        await manager.initialize(SERVER_URL);
+
+        manager.enqueueWebSocketEvent(SERVER_URL, fakeEvent());
+        expect(internals(manager).eventBuffers[SERVER_URL].length).toBe(1);
+        expect(jest.getTimerCount()).toBe(1);
+
+        const epochBefore = internals(manager).lifecycleEpoch[SERVER_URL];
+        manager.invalidate(SERVER_URL);
+
+        expect(internals(manager).lifecycleEpoch[SERVER_URL]).toBe(epochBefore + 1);
+        expect(jest.getTimerCount()).toBe(0);
+        expect(internals(manager).eventBuffers[SERVER_URL].length).toBe(0);
+
+        // Post-invalidate the server is treated as disabled: new events are ignored.
+        manager.enqueueWebSocketEvent(SERVER_URL, fakeEvent());
+        expect(internals(manager).eventBuffers[SERVER_URL].length).toBe(0);
+    });
+
+    it('rejects a retry-timer continuation captured before invalidate as stale and touches nothing', async () => {
+        await setSyncConfig('true');
+        await createOutbox(DraftOutboxStatus.Pending, 0);
+
+        const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+        await manager.initialize(SERVER_URL);
+
+        // Capture the heartbeat callback the manager registered.
+        const lastCall = setTimeoutSpy.mock.calls[setTimeoutSpy.mock.calls.length - 1];
+        const fireCallback = lastCall[0] as () => void;
+
+        manager.invalidate(SERVER_URL);
+
+        const querySpy = jest.spyOn(database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX), 'query');
+
+        // Firing the stale continuation must not re-query the DB nor reschedule a timer.
+        fireCallback();
+        await advanceTimers(0);
+
+        expect(querySpy).not.toHaveBeenCalled();
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('enqueueWebSocketEvent appends synchronously and enforces MAX_DRAFT_SYNC_EVENT_BUFFER', async () => {
+        await setSyncConfig('true');
+        await manager.initialize(SERVER_URL);
+
+        const logSpy = jest.spyOn(log, 'logDebug');
+
+        // Push cap + 1 events; the buffer must stop growing at the cap and log one overflow.
+        for (let i = 0; i < MAX_DRAFT_SYNC_EVENT_BUFFER + 1; i++) {
+            manager.enqueueWebSocketEvent(SERVER_URL, fakeEvent());
+        }
+
+        expect(internals(manager).eventBuffers[SERVER_URL].length).toBe(MAX_DRAFT_SYNC_EVENT_BUFFER);
+        expect(logSpy).toHaveBeenCalledWith(
+            'DraftSyncManager.enqueueWebSocketEvent: buffer overflow, dropping event',
+            SERVER_URL,
+            MAX_DRAFT_SYNC_EVENT_BUFFER,
+        );
+    });
+
+    it('handleCapabilityChange reconstructs the timer on disabled->enabled and cancels it on enabled->disabled without deleting outbox rows', async () => {
+        // Start disabled with an eligible row: initialize leaves capability off and no timer.
+        await createOutbox(DraftOutboxStatus.Pending, 0);
+        await manager.initialize(SERVER_URL);
+        expect(jest.getTimerCount()).toBe(0);
+
+        // disabled -> enabled reconstructs the heartbeat.
+        await setSyncConfig('true');
+        await manager.handleCapabilityChange(SERVER_URL);
+        expect(jest.getTimerCount()).toBe(1);
+
+        // enabled -> disabled cancels the timer but keeps the durable outbox row.
+        await setSyncConfig('false');
+        await manager.handleCapabilityChange(SERVER_URL);
+        expect(jest.getTimerCount()).toBe(0);
+
+        const rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
+            Q.where('status', DraftOutboxStatus.Pending),
+        ).fetch();
+        expect(rows.length).toBe(1);
+    });
+
+    it('exposes a singleton default instance', () => {
+        expect(DraftSyncManagerDefault).toBeDefined();
+    });
+});

--- a/app/managers/draft_sync_manager/index.ts
+++ b/app/managers/draft_sync_manager/index.ts
@@ -1,0 +1,322 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Q, type Database} from '@nozbe/watermelondb';
+
+import {MM_TABLES} from '@constants/database';
+import {DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
+import DatabaseManager from '@database/manager';
+import {getIsDraftSyncEnabled} from '@queries/servers/drafts';
+import {logDebug} from '@utils/log';
+
+import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+
+const {DRAFT_OUTBOX} = MM_TABLES.SERVER;
+
+// RETRY_ELIGIBLE_STATUSES: outbox statuses that represent outstanding work the retry timer must
+// wake up for. Blocked/BlockedUpload/WaitingForUpload rows are intentionally excluded — they are
+// parked awaiting an external signal (unblock, upload completion) and are NOT time-driven.
+const RETRY_ELIGIBLE_STATUSES: DraftOutboxStatus[] = [
+    DraftOutboxStatus.Pending,
+    DraftOutboxStatus.ConfirmingDelete,
+];
+
+/**
+ * DraftSyncManager (Phase 3 shell): the per-server coordinator for synchronized drafts.
+ *
+ * CRITICAL: this phase performs NO network activity. It owns per-server lifecycle state, a
+ * lifecycle epoch used to reject stale async continuations, a bounded inbound WebSocket event
+ * buffer, and a single durable retry timer per server that reconstructs itself from the
+ * DraftOutbox. The retry timer's fire callback does NOT send anything — it merely re-queries the
+ * outbox and reschedules itself (a self-rescheduling heartbeat). Phase 4 will add draining/POST/
+ * DELETE/GET at the marked call sites.
+ *
+ * Per-server state is keyed by serverUrl. A server entry is "present" once initialize() (or any
+ * scheduling path) has created it. A missing entry is treated as invalidated: no new work is
+ * scheduled and captured epochs are considered stale.
+ */
+class DraftSyncManagerSingleton {
+    // lifecycleEpoch: monotonically increasing per server; bumped by invalidate(). A captured
+    // epoch that no longer matches (or whose server entry is gone) marks a stale continuation.
+    private lifecycleEpoch: Record<string, number> = {};
+
+    // retryTimers: at most one active setTimeout per server (the self-rescheduling heartbeat).
+    private retryTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+    // eventBuffers: inbound WebSocket events awaiting Phase 4 draining, bounded by
+    // MAX_DRAFT_SYNC_EVENT_BUFFER. Overflowing events are dropped (oldest kept) with a debug log.
+    private eventBuffers: Record<string, WebSocketMessage[]> = {};
+
+    // enabled: cached draft-sync capability per server (config AND user preference). false when
+    // disabled OR invalidated so no work is scheduled.
+    private enabled: Record<string, boolean> = {};
+
+    // activeCriticalSections: count of in-flight DB writer sections. invalidate() only needs to
+    // wait for these to reach 0 (there is no HTTP in this phase). Tracked here for Phase 4.
+    private activeCriticalSections: Record<string, number> = {};
+
+    // lastReconcile: last requested reconciliation intent per server (Phase 3 records only).
+    private lastReconcile: Record<string, {teamId: string; reason: string}> = {};
+
+    /**
+     * initialize: idempotent per-server setup. Reads the draft-sync capability into `enabled` and,
+     * when enabled, reconstructs the retry timer from the outbox. Safe to call when the server
+     * database is absent (no-op after ensuring the entry exists). Never throws.
+     */
+    public initialize = async (serverUrl: string): Promise<void> => {
+        this.ensureServer(serverUrl);
+
+        const database = this.getDatabase(serverUrl);
+        if (!database) {
+            logDebug('DraftSyncManager.initialize: database absent', serverUrl);
+            return;
+        }
+
+        try {
+            this.enabled[serverUrl] = await getIsDraftSyncEnabled(database);
+        } catch (error) {
+            logDebug('DraftSyncManager.initialize: capability read failed', serverUrl);
+            return;
+        }
+
+        if (this.enabled[serverUrl]) {
+            await this.reconstructRetryTimer(serverUrl);
+        }
+    };
+
+    /**
+     * wake: called after a committed local mutation. Reconstructs/reschedules the retry timer so
+     * newly-enqueued outbox work gets a heartbeat. Never sends.
+     */
+    public wake = (serverUrl: string): void => {
+        if (!this.isActive(serverUrl)) {
+            return;
+        }
+
+        // Fire-and-forget: reconstruction is async (DB query) but wake() is synchronous by contract.
+        this.reconstructRetryTimer(serverUrl);
+    };
+
+    /**
+     * requestReconcile: Phase 3 records the request (last teamId/reason) and ensures a retry timer
+     * exists. It does NOT perform a GET — baseline reconciliation is Phase 4.
+     */
+    public requestReconcile = (serverUrl: string, teamId: string, reason: string): void => {
+        if (!this.isActive(serverUrl)) {
+            return;
+        }
+
+        this.lastReconcile[serverUrl] = {teamId, reason};
+        logDebug('DraftSyncManager.requestReconcile', serverUrl, reason);
+
+        // Phase 4: trigger baseline reconciliation here (GET drafts for the team, diff, reconcile).
+        this.reconstructRetryTimer(serverUrl);
+    };
+
+    /**
+     * enqueueWebSocketEvent: appends an inbound event synchronously before returning. Enforces the
+     * buffer cap: when the buffer is full the event is dropped and an overflow is logged. Ignored
+     * when disabled/invalidated. Does NOT process the event (Phase 4 drains it).
+     */
+    public enqueueWebSocketEvent = (serverUrl: string, event: WebSocketMessage): void => {
+        if (!this.isActive(serverUrl)) {
+            return;
+        }
+
+        const buffer = this.eventBuffers[serverUrl];
+        if (buffer.length >= MAX_DRAFT_SYNC_EVENT_BUFFER) {
+            logDebug('DraftSyncManager.enqueueWebSocketEvent: buffer overflow, dropping event', serverUrl, buffer.length);
+            return;
+        }
+
+        buffer.push(event);
+    };
+
+    /**
+     * handleCapabilityChange: re-reads the capability. enabled->disabled cancels the retry timer and
+     * clears the event buffer WITHOUT deleting Draft/DraftOutbox data. disabled->enabled reconstructs
+     * the retry timer and wakes.
+     */
+    public handleCapabilityChange = async (serverUrl: string): Promise<void> => {
+        this.ensureServer(serverUrl);
+
+        const database = this.getDatabase(serverUrl);
+        if (!database) {
+            logDebug('DraftSyncManager.handleCapabilityChange: database absent', serverUrl);
+            return;
+        }
+
+        let nowEnabled: boolean;
+        try {
+            nowEnabled = await getIsDraftSyncEnabled(database);
+        } catch (error) {
+            logDebug('DraftSyncManager.handleCapabilityChange: capability read failed', serverUrl);
+            return;
+        }
+
+        const wasEnabled = this.enabled[serverUrl];
+        this.enabled[serverUrl] = nowEnabled;
+
+        if (wasEnabled && !nowEnabled) {
+            // enabled -> disabled: stop scheduling and drop transient state, but keep durable rows.
+            this.clearRetryTimer(serverUrl);
+            this.eventBuffers[serverUrl] = [];
+            logDebug('DraftSyncManager.handleCapabilityChange: disabled', serverUrl);
+            return;
+        }
+
+        if (!wasEnabled && nowEnabled) {
+            // disabled -> enabled: resume the heartbeat.
+            logDebug('DraftSyncManager.handleCapabilityChange: enabled', serverUrl);
+            await this.reconstructRetryTimer(serverUrl);
+            this.wake(serverUrl);
+        }
+    };
+
+    /**
+     * invalidate: SYNCHRONOUS teardown. Bumps the lifecycle epoch (so any captured epoch becomes
+     * stale), cancels and clears the retry timer, clears the event buffer, and marks the server
+     * disabled so no new work is scheduled. Does NOT await HTTP (there is none in this phase).
+     */
+    public invalidate = (serverUrl: string): void => {
+        this.lifecycleEpoch[serverUrl] = (this.lifecycleEpoch[serverUrl] ?? 0) + 1;
+        this.clearRetryTimer(serverUrl);
+        this.eventBuffers[serverUrl] = [];
+        this.enabled[serverUrl] = false;
+        this.lastReconcile[serverUrl] = {teamId: '', reason: ''};
+        logDebug('DraftSyncManager.invalidate', serverUrl);
+    };
+
+    // captureEpoch: returns the current lifecycle epoch for a later staleness comparison.
+    private captureEpoch = (serverUrl: string): number => {
+        return this.lifecycleEpoch[serverUrl] ?? 0;
+    };
+
+    // isEpochStale: true when the captured epoch no longer matches the current epoch or the server
+    // entry has been removed. Guards async continuations before they touch the database.
+    private isEpochStale = (serverUrl: string, captured: number): boolean => {
+        if (!(serverUrl in this.lifecycleEpoch)) {
+            return true;
+        }
+        return this.captureEpoch(serverUrl) !== captured;
+    };
+
+    /**
+     * reconstructRetryTimer: rebuilds the single per-server heartbeat from the outbox.
+     *
+     * - When disabled/invalidated or the DB is absent, clears any existing timer and returns.
+     * - Queries retry-eligible rows (Pending / ConfirmingDelete) and finds the earliest
+     *   nextAttemptAt (0 meaning "eligible now").
+     * - With none pending, clears the timer.
+     * - Otherwise schedules ONE setTimeout for max(0, earliest - now). When it fires it guards on
+     *   epoch staleness, then re-runs reconstruction (self-rescheduling). It sends NOTHING.
+     */
+    private reconstructRetryTimer = async (serverUrl: string): Promise<void> => {
+        if (!this.isActive(serverUrl)) {
+            this.clearRetryTimer(serverUrl);
+            return;
+        }
+
+        const database = this.getDatabase(serverUrl);
+        if (!database) {
+            this.clearRetryTimer(serverUrl);
+            return;
+        }
+
+        const captured = this.captureEpoch(serverUrl);
+
+        let earliest: number | undefined;
+        try {
+            earliest = await this.getEarliestNextAttemptAt(database);
+        } catch (error) {
+            logDebug('DraftSyncManager.reconstructRetryTimer: outbox query failed', serverUrl);
+            return;
+        }
+
+        // A concurrent invalidate/disable during the await must not resurrect a timer.
+        if (this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl)) {
+            return;
+        }
+
+        // Always clear the prior timer before deciding — guarantees one timer per server.
+        this.clearRetryTimer(serverUrl);
+
+        if (earliest === undefined) {
+            return;
+        }
+
+        const delay = Math.max(0, earliest - Date.now());
+        this.retryTimers[serverUrl] = setTimeout(() => {
+            if (this.isEpochStale(serverUrl, captured)) {
+                return;
+            }
+
+            // Phase 3: do NOT drain/POST/DELETE. Behave as a self-rescheduling heartbeat.
+            // Phase 4: drain eligible outbox work here.
+            this.reconstructRetryTimer(serverUrl);
+        }, delay);
+    };
+
+    // getEarliestNextAttemptAt: earliest nextAttemptAt across retry-eligible outbox rows, or
+    // undefined when there is no outstanding work.
+    private getEarliestNextAttemptAt = async (database: Database): Promise<number | undefined> => {
+        const rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
+            Q.where('status', Q.oneOf(RETRY_ELIGIBLE_STATUSES)),
+        ).fetch();
+
+        if (!rows.length) {
+            return undefined;
+        }
+
+        let earliest = rows[0].nextAttemptAt;
+        for (const row of rows) {
+            if (row.nextAttemptAt < earliest) {
+                earliest = row.nextAttemptAt;
+            }
+        }
+        return earliest;
+    };
+
+    // clearRetryTimer: cancels and forgets the per-server timer if present.
+    private clearRetryTimer = (serverUrl: string): void => {
+        const timer = this.retryTimers[serverUrl];
+        if (timer) {
+            clearTimeout(timer);
+            delete this.retryTimers[serverUrl];
+        }
+    };
+
+    // ensureServer: lazily creates the per-server state entry (idempotent).
+    private ensureServer = (serverUrl: string): void => {
+        if (!(serverUrl in this.lifecycleEpoch)) {
+            this.lifecycleEpoch[serverUrl] = 0;
+        }
+        if (!(serverUrl in this.eventBuffers)) {
+            this.eventBuffers[serverUrl] = [];
+        }
+        if (!(serverUrl in this.enabled)) {
+            this.enabled[serverUrl] = false;
+        }
+        if (!(serverUrl in this.activeCriticalSections)) {
+            this.activeCriticalSections[serverUrl] = 0;
+        }
+    };
+
+    // isActive: the server is present, enabled, and not invalidated (invalidate sets enabled=false).
+    private isActive = (serverUrl: string): boolean => {
+        return Boolean(this.enabled[serverUrl]) && (serverUrl in this.eventBuffers);
+    };
+
+    // getDatabase: the server database or undefined when it is absent/destroyed. Never throws.
+    private getDatabase = (serverUrl: string): Database | undefined => {
+        return DatabaseManager.serverDatabases[serverUrl]?.database;
+    };
+}
+
+const DraftSyncManager = new DraftSyncManagerSingleton();
+export default DraftSyncManager;
+
+export const exportedForTesting = {
+    DraftSyncManagerSingleton,
+    RETRY_ELIGIBLE_STATUSES,
+};

--- a/app/queries/servers/channel.test.ts
+++ b/app/queries/servers/channel.test.ts
@@ -355,7 +355,6 @@ describe('prepareDeleteChannel', () => {
         const infoModel = TestHelper.fakeChannelInfoModel({prepareDestroyPermanently: jest.fn().mockReturnValue({id: 'info'})});
         const categoryChannelModel = TestHelper.fakeCategoryChannelModel({prepareDestroyPermanently: jest.fn().mockReturnValue({id: 'category'})});
         const memberModels = [TestHelper.fakeChannelMembershipModel({prepareDestroyPermanently: jest.fn().mockReturnValue({id: 'member'})})];
-        const draftModels = [TestHelper.fakeDraftModel({prepareDestroyPermanently: jest.fn().mockReturnValue({id: 'draft'})})];
         const postsInChannelModels = [
             TestHelper.fakePostsInChannelModel({prepareDestroyPermanently: jest.fn().mockReturnValue({id: 'postsInChannel'})}),
         ];
@@ -380,7 +379,6 @@ describe('prepareDeleteChannel', () => {
         jest.mocked(channel.info.fetch).mockResolvedValue(infoModel);
         jest.mocked(channel.categoryChannel.fetch).mockResolvedValue(categoryChannelModel);
         jest.mocked(channel.members.fetch).mockResolvedValue(memberModels);
-        jest.mocked(channel.drafts.fetch).mockResolvedValue(draftModels);
         jest.mocked(channel.postsInChannel.fetch).mockResolvedValue(postsInChannelModels);
         jest.mocked(channel.posts.fetch).mockResolvedValue(postModels);
         jest.mocked(channel.bookmarks.fetch).mockResolvedValue(bookmarkModels);
@@ -394,7 +392,6 @@ describe('prepareDeleteChannel', () => {
             {id: 'info'},
             {id: 'category'},
             {id: 'member'},
-            {id: 'draft'},
             {id: 'postsInChannel'},
             {id: 'post'},
             {id: 'bookmark'},
@@ -405,7 +402,10 @@ describe('prepareDeleteChannel', () => {
         expect(channel.info.fetch).toHaveBeenCalled();
         expect(channel.categoryChannel.fetch).toHaveBeenCalled();
         expect(channel.members.fetch).toHaveBeenCalled();
-        expect(channel.drafts.fetch).toHaveBeenCalled();
+
+        // Channel deletion must PRESERVE drafts (and their DraftOutbox sync intent): the
+        // drafts relation must never be fetched or destroyed by prepareDeleteChannel.
+        expect(channel.drafts.fetch).not.toHaveBeenCalled();
         expect(channel.postsInChannel.fetch).toHaveBeenCalled();
         expect(channel.posts.fetch).toHaveBeenCalled();
         expect(channel.bookmarks.fetch).toHaveBeenCalled();

--- a/app/queries/servers/channel.ts
+++ b/app/queries/servers/channel.ts
@@ -173,9 +173,12 @@ export const prepareDeleteChannel = async (serverUrl: string, channel: ChannelMo
         }
     }));
 
+    // Deliberately omit channel.drafts: a channel delete/leave/purge must PRESERVE both the
+    // Draft and its durable DraftOutbox sync intent. Cascade-destroying drafts here would
+    // silently discard sync intent. Only user delete/send/empty (actions/local/draft.ts) or a
+    // confirmed server post deletion may remove a Draft.
     const associatedChildren: Array<Query<Model> | undefined> = [
         channel.members,
-        channel.drafts,
         channel.postsInChannel,
     ];
     await Promise.all(associatedChildren.map(async (children) => {

--- a/app/queries/servers/drafts.test.ts
+++ b/app/queries/servers/drafts.test.ts
@@ -13,12 +13,14 @@ import {
     getDraft,
     getDraftOutbox,
     mutateDraftAndOutbox,
+    prepareDeleteCleanReplyDrafts,
     prepareDraftOutbox,
     repairDuplicateDrafts,
     type OutboxIntent,
     type PrepareDraftAndOutbox,
 } from './drafts';
 
+import type Model from '@nozbe/watermelondb/Model';
 import type DraftModel from '@typings/database/models/servers/draft';
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
 
@@ -379,6 +381,96 @@ describe('prepareDraftOutbox coalescing', () => {
         await applyIntent({type: 'waitingForUpload'});
         const outbox = await applyIntent({type: 'remove'});
         expect(outbox).toBeUndefined();
+    });
+});
+
+describe('prepareDeleteCleanReplyDrafts', () => {
+    let database: Database;
+
+    const seedDraft = async (channelId: string, rootId: string) => {
+        await database.write(async () => {
+            await database.get<DraftModel>(DRAFT).create((d) => {
+                d.channelId = channelId;
+                d.rootId = rootId;
+                d.message = 'a reply draft';
+                d.updateAt = 1;
+            });
+        }, 'seed-draft');
+    };
+
+    const seedOutbox = async (channelId: string, rootId: string) => {
+        await database.write(async () => {
+            await database.get<DraftOutboxModel>(DRAFT_OUTBOX).create((o) => {
+                o._raw.id = buildDraftOutboxId(channelId, rootId);
+                o.channelId = channelId;
+                o.rootId = rootId;
+                o.teamId = 'team1';
+                o.operation = 'upsert';
+                o.generation = 1;
+                o.keepLocal = false;
+                o.attemptCount = 0;
+                o.nextAttemptAt = 0;
+                o.status = 'pending';
+            });
+        }, 'seed-outbox');
+    };
+
+    const commit = async (models: Model[]) => {
+        if (models.length) {
+            await database.write(async (writer) => {
+                await writer.batch(...models);
+            }, 'commit-clean-drafts');
+        }
+    };
+
+    beforeEach(async () => {
+        await DatabaseManager.init([SERVER_URL]);
+        database = DatabaseManager.serverDatabases[SERVER_URL]!.database;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(SERVER_URL);
+    });
+
+    it('destroys a clean reply draft (no outbox) and enqueues no delete outbox row', async () => {
+        const channelId = 'cleanreplychannelid000000000';
+        const rootId = 'cleanreplyrootid000000000000';
+        await seedDraft(channelId, rootId);
+
+        const models = await prepareDeleteCleanReplyDrafts(database, [rootId]);
+        expect(models.length).toBe(1);
+        await commit(models);
+
+        expect(await getDraft(database, channelId, rootId)).toBeUndefined();
+
+        // Server cleanup owns the deletion: no DraftOutbox row must be created.
+        expect(await getDraftOutbox(database, channelId, rootId)).toBeUndefined();
+    });
+
+    it('preserves a dirty reply draft and its outbox (local-wins)', async () => {
+        const channelId = 'dirtyreplychannelid000000000';
+        const rootId = 'dirtyreplyrootid000000000000';
+        await seedDraft(channelId, rootId);
+        await seedOutbox(channelId, rootId);
+
+        const models = await prepareDeleteCleanReplyDrafts(database, [rootId]);
+        expect(models.length).toBe(0);
+        await commit(models);
+
+        expect(await getDraft(database, channelId, rootId)).toBeDefined();
+        expect(await getDraftOutbox(database, channelId, rootId)).toBeDefined();
+    });
+
+    it('ignores channel drafts (root_id === "") even when a root id matches the channel id', async () => {
+        // Channel draft: root_id === '' and channelId equal to a passed root id.
+        const channelId = 'channelrootcollisionid000000';
+        await seedDraft(channelId, '');
+
+        const models = await prepareDeleteCleanReplyDrafts(database, [channelId]);
+        expect(models.length).toBe(0);
+        await commit(models);
+
+        expect(await getDraft(database, channelId, '')).toBeDefined();
     });
 });
 

--- a/app/queries/servers/drafts.test.ts
+++ b/app/queries/servers/drafts.test.ts
@@ -8,11 +8,14 @@ import DatabaseManager from '@database/manager';
 import ServerDatabaseMigrations from '@database/migration/server';
 
 import {
+    adoptLegacyDrafts,
     buildDraftOutboxId,
     getDraft,
     getDraftOutbox,
     mutateDraftAndOutbox,
+    prepareDraftOutbox,
     repairDuplicateDrafts,
+    type OutboxIntent,
     type PrepareDraftAndOutbox,
 } from './drafts';
 
@@ -287,5 +290,191 @@ describe('DraftOutbox serialized writer and repair', () => {
         // The mutation created its outbox row regardless of ordering.
         const outbox = await getDraftOutbox(database, channelId, '');
         expect(outbox).toBeDefined();
+    });
+});
+
+describe('prepareDraftOutbox coalescing', () => {
+    let database: Database;
+    const channelId = 'coalescechannelid00000000000';
+
+    beforeEach(async () => {
+        await DatabaseManager.init([SERVER_URL]);
+        database = DatabaseManager.serverDatabases[SERVER_URL]!.database;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(SERVER_URL);
+    });
+
+    const applyIntent = async (intent: OutboxIntent) => {
+        await database.write(async (writer) => {
+            const existing = await getDraftOutbox(database, channelId, '');
+            const models = prepareDraftOutbox(database, channelId, '', 'team1', existing, intent);
+            if (models.length) {
+                await writer.batch(...models);
+            }
+        }, 'apply-intent');
+        return getDraftOutbox(database, channelId, '');
+    };
+
+    it('creates a pending upsert from nothing with the given team scope', async () => {
+        const outbox = await applyIntent({type: 'upsert'});
+        expect(outbox?.operation).toBe('upsert');
+        expect(outbox?.status).toBe('pending');
+        expect(outbox?.generation).toBe(1);
+        expect(outbox?.teamId).toBe('team1');
+        expect(outbox?.deletedFingerprint).toBeNull();
+    });
+
+    it('keeps a pending upsert and increments the generation on a second upsert', async () => {
+        await applyIntent({type: 'upsert'});
+        const outbox = await applyIntent({type: 'upsert'});
+        expect(outbox?.operation).toBe('upsert');
+        expect(outbox?.generation).toBe(2);
+        expect(outbox?.status).toBe('pending');
+    });
+
+    it('flips a pending delete to a reset pending upsert on a genuine edit', async () => {
+        await applyIntent({type: 'upsert'});
+        await applyIntent({type: 'delete', keepLocal: true, deletedFingerprint: 'abc123'});
+        const outbox = await applyIntent({type: 'upsert'});
+        expect(outbox?.operation).toBe('upsert');
+        expect(outbox?.status).toBe('pending');
+        expect(outbox?.generation).toBe(3);
+        expect(outbox?.keepLocal).toBe(false);
+        expect(outbox?.deletedFingerprint).toBeNull();
+        expect(outbox?.attemptCount).toBe(0);
+    });
+
+    it('ignores a staleCleanup while a delete is already pending', async () => {
+        await applyIntent({type: 'delete', keepLocal: false, deletedFingerprint: 'fp'});
+        const outbox = await applyIntent({type: 'staleCleanup'});
+        expect(outbox?.operation).toBe('delete');
+        expect(outbox?.deletedFingerprint).toBe('fp');
+        expect(outbox?.generation).toBe(1);
+    });
+
+    it('does not create any row for a staleCleanup when nothing is queued', async () => {
+        const outbox = await applyIntent({type: 'staleCleanup'});
+        expect(outbox).toBeUndefined();
+    });
+
+    it('parks an empty draft as blocked/unsyncable_empty', async () => {
+        const outbox = await applyIntent({type: 'park'});
+        expect(outbox?.operation).toBe('upsert');
+        expect(outbox?.status).toBe('blocked');
+        expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
+    });
+
+    it('flips a parked blocked row to a reset pending upsert on a genuine edit', async () => {
+        await applyIntent({type: 'park'});
+        const outbox = await applyIntent({type: 'upsert'});
+        expect(outbox?.status).toBe('pending');
+        expect(outbox?.lastErrorCode).toBeNull();
+        expect(outbox?.generation).toBe(2);
+        expect(outbox?.attemptCount).toBe(0);
+    });
+
+    it('removes an existing row on a remove intent', async () => {
+        await applyIntent({type: 'waitingForUpload'});
+        const outbox = await applyIntent({type: 'remove'});
+        expect(outbox).toBeUndefined();
+    });
+});
+
+describe('adoptLegacyDrafts', () => {
+    let database: Database;
+
+    const seedDraft = async (channelId: string, message: string, extra?: (d: DraftModel) => void) => {
+        await database.write(async () => {
+            await database.get<DraftModel>(DRAFT).create((d) => {
+                d.channelId = channelId;
+                d.rootId = '';
+                d.message = message;
+                d.updateAt = 1;
+                extra?.(d);
+            });
+        }, 'seed-legacy');
+    };
+
+    beforeEach(async () => {
+        await DatabaseManager.init([SERVER_URL]);
+        database = DatabaseManager.serverDatabases[SERVER_URL]!.database;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(SERVER_URL);
+    });
+
+    it('adopts a non-empty legacy draft as a generation-1 pending upsert', async () => {
+        const channelId = 'legacynonemptychannelid00000';
+        await seedDraft(channelId, 'hello');
+
+        const count = await adoptLegacyDrafts(database);
+        expect(count).toBe(1);
+
+        const outbox = await getDraftOutbox(database, channelId, '');
+        expect(outbox?.operation).toBe('upsert');
+        expect(outbox?.status).toBe('pending');
+        expect(outbox?.generation).toBe(1);
+        expect(outbox?.nextAttemptAt).toBe(0);
+    });
+
+    it('parks an empty legacy draft as unsyncable_empty', async () => {
+        const channelId = 'legacyemptychannelid00000000';
+        await seedDraft(channelId, '');
+
+        const count = await adoptLegacyDrafts(database);
+        expect(count).toBe(1);
+
+        const outbox = await getDraftOutbox(database, channelId, '');
+        expect(outbox?.status).toBe('blocked');
+        expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
+    });
+
+    it('backfills fileIds from completed files when adopting', async () => {
+        const channelId = 'legacyfileschannelid00000000';
+        await seedDraft(channelId, 'with files', (d) => {
+            d.files = [{id: 'srv1', clientId: 'c1'} as FileInfo, {clientId: 'c2'} as FileInfo];
+        });
+
+        await adoptLegacyDrafts(database);
+
+        const draftAfter = await getDraft(database, channelId, '');
+        expect(draftAfter?.fileIds).toEqual(['srv1']);
+    });
+
+    it('skips a draft that already has an outbox and is idempotent', async () => {
+        const channelId = 'legacyidempotentchannelid000';
+        await seedDraft(channelId, 'hello');
+
+        const first = await adoptLegacyDrafts(database);
+        expect(first).toBe(1);
+
+        // Bump the generation so we can detect if a second run overwrites the existing row.
+        await database.write(async () => {
+            const outbox = await getDraftOutbox(database, channelId, '');
+            await outbox!.update((o) => {
+                o.generation = 7;
+            });
+        }, 'bump');
+
+        const second = await adoptLegacyDrafts(database);
+        expect(second).toBe(0);
+
+        const rows = await database.get<DraftOutboxModel>(DRAFT_OUTBOX).query(Q.where('channel_id', channelId)).fetch();
+        expect(rows.length).toBe(1);
+        expect(rows[0].generation).toBe(7);
+    });
+
+    it('does not adopt a draft that already has server ancestry', async () => {
+        const channelId = 'legacyserverbackedchannelid0';
+        await seedDraft(channelId, 'synced', (d) => {
+            d.serverUpdateAt = 999;
+        });
+
+        const count = await adoptLegacyDrafts(database);
+        expect(count).toBe(0);
+        expect(await getDraftOutbox(database, channelId, '')).toBeUndefined();
     });
 });

--- a/app/queries/servers/drafts.ts
+++ b/app/queries/servers/drafts.ts
@@ -6,13 +6,18 @@ import {combineLatest, distinctUntilChanged, of as of$, switchMap} from 'rxjs';
 
 import {Preferences} from '@constants';
 import {MM_TABLES} from '@constants/database';
+import {DraftOutboxOperation, DraftOutboxStatus} from '@constants/draft';
 import DraftModel from '@typings/database/models/servers/draft';
 
+import {getChannelById} from './channel';
 import {queryPreferencesByCategoryAndName} from './preference';
 import {getConfigBooleanValue, observeConfigBooleanValue} from './system';
 
 import type Model from '@nozbe/watermelondb/Model';
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+
+/** UNSYNCABLE_EMPTY: parked-outbox error code for a draft that cannot POST because its message is empty. */
+export const UNSYNCABLE_EMPTY = 'unsyncable_empty';
 
 const {SERVER: {DRAFT, DRAFT_OUTBOX, CHANNEL}} = MM_TABLES;
 
@@ -237,4 +242,230 @@ export const repairDuplicateDrafts = async (database: Database): Promise<number>
 
         return toDestroy.length;
     }, 'repairDuplicateDrafts');
+};
+
+/**
+ * OutboxIntent: the abstract intents a Draft mutation can express toward the DraftOutbox row.
+ * The coalescing helper below turns an intent plus the existing outbox row into the prepared
+ * create/update/destroy record(s), applying the authoritative coalescing table.
+ *  - upsert: a genuine portable content create/edit -> pending upsert (resets retry state).
+ *  - delete: a user delete / send / content-emptied -> pending delete carrying keepLocal + fingerprint.
+ *  - park: an unsyncable empty-message draft with local-only content -> blocked/unsyncable_empty.
+ *  - waitingForUpload: an in-progress attachment with no portable content yet -> waiting_for_upload.
+ *  - staleCleanup: a blur/unmount empty cleanup that must never disturb an already-queued op (no-op).
+ *  - remove: drop the outbox row entirely (nothing left to sync).
+ */
+export type OutboxIntent =
+    | {type: 'upsert'}
+    | {type: 'delete'; keepLocal: boolean; deletedFingerprint: string}
+    | {type: 'park'}
+    | {type: 'waitingForUpload'}
+    | {type: 'staleCleanup'}
+    | {type: 'remove'};
+
+/**
+ * prepareDraftOutbox: pure, serialized-writer-safe coalescing of a DraftOutbox row. Given the
+ * existing outbox (or none) and a new intent, it returns the prepared record(s) to commit inside a
+ * mutateDraftAndOutbox writer. It NEVER commits anything itself and NEVER reads/writes the Draft row.
+ * See OutboxIntent and the coalescing table in the feature spec for the authoritative transitions.
+ */
+export const prepareDraftOutbox = (
+    database: Database,
+    channelId: string,
+    rootId: string,
+    teamId: string,
+    existing: DraftOutboxModel | undefined,
+    intent: OutboxIntent,
+): Model[] => {
+    const collection = database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX);
+
+    const createOutbox = (init: (o: DraftOutboxModel) => void): Model => {
+        return collection.prepareCreate((o) => {
+            o._raw.id = buildDraftOutboxId(channelId, rootId);
+            o.channelId = channelId;
+            o.rootId = rootId;
+            o.teamId = teamId;
+            o.generation = 1;
+            o.attemptCount = 0;
+            o.nextAttemptAt = 0;
+            o.keepLocal = false;
+            o.lastErrorCode = null;
+            o.deletedFingerprint = null;
+            init(o);
+        });
+    };
+
+    switch (intent.type) {
+        case 'upsert': {
+            if (!existing) {
+                return [createOutbox((o) => {
+                    o.operation = DraftOutboxOperation.Upsert;
+                    o.status = DraftOutboxStatus.Pending;
+                })];
+            }
+
+            // A genuine new content generation is always immediately retryable: reset retry state
+            // and clear any delete-only metadata regardless of the previous operation/status.
+            return [existing.prepareUpdate((o) => {
+                o.operation = DraftOutboxOperation.Upsert;
+                o.status = DraftOutboxStatus.Pending;
+                o.generation += 1;
+                o.attemptCount = 0;
+                o.nextAttemptAt = 0;
+                o.lastErrorCode = null;
+                o.deletedFingerprint = null;
+                o.keepLocal = false;
+            })];
+        }
+
+        case 'delete': {
+            if (!existing) {
+                return [createOutbox((o) => {
+                    o.operation = DraftOutboxOperation.Delete;
+                    o.status = DraftOutboxStatus.Pending;
+                    o.keepLocal = intent.keepLocal;
+                    o.deletedFingerprint = intent.deletedFingerprint;
+                })];
+            }
+
+            return [existing.prepareUpdate((o) => {
+                o.operation = DraftOutboxOperation.Delete;
+                o.status = DraftOutboxStatus.Pending;
+                o.generation += 1;
+                o.attemptCount = 0;
+                o.nextAttemptAt = 0;
+                o.lastErrorCode = null;
+                o.keepLocal = intent.keepLocal;
+                o.deletedFingerprint = intent.deletedFingerprint;
+            })];
+        }
+
+        case 'park': {
+            if (!existing) {
+                return [createOutbox((o) => {
+                    o.operation = DraftOutboxOperation.Upsert;
+                    o.status = DraftOutboxStatus.Blocked;
+                    o.lastErrorCode = UNSYNCABLE_EMPTY;
+                })];
+            }
+
+            return [existing.prepareUpdate((o) => {
+                o.operation = DraftOutboxOperation.Upsert;
+                o.status = DraftOutboxStatus.Blocked;
+                o.generation += 1;
+                o.attemptCount = 0;
+                o.nextAttemptAt = 0;
+                o.lastErrorCode = UNSYNCABLE_EMPTY;
+                o.keepLocal = false;
+                o.deletedFingerprint = null;
+            })];
+        }
+
+        case 'waitingForUpload': {
+            if (!existing) {
+                return [createOutbox((o) => {
+                    o.operation = DraftOutboxOperation.Upsert;
+                    o.status = DraftOutboxStatus.WaitingForUpload;
+                })];
+            }
+
+            // Never downgrade a draft that already has portable content queued.
+            if (existing.status === DraftOutboxStatus.Pending) {
+                return [];
+            }
+
+            // An in-progress attachment is a device-local change: keep the generation as-is.
+            return [existing.prepareUpdate((o) => {
+                o.operation = DraftOutboxOperation.Upsert;
+                o.status = DraftOutboxStatus.WaitingForUpload;
+            })];
+        }
+
+        case 'remove': {
+            return existing ? [existing.prepareDestroyPermanently()] : [];
+        }
+
+        case 'staleCleanup':
+        default: {
+            // A stale blur/unmount cleanup must never create or disturb a queued operation.
+            return [];
+        }
+    }
+};
+
+/**
+ * adoptLegacyDrafts: one-time backfill that gives every pre-sync Draft (serverUpdateAt null/0 and
+ * no existing DraftOutbox row) a DraftOutbox intent so it can participate in synchronization.
+ * A non-empty draft becomes a generation-1 pending upsert (immediately eligible). An empty-message
+ * draft becomes a parked blocked/unsyncable_empty row. Optionally restricted to a single team scope
+ * (a draft's scope is its channel's teamId; '' for DM/GM). Idempotent: drafts that already have an
+ * outbox are skipped. Returns the number of drafts adopted.
+ */
+export const adoptLegacyDrafts = async (database: Database, teamId?: string): Promise<number> => {
+    return database.write(async (writer) => {
+        const drafts = await database.collections.get<DraftModel>(DRAFT).query().fetch();
+        const outboxes = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query().fetch();
+        const existingOutboxIds = new Set(outboxes.map((o) => o.id));
+        const collection = database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX);
+
+        const models: Model[] = [];
+        let adopted = 0;
+        for (const draft of drafts) {
+            if ((draft.serverUpdateAt ?? 0) > 0) {
+                continue;
+            }
+
+            const outboxId = buildDraftOutboxId(draft.channelId, draft.rootId);
+            if (existingOutboxIds.has(outboxId)) {
+                continue;
+            }
+
+            // eslint-disable-next-line no-await-in-loop
+            const scope = (await getChannelById(database, draft.channelId))?.teamId ?? '';
+            if (teamId != null && scope !== teamId) {
+                continue;
+            }
+
+            // Backfill portable attachment ids from hydrated files when the new column is empty.
+            let fileIds = draft.fileIds ?? [];
+            if (fileIds.length === 0) {
+                fileIds = (draft.files ?? []).filter((f): f is FileInfo & {id: string} => Boolean(f.id)).map((f) => f.id);
+                if (fileIds.length) {
+                    const derived = fileIds;
+                    models.push(draft.prepareUpdate((d) => {
+                        d.fileIds = derived;
+                    }));
+                }
+            }
+
+            const hasMessage = (draft.message ?? '').length > 0;
+            models.push(collection.prepareCreate((o) => {
+                o._raw.id = outboxId;
+                o.channelId = draft.channelId;
+                o.rootId = draft.rootId;
+                o.teamId = scope;
+                o.operation = DraftOutboxOperation.Upsert;
+                o.generation = 1;
+                o.attemptCount = 0;
+                o.nextAttemptAt = 0;
+                o.keepLocal = false;
+                o.deletedFingerprint = null;
+                if (hasMessage) {
+                    o.status = DraftOutboxStatus.Pending;
+                    o.lastErrorCode = null;
+                } else {
+                    o.status = DraftOutboxStatus.Blocked;
+                    o.lastErrorCode = UNSYNCABLE_EMPTY;
+                }
+            }));
+            existingOutboxIds.add(outboxId);
+            adopted += 1;
+        }
+
+        if (models.length) {
+            await writer.batch(...models);
+        }
+
+        return adopted;
+    }, 'adoptLegacyDrafts');
 };

--- a/app/queries/servers/drafts.ts
+++ b/app/queries/servers/drafts.ts
@@ -146,6 +146,48 @@ export const getDraftOutbox = async (database: Database, channelId: string, root
 };
 
 /**
+ * prepareDeleteCleanReplyDrafts: deletion-origin helper for the CONFIRMED server post deletion
+ * path only. When a root post is confirmed deleted on the server, any reply draft under that root
+ * whose message will never be posted should be removed — but ONLY if it is CLEAN (has no pending
+ * local DraftOutbox intent). Server cleanup already owns the deletion, so we NEVER enqueue a DELETE
+ * outbox row here.
+ *
+ * Rules:
+ *  - Considers Draft rows whose root_id is one of `rootIds` AND root_id !== '' (reply drafts only;
+ *    channel drafts, root_id === '', are never touched even if their channel matches).
+ *  - A draft with NO DraftOutbox row is CLEAN -> prepareDestroyPermanently().
+ *  - A draft WITH a DraftOutbox row carries pending local intent -> local-wins: PRESERVE both the
+ *    Draft and its outbox (add nothing for it).
+ *
+ * Returns prepared destroy records (uncommitted). Never creates or modifies a DraftOutbox row.
+ */
+export const prepareDeleteCleanReplyDrafts = async (database: Database, rootIds: string[]): Promise<Model[]> => {
+    if (!rootIds.length) {
+        return [];
+    }
+
+    const drafts = await database.collections.get<DraftModel>(DRAFT).query(
+        Q.where('root_id', Q.oneOf(rootIds)),
+        Q.where('root_id', Q.notEq('')),
+    ).fetch();
+
+    if (!drafts.length) {
+        return [];
+    }
+
+    const models: Model[] = [];
+    for (const draft of drafts) {
+        // eslint-disable-next-line no-await-in-loop
+        const outbox = await getDraftOutbox(database, draft.channelId, draft.rootId);
+        if (!outbox) {
+            models.push(draft.prepareDestroyPermanently());
+        }
+    }
+
+    return models;
+};
+
+/**
  * Prepare function passed to mutateDraftAndOutbox. It receives the current Draft and
  * DraftOutbox rows for the composite key (already fetched inside the writer) and must
  * return the prepared records (via prepareCreate/prepareUpdate/prepareDestroyPermanently)

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -28,7 +28,12 @@ const DEFAULT_BURN_ON_READ_MAXIMUM_TTL_SECONDS = '604800';
 
 export const prepareDeletePost = async (post: PostModel): Promise<Model[]> => {
     const preparedModels: Model[] = [post.prepareDestroyPermanently()];
-    const relations: Array<Query<Model>> = [post.drafts, post.files, post.reactions];
+
+    // Deliberately omit post.drafts: a generic post deletion must NOT cascade-destroy reply
+    // drafts, because that would silently discard the durable DraftOutbox sync intent. Only a
+    // confirmed server post deletion may remove a CLEAN reply draft, handled explicitly via
+    // prepareDeleteCleanReplyDrafts in the confirmed-deletion path (actions/local/post.ts).
+    const relations: Array<Query<Model>> = [post.files, post.reactions];
     for await (const models of relations) {
         try {
             models.forEach((m) => {

--- a/app/utils/draft/index.ts
+++ b/app/utils/draft/index.ts
@@ -6,6 +6,7 @@ import {Alert, type AlertButton} from 'react-native';
 import {type SwipeableMethods} from 'react-native-gesture-handler/ReanimatedSwipeable';
 
 import {parseMarkdownImages, removeDraft, updateDraftMarkdownImageMetadata, updateDraftMessage} from '@actions/local/draft';
+import {buildEditorKey, invalidateEditor} from '@components/post_draft/editor_guard';
 import {General} from '@constants';
 import {CODE_REGEX} from '@constants/autocomplete';
 
@@ -185,15 +186,23 @@ export const handleDraftUpdate = async ({
     channelId,
     rootId,
     value,
+    isStillValid,
 }: {
     serverUrl: string;
     channelId: string;
     rootId: string;
     value: string;
+    isStillValid?: () => boolean;
 }) => {
     await updateDraftMessage(serverUrl, channelId, rootId, value);
     const imageMetadata: Dictionary<PostImage | undefined> = {};
     await parseMarkdownImages(serverUrl, value, imageMetadata);
+
+    // Discard stale markdown metadata if the editor generation changed (e.g. a
+    // Send/Delete invalidated this composer) while parsing was in flight.
+    if (isStillValid?.() === false) {
+        return;
+    }
 
     if (Object.keys(imageMetadata).length !== 0) {
         updateDraftMarkdownImageMetadata({serverUrl, channelId, rootId, imageMetadata});
@@ -209,6 +218,10 @@ export function deleteDraftConfirmation({intl, serverUrl, channelId, rootId, swi
 }) {
     const deleteDraft = async () => {
         removeDraft(serverUrl, channelId, rootId);
+
+        // Resurrection guard: invalidate the editor generation so deleting an
+        // active composer's draft can't be resurrected by a later lifecycle save.
+        invalidateEditor(buildEditorKey(serverUrl, channelId, rootId));
     };
 
     const onDismiss = () => {

--- a/app/utils/draft/sync.test.ts
+++ b/app/utils/draft/sync.test.ts
@@ -3,7 +3,7 @@
 
 import TestHelper from '@test/test_helper';
 
-import {buildDraftUpsertRequest, isSyncableDraft, normalizeServerDraft, reconstructDraftBoRConfig} from './sync';
+import {buildDraftUpsertRequest, draftContentFingerprint, isSyncableDraft, normalizeServerDraft, reconstructDraftBoRConfig} from './sync';
 
 const baseServerDraft: DraftApi = {
     create_at: 100,
@@ -174,6 +174,58 @@ describe('buildDraftUpsertRequest (mobile -> server)', () => {
         };
 
         expect(buildDraftUpsertRequest(draft)).toBeNull();
+    });
+});
+
+describe('draftContentFingerprint', () => {
+    const base = {
+        message: 'hello',
+        type: '' as PostTypesUserCreatable,
+        props: {from_webhook: 'true'} as DraftProps,
+        fileIds: ['file1', 'file2'],
+        priority: {priority: 'urgent'} as PostPriority,
+    };
+
+    it('should produce the same hash for identical content', () => {
+        expect(draftContentFingerprint(base)).toBe(draftContentFingerprint({...base}));
+    });
+
+    it('should never return the raw content', () => {
+        const fingerprint = draftContentFingerprint(base);
+        expect(fingerprint).not.toContain('hello');
+        expect(fingerprint).not.toContain('file1');
+        expect(fingerprint).not.toContain('urgent');
+        expect(fingerprint.length).toBeGreaterThan(0);
+    });
+
+    it('should change when the message changes', () => {
+        expect(draftContentFingerprint({...base, message: 'world'})).not.toBe(draftContentFingerprint(base));
+    });
+
+    it('should change when the fileIds change', () => {
+        expect(draftContentFingerprint({...base, fileIds: ['file1']})).not.toBe(draftContentFingerprint(base));
+    });
+
+    it('should change when the props change', () => {
+        expect(draftContentFingerprint({...base, props: {from_webhook: 'false'}})).not.toBe(draftContentFingerprint(base));
+    });
+
+    it('should change when the priority changes', () => {
+        expect(draftContentFingerprint({...base, priority: {priority: 'important'} as PostPriority})).not.toBe(draftContentFingerprint(base));
+    });
+
+    it('should be independent of prop key order and fileId order', () => {
+        const a = draftContentFingerprint({
+            ...base,
+            props: {a: '1', b: '2'} as unknown as DraftProps,
+            fileIds: ['file1', 'file2'],
+        });
+        const b = draftContentFingerprint({
+            ...base,
+            props: {b: '2', a: '1'} as unknown as DraftProps,
+            fileIds: ['file2', 'file1'],
+        });
+        expect(a).toBe(b);
     });
 });
 

--- a/app/utils/draft/sync.ts
+++ b/app/utils/draft/sync.ts
@@ -64,6 +64,71 @@ export const reconstructDraftBoRConfig = (
 };
 
 /**
+ * stableStringify: deterministic JSON serialization with object keys sorted at every level.
+ * Two structurally-equal objects always produce the same string regardless of key insertion
+ * order, which is what makes the fingerprint below order-independent.
+ */
+const stableStringify = (value: unknown): string => {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value) ?? 'null';
+    }
+
+    if (Array.isArray(value)) {
+        return `[${value.map(stableStringify).join(',')}]`;
+    }
+
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+};
+
+/**
+ * cyrb53: a small, fast, deterministic non-cryptographic 53-bit string hash. It is NOT
+ * reversible and NOT collision-proof, but collisions between two different draft contents are
+ * astronomically unlikely for our purposes. Returned as a hex string.
+ */
+const cyrb53 = (str: string, seed = 0): string => {
+    let h1 = 0xdeadbeef ^ seed;
+    let h2 = 0x41c6ce57 ^ seed;
+    for (let i = 0; i < str.length; i++) {
+        const ch = str.charCodeAt(i);
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+    h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+    h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    const hash = (4294967296 * (2097151 & h2)) + (h1 >>> 0);
+    return hash.toString(16);
+};
+
+/**
+ * draftContentFingerprint: produce a stable, deterministic, non-reversible hash of a draft's
+ * canonical server-visible content (message, type, props, sorted fileIds, priority). Same content
+ * always yields the same hash; different content practically always yields a different hash. The
+ * raw content is NEVER returned, only the hash — this lets the outbox distinguish a stale replica
+ * echo of deleted content from genuinely new content without persisting the content itself.
+ */
+export const draftContentFingerprint = (input: {
+    message: string;
+    type: string | null;
+    props: DraftProps | null;
+    fileIds: string[];
+    priority?: PostPriority;
+}): string => {
+    const canonical = {
+        message: input.message,
+        type: input.type ?? '',
+        props: input.props ?? {},
+        fileIds: [...input.fileIds].sort(),
+        priority: input.priority ?? null,
+    };
+
+    return cyrb53(stableStringify(canonical));
+};
+
+/**
  * isSyncableDraft: a draft is only syncable when it has message content. Empty-message
  * drafts (attachment-only, priority-only, burn-on-read-only, type/props-only) are never
  * synced because the server treats an empty-message upsert as a delete.

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -669,6 +669,7 @@
   "mobile.burn_on_read.placeholder": "View message",
   "mobile.burn_on_read.read_receipt.text": "Read by {readReceipts} of {totalReceipts} recipients",
   "mobile.burn_on_read.read_receipt.title": "Burn-on-read message",
+  "mobile.burn_on_read.send_failed": "This burn-on-read message can't be sent right now. Your draft has been saved.",
   "mobile.calls_bluetooth": "Bluetooth",
   "mobile.calls_call_ended": "Call ended",
   "mobile.calls_call_screen": "Call",


### PR DESCRIPTION
## Summary

Phase 3 of synchronized drafts — **complete** (all four sub-steps). Still **local-only, no network activity**; the app is functionally unchanged for users. This phase builds the durable intent + race guards that Phase 4 will drive. Stacked on the Phase 2 branch (#9964).

### Sub-steps

**3.1 — Atomic local draft intent** (`6fdb18f`)
Every portable Draft mutation commits content **and** durable sync intent atomically via `mutateDraftAndOutbox`. Coalescing table (upsert/delete/park/waitingForUpload/remove/staleCleanup), generation, `keep_local`, `waiting_for_upload`, pre-empty `deleted_fingerprint`, team scope, legacy adoption; `prepareRecordsOnly` removed. Empty-message drafts never POST — they park as `unsyncable_empty`.

**3.2 — Deletion-origin routing** (`cb16a8e`)
Stripped drafts from every generic cascade (post/channel/data-retention) so eviction **preserves** Draft+outbox; clean reply drafts removed only at the confirmed-server-post-deletion origin (no redundant DELETE; dirty drafts preserved, local-wins).

**3.3 — Composer race guards + fail-closed BoR send guard** (`5cb2fbe`)
Per-composer `editor_guard` module (keyed by `serverUrl:channelId:rootId`) tracking genuine unsaved edits + a generation bumped on Send/Delete. Blur/background/unmount route through `guardedSave` (no-op when clean; discards its write if invalidated mid-save). `clearDraft`/delete invalidate the editor so a pending lifecycle save can't resurrect a just-sent/deleted draft. Stale markdown-image metadata discarded on generation change. Fail-closed burn-on-read send guard on both paths (keeps the draft, no downgraded plain post).

**3.4 — DraftSyncManager shell** (`b31a9b4`)
Per-server coordinator scaffolding with **no network**: lifecycle epoch (rejects stale continuations), synchronous `invalidate`, bounded event buffer, self-rescheduling retry timer that reconstructs from the outbox but sends nothing. Timing constants added.

### Checks
- `npm run tsc` — clean; `eslint --quiet` on all changed files — clean.
- Jest — every touched + adjacent suite green (draft/post/channel actions & queries, editor guard, handle_send_message incl. BoR fail-closed, manager shell, draft_upload_manager, handle_send_message). Combined runs: 241 / 179 / 126 / 10 pass.

### Verification notes / follow-ups
- **Mobile-MCP** verification of the live composer (type → blur-save → send → delete, BoR) is deferred to **Phase 7** — Phase 3 has no network, so cross-client behavior isn't exercisable yet, and the guards preserve existing local UX.
- **Phase-4 prerequisite refinement:** the BoR send guard currently keys on `postBoRConfig?.enabled` (covers all Phase-3-reachable states). When Phase 4 loads *remote* BoR drafts whose config can't be reconstructed, the guard should also key on the persisted draft `type` so an unreconstructable remote BoR draft fails closed instead of silently downgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)