### PR TITLE
Add Sentry performance instrumentation for real-device tracing

### DIFF
--- a/app/actions/websocket/event.ts
+++ b/app/actions/websocket/event.ts
@@ -14,6 +14,7 @@ import {handleAgentsEvents} from '@agents/actions/websocket/events';
 import * as calls from '@calls/connection/websocket_event_handlers';
 import {WebsocketEvents} from '@constants';
 import {handlePlaybookEvents} from '@playbooks/actions/websocket/events';
+import {shouldTraceWebsocketEvent, withSpanSync} from '@utils/sentry_tracing';
 
 import * as category from './category';
 import * as channel from './channel';
@@ -33,6 +34,21 @@ import {handleThreadUpdatedEvent, handleThreadReadChangedEvent, handleThreadFoll
 import {handleUserUpdatedEvent, handleUserTypingEvent, handleStatusChangedEvent, handleCustomProfileAttributesValuesUpdatedEvent, handleCustomProfileAttributesFieldUpdatedEvent, handleCustomProfileAttributesFieldDeletedEvent} from './users';
 
 export async function handleWebSocketEvent(serverUrl: string, msg: WebSocketMessage) {
+    if (!shouldTraceWebsocketEvent(msg.event)) {
+        dispatchWebSocketEvent(serverUrl, msg);
+        return;
+    }
+
+    withSpanSync(`ws.${msg.event}`, 'ws.handle', () => {
+        dispatchWebSocketEvent(serverUrl, msg);
+    }, {
+        attributes: {
+            'mm.ws.event': msg.event,
+        },
+    });
+}
+
+function dispatchWebSocketEvent(serverUrl: string, msg: WebSocketMessage) {
     switch (msg.event) {
         case WebsocketEvents.POSTED:
         case WebsocketEvents.EPHEMERAL_MESSAGE:

--- a/app/client/rest/tracking.ts
+++ b/app/client/rest/tracking.ts
@@ -13,7 +13,9 @@ import {NetworkRequestMetrics} from '@managers/performance_metrics_manager/const
 import {isErrorWithStatusCode} from '@utils/errors';
 import {getFormattedFileSize} from '@utils/file';
 import {logDebug, logInfo} from '@utils/log';
+import {withSpan} from '@utils/sentry_tracing';
 import {semverFromServerVersion} from '@utils/server';
+import {cleanUrlForLogging} from '@utils/url';
 
 import * as ClientConstants from './constants';
 import ClientError from './error';
@@ -385,10 +387,23 @@ export default class ClientTracking {
         }
 
         const performanceRequestId = NetworkPerformanceManager.startRequestTracking(this.apiClient.baseUrl, url);
+        const sanitizedPath = cleanUrlForLogging(this.apiClient.baseUrl, url);
+        const methodLabel = (method || 'get').toUpperCase();
 
         let response: ClientResponse;
         try {
-            response = await request!(url, this.buildRequestOptions(options));
+            response = await withSpan(
+                `${methodLabel} ${sanitizedPath}`,
+                'http.client',
+                () => request!(url, this.buildRequestOptions(options)),
+                {
+                    attributes: {
+                        'http.request.method': methodLabel,
+                        'http.route': sanitizedPath,
+                        ...(groupLabel ? {'mm.network_group': groupLabel} : {}),
+                    },
+                },
+            );
         } catch (error) {
             NetworkPerformanceManager.cancelRequestTracking(this.apiClient.baseUrl, performanceRequestId);
             const response_error = error as ClientError;

--- a/app/database/operator/base_data_operator/index.ts
+++ b/app/database/operator/base_data_operator/index.ts
@@ -13,6 +13,7 @@ import {
 } from '@database/operator/utils/general';
 import {isDatabaseCorruptionError} from '@utils/database_errors';
 import {logWarning} from '@utils/log';
+import {withSpan} from '@utils/sentry_tracing';
 
 import type {
     HandleRecordsArgs,
@@ -191,9 +192,21 @@ export default class BaseDataOperator {
     async batchRecords(models: Model[], description: string): Promise<void> {
         try {
             if (models.length > 0) {
-                await this.database.write(async (writer) => {
-                    await writer.batch(...models);
-                }, description);
+                await withSpan(
+                    `db.batch.${description}`,
+                    'db',
+                    async () => {
+                        await this.database.write(async (writer) => {
+                            await writer.batch(...models);
+                        }, description);
+                    },
+                    {
+                        attributes: {
+                            'mm.db.description': description,
+                            'mm.db.record_count': models.length,
+                        },
+                    },
+                );
             }
         } catch (e) {
             logWarning('batchRecords error ', description, e as Error);

--- a/app/init/app.ts
+++ b/app/init/app.ts
@@ -15,6 +15,7 @@ import SessionManager from '@managers/session_manager';
 import WebsocketManager from '@managers/websocket_manager';
 import EphemeralStore from '@store/ephemeral_store';
 import {NavigationStore} from '@store/navigation_store';
+import {withSpan} from '@utils/sentry_tracing';
 
 // Controls whether the main initialization (database, etc...) is done, either on app launch
 // or on the Share Extension, for example.
@@ -36,33 +37,37 @@ Promise.allSettled = Promise.allSettled || (<T>(promises: Array<Promise<T>>) => 
 ));
 
 export async function initialize() {
-    if (!baseAppInitialized) {
-        baseAppInitialized = true;
-        serverCredentials = await getAllServerCredentials();
-        const serverUrls = serverCredentials.map((credential) => credential.serverUrl);
+    await withSpan('app.initialize', 'app.init', async () => {
+        if (!baseAppInitialized) {
+            baseAppInitialized = true;
+            serverCredentials = await getAllServerCredentials();
+            const serverUrls = serverCredentials.map((credential) => credential.serverUrl);
 
-        await DatabaseManager.init(serverUrls);
-        await NetworkManager.init(serverCredentials);
+            await withSpan('app.initialize.database', 'app.init', () => DatabaseManager.init(serverUrls), {
+                attributes: {'mm.server_count': serverUrls.length},
+            });
+            await withSpan('app.initialize.network', 'app.init', () => NetworkManager.init(serverCredentials));
 
-        // EphemeralModeManager init runs before WS init so any pending wipes
-        // complete before WebSocket clients start populating server databases.
-        await EphemeralModeManager.init(serverCredentials);
-        await WebsocketManager.init(serverCredentials);
-    }
+            // EphemeralModeManager init runs before WS init so any pending wipes
+            // complete before WebSocket clients start populating server databases.
+            await withSpan('app.initialize.ephemeral_mode', 'app.init', () => EphemeralModeManager.init(serverCredentials));
+            await withSpan('app.initialize.websocket', 'app.init', () => WebsocketManager.init(serverCredentials));
+        }
 
-    NavigationStore.reset();
-    EphemeralStore.setCurrentThreadId('');
-    EphemeralStore.setProcessingNotification('');
+        NavigationStore.reset();
+        EphemeralStore.setCurrentThreadId('');
+        EphemeralStore.setProcessingNotification('');
 
-    await SecurityManager.init();
+        await withSpan('app.initialize.security', 'app.init', () => SecurityManager.init());
 
-    GlobalEventHandler.init();
-    ManagedApp.init();
-    SessionManager.init();
-    CallsManager.initialize();
-    CallsNative.init();
+        GlobalEventHandler.init();
+        ManagedApp.init();
+        SessionManager.init();
+        CallsManager.initialize();
+        CallsNative.init();
 
-    PushNotifications.init(serverCredentials.length > 0);
+        PushNotifications.init(serverCredentials.length > 0);
+    }, {onlyIfParent: false});
 }
 
 export function cleanup() {

--- a/app/managers/performance_metrics_manager/index.ts
+++ b/app/managers/performance_metrics_manager/index.ts
@@ -6,6 +6,7 @@ import {AppState, type AppStateStatus} from 'react-native';
 import performance from 'react-native-performance';
 
 import {logDebug, logInfo, logWarning} from '@utils/log';
+import {endManualTransaction, startManualTransaction} from '@utils/sentry_tracing';
 
 import Batcher from './performance_metrics_batcher';
 
@@ -24,6 +25,7 @@ type MetricName = 'mobile_channel_switch' |
 
 const RETRY_TIME = 100;
 const MAX_RETRIES = 3;
+const LOAD_TRANSACTION_KEY = 'ui.load.first_screen';
 
 class PerformanceMetricsManagerSingleton {
     private target: Target;
@@ -55,9 +57,15 @@ class PerformanceMetricsManagerSingleton {
 
     public setLoadTarget(target: Target) {
         this.target = target;
+        if (target) {
+            startManualTransaction(LOAD_TRANSACTION_KEY, 'ui.load.first_screen', 'ui.load', {
+                'mm.target': target,
+            });
+        }
     }
 
     public skipLoadMetric() {
+        endManualTransaction(LOAD_TRANSACTION_KEY, {'mm.skipped': true});
         RNUtils.setHasRegisteredLoad();
     }
 
@@ -78,6 +86,10 @@ class PerformanceMetricsManagerSingleton {
                 timestamp: Date.now(),
             });
             performance.clearMeasures('mobile_load');
+            endManualTransaction(LOAD_TRANSACTION_KEY, {
+                'mm.target': location || 'unknown',
+                'mm.duration_ms': Math.round(measure.duration),
+            });
         } catch {
             // There seems to be a race condition where in some scenarios, the mobile load
             // mark does not exist. We add this to avoid crashes related to this.
@@ -86,6 +98,10 @@ class PerformanceMetricsManagerSingleton {
                 return;
             }
             logWarning('We could not retrieve the mobile load metric');
+            endManualTransaction(LOAD_TRANSACTION_KEY, {
+                'mm.target': location || 'unknown',
+                'mm.error': 'missing_native_launch_mark',
+            });
         }
 
         RNUtils.setHasRegisteredLoad();
@@ -93,6 +109,9 @@ class PerformanceMetricsManagerSingleton {
 
     public startMetric(metricName: MetricName) {
         performance.mark(metricName, {detail: 'startMetric'});
+        startManualTransaction(metricName, metricName, 'ui.action', {
+            'mm.metric': metricName,
+        });
     }
 
     public mark(metricName: MetricName, options?: MarkOptions) {
@@ -131,6 +150,11 @@ class PerformanceMetricsManagerSingleton {
             metric: metricName,
             value: duration,
             timestamp: Date.now(),
+        });
+
+        endManualTransaction(metricName, {
+            'mm.metric': metricName,
+            'mm.duration_ms': Math.round(duration),
         });
 
         performance.clearMarks(metricName);

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -27,6 +27,7 @@ import SnackBarContainer from '@screens/snack_bar';
 import WatermarkContainer from '@screens/watermark';
 import EphemeralStore from '@store/ephemeral_store';
 import {NavigationStore, useCurrentScreen} from '@store/navigation_store';
+import {registerNavigationContainer} from '@utils/sentry';
 
 import type {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 import type {AvailableScreens} from '@typings/screens/navigation';
@@ -94,6 +95,10 @@ export default function RootLayout() {
             cleanup();
         };
     });
+
+    useEffect(() => {
+        registerNavigationContainer(navigationRef);
+    }, [navigationRef]);
 
     useEffect(() => {
         if (appReady) {

--- a/app/utils/sentry.test.ts
+++ b/app/utils/sentry.test.ts
@@ -13,6 +13,7 @@ import {getCurrentUser} from '@queries/servers/user';
 
 import * as log from './log';
 import {initializeSentry, captureException, captureJSException, addSentryContext} from './sentry';
+import {testExports as sentryTracingTestExports} from './sentry_tracing';
 
 // Mocks
 jest.mock('@sentry/react-native', () => ({
@@ -20,9 +21,19 @@ jest.mock('@sentry/react-native', () => ({
     captureException: jest.fn(),
     addBreadcrumb: jest.fn(),
     setContext: jest.fn(),
-    ReactNativeTracing: jest.fn(),
-    reactNativeExpoIntegration: jest.fn().mockImplementation(() => ({
-        name: 'expo-router',
+    wrap: jest.fn((component) => component),
+    startSpan: jest.fn((_options, callback) => callback()),
+    startSpanManual: jest.fn((_options, callback) => {
+        const span = {end: jest.fn(), setAttribute: jest.fn()};
+        callback(span);
+        return span;
+    }),
+    reactNavigationIntegration: jest.fn().mockImplementation(() => ({
+        name: 'ReactNavigation',
+        registerNavigationContainer: jest.fn(),
+    })),
+    hermesProfilingIntegration: jest.fn().mockImplementation(() => ({
+        name: 'HermesProfiling',
     })),
 }));
 
@@ -70,7 +81,8 @@ jest.mock('@utils/errors', () => ({
 
 describe('initializeSentry function', () => {
     afterEach(() => {
-        jest.clearAllMocks(); // Clear all mock calls after each test
+        jest.clearAllMocks();
+        sentryTracingTestExports.resetForTesting();
     });
 
     it('should not initialize Sentry if SentryEnabled is false', () => {
@@ -95,19 +107,21 @@ describe('initializeSentry function', () => {
         Config.SentryEnabled = true;
         Config.SentryDsnAndroid = 'YOUR_ANDROID_DSN_HERE';
         Config.SentryDsnIos = 'YOUR_IOS_DSN_HERE';
+        Platform.OS = 'ios';
 
         initializeSentry();
 
         expect(Sentry.init).toHaveBeenCalled();
-        Platform.OS = 'ios';
         expect(Sentry.init).toHaveBeenCalledWith({
             dsn: 'YOUR_IOS_DSN_HERE',
             sendDefaultPii: false,
             environment: 'beta', // Assuming isBetaApp() returns true in this test
             tracesSampleRate: 1.0,
             sampleRate: 1.0,
+            profilesSampleRate: 1.0,
             attachStacktrace: true, // Adjust based on your actual logic
             enableCaptureFailedRequests: false,
+            integrations: expect.any(Array),
             beforeSend: expect.any(Function),
         });
 
@@ -123,6 +137,7 @@ describe('initializeSentry function', () => {
 describe('captureException function', () => {
     afterEach(() => {
         jest.clearAllMocks(); // Clear all mock calls after each test
+        sentryTracingTestExports.resetForTesting();
     });
 
     it('should not capture exception if Sentry is disabled', () => {
@@ -143,6 +158,7 @@ describe('captureException function', () => {
     });
 
     it('should capture exception correctly', () => {
+        Config.SentryEnabled = true;
         captureException(new Error('Test error'));
 
         expect(Sentry.captureException).toHaveBeenCalled();
@@ -153,6 +169,7 @@ describe('captureException function', () => {
 describe('captureJSException function', () => {
     afterEach(() => {
         jest.clearAllMocks(); // Clear all mock calls after each test
+        sentryTracingTestExports.resetForTesting();
     });
 
     it('should not capture exception if Sentry is disabled', () => {
@@ -173,6 +190,7 @@ describe('captureJSException function', () => {
     });
 
     it('should capture ClientError as breadcrumb', () => {
+        Config.SentryEnabled = true;
         const errorData: ClientErrorProps = {
             url: 'https://example.com',
             status_code: 400,
@@ -197,6 +215,7 @@ describe('captureJSException function', () => {
     });
 
     it('should capture other exceptions', () => {
+        Config.SentryEnabled = true;
         const error = new Error('Test error');
 
         captureJSException(error, true);
@@ -209,6 +228,7 @@ describe('captureJSException function', () => {
 describe('addSentryContext function', () => {
     afterEach(() => {
         jest.clearAllMocks(); // Clear all mock calls after each test
+        sentryTracingTestExports.resetForTesting();
     });
 
     it('should not add context if Sentry is disabled', async () => {
@@ -252,6 +272,7 @@ describe('addSentryContext function', () => {
     });
 
     it('should log an error if an exception occurs', async () => {
+        Config.SentryEnabled = true;
         (DatabaseManager.getServerDatabaseAndOperator as jest.Mock).mockImplementation(() => {
             throw new Error('Database error');
         });

--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -4,55 +4,58 @@
 import {Platform} from 'react-native';
 
 import Config from '@assets/config.json';
-import ClientError from '@client/rest/error';
-import DatabaseManager from '@database/manager';
-import {getConfig} from '@queries/servers/system';
-import {getCurrentUser} from '@queries/servers/user';
 import {getFullErrorMessage} from '@utils/errors';
 import {isBetaApp} from '@utils/general';
+import {
+    initializeSentryTracing,
+    registerNavigationContainer as registerSentryNavigationContainer,
+    wrapRootComponent,
+} from '@utils/sentry_tracing';
 
 import {logError, logWarning} from './log';
 
+import type ClientError from '@client/rest/error';
 import type {Database} from '@nozbe/watermelondb';
 import type {Breadcrumb, ErrorEvent} from '@sentry/core';
+import type {ComponentType} from 'react';
 
 export const BREADCRUMB_UNCAUGHT_APP_ERROR = 'uncaught-app-error';
 export const BREADCRUMB_UNCAUGHT_NON_ERROR = 'uncaught-non-error';
 
-let Sentry: any;
+let Sentry: typeof import('@sentry/react-native') | undefined;
+
+function ensureSentryModule() {
+    if (!Sentry) {
+        Sentry = require('@sentry/react-native');
+    }
+    return Sentry!;
+}
+
 export function initializeSentry() {
     if (!Config.SentryEnabled) {
         return;
     }
 
-    if (!Sentry) {
-        Sentry = require('@sentry/react-native');
-    }
-
     const dsn = getDsn();
-
     if (!dsn) {
         logWarning('Sentry is enabled, but not configured on this platform');
         return;
     }
 
-    const mmConfig = {
+    const eventFilter = Array.isArray(Config.SentryOptions?.severityLevelFilter) ? Config.SentryOptions.severityLevelFilter : [];
+    const sentryOptions = {...Config.SentryOptions} as Record<string, unknown>;
+    Reflect.deleteProperty(sentryOptions, 'severityLevelFilter');
+
+    const initialized = initializeSentryTracing({
+        dsn,
         environment: isBetaApp ? 'beta' : 'production',
         tracesSampleRate: isBetaApp ? 1.0 : 0.2,
         sampleRate: isBetaApp ? 1.0 : 0.2,
-        attachStacktrace: Boolean(isBetaApp), // For Beta, stack traces are automatically attached to all messages logged
-    };
 
-    const eventFilter = Array.isArray(Config.SentryOptions?.severityLevelFilter) ? Config.SentryOptions.severityLevelFilter : [];
-    const sentryOptions = {...Config.SentryOptions};
-    Reflect.deleteProperty(sentryOptions, 'severityLevelFilter');
-
-    Sentry.init({
-        dsn,
-        sendDefaultPii: false,
-        ...mmConfig,
-        ...sentryOptions,
-        enableCaptureFailedRequests: false,
+        // Capture profiles for sampled transactions (relative to tracesSampleRate).
+        profilesSampleRate: isBetaApp ? 1.0 : 0.2,
+        attachStacktrace: Boolean(isBetaApp),
+        sentryOptions,
         beforeSend: (event: ErrorEvent) => {
             if (isBetaApp || (event?.level && eventFilter.includes(event.level))) {
                 return event;
@@ -61,6 +64,10 @@ export function initializeSentry() {
             return null;
         },
     });
+
+    if (initialized) {
+        ensureSentryModule();
+    }
 }
 
 function getDsn() {
@@ -73,6 +80,14 @@ function getDsn() {
     return '';
 }
 
+export function wrapWithSentry<P extends Record<string, unknown>>(RootComponent: ComponentType<P>) {
+    return wrapRootComponent(RootComponent);
+}
+
+export function registerNavigationContainer(ref: unknown) {
+    registerSentryNavigationContainer(ref);
+}
+
 export function captureException(error: unknown) {
     if (!Config.SentryEnabled) {
         return;
@@ -82,7 +97,7 @@ export function captureException(error: unknown) {
         logWarning('captureException called with missing arguments', error);
         return;
     }
-    Sentry.captureException(error);
+    ensureSentryModule().captureException(error);
 }
 
 export function captureJSException(error: unknown, isFatal: boolean) {
@@ -95,7 +110,9 @@ export function captureJSException(error: unknown, isFatal: boolean) {
         return;
     }
 
-    if (error instanceof ClientError) {
+    // Lazy require to keep early Sentry init off the critical import path.
+    const ClientErrorClass = require('@client/rest/error').default as typeof ClientError;
+    if (error instanceof ClientErrorClass) {
         captureClientErrorAsBreadcrumb(error, isFatal);
     } else {
         captureException(error);
@@ -130,7 +147,7 @@ function captureClientErrorAsBreadcrumb(error: ClientError, isFatal: boolean) {
     }
 
     try {
-        Sentry.addBreadcrumb(breadcrumb);
+        ensureSentryModule().addBreadcrumb(breadcrumb);
     } catch (e) {
         // Do nothing since this is only here to make sure we don't crash when handling an exception
         logWarning('Failed to capture breadcrumb of non-error', e);
@@ -138,6 +155,7 @@ function captureClientErrorAsBreadcrumb(error: ClientError, isFatal: boolean) {
 }
 
 const getUserContext = async (database: Database) => {
+    const {getCurrentUser} = require('@queries/servers/user') as typeof import('@queries/servers/user');
     const currentUser = {
         id: 'currentUserId',
         locale: 'en',
@@ -156,6 +174,7 @@ const getUserContext = async (database: Database) => {
 };
 
 const getExtraContext = async (database: Database) => {
+    const {getConfig} = require('@queries/servers/system') as typeof import('@queries/servers/system');
     const context = {
         config: {},
         currentChannel: {},
@@ -177,6 +196,7 @@ const getExtraContext = async (database: Database) => {
 };
 
 const getBuildTags = async (database: Database) => {
+    const {getConfig} = require('@queries/servers/system') as typeof import('@queries/servers/system');
     const tags = {
         serverBuildHash: '',
         serverBuildNumber: '',
@@ -192,20 +212,23 @@ const getBuildTags = async (database: Database) => {
 };
 
 export const addSentryContext = async (serverUrl: string) => {
-    if (!Config.SentryEnabled || !Sentry) {
+    if (!Config.SentryEnabled) {
         return;
     }
 
     try {
+        const sentry = ensureSentryModule();
+        const databaseManagerModule = require('@database/manager');
+        const DatabaseManager = databaseManagerModule.default ?? databaseManagerModule;
         const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         const userContext = await getUserContext(database);
-        Sentry.setContext('User-Information', userContext);
+        sentry.setContext('User-Information', userContext);
 
         const buildContext = await getBuildTags(database);
-        Sentry.setContext('App-Build Information', buildContext);
+        sentry.setContext('App-Build Information', buildContext);
 
         const extraContext = await getExtraContext(database);
-        Sentry.setContext('Server-Information', extraContext);
+        sentry.setContext('Server-Information', extraContext);
     } catch (e) {
         logError(`addSentryContext for serverUrl ${serverUrl}`, e);
     }

--- a/app/utils/sentry_tracing.test.ts
+++ b/app/utils/sentry_tracing.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import Config from '@assets/config.json';
+
+const mockStartSpan = jest.fn((_options: unknown, callback: () => unknown) => callback());
+const mockStartSpanManual = jest.fn((options: unknown, callback: (span: {end: jest.Mock; setAttribute: jest.Mock}) => void) => {
+    const span = {
+        end: jest.fn(),
+        setAttribute: jest.fn(),
+        options,
+    };
+    callback(span);
+    return span;
+});
+const mockInit = jest.fn();
+const mockWrap = jest.fn((component: unknown) => component);
+const mockRegisterNavigationContainer = jest.fn();
+const mockReactNavigationIntegration = jest.fn(() => ({
+    name: 'ReactNavigation',
+    registerNavigationContainer: mockRegisterNavigationContainer,
+}));
+const mockHermesProfilingIntegration = jest.fn(() => ({name: 'HermesProfiling'}));
+
+jest.mock('@sentry/react-native', () => ({
+    init: mockInit,
+    wrap: mockWrap,
+    startSpan: mockStartSpan,
+    startSpanManual: mockStartSpanManual,
+    reactNavigationIntegration: mockReactNavigationIntegration,
+    hermesProfilingIntegration: mockHermesProfilingIntegration,
+}));
+
+jest.mock('@assets/config.json', () => ({
+    SentryEnabled: true,
+}));
+
+describe('sentry_tracing', () => {
+    let tracing: typeof import('./sentry_tracing');
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        Config.SentryEnabled = true;
+        tracing = require('./sentry_tracing');
+        tracing.testExports.resetForTesting();
+    });
+
+    it('should initialize Sentry with navigation and profiling integrations', () => {
+        const beforeSend = jest.fn();
+        const result = tracing.initializeSentryTracing({
+            dsn: 'https://example.ingest.sentry.io/1',
+            environment: 'beta',
+            tracesSampleRate: 1,
+            sampleRate: 1,
+            profilesSampleRate: 1,
+            attachStacktrace: true,
+            sentryOptions: {debug: false},
+            beforeSend,
+        });
+
+        expect(result).toBe(true);
+        expect(mockInit).toHaveBeenCalledWith(expect.objectContaining({
+            dsn: 'https://example.ingest.sentry.io/1',
+            sendDefaultPii: false,
+            tracesSampleRate: 1,
+            profilesSampleRate: 1,
+            integrations: expect.any(Array),
+            beforeSend,
+        }));
+        expect(mockReactNavigationIntegration).toHaveBeenCalled();
+        expect(mockHermesProfilingIntegration).toHaveBeenCalled();
+    });
+
+    it('should no-op helpers when Sentry is disabled', async () => {
+        Config.SentryEnabled = false;
+
+        const value = await tracing.withSpan('name', 'op', async () => 'ok');
+        expect(value).toBe('ok');
+        expect(mockStartSpan).not.toHaveBeenCalled();
+
+        const handle = tracing.startManualTransaction('key', 'name', 'op');
+        handle.end();
+        expect(mockStartSpanManual).not.toHaveBeenCalled();
+    });
+
+    it('should end manual transactions by key', () => {
+        tracing.testExports.setInitializedForTesting(true);
+
+        const handle = tracing.startManualTransaction('mobile_channel_switch', 'mobile_channel_switch', 'ui.action');
+        expect(mockStartSpanManual).toHaveBeenCalled();
+        expect(tracing.testExports.activeManualSpans.has('mobile_channel_switch')).toBe(true);
+
+        handle.end();
+        expect(tracing.testExports.activeManualSpans.has('mobile_channel_switch')).toBe(false);
+    });
+
+    it('should skip high-volume websocket events', () => {
+        expect(tracing.shouldTraceWebsocketEvent('typing')).toBe(false);
+        expect(tracing.shouldTraceWebsocketEvent('posted')).toBe(true);
+    });
+
+    it('should create child spans with onlyIfParent by default', async () => {
+        tracing.testExports.setInitializedForTesting(true);
+
+        await tracing.withSpan('db.batch.handlePosts', 'db', async () => undefined, {
+            attributes: {'mm.db.record_count': 3},
+        });
+
+        expect(mockStartSpan).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: 'db.batch.handlePosts',
+                op: 'db',
+                onlyIfParent: true,
+                attributes: {'mm.db.record_count': 3},
+            }),
+            expect.any(Function),
+        );
+    });
+});

--- a/app/utils/sentry_tracing.ts
+++ b/app/utils/sentry_tracing.ts
@@ -1,0 +1,288 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import Config from '@assets/config.json';
+
+import type {Span} from '@sentry/core';
+import type {ComponentType} from 'react';
+
+type SpanAttributes = Record<string, string | number | boolean | undefined>;
+
+type ManualSpanHandle = {
+    end: () => void;
+    setAttribute: (key: string, value: string | number | boolean) => void;
+};
+
+const NOOP_HANDLE: ManualSpanHandle = {
+    end: () => {
+        // no-op when Sentry tracing is disabled
+    },
+    setAttribute: () => {
+        // no-op when Sentry tracing is disabled
+    },
+};
+
+type NavigationIntegration = {
+    registerNavigationContainer: (ref: unknown) => void;
+};
+
+let Sentry: typeof import('@sentry/react-native') | undefined;
+let navigationIntegration: NavigationIntegration | undefined;
+let initialized = false;
+
+const activeManualSpans = new Map<string, Span>();
+
+// High-volume websocket events that would drown useful traces.
+const SKIPPED_WS_EVENTS = new Set([
+    'typing',
+    'stop_typing',
+    'status_change',
+]);
+
+function ensureSentryModule() {
+    if (!Sentry) {
+        Sentry = require('@sentry/react-native');
+    }
+    return Sentry!;
+}
+
+export function isSentryTracingEnabled() {
+    return Boolean(Config.SentryEnabled);
+}
+
+export function getNavigationIntegration() {
+    return navigationIntegration;
+}
+
+/**
+ * Initialize Sentry once with performance integrations.
+ * Safe to call multiple times.
+ */
+export function initializeSentryTracing(initOptions: {
+    dsn: string;
+    environment: string;
+    tracesSampleRate: number;
+    sampleRate: number;
+    attachStacktrace: boolean;
+    profilesSampleRate: number;
+    beforeSend: NonNullable<Parameters<typeof import('@sentry/react-native').init>[0]>['beforeSend'];
+    sentryOptions: Record<string, unknown>;
+}) {
+    if (initialized || !isSentryTracingEnabled()) {
+        return initialized;
+    }
+
+    const sentry = ensureSentryModule();
+    const reactNavigation = sentry.reactNavigationIntegration({
+        enableTimeToInitialDisplay: true,
+        useDispatchedActionData: true,
+    });
+    navigationIntegration = reactNavigation;
+
+    sentry.init({
+        dsn: initOptions.dsn,
+        sendDefaultPii: false,
+        environment: initOptions.environment,
+        tracesSampleRate: initOptions.tracesSampleRate,
+        sampleRate: initOptions.sampleRate,
+        profilesSampleRate: initOptions.profilesSampleRate,
+        attachStacktrace: initOptions.attachStacktrace,
+        enableCaptureFailedRequests: false,
+        ...initOptions.sentryOptions,
+        integrations: [
+            reactNavigation,
+            sentry.hermesProfilingIntegration({platformProfilers: true}),
+        ],
+        beforeSend: initOptions.beforeSend,
+    });
+
+    initialized = true;
+    return true;
+}
+
+export function wrapRootComponent<P extends Record<string, unknown>>(
+    RootComponent: ComponentType<P>,
+): ComponentType<P> {
+    if (!isSentryTracingEnabled()) {
+        return RootComponent;
+    }
+
+    const sentry = ensureSentryModule();
+    return sentry.wrap(RootComponent);
+}
+
+export function registerNavigationContainer(ref: unknown) {
+    if (!isSentryTracingEnabled() || !navigationIntegration || !ref) {
+        return;
+    }
+
+    navigationIntegration.registerNavigationContainer(ref);
+}
+
+/**
+ * Start a long-lived span/transaction that is ended later by key.
+ * Used for channel/team switch and first useful screen load.
+ */
+export function startManualTransaction(
+    key: string,
+    name: string,
+    op: string,
+    attributes?: SpanAttributes,
+): ManualSpanHandle {
+    if (!isSentryTracingEnabled() || !initialized) {
+        return NOOP_HANDLE;
+    }
+
+    const existing = activeManualSpans.get(key);
+    if (existing) {
+        existing.end();
+        activeManualSpans.delete(key);
+    }
+
+    const sentry = ensureSentryModule();
+    let spanRef: Span | undefined;
+
+    sentry.startSpanManual(
+        {
+            name,
+            op,
+            forceTransaction: true,
+            attributes: sanitizeAttributes(attributes),
+        },
+        (span) => {
+            spanRef = span;
+            activeManualSpans.set(key, span);
+        },
+    );
+
+    if (!spanRef) {
+        return NOOP_HANDLE;
+    }
+
+    return {
+        end: () => {
+            const span = activeManualSpans.get(key);
+            if (!span) {
+                return;
+            }
+            span.end();
+            activeManualSpans.delete(key);
+        },
+        setAttribute: (attrKey, value) => {
+            const span = activeManualSpans.get(key);
+            span?.setAttribute(attrKey, value);
+        },
+    };
+}
+
+export function endManualTransaction(key: string, attributes?: SpanAttributes) {
+    const span = activeManualSpans.get(key);
+    if (!span) {
+        return;
+    }
+
+    if (attributes) {
+        const sanitized = sanitizeAttributes(attributes);
+        for (const [attrKey, value] of Object.entries(sanitized)) {
+            span.setAttribute(attrKey, value);
+        }
+    }
+
+    span.end();
+    activeManualSpans.delete(key);
+}
+
+type ChildSpanOptions = {
+    attributes?: SpanAttributes;
+
+    /**
+     * When true (default), skip creating a span unless a parent transaction/span is active.
+     * Keeps HTTP/DB/WS spans attached to UX transactions instead of flooding Sentry.
+     */
+    onlyIfParent?: boolean;
+};
+
+/**
+ * Run work inside a child span. By default only records when a parent span is active.
+ */
+export async function withSpan<T>(
+    name: string,
+    op: string,
+    callback: () => Promise<T> | T,
+    options?: ChildSpanOptions,
+): Promise<T> {
+    if (!isSentryTracingEnabled() || !initialized) {
+        return callback();
+    }
+
+    const sentry = ensureSentryModule();
+    return sentry.startSpan(
+        {
+            name,
+            op,
+            onlyIfParent: options?.onlyIfParent ?? true,
+            attributes: sanitizeAttributes(options?.attributes),
+        },
+        () => callback(),
+    );
+}
+
+/**
+ * Synchronous span wrapper for fire-and-forget paths (e.g. WS dispatch).
+ */
+export function withSpanSync<T>(
+    name: string,
+    op: string,
+    callback: () => T,
+    options?: ChildSpanOptions,
+): T {
+    if (!isSentryTracingEnabled() || !initialized) {
+        return callback();
+    }
+
+    const sentry = ensureSentryModule();
+    return sentry.startSpan(
+        {
+            name,
+            op,
+            onlyIfParent: options?.onlyIfParent ?? true,
+            attributes: sanitizeAttributes(options?.attributes),
+        },
+        () => callback(),
+    );
+}
+
+export function shouldTraceWebsocketEvent(event: string | undefined) {
+    if (!event) {
+        return false;
+    }
+    return !SKIPPED_WS_EVENTS.has(event);
+}
+
+function sanitizeAttributes(attributes?: SpanAttributes): Record<string, string | number | boolean> {
+    if (!attributes) {
+        return {};
+    }
+
+    const result: Record<string, string | number | boolean> = {};
+    for (const [key, value] of Object.entries(attributes)) {
+        if (value !== undefined) {
+            result[key] = value;
+        }
+    }
+    return result;
+}
+
+export const testExports = {
+    activeManualSpans,
+    SKIPPED_WS_EVENTS,
+    resetForTesting: () => {
+        activeManualSpans.clear();
+        initialized = false;
+        navigationIntegration = undefined;
+        Sentry = undefined;
+    },
+    setInitializedForTesting: (value: boolean) => {
+        initialized = value;
+    },
+};

--- a/index.tsx
+++ b/index.tsx
@@ -9,6 +9,7 @@ import {AppRegistry, LogBox, Platform} from 'react-native';
 import {BackgroundTimer} from 'react-native-nitro-bg-timer-plus';
 
 import {logInfo} from './app/utils/log';
+import {initializeSentry, wrapWithSentry} from './app/utils/sentry';
 
 // Opt out of the nitro-bg-timer-plus foreground service — we removed its manifest
 // entries, so we also disable it at runtime to prevent the library from attempting
@@ -16,6 +17,10 @@ import {logInfo} from './app/utils/log';
 if (Platform.OS === 'android') {
     BackgroundTimer.disableForegroundService();
 }
+
+// Initialize Sentry as early as possible so app-start and navigation instrumentation
+// can attach to the root component and navigation container.
+initializeSentry();
 
 // eslint-disable-next-line no-process-env
 process.env.EXPO_OS = Platform.OS;
@@ -67,4 +72,4 @@ export function App() {
 }
 
 // Register with the name that iOS AppDelegate expects
-AppRegistry.registerComponent('Mattermost', () => App);
+AppRegistry.registerComponent('Mattermost', () => wrapWithSentry(App));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Adds Sentry-based performance instrumentation so we can collect and inspect low-level UX breakdowns (cold start, channel/team switch, HTTP, DB, websocket dispatch) on a real device against a real server when Sentry is enabled.

This builds on the existing `PerformanceMetricsManager` / `client_perf` marks by also emitting Sentry transactions and child spans, plus navigation instrumentation and Hermes/native profiling sampling.

#### What was added
- Early `initializeSentry()` + `Sentry.wrap` in `index.tsx`
- React Navigation integration registration from the expo-router root layout
- `profilesSampleRate` + `hermesProfilingIntegration`
- New helpers in `app/utils/sentry_tracing.ts`:
  - Manual transactions for `ui.load.first_screen`, `mobile_channel_switch`, `mobile_team_switch`
  - Child spans (`onlyIfParent`) for HTTP (`cleanUrlForLogging`), DB `batchRecords`, and websocket dispatch
- App init stage spans (`database`, `network`, `websocket`, `security`, etc.)
- High-volume WS events skipped: `typing`, `stop_typing`, `status_change`
- Unit tests for tracing helpers / updated Sentry init expectations

PII-safe by design: `sendDefaultPii: false`, scrubbed HTTP paths, no message bodies/display names on spans.

#### How to test on a physical device
1. In your local config (do **not** commit secrets), set:
   - `SentryEnabled: true`
   - `SentryDsnIos` / `SentryDsnAndroid` to your project DSN
2. Build/install a release or beta build on a physical device (profiling is unreliable on simulators).
3. Exercise:
   - Cold launch → home/channel
   - Channel switches
   - Team switches
   - Busy channel scroll / message send
4. In Sentry → **Performance**:
   - Look for transactions: `ui.load.first_screen`, `mobile_channel_switch`, `mobile_team_switch`, `app.initialize`, navigation routes
   - Open a slow transaction waterfall for HTTP (`http.client`), DB (`db.batch.*`), and WS (`ws.*`) child spans
   - Open attached profiles when present

Sampling: beta uses `tracesSampleRate` / `profilesSampleRate` `1.0`; production uses `0.2`.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: unit tests + `tsc` in CI agent environment (no physical device/mobile MCP available here). Please validate on device with Sentry enabled.

#### Release Note
```release-note
Added Sentry performance tracing for cold start, channel/team switches, network requests, database batches, and websocket dispatch to improve mobile performance investigation.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc26d-9b08-70aa-9e2f-874dc781b649?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc26d-9b08-70aa-9e2f-874dc781b649&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

