### PR TITLE
fix(ci): recycle Jest workers to prevent test-coverage OOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "preinstall": "./scripts/preinstall.sh && npx solidarity",
     "start": "react-native start --host 127.0.0.1",
     "test": "NODE_OPTIONS=--max_old_space_size=12000 jest --maxWorkers=4",
-    "test:ci": "NODE_OPTIONS=--max_old_space_size=12000 jest --verbose=false --forceExit",
+    "test:ci": "NODE_OPTIONS=--max_old_space_size=12000 jest --verbose=false --forceExit --workerIdleMemoryLimit=1GB",
     "test:ci:coverage": "npm run test:ci -- --coverage",
     "test:coverage": "npm test -- --coverage",
     "test:watch": "npm test -- --watch",


### PR DESCRIPTION
#### Summary

The `ci/test-coverage` step (`npm run test:ci -- --coverage`) intermittently fails on our base GitHub-hosted runners.

- **All test suites pass first** (659 suites, ~8.8k tests — verified locally, exit 0).
- ~25s later, the Jest process is killed with **exit code 143 (SIGTERM)** during the coverage-report aggregation phase (the peak-memory moment).
- The OOM takes the runner VM down, so GitHub reports *"The hosted runner lost communication with the server"* and the job hangs ~45 min on the heartbeat timeout before failing (the inflated ~59-min duration).

This is a **runner memory-ceiling** issue that trips intermittently as the codebase grows, not a bug in any one PR — it's been hit across multiple unrelated PRs.

**Fix:** add `--workerIdleMemoryLimit=1GB` to `test:ci`, so Jest recycles a worker once its heap exceeds 1 GB, releasing accumulated memory and keeping peak usage under the runner's RAM. Worker count is left at the default.

**Validation:** applied this exact change on a branch that was reliably OOMing (2/2 failures on the same commit). The `test` job then went **green in 10m20s** — in line with `main`'s ~10.5 min, confirming no slowdown.

#### Ticket Link
NONE

#### Checklist
- [ ] Added or updated unit tests (required for all new features)  <!-- N/A: CI config only; existing suite used as validation -->
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
N/A — CI configuration change only.

#### Release Note
```release-note
NONE
```
