### PR TITLE
[MM-66467] Recover and prevent channels blanked by post-less PostsInChannel intervals

### DIFF
--- a/app/actions/local/post.test.ts
+++ b/app/actions/local/post.test.ts
@@ -4,7 +4,7 @@
 import {ActionType, Post} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {getPostById} from '@queries/servers/post';
+import {getPostById, queryPostsInChannel} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {COMBINED_USER_ACTIVITY} from '@utils/post_list';
 
@@ -15,6 +15,7 @@ import {
     markPostAsDeleted,
     storePostsForChannel,
     getPosts,
+    pruneEmptyPostsInChannelIntervals,
     addPostAcknowledgement,
     removePostAcknowledgement,
     deletePosts,
@@ -222,6 +223,50 @@ describe('storePostsForChannel', () => {
         expect(error).toBeUndefined();
         expect(models).toBeDefined();
         expect(models?.length).toBe(4); // Post, PostsInChannel, User, MyChannel
+    });
+});
+
+describe('pruneEmptyPostsInChannelIntervals', () => {
+    const seedInterval = (earliest: number, latest: number) => operator.handleReceivedPostsInChannel([
+        TestHelper.fakePost({channel_id: channelId, create_at: earliest}),
+        TestHelper.fakePost({channel_id: channelId, create_at: latest}),
+    ]);
+
+    it('handle not found database', async () => {
+        const {models, error} = await pruneEmptyPostsInChannelIntervals('foo', channelId);
+        expect(models).toBeUndefined();
+        expect(error).toBeTruthy();
+    });
+
+    it('should remove the intervals with no posts and keep the ones with posts', async () => {
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        const post = TestHelper.fakePost({channel_id: channelId, create_at: 1000, update_at: 1000});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [post.id],
+            posts: [post],
+            prepareRecordsOnly: false,
+        });
+
+        // An interval covering a range where no post is left, as happens once every post it was
+        // built from is deleted on the server.
+        await seedInterval(8000, 9000);
+        expect((await queryPostsInChannel(database, channelId).fetch()).length).toBe(2);
+
+        const {models, error} = await pruneEmptyPostsInChannelIntervals(serverUrl, channelId);
+        expect(error).toBeUndefined();
+        expect(models?.length).toBe(1);
+
+        const remaining = await queryPostsInChannel(database, channelId).fetch();
+        expect(remaining.length).toBe(1);
+        expect(remaining[0].earliest).toBe(1000);
+        expect(remaining[0].latest).toBe(1000);
+    });
+
+    it('should do nothing when the channel has no intervals', async () => {
+        const {models, error} = await pruneEmptyPostsInChannelIntervals(serverUrl, channelId);
+        expect(error).toBeUndefined();
+        expect(models?.length).toBe(0);
     });
 });
 

--- a/app/actions/local/post.ts
+++ b/app/actions/local/post.ts
@@ -5,12 +5,12 @@ import {fetchPostAuthors} from '@actions/remote/post';
 import {ActionType, Post} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {countUsersFromMentions, getPostById, prepareDeletePost, queryPostsById} from '@queries/servers/post';
+import {countUsersFromMentions, getPostById, prepareDeletePost, queryPostsById, queryPostsChunk, queryPostsInChannel} from '@queries/servers/post';
 import {getCurrentUserId} from '@queries/servers/system';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
 import {generateId} from '@utils/general';
 import {safeParseJSON} from '@utils/helpers';
-import {logError} from '@utils/log';
+import {logDebug, logError} from '@utils/log';
 import {getLastFetchedAtFromPosts} from '@utils/post';
 import {getPostIdsForCombinedUserActivityPost} from '@utils/post_list';
 
