### PR TITLE
docs(e2e): manual E2E/Run for release cherry-pick PRs

### DIFF
--- a/.github/workflows/e2e-detox-pr.yml
+++ b/.github/workflows/e2e-detox-pr.yml
@@ -9,6 +9,14 @@
 # main-branch pushes, RELEASE). Renaming the file would break the dispatch URL
 # above, so it needs a coordinated Matterwick change.
 #
+# Who gets E2E automatically vs manually:
+#   - PRs → main: auto E2E/Run via e2e-label-manager (app-impacting paths).
+#   - Push → main: Matterwick provisions + dispatches (run_type MAIN/MASTER).
+#   - Push → build-release-*: Matterwick CMT / release E2E.
+#   - PRs → release-* (incl. AutomatedCherryPick): manual E2E/Run only — see
+#     e2e-label-manager.yml base-branch guard. Capacity cost is five cloud
+#     servers per run; auto-trigger on cherry-pick batches is deliberately off.
+#
 # Newer dispatches cancel older in-flight runs on the same branch via the workflow
 # `concurrency` group below, so the latest SHA starts immediately instead of
 # queueing behind a long run.

--- a/.github/workflows/e2e-label-manager.yml
+++ b/.github/workflows/e2e-label-manager.yml
@@ -39,9 +39,14 @@
 # addLabels / removeLabel would all 403. Mandatory E2E for fork PRs is enforced
 # separately.
 #
-# Base-branch guard: auto E2E/Run refresh only runs for PRs targeting main.
-# Stacked PRs (base != main) are skipped so Matterwick is not triggered on every
-# intermediate-branch push.
+# Base-branch guard: auto E2E/Run only for PRs targeting main.
+# Intentionally NOT auto-applied for cherry-picks or other PRs targeting
+# release-* (or stacked feature-branch bases). Those stay opt-in: add E2E/Run
+# manually when coverage is needed. Each mobile E2E holds five cloud installs;
+# auto-running on every release cherry-pick batch overloads provisioning
+# (409s / failed dispatches). We are improving Matterwick capacity handling
+# (retries, shorter PR server TTL, clearer failure alerts) separately so
+# manual runs stay reliable under high create demand.
 #
 name: E2E label manager
 

--- a/detox/CLAUDE.md
+++ b/detox/CLAUDE.md
@@ -94,9 +94,12 @@ cd detox && npm run e2e:save-report
 
 | Tier | Trigger | Platform | Shards | Search Path | Approx Time |
 |------|---------|----------|--------|-------------|-------------|
-| **PR full** | Matterwick + `E2E/Run` label | Detox iOS/Android/iPad + Maestro | 20 Detox (iOS/Android), 1 iPad, 1 Maestro each | `detox/e2e/test` (full) | ~30–45+ min wall-clock |
+| **PR full** | Matterwick + `E2E/Run` label (auto on PRs → `main` only) | Detox iOS/Android/iPad + Maestro | 20 Detox (iOS/Android), 1 iPad, 1 Maestro each | `detox/e2e/test` (full) | ~30–45+ min wall-clock |
 | **Main** | Matterwick main push (`run_type=MASTER` today; `MAIN` also accepted → TSIO `mobile-main`) | Same as PR | Same as PR | `detox/e2e/test` | Same as PR |
 | **CMT / Release** | Matterwick on `build-release-*` → CMT | Detox + Maestro across server versions | Full suite on latest server; smoke subset on older | latest: `detox/e2e/test`; older: `…/smoke_test` | Varies by matrix |
+| **Release cherry-pick / PR → `release-*`** | **Manual** `E2E/Run` only (not auto-labeled) | Same as PR when labeled | Same as PR | `detox/e2e/test` | Same as PR |
+
+Cherry-picks and other PRs targeting `release-*` deliberately do **not** get auto `E2E/Run`: each mobile run holds five cloud installs, and auto-running on every release batch overloads provisioning. Add `E2E/Run` when coverage is needed. Cloud provisioning resilience under high create demand is being improved in Matterwick separately.
 
 Status contexts live under the `e2e-test/` namespace, matching the mattermost monorepo. PR/Main: `e2e-test/detox-ios`, `e2e-test/detox-android`, `e2e-test/detox-ipad`, `e2e-test/maestro-ios`, `e2e-test/maestro-android`. CMT: per-shard `e2e-test/<tsio-shard-name>` plus umbrella `e2e-test/compatibility-matrix-testing`. TSIO groups: `mobile-pr-<job>` / `mobile-main-<job>` / `mobile-release-<shard>`.
 


### PR DESCRIPTION
## Summary
- **Decision:** Do not auto-apply `E2E/Run` for cherry-pick PRs (or other PRs targeting `release-*`). E2E stays opt-in via a manual `E2E/Run` label.
- Auto E2E remains for PRs against `main` and for release E2E on `build-release-*` pushes (existing Matterwick flows).
- Rationale: each mobile E2E holds five cloud installs; auto-running on every release cherry-pick batch overloads provisioning (409s / failed dispatches).
- Release-* PRs are normal PRs for Matterwick (`ref=<PR head>`). For manual `E2E/Run` to succeed, the release line must have current E2E CI (five-server inputs + `e2e-test/*` statuses) — tracked as a separate release backport, not a Matterwick special-case.
- We are investigating cloud provisioning improvements (retries, shorter PR server TTL, clearer failure alerts) for high create-demand.

## Test plan
- [ ] Confirm cherry-pick / `release-*` PRs do **not** get `E2E/Run` on open/sync
- [ ] Confirm manual `E2E/Run` still triggers Matterwick the same way as on `main` PRs
- [ ] Confirm `main` PRs still auto-label as today