### PR TITLE
fix: restore gallery images after closing viewer on Android

### DIFF
--- a/app/screens/gallery/index.test.tsx
+++ b/app/screens/gallery/index.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+
+import {Screens} from '@constants';
+import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
+import {navigateBack} from '@screens/navigation';
+
+import GalleryScreen from './index';
+
+const mockCloseGallery = jest.fn();
+const mockHideHeaderAndFooter = jest.fn();
+
+jest.mock('@hooks/android_back_handler', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+jest.mock('@hooks/device', () => ({
+    useWindowDimensions: jest.fn(() => ({height: 800, width: 400})),
+}));
+
+jest.mock('@hooks/gallery', () => ({
+    useGalleryControls: jest.fn(() => ({
+        footerStyles: {},
+        headerAndFooterHidden: {value: false},
+        headerStyles: {},
+        hideHeaderAndFooter: mockHideHeaderAndFooter,
+    })),
+}));
+
+jest.mock('@screens/navigation', () => ({
+    navigateBack: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: jest.fn(() => ({bottom: 0})),
+}));
+
+jest.mock('./footer', () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+}));
+
+jest.mock('./gallery', () => {
+    const ReactModule = require('react');
+    const MockGallery = ReactModule.forwardRef((_props: unknown, ref: React.Ref<unknown>) => {
+        ReactModule.useImperativeHandle(ref, () => ({close: mockCloseGallery}));
+        return null;
+    });
+    MockGallery.displayName = 'MockGallery';
+
+    return {
+        __esModule: true,
+        default: MockGallery,
+    };
+});
+
+jest.mock('./header', () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+}));
+
+describe('GalleryScreen', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(global, 'requestAnimationFrame').mockImplementation((callback) => {
+            callback(0);
+            return 0;
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should animate the gallery closed before navigating back on Android hardware back', () => {
+        render(
+            <GalleryScreen
+                galleryIdentifier='post-1'
+                hideActions={false}
+                initialIndex={0}
+                items={[]}
+            />,
+        );
+
+        expect(useAndroidHardwareBackHandler).toHaveBeenCalledWith(Screens.GALLERY, expect.any(Function));
+
+        const backHandler = jest.mocked(useAndroidHardwareBackHandler).mock.calls[0][1];
+        act(() => {
+            backHandler();
+        });
+
+        expect(mockHideHeaderAndFooter).toHaveBeenCalledTimes(1);
+        expect(mockCloseGallery).toHaveBeenCalledTimes(1);
+        expect(navigateBack).not.toHaveBeenCalled();
+    });
+});

--- a/app/screens/gallery/index.test.tsx
+++ b/app/screens/gallery/index.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {Screens} from '@constants';
 import useAndroidHardwareBackHandler from '@hooks/android_back_handler';
 import {navigateBack} from '@screens/navigation';
+import {advanceTimers, disableFakeTimers, enableFakeTimers} from '@test/timer_helpers';
 
 import GalleryScreen from './index';
 