@@ -307,6 +307,50 @@ export async function storePostsForChannel(
         return {models};
     } catch (error) {
         logError('storePostsForChannel', error);
+        return {error};
+    }
+}
+
+/**
+ * pruneEmptyPostsInChannelIntervals: removes the PostsInChannel intervals of a channel that no
+ * longer contain any post.
+ *
+ * The channel post list renders the newest interval only (`postsInChannel[0]`, the one with the
+ * greatest `latest`). An interval whose posts are all gone -- every post in it was deleted on the
+ * server, so `handlePosts` destroyed them locally -- renders zero rows and hides the whole channel,
+ * and nothing repairs it: a since-fetch has no posts to widen it with, and a full page fetch lands
+ * on a lower interval that never becomes `postsInChannel[0]` (MM-66467). Since an interval with no
+ * posts carries no information -- re-fetching an empty range is harmless -- dropping it lets the
+ * next interval (or a fresh page fetch) render again.
+ *
+ * @param {string} serverUrl
+ * @param {string} channelId
+ * @returns {Promise<{models?: PostsInChannelModel[]; error?: unknown}>}
+ */
+export async function pruneEmptyPostsInChannelIntervals(serverUrl: string, channelId: string) {
+    try {
+        const {database, operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const intervals = await queryPostsInChannel(database, channelId).fetch();
+        if (!intervals.length) {
+            logDebug('pruneEmptyPostsInChannelIntervals no intervals for channel', channelId);
+            return {models: []};
+        }
+
+        const counts = await Promise.all(intervals.map(
+            (interval) => queryPostsChunk(database, channelId, interval.earliest, interval.latest).fetchCount(),
+        ));
+        const models = intervals.
+            filter((_, index) => counts[index] === 0).
+            map((interval) => interval.prepareDestroyPermanently());
+
+        if (models.length) {
+            logDebug('pruneEmptyPostsInChannelIntervals removing empty intervals', channelId, models.length);
+            await operator.batchRecords(models, 'pruneEmptyPostsInChannelIntervals');
+        }
+
+        return {models};
+    } catch (error) {
+        logError('Failed pruneEmptyPostsInChannelIntervals', error);
         return {error};
     }
 }

--- a/app/actions/remote/post.test.ts
+++ b/app/actions/remote/post.test.ts
@@ -3,11 +3,14 @@
 
 /* eslint-disable max-lines */
 
+import {storePostsForChannel} from '@actions/local/post';
 import {ActionType, Post, ServerErrors} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import PostModel from '@database/models/server/post';
 import NetworkManager from '@managers/network_manager';
+import {getMyChannel} from '@queries/servers/channel';
+import {getRecentPostsInChannel, queryPostsInChannel} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {getFullErrorMessage} from '@utils/errors';
 
@@ -831,6 +834,71 @@ describe('get posts', () => {
         expect(result.error).toBeUndefined();
         expect(result.posts).toBeTruthy();
         expect(result.posts?.length).toBe(0);
+    });
+
+    it('fetchPostsForChannel - recovers a channel whose newest interval has no posts left (MM-66467)', async () => {
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+
+        // History of the channel: interval [1000, 1000].
+        const oldPost = TestHelper.fakePost({channel_id: channelId, id: 'oldpostid', user_id: user1.id, create_at: 1000, update_at: 1000});
+        await storePostsForChannel(serverUrl, channelId, [oldPost], [oldPost.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+
+        // A much newer post arrives, creating a second, disjoint interval [9000, 9000].
+        const newPost = TestHelper.fakePost({channel_id: channelId, id: 'newpostid', user_id: user2.id, create_at: 9000, update_at: 9000});
+        await storePostsForChannel(serverUrl, channelId, [newPost], [newPost.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        expect((await queryPostsInChannel(database, channelId).fetch()).length).toBe(2);
+
+        // The newer post is deleted on the server, so it is dropped locally and its interval is left
+        // with no posts. That interval still has the greatest `latest`, so it is the one the channel
+        // post list renders: the channel goes blank even though the old post is still in the database.
+        await storePostsForChannel(
+            serverUrl, channelId,
+            [{...newPost, delete_at: 9500, update_at: 9500}], [newPost.id], '',
+            ActionType.POSTS.RECEIVED_IN_CHANNEL, [],
+        );
+        expect(await getRecentPostsInChannel(database, channelId)).toHaveLength(0);
+
+        // Nothing new on the server, so a since-fetch cannot repair anything.
+        mockClient.getPostsSince.mockImplementationOnce(jest.fn(() => ({posts: {}, order: []})));
+        const result = await fetchPostsForChannel(serverUrl, channelId);
+        expect(result.error).toBeUndefined();
+
+        // The post-less interval is gone and the channel renders its history again.
+        const intervals = await queryPostsInChannel(database, channelId).fetch();
+        expect(intervals.length).toBe(1);
+        expect(intervals[0].earliest).toBe(1000);
+        const recent = await getRecentPostsInChannel(database, channelId);
+        expect(recent.length).toBe(1);
+        expect(recent[0].id).toBe(oldPost.id);
+    });
+
+    it('fetchPostsForChannel - falls back to a page fetch when no interval has posts left', async () => {
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+
+        const onlyPost = TestHelper.fakePost({channel_id: channelId, id: 'onlypostid', user_id: user1.id, create_at: 1000, update_at: 1000});
+        await storePostsForChannel(serverUrl, channelId, [onlyPost], [onlyPost.id], '', ActionType.POSTS.RECEIVED_IN_CHANNEL, []);
+        await storePostsForChannel(
+            serverUrl, channelId,
+            [{...onlyPost, delete_at: 1500, update_at: 1500}], [onlyPost.id], '',
+            ActionType.POSTS.RECEIVED_IN_CHANNEL, [],
+        );
+
+        // lastFetchedAt is now 1500 while the channel has no posts at all: a since-fetch would ask
+        // for posts newer than 1500 and get nothing, leaving the channel blank forever.
+        expect((await getMyChannel(database, channelId))!.lastFetchedAt).toBe(1500);
+
+        mockClient.getPosts.mockClear();
+        mockClient.getPostsSince.mockClear();
+        const result = await fetchPostsForChannel(serverUrl, channelId);
+        expect(result.error).toBeUndefined();
+        expect(mockClient.getPostsSince).not.toHaveBeenCalled();
+        expect(mockClient.getPosts).toHaveBeenCalled();
+        expect(result.actionType).toBe(ActionType.POSTS.RECEIVED_IN_CHANNEL);
+        expect((await getRecentPostsInChannel(database, channelId)).length).toBe(2);
     });
 
     it('fetchPostsForChannel - request error', async () => {

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -5,7 +5,7 @@
 /* eslint-disable max-lines */
 
 import {markChannelAsUnread, updateLastPostAt} from '@actions/local/channel';
-import {addPostAcknowledgement, removePost, removePostAcknowledgement, storePostsForChannel} from '@actions/local/post';
+import {addPostAcknowledgement, pruneEmptyPostsInChannelIntervals, removePost, removePostAcknowledgement, storePostsForChannel} from '@actions/local/post';
 import {addRecentReaction} from '@actions/local/reactions';
 import {createThreadFromNewPost} from '@actions/local/thread';
 import {fetchChannelStats} from '@actions/remote/channel';
@@ -296,8 +296,19 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
         let postAction: Promise<PostsRequest>|undefined;
         let actionType: string|undefined;
         const myChannel = await getMyChannel(database, channelId);
-        const postsInChannel = await getRecentPostsInChannel(database, channelId);
-        const since = myChannel?.lastFetchedAt || postsInChannel?.[0]?.createAt || 0;
+        let postsInChannel = await getRecentPostsInChannel(database, channelId);
+        if (!postsInChannel.length) {
+            // The newest PostsInChannel interval renders no posts, so the channel looks blank. That
+            // happens when every post of that interval was deleted on the server, and neither a
+            // since-fetch nor a full page fetch can repair it while the empty interval stays the
+            // newest one (MM-66467). Drop the post-less intervals so a lower interval can render.
+            await pruneEmptyPostsInChannelIntervals(serverUrl, channelId);
+            postsInChannel = await getRecentPostsInChannel(database, channelId);
+        }
+
+        // Only trust lastFetchedAt while we still have posts to show: a since-fetch returns nothing
+        // when there is nothing newer, which would leave a channel with no local posts blank.
+        const since = postsInChannel.length ? (myChannel?.lastFetchedAt || postsInChannel[0].createAt) : 0;
         if (since) {
             postAction = fetchPostsSince(serverUrl, channelId, since, true, groupLabel);
             actionType = ActionType.POSTS.RECEIVED_SINCE;

--- a/app/database/operator/server_data_operator/handlers/post.test.ts
+++ b/app/database/operator/server_data_operator/handlers/post.test.ts
@@ -1237,3 +1237,120 @@ describe('*** Operator: deleted post must not create an empty PostsInChannel int
         expect(after[0].latest).toBe(1000);
     });
 });
+
+describe('*** Operator: SINCE/BEFORE/NEW handlers must not build intervals from deleted posts (MM-66467) ***', () => {
+    let database: Database;
+    let operator: ServerDataOperator;
+    const databaseName = 'baseHandler.test.com';
+    const channelId = 'mm66467sincechannel';
+
+    beforeEach(async () => {
+        await DatabaseManager.init([databaseName]);
+        const serverDatabase = DatabaseManager.serverDatabases[databaseName]!;
+        database = serverDatabase.database;
+        operator = serverDatabase.operator;
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(databaseName);
+    });
+
+    const makePost = (over: Partial<Post>): Post => ({
+        id: 'p',
+        channel_id: channelId,
+        create_at: 1000,
+        update_at: 1000,
+        edit_at: 0,
+        delete_at: 0,
+        is_pinned: false,
+        is_following: false,
+        user_id: 'user1',
+        root_id: '',
+        original_id: '',
+        message: 'message',
+        type: '',
+        props: {},
+        hashtags: '',
+        pending_post_id: '',
+        reply_count: 0,
+        last_reply_at: 0,
+        participants: null,
+        metadata: {},
+        ...over,
+    } as Post);
+
+    const intervalsForChannel = async () =>
+        (await database.get(MM_TABLES.SERVER.POSTS_IN_CHANNEL).
+            query(Q.where('channel_id', channelId), Q.sortBy('latest', Q.desc)).fetch()) as PostsInChannelModel[];
+
+    it('RECEIVED_SINCE should not create an interval when every post is deleted', async () => {
+        // getPostsSince returns deleted posts too. If the channel has no interval yet (e.g. its
+        // interval rows were removed while myChannel.lastFetchedAt survived), building one out of
+        // deleted posts creates a zero-row interval that permanently blanks the channel.
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_SINCE,
+            order: ['since-deleted-id'],
+            posts: [makePost({id: 'since-deleted-id', create_at: 8000, update_at: 9000, delete_at: 9000})],
+        });
+
+        expect(await intervalsForChannel()).toHaveLength(0);
+    });
+
+    it('RECEIVED_SINCE should build a new interval from live posts only', async () => {
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_SINCE,
+            order: ['since-deleted-id', 'since-live-id'],
+            posts: [
+                makePost({id: 'since-live-id', create_at: 2000, update_at: 2000}),
+                makePost({id: 'since-deleted-id', create_at: 9000, update_at: 9500, delete_at: 9500}),
+            ],
+        });
+
+        const intervals = await intervalsForChannel();
+        expect(intervals).toHaveLength(1);
+        expect(intervals[0].earliest).toBe(2000);
+        expect(intervals[0].latest).toBe(2000);
+    });
+
+    it('RECEIVED_SINCE should not extend the interval to a deleted post', async () => {
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: ['live-post-id'],
+            posts: [makePost({id: 'live-post-id', create_at: 1000, update_at: 1000})],
+        });
+
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_SINCE,
+            order: ['since-deleted-id', 'since-live-id'],
+            posts: [
+                makePost({id: 'since-live-id', create_at: 2500, update_at: 2500}),
+                makePost({id: 'since-deleted-id', create_at: 9000, update_at: 9500, delete_at: 9500}),
+            ],
+        });
+
+        const intervals = await intervalsForChannel();
+        expect(intervals).toHaveLength(1);
+        expect(intervals[0].earliest).toBe(1000);
+        expect(intervals[0].latest).toBe(2500);
+    });
+
+    it('RECEIVED_BEFORE should not create an interval when every post is deleted', async () => {
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_BEFORE,
+            order: ['before-deleted-id'],
+            posts: [makePost({id: 'before-deleted-id', create_at: 500, update_at: 900, delete_at: 900})],
+        });
+
+        expect(await intervalsForChannel()).toHaveLength(0);
+    });
+
+    it('RECEIVED_NEW should not create an interval when the post is deleted', async () => {
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_NEW,
+            order: ['new-deleted-id'],
+            posts: [makePost({id: 'new-deleted-id', create_at: 7000, update_at: 7500, delete_at: 7500})],
+        });
+
+        expect(await intervalsForChannel()).toHaveLength(0);
+    });
+});

