### PR TITLE
Self-heal a channel hidden by a post-less PostsInChannel interval

### DIFF
--- a/app/actions/local/post.test.ts
+++ b/app/actions/local/post.test.ts
@@ -4,7 +4,7 @@
 import {ActionType, Post} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {getPostById} from '@queries/servers/post';
+import {getPostById, queryPostsInChannel} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {COMBINED_USER_ACTIVITY} from '@utils/post_list';
 
@@ -15,6 +15,7 @@ import {
     markPostAsDeleted,
     storePostsForChannel,
     getPosts,
+    pruneEmptyPostsInChannelIntervals,
     addPostAcknowledgement,
     removePostAcknowledgement,
     deletePosts,
@@ -222,6 +223,50 @@ describe('storePostsForChannel', () => {
         expect(error).toBeUndefined();
         expect(models).toBeDefined();
         expect(models?.length).toBe(4); // Post, PostsInChannel, User, MyChannel
+    });
+});
+
+describe('pruneEmptyPostsInChannelIntervals', () => {
+    const seedInterval = (earliest: number, latest: number) => operator.handleReceivedPostsInChannel([
+        TestHelper.fakePost({channel_id: channelId, create_at: earliest}),
+        TestHelper.fakePost({channel_id: channelId, create_at: latest}),
+    ]);
+
+    it('handle not found database', async () => {
+        const {models, error} = await pruneEmptyPostsInChannelIntervals('foo', channelId);
+        expect(models).toBeUndefined();
+        expect(error).toBeTruthy();
+    });
+
+    it('should remove the intervals with no posts and keep the ones with posts', async () => {
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        const post = TestHelper.fakePost({channel_id: channelId, create_at: 1000, update_at: 1000});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [post.id],
+            posts: [post],
+            prepareRecordsOnly: false,
+        });
+
+        // An interval covering a range where no post is left, as happens once every post it was
+        // built from is deleted on the server.
+        await seedInterval(8000, 9000);
+        expect((await queryPostsInChannel(database, channelId).fetch()).length).toBe(2);
+
+        const {models, error} = await pruneEmptyPostsInChannelIntervals(serverUrl, channelId);
+        expect(error).toBeUndefined();
+        expect(models?.length).toBe(1);
+
+        const remaining = await queryPostsInChannel(database, channelId).fetch();
+        expect(remaining.length).toBe(1);
+        expect(remaining[0].earliest).toBe(1000);
+        expect(remaining[0].latest).toBe(1000);
+    });
+
+    it('should do nothing when the channel has no intervals', async () => {
+        const {models, error} = await pruneEmptyPostsInChannelIntervals(serverUrl, channelId);
+        expect(error).toBeUndefined();
+        expect(models?.length).toBe(0);
     });
 });
 

--- a/app/actions/local/post.ts
+++ b/app/actions/local/post.ts
@@ -5,12 +5,12 @@ import {fetchPostAuthors} from '@actions/remote/post';
 import {ActionType, Post} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {countUsersFromMentions, getPostById, prepareDeletePost, queryPostsById} from '@queries/servers/post';
+import {countUsersFromMentions, getPostById, prepareDeletePost, queryPostsById, queryPostsChunk, queryPostsInChannel} from '@queries/servers/post';
 import {getCurrentUserId} from '@queries/servers/system';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
 import {generateId} from '@utils/general';
 import {safeParseJSON} from '@utils/helpers';
-import {logError} from '@utils/log';
+import {logDebug, logError} from '@utils/log';
 import {getLastFetchedAtFromPosts} from '@utils/post';
 import {getPostIdsForCombinedUserActivityPost} from '@utils/post_list';
 
@@ -307,6 +307,50 @@ export async function storePostsForChannel(
         return {models};
     } catch (error) {
         logError('storePostsForChannel', error);
+        return {error};
+    }
+}
+
+/**
+ * pruneEmptyPostsInChannelIntervals: removes the PostsInChannel intervals of a channel that no
+ * longer contain any post.
+ *
+ * The channel post list renders the newest interval only (`postsInChannel[0]`, the one with the
+ * greatest `latest`). An interval whose posts are all gone -- every post in it was deleted on the
+ * server, so `handlePosts` destroyed them locally -- renders zero rows and hides the whole channel,
+ * and nothing repairs it: a since-fetch has no posts to widen it with, and a full page fetch lands
+ * on a lower interval that never becomes `postsInChannel[0]` (MM-66467). Since an interval with no
+ * posts carries no information -- re-fetching an empty range is harmless -- dropping it lets the
+ * next interval (or a fresh page fetch) render again.
+ *
+ * @param {string} serverUrl
+ * @param {string} channelId
+ * @returns {Promise<{models?: PostsInChannelModel[]; error?: unknown}>}
+ */
+export async function pruneEmptyPostsInChannelIntervals(serverUrl: string, channelId: string) {
+    try {
+        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const intervals = await queryPostsInChannel(database, channelId).fetch();
+        if (!intervals.length) {
+            logDebug('pruneEmptyPostsInChannelIntervals no intervals for channel', channelId);
+            return {models: []};
+        }
+
+        const counts = await Promise.all(intervals.map(
+            (interval) => queryPostsChunk(database, channelId, interval.earliest, interval.latest).fetchCount(),
+        ));
+        const models = intervals.
+            filter((_, index) => counts[index] === 0).
+            map((interval) => interval.prepareDestroyPermanently());
+
+        if (models.length) {
+            logDebug('pruneEmptyPostsInChannelIntervals removing empty intervals', channelId, models.length);
+            await operator.batchRecords(models, 'pruneEmptyPostsInChannelIntervals');
+        }
+
+        return {models};
+    } catch (error) {
+        logError('Failed pruneEmptyPostsInChannelIntervals', error);
         return {error};
     }
 }

--- a/app/actions/remote/post.test.ts
+++ b/app/actions/remote/post.test.ts
@@ -10,7 +10,7 @@ import DatabaseManager from '@database/manager';
 import PostModel from '@database/models/server/post';
 import NetworkManager from '@managers/network_manager';
 import {getMyChannel} from '@queries/servers/channel';
-import {getRecentPostsInChannel, queryPostsInChannel} from '@queries/servers/post';
+import {getPostById, getRecentPostsInChannel, queryPostsInChannel} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {getFullErrorMessage} from '@utils/errors';
 
