### PR TITLE
[MM-70023] Consider attachment fields with no title for block translation

### DIFF
--- a/app/components/block_renderer/translation/__snapshots__/index.test.ts.snap
+++ b/app/components/block_renderer/translation/__snapshots__/index.test.ts.snap
@@ -779,6 +779,17 @@ exports[`translatePostProps complex payloads should translate rich attachments (
                     ],
                     "type": "column_set",
                   },
+                  {
+                    "content": [
+                      {
+                        "text": "value without title",
+                        "type": "text",
+                      },
+                    ],
+                    "flow": "vertical",
+                    "gap": "none",
+                    "type": "container",
+                  },
                 ],
                 "flow": "vertical",
                 "gap": "medium",

--- a/app/components/block_renderer/translation/__snapshots__/index.test.ts.snap
+++ b/app/components/block_renderer/translation/__snapshots__/index.test.ts.snap
@@ -790,6 +790,17 @@ exports[`translatePostProps complex payloads should translate rich attachments (
                     "gap": "none",
                     "type": "container",
                   },
+                  {
+                    "content": [
+                      {
+                        "text": "value with whitespace-only title",
+                        "type": "text",
+                      },
+                    ],
+                    "flow": "vertical",
+                    "gap": "none",
+                    "type": "container",
+                  },
                 ],
                 "flow": "vertical",
                 "gap": "medium",

--- a/app/components/block_renderer/translation/attachments.ts
+++ b/app/components/block_renderer/translation/attachments.ts
@@ -235,15 +235,12 @@ function parseAttachmentFields(fields: unknown): ParsedAttachmentField[] {
             continue;
         }
         const field = f as Record<string, unknown>;
-        if (typeof field.title !== 'string' || !field.title) {
-            continue;
-        }
         const valueStr = formatAttachmentFieldValue(field.value);
         if (!valueStr) {
             continue;
         }
         result.push({
-            title: field.title,
+            title: typeof field.title === 'string' ? field.title : '',
             value: valueStr,
             short: field.short === true,
         });
@@ -253,7 +250,9 @@ function parseAttachmentFields(fields: unknown): ParsedAttachmentField[] {
 
 function attachmentFieldBlocks(f: ParsedAttachmentField): MmBlock[] {
     const blocks: MmBlock[] = [];
-    blocks.push({type: 'text', text: `**${f.title}:**`});
+    if (f.title) {
+        blocks.push({type: 'text', text: `**${f.title}:**`});
+    }
     blocks.push({type: 'text', text: f.value});
     return blocks;
 }

--- a/app/components/block_renderer/translation/attachments.ts
+++ b/app/components/block_renderer/translation/attachments.ts
@@ -240,7 +240,7 @@ function parseAttachmentFields(fields: unknown): ParsedAttachmentField[] {
             continue;
         }
         result.push({
-            title: typeof field.title === 'string' ? field.title : '',
+            title: typeof field.title === 'string' && field.title.trim() ? field.title : '',
             value: valueStr,
             short: field.short === true,
         });

--- a/app/components/block_renderer/translation/test_fixtures_complex.ts
+++ b/app/components/block_renderer/translation/test_fixtures_complex.ts
@@ -242,6 +242,7 @@ export const ATTACHMENTS_COMPLEX = [
             {title: 'Next update', value: 'In 15 minutes or on status change', short: true},
             {title: 'Commander', value: '@sre-oncall', short: true},
             {title: '', value: 'value without title'},
+            {title: ' ', value: 'value with whitespace-only title'},
             {title: 'Empty value', value: null},
         ],
         image_url: 'https://example.com/error-rate-chart.png',

--- a/app/components/block_renderer/translation/test_fixtures_complex.ts
+++ b/app/components/block_renderer/translation/test_fixtures_complex.ts
@@ -241,7 +241,7 @@ export const ATTACHMENTS_COMPLEX = [
             {title: 'Customer impact', value: 'Delayed message delivery for ~4% of active sessions', short: false},
             {title: 'Next update', value: 'In 15 minutes or on status change', short: true},
             {title: 'Commander', value: '@sre-oncall', short: true},
-            {title: '', value: 'skipped empty title'},
+            {title: '', value: 'value without title'},
             {title: 'Empty value', value: null},
         ],
         image_url: 'https://example.com/error-rate-chart.png',


### PR DESCRIPTION
#### Summary
In the initial implementation, we considered that a field without a title was malformed. During internal usage, we discovered we were relying on that to show certain information, and "it was working". So we updated this to not ignore the fields without a title.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-70023

#### Release Note
No release note needed, since this is a bug in a feature for this release
```release-note
NONE
```
