### PR TITLE
Mobile: single-click leave for non-hosts + remove end confirmation

### DIFF
--- a/app/products/calls/actions/calls.test.ts
+++ b/app/products/calls/actions/calls.test.ts
@@ -365,7 +365,6 @@ describe('Actions.Calls', () => {
                 'channel-id',
                 leaveCb,
             );
-            myselfLeftCall();
         });
 
         expect(mockAlert).not.toHaveBeenCalled();

--- a/app/products/calls/actions/calls.test.ts
+++ b/app/products/calls/actions/calls.test.ts
@@ -9,7 +9,7 @@ import {Alert} from 'react-native';
 import InCallManager from 'react-native-incall-manager';
 
 import * as CallsActions from '@calls/actions';
-import {getConnectionForTesting} from '@calls/actions/calls';
+import {getConnectionForTesting, leaveCallConfirmation} from '@calls/actions/calls';
 import * as Permissions from '@calls/actions/permissions';
 import {needsRecordingWillBePostedAlert, needsRecordingErrorAlert} from '@calls/alerts';
 import {userLeftChannelErr, userRemovedFromChannelErr} from '@calls/errors';
@@ -337,6 +337,40 @@ describe('Actions.Calls', () => {
         expect(disconnectMock).toHaveBeenCalled();
         expect(getConnectionForTesting()).toBe(null);
         assert.equal((result.current[1] as CurrentCall | null), null);
+    });
+
+    it('leaveCallConfirmation leaves immediately for non-hosts without showing an alert', async () => {
+        // setup
+        addFakeCall('server1', 'channel-id');
+        await act(async () => {
+            await CallsActions.joinCall('server1', 'channel-id', 'myUserId', true, createIntl({
+                locale: 'en',
+                messages: {},
+            }));
+            newCurrentCall('server1', 'channel-id', 'myUserId');
+            userJoinedCall('server1', 'channel-id', 'myUserId', 'mySessionId');
+        });
+
+        const disconnectMock = getConnectionForTesting()!.disconnect;
+        const mockAlert = jest.spyOn(Alert, 'alert');
+        const leaveCb = jest.fn();
+
+        await act(async () => {
+            await leaveCallConfirmation(
+                createIntl({locale: 'en', messages: {}}),
+                true,
+                false,
+                false,
+                'server1',
+                'channel-id',
+                leaveCb,
+            );
+            myselfLeftCall();
+        });
+
+        expect(mockAlert).not.toHaveBeenCalled();
+        expect(disconnectMock).toHaveBeenCalled();
+        expect(leaveCb).toHaveBeenCalled();
     });
 
     it('muteMyself', async () => {

--- a/app/products/calls/actions/calls.ts
+++ b/app/products/calls/actions/calls.ts
@@ -314,7 +314,13 @@ export const leaveCallConfirmation = async (
     channelId: string,
     leaveCb?: () => void) => {
     const showHostControls = (isHost || isAdmin) && otherParticipants;
-    const ret = await endCallConfirmationAlert(intl, showHostControls) as EndCallReturn;
+    if (!showHostControls) {
+        leaveCall();
+        leaveCb?.();
+        return;
+    }
+
+    const ret = await endCallConfirmationAlert(intl) as EndCallReturn;
     switch (ret) {
         case EndCallReturn.Cancel:
             return;

--- a/app/products/calls/alerts.test.ts
+++ b/app/products/calls/alerts.test.ts
@@ -470,25 +470,15 @@ describe('alerts', () => {
             formatMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
         };
 
-        it('shows end call confirmation for non-host', async () => {
+        it('shows the host end call choice, with no separate confirmation step', async () => {
             const mockAlert = jest.spyOn(Alert, 'alert');
-            const promise = endCallConfirmationAlert(intl as any, false);
+            const promise = endCallConfirmationAlert(intl as any);
 
             expect(mockAlert).toHaveBeenCalledWith(
                 'Are you sure you want to leave this call?',
                 '',
                 expect.any(Array),
             );
-
-            // Simulate leave
-            const leaveButton = mockAlert.mock.calls[0][2]![1];
-            leaveButton.onPress?.();
-            expect(await promise).toBe(EndCallReturn.LeaveCall);
-        });
-
-        it('shows end call confirmation for host', async () => {
-            const mockAlert = jest.spyOn(Alert, 'alert');
-            const promise = endCallConfirmationAlert(intl as any, true);
 
             const buttons = mockAlert.mock.calls[0][2]!;
             expect(buttons).toHaveLength(3);

--- a/app/products/calls/alerts.ts
+++ b/app/products/calls/alerts.ts
@@ -523,53 +523,39 @@ export const removeFromCall = (serverUrl: string, displayName: string, callId: s
     }]);
 };
 
-export const endCallConfirmationAlert = (intl: IntlShape, showHostControls: boolean) => {
+export const endCallConfirmationAlert = (intl: IntlShape) => {
     const {formatMessage} = intl;
 
     const asyncAlert = async () => new Promise((resolve) => {
-        const buttons: AlertButton[] = [{
+        const cancelButton: AlertButton = {
             text: formatMessage({
                 id: 'mobile.calls_cancel',
                 defaultMessage: 'Cancel',
             }),
             onPress: () => resolve(EndCallReturn.Cancel),
             style: 'cancel',
-        }, {
+        };
+        const endCallButton: AlertButton = {
+            text: formatMessage({
+                id: 'mobile.calls_host_end_confirm',
+                defaultMessage: 'End call for everyone',
+            }),
+            onPress: () => resolve(EndCallReturn.EndCall),
+            style: 'destructive',
+        };
+        const leaveCallButton: AlertButton = {
             text: formatMessage({
                 id: 'mobile.calls_host_leave_confirm',
                 defaultMessage: 'Leave call',
             }),
             onPress: () => resolve(EndCallReturn.LeaveCall),
-            style: 'destructive',
-        }];
+        };
+        const buttons = Platform.OS === 'ios' ? [cancelButton, endCallButton, leaveCallButton] : [cancelButton, leaveCallButton, endCallButton];
+
         const questionMsg = formatMessage({
             id: 'mobile.calls_host_leave_title',
             defaultMessage: 'Are you sure you want to leave this call?',
         });
-
-        if (showHostControls) {
-            const endCallButton: AlertButton = {
-                text: formatMessage({
-                    id: 'mobile.calls_host_end_confirm',
-                    defaultMessage: 'End call for everyone',
-                }),
-                onPress: () => resolve(EndCallReturn.EndCall),
-                style: 'destructive',
-            };
-            const leaveCallButton = {
-                text: formatMessage({
-                    id: 'mobile.calls_host_leave_confirm',
-                    defaultMessage: 'Leave call',
-                }),
-                onPress: () => resolve(EndCallReturn.LeaveCall),
-            };
-
-            if (Platform.OS === 'ios') {
-                buttons.splice(1, 1, endCallButton, leaveCallButton);
-            } else {
-                buttons.splice(1, 1, leaveCallButton, endCallButton);
-            }
-        }
 
         if (Platform.OS === 'ios') {
             Alert.alert(questionMsg, '', buttons);


### PR DESCRIPTION
#### Summary
- Non-hosts leaving a call now hang up immediately instead of seeing a leave/cancel confirmation popup.
- Hosts with other participants still choose between "Leave call" and "End call for everyone", with no additional confirmation step after that choice.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69764

#### Checklist
- [x] Added or updated unit tests
- [x] Has UI changes

#### Test plan
- [x] Unit tests updated/added in `alerts.test.ts` and `calls.test.ts`
- [x] `npm run tsc` passes
- [x] `npx eslint` on changed files passes with no new warnings
- [x] Manual verification: non-host tap Leave in a channel/GM call with other participants leaves with no popup
- [x] Manual verification: host tap Leave in a call with other participants still shows Leave/End choice
- [x] Manual verification: sysadmin (non-host) tap Leave with other participants also shows the choice menu
- [x] Manual verification: solo participant (host or non-host, alone in call) tap Leave ends immediately with no popup

#### Screenshots
Host/sysadmin confirmation menu (iOS), shown only when the leaver is a host or system admin and other participants remain in the call:

<!-- screenshot to be attached: CleanShot 2026-08-03 at 14.52.57@2x.png -->
<img width="544" height="434" alt="CleanShot 2026-08-03 at 14 52 57@2x" src="https://github.com/user-attachments/assets/1c00ed37-b513-4b5f-b3a4-3e00bd1dd867" />

"Are you sure you want to leave this call?" / End call for everyone / Leave call / Cancel

#### Release Note
```release-note
Leaving a call as a non-host no longer requires an extra confirmation tap.
```