@@ -66,17 +67,14 @@ jest.mock('./header', () => ({
 describe('GalleryScreen', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        jest.spyOn(global, 'requestAnimationFrame').mockImplementation((callback) => {
-            callback(0);
-            return 0;
-        });
+        enableFakeTimers();
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        disableFakeTimers();
     });
 
-    it('should animate the gallery closed before navigating back on Android hardware back', () => {
+    it('should animate the gallery closed before navigating back on Android hardware back', async () => {
         render(
             <GalleryScreen
                 galleryIdentifier='post-1'
@@ -89,8 +87,9 @@ describe('GalleryScreen', () => {
         expect(useAndroidHardwareBackHandler).toHaveBeenCalledWith(Screens.GALLERY, expect.any(Function));
 
         const backHandler = jest.mocked(useAndroidHardwareBackHandler).mock.calls[0][1];
-        act(() => {
+        await act(async () => {
             backHandler();
+            await advanceTimers(16);
         });
 
         expect(mockHideHeaderAndFooter).toHaveBeenCalledTimes(1);

--- a/app/screens/gallery/index.tsx
+++ b/app/screens/gallery/index.tsx
@@ -61,7 +61,7 @@ const GalleryScreen = ({galleryIdentifier, hideActions, initialIndex, items}: Ga
         };
     }, [onClose]);
 
-    useAndroidHardwareBackHandler(Screens.GALLERY, close);
+    useAndroidHardwareBackHandler(Screens.GALLERY, onClose);
 
     return (
         <View style={containerStyle}>

--- a/app/screens/gallery/lightbox_swipeout/lightbox.test.tsx
+++ b/app/screens/gallery/lightbox_swipeout/lightbox.test.tsx
@@ -9,12 +9,18 @@ import Lightbox from './lightbox';
 
 import type {GalleryItemType, GalleryManagerSharedValues} from '@typings/screens/gallery';
 
+type MockExpoImageAnimatedProps = React.ComponentProps<(typeof import('@components/expo_image'))['ExpoImageAnimated']>;
+type MockViewProps = React.ComponentProps<(typeof import('react-native'))['View']>;
+
 jest.mock('@components/expo_image', () => {
-    const ReactModule = require('react');
-    const {View: MockView} = require('react-native');
+    const ReactModule: typeof import('react') = require('react');
+    const {View: MockView}: typeof import('react-native') = require('react-native');
 
     return {
-        ExpoImageAnimated: jest.fn((props) => ReactModule.createElement(MockView, {...props, testID: 'lightbox-transition-image'})),
+        ExpoImageAnimated: jest.fn((props: MockExpoImageAnimatedProps) => ReactModule.createElement(MockView, {
+            ...props,
+            testID: 'lightbox.transition.image',
+        } as MockViewProps)),
     };
 });
 
@@ -68,7 +74,7 @@ describe('Lightbox', () => {
             </Lightbox>,
         );
 
-        const transitionImage = getByTestId('lightbox-transition-image');
+        const transitionImage = getByTestId('lightbox.transition.image');
         expect(transitionImage).toHaveProp('source', {uri: 'https://example.com/image.png'});
         expect(transitionImage).not.toHaveProp('placeholder');
     });

--- a/app/screens/gallery/lightbox_swipeout/lightbox.test.tsx
+++ b/app/screens/gallery/lightbox_swipeout/lightbox.test.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {render} from '@testing-library/react-native';
+import React from 'react';
+
+import {useLightboxSharedValues} from './context';
+import Lightbox from './lightbox';
+
+import type {GalleryItemType, GalleryManagerSharedValues} from '@typings/screens/gallery';
+
+jest.mock('@components/expo_image', () => {
+    const ReactModule = require('react');
+    const {View: MockView} = require('react-native');
+
+    return {
+        ExpoImageAnimated: jest.fn((props) => ReactModule.createElement(MockView, {...props, testID: 'lightbox-transition-image'})),
+    };
+});
+
+jest.mock('@hooks/did_mount', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+jest.mock('./context', () => ({
+    useLightboxSharedValues: jest.fn(),
+}));
+
+const sharedValue = <T, >(value: T) => ({value});
+
+describe('Lightbox', () => {
+    it('should render the transition image without a separately cached placeholder', () => {
+        const image = {
+            cacheKey: 'file-1',
+            height: 200,
+            type: 'image',
+            width: 300,
+        } as GalleryItemType;
+        const sharedValues = {
+            height: sharedValue(100),
+            width: sharedValue(150),
+            x: sharedValue(10),
+            y: sharedValue(20),
+        } as GalleryManagerSharedValues;
+
+        jest.mocked(useLightboxSharedValues).mockReturnValue({
+            animationProgress: sharedValue(0),
+            childTranslateY: sharedValue(0),
+            childrenOpacity: sharedValue(0),
+            headerAndFooterHidden: sharedValue(false),
+            imageOpacity: sharedValue(1),
+            opacity: sharedValue(1),
+            scale: sharedValue(1),
+            target: image,
+            targetDimensions: {height: 800, width: 400},
+            translateX: sharedValue(0),
+            translateY: sharedValue(0),
+        } as ReturnType<typeof useLightboxSharedValues>);
+
+        const {getByTestId} = render(
+            <Lightbox
+                renderItem={jest.fn()}
+                sharedValues={sharedValues}
+                source='https://example.com/image.png'
+            >
+                {null}
+            </Lightbox>,
+        );
+
+        const transitionImage = getByTestId('lightbox-transition-image');
+        expect(transitionImage).toHaveProp('source', {uri: 'https://example.com/image.png'});
+        expect(transitionImage).not.toHaveProp('placeholder');
+    });
+});

--- a/app/screens/gallery/lightbox_swipeout/lightbox.tsx
+++ b/app/screens/gallery/lightbox_swipeout/lightbox.tsx
@@ -179,8 +179,6 @@ export default function Lightbox({
                             <ExpoImageAnimated
                                 id={target.cacheKey}
                                 source={imageSource}
-                                placeholder={imageSource}
-                                placeholderContentFit='cover'
                                 style={itemStyles}
                                 autoplay={false}
                             />


### PR DESCRIPTION
#### Summary

Opening a post image hides the inline source while the lightbox transition is active. On Android, hardware Back navigated away directly instead of running the lightbox close animation, so the callback that restores the inline image opacity never ran. This routes hardware Back through the same animated close path as the header close button.

The lightbox transition also used the full image as both its source and placeholder. Mattermost caches placeholders under a separate `-thumb` key, which could briefly show stale image data on later gallery opens. This removes the redundant placeholder.

Added regression tests for the Android Back close path and transition image props. Manually verified repeated open and close cycles on a Pixel 9 Pro running Android 17.

#### Ticket Link

Related to https://github.com/mattermost/mattermost-mobile/issues/9894
Related to https://github.com/mattermost/mattermost-mobile/issues/9742

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

#### Device Information
This PR was tested on: Pixel 9 Pro, Android 17

#### Screenshots
N/A

#### Release Note

```release-note
Fixed inline images disappearing after closing the gallery on Android and stale image flashes when reopening the gallery.
```