@@ -26,6 +26,7 @@ import {
     revealBoRPost,
     fetchPostsForChannel,
     fetchPostsForUnreadChannels,
+    refreshPostsForChannel,
     fetchPosts,
     fetchPostsBefore,
     fetchPostsSince,
@@ -42,6 +43,7 @@ import {
 import * as PostAuxilaryFunctions from './post.auxiliary';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
+import type {Database} from '@nozbe/watermelondb';
 
 const serverUrl = 'baseHandler.test.com';
 let operator: ServerDataOperator;
@@ -899,6 +901,59 @@ describe('get posts', () => {
         expect(mockClient.getPosts).toHaveBeenCalled();
         expect(result.actionType).toBe(ActionType.POSTS.RECEIVED_IN_CHANNEL);
         expect((await getRecentPostsInChannel(database, channelId)).length).toBe(2);
+    });
+
+    describe('refreshPostsForChannel', () => {
+        let database: Database;
+        const seedChannel = async () => {
+            await operator.handleChannel({channels: [channel1], prepareRecordsOnly: false});
+            await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+        };
+
+        beforeEach(() => {
+            database = DatabaseManager.serverDatabases[serverUrl]!.database;
+            mockClient.getPosts.mockClear();
+        });
+
+        it('should just fetch a page when the list is showing posts', async () => {
+            await seedChannel();
+            const post = TestHelper.fakePost({channel_id: channelId, id: 'shownpostid', create_at: 1000, update_at: 1000});
+            await storePostsForChannel(serverUrl, channelId, [post], [post.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+            await refreshPostsForChannel(serverUrl, channelId, false);
+
+            expect(mockClient.getPosts).toHaveBeenCalledWith(channelId, 0, expect.any(Number), true, true, undefined);
+            expect(await getPostById(database, post.id)).toBeDefined();
+        });
+
+        it('should reset the cached posts when the list is blank but the channel has posts', async () => {
+            await seedChannel();
+
+            // A blank channel: its only interval covers a range where no post is left, so the post
+            // list renders nothing while the older post is still stored.
+            const hiddenPost = TestHelper.fakePost({channel_id: channelId, id: 'hiddenpostid', create_at: 1000, update_at: 1000});
+            await storePostsForChannel(serverUrl, channelId, [hiddenPost], [hiddenPost.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+            await operator.handleReceivedPostsInChannel([TestHelper.fakePost({channel_id: channelId, create_at: 9000})]);
+
+            await refreshPostsForChannel(serverUrl, channelId, true);
+
+            // The stale interval and the hidden post are gone, replaced by a clean fetch.
+            expect(await getPostById(database, hiddenPost.id)).toBeUndefined();
+            const intervals = await queryPostsInChannel(database, channelId).fetch();
+            expect(intervals.length).toBe(1);
+            expect((await getRecentPostsInChannel(database, channelId)).length).toBe(2);
+            expect((await getMyChannel(database, channelId))!.lastFetchedAt).toBeGreaterThan(0);
+        });
+
+        it('should not reset anything when the channel is genuinely empty', async () => {
+            await seedChannel();
+
+            await refreshPostsForChannel(serverUrl, channelId, true);
+
+            // Nothing to repair, so it behaves like a regular refresh.
+            expect(mockClient.getPosts).toHaveBeenCalled();
+            expect((await getRecentPostsInChannel(database, channelId)).length).toBe(2);
+        });
     });
 
     it('fetchPostsForChannel - request error', async () => {

--- a/app/actions/remote/post.test.ts
+++ b/app/actions/remote/post.test.ts
@@ -3,11 +3,14 @@
 
 /* eslint-disable max-lines */
 
+import {storePostsForChannel} from '@actions/local/post';
 import {ActionType, Post, ServerErrors} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import PostModel from '@database/models/server/post';
 import NetworkManager from '@managers/network_manager';
+import {getMyChannel} from '@queries/servers/channel';
+import {getRecentPostsInChannel, queryPostsInChannel} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {getFullErrorMessage} from '@utils/errors';
 
@@ -831,6 +834,71 @@ describe('get posts', () => {
         expect(result.error).toBeUndefined();
         expect(result.posts).toBeTruthy();
         expect(result.posts?.length).toBe(0);
+    });
+
+    it('fetchPostsForChannel - recovers a channel whose newest interval has no posts left (MM-66467)', async () => {
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+
+        // History of the channel: interval [1000, 1000].
+        const oldPost = TestHelper.fakePost({channel_id: channelId, id: 'oldpostid', user_id: user1.id, create_at: 1000, update_at: 1000});
+        await storePostsForChannel(serverUrl, channelId, [oldPost], [oldPost.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        // A much newer post arrives, creating a second, disjoint interval [9000, 9000].
+        const newPost = TestHelper.fakePost({channel_id: channelId, id: 'newpostid', user_id: user2.id, create_at: 9000, update_at: 9000});
+        await storePostsForChannel(serverUrl, channelId, [newPost], [newPost.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        expect((await queryPostsInChannel(database, channelId).fetch()).length).toBe(2);
+
+        // The newer post is deleted on the server, so it is dropped locally and its interval is left
+        // with no posts. That interval still has the greatest `latest`, so it is the one the channel
+        // post list renders: the channel goes blank even though the old post is still in the database.
+        await storePostsForChannel(
+            serverUrl, channelId,
+            [{...newPost, delete_at: 9500, update_at: 9500}], [newPost.id], '',
+            ActionType.POSTS.RECEIVED_IN_CHANNEL, [],
+        );
+        expect(await getRecentPostsInChannel(database, channelId)).toHaveLength(0);
+
+        // Nothing new on the server, so a since-fetch cannot repair anything.
+        mockClient.getPostsSince.mockImplementationOnce(jest.fn(() => ({posts: {}, order: []})));
+        const result = await fetchPostsForChannel(serverUrl, channelId);
+        expect(result.error).toBeUndefined();
+
+        // The post-less interval is gone and the channel renders its history again.
+        const intervals = await queryPostsInChannel(database, channelId).fetch();
+        expect(intervals.length).toBe(1);
+        expect(intervals[0].earliest).toBe(1000);
+        const recent = await getRecentPostsInChannel(database, channelId);
+        expect(recent.length).toBe(1);
+        expect(recent[0].id).toBe(oldPost.id);
+    });
+
+    it('fetchPostsForChannel - falls back to a page fetch when no interval has posts left', async () => {
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+
+        const onlyPost = TestHelper.fakePost({channel_id: channelId, id: 'onlypostid', user_id: user1.id, create_at: 1000, update_at: 1000});
+        await storePostsForChannel(serverUrl, channelId, [onlyPost], [onlyPost.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        await storePostsForChannel(
+            serverUrl, channelId,
+            [{...onlyPost, delete_at: 1500, update_at: 1500}], [onlyPost.id], '',
+            ActionType.POSTS.RECEIVED_IN_CHANNEL, [],
+        );
+
+        // lastFetchedAt is now 1500 while the channel has no posts at all: a since-fetch would ask
+        // for posts newer than 1500 and get nothing, leaving the channel blank forever.
+        expect((await getMyChannel(database, channelId))!.lastFetchedAt).toBe(1500);
+
+        mockClient.getPosts.mockClear();
+        mockClient.getPostsSince.mockClear();
+        const result = await fetchPostsForChannel(serverUrl, channelId);
+        expect(result.error).toBeUndefined();
+        expect(mockClient.getPostsSince).not.toHaveBeenCalled();
+        expect(mockClient.getPosts).toHaveBeenCalled();
+        expect(result.actionType).toBe(ActionType.POSTS.RECEIVED_IN_CHANNEL);
+        expect((await getRecentPostsInChannel(database, channelId)).length).toBe(2);
     });
 
     it('fetchPostsForChannel - request error', async () => {

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -5,7 +5,7 @@
 /* eslint-disable max-lines */
 
 import {markChannelAsUnread, updateLastPostAt} from '@actions/local/channel';
-import {addPostAcknowledgement, removePost, removePostAcknowledgement, storePostsForChannel} from '@actions/local/post';
+import {addPostAcknowledgement, pruneEmptyPostsInChannelIntervals, removePost, removePostAcknowledgement, storePostsForChannel} from '@actions/local/post';
 import {addRecentReaction} from '@actions/local/reactions';
 import {createThreadFromNewPost} from '@actions/local/thread';
 import {fetchChannelStats} from '@actions/remote/channel';
@@ -296,8 +296,19 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
         let postAction: Promise<PostsRequest>|undefined;
         let actionType: string|undefined;
         const myChannel = await getMyChannel(database, channelId);
-        const postsInChannel = await getRecentPostsInChannel(database, channelId);
-        const since = myChannel?.lastFetchedAt || postsInChannel?.[0]?.createAt || 0;
+        let postsInChannel = await getRecentPostsInChannel(database, channelId);
+        if (!postsInChannel.length) {
+            // The newest PostsInChannel interval renders no posts, so the channel looks blank. That
+            // happens when every post of that interval was deleted on the server, and neither a
+            // since-fetch nor a full page fetch can repair it while the empty interval stays the
+            // newest one (MM-66467). Drop the post-less intervals so a lower interval can render.
+            await pruneEmptyPostsInChannelIntervals(serverUrl, channelId);
+            postsInChannel = await getRecentPostsInChannel(database, channelId);
+        }
+
+        // Only trust lastFetchedAt while we still have posts to show: a since-fetch returns nothing
+        // when there is nothing newer, which would leave a channel with no local posts blank.
+        const since = postsInChannel.length ? (myChannel?.lastFetchedAt || postsInChannel[0].createAt) : 0;
         if (since) {
             postAction = fetchPostsSince(serverUrl, channelId, since, true, groupLabel);
             actionType = ActionType.POSTS.RECEIVED_SINCE;

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable max-lines */
 
-import {markChannelAsUnread, updateLastPostAt} from '@actions/local/channel';
+import {deletePostsForChannel, markChannelAsUnread, updateLastPostAt} from '@actions/local/channel';
 import {addPostAcknowledgement, pruneEmptyPostsInChannelIntervals, removePost, removePostAcknowledgement, storePostsForChannel} from '@actions/local/post';
 import {addRecentReaction} from '@actions/local/reactions';
 import {createThreadFromNewPost} from '@actions/local/thread';
@@ -17,7 +17,7 @@ import NetworkManager from '@managers/network_manager';
 import {getMyChannel, prepareMissingChannelsForAllTeams, queryAllMyChannel} from '@queries/servers/channel';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
 import {getFilesByIds, queryFilesForPost} from '@queries/servers/file';
-import {getPostById, getRecentPostsInChannel} from '@queries/servers/post';
+import {getPostById, getRecentPostsInChannel, queryPostsForChannel} from '@queries/servers/post';
 import {getCurrentUserId} from '@queries/servers/system';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
 import {queryAllUsers} from '@queries/servers/user';
@@ -27,7 +27,7 @@ import {isBoRPost} from '@utils/bor';
 import {getValidEmojis, matchEmoticons} from '@utils/emoji/helpers';
 import {getFullErrorMessage, isServerError} from '@utils/errors';
 import {hasArrayChanged} from '@utils/helpers';
-import {logDebug, logError} from '@utils/log';
+import {logDebug, logError, logWarning} from '@utils/log';
 import {processPostsFetched} from '@utils/post';
 import {getPostIdsForCombinedUserActivityPost} from '@utils/post_list';
 
@@ -346,6 +346,42 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
             EphemeralStore.stopLoadingMessagesForChannel(serverUrl, channelId);
         }
     }
+}
+
+/**
+ * refreshPostsForChannel: handles pull-to-refresh on a channel post list.
+ *
+ * `isBlank` says the list is rendering nothing. A channel renders nothing while it still has posts
+ * stored when its local PostsInChannel bookkeeping hides them -- the rendered interval holds no
+ * post, or holds only posts the list filters out -- and a page fetch cannot repair that: the
+ * interval it creates sorts below the bad one, so it never becomes the interval the list renders
+ * (MM-66467). Clearing the channel's cached posts and re-fetching from scratch is the only reliable
+ * recovery, so do that when we find posts the user should be seeing. Every other refresh keeps the
+ * plain page fetch.
+ *
+ * @param {string} serverUrl
+ * @param {string} channelId
+ * @param {boolean} isBlank whether the post list is currently rendering no posts
+ */
+export async function refreshPostsForChannel(serverUrl: string, channelId: string, isBlank = false) {
+    if (isBlank) {
+        try {
+            const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+            const hidden = await queryPostsForChannel(database, channelId).fetchCount();
+            if (hidden) {
+                logWarning('refreshPostsForChannel resetting the cached posts of a blank channel', channelId, hidden);
+                const {error} = await deletePostsForChannel(serverUrl, channelId);
+                if (!error) {
+                    return fetchPostsForChannel(serverUrl, channelId);
+                }
+            }
+        } catch (error) {
+            // Fall through to the regular refresh, which reports its own errors
+            logDebug('error on refreshPostsForChannel', getFullErrorMessage(error));
+        }
+    }
+
+    return fetchPosts(serverUrl, channelId);
 }
 
 export const fetchPostsForUnreadChannels = async (

--- a/app/actions/remote/post_desync.probe.test.ts
+++ b/app/actions/remote/post_desync.probe.test.ts
@@ -1,0 +1,344 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Diagnostic probes for the watermark/interval desync class behind #9103 ("Empty channels").
+//
+// Each probe drives real code and then asserts WHAT THE CODE CURRENTLY DOES, so several of them
+// assert broken outcomes on purpose. They are not regression tests and no fix is applied here:
+// the point is to find out which of the suspected mechanisms actually produce the reported
+// symptoms (blank channel / permanently missing messages) and which ones turn out to be harmless.
+//
+// The two invariants under test:
+//   I1  MyChannel.lastFetchedAt (the `since` watermark) must not exceed the newest post the
+//       PostsInChannel intervals actually cover -- getPostsSince can never return anything older.
+//   I2  The interval the channel list renders (postsInChannel[0]) must contain at least one post
+//       the list can render. Under CRT the list renders root posts only.
+
+import {Q, type Database} from '@nozbe/watermelondb';
+
+import {storePostsForChannel} from '@actions/local/post';
+import {ActionType} from '@constants';
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+import {getMyChannel} from '@queries/servers/channel';
+import {getRecentPostsInChannel, queryPostsBetween, queryPostsInChannel} from '@queries/servers/post';
+import TestHelper from '@test/test_helper';
+
+import {backgroundNotification} from './notifications';
+import {fetchPostsAround, fetchPostsForChannel} from './post';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+
+const serverUrl = 'desync.probe.test.com';
+const channelId = 'channelid1';
+const teamId = 'teamid1';
+const userId = 'userid1';
+
+let database: Database;
+let operator: ServerDataOperator;
+
+const post = (id: string, createAt: number, over: Partial<Post> = {}) => TestHelper.fakePost({
+    id,
+    channel_id: channelId,
+    user_id: userId,
+    create_at: createAt,
+    update_at: createAt,
+    ...over,
+});
+
+const mockClient = {
+    getPosts: jest.fn(() => ({posts: {}, order: []})),
+    getPostsSince: jest.fn(() => ({posts: {}, order: []})),
+    getPostsBefore: jest.fn(() => ({posts: {}, order: []})),
+    getPostsAfter: jest.fn(() => ({posts: {}, order: []})),
+    getPostThread: jest.fn(() => ({posts: {}, order: []})),
+    getProfilesByIds: jest.fn(() => []),
+    getProfilesByUsernames: jest.fn(() => []),
+};
+
+let mockIsCRTEnabled: jest.Mock;
+jest.mock('@queries/servers/thread', () => {
+    const original = jest.requireActual('@queries/servers/thread');
+    mockIsCRTEnabled = jest.fn(() => true);
+    return {...original, getIsCRTEnabled: mockIsCRTEnabled};
+});
+
+beforeAll(() => {
+    // @ts-expect-error partial client
+    NetworkManager.getClient = () => mockClient;
+});
+
+beforeEach(async () => {
+    await DatabaseManager.init([serverUrl]);
+    const server = DatabaseManager.serverDatabases[serverUrl]!;
+    database = server.database;
+    operator = server.operator;
+    mockIsCRTEnabled.mockImplementation(() => true);
+    Object.values(mockClient).forEach((m) => m.mockClear());
+
+    await operator.handleChannel({channels: [TestHelper.fakeChannel({id: channelId, team_id: teamId})], prepareRecordsOnly: false});
+    await operator.handleMyChannel({
+        channels: [TestHelper.fakeChannel({id: channelId, team_id: teamId})],
+        myChannels: [TestHelper.fakeChannelMember({id: channelId, channel_id: channelId, user_id: userId})],
+        prepareRecordsOnly: false,
+    });
+});
+
+afterEach(async () => {
+    await DatabaseManager.destroyServerDatabase(serverUrl);
+});
+
+const intervals = () => queryPostsInChannel(database, channelId).fetch();
+const watermark = async () => (await getMyChannel(database, channelId))!.lastFetchedAt;
+
+// Mirrors the channel post list enhancer (app/screens/channel/channel_post_list/index.ts): it
+// renders postsInChannel[0] only, and filters to root posts when CRT is on.
+const renderedPosts = async (isCRTEnabled: boolean) => {
+    const chunks = await intervals();
+    if (!chunks.length) {
+        return [];
+    }
+    const {earliest, latest} = chunks[0];
+    return queryPostsBetween(database, earliest, latest, Q.desc, '', channelId, isCRTEnabled ? '' : undefined).fetch();
+};
+
+const seedHistory = async (timestamps: number[]) => {
+    const posts = timestamps.map((t) => post(`seed-${t}`, t));
+    await storePostsForChannel(serverUrl, channelId, posts, posts.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+};
+
+describe('PROBE 1: a thread-reply push moves the watermark past the interval, and the next since-fetch cements the gap', () => {
+    it('reproduces the hole and shows nothing will ever fetch it', async () => {
+        await seedHistory([100, 105, 110]);
+        expect(await watermark()).toBe(110);
+        expect(await intervals()).toHaveLength(1);
+
+        // The push path: a CRT thread reply, far newer than the interval (kondo97's repro).
+        const root = post('root', 90);
+        const reply = post('reply', 200, {root_id: 'root'});
+        await storePostsForChannel(
+            serverUrl, channelId, [root, reply], [reply.id, root.id], '',
+            ActionType.POSTS.RECEIVED_IN_THREAD, [],
+        );
+
+        const afterPush = await intervals();
+        expect(await watermark()).toBe(200); // watermark advanced
+        expect(afterPush).toHaveLength(1);
+        expect(afterPush[0].latest).toBe(110); // interval did not
+
+        // Posts 111..199 exist on the server but were never fetched. The next channel open asks
+        // for posts since the watermark, so they are already out of reach.
+        await fetchPostsForChannel(serverUrl, channelId);
+        expect(mockClient.getPostsSince).toHaveBeenCalledWith(channelId, 200, true, true, undefined);
+
+        // And when a later since-fetch does bring something back, the interval is stretched over
+        // the gap, so the app now claims to hold 111..199 contiguously.
+        const newer = post('newer', 300);
+        await storePostsForChannel(serverUrl, channelId, [newer], [newer.id], '', ActionType.POSTS.RECEIVED_SINCE, []);
+
+        const afterSince = await intervals();
+        expect(afterSince).toHaveLength(1);
+        expect(afterSince[0].earliest).toBe(100);
+        expect(afterSince[0].latest).toBe(300);
+
+        // Interval claims [100,300]; the posts it actually holds skip everything between 110 and 200.
+        // (The thread root at 90 is not even in the interval, so it never renders in the channel.)
+        const held = (await queryPostsBetween(database, 100, 300, Q.desc, '', channelId).fetch()).map((p) => p.createAt).sort((a, b) => a - b);
+        expect(held).toEqual([100, 105, 110, 200, 300]);
+    });
+});
+
+describe('PROBE 2: an edited old post in a partial payload pushes the watermark past the interval', () => {
+    it('advances lastFetchedAt to update_at while the interval only tracks create_at', async () => {
+        await seedHistory([100, 105, 110]);
+
+        // A push payload carrying a single old post that was edited recently. No thread involved.
+        const edited = post('seed-105', 105, {update_at: 5000});
+        await storePostsForChannel(serverUrl, channelId, [edited], [edited.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        expect((await intervals())[0].latest).toBe(110);
+        expect(await watermark()).toBe(5000);
+
+        await fetchPostsForChannel(serverUrl, channelId);
+        expect(mockClient.getPostsSince).toHaveBeenCalledWith(channelId, 5000, true, true, undefined);
+    });
+});
+
+describe('PROBE 3: an interval that holds only thread replies renders a blank channel under CRT', () => {
+    it('3a: extending the interval with replies is harmless', async () => {
+        await seedHistory([1000, 2000]);
+
+        const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
+        await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_SINCE, []);
+
+        const chunks = await intervals();
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].latest).toBe(9000);
+        expect(await renderedPosts(true)).not.toHaveLength(0);
+    });
+
+    it('3b: a replies-only IN_CHANNEL store creates a disjoint interval that renders nothing under CRT', async () => {
+        await seedHistory([1000, 2000]);
+
+        const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
+        await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        const chunks = await intervals();
+        expect(chunks).toHaveLength(2);
+        expect(chunks[0].earliest).toBe(8000);
+        expect(chunks[0].latest).toBe(9000);
+
+        // The reported symptom and the reported recovery, side by side.
+        expect(await renderedPosts(true)).toHaveLength(0);
+        expect(await renderedPosts(false)).toHaveLength(2);
+    });
+
+    it('3c: a full page fetch cannot dislodge the bad interval', async () => {
+        await seedHistory([1000, 2000]);
+        const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
+        await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        // What pull-to-refresh and the "too few posts" fallback do: page 0 with CRT, i.e. roots only.
+        const roots = [post('seed-1000', 1000), post('seed-2000', 2000), post('newroot', 2500)];
+        mockClient.getPosts.mockImplementationOnce(() => ({
+            posts: Object.fromEntries(roots.map((p) => [p.id, p])),
+            order: roots.map((p) => p.id).reverse(),
+        }) as never);
+        await storePostsForChannel(serverUrl, channelId, roots, roots.map((p) => p.id).reverse(), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        const chunks = await intervals();
+        expect(chunks[0].latest).toBe(9000); // still the replies-only interval
+        expect(await renderedPosts(true)).toHaveLength(0);
+    });
+
+    it('3d: the interval prune added in #9970 does not catch it (CRT-blind predicate)', async () => {
+        await seedHistory([1000, 2000]);
+        const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
+        await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        // getRecentPostsInChannel counts every non-deleted post in the interval, replies included,
+        // so fetchPostsForChannel does not consider the channel blank and never prunes.
+        expect(await getRecentPostsInChannel(database, channelId)).toHaveLength(2);
+        await fetchPostsForChannel(serverUrl, channelId);
+        expect((await intervals())[0].latest).toBe(9000);
+        expect(await renderedPosts(true)).toHaveLength(0);
+    });
+});
+
+describe('PROBE 4: backgroundNotification classifies a thread reply from the payload flag', () => {
+    const pushNotification = (isCRTEnabled: boolean | undefined, posts: Post[], order: string[]) => ({
+        payload: {
+            channel_id: channelId,
+            team_id: teamId,
+            post_id: order[0],
+            root_id: 'root',
+            isCRTEnabled,
+            data: {
+                posts: {posts: Object.fromEntries(posts.map((p) => [p.id, p])), order},
+            },
+        },
+    });
+
+    it('4a: with the flag set, the reply is stored as a thread post (no interval change)', async () => {
+        await seedHistory([100, 110]);
+        const reply = post('reply', 200, {root_id: 'root'});
+
+        await backgroundNotification(serverUrl, pushNotification(true, [reply], [reply.id]) as never);
+
+        expect((await intervals())[0].latest).toBe(110);
+        expect(await watermark()).toBe(200);
+    });
+
+    // convertToNotificationData turns a missing `is_crt_enabled` into `false`, so `false` is what a
+    // payload without the field (or one the platform failed to parse) looks like by the time it
+    // reaches here. This probe is therefore a CRT mismatch: the app has CRT on, the payload says off.
+    it('4b: with the flag false while the app has CRT on, the same reply is stored as a channel post', async () => {
+        await seedHistory([100, 110]);
+        const reply = post('reply', 200, {root_id: 'root'});
+
+        await backgroundNotification(serverUrl, pushNotification(false, [reply], [reply.id]) as never);
+
+        // A single push creates a disjoint interval holding nothing but that reply, and it becomes
+        // the interval the channel list renders: blank under CRT, visible with CRT off.
+        const chunks = await intervals();
+        expect(chunks).toHaveLength(2);
+        expect(chunks[0].earliest).toBe(200);
+        expect(chunks[0].latest).toBe(200);
+        expect(await renderedPosts(true)).toHaveLength(0);
+        expect(await renderedPosts(false)).toHaveLength(1);
+    });
+});
+
+describe('PROBE 7: a thread-reply push on a channel with no local history', () => {
+    it('leaves a watermark with no interval at all, so the channel has nothing to render', async () => {
+        // Nothing seeded: a channel in the sidebar the user has never opened.
+        expect(await intervals()).toHaveLength(0);
+
+        const reply = post('reply', 200, {root_id: 'root'});
+        await backgroundNotification(serverUrl, {
+            payload: {
+                channel_id: channelId,
+                team_id: teamId,
+                post_id: reply.id,
+                root_id: 'root',
+                isCRTEnabled: true,
+                data: {posts: {posts: {[reply.id]: reply}, order: [reply.id]}},
+            },
+        } as never);
+
+        // The corruption: a watermark for a channel we hold no interval for. Every later
+        // getPostsSince(200) can only return newer posts, so the history is out of reach.
+        expect(await watermark()).toBe(200);
+        expect(await intervals()).toHaveLength(0);
+        expect(await renderedPosts(true)).toHaveLength(0);
+
+        // On this branch #9970 refuses to trust the watermark when nothing renders, so the channel
+        // recovers with a page fetch. Upstream (2.42.2) this line asks getPostsSince(200) instead.
+        await fetchPostsForChannel(serverUrl, channelId);
+        expect(mockClient.getPosts).toHaveBeenCalled();
+        expect(mockClient.getPostsSince).not.toHaveBeenCalled();
+    });
+});
+
+describe('PROBE 5: RECEIVED_AROUND stores posts with no interval bookkeeping', () => {
+    it('leaves the fetched posts outside every interval', async () => {
+        const around = [post('a1', 500), post('a2', 600), post('a3', 700)];
+        mockClient.getPostsBefore.mockImplementationOnce(() => ({posts: {a1: around[0]}, order: ['a1']}) as never);
+        mockClient.getPostsAfter.mockImplementationOnce(() => ({posts: {a3: around[2]}, order: ['a3']}) as never);
+        mockClient.getPostThread.mockImplementationOnce(() => ({posts: {a2: around[1]}, order: ['a2']}) as never);
+
+        await fetchPostsAround(serverUrl, channelId, 'a2', 5, true);
+
+        expect(await queryPostsBetween(database, 0, 1000, Q.desc, '', channelId).fetch()).toHaveLength(3);
+        expect(await intervals()).toHaveLength(0);
+        expect(await renderedPosts(true)).toHaveLength(0);
+    });
+});
+
+describe('PROBE 6: the native interval predicate, transcribed', () => {
+    // ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift:159-186 selects the interval to
+    // extend with `earliest <= new.earliest || latest >= new.latest` -- not an overlap test. The
+    // Swift tests need the pod workspace, so this transcribes the predicate to show the property.
+    const nativePick = (chunks: Array<{earliest: number; latest: number}>, earliest: number, latest: number) => {
+        return chunks.
+            filter((c) => c.earliest <= earliest || c.latest >= latest).
+            sort((a, b) => b.latest - a.latest)[0];
+    };
+
+    it('picks an interval that ended long before the new posts, and swallows the gap', () => {
+        const chunks = [{earliest: 100, latest: 110}];
+        const picked = nativePick(chunks, 5000, 5000);
+
+        expect(picked).toBeDefined();
+        const merged = {earliest: Math.min(picked.earliest, 5000), latest: Math.max(picked.latest, 5000)};
+        expect(merged).toEqual({earliest: 100, latest: 5000});
+    });
+
+    it('the JS overlap test rejects the same pair', () => {
+        const jsOverlaps = (chunk: {earliest: number; latest: number}, earliest: number, latest: number) =>
+            (earliest >= chunk.earliest && earliest <= chunk.latest) ||
+            (latest <= chunk.latest && latest >= chunk.earliest);
+
+        expect(jsOverlaps({earliest: 100, latest: 110}, 5000, 5000)).toBe(false);
+    });
+});

--- a/app/actions/remote/post_desync.probe.test.ts
+++ b/app/actions/remote/post_desync.probe.test.ts
@@ -52,7 +52,7 @@ import TestHelper from '@test/test_helper';
 import {convertToNotificationData} from '@utils/notification';
 
 import {backgroundNotification} from './notifications';
-import {fetchPosts, fetchPostsAround, fetchPostsBefore, fetchPostsForChannel, refreshPostsForChannel} from './post';
+import {fetchPosts, fetchPostsAround, fetchPostsBefore, fetchPostsForChannel, fetchPostsSince, refreshPostsForChannel} from './post';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 
@@ -490,11 +490,35 @@ describe('PROBE 7: a thread-reply push on a channel with no local history', () =
         expect(await renderedPosts()).toHaveLength(0);
 
         // On this branch #9970 refuses to trust the watermark when nothing renders, so the channel
-        // recovers with a page fetch that actually renders the history. Verified against the
-        // pre-#9970 line, which asks getPostsSince(200) here and renders nothing.
+        // recovers with a page fetch that actually renders the history. Upstream this line asks
+        // getPostsSince(200) and renders nothing -- but see PROBE 7b: the page-zero fallback heals
+        // that within the same screen visit, so upstream the blank is transient, not permanent.
         await fetchPostsForChannel(serverUrl, channelId);
         expect(mockClient.getPosts).toHaveBeenCalled();
         expect(mockClient.getPostsSince).not.toHaveBeenCalled();
+        expect(await intervals()).toHaveLength(1);
+        expect((await renderedPosts()).map((p) => p.createAt).sort((a, b) => a - b)).toEqual([100, 105, 110]);
+    });
+});
+
+describe('PROBE 7b: does that blank channel survive, upstream?', () => {
+    it('no: the page-zero fallback heals it within the same screen visit', async () => {
+        const history = [post('seed-100', 100), post('seed-105', 105), post('seed-110', 110)];
+        const reply = post('reply', 200, {root_id: 'seed-100'});
+        seedServer([...history, reply]);
+
+        await pushThreadReply(reply);
+        expect(await watermark()).toBe(200);
+        expect(await intervals()).toHaveLength(0);
+
+        // Model the pre-#9970 fetchPostsForChannel, which trusts the watermark and asks for changes
+        // since 200: nothing comes back, so the channel still renders nothing.
+        await fetchPostsSince(serverUrl, channelId, 200);
+        expect(await renderedPosts()).toHaveLength(0);
+
+        // But the rendered list is empty, so channel_post_list fetches page zero, which does not use
+        // the watermark at all. The blank is transient, not permanent.
+        await fetchPosts(serverUrl, channelId);
         expect(await intervals()).toHaveLength(1);
         expect((await renderedPosts()).map((p) => p.createAt).sort((a, b) => a - b)).toEqual([100, 105, 110]);
     });

--- a/app/actions/remote/post_desync.probe.test.ts
+++ b/app/actions/remote/post_desync.probe.test.ts
@@ -3,31 +3,50 @@
 
 // Diagnostic probes for the watermark/interval desync class behind #9103 ("Empty channels").
 //
-// Each probe drives real code and then asserts WHAT THE CODE CURRENTLY DOES, so several of them
-// assert broken outcomes on purpose. They are not regression tests and no fix is applied here:
-// the point is to find out which of the suspected mechanisms actually produce the reported
-// symptoms (blank channel / permanently missing messages) and which ones turn out to be harmless.
+// These assert WHAT THE CODE CURRENTLY DOES, so several of them assert broken outcomes on purpose.
+// They are not regression tests and no fix is applied for them: the point is to establish which
+// suspected mechanisms actually produce the reported symptoms (blank channel, permanently missing
+// messages) and which turn out to be harmless.
 //
 // The two invariants under test:
 //   I1  MyChannel.lastFetchedAt (the `since` watermark) must not exceed the newest post the
 //       PostsInChannel intervals actually cover -- getPostsSince can never return anything older.
 //   I2  The interval the channel list renders (postsInChannel[0]) must contain at least one post
 //       the list can render. Under CRT the list renders root posts only.
+//
+// Scope, per probe, so none of this reads as more than it is:
+//   - CRT is real here: it comes from persisted config + preference through getIsCRTEnabled, and
+//     "toggling thread display mode" is modelled by writing the preference the user would change.
+//   - Probes 1, 2 and 3 enter at storePostsForChannel, the storage step shared by the push path and
+//     the deferred channel fetch. Probe 4 enters one step earlier, at convertToNotificationData ->
+//     backgroundNotification, so the payload flag conversion is real code.
+//   - Out of reach from Jest, and therefore NOT covered: the native iOS/Android notification fetch
+//     and the native SQLite writers (ios/Gekidou, android/app/src/main/java/com/mattermost/helpers),
+//     which maintain the same two tables with their own implementations.
+//   - Probe 6 is explicitly a static model of a Swift predicate, not a test of it.
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
 import {storePostsForChannel} from '@actions/local/post';
-import {ActionType} from '@constants';
+import {ActionType, Preferences} from '@constants';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {getMyChannel} from '@queries/servers/channel';
 import {getRecentPostsInChannel, queryPostsBetween, queryPostsInChannel} from '@queries/servers/post';
+import {getIsCRTEnabled} from '@queries/servers/thread';
 import TestHelper from '@test/test_helper';
+import {convertToNotificationData} from '@utils/notification';
 
 import {backgroundNotification} from './notifications';
-import {fetchPostsAround, fetchPostsForChannel} from './post';
+import {fetchPosts, fetchPostsAround, fetchPostsForChannel, refreshPostsForChannel} from './post';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
+
+jest.mock('@screens/navigation', () => ({
+    navigateToRoot: jest.fn(),
+    dismissAllModals: jest.fn(),
+    popToRoot: jest.fn(),
+}));
 
 const serverUrl = 'desync.probe.test.com';
 const channelId = 'channelid1';
@@ -46,22 +65,47 @@ const post = (id: string, createAt: number, over: Partial<Post> = {}) => TestHel
     ...over,
 });
 
+const emptyPage = () => ({posts: {}, order: []});
+const pageOf = (posts: Post[]) => ({
+    posts: Object.fromEntries(posts.map((p) => [p.id, p])),
+    order: [...posts].sort((a, b) => b.create_at - a.create_at).map((p) => p.id),
+});
+
 const mockClient = {
-    getPosts: jest.fn(() => ({posts: {}, order: []})),
-    getPostsSince: jest.fn(() => ({posts: {}, order: []})),
-    getPostsBefore: jest.fn(() => ({posts: {}, order: []})),
-    getPostsAfter: jest.fn(() => ({posts: {}, order: []})),
-    getPostThread: jest.fn(() => ({posts: {}, order: []})),
-    getProfilesByIds: jest.fn(() => []),
-    getProfilesByUsernames: jest.fn(() => []),
+    getPosts: jest.fn(),
+    getPostsSince: jest.fn(),
+    getPostsBefore: jest.fn(),
+    getPostsAfter: jest.fn(),
+    getPostThread: jest.fn(),
+    getProfilesByIds: jest.fn(),
+    getProfilesByUsernames: jest.fn(),
 };
 
-let mockIsCRTEnabled: jest.Mock;
-jest.mock('@queries/servers/thread', () => {
-    const original = jest.requireActual('@queries/servers/thread');
-    mockIsCRTEnabled = jest.fn(() => true);
-    return {...original, getIsCRTEnabled: mockIsCRTEnabled};
-});
+// mockClear() keeps queued mockImplementationOnce values alive, which leaks a one-time response
+// from one probe into the next one that fetches. Reset and reinstall the defaults instead.
+const resetClientMocks = () => {
+    Object.values(mockClient).forEach((m) => m.mockReset());
+    mockClient.getPosts.mockImplementation(emptyPage);
+    mockClient.getPostsSince.mockImplementation(emptyPage);
+    mockClient.getPostsBefore.mockImplementation(emptyPage);
+    mockClient.getPostsAfter.mockImplementation(emptyPage);
+    mockClient.getPostThread.mockImplementation(emptyPage);
+    mockClient.getProfilesByIds.mockImplementation(() => []);
+    mockClient.getProfilesByUsernames.mockImplementation(() => []);
+};
+
+// CRT as the app really computes it: server config plus the display preference the user toggles.
+const setCRT = async (enabled: boolean) => {
+    await operator.handlePreferences({
+        preferences: [{
+            category: Preferences.CATEGORIES.DISPLAY_SETTINGS,
+            name: Preferences.COLLAPSED_REPLY_THREADS,
+            user_id: userId,
+            value: enabled ? Preferences.COLLAPSED_REPLY_THREADS_ON : 'off',
+        }],
+        prepareRecordsOnly: false,
+    });
+};
 
 beforeAll(() => {
     // @ts-expect-error partial client
@@ -73,12 +117,23 @@ beforeEach(async () => {
     const server = DatabaseManager.serverDatabases[serverUrl]!;
     database = server.database;
     operator = server.operator;
-    mockIsCRTEnabled.mockImplementation(() => true);
-    Object.values(mockClient).forEach((m) => m.mockClear());
+    resetClientMocks();
 
-    await operator.handleChannel({channels: [TestHelper.fakeChannel({id: channelId, team_id: teamId})], prepareRecordsOnly: false});
+    await operator.handleConfigs({
+        configs: [
+            {id: 'Version', value: '11.10.0'},
+            {id: 'CollapsedThreads', value: 'default_on'},
+            {id: 'FeatureFlagCollapsedThreads', value: 'true'},
+        ],
+        configsToDelete: [],
+        prepareRecordsOnly: false,
+    });
+    await setCRT(true);
+
+    const channel = TestHelper.fakeChannel({id: channelId, team_id: teamId});
+    await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
     await operator.handleMyChannel({
-        channels: [TestHelper.fakeChannel({id: channelId, team_id: teamId})],
+        channels: [channel],
         myChannels: [TestHelper.fakeChannelMember({id: channelId, channel_id: channelId, user_id: userId})],
         prepareRecordsOnly: false,
     });
@@ -93,11 +148,12 @@ const watermark = async () => (await getMyChannel(database, channelId))!.lastFet
 
 // Mirrors the channel post list enhancer (app/screens/channel/channel_post_list/index.ts): it
 // renders postsInChannel[0] only, and filters to root posts when CRT is on.
-const renderedPosts = async (isCRTEnabled: boolean) => {
+const renderedPosts = async () => {
     const chunks = await intervals();
     if (!chunks.length) {
         return [];
     }
+    const isCRTEnabled = await getIsCRTEnabled(database);
     const {earliest, latest} = chunks[0];
     return queryPostsBetween(database, earliest, latest, Q.desc, '', channelId, isCRTEnabled ? '' : undefined).fetch();
 };
@@ -107,13 +163,19 @@ const seedHistory = async (timestamps: number[]) => {
     await storePostsForChannel(serverUrl, channelId, posts, posts.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
 };
 
-describe('PROBE 1: a thread-reply push moves the watermark past the interval, and the next since-fetch cements the gap', () => {
+const seedRepliesOnlyInterval = async () => {
+    const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
+    await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+};
+
+describe('PROBE 1: the watermark outruns the interval, and the next since-fetch cements the gap', () => {
+    // Enters at the storage step. Probe 4a drives the same thing from the notification entry point.
     it('reproduces the hole and shows nothing will ever fetch it', async () => {
         await seedHistory([100, 105, 110]);
         expect(await watermark()).toBe(110);
         expect(await intervals()).toHaveLength(1);
 
-        // The push path: a CRT thread reply, far newer than the interval (kondo97's repro).
+        // A CRT thread reply, far newer than the interval (kondo97's repro).
         const root = post('root', 90);
         const reply = post('reply', 200, {root_id: 'root'});
         await storePostsForChannel(
@@ -152,7 +214,7 @@ describe('PROBE 2: an edited old post in a partial payload pushes the watermark 
     it('advances lastFetchedAt to update_at while the interval only tracks create_at', async () => {
         await seedHistory([100, 105, 110]);
 
-        // A push payload carrying a single old post that was edited recently. No thread involved.
+        // A payload carrying a single old post that was edited recently. No thread involved.
         const edited = post('seed-105', 105, {update_at: 5000});
         await storePostsForChannel(serverUrl, channelId, [edited], [edited.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
 
@@ -174,98 +236,120 @@ describe('PROBE 3: an interval that holds only thread replies renders a blank ch
         const chunks = await intervals();
         expect(chunks).toHaveLength(1);
         expect(chunks[0].latest).toBe(9000);
-        expect(await renderedPosts(true)).not.toHaveLength(0);
+        expect(await renderedPosts()).not.toHaveLength(0);
     });
 
     it('3b: a replies-only IN_CHANNEL store creates a disjoint interval that renders nothing under CRT', async () => {
         await seedHistory([1000, 2000]);
-
-        const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
-        await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        await seedRepliesOnlyInterval();
 
         const chunks = await intervals();
         expect(chunks).toHaveLength(2);
         expect(chunks[0].earliest).toBe(8000);
         expect(chunks[0].latest).toBe(9000);
 
-        // The reported symptom and the reported recovery, side by side.
-        expect(await renderedPosts(true)).toHaveLength(0);
-        expect(await renderedPosts(false)).toHaveLength(2);
+        // The reported symptom, then the reported recovery: the user toggles thread display mode.
+        expect(await renderedPosts()).toHaveLength(0);
+        await setCRT(false);
+        expect(await renderedPosts()).toHaveLength(2);
     });
 
-    it('3c: a full page fetch cannot dislodge the bad interval', async () => {
+    it('3c: the automatic "too few posts" page fetch cannot dislodge the bad interval', async () => {
         await seedHistory([1000, 2000]);
-        const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
-        await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        await seedRepliesOnlyInterval();
 
-        // What pull-to-refresh and the "too few posts" fallback do: page 0 with CRT, i.e. roots only.
-        const roots = [post('seed-1000', 1000), post('seed-2000', 2000), post('newroot', 2500)];
-        mockClient.getPosts.mockImplementationOnce(() => ({
-            posts: Object.fromEntries(roots.map((p) => [p.id, p])),
-            order: roots.map((p) => p.id).reverse(),
-        }) as never);
-        await storePostsForChannel(serverUrl, channelId, roots, roots.map((p) => p.id).reverse(), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        // What channel_post_list does when the rendered list is short: fetchPosts page 0, which
+        // under CRT returns root posts only -- all of them older than the replies-only interval.
+        mockClient.getPosts.mockImplementationOnce(() => pageOf([post('seed-1000', 1000), post('seed-2000', 2000), post('newroot', 2500)]) as never);
+        await fetchPosts(serverUrl, channelId);
 
-        const chunks = await intervals();
-        expect(chunks[0].latest).toBe(9000); // still the replies-only interval
-        expect(await renderedPosts(true)).toHaveLength(0);
+        expect(mockClient.getPosts).toHaveBeenCalledTimes(1);
+        expect((await intervals())[0].latest).toBe(9000); // still the replies-only interval
+        expect(await renderedPosts()).toHaveLength(0);
     });
 
     it('3d: the interval prune added in #9970 does not catch it (CRT-blind predicate)', async () => {
         await seedHistory([1000, 2000]);
-        const replies = [post('r1', 8000, {root_id: 'seed-1000'}), post('r2', 9000, {root_id: 'seed-1000'})];
-        await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        await seedRepliesOnlyInterval();
 
         // getRecentPostsInChannel counts every non-deleted post in the interval, replies included,
         // so fetchPostsForChannel does not consider the channel blank and never prunes.
         expect(await getRecentPostsInChannel(database, channelId)).toHaveLength(2);
         await fetchPostsForChannel(serverUrl, channelId);
         expect((await intervals())[0].latest).toBe(9000);
-        expect(await renderedPosts(true)).toHaveLength(0);
+        expect(await renderedPosts()).toHaveLength(0);
+    });
+
+    it('3e: pull-to-refresh on this branch does repair it', async () => {
+        await seedHistory([1000, 2000]);
+        await seedRepliesOnlyInterval();
+        expect(await renderedPosts()).toHaveLength(0);
+
+        // refreshPostsForChannel sees a blank list plus stored posts, so it clears the channel
+        // cache and refetches from scratch instead of paging.
+        mockClient.getPosts.mockImplementationOnce(() => pageOf([post('newroot', 2500)]) as never);
+        await refreshPostsForChannel(serverUrl, channelId, true);
+
+        const chunks = await intervals();
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].latest).toBe(2500);
+        expect(await renderedPosts()).toHaveLength(1);
     });
 });
 
 describe('PROBE 4: backgroundNotification classifies a thread reply from the payload flag', () => {
-    const pushNotification = (isCRTEnabled: boolean | undefined, posts: Post[], order: string[]) => ({
+    // Enters at convertToNotificationData with a raw payload, so the string/missing handling of
+    // is_crt_enabled is real code. Still not covered: the native fetch that builds data.posts and
+    // the native SQLite writers that touch the same two tables.
+    const rawPush = (isCRTEnabled: string | undefined, posts: Post[], order: string[]) => convertToNotificationData({
         payload: {
             channel_id: channelId,
             team_id: teamId,
             post_id: order[0],
             root_id: 'root',
-            isCRTEnabled,
+            type: 'message',
+            version: 'v2',
+            ...(isCRTEnabled === undefined ? {} : {is_crt_enabled: isCRTEnabled}),
             data: {
                 posts: {posts: Object.fromEntries(posts.map((p) => [p.id, p])), order},
             },
         },
-    });
+    } as never, false);
 
-    it('4a: with the flag set, the reply is stored as a thread post (no interval change)', async () => {
+    it('4a: with is_crt_enabled "true", the reply is stored as a thread post (no interval change)', async () => {
         await seedHistory([100, 110]);
         const reply = post('reply', 200, {root_id: 'root'});
 
-        await backgroundNotification(serverUrl, pushNotification(true, [reply], [reply.id]) as never);
+        const notification = rawPush('true', [reply], [reply.id]);
+        expect(notification.payload!.isCRTEnabled).toBe(true);
+
+        await backgroundNotification(serverUrl, notification);
 
         expect((await intervals())[0].latest).toBe(110);
         expect(await watermark()).toBe(200);
     });
 
-    // convertToNotificationData turns a missing `is_crt_enabled` into `false`, so `false` is what a
-    // payload without the field (or one the platform failed to parse) looks like by the time it
-    // reaches here. This probe is therefore a CRT mismatch: the app has CRT on, the payload says off.
-    it('4b: with the flag false while the app has CRT on, the same reply is stored as a channel post', async () => {
+    it('4b: with is_crt_enabled absent, the same reply is stored as a channel post', async () => {
         await seedHistory([100, 110]);
         const reply = post('reply', 200, {root_id: 'root'});
 
-        await backgroundNotification(serverUrl, pushNotification(false, [reply], [reply.id]) as never);
+        // A payload without the field converts to isCRTEnabled false, while the app has CRT on:
+        // the classification disagrees with how the channel list will render.
+        const notification = rawPush(undefined, [reply], [reply.id]);
+        expect(notification.payload!.isCRTEnabled).toBe(false);
+        expect(await getIsCRTEnabled(database)).toBe(true);
 
-        // A single push creates a disjoint interval holding nothing but that reply, and it becomes
-        // the interval the channel list renders: blank under CRT, visible with CRT off.
+        await backgroundNotification(serverUrl, notification);
+
+        // One push creates a disjoint interval holding nothing but that reply, and it becomes the
+        // interval the channel list renders: blank under CRT, visible with CRT off.
         const chunks = await intervals();
         expect(chunks).toHaveLength(2);
         expect(chunks[0].earliest).toBe(200);
         expect(chunks[0].latest).toBe(200);
-        expect(await renderedPosts(true)).toHaveLength(0);
-        expect(await renderedPosts(false)).toHaveLength(1);
+        expect(await renderedPosts()).toHaveLength(0);
+        await setCRT(false);
+        expect(await renderedPosts()).toHaveLength(1);
     });
 });
 
@@ -275,25 +359,28 @@ describe('PROBE 7: a thread-reply push on a channel with no local history', () =
         expect(await intervals()).toHaveLength(0);
 
         const reply = post('reply', 200, {root_id: 'root'});
-        await backgroundNotification(serverUrl, {
+        await backgroundNotification(serverUrl, convertToNotificationData({
             payload: {
                 channel_id: channelId,
                 team_id: teamId,
                 post_id: reply.id,
                 root_id: 'root',
-                isCRTEnabled: true,
+                type: 'message',
+                version: 'v2',
+                is_crt_enabled: 'true',
                 data: {posts: {posts: {[reply.id]: reply}, order: [reply.id]}},
             },
-        } as never);
+        } as never, false));
 
         // The corruption: a watermark for a channel we hold no interval for. Every later
         // getPostsSince(200) can only return newer posts, so the history is out of reach.
         expect(await watermark()).toBe(200);
         expect(await intervals()).toHaveLength(0);
-        expect(await renderedPosts(true)).toHaveLength(0);
+        expect(await renderedPosts()).toHaveLength(0);
 
         // On this branch #9970 refuses to trust the watermark when nothing renders, so the channel
-        // recovers with a page fetch. Upstream (2.42.2) this line asks getPostsSince(200) instead.
+        // recovers with a page fetch. Verified against the pre-#9970 line, which asks
+        // getPostsSince(200) here and leaves the channel empty.
         await fetchPostsForChannel(serverUrl, channelId);
         expect(mockClient.getPosts).toHaveBeenCalled();
         expect(mockClient.getPostsSince).not.toHaveBeenCalled();
@@ -311,14 +398,16 @@ describe('PROBE 5: RECEIVED_AROUND stores posts with no interval bookkeeping', (
 
         expect(await queryPostsBetween(database, 0, 1000, Q.desc, '', channelId).fetch()).toHaveLength(3);
         expect(await intervals()).toHaveLength(0);
-        expect(await renderedPosts(true)).toHaveLength(0);
+        expect(await renderedPosts()).toHaveLength(0);
     });
 });
 
-describe('PROBE 6: the native interval predicate, transcribed', () => {
-    // ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift:159-186 selects the interval to
-    // extend with `earliest <= new.earliest || latest >= new.latest` -- not an overlap test. The
-    // Swift tests need the pod workspace, so this transcribes the predicate to show the property.
+describe('PROBE 6: STATIC MODEL of the native interval predicate (does not execute Swift)', () => {
+    // Transcription of ios/Gekidou/Sources/Gekidou/Storage/Database+Posts.swift:159-186, which
+    // selects the interval to extend with `earliest <= new.earliest || latest >= new.latest`.
+    // It will keep passing if that Swift changes, and it exercises neither SQLite selection nor the
+    // update itself. Running the real thing needs the pod workspace (Gekidou has no Package.swift),
+    // so treat this as explanatory evidence only.
     const nativePick = (chunks: Array<{earliest: number; latest: number}>, earliest: number, latest: number) => {
         return chunks.
             filter((c) => c.earliest <= earliest || c.latest >= latest).

--- a/app/actions/remote/post_desync.probe.test.ts
+++ b/app/actions/remote/post_desync.probe.test.ts
@@ -9,17 +9,24 @@
 // messages) and which turn out to be harmless.
 //
 // The two invariants under test:
-//   I1  MyChannel.lastFetchedAt (the `since` watermark) must not exceed the newest post the
-//       PostsInChannel intervals actually cover -- getPostsSince can never return anything older.
+//   I1  SYNC COMPLETENESS. MyChannel.lastFetchedAt may only advance to T once every change with
+//       update_at <= T has been processed, because getPostsSince(T) filters on update_at and can
+//       never return a post created before T that was not edited after it. Note what I1 is NOT:
+//       lastFetchedAt > interval.latest is legitimate on its own, since the watermark is
+//       max(create_at, update_at, delete_at) while intervals track create_at, so any edit of an old
+//       post diverges them harmlessly. Divergence is not loss; loss needs an unfetched post whose
+//       update_at sits below the watermark (PROBE 1) and out of reach of paging (PROBE 1b).
 //   I2  The interval the channel list renders (postsInChannel[0]) must contain at least one post
 //       the list can render. Under CRT the list renders root posts only.
 //
 // Scope, per probe, so none of this reads as more than it is:
 //   - CRT is real here: it comes from persisted config + preference through getIsCRTEnabled, and
 //     "toggling thread display mode" is modelled by writing the preference the user would change.
-//   - Probes 1, 2 and 3 enter at storePostsForChannel, the storage step shared by the push path and
-//     the deferred channel fetch. Probe 4 enters one step earlier, at convertToNotificationData ->
-//     backgroundNotification, so the payload flag conversion is real code.
+//   - The server side is modelled (see fakeServer) with the semantics that decide these probes, so
+//     "still missing" can be asserted after actually running every mechanism that refetches.
+//   - Probes 1, 4 and 7 enter at convertToNotificationData -> backgroundNotification, so the payload
+//     flag conversion is real code; probes 2 and 3 enter at storePostsForChannel, the storage step
+//     shared by the push path and the deferred channel fetch.
 //   - Out of reach from Jest, and therefore NOT covered: the native iOS/Android notification fetch
 //     and the native SQLite writers (ios/Gekidou, android/app/src/main/java/com/mattermost/helpers),
 //     which maintain the same two tables with their own implementations.
@@ -38,7 +45,7 @@ import TestHelper from '@test/test_helper';
 import {convertToNotificationData} from '@utils/notification';
 
 import {backgroundNotification} from './notifications';
-import {fetchPosts, fetchPostsAround, fetchPostsForChannel, refreshPostsForChannel} from './post';
+import {fetchPosts, fetchPostsAround, fetchPostsBefore, fetchPostsForChannel, refreshPostsForChannel} from './post';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 
@@ -65,33 +72,65 @@ const post = (id: string, createAt: number, over: Partial<Post> = {}) => TestHel
     ...over,
 });
 
-const emptyPage = () => ({posts: {}, order: []});
-const pageOf = (posts: Post[]) => ({
-    posts: Object.fromEntries(posts.map((p) => [p.id, p])),
-    order: [...posts].sort((a, b) => b.create_at - a.create_at).map((p) => p.id),
-});
+// A stand-in for the server's post endpoints with the semantics that decide these probes:
+//   - getPostsSince filters on update_at, so a post created inside a gap and never edited after the
+//     watermark is invisible to it no matter how many times the app syncs;
+//   - getPosts pages by create_at, newest first, and returns root posts only under CRT, so it only
+//     reaches back POST_CHUNK_SIZE posts;
+//   - getPostsBefore pages backwards from a given post, so it can only fill below the oldest post
+//     the list already holds, never a gap in the middle.
+// Every probe seeds this instead of queueing one-off responses, which also removes the
+// mockImplementationOnce leak class entirely.
+const fakeServer: {posts: Post[]} = {posts: []};
 
-const mockClient = {
-    getPosts: jest.fn(),
-    getPostsSince: jest.fn(),
-    getPostsBefore: jest.fn(),
-    getPostsAfter: jest.fn(),
-    getPostThread: jest.fn(),
-    getProfilesByIds: jest.fn(),
-    getProfilesByUsernames: jest.fn(),
+const seedServer = (posts: Post[]) => {
+    fakeServer.posts = [...posts];
 };
 
-// mockClear() keeps queued mockImplementationOnce values alive, which leaks a one-time response
-// from one probe into the next one that fetches. Reset and reinstall the defaults instead.
+const newestFirst = (posts: Post[]) => [...posts].sort((a, b) => b.create_at - a.create_at);
+
+const respond = (selected: Post[]) => {
+    const ordered = newestFirst(selected);
+    const oldest = ordered[ordered.length - 1];
+    const older = oldest ? newestFirst(fakeServer.posts.filter((p) => p.create_at < oldest.create_at)) : [];
+    return {
+        posts: Object.fromEntries(ordered.map((p) => [p.id, p])),
+        order: ordered.map((p) => p.id),
+        prev_post_id: older[0]?.id ?? '',
+    };
+};
+
+const mockClient = {
+    getPosts: jest.fn((_channelId: string, page = 0, perPage = 60, collapsedThreads = false) => {
+        const pool = collapsedThreads ? fakeServer.posts.filter((p) => !p.root_id) : fakeServer.posts;
+        return respond(newestFirst(pool).slice(page * perPage, (page + 1) * perPage));
+    }),
+    getPostsSince: jest.fn((_channelId: string, since: number) => {
+        return respond(fakeServer.posts.filter((p) => p.update_at > since));
+    }),
+    getPostsBefore: jest.fn((_channelId: string, postId: string, page = 0, perPage = 60, collapsedThreads = false) => {
+        const from = fakeServer.posts.find((p) => p.id === postId);
+        const pool = (collapsedThreads ? fakeServer.posts.filter((p) => !p.root_id) : fakeServer.posts).
+            filter((p) => from && p.create_at < from.create_at);
+        return respond(newestFirst(pool).slice(page * perPage, (page + 1) * perPage));
+    }),
+    getPostsAfter: jest.fn((_channelId: string, postId: string, page = 0, perPage = 60) => {
+        const from = fakeServer.posts.find((p) => p.id === postId);
+        const pool = fakeServer.posts.filter((p) => from && p.create_at > from.create_at);
+        return respond(newestFirst(pool).slice(page * perPage, (page + 1) * perPage));
+    }),
+    getPostThread: jest.fn((postId: string) => {
+        const root = fakeServer.posts.find((p) => p.id === postId);
+        const replies = fakeServer.posts.filter((p) => p.root_id === postId);
+        return respond([...(root ? [root] : []), ...replies]);
+    }),
+    getProfilesByIds: jest.fn(() => []),
+    getProfilesByUsernames: jest.fn(() => []),
+};
+
 const resetClientMocks = () => {
-    Object.values(mockClient).forEach((m) => m.mockReset());
-    mockClient.getPosts.mockImplementation(emptyPage);
-    mockClient.getPostsSince.mockImplementation(emptyPage);
-    mockClient.getPostsBefore.mockImplementation(emptyPage);
-    mockClient.getPostsAfter.mockImplementation(emptyPage);
-    mockClient.getPostThread.mockImplementation(emptyPage);
-    mockClient.getProfilesByIds.mockImplementation(() => []);
-    mockClient.getProfilesByUsernames.mockImplementation(() => []);
+    Object.values(mockClient).forEach((m) => m.mockClear());
+    fakeServer.posts = [];
 };
 
 // CRT as the app really computes it: server config plus the display preference the user toggles.
@@ -114,9 +153,9 @@ beforeAll(() => {
 
 beforeEach(async () => {
     await DatabaseManager.init([serverUrl]);
-    const server = DatabaseManager.serverDatabases[serverUrl]!;
-    database = server.database;
-    operator = server.operator;
+    const serverDb = DatabaseManager.serverDatabases[serverUrl]!;
+    database = serverDb.database;
+    operator = serverDb.operator;
     resetClientMocks();
 
     await operator.handleConfigs({
@@ -168,61 +207,118 @@ const seedRepliesOnlyInterval = async () => {
     await storePostsForChannel(serverUrl, channelId, replies, replies.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
 };
 
-describe('PROBE 1: the watermark outruns the interval, and the next since-fetch cements the gap', () => {
-    // Enters at the storage step. Probe 4a drives the same thing from the notification entry point.
-    it('reproduces the hole and shows nothing will ever fetch it', async () => {
-        await seedHistory([100, 105, 110]);
+const pushThreadReply = (reply: Post) => backgroundNotification(serverUrl, convertToNotificationData({
+    payload: {
+        channel_id: channelId,
+        team_id: teamId,
+        post_id: reply.id,
+        root_id: reply.root_id,
+        type: 'message',
+        version: 'v2',
+        is_crt_enabled: 'true',
+        data: {posts: {posts: {[reply.id]: reply}, order: [reply.id]}},
+    },
+} as never, false));
+
+const heldCreateAts = async () => (await queryPostsBetween(database, 0, Number.MAX_SAFE_INTEGER, Q.desc, '', channelId).fetch()).
+    map((p) => p.createAt).sort((a, b) => a - b);
+
+describe('PROBE 1: does the watermark hole actually lose messages?', () => {
+    // The hole itself is easy to produce, but "permanently missing" has to survive every mechanism
+    // that refetches: the since-fetch, the page-zero fallback channel_post_list runs whenever the
+    // rendered list is shorter than POST_CHUNK_SIZE, and the scroll-back fetch. So the server is
+    // modelled here (getPostsSince filters on update_at) and each mechanism is actually run.
+    const history = [post('seed-100', 100), post('seed-105', 105), post('seed-110', 110)];
+    const missed = [post('missed-150', 150), post('missed-160', 160)];
+    const reply = post('reply-170', 170, {root_id: 'seed-100'});
+
+    it('1a: with fewer than a page of posts above the gap, the page-zero fallback heals it', async () => {
+        seedServer([...history, ...missed, reply]);
+        await storePostsForChannel(serverUrl, channelId, history, history.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
         expect(await watermark()).toBe(110);
-        expect(await intervals()).toHaveLength(1);
 
-        // A CRT thread reply, far newer than the interval (kondo97's repro).
-        const root = post('root', 90);
-        const reply = post('reply', 200, {root_id: 'root'});
-        await storePostsForChannel(
-            serverUrl, channelId, [root, reply], [reply.id, root.id], '',
-            ActionType.POSTS.RECEIVED_IN_THREAD, [],
-        );
+        // The push moves the watermark past the interval without extending it.
+        await pushThreadReply(reply);
+        expect(await watermark()).toBe(170);
+        expect((await intervals())[0].latest).toBe(110);
 
-        const afterPush = await intervals();
-        expect(await watermark()).toBe(200); // watermark advanced
-        expect(afterPush).toHaveLength(1);
-        expect(afterPush[0].latest).toBe(110); // interval did not
-
-        // Posts 111..199 exist on the server but were never fetched. The next channel open asks
-        // for posts since the watermark, so they are already out of reach.
+        // Opening the channel asks for changes since 170, which cannot return posts created at 150
+        // and 160 and never edited: the hole is real at this point.
         await fetchPostsForChannel(serverUrl, channelId);
-        expect(mockClient.getPostsSince).toHaveBeenCalledWith(channelId, 200, true, true, undefined);
+        expect(mockClient.getPostsSince).toHaveBeenCalledWith(channelId, 170, true, true, undefined);
+        expect(await heldCreateAts()).toEqual([100, 105, 110, 170]);
 
-        // And when a later since-fetch does bring something back, the interval is stretched over
-        // the gap, so the app now claims to hold 111..199 contiguously.
-        const newer = post('newer', 300);
-        await storePostsForChannel(serverUrl, channelId, [newer], [newer.id], '', ActionType.POSTS.RECEIVED_SINCE, []);
+        // But the list is far shorter than POST_CHUNK_SIZE, so channel_post_list fetches page zero,
+        // which pages by create_at and does reach back over the gap.
+        await fetchPosts(serverUrl, channelId);
+        expect(await heldCreateAts()).toEqual([100, 105, 110, 150, 160, 170]);
+    });
 
-        const afterSince = await intervals();
-        expect(afterSince).toHaveLength(1);
-        expect(afterSince[0].earliest).toBe(100);
-        expect(afterSince[0].latest).toBe(300);
+    it('1b: with a full page of posts above the gap, nothing can reach it any more', async () => {
+        // 60 posts newer than the gap, so page zero never pages back far enough.
+        const newer = Array.from({length: 60}, (_, i) => post(`newer-${200 + i}`, 200 + i));
+        seedServer([...history, ...missed, reply, ...newer]);
+        await storePostsForChannel(serverUrl, channelId, history, history.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
 
-        // Interval claims [100,300]; the posts it actually holds skip everything between 110 and 200.
-        // (The thread root at 90 is not even in the interval, so it never renders in the channel.)
-        const held = (await queryPostsBetween(database, 100, 300, Q.desc, '', channelId).fetch()).map((p) => p.createAt).sort((a, b) => a - b);
-        expect(held).toEqual([100, 105, 110, 200, 300]);
+        await pushThreadReply(reply);
+        expect(await watermark()).toBe(170);
+
+        // Reconnect sync: everything with update_at > 170 arrives and extends the interval over the
+        // gap, so the app now claims to hold 150 and 160 contiguously.
+        await fetchPostsForChannel(serverUrl, channelId);
+        const claimed = await intervals();
+        expect(claimed).toHaveLength(1);
+        expect(claimed[0].earliest).toBe(100);
+        expect(claimed[0].latest).toBe(259);
+        expect(await watermark()).toBe(259);
+        expect(await heldCreateAts()).not.toContain(150);
+
+        // Now run every mechanism that could refetch, and show none of them can.
+        await fetchPostsForChannel(serverUrl, channelId); // since-fetch: filters on update_at
+        await fetchPosts(serverUrl, channelId); // page zero: newest 60 by create_at, i.e. 200..259
+        const rendered = await renderedPosts();
+        const oldestRendered = rendered[rendered.length - 1];
+        expect(oldestRendered.createAt).toBe(100);
+        await fetchPostsBefore(serverUrl, channelId, oldestRendered.id); // scroll-back: below 100 only
+
+        const held = await heldCreateAts();
+        expect(held).not.toContain(150);
+        expect(held).not.toContain(160);
+
+        // The two posts are inside the interval the app believes is complete, so no later sync will
+        // ask for them: they are permanently missing from this install.
+        expect(claimed[0].earliest).toBeLessThan(150);
+        expect(claimed[0].latest).toBeGreaterThan(160);
     });
 });
 
-describe('PROBE 2: an edited old post in a partial payload pushes the watermark past the interval', () => {
-    it('advances lastFetchedAt to update_at while the interval only tracks create_at', async () => {
-        await seedHistory([100, 105, 110]);
+describe('PROBE 2: what the watermark/interval divergence does and does not mean', () => {
+    // The watermark is max(create_at, update_at, delete_at) while intervals track create_at, so an
+    // edit of an old post diverges them by design. That alone is not loss -- getPostsSince filters
+    // on update_at, so whether a post inside the gap is still reachable depends on its update_at.
+    it('a post edited after the watermark stays reachable; one created before it does not', async () => {
+        const history = [post('seed-100', 100), post('seed-110', 110)];
+        const neverEdited = post('gap-a', 150);
+        const editedLater = post('gap-b', 160, {update_at: 6000});
+        seedServer([...history, neverEdited, editedLater]);
 
-        // A payload carrying a single old post that was edited recently. No thread involved.
+        await storePostsForChannel(serverUrl, channelId, history, history.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        // A payload carrying one old post that was edited recently: legitimate divergence.
         const edited = post('seed-105', 105, {update_at: 5000});
         await storePostsForChannel(serverUrl, channelId, [edited], [edited.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
-
-        expect((await intervals())[0].latest).toBe(110);
         expect(await watermark()).toBe(5000);
+        expect((await intervals())[0].latest).toBe(110);
 
         await fetchPostsForChannel(serverUrl, channelId);
         expect(mockClient.getPostsSince).toHaveBeenCalledWith(channelId, 5000, true, true, undefined);
+
+        // gap-b was edited after the watermark so the since-fetch still returns it; gap-a was not,
+        // so it is only reachable by paging. The divergence is not the defect -- the unprocessed
+        // create inside the skipped window is.
+        const held = await heldCreateAts();
+        expect(held).toContain(160);
+        expect(held).not.toContain(150);
     });
 });
 
@@ -260,7 +356,7 @@ describe('PROBE 3: an interval that holds only thread replies renders a blank ch
 
         // What channel_post_list does when the rendered list is short: fetchPosts page 0, which
         // under CRT returns root posts only -- all of them older than the replies-only interval.
-        mockClient.getPosts.mockImplementationOnce(() => pageOf([post('seed-1000', 1000), post('seed-2000', 2000), post('newroot', 2500)]) as never);
+        seedServer([post('seed-1000', 1000), post('seed-2000', 2000), post('newroot', 2500)]);
         await fetchPosts(serverUrl, channelId);
 
         expect(mockClient.getPosts).toHaveBeenCalledTimes(1);
@@ -287,13 +383,13 @@ describe('PROBE 3: an interval that holds only thread replies renders a blank ch
 
         // refreshPostsForChannel sees a blank list plus stored posts, so it clears the channel
         // cache and refetches from scratch instead of paging.
-        mockClient.getPosts.mockImplementationOnce(() => pageOf([post('newroot', 2500)]) as never);
+        seedServer([post('seed-1000', 1000), post('seed-2000', 2000), post('newroot', 2500)]);
         await refreshPostsForChannel(serverUrl, channelId, true);
 
         const chunks = await intervals();
         expect(chunks).toHaveLength(1);
         expect(chunks[0].latest).toBe(2500);
-        expect(await renderedPosts()).toHaveLength(1);
+        expect(await renderedPosts()).toHaveLength(3);
     });
 });
 
@@ -355,10 +451,11 @@ describe('PROBE 4: backgroundNotification classifies a thread reply from the pay
 
 describe('PROBE 7: a thread-reply push on a channel with no local history', () => {
     it('leaves a watermark with no interval at all, so the channel has nothing to render', async () => {
-        // Nothing seeded: a channel in the sidebar the user has never opened.
-        expect(await intervals()).toHaveLength(0);
-
+        // Nothing stored locally: a channel in the sidebar the user has never opened. The server
+        // does hold its history, so we can tell recovery from silence.
         const reply = post('reply', 200, {root_id: 'root'});
+        seedServer([post('seed-100', 100), post('seed-105', 105), post('seed-110', 110), reply]);
+        expect(await intervals()).toHaveLength(0);
         await backgroundNotification(serverUrl, convertToNotificationData({
             payload: {
                 channel_id: channelId,
@@ -379,20 +476,19 @@ describe('PROBE 7: a thread-reply push on a channel with no local history', () =
         expect(await renderedPosts()).toHaveLength(0);
 
         // On this branch #9970 refuses to trust the watermark when nothing renders, so the channel
-        // recovers with a page fetch. Verified against the pre-#9970 line, which asks
-        // getPostsSince(200) here and leaves the channel empty.
+        // recovers with a page fetch that actually renders the history. Verified against the
+        // pre-#9970 line, which asks getPostsSince(200) here and renders nothing.
         await fetchPostsForChannel(serverUrl, channelId);
         expect(mockClient.getPosts).toHaveBeenCalled();
         expect(mockClient.getPostsSince).not.toHaveBeenCalled();
+        expect(await intervals()).toHaveLength(1);
+        expect((await renderedPosts()).map((p) => p.createAt).sort((a, b) => a - b)).toEqual([100, 105, 110]);
     });
 });
 
 describe('PROBE 5: RECEIVED_AROUND stores posts with no interval bookkeeping', () => {
     it('leaves the fetched posts outside every interval', async () => {
-        const around = [post('a1', 500), post('a2', 600), post('a3', 700)];
-        mockClient.getPostsBefore.mockImplementationOnce(() => ({posts: {a1: around[0]}, order: ['a1']}) as never);
-        mockClient.getPostsAfter.mockImplementationOnce(() => ({posts: {a3: around[2]}, order: ['a3']}) as never);
-        mockClient.getPostThread.mockImplementationOnce(() => ({posts: {a2: around[1]}, order: ['a2']}) as never);
+        seedServer([post('a1', 500), post('a2', 600), post('a3', 700)]);
 
         await fetchPostsAround(serverUrl, channelId, 'a2', 5, true);
 

--- a/app/actions/remote/post_desync.probe.test.ts
+++ b/app/actions/remote/post_desync.probe.test.ts
@@ -24,9 +24,15 @@
 //     "toggling thread display mode" is modelled by writing the preference the user would change.
 //   - The server side is modelled (see fakeServer) with the semantics that decide these probes, so
 //     "still missing" can be asserted after actually running every mechanism that refetches.
-//   - Probes 1, 4 and 7 enter at convertToNotificationData -> backgroundNotification, so the payload
-//     flag conversion is real code; probes 2 and 3 enter at storePostsForChannel, the storage step
-//     shared by the push path and the deferred channel fetch.
+//   - Notifications: probes 1, 4, 7 and 9 enter at convertToNotificationData ->
+//     backgroundNotification, the JS path that runs while the app is alive in the background, so the
+//     payload flag conversion is real code. NOT covered: fetchNotificationData/openNotification
+//     (tap-through), and the native handlers that run when the app is killed.
+//   - WebSocket: probes 8 and 9 drive handleNewPostEvent, the path that writes intervals for live
+//     posts. NOT covered: handleReconnect/doReconnect (it runs the whole entry sync, which needs far
+//     more of the app stubbed), handlePostDeleted, and the channel-membership events that also store
+//     posts. Probes 2 and 3 enter at storePostsForChannel, the storage step shared by the push path
+//     and the deferred channel fetch.
 //   - Out of reach from Jest, and therefore NOT covered: the native iOS/Android notification fetch
 //     and the native SQLite writers (ios/Gekidou, android/app/src/main/java/com/mattermost/helpers),
 //     which maintain the same two tables with their own implementations.
@@ -35,6 +41,7 @@
 import {Q, type Database} from '@nozbe/watermelondb';
 
 import {storePostsForChannel} from '@actions/local/post';
+import {handleNewPostEvent} from '@actions/websocket/posts';
 import {ActionType, Preferences} from '@constants';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
@@ -219,6 +226,13 @@ const pushThreadReply = (reply: Post) => backgroundNotification(serverUrl, conve
         data: {posts: {posts: {[reply.id]: reply}, order: [reply.id]}},
     },
 } as never, false));
+
+const wsNewPost = (p: Post) => handleNewPostEvent(serverUrl, {
+    event: 'posted',
+    data: {post: JSON.stringify(p)},
+    broadcast: {channel_id: channelId, omit_users: null, user_id: '', team_id: teamId},
+    seq: 1,
+} as never);
 
 const heldCreateAts = async () => (await queryPostsBetween(database, 0, Number.MAX_SAFE_INTEGER, Q.desc, '', channelId).fetch()).
     map((p) => p.createAt).sort((a, b) => a - b);
@@ -495,6 +509,76 @@ describe('PROBE 5: RECEIVED_AROUND stores posts with no interval bookkeeping', (
         expect(await queryPostsBetween(database, 0, 1000, Q.desc, '', channelId).fetch()).toHaveLength(3);
         expect(await intervals()).toHaveLength(0);
         expect(await renderedPosts()).toHaveLength(0);
+    });
+});
+
+describe('PROBE 8: a websocket post extends the interval across a gap the socket missed', () => {
+    it('lies about contiguity but leaves the watermark behind, so the next since-fetch heals it', async () => {
+        const history = [post('seed-100', 100), post('seed-105', 105), post('seed-110', 110)];
+        const missed = [post('missed-150', 150), post('missed-160', 160)];
+        const live = post('live-200', 200);
+        seedServer([...history, ...missed, live]);
+        await storePostsForChannel(serverUrl, channelId, history, history.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        expect(await watermark()).toBe(110);
+
+        // The socket dropped while 150 and 160 were created, then delivers 200 on reconnect.
+        await wsNewPost(live);
+
+        // handleReceivedNewPostForChannel extends chunks[0].latest with no contiguity check, so the
+        // interval now claims two posts the app never fetched. No push notification involved.
+        const claimed = await intervals();
+        expect(claimed).toHaveLength(1);
+        expect(claimed[0].latest).toBe(200);
+        expect(await heldCreateAts()).toEqual([100, 105, 110, 200]);
+
+        // The saving grace: the websocket path does not touch lastFetchedAt, so the watermark stays
+        // behind the gap and the next since-fetch fills it. The interval lie is self-correcting.
+        expect(await watermark()).toBe(110);
+        await fetchPostsForChannel(serverUrl, channelId);
+        expect(await heldCreateAts()).toEqual([100, 105, 110, 150, 160, 200]);
+    });
+});
+
+describe('PROBE 9: push then websocket backlog, the field sequence', () => {
+    it('loses the missed posts for good, through the real notification and websocket paths', async () => {
+        const history = [post('seed-100', 100), post('seed-105', 105), post('seed-110', 110)];
+        const missed = [post('missed-150', 150), post('missed-160', 160)];
+        const reply = post('reply-170', 170, {root_id: 'seed-100'});
+        const live = Array.from({length: 60}, (_, i) => post(`live-${200 + i}`, 200 + i));
+        seedServer([...history, ...missed, reply, ...live]);
+        await storePostsForChannel(serverUrl, channelId, history, history.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        // 1. App suspended with the socket down: 150 and 160 are missed, then a push for a thread
+        //    reply is processed by JS, which advances the watermark past them.
+        await pushThreadReply(reply);
+        expect(await watermark()).toBe(170);
+        expect((await intervals())[0].latest).toBe(110);
+
+        // 2. The socket comes back and the backlog streams in as posted events, each extending the
+        //    interval, so it ends up spanning the gap.
+        for (const p of live) {
+            /* eslint-disable-next-line no-await-in-loop */
+            await wsNewPost(p);
+        }
+        const claimed = await intervals();
+        expect(claimed).toHaveLength(1);
+        expect(claimed[0].earliest).toBe(100);
+        expect(claimed[0].latest).toBe(259);
+        expect(await heldCreateAts()).not.toContain(150);
+
+        // 3. Everything that could still refetch: the since-fetch cannot see update_at 150/160 from
+        //    a watermark of 170, page zero only reaches the newest 60 by create_at, and scroll-back
+        //    pages below the oldest post held rather than through the middle.
+        await fetchPostsForChannel(serverUrl, channelId);
+        await fetchPosts(serverUrl, channelId);
+        const rendered = await renderedPosts();
+        const oldestRendered = rendered[rendered.length - 1];
+        expect(oldestRendered.createAt).toBe(100);
+        await fetchPostsBefore(serverUrl, channelId, oldestRendered.id);
+
+        const held = await heldCreateAts();
+        expect(held).not.toContain(150);
+        expect(held).not.toContain(160);
     });
 });
 

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -19,8 +19,8 @@ jest.mock('@components/post_list/combined_user_activity', () => 'CombinedUserAct
 jest.mock('@components/post_list/scroll_to_end_view', () => 'ScrollToEndView');
 jest.mock('@actions/remote/post', () => {
     return {
-        fetchPosts: jest.fn(),
         fetchPostThread: jest.fn(),
+        refreshPostsForChannel: jest.fn(),
     };
 });
 jest.mock('@actions/local/post', () => ({
@@ -33,8 +33,8 @@ import type Database from '@nozbe/watermelondb/Database';
 describe('components/post_list/PostList', () => {
     let database: Database;
     const serverUrl = 'https://server.com';
-    const fetchPostsSpy = jest.spyOn(postFunctions, 'fetchPosts');
     const fetchPostThreadSpy = jest.spyOn(postFunctions, 'fetchPostThread');
+    const refreshPostsForChannelSpy = jest.spyOn(postFunctions, 'refreshPostsForChannel');
     const removePostSpy = jest.spyOn(localPostFunctions, 'removePost');
     const unrelatedNativeEventsAttributes = {
         contentSize: {height: 1000, width: 100},
@@ -128,7 +128,19 @@ describe('components/post_list/PostList', () => {
             flatList.props.onRefresh();
         });
 
-        expect(fetchPostsSpy).toHaveBeenCalledWith('https://server.com', 'channel-id');
+        expect(refreshPostsForChannelSpy).toHaveBeenCalledWith('https://server.com', 'channel-id', false);
+    });
+
+    it('flags the refresh as blank when the channel renders no posts', async () => {
+        const props = {...baseProps, posts: []};
+        const {getByTestId} = renderWithEverything(<PostList {...props}/>, {database, serverUrl});
+        const flatList = getByTestId('post_list.flat_list');
+
+        await act(async () => {
+            flatList.props.onRefresh();
+        });
+
+        expect(refreshPostsForChannelSpy).toHaveBeenCalledWith('https://server.com', 'channel-id', true);
     });
 
     it('handles refresh in thread', async () => {
@@ -421,6 +433,6 @@ describe('components/post_list/PostList', () => {
             flatList.props.onRefresh();
         });
 
-        expect(fetchPostsSpy).not.toHaveBeenCalled();
+        expect(refreshPostsForChannelSpy).not.toHaveBeenCalled();
     });
 });

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -10,7 +10,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {scheduleOnRN, scheduleOnUI} from 'react-native-worklets';
 
 import {removePost} from '@actions/local/post';
-import {fetchPosts, fetchPostThread} from '@actions/remote/post';
+import {fetchPostThread, refreshPostsForChannel} from '@actions/remote/post';
 import CombinedUserActivity from '@components/post_list/combined_user_activity';
 import DateSeparator from '@components/post_list/date_separator';
 import NewMessagesLine from '@components/post_list/new_message_line';
@@ -273,7 +273,9 @@ const PostList = ({
         }
         setRefreshing(true);
         if (location === Screens.CHANNEL && channelId) {
-            await fetchPosts(serverUrl, channelId);
+            // Tell the refresh whether the list is showing nothing, so it can repair a channel that
+            // is hiding posts it already has instead of just fetching another page it cannot show.
+            await refreshPostsForChannel(serverUrl, channelId, !orderedPosts.length);
         } else if (location === Screens.THREAD && rootId) {
             const options: FetchPaginatedThreadOptions = {};
             const lastPost = posts[0];
@@ -289,7 +291,7 @@ const PostList = ({
             map((post) => removePost(serverUrl, post));
         await Promise.all(removalPromises);
         setRefreshing(false);
-    }, [disablePullToRefresh, location, channelId, rootId, posts, serverUrl]);
+    }, [disablePullToRefresh, location, channelId, orderedPosts.length, rootId, posts, serverUrl]);
 
     const scrollToIndex = useCallback((index: number, animated = true, applyOffset = true) => {
         if (index < 0 || !listRef?.current) {

--- a/app/queries/servers/post.ts
+++ b/app/queries/servers/post.ts
@@ -120,6 +120,18 @@ export const queryPostsInChannel = (database: Database, channelId: string) => {
     );
 };
 
+// Note: unlike queryPostsInChannel, which queries the PostsInChannel intervals, this queries the
+// posts of a channel themselves, with no interval bounds. Use it with fetchCount() to tell whether
+// a channel that renders nothing still has posts stored.
+export const queryPostsForChannel = (database: Database, channelId: string, includeDeleted = false) => {
+    const conditions: Q.Where[] = [Q.where('channel_id', channelId)];
+    if (!includeDeleted) {
+        conditions.push(Q.where('delete_at', Q.eq(0)));
+    }
+
+    return database.get<PostModel>(POST).query(Q.and(...conditions));
+};
+
 export const queryPostsInThread = (database: Database, rootId: string, sorted = false, includeDeleted = false) => {
     const clauses: Q.Clause[] = [Q.where('root_id', rootId)];
     if (!includeDeleted) {


### PR DESCRIPTION
## Summary

Investigation of a report of *"sometimes messages in a GM don't get loaded and the channel appears blank"* (app 2.42.2 / build 787, server 11.10.0, no logs).

The channel post list renders **one** interval: `postsInChannel[0]`, the `PostsInChannel` row with the greatest `latest` ([channel_post_list/index.ts](https://github.com/mattermost/mattermost-mobile/blob/main/app/screens/channel/channel_post_list/index.ts)). If that interval contains no posts, the channel renders zero rows — blank, even though older posts are still in the database — and **nothing recovers it today**.

## How an interval ends up with no posts

Every post it was built from gets deleted on the server. A later fetch returns them with `delete_at` set, `handlePosts` destroys them locally, and the interval is left untouched. From then on:

- `fetchPostsForChannel` takes the since-branch — `myChannel.lastFetchedAt` is advanced by deletions too, because `getLastFetchedAtFromPosts` uses `max(create_at, update_at, delete_at)` — and `getPostsSince` returns nothing when there is nothing newer, so no post is ever stored again.
- The `channel_post_list` fallback page-0 fetch (`posts.length < PER_PAGE_DEFAULT`) *does* store posts, but its interval sorts **below** the empty one, so `postsInChannel[0]` never changes and the list stays empty.
- `handleReceivedPostsInChannel` does not merge the empty interval away: it is disjoint and newer than the page just fetched, so the merge loop `break`s before reaching it.

MM-66467 stopped these intervals from being *created* from deleted posts, but an interval that **later** loses all its posts — or one left behind in a database poisoned by a pre-2.42.2 build, since no repair shipped with that fix — still hides the channel permanently. "Reset cached messages" is currently the only way out, and it requires the user to know it exists.

Small/low-traffic channels (DMs and GMs) are the most exposed: the deleted messages are more likely to be *all* of the newest interval.

## Change

**1. Prune post-less intervals (self-healing, silent).** New local action `pruneEmptyPostsInChannelIntervals(serverUrl, channelId)`: destroys the channel's `PostsInChannel` rows that contain no post. Such an interval carries no information — re-fetching an empty range is harmless — so dropping it lets the next interval, or a fresh page fetch, render again. `fetchPostsForChannel` prunes when the channel has no visible posts, and stops trusting `lastFetchedAt` in that state, so the fallback is a full page fetch (`RECEIVED_IN_CHANNEL`) instead of a no-op since-fetch.

**2. Escalate on pull-to-refresh (user-triggered).** Refresh on a channel was a plain page-0 fetch — precisely what cannot recover a hidden channel. `refreshPostsForChannel` now takes whether the list is rendering nothing; when it is *and* the channel still has non-deleted posts stored, those posts are hidden rather than absent, so it clears the channel's cached posts and re-fetches from scratch (the same recovery as "Reset cached messages"). Posts on screen, or a genuinely empty channel, keep the previous behaviour.

This second part covers what the prune cannot: an interval that *does* hold posts, none of which the list renders — all replies with CRT on, or only join/leave messages with that preference off — survives the prune and still shows nothing. Its blankness signal is `orderedPosts`, what the list actually renders after `preparePostList`, so it accounts for filtering the prune's DB-level check can't see.

Both only act in the already-broken state, so the normal since/page paths are untouched. Together they repair already-poisoned databases — on the next channel open, or on a pull-to-refresh — whatever produced the bad interval. The warning logged on the reset path (channel id and a count, no PII) is also the breadcrumb that was missing from the report that started this.

## Tests

- `fetchPostsForChannel - recovers a channel whose newest interval has no posts left (MM-66467)` — seeds history + a disjoint newer interval, deletes the newer post, asserts the channel is blank, then asserts `fetchPostsForChannel` renders history again with a server that has nothing new.
- `fetchPostsForChannel - falls back to a page fetch when no interval has posts left` — asserts `getPostsSince` is not called and `getPosts` is.
- `refreshPostsForChannel` — three tests: posts on screen → plain page fetch; blank with hidden posts → cached posts cleared and re-fetched; genuinely empty → plain page fetch, nothing reset. The middle one was verified red against a `refreshPostsForChannel` that always page-fetches.
- `PostList` — refresh passes `isBlank: false` with posts and `true` with none.
- Three unit tests for the new local action (branch coverage of new code, not regression tests — they cannot fail without it).

Both `fetchPostsForChannel` tests were verified **red** against the pre-fix code, failing on the right assertions: the first gets `intervals.length` 2 instead of 1 (the post-less interval survives, after its earlier assertion confirms the channel renders blank), the second gets `getPostsSince` called once instead of never. The 5 pre-existing `fetchPostsForChannel` tests still pass against the pre-fix code, so the failures are behavioural rather than a mechanical break.

`npx jest app/actions/{remote,local}/post app/database/operator/server_data_operator/handlers/post app/actions/websocket app/screens/channel app/components/post_list app/queries/servers/post` → 780 passed. `npm run tsc` and eslint clean.

**Not verified on a device:** reproducing this needs a database with an interval whose posts were all deleted server-side, which is not reachable through the UI, and no simulator build was available in this environment. Verification is at the DB/action layer.

## Possible follow-ups

- Prune at write time too (in `handlePosts`, when deleted posts are destroyed) so a channel heals without waiting for the next open or refresh.
- The same class of state is reachable for threads (`PostsInThread` intervals) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