--- a/app/database/operator/server_data_operator/handlers/post.ts
+++ b/app/database/operator/server_data_operator/handlers/post.ts
@@ -627,7 +627,17 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
             return [];
         }
 
-        const {firstPost, lastPost} = getPostListEdges(posts);
+        // getPostsSince returns deleted posts too, and those are dropped before persistence
+        // (see handlePosts), so they must not define the PostsInChannel interval: building or
+        // extending one from a deleted post can leave a zero-row interval on top that blanks
+        // the channel (MM-66467).
+        const validPosts = posts.filter((post) => post.delete_at === 0);
+        if (!validPosts.length) {
+            logDebug('handleReceivedPostsInChannelSince received only deleted posts; skipping interval update');
+            return [];
+        }
+
+        const {firstPost, lastPost} = getPostListEdges(validPosts);
         const channelId = firstPost.channel_id;
         const latest = lastPost.create_at;
 
@@ -668,7 +678,15 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
             return [];
         }
 
-        const {firstPost, lastPost} = getPostListEdges(posts);
+        // Deleted posts are dropped before persistence (see handlePosts), so they must not
+        // define the PostsInChannel interval (MM-66467).
+        const validPosts = posts.filter((post) => post.delete_at === 0);
+        if (!validPosts.length) {
+            logDebug('handleReceivedPostsInChannelBefore received only deleted posts; skipping interval update');
+            return [];
+        }
+
+        const {firstPost, lastPost} = getPostListEdges(validPosts);
         const channelId = firstPost.channel_id;
         const earliest = firstPost.create_at;
 
