### PR TITLE
Fix three causes of channels rendering blank

### DIFF
--- a/app/actions/local/channel.test.ts
+++ b/app/actions/local/channel.test.ts
@@ -26,6 +26,7 @@ import {
     updateMyChannelFromWebsocket,
     updateChannelInfoFromChannel,
     updateLastPostAt,
+    updateMyChannelLastFetchedAt,
     updateChannelsDisplayName,
     showUnreadChannelsOnly,
     updateDmGmDisplayName,
@@ -1204,11 +1205,14 @@ describe('deletePostsForChannel', () => {
         expect(error).toBeFalsy();
     });
 
-    it('channel with no posts still clears intervals and resets the watermark', async () => {
+    it('should clear intervals and reset the watermark for a channel with no posts', async () => {
         // A PostsInChannel interval that outlived its posts is exactly the state that
         // renders a channel blank, so this must not early-return.
         await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
         await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
+        await updateMyChannelLastFetchedAt(serverUrl, channelId, 900, false);
+        expect((await getMyChannel(operator.database, channelId))?.lastFetchedAt).toBe(900);
+
         const gone = TestHelper.fakePost({id: 'gone', channel_id: channelId, create_at: 500});
         await operator.handlePosts({actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL, order: [gone.id], posts: [gone], prepareRecordsOnly: false});
 

--- a/app/actions/local/channel.test.ts
+++ b/app/actions/local/channel.test.ts
@@ -9,7 +9,7 @@ import {ActionType, Events, Navigation} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import {getMyChannel} from '@queries/servers/channel';
-import {getPostById} from '@queries/servers/post';
+import {getPostById, queryPostsInChannel} from '@queries/servers/post';
 import {getCommonSystemValues, getTeamHistory} from '@queries/servers/system';
 import {getTeamChannelHistory} from '@queries/servers/team';
 import {navigateToRoot, dismissAllRoutesAndPopToScreen} from '@screens/navigation';
@@ -1204,13 +1204,24 @@ describe('deletePostsForChannel', () => {
         expect(error).toBeFalsy();
     });
 
-    it('channel with no posts', async () => {
+    it('channel with no posts still clears intervals and resets the watermark', async () => {
+        // A PostsInChannel interval that outlived its posts is exactly the state that
+        // renders a channel blank, so this must not early-return.
         await operator.handleChannel({channels: [channel], prepareRecordsOnly: false});
         await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
+        const gone = TestHelper.fakePost({id: 'gone', channel_id: channelId, create_at: 500});
+        await operator.handlePosts({actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL, order: [gone.id], posts: [gone], prepareRecordsOnly: false});
 
-        const {models, error} = await deletePostsForChannel(serverUrl, channelId);
-        expect(models).toEqual([]);
+        // the post is destroyed the way a received deletion destroys it, leaving the interval
+        await operator.handlePosts({actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL, order: [gone.id], posts: [{...gone, delete_at: 900, update_at: 900}], prepareRecordsOnly: false});
+        expect(await queryPostsInChannel(operator.database, channelId).fetch()).toHaveLength(1);
+        expect(await getPostById(operator.database, gone.id)).toBeUndefined();
+
+        const {error} = await deletePostsForChannel(serverUrl, channelId);
         expect(error).toBeFalsy();
+
+        expect(await queryPostsInChannel(operator.database, channelId).fetch()).toHaveLength(0);
+        expect((await getMyChannel(operator.database, channelId))?.lastFetchedAt).toBe(0);
     });
 
     it('channel with posts - batch written and event emitted', async () => {

--- a/app/actions/local/channel.ts
+++ b/app/actions/local/channel.ts
@@ -507,21 +507,18 @@ export async function deletePostsForChannel(serverUrl: string, channelId: string
             return {models: []};
         }
 
+        // Note: intervals are cleared even when there are no posts left. A PostsInChannel
+        // row that no longer contains any post still wins postsInChannel[0] and hides the
+        // channel, so returning early here would leave the channel blank.
         const posts = await channel.posts.fetch();
-        if (!posts.length) {
-            return {models: []};
-        }
 
         const preparedPostsPromises = posts.map((post) => prepareDeletePost(post));
         const preparedPostsArrays = await Promise.all(preparedPostsPromises);
         const preparedModels: Model[] = preparedPostsArrays.flat();
 
-        const postsInChannel = await queryPostsInChannel(database, channelId);
-        if (postsInChannel.length) {
-            for (const postRange of postsInChannel) {
-                const preparedPostRanges = postRange.prepareDestroyPermanently();
-                preparedModels.push(preparedPostRanges);
-            }
+        const postsInChannel = await queryPostsInChannel(database, channelId).fetch();
+        for (const postRange of postsInChannel) {
+            preparedModels.push(postRange.prepareDestroyPermanently());
         }
 
         const threadPromises = posts.filter((post) => post.rootId === '').map((post) => {

--- a/app/actions/local/post.test.ts
+++ b/app/actions/local/post.test.ts
@@ -4,7 +4,8 @@
 import {ActionType, Post} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
-import {getPostById} from '@queries/servers/post';
+import {getMyChannel} from '@queries/servers/channel';
+import {getPostById, queryPostsInChannel} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {COMBINED_USER_ACTIVITY} from '@utils/post_list';
 
@@ -222,6 +223,33 @@ describe('storePostsForChannel', () => {
         expect(error).toBeUndefined();
         expect(models).toBeDefined();
         expect(models?.length).toBe(4); // Post, PostsInChannel, User, MyChannel
+    });
+
+    it('should not advance lastFetchedAt for a thread payload', async () => {
+        await operator.handleMyChannel({channels: [channel], myChannels: [channelMember], prepareRecordsOnly: false});
+
+        const seed = [100, 105, 110].map((t) => TestHelper.fakePost({
+            id: `seed-${t}`, channel_id: channelId, user_id: user.id, create_at: t, update_at: t,
+        }));
+        await storePostsForChannel(serverUrl, channelId, seed, seed.map((p) => p.id), '', ActionType.POSTS.RECEIVED_IN_CHANNEL, [user]);
+
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        expect((await getMyChannel(database, channelId))?.lastFetchedAt).toBe(110);
+        const intervalsBefore = await queryPostsInChannel(database, channelId).fetch();
+        expect(intervalsBefore.length).toBe(1);
+
+        // A thread reply far newer than the channel tail, as delivered by a push notification.
+        const root = TestHelper.fakePost({id: 'root', channel_id: channelId, user_id: user.id, create_at: 90, update_at: 90});
+        const reply = TestHelper.fakePost({id: 'reply', channel_id: channelId, user_id: user.id, create_at: 200, update_at: 200, root_id: 'root'});
+        await storePostsForChannel(serverUrl, channelId, [root, reply], [reply.id, root.id], '', ActionType.POSTS.RECEIVED_IN_THREAD, [user]);
+
+        // The watermark must stay put: posts created between 110 and 200 were never fetched,
+        // and getPostsSince would skip them forever if it moved.
+        expect((await getMyChannel(database, channelId))?.lastFetchedAt).toBe(110);
+
+        const intervalsAfter = await queryPostsInChannel(database, channelId).fetch();
+        expect(intervalsAfter.length).toBe(1);
+        expect(intervalsAfter[0].latest).toBe(110);
     });
 });
 

--- a/app/actions/local/post.ts
+++ b/app/actions/local/post.ts
@@ -244,9 +244,11 @@ export async function prepareModelsForChannelPosts(
         models.push(...userModels);
     }
 
+    // A thread payload doesn't cover the channel timeline, so it must not advance the
+    // channel watermark; handlePosts skips PostsInChannel for the same reason.
     const lastFetchedAt = getLastFetchedAtFromPosts(posts);
     let myChannelModel: MyChannelModel | undefined;
-    if (lastFetchedAt) {
+    if (lastFetchedAt && actionType !== ActionType.POSTS.RECEIVED_IN_THREAD) {
         const {member} = await updateMyChannelLastFetchedAt(serverUrl, channelId, lastFetchedAt, true);
         myChannelModel = member;
     }

--- a/app/actions/remote/post.test.ts
+++ b/app/actions/remote/post.test.ts
@@ -8,8 +8,11 @@ import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import PostModel from '@database/models/server/post';
 import NetworkManager from '@managers/network_manager';
+import {getPostById, getRecentPostsInChannel, queryPostsInChannel} from '@queries/servers/post';
 import TestHelper from '@test/test_helper';
 import {getFullErrorMessage} from '@utils/errors';
+
+import * as LocalChannelActions from '../local/channel';
 
 import {
     createPost,
@@ -22,6 +25,7 @@ import {
     unacknowledgePost,
     revealBoRPost,
     fetchPostsForChannel,
+    refreshPostsForChannel,
     fetchPostsForUnreadChannels,
     fetchPosts,
     fetchPostsBefore,
@@ -842,6 +846,95 @@ describe('get posts', () => {
         const result = await fetchPostsForChannel(serverUrl, channelId);
         expect(result).toBeDefined();
         expect(result.error).toBeDefined();
+    });
+
+    it('fetchPostsForChannel - recovers a channel whose newest interval lost all its posts', async () => {
+        // The only cached post is deleted server-side while the app is closed. On the next
+        // open the since-fetch returns the tombstone, handlePosts destroys the post, and the
+        // interval is left covering nothing - which would render the channel blank forever.
+        const only = TestHelper.fakePost({channel_id: channelId, id: 'only', user_id: user1.id, create_at: 5000, update_at: 5000});
+        mockClient.getPostsSince.mockImplementationOnce(jest.fn(() => ({posts: {only: {...only, delete_at: 6000, update_at: 6000}}, order: [only.id]})));
+
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleChannel({channels: [channel1], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_NEW,
+            order: [only.id],
+            posts: [only],
+            prepareRecordsOnly: false,
+        });
+
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        mockClient.getPosts.mockClear();
+
+        await fetchPostsForChannel(serverUrl, channelId);
+
+        // the empty interval is gone and a page fetch repopulated the channel
+        expect(mockClient.getPosts).toHaveBeenCalled();
+        const intervals = await queryPostsInChannel(database, channelId).fetch();
+        expect(intervals).toHaveLength(1);
+        expect(intervals[0].latest).not.toBe(5000);
+        expect(await getRecentPostsInChannel(database, channelId)).not.toHaveLength(0);
+    });
+
+    it('refreshPostsForChannel - not blank, does a plain fetch and keeps cached posts', async () => {
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [post1.id],
+            posts: [post1],
+            prepareRecordsOnly: false,
+        });
+
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        const before = await getPostById(database, post1.id);
+        expect(before).toBeDefined();
+
+        const result = await refreshPostsForChannel(serverUrl, channelId, false);
+        expect(result.error).toBeUndefined();
+
+        // the cached post was not wiped
+        expect(await getPostById(database, post1.id)).toBeDefined();
+    });
+
+    it('refreshPostsForChannel - blank with hidden posts, clears cache and re-fetches', async () => {
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleChannel({channels: [channel1], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [post1.id],
+            posts: [post1],
+            prepareRecordsOnly: false,
+        });
+
+        const database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        mockClient.getPosts.mockClear();
+        mockClient.getPostsSince.mockClear();
+
+        const result = await refreshPostsForChannel(serverUrl, channelId, true);
+        expect(result.error).toBeUndefined();
+
+        // the stale interval was cleared, so a full page fetch runs instead of a
+        // since-fetch that would return nothing and leave the channel blank.
+        expect(await queryPostsInChannel(database, channelId).fetch()).toHaveLength(1);
+        expect(mockClient.getPosts).toHaveBeenCalled();
+        expect(mockClient.getPostsSince).not.toHaveBeenCalled();
+    });
+
+    it('refreshPostsForChannel - genuinely empty channel is not reset', async () => {
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+
+        const spyOnDelete = jest.spyOn(LocalChannelActions, 'deletePostsForChannel');
+
+        const result = await refreshPostsForChannel(serverUrl, channelId, true);
+        expect(result.error).toBeUndefined();
+        expect(spyOnDelete).not.toHaveBeenCalled();
+
+        spyOnDelete.mockRestore();
     });
 
     it('fetchPostsForUnreadChannels - base case', async () => {

--- a/app/actions/remote/post.test.ts
+++ b/app/actions/remote/post.test.ts
@@ -848,7 +848,7 @@ describe('get posts', () => {
         expect(result.error).toBeDefined();
     });
 
-    it('fetchPostsForChannel - recovers a channel whose newest interval lost all its posts', async () => {
+    it('fetchPostsForChannel - should recover a channel whose newest interval lost all its posts', async () => {
         // The only cached post is deleted server-side while the app is closed. On the next
         // open the since-fetch returns the tombstone, handlePosts destroys the post, and the
         // interval is left covering nothing - which would render the channel blank forever.
@@ -878,7 +878,7 @@ describe('get posts', () => {
         expect(await getRecentPostsInChannel(database, channelId)).not.toHaveLength(0);
     });
 
-    it('refreshPostsForChannel - not blank, does a plain fetch and keeps cached posts', async () => {
+    it('refreshPostsForChannel - should do a plain fetch and keep cached posts when not blank', async () => {
         await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
         await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
         await operator.handlePosts({
@@ -899,7 +899,7 @@ describe('get posts', () => {
         expect(await getPostById(database, post1.id)).toBeDefined();
     });
 
-    it('refreshPostsForChannel - blank with hidden posts, clears cache and re-fetches', async () => {
+    it('refreshPostsForChannel - should clear the cache and re-fetch when blank with hidden posts', async () => {
         await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
         await operator.handleChannel({channels: [channel1], prepareRecordsOnly: false});
         await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
@@ -924,7 +924,32 @@ describe('get posts', () => {
         expect(mockClient.getPostsSince).not.toHaveBeenCalled();
     });
 
-    it('refreshPostsForChannel - genuinely empty channel is not reset', async () => {
+    it('refreshPostsForChannel - should return the error and not fetch when clearing the cache fails', async () => {
+        await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
+        await operator.handleChannel({channels: [channel1], prepareRecordsOnly: false});
+        await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [post1.id],
+            posts: [post1],
+            prepareRecordsOnly: false,
+        });
+
+        const spyOnDelete = jest.spyOn(LocalChannelActions, 'deletePostsForChannel').
+            mockResolvedValueOnce({models: [], error: 'delete failed'});
+        mockClient.getPosts.mockClear();
+        mockClient.getPostsSince.mockClear();
+
+        const result = await refreshPostsForChannel(serverUrl, channelId, true);
+
+        expect(result.error).toBe('delete failed');
+        expect(mockClient.getPosts).not.toHaveBeenCalled();
+        expect(mockClient.getPostsSince).not.toHaveBeenCalled();
+
+        spyOnDelete.mockRestore();
+    });
+
+    it('refreshPostsForChannel - should not reset a genuinely empty channel', async () => {
         await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: user1.id}], prepareRecordsOnly: false});
         await operator.handleMyChannel({channels: [channel1], myChannels: [channelMember1], prepareRecordsOnly: false});
 

--- a/app/actions/remote/post.ts
+++ b/app/actions/remote/post.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable max-lines */
 
-import {markChannelAsUnread, updateLastPostAt} from '@actions/local/channel';
+import {deletePostsForChannel, markChannelAsUnread, updateLastPostAt} from '@actions/local/channel';
 import {addPostAcknowledgement, removePost, removePostAcknowledgement, storePostsForChannel} from '@actions/local/post';
 import {addRecentReaction} from '@actions/local/reactions';
 import {createThreadFromNewPost} from '@actions/local/thread';
@@ -17,7 +17,7 @@ import NetworkManager from '@managers/network_manager';
 import {getMyChannel, prepareMissingChannelsForAllTeams, queryAllMyChannel} from '@queries/servers/channel';
 import {queryAllCustomEmojis} from '@queries/servers/custom_emoji';
 import {getFilesByIds, queryFilesForPost} from '@queries/servers/file';
-import {getPostById, getRecentPostsInChannel} from '@queries/servers/post';
+import {getPostById, getRecentPostsInChannel, queryPostsInChannel} from '@queries/servers/post';
 import {getCurrentUserId} from '@queries/servers/system';
 import {getIsCRTEnabled, prepareThreadsFromReceivedPosts} from '@queries/servers/thread';
 import {queryAllUsers} from '@queries/servers/user';
@@ -27,7 +27,7 @@ import {isBoRPost} from '@utils/bor';
 import {getValidEmojis, matchEmoticons} from '@utils/emoji/helpers';
 import {getFullErrorMessage, isServerError} from '@utils/errors';
 import {hasArrayChanged} from '@utils/helpers';
-import {logDebug, logError} from '@utils/log';
+import {logDebug, logError, logWarning} from '@utils/log';
 import {processPostsFetched} from '@utils/post';
 import {getPostIdsForCombinedUserActivityPost} from '@utils/post_list';
 
@@ -326,6 +326,25 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
             }
         }
 
+        // A since-fetch is the only path that receives deletions, and handlePosts destroys
+        // those posts locally. If the newest interval no longer covers any post it still
+        // wins postsInChannel[0] and renders a blank channel, and no since-fetch can
+        // repopulate it: once lastFetchedAt is past the deletion the server correctly
+        // returns nothing. Drop that interval and pull a page instead.
+        if (!fetchOnly && actionType === ActionType.POSTS.RECEIVED_SINCE) {
+            const remaining = await getRecentPostsInChannel(database, channelId);
+            if (!remaining.length) {
+                const intervals = await queryPostsInChannel(database, channelId).fetch();
+                if (intervals.length) {
+                    logWarning('fetchPostsForChannel: newest interval has no posts left, refetching', channelId);
+                    await database.write(() => intervals[0].destroyPermanently());
+
+                    const page = await fetchPosts(serverUrl, channelId, 0, General.POST_CHUNK_SIZE, false, groupLabel);
+                    return {...page, actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL, channelId};
+                }
+            }
+        }
+
         return {posts: data.posts, order: data.order, authors, actionType, previousPostId: data.previousPostId, channelId};
     } catch (error) {
         logDebug('error on fetchPostsForChannel', getFullErrorMessage(error));
@@ -334,6 +353,36 @@ export async function fetchPostsForChannel(serverUrl: string, channelId: string,
         if (!fetchOnly) {
             EphemeralStore.stopLoadingMessagesForChannel(serverUrl, channelId);
         }
+    }
+}
+
+/**
+ * Pull-to-refresh for a channel. Normally a plain page fetch, but when the list is
+ * rendering nothing while posts are still stored, those posts are hidden rather than
+ * absent (e.g. a PostsInChannel interval that no longer contains any renderable post,
+ * which stays postsInChannel[0] and shadows the rest). A page fetch cannot recover that,
+ * so clear the channel's cached posts and intervals and re-fetch from scratch.
+ * @param isBlank whether the list is currently rendering zero rows
+ */
+export async function refreshPostsForChannel(serverUrl: string, channelId: string, isBlank = false) {
+    try {
+        const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+
+        if (isBlank) {
+            const intervals = await queryPostsInChannel(database, channelId).fetch();
+            if (intervals.length) {
+                logWarning('refreshPostsForChannel resetting hidden channel', channelId, intervals.length);
+                const {error: deleteError} = await deletePostsForChannel(serverUrl, channelId);
+                if (deleteError) {
+                    return {error: deleteError};
+                }
+            }
+        }
+
+        return await fetchPostsForChannel(serverUrl, channelId);
+    } catch (error) {
+        logDebug('error on refreshPostsForChannel', getFullErrorMessage(error));
+        return {error};
     }
 }
 

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -139,7 +139,7 @@ describe('components/post_list/PostList', () => {
         const flatList = getByTestId('post_list.flat_list');
 
         await act(async () => {
-            flatList.props.onRefresh();
+            await flatList.props.onRefresh();
         });
 
         expect(refreshPostsSpy).toHaveBeenCalledWith('https://server.com', 'channel-id', true);

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -21,6 +21,7 @@ jest.mock('@actions/remote/post', () => {
     return {
         fetchPosts: jest.fn(),
         fetchPostThread: jest.fn(),
+        refreshPostsForChannel: jest.fn(),
     };
 });
 jest.mock('@actions/local/post', () => ({
@@ -33,7 +34,7 @@ import type Database from '@nozbe/watermelondb/Database';
 describe('components/post_list/PostList', () => {
     let database: Database;
     const serverUrl = 'https://server.com';
-    const fetchPostsSpy = jest.spyOn(postFunctions, 'fetchPosts');
+    const refreshPostsSpy = jest.spyOn(postFunctions, 'refreshPostsForChannel');
     const fetchPostThreadSpy = jest.spyOn(postFunctions, 'fetchPostThread');
     const removePostSpy = jest.spyOn(localPostFunctions, 'removePost');
     const unrelatedNativeEventsAttributes = {
@@ -128,7 +129,20 @@ describe('components/post_list/PostList', () => {
             flatList.props.onRefresh();
         });
 
-        expect(fetchPostsSpy).toHaveBeenCalledWith('https://server.com', 'channel-id');
+        // isBlank is false: the list has posts, so refresh must not reset the cache
+        expect(refreshPostsSpy).toHaveBeenCalledWith('https://server.com', 'channel-id', false);
+    });
+
+    it('passes isBlank when the list renders nothing', async () => {
+        const props = {...baseProps, posts: []};
+        const {getByTestId} = renderWithEverything(<PostList {...props}/>, {database, serverUrl});
+        const flatList = getByTestId('post_list.flat_list');
+
+        await act(async () => {
+            flatList.props.onRefresh();
+        });
+
+        expect(refreshPostsSpy).toHaveBeenCalledWith('https://server.com', 'channel-id', true);
     });
 
     it('handles refresh in thread', async () => {
@@ -421,6 +435,6 @@ describe('components/post_list/PostList', () => {
             flatList.props.onRefresh();
         });
 
-        expect(fetchPostsSpy).not.toHaveBeenCalled();
+        expect(refreshPostsSpy).not.toHaveBeenCalled();
     });
 });

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -133,7 +133,7 @@ describe('components/post_list/PostList', () => {
         expect(refreshPostsSpy).toHaveBeenCalledWith('https://server.com', 'channel-id', false);
     });
 
-    it('passes isBlank when the list renders nothing', async () => {
+    it('should pass isBlank when the list renders nothing', async () => {
         const props = {...baseProps, posts: []};
         const {getByTestId} = renderWithEverything(<PostList {...props}/>, {database, serverUrl});
         const flatList = getByTestId('post_list.flat_list');

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -10,7 +10,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {scheduleOnRN, scheduleOnUI} from 'react-native-worklets';
 
 import {removePost} from '@actions/local/post';
-import {fetchPosts, fetchPostThread} from '@actions/remote/post';
+import {fetchPostThread, refreshPostsForChannel} from '@actions/remote/post';
 import CombinedUserActivity from '@components/post_list/combined_user_activity';
 import DateSeparator from '@components/post_list/date_separator';
 import NewMessagesLine from '@components/post_list/new_message_line';
@@ -273,7 +273,7 @@ const PostList = ({
         }
         setRefreshing(true);
         if (location === Screens.CHANNEL && channelId) {
-            await fetchPosts(serverUrl, channelId);
+            await refreshPostsForChannel(serverUrl, channelId, orderedPosts.length === 0);
         } else if (location === Screens.THREAD && rootId) {
             const options: FetchPaginatedThreadOptions = {};
             const lastPost = posts[0];
@@ -289,7 +289,7 @@ const PostList = ({
             map((post) => removePost(serverUrl, post));
         await Promise.all(removalPromises);
         setRefreshing(false);
-    }, [disablePullToRefresh, location, channelId, rootId, posts, serverUrl]);
+    }, [disablePullToRefresh, location, channelId, rootId, posts, serverUrl, orderedPosts.length]);
 
     const scrollToIndex = useCallback((index: number, animated = true, applyOffset = true) => {
         if (index < 0 || !listRef?.current) {


### PR DESCRIPTION
#### Summary

Recover a channel whose newest interval lost all its posts. A since-fetch is the only path that receives deletions, and handlePosts destroys those posts locally — but nothing shrinks the PostsInChannel interval they came from. An empty interval still wins postsInChannel[0] and renders blank, and no later since-fetch can repopulate it: once lastFetchedAt is past the deletion the server correctly returns nothing. fetchPostsForChannel now detects that state, drops the interval and pulls a page instead, which merges into a surviving interval or records a real gap that closes on scroll. Scoped to fetchOnly=false; the fetchOnly callers can leave the same state behind but are repaired when the user opens the channel.

Thread payloads no longer advance MyChannel.lastFetchedAt. A CRT thread-reply push carries only that thread's posts, so it is not evidence the channel was fetched up to the reply's timestamp — advancing the watermark let getPostsSince skip channel posts that were never fetched. handlePosts already skips PostsInChannel for RECEIVED_IN_THREAD, and the native handlers already guard this via receivingThreads.

Pull-to-refresh self-heals as a manual escape hatch for blank states the automatic recovery cannot see — an interval holding only posts that get filtered out (replies with CRT on, join/leave messages). Blankness is measured from orderedPosts rather than posts so it accounts for those filters.

Also fixes deletePostsForChannel, which returned early when a channel had no posts left — precisely the post-less-interval case — and never destroyed intervals because it called .length on a Query instead of fetching it.

#### Ticket Link
TBD

Fixes: https://github.com/mattermost/mattermost-mobile/issues/9103

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)

#### Release Note
```release-note
Fixed potential causes of rendering a channel empty
```