@@ -717,7 +735,15 @@ const PostHandler = <TBase extends Constructor<ServerDataOperatorBase>>(supercla
             return [];
         }
 
-        const {firstPost, lastPost} = getPostListEdges(posts);
+        // Deleted posts are dropped before persistence (see handlePosts), so they must not
+        // define the PostsInChannel interval (MM-66467).
+        const validPosts = posts.filter((post) => post.delete_at === 0);
+        if (!validPosts.length) {
+            logDebug('handleReceivedNewPostForChannel received only deleted posts; skipping interval update');
+            return [];
+        }
+
+        const {firstPost, lastPost} = getPostListEdges(validPosts);
         const channelId = firstPost.channel_id;
         const earliest = firstPost.create_at;
         const latest = lastPost.create_at;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Multiple staff members have reported channels/DMs/GMs that render completely empty ("beginning of channel" intro) even though the message history exists on the server — and often still exists in the local database.

**Root cause.** The channel post list renders exactly one `PostsInChannel` interval: `postsInChannel[0]`, the row with the greatest `latest`. If that interval contains zero posts, the channel renders zero rows, and nothing recovers it:

- `fetchPostsForChannel` takes the since-branch (`myChannel.lastFetchedAt` is advanced by deletions too, since `getLastFetchedAtFromPosts` uses `max(create_at, update_at, delete_at)`), and `getPostsSince` returns nothing when there is nothing newer, so no post is ever stored again.
- The `channel_post_list` fallback page-0 fetch does store posts, but the surviving history is older than the empty interval, so it lands in a *second, lower* interval that never becomes `postsInChannel[0]`.
- The merge pass only fuses overlapping intervals, so the empty one is never absorbed.

An interval becomes post-less when every post it was built from is deleted on the server (a later fetch returns them with `delete_at` set and `handlePosts` destroys the rows while leaving the interval untouched). This is easy to hit on low-traffic DMs/GMs, where the newest interval is often a single websocket post: post + delete = permanently blank channel, with "Reset cached messages" as the only way out.

**Changes** (each symptom is reproduced by a regression test first):

1. **Self-heal** (cherry-picked from `worktree-blank-gm-empty-interval`): `fetchPostsForChannel` prunes post-less intervals via the new `pruneEmptyPostsInChannelIntervals` local action when the channel has no visible posts, and stops trusting `lastFetchedAt` in that state so the fallback is a full page fetch instead of a no-op since-fetch. This repairs already-poisoned databases on the next channel open.
2. **Prevention**: `handleReceivedPostsInChannelSince`, `handleReceivedPostsInChannelBefore` and `handleReceivedNewPostForChannel` now compute interval edges from live (`delete_at === 0`) posts only and skip the interval update when no post in the batch survives persistence — the same filter the earlier MM-66467 fix added to `handleReceivedPostsInChannel` only. Without this, a since-fetch returning only deleted posts still creates a zero-row interval whenever the channel has no interval row yet.

**Verification.** New tests failed against the unfixed code exactly as the symptom predicts (zero-row `[8000,8000]`/`[500,500]`/`[7000,7000]` intervals created from deleted posts; recovery tests left the channel blank) and pass with the fixes. Affected suites (`app/database/operator/**`, `app/actions/local/post.test.ts`, `app/actions/remote/post.test.ts`) pass; the 4 failures in `app/actions/websocket/posts.test.ts` are pre-existing on `main` and unrelated.

#### Ticket Link

MM-66467

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information

Not device-tested (logic + unit-test change only; no UI changes).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b463c44-d2c5-4ef8-ad61-c915799ca6d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b463c44-d2c5-4ef8-ad61-c915799ca6d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

