### PR TITLE
feat(drafts): Phase 4 — snapshot reconciliation + gated outbox workers (network on)

### DIFF
--- a/app/actions/local/draft.test.ts
+++ b/app/actions/local/draft.test.ts
@@ -9,6 +9,7 @@ import {MM_TABLES, SYSTEM_IDENTIFIERS} from '@constants/database';
 import {DRAFT_SCREEN_TAB_DRAFTS, DRAFT_SCREEN_TAB_SCHEDULED_POSTS} from '@constants/draft';
 import {PostTypes} from '@constants/post';
 import DatabaseManager from '@database/manager';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import {getDraft, getDraftOutbox} from '@queries/servers/drafts';
 import {dismissAllRoutesAndPopToScreen} from '@screens/navigation';
 import {NavigationStore} from '@store/navigation_store';
@@ -59,6 +60,11 @@ jest.mock('@utils/helpers', () => ({
 jest.mock('@screens/navigation', () => ({
     dismissAllRoutesAndPopToScreen: jest.fn(),
     navigateToScreen: jest.fn(),
+}));
+
+jest.mock('@managers/draft_sync_manager', () => ({
+    __esModule: true,
+    default: {wake: jest.fn(), initialize: jest.fn(), invalidate: jest.fn()},
 }));
 
 jest.mock('@store/navigation_store', () => ({
@@ -432,6 +438,30 @@ describe('draft actions', () => {
             });
 
             expect(await countOutbox()).toBe(0);
+        });
+    });
+
+    describe('DraftSyncManager wake coordination', () => {
+        const wakeMock = jest.mocked(DraftSyncManager.wake);
+
+        beforeEach(() => {
+            wakeMock.mockClear();
+        });
+
+        it('wakes the coordinator once after a committed portable mutation', async () => {
+            const {error} = await updateDraftMessage(serverUrl, channelId, '', 'hello');
+
+            expect(error).toBeUndefined();
+            expect(wakeMock).toHaveBeenCalledTimes(1);
+            expect(wakeMock).toHaveBeenCalledWith(serverUrl);
+        });
+
+        it('does not wake on an error/no-op path', async () => {
+            // No draft exists, so updateDraftFile short-circuits with an error and never mutates.
+            const {error} = await updateDraftFile(serverUrl, channelId, '', fileInfo);
+
+            expect(error).toBe('no draft');
+            expect(wakeMock).not.toHaveBeenCalled();
         });
     });
 

--- a/app/actions/local/draft.ts
+++ b/app/actions/local/draft.ts
@@ -9,6 +9,7 @@ import {MM_TABLES} from '@constants/database';
 import {DraftOutboxOperation, DraftOutboxStatus, type DraftScreenTab} from '@constants/draft';
 import {PostTypes} from '@constants/post';
 import DatabaseManager from '@database/manager';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import {getChannelById} from '@queries/servers/channel';
 import {mutateDraftAndOutbox, prepareDraftOutbox, type OutboxIntent} from '@queries/servers/drafts';
 import {getCurrentTeamId, setCurrentTeamAndChannelId} from '@queries/servers/system';
@@ -216,6 +217,7 @@ export async function updateDraftFile(serverUrl: string, channelId: string, root
             return {error: earlyError};
         }
 
+        DraftSyncManager.wake(serverUrl);
         return {draft: result};
     } catch (error) {
         logError('Failed updateDraftFile', error);
@@ -287,6 +289,7 @@ export async function removeDraftFile(serverUrl: string, channelId: string, root
             return {error: earlyError};
         }
 
+        DraftSyncManager.wake(serverUrl);
         return {draft: result};
     } catch (error) {
         logError('Failed removeDraftFile', error);
@@ -343,6 +346,7 @@ export async function updateDraftMessage(serverUrl: string, channelId: string, r
             return prepareEmptyTransition(database, channelId, rootId, draft, outbox, hasLocalContent);
         });
 
+        DraftSyncManager.wake(serverUrl);
         return {draft: result};
     } catch (error) {
         logError('Failed updateDraftMessage', error);
@@ -403,6 +407,7 @@ export async function addFilesToDraft(serverUrl: string, channelId: string, root
             return models;
         });
 
+        DraftSyncManager.wake(serverUrl);
         return {draft: result};
     } catch (error) {
         logError('Failed addFilesToDraft', error);
@@ -436,6 +441,7 @@ export const removeDraft = async (serverUrl: string, channelId: string, rootId =
             ];
         });
 
+        DraftSyncManager.wake(serverUrl);
         return {draft: result};
     } catch (error) {
         logError('Failed removeDraft', error);
@@ -485,6 +491,7 @@ export async function updateDraftPriority(serverUrl: string, channelId: string, 
             return models;
         });
 
+        DraftSyncManager.wake(serverUrl);
         return {draft: result};
     } catch (error) {
         logError('Failed updateDraftPriority', error);
@@ -537,6 +544,7 @@ export async function updateDraftBoRConfig(serverUrl: string, channelId: string,
             return models;
         });
 
+        DraftSyncManager.wake(serverUrl);
         return {draft: result};
     } catch (error) {
         logError('Failed updateDraftBoRConfig', error);

--- a/app/actions/local/session/index.ts
+++ b/app/actions/local/session/index.ts
@@ -12,6 +12,7 @@ import DatabaseManager from '@database/manager';
 import {resetMomentLocale} from '@i18n';
 import {getAllServerCredentials, removeServerCredentials} from '@init/credentials';
 import PushNotifications from '@init/push_notifications';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import NetworkManager from '@managers/network_manager';
 import WebsocketManager from '@managers/websocket_manager';
 import {getDeviceToken} from '@queries/app/global';
@@ -140,6 +141,11 @@ export const terminateSession = async (serverUrl: string, removeServer: boolean)
 
     // Remove push notifications (synchronous, no error handling needed)
     PushNotifications.removeServerNotifications(serverUrl);
+
+    // Stop draft sync before invalidating the client and destroying the database so a late
+    // HTTP completion cannot touch a destroyed database (invalidate is synchronous). Un-flushed
+    // outbox intent is intentionally discarded on logout/session termination.
+    DraftSyncManager.invalidate(serverUrl);
 
     // Invalidate clients (websocket waits for close event before destroying)
     await safeExecute('invalidateNetworkClient', async () => {

--- a/app/actions/remote/draft.test.ts
+++ b/app/actions/remote/draft.test.ts
@@ -478,6 +478,35 @@ describe('app/actions/remote/draft', () => {
             expect(result.error).toBeDefined();
         });
 
+        // --- Fix #1: the GET path must not write to a torn-down database after the HTTP await. ---
+        it('writes nothing and returns {error} when shouldAbort() fires after the GET (fix #1)', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'late', update_at: 4000})]);
+
+            // The server was torn down while the GET was in flight: the snapshot write must be skipped.
+            const result = await reconcileTeamDrafts(serverUrl, teamId, {shouldAbort: () => true});
+
+            expect(result.error).toBeDefined();
+            expect(await getDraft(database, channelId, '')).toBeUndefined();
+            expect(await getDraftOutbox(database, channelId, '')).toBeUndefined();
+        });
+
+        // --- Fix #6: every observed key is announced via onSnapshot as the GET resolves (the manager
+        // uses this to bump the in-flight observation ordinal; the synchronous timing that closes the
+        // race is asserted in the manager suite's "bumps the observation ordinal" test). ---
+        it('announces every observed key via onSnapshot (fix #6)', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            const onSnapshot = jest.fn();
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'observed', update_at: 4200})]);
+
+            await reconcileTeamDrafts(serverUrl, teamId, {onSnapshot});
+
+            expect(onSnapshot).toHaveBeenCalledTimes(1);
+            expect(onSnapshot).toHaveBeenCalledWith([{channelId, rootId: ''}]);
+        });
+
         // --- Fix #9: tightened, authoritative per-draft scope + non-PII missing-channel handling. ---
         describe('scope (fix #9)', () => {
             it('skips a DM/GM channel draft when the user has no confirmed membership', async () => {

--- a/app/actions/remote/draft.test.ts
+++ b/app/actions/remote/draft.test.ts
@@ -10,13 +10,36 @@ import NetworkManager from '@managers/network_manager';
 import {buildDraftOutboxId, getDraft, getDraftOutbox} from '@queries/servers/drafts';
 import {draftContentFingerprint, normalizeServerDraft} from '@utils/draft/sync';
 
-import {confirmDeleteTombstone, deleteAbsentCleanDraft, fetchDraftsForTeam, getReconcilableKeys, reconcileTeamDrafts} from './draft';
+import {computeNextAttemptAt, confirmDeleteTombstone, deleteAbsentCleanDraft, fetchDraftsForTeam, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts} from './draft';
+import {forceLogoutIfNecessary} from './session';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 import type DraftModel from '@typings/database/models/servers/draft';
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
 
+jest.mock('./session', () => ({
+    forceLogoutIfNecessary: jest.fn(),
+}));
+
+jest.mock('@managers/websocket_manager', () => ({
+    __esModule: true,
+    default: {
+        getClient: jest.fn(() => ({getConnectionId: () => 'conn-test'})),
+    },
+}));
+
+const mockedForceLogout = jest.mocked(forceLogoutIfNecessary);
+
 const {SERVER: {DRAFT, DRAFT_OUTBOX}} = MM_TABLES;
+
+// httpError: a minimal ClientError-shaped rejection carrying a status code (and optionally headers)
+// for exercising the worker error-classification table.
+const httpError = (statusCode: number, headers?: Record<string, string>) => ({
+    status_code: statusCode,
+    url: `https://${'drafts.remote.test.com'}/api/v4/users/me/drafts`,
+    message: 'request failed',
+    headers,
+});
 
 const serverUrl = 'drafts.remote.test.com';
 const teamId = 'teamid1teamid1teamid1teamid1';
@@ -28,6 +51,8 @@ const userId = 'userid1userid1userid1userid1';
 
 const mockClient = {
     getDrafts: jest.fn(),
+    upsertDraft: jest.fn(),
+    deleteDraft: jest.fn(),
 };
 
 type SeedDraft = {
@@ -135,6 +160,9 @@ describe('app/actions/remote/draft', () => {
         database = DatabaseManager.serverDatabases[serverUrl]!.database;
         operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
         mockClient.getDrafts.mockReset();
+        mockClient.upsertDraft.mockReset();
+        mockClient.deleteDraft.mockReset();
+        mockedForceLogout.mockReset();
     });
 
     afterEach(async () => {
@@ -550,6 +578,272 @@ describe('app/actions/remote/draft', () => {
             const outbox = await getDraftOutbox(database, channelId, '');
             expect(outbox?.operation).toBe(DraftOutboxOperation.Upsert);
             expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+        });
+    });
+
+    describe('computeNextAttemptAt', () => {
+        it('honors a Retry-After (retryAfterMs) verbatim, ignoring backoff', () => {
+            expect(computeNextAttemptAt(0, 1000, 5000)).toBe(6000);
+            expect(computeNextAttemptAt(9, 1000, 250)).toBe(1250);
+        });
+
+        it('grows exponentially from the base and caps at DRAFT_SYNC_RETRY_MAX_MS', () => {
+            // Neutralize jitter (0.5 -> (0.5*2 - 1) === 0) for exact backoff assertions.
+            const rand = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+            expect(computeNextAttemptAt(0, 0)).toBe(1000);
+            expect(computeNextAttemptAt(3, 0)).toBe(8000);
+
+            // 1000 * 2^100 is astronomically large -> ceilinged at the max.
+            expect(computeNextAttemptAt(100, 0)).toBe(300000);
+
+            rand.mockRestore();
+        });
+
+        it('stays within the jitter band and is never negative', () => {
+            const low = jest.spyOn(Math, 'random').mockReturnValue(0);
+
+            // Fully negative jitter: base 1000 - 20% = 800, still >= 0.
+            expect(computeNextAttemptAt(0, 0)).toBe(800);
+            low.mockRestore();
+
+            const high = jest.spyOn(Math, 'random').mockReturnValue(1);
+
+            // Fully positive jitter: base 1000 + 20% = 1200.
+            expect(computeNextAttemptAt(0, 0)).toBe(1200);
+            high.mockRestore();
+        });
+    });
+
+    describe('processOutboxUpsert', () => {
+        const seedUpsertReady = async (over: Partial<SeedDraft> = {}) => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedDraft({channelId, message: 'hello', serverUpdateAt: 0, ...over});
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Pending});
+        };
+
+        it('POSTs and removes the outbox on success, stamping serverUpdateAt from the response', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockResolvedValueOnce(serverDraft({message: 'hello', update_at: 4242}));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'done'});
+            expect(mockClient.upsertDraft).toHaveBeenCalledTimes(1);
+            expect(mockClient.upsertDraft.mock.calls[0][1]).toBe('conn-test');
+            expect(await getDraftOutbox(database, channelId, '')).toBeUndefined();
+            expect((await getDraft(database, channelId, ''))?.serverUpdateAt).toBe(4242);
+        });
+
+        it('does not clear the outbox or overwrite content when the generation changed during the POST', async () => {
+            await seedUpsertReady();
+
+            // Simulate a newer local edit landing while the POST is in flight: bump the generation.
+            mockClient.upsertDraft.mockImplementationOnce(async () => {
+                await database.write(async (writer) => {
+                    const o = await getDraftOutbox(database, channelId, '');
+                    await writer.batch(o!.prepareUpdate((x) => {
+                        x.generation = 9;
+                    }));
+                });
+                return serverDraft({message: 'hello', update_at: 5555});
+            });
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'retry'});
+
+            // The newer outbox row survives (still pending) and only serverUpdateAt is advanced.
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect(outbox?.generation).toBe(9);
+            expect((await getDraft(database, channelId, ''))?.serverUpdateAt).toBe(5555);
+        });
+
+        it('blocks with missing_local_draft and never POSTs when no Draft exists', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Pending});
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'blocked'});
+            expect(mockClient.upsertDraft).not.toHaveBeenCalled();
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Blocked);
+            expect(outbox?.lastErrorCode).toBe('missing_local_draft');
+        });
+
+        it('converts an empty-message draft with an attachment into a keepLocal delete without POSTing', async () => {
+            await seedUpsertReady({message: '', files: [{id: 'f1', clientId: 'c1'} as FileInfo], fileIds: ['f1']});
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'converted'});
+            expect(mockClient.upsertDraft).not.toHaveBeenCalled();
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Delete);
+            expect(outbox?.keepLocal).toBe(true);
+            expect(outbox?.deletedFingerprint).toBeTruthy();
+        });
+
+        it('keeps the row as waiting_for_upload when an in-progress upload (file without id) remains', async () => {
+            await seedUpsertReady({files: [{clientId: 'c1', localPath: 'p'} as FileInfo]});
+            mockClient.upsertDraft.mockResolvedValueOnce(serverDraft({message: 'hello', update_at: 7000}));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'done'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.WaitingForUpload);
+        });
+
+        it('forces logout and leaves the row pending on 401', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockRejectedValueOnce(httpError(401));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'retry'});
+            expect(mockedForceLogout).toHaveBeenCalledTimes(1);
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect(outbox?.lastErrorCode).toBeNull();
+        });
+
+        it('blocks with forbidden on 403', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockRejectedValueOnce(httpError(403));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'blocked'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Blocked);
+            expect(outbox?.lastErrorCode).toBe('forbidden');
+        });
+
+        it('blocks with invalid on 400', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockRejectedValueOnce(httpError(400));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'blocked'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.lastErrorCode).toBe('invalid');
+        });
+
+        it('suspends with sync_disabled on 501', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockRejectedValueOnce(httpError(501));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'suspend'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Blocked);
+            expect(outbox?.lastErrorCode).toBe('sync_disabled');
+        });
+
+        it('keeps the row pending with a future nextAttemptAt honoring Retry-After on 429', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockRejectedValueOnce(httpError(429, {'Retry-After': '2'}));
+
+            const before = Date.now();
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'retry', retryAfterMs: 2000});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect(outbox?.attemptCount).toBe(1);
+            expect(outbox?.nextAttemptAt).toBeGreaterThanOrEqual(before + 2000);
+        });
+
+        it('keeps the row pending and backs off with an incremented attemptCount on a 500/network error', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockRejectedValueOnce(httpError(500));
+
+            const before = Date.now();
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'retry'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect(outbox?.attemptCount).toBe(1);
+            expect(outbox?.nextAttemptAt).toBeGreaterThan(before);
+        });
+
+        it('is a no-op for a non-pending / non-upsert outbox row', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedDraft({channelId, message: 'hello', serverUpdateAt: 0});
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Blocked});
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'done'});
+            expect(mockClient.upsertDraft).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('processOutboxDelete', () => {
+        const seedDeleteReady = async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, deletedFingerprint: 'fp'});
+        };
+
+        it('hands off to confirming_delete on success while retaining the tombstone', async () => {
+            await seedDeleteReady();
+            mockClient.deleteDraft.mockResolvedValueOnce(serverDraft());
+
+            const result = await processOutboxDelete(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'done'});
+            expect(mockClient.deleteDraft).toHaveBeenCalledWith(channelId, '', 'conn-test');
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Delete);
+            expect(outbox?.status).toBe(DraftOutboxStatus.ConfirmingDelete);
+            expect(outbox?.deletedFingerprint).toBe('fp');
+        });
+
+        it('blocks with unsupported_route and suspends on a 404 (a 404 is NOT success)', async () => {
+            await seedDeleteReady();
+            mockClient.deleteDraft.mockRejectedValueOnce(httpError(404));
+
+            const result = await processOutboxDelete(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'suspend'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Blocked);
+            expect(outbox?.lastErrorCode).toBe('unsupported_route');
+        });
+
+        it('blocks with scope_unverifiable and never DELETEs when channel membership is lost', async () => {
+            // Non-DM/GM channel with NO membership row -> authority cannot be verified.
+            await seedChannel(channelId, teamId, 'O');
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending});
+
+            const result = await processOutboxDelete(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'blocked'});
+            expect(mockClient.deleteDraft).not.toHaveBeenCalled();
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Blocked);
+            expect(outbox?.lastErrorCode).toBe('scope_unverifiable');
+        });
+
+        it('is a no-op for a non-pending delete row', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.ConfirmingDelete});
+
+            const result = await processOutboxDelete(serverUrl, channelId, '');
+
+            expect(result).toEqual({outcome: 'done'});
+            expect(mockClient.deleteDraft).not.toHaveBeenCalled();
         });
     });
 });

--- a/app/actions/remote/draft.test.ts
+++ b/app/actions/remote/draft.test.ts
@@ -1,0 +1,436 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {type Database} from '@nozbe/watermelondb';
+
+import {MM_TABLES} from '@constants/database';
+import {DraftOutboxOperation, DraftOutboxStatus} from '@constants/draft';
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+import {buildDraftOutboxId, getDraft, getDraftOutbox} from '@queries/servers/drafts';
+import {draftContentFingerprint, normalizeServerDraft} from '@utils/draft/sync';
+
+import {fetchDraftsForTeam, reconcileTeamDrafts} from './draft';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+import type DraftModel from '@typings/database/models/servers/draft';
+import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+
+const {SERVER: {DRAFT, DRAFT_OUTBOX}} = MM_TABLES;
+
+const serverUrl = 'drafts.remote.test.com';
+const teamId = 'teamid1teamid1teamid1teamid1';
+const channelId = 'channelid1channelid1channel1';
+const dmChannelId = 'dmchannel1dmchannel1dmchan01';
+const userId = 'userid1userid1userid1userid1';
+
+const mockClient = {
+    getDrafts: jest.fn(),
+};
+
+type SeedDraft = {
+    channelId: string;
+    rootId?: string;
+    message?: string;
+    type?: PostTypesUserCreatable | null;
+    props?: DraftProps | null;
+    fileIds?: string[];
+    files?: FileInfo[];
+    metadata?: PostMetadata;
+    serverUpdateAt?: number | null;
+    updateAt?: number;
+};
+
+type SeedOutbox = {
+    channelId: string;
+    rootId?: string;
+    operation: typeof DraftOutboxOperation[keyof typeof DraftOutboxOperation];
+    status: typeof DraftOutboxStatus[keyof typeof DraftOutboxStatus];
+    deletedFingerprint?: string | null;
+    lastErrorCode?: string | null;
+    keepLocal?: boolean;
+};
+
+const serverDraft = (over: Partial<DraftApi> = {}): DraftApi => ({
+    create_at: 1000,
+    update_at: 2000,
+    delete_at: 0,
+    user_id: userId,
+    channel_id: channelId,
+    root_id: '',
+    message: 'server message',
+    type: '' as PostType,
+    props: {},
+    file_ids: [],
+    ...over,
+});
+
+describe('app/actions/remote/draft', () => {
+    let database: Database;
+    let operator: ServerDataOperator;
+
+    const seedChannel = async (id: string, tId: string, type: ChannelType) => {
+        await operator.handleChannel({
+            channels: [{id, team_id: tId, type, display_name: 'channel', total_msg_count: 0} as Channel],
+            prepareRecordsOnly: false,
+        });
+    };
+
+    const seedMembership = async (id: string, tId: string) => {
+        await operator.handleMyChannel({
+            channels: [{id, team_id: tId, total_msg_count: 0} as Channel],
+            myChannels: [{id, channel_id: id, user_id: userId, msg_count: 0} as ChannelMembership],
+            prepareRecordsOnly: false,
+        });
+    };
+
+    const seedDraft = async (fields: SeedDraft) => {
+        await database.write(async (writer) => {
+            const record = database.collections.get<DraftModel>(DRAFT).prepareCreate((d) => {
+                d.channelId = fields.channelId;
+                d.rootId = fields.rootId ?? '';
+                d.message = fields.message ?? '';
+                d.type = fields.type ?? '';
+                d.props = fields.props ?? {};
+                d.fileIds = fields.fileIds ?? [];
+                d.files = fields.files ?? [];
+                d.metadata = fields.metadata;
+                d.serverUpdateAt = fields.serverUpdateAt ?? null;
+                d.updateAt = fields.updateAt ?? 1;
+            });
+            await writer.batch(record);
+        });
+    };
+
+    const seedOutbox = async (fields: SeedOutbox) => {
+        await database.write(async (writer) => {
+            const record = database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).prepareCreate((o) => {
+                o._raw.id = buildDraftOutboxId(fields.channelId, fields.rootId ?? '');
+                o.channelId = fields.channelId;
+                o.rootId = fields.rootId ?? '';
+                o.teamId = teamId;
+                o.operation = fields.operation;
+                o.status = fields.status;
+                o.generation = 1;
+                o.attemptCount = 0;
+                o.nextAttemptAt = 0;
+                o.keepLocal = fields.keepLocal ?? false;
+                o.lastErrorCode = fields.lastErrorCode ?? null;
+                o.deletedFingerprint = fields.deletedFingerprint ?? null;
+            });
+            await writer.batch(record);
+        });
+    };
+
+    beforeAll(() => {
+        // @ts-expect-error mock client only implements the methods used here
+        NetworkManager.getClient = () => mockClient;
+    });
+
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        database = DatabaseManager.serverDatabases[serverUrl]!.database;
+        operator = DatabaseManager.serverDatabases[serverUrl]!.operator;
+        mockClient.getDrafts.mockReset();
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    describe('fetchDraftsForTeam', () => {
+        it('returns the server drafts on success', async () => {
+            const drafts = [serverDraft()];
+            mockClient.getDrafts.mockResolvedValueOnce(drafts);
+
+            const result = await fetchDraftsForTeam(serverUrl, teamId);
+
+            expect(result.error).toBeUndefined();
+            expect(result.drafts).toEqual(drafts);
+            expect(mockClient.getDrafts).toHaveBeenCalledWith(teamId, undefined);
+        });
+
+        it('returns {error} and no drafts when the client rejects', async () => {
+            mockClient.getDrafts.mockRejectedValueOnce(new Error('network'));
+
+            const result = await fetchDraftsForTeam(serverUrl, teamId);
+
+            expect(result.drafts).toBeUndefined();
+            expect(result.error).toBeDefined();
+        });
+    });
+
+    describe('reconcileTeamDrafts', () => {
+        it('creates a local draft for a server-only draft (serverUpdateAt set, no outbox)', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'hello', update_at: 2500})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.error).toBeUndefined();
+            expect(result.applied).toBe(1);
+            expect(result.drafts?.length).toBe(1);
+
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('hello');
+            expect(draft?.serverUpdateAt).toBe(2500);
+            expect(draft?.updateAt).toBeGreaterThan(0);
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox).toBeUndefined();
+        });
+
+        it('replaces a clean existing draft when server content differs', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedDraft({channelId, message: 'old', serverUpdateAt: 1000});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'new', update_at: 3000})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('new');
+            expect(draft?.serverUpdateAt).toBe(3000);
+        });
+
+        it('does not write when a clean existing draft equals the server content (idempotent)', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedDraft({channelId, message: 'same', serverUpdateAt: 1000});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'same', update_at: 5000})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(0);
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('same');
+
+            // No write: the previously-observed serverUpdateAt is left untouched.
+            expect(draft?.serverUpdateAt).toBe(1000);
+        });
+
+        it('applies a differing payload even when server update_at equals the local observation', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedDraft({channelId, message: 'a', serverUpdateAt: 2000});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'b', update_at: 2000})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('b');
+            expect(draft?.serverUpdateAt).toBe(2000);
+        });
+
+        it('preserves local pending-upsert content and merges only server props', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            const localPriority = {priority: 'urgent'} as PostPriority;
+            await seedDraft({
+                channelId,
+                message: 'local',
+                fileIds: ['f1'],
+                files: [{id: 'f1', clientId: 'c1'} as FileInfo],
+                props: {a: 1},
+                metadata: {priority: localPriority},
+                serverUpdateAt: 0,
+                updateAt: 50,
+            });
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Pending});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({
+                message: 'server',
+                props: {b: 2},
+                file_ids: ['f2'],
+                priority: {priority: 'important'} as PostPriority,
+                update_at: 4000,
+            })]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+            const draft = await getDraft(database, channelId, '');
+
+            // Local intent wins for portable content.
+            expect(draft?.message).toBe('local');
+            expect(draft?.fileIds).toEqual(['f1']);
+            expect(draft?.metadata?.priority).toEqual(localPriority);
+            expect(draft?.updateAt).toBe(50);
+
+            // Server-owned passthrough props are merged; the observation is recorded.
+            expect(draft?.props).toEqual({b: 2});
+            expect(draft?.serverUpdateAt).toBe(4000);
+        });
+
+        it('applies remote portable fields for waiting_for_upload but preserves local files', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            const localFile = {id: 'old1', clientId: 'c1', localPath: 'path'} as FileInfo;
+            await seedDraft({
+                channelId,
+                message: 'old',
+                fileIds: ['old1'],
+                files: [localFile],
+                serverUpdateAt: 0,
+                updateAt: 50,
+            });
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.WaitingForUpload});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'new', file_ids: ['new1'], update_at: 6000})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('new');
+            expect(draft?.fileIds).toEqual(['new1']);
+            expect(draft?.serverUpdateAt).toBe(6000);
+
+            // In-progress upload state must survive.
+            expect(draft?.files).toEqual([localFile]);
+        });
+
+        it('leaves a blocked (unsyncable_empty) draft untouched', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedDraft({channelId, message: '', metadata: {priority: {priority: 'urgent'} as PostPriority}, serverUpdateAt: 0});
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Blocked, lastErrorCode: 'unsyncable_empty'});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'server', update_at: 7000})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(0);
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('');
+            expect(draft?.serverUpdateAt).toBe(0);
+        });
+
+        it('preserves a pending DELETE when the server fingerprint matches (stale echo)', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            const sdApi = serverDraft({message: 'deleted content', update_at: 8000});
+            const normalized = normalizeServerDraft(sdApi);
+            const fp = draftContentFingerprint({
+                message: normalized.message,
+                type: normalized.type,
+                props: normalized.props,
+                fileIds: normalized.fileIds,
+                priority: normalized.metadata?.priority,
+            });
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, deletedFingerprint: fp});
+            mockClient.getDrafts.mockResolvedValueOnce([sdApi]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(0);
+
+            // The draft is NOT recreated and the DELETE intent is retained.
+            const draft = await getDraft(database, channelId, '');
+            expect(draft).toBeUndefined();
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Delete);
+        });
+
+        it('abandons a pending DELETE and adopts server content when the fingerprint differs', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, deletedFingerprint: 'staleotherfingerprint'});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'reappeared', update_at: 8500})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+
+            // DELETE intent removed, server content adopted as a clean draft.
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox).toBeUndefined();
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('reappeared');
+            expect(draft?.serverUpdateAt).toBe(8500);
+        });
+
+        it('adopts a legacy draft first, then local intent wins over the snapshot', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+
+            // Legacy: serverUpdateAt null and NO outbox row.
+            await seedDraft({channelId, message: 'legacylocal', serverUpdateAt: null, updateAt: 20});
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'serverlegacy', props: {x: 1}, update_at: 9000})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+
+            // Adopted to a pending upsert, so local content wins; only props merge from the server.
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('legacylocal');
+            expect(draft?.props).toEqual({x: 1});
+            expect(draft?.serverUpdateAt).toBe(9000);
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Upsert);
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+        });
+
+        it('skips a non-member non-DM/GM channel but applies a DM/GM channel draft', async () => {
+            // In-team channel with NO membership: out of scope.
+            await seedChannel(channelId, teamId, 'O');
+
+            // DM channel (type D, empty team): always in scope.
+            await seedChannel(dmChannelId, '', 'D');
+
+            mockClient.getDrafts.mockResolvedValueOnce([
+                serverDraft({channel_id: channelId, message: 'private', update_at: 100}),
+                serverDraft({channel_id: dmChannelId, message: 'dm', update_at: 200}),
+            ]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+            expect(result.drafts?.length).toBe(1);
+
+            expect(await getDraft(database, channelId, '')).toBeUndefined();
+            const dmDraft = await getDraft(database, dmChannelId, '');
+            expect(dmDraft?.message).toBe('dm');
+        });
+
+        it('persists a reply draft even when its root post is not cached', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            const rootId = 'uncachedrootpostuncachedroot';
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({root_id: rootId, message: 'reply', update_at: 10000})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+            const draft = await getDraft(database, channelId, rootId);
+            expect(draft?.message).toBe('reply');
+            expect(draft?.rootId).toBe(rootId);
+        });
+
+        it('applies and deletes nothing when the drafts fetch fails', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+
+            // Already-synced local draft: adoptLegacyDrafts leaves it alone, so nothing should change.
+            await seedDraft({channelId, message: 'untouched', serverUpdateAt: 5000});
+            mockClient.getDrafts.mockRejectedValueOnce(new Error('network'));
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.error).toBeDefined();
+            expect(result.applied).toBeUndefined();
+
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('untouched');
+            expect(draft?.serverUpdateAt).toBe(5000);
+            expect(await getDraftOutbox(database, channelId, '')).toBeUndefined();
+        });
+
+        it('returns {error} when the server database is missing', async () => {
+            const result = await reconcileTeamDrafts('nonexistent.server', teamId);
+            expect(result.error).toBeDefined();
+        });
+    });
+});

--- a/app/actions/remote/draft.test.ts
+++ b/app/actions/remote/draft.test.ts
@@ -5,10 +5,12 @@ import {type Database} from '@nozbe/watermelondb';
 
 import {MM_TABLES} from '@constants/database';
 import {DraftOutboxOperation, DraftOutboxStatus} from '@constants/draft';
+import {PostTypes} from '@constants/post';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {buildDraftOutboxId, getDraft, getDraftOutbox} from '@queries/servers/drafts';
 import {draftContentFingerprint, normalizeServerDraft} from '@utils/draft/sync';
+import * as log from '@utils/log';
 
 import {computeNextAttemptAt, confirmDeleteTombstone, deleteAbsentCleanDraft, fetchDraftsForTeam, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts} from './draft';
 import {forceLogoutIfNecessary} from './session';
@@ -127,6 +129,17 @@ describe('app/actions/remote/draft', () => {
                 d.updateAt = fields.updateAt ?? 1;
             });
             await writer.batch(record);
+        });
+    };
+
+    const seedBoRConfig = async (duration = '30', maxTtl = '300') => {
+        await operator.handleConfigs({
+            configs: [
+                {id: 'BurnOnReadDurationSeconds', value: duration},
+                {id: 'BurnOnReadMaximumTimeToLiveSeconds', value: maxTtl},
+            ],
+            configsToDelete: [],
+            prepareRecordsOnly: false,
         });
     };
 
@@ -408,8 +421,9 @@ describe('app/actions/remote/draft', () => {
             // In-team channel with NO membership: out of scope.
             await seedChannel(channelId, teamId, 'O');
 
-            // DM channel (type D, empty team): always in scope.
+            // DM channel (type D, empty team) WITH a membership row: in scope.
             await seedChannel(dmChannelId, '', 'D');
+            await seedMembership(dmChannelId, '');
 
             mockClient.getDrafts.mockResolvedValueOnce([
                 serverDraft({channel_id: channelId, message: 'private', update_at: 100}),
@@ -462,6 +476,202 @@ describe('app/actions/remote/draft', () => {
         it('returns {error} when the server database is missing', async () => {
             const result = await reconcileTeamDrafts('nonexistent.server', teamId);
             expect(result.error).toBeDefined();
+        });
+
+        // --- Fix #9: tightened, authoritative per-draft scope + non-PII missing-channel handling. ---
+        describe('scope (fix #9)', () => {
+            it('skips a DM/GM channel draft when the user has no confirmed membership', async () => {
+                // DM channel present but NO membership row -> not authoritative.
+                await seedChannel(dmChannelId, '', 'D');
+                mockClient.getDrafts.mockResolvedValueOnce([serverDraft({channel_id: dmChannelId, message: 'dm', update_at: 100})]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                expect(result.applied).toBe(0);
+                expect(result.drafts?.length).toBe(0);
+                expect(await getDraft(database, dmChannelId, '')).toBeUndefined();
+            });
+
+            it('skips a non-DM/GM draft whose channel belongs to a different team even with membership', async () => {
+                // Member of the channel, but the channel is scoped to another team than the one reconciled.
+                await seedChannel(channelId, otherTeamId, 'O');
+                await seedMembership(channelId, otherTeamId);
+                mockClient.getDrafts.mockResolvedValueOnce([serverDraft({channel_id: channelId, message: 'x', update_at: 100})]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                expect(result.applied).toBe(0);
+                expect(result.drafts?.length).toBe(0);
+                expect(await getDraft(database, channelId, '')).toBeUndefined();
+            });
+
+            it('applies a non-DM/GM draft only with membership AND a matching channel team', async () => {
+                await seedChannel(channelId, teamId, 'O');
+                await seedMembership(channelId, teamId);
+                mockClient.getDrafts.mockResolvedValueOnce([serverDraft({channel_id: channelId, message: 'ok', update_at: 100})]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                expect(result.applied).toBe(1);
+                expect(result.drafts?.length).toBe(1);
+                expect((await getDraft(database, channelId, ''))?.message).toBe('ok');
+            });
+
+            it('skips a draft for a missing channel, sets missingDeps, and never logs a channel id', async () => {
+                await seedChannel(channelId, teamId, 'O');
+                await seedMembership(channelId, teamId);
+                const logSpy = jest.spyOn(log, 'logDebug');
+
+                const missingChannelId = 'missingchan00missingchan0000';
+                mockClient.getDrafts.mockResolvedValueOnce([
+                    serverDraft({channel_id: channelId, message: 'ok', update_at: 100}),
+                    serverDraft({channel_id: missingChannelId, message: 'orphan', update_at: 200}),
+                ]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                // The present-channel draft applies; the missing-channel draft is skipped but signals a retry.
+                expect(result.applied).toBe(1);
+                expect(result.missingDeps).toBe(true);
+                expect(await getDraft(database, missingChannelId, '')).toBeUndefined();
+
+                // No log call may carry the (PII) channel id — only a count is logged.
+                for (const call of logSpy.mock.calls) {
+                    expect(call).not.toContain(missingChannelId);
+                }
+            });
+
+            it('does not set missingDeps when every channel is present', async () => {
+                await seedChannel(channelId, teamId, 'O');
+                await seedMembership(channelId, teamId);
+                mockClient.getDrafts.mockResolvedValueOnce([serverDraft({channel_id: channelId, message: 'ok', update_at: 100})]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                expect(result.missingDeps).toBe(false);
+            });
+        });
+
+        // --- Fix #10: burn-on-read <-> normal transitions keep type and borConfig consistent. ---
+        describe('burn-on-read reconciliation (fix #10)', () => {
+            const images = {'http://img.test/a.png': {height: 10, width: 10}} as PostMetadata['images'];
+
+            it('drops a stale enabled borConfig when a clean BoR draft becomes normal on the server', async () => {
+                await seedChannel(channelId, teamId, 'O');
+                await seedMembership(channelId, teamId);
+                await seedDraft({
+                    channelId,
+                    message: 'hi',
+                    type: PostTypes.BURN_ON_READ as PostTypesUserCreatable,
+                    metadata: {images, borConfig: {enabled: true, borDurationSeconds: 30, borMaximumTimeToLiveSeconds: 300}},
+                    serverUpdateAt: 1000,
+                });
+
+                // Server now reports a normal (type '') draft.
+                mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'hi', update_at: 3000})]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                expect(result.applied).toBe(1);
+                const draft = await getDraft(database, channelId, '');
+                expect(draft?.type).toBe('');
+                expect(draft?.metadata?.borConfig).toBeUndefined();
+
+                // Device-local images survive the update.
+                expect(draft?.metadata?.images).toEqual(images);
+            });
+
+            it('reconstructs borConfig when a normal draft becomes BoR with valid server durations', async () => {
+                await seedChannel(channelId, teamId, 'O');
+                await seedMembership(channelId, teamId);
+                await seedBoRConfig('30', '300');
+                await seedDraft({channelId, message: 'hi', type: '', metadata: {images}, serverUpdateAt: 1000});
+
+                mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'hi', type: PostTypes.BURN_ON_READ as PostType, update_at: 3000})]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                expect(result.applied).toBe(1);
+                const draft = await getDraft(database, channelId, '');
+                expect(draft?.type).toBe(PostTypes.BURN_ON_READ);
+                expect(draft?.metadata?.borConfig).toEqual({enabled: true, borDurationSeconds: 30, borMaximumTimeToLiveSeconds: 300});
+                expect(draft?.metadata?.images).toEqual(images);
+            });
+
+            it('fails closed (BoR type, no borConfig) when the server BoR draft has no valid durations', async () => {
+                await seedChannel(channelId, teamId, 'O');
+                await seedMembership(channelId, teamId);
+
+                // No BoR durations config seeded -> reconstruction must not fabricate one.
+                await seedDraft({channelId, message: 'hi', type: '', metadata: {images}, serverUpdateAt: 1000});
+                mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'hi', type: PostTypes.BURN_ON_READ as PostType, update_at: 3000})]);
+
+                const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+                expect(result.applied).toBe(1);
+                const draft = await getDraft(database, channelId, '');
+                expect(draft?.type).toBe(PostTypes.BURN_ON_READ);
+                expect(draft?.metadata?.borConfig).toBeUndefined();
+                expect(draft?.metadata?.images).toEqual(images);
+            });
+        });
+
+        // --- Fix #4: a confirming-delete tombstone that matches the reappearing server content retries. ---
+        it('resets a ConfirmingDelete tombstone to Pending when the server fingerprint still matches (fix #4)', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            const sdApi = serverDraft({message: 'deleted content', update_at: 8000});
+            const normalized = normalizeServerDraft(sdApi);
+            const fp = draftContentFingerprint({
+                message: normalized.message,
+                type: normalized.type,
+                props: normalized.props,
+                fileIds: normalized.fileIds,
+                priority: normalized.metadata?.priority,
+            });
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.ConfirmingDelete, deletedFingerprint: fp});
+            mockClient.getDrafts.mockResolvedValueOnce([sdApi]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+
+            // The delete did NOT take (content still present) -> retry it: reset to Pending, retry state cleared.
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Delete);
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect(outbox?.attemptCount).toBe(0);
+            expect(outbox?.nextAttemptAt).toBe(0);
+            expect(await getDraft(database, channelId, '')).toBeUndefined();
+        });
+
+        // --- Fix #5: a keep_local delete whose fingerprint differs parks without disturbing the local draft. ---
+        it('parks a keep_local delete as unsyncable_empty on a differing fingerprint without touching the local draft (fix #5)', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+
+            // Retained empty/attachment-only local draft behind a keepLocal delete tombstone.
+            await seedDraft({channelId, message: '', fileIds: ['f1'], files: [{id: 'f1', clientId: 'c1'} as FileInfo], serverUpdateAt: 0});
+            await seedOutbox({channelId, operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, keepLocal: true, deletedFingerprint: 'staleotherfingerprintstale00'});
+
+            // Another client wrote genuinely new content after our delete.
+            mockClient.getDrafts.mockResolvedValueOnce([serverDraft({message: 'reappeared', update_at: 8500})]);
+
+            const result = await reconcileTeamDrafts(serverUrl, teamId);
+
+            expect(result.applied).toBe(1);
+
+            // The retained local draft is NEITHER resurrected with remote text NOR destroyed.
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.message).toBe('');
+            expect(draft?.fileIds).toEqual(['f1']);
+
+            // The delete is abandoned by parking the outbox as an unsyncable-empty upsert.
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Upsert);
+            expect(outbox?.status).toBe(DraftOutboxStatus.Blocked);
+            expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
+            expect(outbox?.keepLocal).toBe(false);
         });
     });
 
@@ -786,6 +996,68 @@ describe('app/actions/remote/draft', () => {
             expect(result).toEqual({outcome: 'done'});
             expect(mockClient.upsertDraft).not.toHaveBeenCalled();
         });
+
+        it('aborts the ack write when shouldAbort becomes true after the POST resolves (fix #1)', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockResolvedValueOnce(serverDraft({message: 'hello', update_at: 4242}));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '', {shouldAbort: () => true});
+
+            // The row is left untouched: no ack, still pending, serverUpdateAt unchanged.
+            expect(result).toEqual({outcome: 'done'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect((await getDraft(database, channelId, ''))?.serverUpdateAt).toBe(0);
+        });
+
+        it('aborts the ack write when the captured database is recreated during the POST (fix #1)', async () => {
+            await seedUpsertReady();
+            const originalDb = DatabaseManager.serverDatabases[serverUrl]!.database;
+            mockClient.upsertDraft.mockImplementationOnce(async () => {
+                // A logout/wipe recreates the server DB while the POST is in flight.
+                DatabaseManager.serverDatabases[serverUrl]!.database = {} as Database;
+                return serverDraft({message: 'hello', update_at: 4242});
+            });
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '');
+
+            // Restore the real DB before asserting and cleaning up.
+            DatabaseManager.serverDatabases[serverUrl]!.database = originalDb;
+
+            expect(result).toEqual({outcome: 'done'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect((await getDraft(database, channelId, ''))?.serverUpdateAt).toBe(0);
+        });
+
+        it('does not clear the outbox when the observation ordinal changed during the POST (fix #6 fence)', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockResolvedValueOnce(serverDraft({message: 'hello', update_at: 8888}));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '', {
+                captureObservation: () => 1,
+                observationChanged: () => true, // a reconcile GET observed newer content mid-POST
+            });
+
+            // Treated like a generation mismatch: outbox retained (pending), only serverUpdateAt advances.
+            expect(result).toEqual({outcome: 'retry'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
+            expect((await getDraft(database, channelId, ''))?.serverUpdateAt).toBe(8888);
+        });
+
+        it('clears the outbox normally when the observation ordinal is unchanged (fix #6 fence)', async () => {
+            await seedUpsertReady();
+            mockClient.upsertDraft.mockResolvedValueOnce(serverDraft({message: 'hello', update_at: 9999}));
+
+            const result = await processOutboxUpsert(serverUrl, channelId, '', {
+                captureObservation: () => 3,
+                observationChanged: () => false,
+            });
+
+            expect(result).toEqual({outcome: 'done'});
+            expect(await getDraftOutbox(database, channelId, '')).toBeUndefined();
+        });
     });
 
     describe('processOutboxDelete', () => {
@@ -844,6 +1116,19 @@ describe('app/actions/remote/draft', () => {
 
             expect(result).toEqual({outcome: 'done'});
             expect(mockClient.deleteDraft).not.toHaveBeenCalled();
+        });
+
+        it('does not transition to confirming_delete when shouldAbort is true after the DELETE (fix #1)', async () => {
+            await seedDeleteReady();
+            mockClient.deleteDraft.mockResolvedValueOnce(serverDraft());
+
+            const result = await processOutboxDelete(serverUrl, channelId, '', {shouldAbort: () => true});
+
+            // The row is left untouched: still a Pending delete, no confirming transition written.
+            expect(result).toEqual({outcome: 'done'});
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Delete);
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
         });
     });
 });

--- a/app/actions/remote/draft.test.ts
+++ b/app/actions/remote/draft.test.ts
@@ -10,7 +10,7 @@ import NetworkManager from '@managers/network_manager';
 import {buildDraftOutboxId, getDraft, getDraftOutbox} from '@queries/servers/drafts';
 import {draftContentFingerprint, normalizeServerDraft} from '@utils/draft/sync';
 
-import {fetchDraftsForTeam, reconcileTeamDrafts} from './draft';
+import {confirmDeleteTombstone, deleteAbsentCleanDraft, fetchDraftsForTeam, getReconcilableKeys, reconcileTeamDrafts} from './draft';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 import type DraftModel from '@typings/database/models/servers/draft';
@@ -20,7 +20,9 @@ const {SERVER: {DRAFT, DRAFT_OUTBOX}} = MM_TABLES;
 
 const serverUrl = 'drafts.remote.test.com';
 const teamId = 'teamid1teamid1teamid1teamid1';
+const otherTeamId = 'otherteamotherteamotherteam1';
 const channelId = 'channelid1channelid1channel1';
+const channelId2 = 'channelid2channelid2channel2';
 const dmChannelId = 'dmchannel1dmchannel1dmchan01';
 const userId = 'userid1userid1userid1userid1';
 
@@ -49,6 +51,7 @@ type SeedOutbox = {
     deletedFingerprint?: string | null;
     lastErrorCode?: string | null;
     keepLocal?: boolean;
+    teamId?: string;
 };
 
 const serverDraft = (over: Partial<DraftApi> = {}): DraftApi => ({
@@ -108,7 +111,7 @@ describe('app/actions/remote/draft', () => {
                 o._raw.id = buildDraftOutboxId(fields.channelId, fields.rootId ?? '');
                 o.channelId = fields.channelId;
                 o.rootId = fields.rootId ?? '';
-                o.teamId = teamId;
+                o.teamId = fields.teamId ?? teamId;
                 o.operation = fields.operation;
                 o.status = fields.status;
                 o.generation = 1;
@@ -431,6 +434,122 @@ describe('app/actions/remote/draft', () => {
         it('returns {error} when the server database is missing', async () => {
             const result = await reconcileTeamDrafts('nonexistent.server', teamId);
             expect(result.error).toBeDefined();
+        });
+    });
+
+    describe('getReconcilableKeys', () => {
+        it('classifies clean drafts, dirty drafts, and in-scope tombstones with correct flags; excludes out-of-scope tombstones', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedMembership(channelId, teamId);
+            await seedChannel(dmChannelId, '', 'D'); // DM: authoritative even without a membership row.
+
+            // Clean server-backed draft (Rule A eligible).
+            await seedDraft({channelId, rootId: '', message: 'clean', serverUpdateAt: 1000});
+
+            // Pending-upsert draft (non-eligible: it has local intent).
+            const dirtyRoot = 'dirtyrootdirtyrootdirtyroot1';
+            await seedDraft({channelId, rootId: dirtyRoot, message: 'dirty', serverUpdateAt: 0});
+            await seedOutbox({channelId, rootId: dirtyRoot, operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Pending});
+
+            // keepLocal delete tombstone on a DM (team '') -> in scope via the DM/GM membership rule.
+            await seedOutbox({channelId: dmChannelId, rootId: '', operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, keepLocal: true, teamId: ''});
+
+            // Out-of-scope tombstone: stored under a different team on a non-DM/GM channel.
+            await seedChannel(channelId2, otherTeamId, 'O');
+            await seedOutbox({channelId: channelId2, rootId: '', operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, teamId: otherTeamId});
+
+            const keys = await getReconcilableKeys(database, teamId);
+
+            const clean = keys.find((k) => k.channelId === channelId && k.rootId === '' && k.kind === 'draft');
+            expect(clean).toMatchObject({serverUpdateAt: 1000, hasOutbox: false, authoritative: true});
+
+            const dirty = keys.find((k) => k.channelId === channelId && k.rootId === dirtyRoot && k.kind === 'draft');
+            expect(dirty).toMatchObject({hasOutbox: true, outboxOperation: DraftOutboxOperation.Upsert, authoritative: true});
+
+            const tombstone = keys.find((k) => k.channelId === dmChannelId && k.kind === 'tombstone');
+            expect(tombstone).toMatchObject({keepLocal: true, outboxOperation: DraftOutboxOperation.Delete, authoritative: true});
+
+            // The out-of-scope tombstone must be excluded entirely.
+            expect(keys.some((k) => k.channelId === channelId2)).toBe(false);
+            expect(keys.length).toBe(3);
+        });
+
+        it('dedups a draft+tombstone key to a single tombstone and flags membership-lost channels non-authoritative', async () => {
+            // In-team channel WITHOUT a membership row -> not authoritative.
+            await seedChannel(channelId, teamId, 'O');
+
+            // A keepLocal=true delete retains a Draft AND a tombstone under the same key.
+            await seedDraft({channelId, rootId: '', message: 'kept', serverUpdateAt: 2000});
+            await seedOutbox({channelId, rootId: '', operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, keepLocal: true});
+
+            const keys = await getReconcilableKeys(database, teamId);
+
+            const forKey = keys.filter((k) => k.channelId === channelId && k.rootId === '');
+            expect(forKey.length).toBe(1);
+            expect(forKey[0].kind).toBe('tombstone');
+            expect(forKey[0].authoritative).toBe(false);
+        });
+    });
+
+    describe('deleteAbsentCleanDraft', () => {
+        it('destroys a still-clean server-backed draft', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedDraft({channelId, rootId: '', message: 'clean', serverUpdateAt: 3000});
+
+            await deleteAbsentCleanDraft(serverUrl, channelId, '');
+
+            expect(await getDraft(database, channelId, '')).toBeUndefined();
+        });
+
+        it('no-ops when the draft gained an outbox (dirtied) since the decision', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedDraft({channelId, rootId: '', message: 'clean', serverUpdateAt: 3000});
+            await seedOutbox({channelId, rootId: '', operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Pending});
+
+            await deleteAbsentCleanDraft(serverUrl, channelId, '');
+
+            expect(await getDraft(database, channelId, '')).toBeDefined();
+        });
+    });
+
+    describe('confirmDeleteTombstone', () => {
+        it('removes the outbox row for an ordinary (keepLocal=false) delete', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedOutbox({channelId, rootId: '', operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, keepLocal: false});
+
+            await confirmDeleteTombstone(serverUrl, channelId, '');
+
+            expect(await getDraftOutbox(database, channelId, '')).toBeUndefined();
+        });
+
+        it('parks unsyncable_empty and clears serverUpdateAt for a keepLocal=true delete', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedDraft({channelId, rootId: '', message: 'kept', serverUpdateAt: 4000});
+            await seedOutbox({channelId, rootId: '', operation: DraftOutboxOperation.Delete, status: DraftOutboxStatus.Pending, keepLocal: true, deletedFingerprint: 'fp'});
+
+            await confirmDeleteTombstone(serverUrl, channelId, '');
+
+            const draft = await getDraft(database, channelId, '');
+            expect(draft?.serverUpdateAt).toBe(0);
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Upsert);
+            expect(outbox?.status).toBe(DraftOutboxStatus.Blocked);
+            expect(outbox?.lastErrorCode).toBe('unsyncable_empty');
+            expect(outbox?.keepLocal).toBe(false);
+            expect(outbox?.deletedFingerprint).toBeNull();
+        });
+
+        it('no-ops when the tombstone flipped to a genuine upsert since the decision', async () => {
+            await seedChannel(channelId, teamId, 'O');
+            await seedDraft({channelId, rootId: '', message: 'edited', serverUpdateAt: 0});
+            await seedOutbox({channelId, rootId: '', operation: DraftOutboxOperation.Upsert, status: DraftOutboxStatus.Pending});
+
+            await confirmDeleteTombstone(serverUrl, channelId, '');
+
+            const outbox = await getDraftOutbox(database, channelId, '');
+            expect(outbox?.operation).toBe(DraftOutboxOperation.Upsert);
+            expect(outbox?.status).toBe(DraftOutboxStatus.Pending);
         });
     });
 });

--- a/app/actions/remote/draft.ts
+++ b/app/actions/remote/draft.ts
@@ -5,14 +5,15 @@ import {Q, type Database, type Model} from '@nozbe/watermelondb';
 
 import {General} from '@constants';
 import {MM_TABLES} from '@constants/database';
-import {DraftOutboxOperation, DraftOutboxStatus} from '@constants/draft';
+import {DRAFT_SYNC_RETRY_BASE_MS, DRAFT_SYNC_RETRY_JITTER, DRAFT_SYNC_RETRY_MAX_MS, DraftOutboxOperation, DraftOutboxStatus} from '@constants/draft';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
+import websocketManager from '@managers/websocket_manager';
 import {getChannelById, getMyChannel} from '@queries/servers/channel';
-import {adoptLegacyDrafts, buildDraftOutboxId, getDraftOutbox, mutateDraftAndOutbox, prepareDraftOutbox, queryDraftsForTeam, type PrepareDraftAndOutbox} from '@queries/servers/drafts';
+import {adoptLegacyDrafts, buildDraftOutboxId, getDraft, getDraftOutbox, mutateDraftAndOutbox, prepareDraftOutbox, queryDraftsForTeam, type PrepareDraftAndOutbox} from '@queries/servers/drafts';
 import {getConfigValue} from '@queries/servers/system';
-import {draftContentFingerprint, normalizeServerDraft, type NormalizedDraft} from '@utils/draft/sync';
-import {getFullErrorMessage} from '@utils/errors';
+import {buildDraftUpsertRequest, draftContentFingerprint, normalizeServerDraft, type NormalizedDraft} from '@utils/draft/sync';
+import {getFullErrorMessage, isErrorWithStatusCode} from '@utils/errors';
 import {logDebug, logError} from '@utils/log';
 
 import {forceLogoutIfNecessary} from './session';
@@ -417,4 +418,335 @@ export async function confirmDeleteTombstone(serverUrl: string, channelId: strin
     } catch (error) {
         logError('confirmDeleteTombstone', getFullErrorMessage(error));
     }
+}
+
+/**
+ * WorkerOutcome: the result of a single per-key outbox worker run.
+ *  - done: nothing left to do for this generation (removed / acked / no-op).
+ *  - retry: transient failure or a newer generation remains; the row stays time-driven.
+ *  - blocked: parked awaiting an external signal (edit/unblock); not time-driven.
+ *  - suspend: a server-wide failure (sync disabled / unsupported route); stop this session.
+ *  - converted: the upsert was rewritten into a delete; drain will pick the delete up next.
+ */
+export type WorkerOutcome = {
+    outcome: 'done' | 'retry' | 'blocked' | 'suspend' | 'converted';
+    retryAfterMs?: number;
+};
+
+// Non-sensitive outbox error classifications persisted to last_error_code.
+const OUTBOX_ERROR = {
+    MissingLocalDraft: 'missing_local_draft',
+    Forbidden: 'forbidden',
+    UnsupportedRoute: 'unsupported_route',
+    SyncDisabled: 'sync_disabled',
+    Invalid: 'invalid',
+    ScopeUnverifiable: 'scope_unverifiable',
+} as const;
+
+/**
+ * computeNextAttemptAt: the next absolute retry timestamp for a failed outbox row. When the server
+ * supplies a Retry-After (retryAfterMs) it is honored verbatim. Otherwise it is capped exponential
+ * backoff (DRAFT_SYNC_RETRY_BASE_MS * 2^attemptCount, ceilinged at DRAFT_SYNC_RETRY_MAX_MS) with
+ * +/-DRAFT_SYNC_RETRY_JITTER proportional jitter. The result is never negative.
+ */
+export function computeNextAttemptAt(attemptCount: number, now: number, retryAfterMs?: number): number {
+    if (retryAfterMs != null) {
+        return Math.max(0, now + retryAfterMs);
+    }
+
+    const base = Math.min(DRAFT_SYNC_RETRY_BASE_MS * (2 ** attemptCount), DRAFT_SYNC_RETRY_MAX_MS);
+    const jitter = base * DRAFT_SYNC_RETRY_JITTER * ((Math.random() * 2) - 1);
+    return Math.max(0, Math.round(now + base + jitter));
+}
+
+// isErrorWithHeaders: narrow guard for a ClientError-shaped object carrying response headers.
+const isErrorWithHeaders = (error: unknown): error is {headers: Record<string, string>} => {
+    return typeof error === 'object' && error !== null && 'headers' in error &&
+        typeof (error as {headers: unknown}).headers === 'object' && (error as {headers: unknown}).headers !== null;
+};
+
+// readRetryAfterMs: parse a Retry-After (seconds) response header into milliseconds, or undefined.
+const readRetryAfterMs = (error: unknown): number | undefined => {
+    if (!isErrorWithHeaders(error)) {
+        return undefined;
+    }
+    const raw = error.headers['Retry-After'] ?? error.headers['retry-after'];
+    if (!raw) {
+        return undefined;
+    }
+    const seconds = parseInt(raw, 10);
+    if (Number.isNaN(seconds) || seconds < 0) {
+        return undefined;
+    }
+    return seconds * 1000;
+};
+
+/**
+ * classifyOutboxError: map a caught worker error to a WorkerOutcome and persist the matching outbox
+ * transition (guarded by generation so a newer local edit during the request is never clobbered).
+ * See the error-classification table in the drafts-sync spec. Never logs message/props/file/ids.
+ */
+const classifyOutboxError = async (
+    serverUrl: string,
+    database: Database,
+    channelId: string,
+    rootId: string,
+    generation: number,
+    error: unknown,
+    logPrefix: string,
+    isDelete: boolean,
+): Promise<WorkerOutcome> => {
+    const status = isErrorWithStatusCode(error) ? error.status_code : undefined;
+    logDebug(`${logPrefix}: request failed`, `status=${status ?? 'none'}`, getFullErrorMessage(error));
+
+    // Persist an outbox transition only while the generation still matches the one we sent.
+    const applyOutbox = (mutate: (o: DraftOutboxModel) => void) => mutateDraftAndOutbox(database, channelId, rootId, ({outbox}) => {
+        if (!outbox || outbox.generation !== generation) {
+            return [];
+        }
+        return [outbox.prepareUpdate(mutate)];
+    });
+
+    switch (status) {
+        case 401:
+            // The forced-logout flow owns recovery; leave the row pending for after re-auth.
+            forceLogoutIfNecessary(serverUrl, error);
+            return {outcome: 'retry'};
+        case 403:
+            await applyOutbox((o) => {
+                o.status = DraftOutboxStatus.Blocked;
+                o.lastErrorCode = OUTBOX_ERROR.Forbidden;
+            });
+            return {outcome: 'blocked'};
+        case 400:
+            await applyOutbox((o) => {
+                o.status = DraftOutboxStatus.Blocked;
+                o.lastErrorCode = OUTBOX_ERROR.Invalid;
+            });
+            return {outcome: 'blocked'};
+        case 429: {
+            const retryAfterMs = readRetryAfterMs(error);
+            await applyOutbox((o) => {
+                o.attemptCount += 1;
+                o.nextAttemptAt = computeNextAttemptAt(o.attemptCount, Date.now(), retryAfterMs);
+            });
+            return {outcome: 'retry', retryAfterMs};
+        }
+        case 501:
+            await applyOutbox((o) => {
+                o.status = DraftOutboxStatus.Blocked;
+                o.lastErrorCode = OUTBOX_ERROR.SyncDisabled;
+            });
+            return {outcome: 'suspend'};
+        case 404:
+            if (isDelete) {
+                // The supported delete route returns 200 even for an already-absent row, so a 404 means
+                // the route/capability is unavailable: block and suspend this session.
+                await applyOutbox((o) => {
+                    o.status = DraftOutboxStatus.Blocked;
+                    o.lastErrorCode = OUTBOX_ERROR.UnsupportedRoute;
+                });
+                return {outcome: 'suspend'};
+            }
+
+            // A 404 on upsert is not otherwise expected; treat as transient with capped backoff.
+            await applyOutbox((o) => {
+                o.attemptCount += 1;
+                o.nextAttemptAt = computeNextAttemptAt(o.attemptCount, Date.now());
+            });
+            return {outcome: 'retry'};
+        default:
+            // 5xx / network / timeout / malformed response: keep pending with capped backoff.
+            await applyOutbox((o) => {
+                o.attemptCount += 1;
+                o.nextAttemptAt = computeNextAttemptAt(o.attemptCount, Date.now());
+            });
+            return {outcome: 'retry'};
+    }
+};
+
+/**
+ * processOutboxUpsert: drain a single Pending upsert outbox row to the server. It is DB-focused: it
+ * captures the row generation, POSTs outside any writer, then re-checks the generation inside the ack
+ * writer so a newer local edit during the POST is never clobbered. Epoch checks are the caller's job.
+ */
+export async function processOutboxUpsert(serverUrl: string, channelId: string, rootId: string): Promise<WorkerOutcome> {
+    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+    if (!database) {
+        return {outcome: 'done'};
+    }
+
+    const outbox = await getDraftOutbox(database, channelId, rootId);
+    if (!outbox || outbox.operation !== DraftOutboxOperation.Upsert || outbox.status !== DraftOutboxStatus.Pending) {
+        return {outcome: 'done'};
+    }
+
+    const draft = await getDraft(database, channelId, rootId);
+
+    // A pending upsert with no local Draft is unresolvable: never fabricate content or POST.
+    if (!draft) {
+        logDebug('processOutboxUpsert: no local draft for pending upsert');
+        await mutateDraftAndOutbox(database, channelId, rootId, ({outbox: o}) => {
+            if (!o || o.operation !== DraftOutboxOperation.Upsert || o.status !== DraftOutboxStatus.Pending) {
+                return [];
+            }
+            return [o.prepareUpdate((x) => {
+                x.status = DraftOutboxStatus.Blocked;
+                x.lastErrorCode = OUTBOX_ERROR.MissingLocalDraft;
+            })];
+        });
+        return {outcome: 'blocked'};
+    }
+
+    const request = buildDraftUpsertRequest({
+        channelId: draft.channelId,
+        rootId: draft.rootId,
+        message: draft.message,
+        type: draft.type as PostTypesUserCreatable | null,
+        props: draft.props,
+        fileIds: draft.fileIds ?? [],
+        metadata: draft.metadata,
+    });
+    if (!request) {
+        // Empty message: the server treats an empty upsert as a delete. Convert to an explicit delete
+        // when there is remote/attachment state to clear; otherwise park as unsyncable-empty.
+        const hasFiles = draft.files.length > 0;
+        const wasDispatched = (draft.serverUpdateAt ?? 0) > 0;
+        if (hasFiles || wasDispatched) {
+            const deletedFingerprint = draftContentFingerprint({
+                message: draft.message,
+                type: draft.type,
+                props: draft.props,
+                fileIds: draft.fileIds ?? [],
+                priority: draft.metadata?.priority,
+            });
+            await mutateDraftAndOutbox(database, channelId, rootId, ({database: db, outbox: o}) => {
+                if (!o) {
+                    return [];
+                }
+                return prepareDraftOutbox(db, channelId, rootId, o.teamId, o, {type: 'delete', keepLocal: hasFiles, deletedFingerprint});
+            });
+            return {outcome: 'converted'};
+        }
+
+        await mutateDraftAndOutbox(database, channelId, rootId, ({database: db, outbox: o}) => {
+            if (!o) {
+                return [];
+            }
+            return prepareDraftOutbox(db, channelId, rootId, o.teamId, o, {type: 'park'});
+        });
+        return {outcome: 'blocked'};
+    }
+
+    const generation = outbox.generation;
+    const connectionId = websocketManager.getClient(serverUrl)?.getConnectionId();
+
+    let draftApi: DraftApi;
+    try {
+        const client = NetworkManager.getClient(serverUrl);
+        draftApi = await client.upsertDraft(request, connectionId);
+    } catch (error) {
+        return classifyOutboxError(serverUrl, database, channelId, rootId, generation, error, 'processOutboxUpsert', false);
+    }
+
+    let outcome: WorkerOutcome = {outcome: 'done'};
+    await mutateDraftAndOutbox(database, channelId, rootId, ({database: db, draft: d, outbox: o}) => {
+        // A newer local mutation happened during the POST: do not clear the outbox or overwrite newer
+        // content; only advance the observed server_update_at. A newer generation remains to send.
+        if (!o || o.generation !== generation) {
+            outcome = {outcome: 'retry'};
+            if (d) {
+                const observed = Math.max(d.serverUpdateAt ?? 0, draftApi.update_at);
+                return [d.prepareUpdate((x) => {
+                    x.serverUpdateAt = observed;
+                })];
+            }
+            return [];
+        }
+
+        const models: Model[] = [];
+        if (d) {
+            models.push(d.prepareUpdate((x) => {
+                x.serverUpdateAt = draftApi.update_at;
+            }));
+        }
+
+        // An in-progress upload (a file with no server id) keeps the row alive as waiting_for_upload so
+        // the eventual upload-complete edit re-sends; otherwise the row is fully acked and removed. The
+        // waitingForUpload INTENT would no-op on a still-Pending row, so transition the status directly.
+        const hasPendingUpload = (d?.files ?? []).some((f) => !f.id);
+        if (hasPendingUpload) {
+            models.push(o.prepareUpdate((x) => {
+                x.status = DraftOutboxStatus.WaitingForUpload;
+                x.attemptCount = 0;
+                x.nextAttemptAt = 0;
+                x.lastErrorCode = null;
+            }));
+        } else {
+            models.push(...prepareDraftOutbox(db, channelId, rootId, o.teamId, o, {type: 'remove'}));
+        }
+        outcome = {outcome: 'done'};
+        return models;
+    });
+
+    return outcome;
+}
+
+/**
+ * processOutboxDelete: drain a single Pending delete tombstone to the server. A 200 is NOT proof of
+ * absence (replica lag), so success hands off to confirming_delete; the reconciliation absence pass
+ * clears the tombstone after confirmed GET absences. A 404 means the delete route is unsupported.
+ */
+export async function processOutboxDelete(serverUrl: string, channelId: string, rootId: string): Promise<WorkerOutcome> {
+    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+    if (!database) {
+        return {outcome: 'done'};
+    }
+
+    const outbox = await getDraftOutbox(database, channelId, rootId);
+    if (!outbox || outbox.operation !== DraftOutboxOperation.Delete || outbox.status !== DraftOutboxStatus.Pending) {
+        return {outcome: 'done'};
+    }
+
+    const generation = outbox.generation;
+
+    // Scope authority: a non-DM/GM channel whose membership row is gone cannot be verified; retain the
+    // tombstone and block rather than risk deleting a draft we no longer have authority over.
+    const channel = await getChannelById(database, channelId);
+    const isDmGm = channel?.type === General.DM_CHANNEL || channel?.type === General.GM_CHANNEL;
+    if (!isDmGm) {
+        const membership = await getMyChannel(database, channelId);
+        if (!membership) {
+            await mutateDraftAndOutbox(database, channelId, rootId, ({outbox: o}) => {
+                if (!o || o.generation !== generation) {
+                    return [];
+                }
+                return [o.prepareUpdate((x) => {
+                    x.status = DraftOutboxStatus.Blocked;
+                    x.lastErrorCode = OUTBOX_ERROR.ScopeUnverifiable;
+                })];
+            });
+            return {outcome: 'blocked'};
+        }
+    }
+
+    const connectionId = websocketManager.getClient(serverUrl)?.getConnectionId();
+    try {
+        const client = NetworkManager.getClient(serverUrl);
+        await client.deleteDraft(channelId, rootId, connectionId);
+    } catch (error) {
+        return classifyOutboxError(serverUrl, database, channelId, rootId, generation, error, 'processOutboxDelete', true);
+    }
+
+    // Success: hand off to the absence pass. A genuine edit that flipped the row to a new operation (or
+    // bumped the generation) is retained untouched for the drain to pick up next.
+    await mutateDraftAndOutbox(database, channelId, rootId, ({outbox: o}) => {
+        if (!o || o.operation !== DraftOutboxOperation.Delete || o.generation !== generation) {
+            return [];
+        }
+        return [o.prepareUpdate((x) => {
+            x.status = DraftOutboxStatus.ConfirmingDelete;
+        })];
+    });
+    return {outcome: 'done'};
 }

--- a/app/actions/remote/draft.ts
+++ b/app/actions/remote/draft.ts
@@ -1,0 +1,246 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {General} from '@constants';
+import {MM_TABLES} from '@constants/database';
+import {DraftOutboxOperation, DraftOutboxStatus} from '@constants/draft';
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+import {getChannelById, getMyChannel} from '@queries/servers/channel';
+import {adoptLegacyDrafts, mutateDraftAndOutbox, type PrepareDraftAndOutbox} from '@queries/servers/drafts';
+import {getConfigValue} from '@queries/servers/system';
+import {draftContentFingerprint, normalizeServerDraft, type NormalizedDraft} from '@utils/draft/sync';
+import {getFullErrorMessage} from '@utils/errors';
+import {logDebug, logError} from '@utils/log';
+
+import {forceLogoutIfNecessary} from './session';
+
+import type {Model} from '@nozbe/watermelondb';
+import type DraftModel from '@typings/database/models/servers/draft';
+
+const {SERVER: {DRAFT}} = MM_TABLES;
+
+/**
+ * fetchDraftsForTeam: fetch the server's authoritative draft snapshot for a team. Returns the raw
+ * DraftApi list on success. On failure it triggers a forced logout when the error warrants it,
+ * logs a non-PII error, and returns {error} so callers can fail closed (apply nothing).
+ */
+export async function fetchDraftsForTeam(serverUrl: string, teamId: string, groupLabel?: RequestGroupLabel): Promise<{drafts?: DraftApi[]; error?: unknown}> {
+    try {
+        const client = NetworkManager.getClient(serverUrl);
+        const drafts = await client.getDrafts(teamId, groupLabel);
+        return {drafts};
+    } catch (error) {
+        logError('fetchDraftsForTeam', getFullErrorMessage(error));
+        forceLogoutIfNecessary(serverUrl, error);
+        return {error};
+    }
+}
+
+/**
+ * applyServerPriority: produce the metadata to persist when the server owns the draft's priority.
+ * Existing device-local/portable metadata keys (borConfig, images) are preserved; only priority is
+ * taken from the server snapshot, and it is removed when the server no longer carries one.
+ */
+const applyServerPriority = (existing: PostMetadata | undefined, sd: NormalizedDraft): PostMetadata => {
+    const next: PostMetadata = {...existing};
+    if (sd.metadata?.priority) {
+        next.priority = sd.metadata.priority;
+    } else {
+        delete next.priority;
+    }
+    return next;
+};
+
+/**
+ * prepareIncomingDraft: the additive reconciliation matrix for a single draft key. Given the current
+ * local Draft/DraftOutbox rows (fetched inside the serialized writer) and the normalized server draft
+ * `sd`, it returns the prepared records to commit. It NEVER deletes a Draft for being absent from the
+ * server and NEVER performs a network operation — this is a READ-path snapshot applier only.
+ */
+const prepareIncomingDraft = (sd: NormalizedDraft): PrepareDraftAndOutbox => ({database, channelId, rootId, draft, outbox}) => {
+    const createCleanDraft = (): Model => database.collections.get<DraftModel>(DRAFT).prepareCreate((d) => {
+        d.channelId = channelId;
+        d.rootId = rootId;
+        d.message = sd.message;
+        d.type = sd.type;
+        d.props = sd.props;
+        d.fileIds = sd.fileIds;
+        d.files = sd.files;
+        d.metadata = sd.metadata;
+        d.serverUpdateAt = sd.serverUpdateAt;
+        d.updateAt = Date.now();
+    });
+
+    const updateCleanDraft = (existing: DraftModel): Model => existing.prepareUpdate((d) => {
+        d.message = sd.message;
+        d.type = sd.type;
+        d.props = sd.props;
+        d.fileIds = sd.fileIds;
+        d.files = sd.files;
+        d.metadata = applyServerPriority(d.metadata, sd);
+        d.serverUpdateAt = sd.serverUpdateAt;
+        d.updateAt = Date.now();
+    });
+
+    // A queued DELETE is authoritative local intent: the fingerprint distinguishes a stale replica
+    // echo of the very content we are deleting from genuinely new content written by another client.
+    if (outbox && outbox.operation === DraftOutboxOperation.Delete) {
+        const fp = draftContentFingerprint({
+            message: sd.message,
+            type: sd.type,
+            props: sd.props,
+            fileIds: sd.fileIds,
+            priority: sd.metadata?.priority,
+        });
+
+        if (fp === outbox.deletedFingerprint) {
+            // Stale echo of what we are deleting: preserve the DELETE, ignore the server content.
+            return [];
+        }
+
+        // New content arrived after our delete was enqueued: abandon the DELETE and adopt the
+        // server content as a clean local draft.
+        return [
+            outbox.prepareDestroyPermanently(),
+            draft ? updateCleanDraft(draft) : createCleanDraft(),
+        ];
+    }
+
+    // A pending UPSERT is unsynced local intent that wins: keep local message/files/type/priority and
+    // only merge the server-owned passthrough props while recording the observed server_update_at.
+    if (outbox && outbox.operation === DraftOutboxOperation.Upsert && outbox.status === DraftOutboxStatus.Pending) {
+        if (!draft) {
+            return [];
+        }
+
+        return [draft.prepareUpdate((d) => {
+            d.props = sd.props;
+            d.serverUpdateAt = sd.serverUpdateAt;
+        })];
+    }
+
+    // An in-progress/failed upload: apply the remote portable fields but preserve the local `files`
+    // array (which carries upload progress/failure state) untouched.
+    if (outbox && (outbox.status === DraftOutboxStatus.WaitingForUpload || outbox.status === DraftOutboxStatus.BlockedUpload)) {
+        if (!draft) {
+            return [];
+        }
+
+        return [draft.prepareUpdate((d) => {
+            d.message = sd.message;
+            d.type = sd.type;
+            d.props = sd.props;
+            d.fileIds = sd.fileIds;
+            d.metadata = applyServerPriority(d.metadata, sd);
+            d.serverUpdateAt = sd.serverUpdateAt;
+            d.updateAt = Date.now();
+        })];
+    }
+
+    // A parked unsyncable-empty draft: preserve it locally, ignore the server content.
+    if (outbox && outbox.status === DraftOutboxStatus.Blocked) {
+        return [];
+    }
+
+    // No outbox and no local draft: create the clean draft from the server snapshot.
+    if (!draft) {
+        return [createCleanDraft()];
+    }
+
+    // No outbox and a clean existing draft: the server snapshot is authoritative. Apply only when the
+    // portable content actually differs (idempotent otherwise); an equal server_update_at with a
+    // differing payload still applies.
+    const localFingerprint = draftContentFingerprint({
+        message: draft.message,
+        type: draft.type,
+        props: draft.props,
+        fileIds: draft.fileIds ?? [],
+        priority: draft.metadata?.priority,
+    });
+    const serverFingerprint = draftContentFingerprint({
+        message: sd.message,
+        type: sd.type,
+        props: sd.props,
+        fileIds: sd.fileIds,
+        priority: sd.metadata?.priority,
+    });
+
+    if (localFingerprint === serverFingerprint) {
+        return [];
+    }
+
+    return [updateCleanDraft(draft)];
+};
+
+/**
+ * reconcileTeamDrafts: apply the server's authoritative draft snapshot to local state additively.
+ * It adopts legacy drafts first (so local intent wins below), fetches the snapshot, and applies the
+ * incoming matrix per in-scope key. It NEVER deletes a Draft for being absent from the response, and
+ * it applies nothing when the GET fails (no baseline, no deletion). Returns the applied write count
+ * and the in-scope normalized drafts so a later absence-detection sub-step can track candidates.
+ */
+export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Promise<{applied?: number; drafts?: NormalizedDraft[]; error?: unknown}> {
+    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+    if (!database) {
+        return {error: `${serverUrl} database not found`};
+    }
+
+    try {
+        // Adopt pre-sync drafts FIRST so their local intent wins over the incoming snapshot below.
+        await adoptLegacyDrafts(database, teamId);
+
+        const res = await fetchDraftsForTeam(serverUrl, teamId);
+        if (res.error || !res.drafts) {
+            // GET failure: apply nothing. Without a baseline we must not create/update/delete anything.
+            return {error: res.error};
+        }
+
+        // BoR durations live in server config, not in draft props. Read them once; fail closed to
+        // undefined when unavailable so burn-on-read reconstruction never fabricates durations.
+        const borDurationSeconds = parseInt(await getConfigValue(database, 'BurnOnReadDurationSeconds') ?? '', 10);
+        const borMaximumTimeToLiveSeconds = parseInt(await getConfigValue(database, 'BurnOnReadMaximumTimeToLiveSeconds') ?? '', 10);
+        const durations = (borDurationSeconds > 0 && borMaximumTimeToLiveSeconds > 0) ? {borDurationSeconds, borMaximumTimeToLiveSeconds} : undefined;
+
+        const inScope: NormalizedDraft[] = [];
+        let applied = 0;
+
+        for (const serverDraft of res.drafts) {
+            const sd = normalizeServerDraft(serverDraft, durations);
+
+            // eslint-disable-next-line no-await-in-loop
+            const channel = await getChannelById(database, sd.channelId);
+            if (!channel) {
+                // Missing channel row: skip this key without aborting the others. A later reschedule
+                // reconciles it once the channel is hydrated.
+                logDebug('reconcileTeamDrafts: skipping draft for missing channel', sd.channelId);
+                continue;
+            }
+
+            const isDmGm = channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
+            let inScopeKey = isDmGm;
+            if (!inScopeKey) {
+                // eslint-disable-next-line no-await-in-loop
+                inScopeKey = Boolean(await getMyChannel(database, sd.channelId));
+            }
+
+            if (!inScopeKey) {
+                continue;
+            }
+
+            inScope.push(sd);
+
+            // eslint-disable-next-line no-await-in-loop
+            const models = await mutateDraftAndOutbox(database, sd.channelId, sd.rootId, prepareIncomingDraft(sd));
+            if (models.length > 0) {
+                applied += 1;
+            }
+        }
+
+        return {applied, drafts: inScope};
+    } catch (error) {
+        logError('reconcileTeamDrafts', getFullErrorMessage(error));
+        forceLogoutIfNecessary(serverUrl, error);
+        return {error};
+    }
+}

--- a/app/actions/remote/draft.ts
+++ b/app/actions/remote/draft.ts
@@ -213,7 +213,7 @@ const prepareIncomingDraft = (sd: NormalizedDraft): PrepareDraftAndOutbox => ({d
  * it applies nothing when the GET fails (no baseline, no deletion). Returns the applied write count
  * and the in-scope normalized drafts so a later absence-detection sub-step can track candidates.
  */
-export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Promise<{applied?: number; drafts?: NormalizedDraft[]; missingDeps?: boolean; error?: unknown}> {
+export async function reconcileTeamDrafts(serverUrl: string, teamId: string, opts?: ReconcileOpts): Promise<{applied?: number; drafts?: NormalizedDraft[]; missingDeps?: boolean; error?: unknown}> {
     const database = DatabaseManager.serverDatabases[serverUrl]?.database;
     if (!database) {
         return {error: `${serverUrl} database not found`};
@@ -229,6 +229,11 @@ export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Pr
             return {error: res.error};
         }
 
+        // Post-dispatch observation fence: announce every observed key SYNCHRONOUSLY, in the same tick
+        // the GET resolved and before any apply-loop await, so an in-flight POST's ack (which may run
+        // during that loop) sees the bumped ordinal and does not clobber content this GET observed.
+        opts?.onSnapshot?.(res.drafts.map((d) => ({channelId: d.channel_id, rootId: d.root_id})));
+
         // BoR durations live in server config, not in draft props. Read them once; fail closed to
         // undefined when unavailable so burn-on-read reconstruction never fabricates durations.
         const borDurationSeconds = parseInt(await getConfigValue(database, 'BurnOnReadDurationSeconds') ?? '', 10);
@@ -240,6 +245,14 @@ export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Pr
         let missingChannelCount = 0;
 
         for (const serverDraft of res.drafts) {
+            // The GET awaited above may have outlived the server: a logout/wipe/persistence-mode change
+            // can have destroyed or recreated the database mid-flight. Re-check before every snapshot
+            // write so a late completion never writes to a stale/destroyed database (the manager's own
+            // epoch check only runs AFTER this function returns — too late for these in-loop writes).
+            if (shouldAbortPostHttpWrite(serverUrl, database, opts)) {
+                return {error: 'reconcileTeamDrafts: server torn down during reconcile'};
+            }
+
             const sd = normalizeServerDraft(serverDraft, durations);
 
             // eslint-disable-next-line no-await-in-loop
@@ -490,12 +503,25 @@ export type OutboxWorkerOpts = {
 };
 
 /**
+ * ReconcileOpts: caller-supplied guards for the GET/reconcile path (see reconcileTeamDrafts).
+ *  - shouldAbort: same semantics as OutboxWorkerOpts.shouldAbort — true when the server lifecycle
+ *    changed under the in-flight GET, so no snapshot may be written to the (now stale) database.
+ *  - onSnapshot: invoked SYNCHRONOUSLY the moment the GET response is received (before any apply-loop
+ *    await), with every observed key. The manager uses it to bump the per-key observation ordinal for
+ *    in-flight POSTs, so a concurrent ack cannot clobber content this GET already observed.
+ */
+export type ReconcileOpts = {
+    shouldAbort?: () => boolean;
+    onSnapshot?: (keys: Array<{channelId: string; rootId: string}>) => void;
+};
+
+/**
  * shouldAbortPostHttpWrite: guards every post-HTTP database write. Returns true (abort, write nothing)
  * when the caller signals staleness OR the server database is no longer the SAME instance captured at
  * the top of the worker (recreated by a logout/wipe/re-login) or is now absent. A late HTTP completion
  * must never write to a destroyed/recreated database.
  */
-const shouldAbortPostHttpWrite = (serverUrl: string, database: Database, opts?: OutboxWorkerOpts): boolean => {
+const shouldAbortPostHttpWrite = (serverUrl: string, database: Database, opts?: {shouldAbort?: () => boolean}): boolean => {
     if (opts?.shouldAbort?.()) {
         return true;
     }

--- a/app/actions/remote/draft.ts
+++ b/app/actions/remote/draft.ts
@@ -41,17 +41,29 @@ export async function fetchDraftsForTeam(serverUrl: string, teamId: string, grou
 }
 
 /**
- * applyServerPriority: produce the metadata to persist when the server owns the draft's priority.
- * Existing device-local/portable metadata keys (borConfig, images) are preserved; only priority is
- * taken from the server snapshot, and it is removed when the server no longer carries one.
+ * applyServerMetadata: produce the metadata to persist for a remote update. Server-owned fields
+ * (priority and the normalized burn-on-read borConfig) come from the snapshot; only genuinely
+ * device-local metadata (markdown image dimensions) is preserved from the existing row. This keeps
+ * type and borConfig consistent: a normal->BoR update carries the reconstructed borConfig (or none
+ * when it fails closed), and a BoR->normal update drops a stale enabled borConfig so it can never
+ * be sent as burn-on-read. `sd.metadata.borConfig` is already reconstructed fail-closed upstream.
  */
-const applyServerPriority = (existing: PostMetadata | undefined, sd: NormalizedDraft): PostMetadata => {
-    const next: PostMetadata = {...existing};
+const applyServerMetadata = (existing: PostMetadata | undefined, sd: NormalizedDraft): PostMetadata => {
+    const next: PostMetadata = {};
+
+    // Device-local, non-portable metadata is preserved.
+    if (existing?.images) {
+        next.images = existing.images;
+    }
+
+    // Server-owned metadata replaces whatever was local.
     if (sd.metadata?.priority) {
         next.priority = sd.metadata.priority;
-    } else {
-        delete next.priority;
     }
+    if (sd.metadata?.borConfig) {
+        next.borConfig = sd.metadata.borConfig;
+    }
+
     return next;
 };
 
@@ -81,7 +93,7 @@ const prepareIncomingDraft = (sd: NormalizedDraft): PrepareDraftAndOutbox => ({d
         d.props = sd.props;
         d.fileIds = sd.fileIds;
         d.files = sd.files;
-        d.metadata = applyServerPriority(d.metadata, sd);
+        d.metadata = applyServerMetadata(d.metadata, sd);
         d.serverUpdateAt = sd.serverUpdateAt;
         d.updateAt = Date.now();
     });
@@ -98,12 +110,30 @@ const prepareIncomingDraft = (sd: NormalizedDraft): PrepareDraftAndOutbox => ({d
         });
 
         if (fp === outbox.deletedFingerprint) {
-            // Stale echo of what we are deleting: preserve the DELETE, ignore the server content.
+            // The server still holds the exact content we are deleting. For a Pending delete (not yet
+            // sent) that is expected — keep it pending; the drain will DELETE it. For a ConfirmingDelete
+            // (we already got a 200 but the content is still present) the delete did NOT take, so reset
+            // to Pending and let the drain retry the DELETE (naturally spaced by the confirmation GETs).
+            if (outbox.status === DraftOutboxStatus.ConfirmingDelete) {
+                return [outbox.prepareUpdate((o) => {
+                    o.status = DraftOutboxStatus.Pending;
+                    o.attemptCount = 0;
+                    o.nextAttemptAt = 0;
+                })];
+            }
             return [];
         }
 
-        // New content arrived after our delete was enqueued: abandon the DELETE and adopt the
-        // server content as a clean local draft.
+        // The server content differs from what we enqueued for deletion — another client wrote new
+        // content after our delete.
+        if (outbox.keepLocal) {
+            // keep_local: the retained empty/attachment-only local Draft must be neither resurrected
+            // nor replaced with remote text. Abandon the DELETE by parking it as unsyncable_empty so
+            // later reconciliations preserve the local Draft (and it never POSTs). Do NOT touch the Draft.
+            return prepareDraftOutbox(database, channelId, rootId, outbox.teamId, outbox, {type: 'park'});
+        }
+
+        // Ordinary delete: abandon it and adopt the new server content as a clean local draft.
         return [
             outbox.prepareDestroyPermanently(),
             draft ? updateCleanDraft(draft) : createCleanDraft(),
@@ -135,7 +165,7 @@ const prepareIncomingDraft = (sd: NormalizedDraft): PrepareDraftAndOutbox => ({d
             d.type = sd.type;
             d.props = sd.props;
             d.fileIds = sd.fileIds;
-            d.metadata = applyServerPriority(d.metadata, sd);
+            d.metadata = applyServerMetadata(d.metadata, sd);
             d.serverUpdateAt = sd.serverUpdateAt;
             d.updateAt = Date.now();
         })];
@@ -183,7 +213,7 @@ const prepareIncomingDraft = (sd: NormalizedDraft): PrepareDraftAndOutbox => ({d
  * it applies nothing when the GET fails (no baseline, no deletion). Returns the applied write count
  * and the in-scope normalized drafts so a later absence-detection sub-step can track candidates.
  */
-export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Promise<{applied?: number; drafts?: NormalizedDraft[]; error?: unknown}> {
+export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Promise<{applied?: number; drafts?: NormalizedDraft[]; missingDeps?: boolean; error?: unknown}> {
     const database = DatabaseManager.serverDatabases[serverUrl]?.database;
     if (!database) {
         return {error: `${serverUrl} database not found`};
@@ -207,6 +237,7 @@ export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Pr
 
         const inScope: NormalizedDraft[] = [];
         let applied = 0;
+        let missingChannelCount = 0;
 
         for (const serverDraft of res.drafts) {
             const sd = normalizeServerDraft(serverDraft, durations);
@@ -214,18 +245,22 @@ export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Pr
             // eslint-disable-next-line no-await-in-loop
             const channel = await getChannelById(database, sd.channelId);
             if (!channel) {
-                // Missing channel row: skip this key without aborting the others. A later reschedule
-                // reconciles it once the channel is hydrated.
-                logDebug('reconcileTeamDrafts: skipping draft for missing channel', sd.channelId);
+                // Missing channel row: skip this key without aborting the others and signal a
+                // guaranteed retry (missingDeps) so a later reschedule reconciles it once the channel
+                // is hydrated. NEVER log the channel id — DM/GM channel ids embed usernames (PII).
+                missingChannelCount += 1;
                 continue;
             }
 
             const isDmGm = channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL;
-            let inScopeKey = isDmGm;
-            if (!inScopeKey) {
-                // eslint-disable-next-line no-await-in-loop
-                inScopeKey = Boolean(await getMyChannel(database, sd.channelId));
-            }
+
+            // Authoritative scope: a confirmed membership row is required in every case (a DM/GM the
+            // user is not a member of is not authoritative). A non-DM/GM channel must additionally
+            // belong to the reconciled team — a channel mis-scoped to another team is not this run's
+            // authority — so it is skipped.
+            // eslint-disable-next-line no-await-in-loop
+            const isMember = Boolean(await getMyChannel(database, sd.channelId));
+            const inScopeKey = isDmGm ? isMember : (isMember && channel.teamId === teamId);
 
             if (!inScopeKey) {
                 continue;
@@ -240,7 +275,12 @@ export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Pr
             }
         }
 
-        return {applied, drafts: inScope};
+        if (missingChannelCount > 0) {
+            // Count only, no ids — the skip stays traceable without logging PII.
+            logDebug('reconcileTeamDrafts: skipped drafts for missing channels', missingChannelCount);
+        }
+
+        return {applied, drafts: inScope, missingDeps: missingChannelCount > 0};
     } catch (error) {
         logError('reconcileTeamDrafts', getFullErrorMessage(error));
         forceLogoutIfNecessary(serverUrl, error);
@@ -433,6 +473,35 @@ export type WorkerOutcome = {
     retryAfterMs?: number;
 };
 
+/**
+ * OutboxWorkerOpts: caller-supplied guards a worker consults ONLY after its HTTP call resolves and
+ * immediately before any post-HTTP database write.
+ *  - shouldAbort: true when the server lifecycle changed under the request (epoch bumped / server
+ *    invalidated); the worker must not write.
+ *  - captureObservation / observationChanged: the per-key observation ordinal fence. captureObservation
+ *    is read right before the POST dispatch; observationChanged(captured) is true in the ack when a
+ *    reconcile GET observed newer content for this key while the POST was in flight, so the ack must
+ *    not clobber it (see the manager's observationOrdinals).
+ */
+export type OutboxWorkerOpts = {
+    shouldAbort?: () => boolean;
+    captureObservation?: () => number;
+    observationChanged?: (captured: number) => boolean;
+};
+
+/**
+ * shouldAbortPostHttpWrite: guards every post-HTTP database write. Returns true (abort, write nothing)
+ * when the caller signals staleness OR the server database is no longer the SAME instance captured at
+ * the top of the worker (recreated by a logout/wipe/re-login) or is now absent. A late HTTP completion
+ * must never write to a destroyed/recreated database.
+ */
+const shouldAbortPostHttpWrite = (serverUrl: string, database: Database, opts?: OutboxWorkerOpts): boolean => {
+    if (opts?.shouldAbort?.()) {
+        return true;
+    }
+    return DatabaseManager.serverDatabases[serverUrl]?.database !== database;
+};
+
 // Non-sensitive outbox error classifications persisted to last_error_code.
 const OUTBOX_ERROR = {
     MissingLocalDraft: 'missing_local_draft',
@@ -570,7 +639,7 @@ const classifyOutboxError = async (
  * captures the row generation, POSTs outside any writer, then re-checks the generation inside the ack
  * writer so a newer local edit during the POST is never clobbered. Epoch checks are the caller's job.
  */
-export async function processOutboxUpsert(serverUrl: string, channelId: string, rootId: string): Promise<WorkerOutcome> {
+export async function processOutboxUpsert(serverUrl: string, channelId: string, rootId: string, opts?: OutboxWorkerOpts): Promise<WorkerOutcome> {
     const database = DatabaseManager.serverDatabases[serverUrl]?.database;
     if (!database) {
         return {outcome: 'done'};
@@ -641,24 +710,39 @@ export async function processOutboxUpsert(serverUrl: string, channelId: string, 
     const generation = outbox.generation;
     const connectionId = websocketManager.getClient(serverUrl)?.getConnectionId();
 
+    // Read the per-key observation ordinal right before dispatch so the ack can detect a reconcile GET
+    // that observed newer content for this key while the POST was in flight (see OutboxWorkerOpts).
+    const observation = opts?.captureObservation?.() ?? 0;
+
     let draftApi: DraftApi;
     try {
         const client = NetworkManager.getClient(serverUrl);
         draftApi = await client.upsertDraft(request, connectionId);
     } catch (error) {
+        // Late failure against a destroyed/recreated DB or a torn-down server: write nothing.
+        if (shouldAbortPostHttpWrite(serverUrl, database, opts)) {
+            return {outcome: 'done'};
+        }
         return classifyOutboxError(serverUrl, database, channelId, rootId, generation, error, 'processOutboxUpsert', false);
+    }
+
+    // Guard the success ack write: a logout/wipe during the POST must not write to a stale DB.
+    if (shouldAbortPostHttpWrite(serverUrl, database, opts)) {
+        return {outcome: 'done'};
     }
 
     let outcome: WorkerOutcome = {outcome: 'done'};
     await mutateDraftAndOutbox(database, channelId, rootId, ({database: db, draft: d, outbox: o}) => {
-        // A newer local mutation happened during the POST: do not clear the outbox or overwrite newer
-        // content; only advance the observed server_update_at. A newer generation remains to send.
-        if (!o || o.generation !== generation) {
+        // A newer local mutation happened during the POST (generation bumped) OR a reconcile GET
+        // observed newer content for this key while the POST was in flight (observation ordinal
+        // changed): do not clear the outbox or overwrite newer content; only advance the observed
+        // server_update_at. A re-POST will capture the new generation/ordinal.
+        if (!o || o.generation !== generation || opts?.observationChanged?.(observation)) {
             outcome = {outcome: 'retry'};
             if (d) {
-                const observed = Math.max(d.serverUpdateAt ?? 0, draftApi.update_at);
+                const observedUpdateAt = Math.max(d.serverUpdateAt ?? 0, draftApi.update_at);
                 return [d.prepareUpdate((x) => {
-                    x.serverUpdateAt = observed;
+                    x.serverUpdateAt = observedUpdateAt;
                 })];
             }
             return [];
@@ -697,7 +781,7 @@ export async function processOutboxUpsert(serverUrl: string, channelId: string, 
  * absence (replica lag), so success hands off to confirming_delete; the reconciliation absence pass
  * clears the tombstone after confirmed GET absences. A 404 means the delete route is unsupported.
  */
-export async function processOutboxDelete(serverUrl: string, channelId: string, rootId: string): Promise<WorkerOutcome> {
+export async function processOutboxDelete(serverUrl: string, channelId: string, rootId: string, opts?: OutboxWorkerOpts): Promise<WorkerOutcome> {
     const database = DatabaseManager.serverDatabases[serverUrl]?.database;
     if (!database) {
         return {outcome: 'done'};
@@ -735,7 +819,16 @@ export async function processOutboxDelete(serverUrl: string, channelId: string, 
         const client = NetworkManager.getClient(serverUrl);
         await client.deleteDraft(channelId, rootId, connectionId);
     } catch (error) {
+        // Late failure against a destroyed/recreated DB or a torn-down server: write nothing.
+        if (shouldAbortPostHttpWrite(serverUrl, database, opts)) {
+            return {outcome: 'done'};
+        }
         return classifyOutboxError(serverUrl, database, channelId, rootId, generation, error, 'processOutboxDelete', true);
+    }
+
+    // Guard the confirming-delete transition: a logout/wipe during the DELETE must not write to a stale DB.
+    if (shouldAbortPostHttpWrite(serverUrl, database, opts)) {
+        return {outcome: 'done'};
     }
 
     // Success: hand off to the absence pass. A genuine edit that flipped the row to a new operation (or

--- a/app/actions/remote/draft.ts
+++ b/app/actions/remote/draft.ts
@@ -1,13 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Q, type Database, type Model} from '@nozbe/watermelondb';
+
 import {General} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import {DraftOutboxOperation, DraftOutboxStatus} from '@constants/draft';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {getChannelById, getMyChannel} from '@queries/servers/channel';
-import {adoptLegacyDrafts, mutateDraftAndOutbox, type PrepareDraftAndOutbox} from '@queries/servers/drafts';
+import {adoptLegacyDrafts, buildDraftOutboxId, getDraftOutbox, mutateDraftAndOutbox, prepareDraftOutbox, queryDraftsForTeam, type PrepareDraftAndOutbox} from '@queries/servers/drafts';
 import {getConfigValue} from '@queries/servers/system';
 import {draftContentFingerprint, normalizeServerDraft, type NormalizedDraft} from '@utils/draft/sync';
 import {getFullErrorMessage} from '@utils/errors';
@@ -15,10 +17,10 @@ import {logDebug, logError} from '@utils/log';
 
 import {forceLogoutIfNecessary} from './session';
 
-import type {Model} from '@nozbe/watermelondb';
 import type DraftModel from '@typings/database/models/servers/draft';
+import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
 
-const {SERVER: {DRAFT}} = MM_TABLES;
+const {SERVER: {DRAFT, DRAFT_OUTBOX}} = MM_TABLES;
 
 /**
  * fetchDraftsForTeam: fetch the server's authoritative draft snapshot for a team. Returns the raw
@@ -242,5 +244,177 @@ export async function reconcileTeamDrafts(serverUrl: string, teamId: string): Pr
         logError('reconcileTeamDrafts', getFullErrorMessage(error));
         forceLogoutIfNecessary(serverUrl, error);
         return {error};
+    }
+}
+
+/**
+ * ReconcileKey: the classification payload for a single in-scope draft key considered by the
+ * manager's absence pass. `kind` distinguishes a plain Draft row from a delete tombstone (which
+ * drives the decision when both a Draft and a delete outbox exist for the key). `authoritative`
+ * is false when the channel membership cannot be confirmed for this scope (membership lost), in
+ * which case the key must be preserved (never deleted).
+ */
+export type ReconcileKey = {
+    channelId: string;
+    rootId: string;
+    kind: 'draft' | 'tombstone';
+    serverUpdateAt: number;
+    hasOutbox: boolean;
+    outboxOperation?: DraftOutboxOperation;
+    outboxStatus?: DraftOutboxStatus;
+    keepLocal?: boolean;
+    authoritative: boolean;
+};
+
+/**
+ * isChannelAuthoritative: a channel is authoritative for absence decisions when it is a DM/GM
+ * (always in scope) or the current user has a confirmed membership row for it. A non-DM/GM channel
+ * whose membership row is gone is NOT authoritative — its keys are preserved, never deleted.
+ */
+const isChannelAuthoritative = async (database: Database, channelId: string): Promise<boolean> => {
+    const channel = await getChannelById(database, channelId);
+    if (channel?.type === General.DM_CHANNEL || channel?.type === General.GM_CHANNEL) {
+        return true;
+    }
+    return Boolean(await getMyChannel(database, channelId));
+};
+
+/**
+ * getReconcilableKeys: enumerate every in-scope draft key (a Draft row and/or a delete tombstone)
+ * that the manager's absence pass may need to classify for `teamId`. Delete tombstones drive the
+ * decision, so a key that has both a Draft and a delete tombstone appears once as a `tombstone`.
+ * Only tombstones within this run's authority are returned: those whose stored teamId matches, or
+ * DM/GM ('' team) tombstones whose channel is a confirmed DM/GM channel. This function performs no
+ * network activity and never mutates state.
+ */
+export async function getReconcilableKeys(database: Database, teamId: string): Promise<ReconcileKey[]> {
+    const keys: ReconcileKey[] = [];
+    const tombstoneKeys = new Set<string>();
+
+    const deleteOutboxes = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
+        Q.where('operation', DraftOutboxOperation.Delete),
+    ).fetch();
+
+    for (const outbox of deleteOutboxes) {
+        // eslint-disable-next-line no-await-in-loop
+        const channel = await getChannelById(database, outbox.channelId);
+        const isDmGm = channel?.type === General.DM_CHANNEL || channel?.type === General.GM_CHANNEL;
+
+        // Scope gate: this run only has authority over tombstones stored under its team, or DM/GM
+        // ('' team) tombstones whose channel is a confirmed DM/GM channel. Skip everything else.
+        if (outbox.teamId !== teamId && !(outbox.teamId === '' && isDmGm)) {
+            continue;
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        const authoritative = isDmGm || Boolean(await getMyChannel(database, outbox.channelId));
+
+        tombstoneKeys.add(buildDraftOutboxId(outbox.channelId, outbox.rootId));
+        keys.push({
+            channelId: outbox.channelId,
+            rootId: outbox.rootId,
+            kind: 'tombstone',
+            serverUpdateAt: 0,
+            hasOutbox: true,
+            outboxOperation: outbox.operation,
+            outboxStatus: outbox.status,
+            keepLocal: outbox.keepLocal,
+            authoritative,
+        });
+    }
+
+    const drafts = await queryDraftsForTeam(database, teamId).fetch();
+    for (const draft of drafts) {
+        const key = buildDraftOutboxId(draft.channelId, draft.rootId);
+        if (tombstoneKeys.has(key)) {
+            // A delete tombstone already represents this key (a keepLocal=true delete retains a Draft).
+            continue;
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        const outbox = await getDraftOutbox(database, draft.channelId, draft.rootId);
+
+        // eslint-disable-next-line no-await-in-loop
+        const authoritative = await isChannelAuthoritative(database, draft.channelId);
+
+        keys.push({
+            channelId: draft.channelId,
+            rootId: draft.rootId,
+            kind: 'draft',
+            serverUpdateAt: draft.serverUpdateAt ?? 0,
+            hasOutbox: Boolean(outbox),
+            outboxOperation: outbox?.operation,
+            outboxStatus: outbox?.status,
+            keepLocal: outbox?.keepLocal,
+            authoritative,
+        });
+    }
+
+    return keys;
+}
+
+/**
+ * deleteAbsentCleanDraft: CONFIRMED-absence deletion of a clean, server-backed Draft (Rule A). It
+ * re-reads the key inside the serialized writer and only destroys the Draft when it is STILL clean
+ * (serverUpdateAt > 0 AND no outbox) — otherwise the state changed since the decision and it no-ops.
+ * Never performs a network operation.
+ */
+export async function deleteAbsentCleanDraft(serverUrl: string, channelId: string, rootId: string): Promise<void> {
+    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+    if (!database) {
+        return;
+    }
+
+    try {
+        await mutateDraftAndOutbox(database, channelId, rootId, ({draft, outbox}) => {
+            if (draft && !outbox && (draft.serverUpdateAt ?? 0) > 0) {
+                return [draft.prepareDestroyPermanently()];
+            }
+            return [];
+        });
+    } catch (error) {
+        logError('deleteAbsentCleanDraft', getFullErrorMessage(error));
+    }
+}
+
+/**
+ * confirmDeleteTombstone: CONFIRMED-absence resolution of a delete tombstone (Rule B). It re-reads
+ * the key inside the serialized writer; if the outbox is no longer a Delete (a genuine edit flipped
+ * it) it no-ops. For an ordinary delete (keepLocal=false) it removes the tombstone row (the visible
+ * Draft was already removed at enqueue time). For a keepLocal=true delete it detaches the retained
+ * Draft from the server (serverUpdateAt=0) and parks the outbox as unsyncable_empty. Never networks.
+ */
+export async function confirmDeleteTombstone(serverUrl: string, channelId: string, rootId: string): Promise<void> {
+    const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+    if (!database) {
+        return;
+    }
+
+    try {
+        await mutateDraftAndOutbox(database, channelId, rootId, ({database: db, draft, outbox}) => {
+            if (!outbox || outbox.operation !== DraftOutboxOperation.Delete) {
+                return [];
+            }
+            if (outbox.status !== DraftOutboxStatus.Pending && outbox.status !== DraftOutboxStatus.ConfirmingDelete) {
+                return [];
+            }
+
+            if (!outbox.keepLocal) {
+                // Ordinary delete: the visible Draft was already removed at enqueue time. If a Draft
+                // unexpectedly exists, leave it — only drop the tombstone row.
+                return prepareDraftOutbox(db, channelId, rootId, outbox.teamId, outbox, {type: 'remove'});
+            }
+
+            const models: Model[] = [];
+            if (draft) {
+                models.push(draft.prepareUpdate((d) => {
+                    d.serverUpdateAt = 0;
+                }));
+            }
+            models.push(...prepareDraftOutbox(db, channelId, rootId, outbox.teamId, outbox, {type: 'park'}));
+            return models;
+        });
+    } catch (error) {
+        logError('confirmDeleteTombstone', getFullErrorMessage(error));
     }
 }

--- a/app/actions/remote/entry/login.ts
+++ b/app/actions/remote/entry/login.ts
@@ -4,6 +4,7 @@
 import {fetchConfigAndLicense} from '@actions/remote/systems';
 import DatabaseManager from '@database/manager';
 import {getServerCredentials} from '@init/credentials';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import IntuneManager from '@managers/intune_manager';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
@@ -39,6 +40,7 @@ export async function loginEntry({serverUrl}: AfterLoginArgs): Promise<{error?: 
             const intunePolicy = await IntuneManager.getPolicy(serverUrl);
             SecurityManager.addServer(serverUrl, clData.config, false, intunePolicy);
             await EphemeralModeManager.addServer(serverUrl);
+            await DraftSyncManager.initialize(serverUrl);
             await WebsocketManager.createClient(serverUrl, credentials.token, credentials.preauthSecret);
             await WebsocketManager.initializeClient(serverUrl, 'Login');
         }

--- a/app/actions/remote/refresh.test.ts
+++ b/app/actions/remote/refresh.test.ts
@@ -6,6 +6,7 @@ import {terminateSession} from '@actions/local/session';
 import {refetchCurrentUser} from '@actions/remote/user';
 import DatabaseManager from '@database/manager';
 import {getServerCredentials} from '@init/credentials';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import WebsocketManager from '@managers/websocket_manager';
 import {getCurrentChannelId, getCurrentTeamId, getPushVerificationStatus, prepareCommonSystemValues} from '@queries/servers/system';
@@ -25,6 +26,10 @@ jest.mock('@actions/remote/user', () => ({
 }));
 jest.mock('@init/credentials', () => ({
     getServerCredentials: jest.fn(),
+}));
+jest.mock('@managers/draft_sync_manager', () => ({
+    __esModule: true,
+    default: {initialize: jest.fn(), invalidate: jest.fn(), wake: jest.fn()},
 }));
 jest.mock('@managers/ephemeral_mode_manager', () => ({
     __esModule: true,
@@ -78,9 +83,20 @@ describe('applyPersistenceModeChange', () => {
 
         expect(WebsocketManager.invalidateClient).toHaveBeenCalledWith(serverUrl);
         expect(EphemeralModeManager.removeServer).toHaveBeenCalledWith(serverUrl);
+        expect(DraftSyncManager.invalidate).toHaveBeenCalledWith(serverUrl);
         expect(wipeServerDatabaseWithRetry).toHaveBeenCalledWith(serverUrl);
         expect(refetchCurrentUser).toHaveBeenCalledWith(serverUrl, undefined);
+        expect(DraftSyncManager.initialize).toHaveBeenCalledWith(serverUrl);
         expect(WebsocketManager.createClient).toHaveBeenCalledWith(serverUrl, 'tok', 'preauth');
+
+        // Draft sync must stop before the wipe and re-initialize after the DB is recreated but before WS startup.
+        const invalidateOrder = jest.mocked(DraftSyncManager.invalidate).mock.invocationCallOrder[0];
+        const wipeOrder = jest.mocked(wipeServerDatabaseWithRetry).mock.invocationCallOrder[0];
+        const initializeOrder = jest.mocked(DraftSyncManager.initialize).mock.invocationCallOrder[0];
+        const createClientOrder = jest.mocked(WebsocketManager.createClient).mock.invocationCallOrder[0];
+        expect(invalidateOrder).toBeLessThan(wipeOrder);
+        expect(wipeOrder).toBeLessThan(initializeOrder);
+        expect(initializeOrder).toBeLessThan(createClientOrder);
         expect(WebsocketManager.initializeClient).toHaveBeenCalledWith(serverUrl);
         expect(setActiveServerDatabaseSpy).toHaveBeenCalledWith(serverUrl);
         expect(terminateSession).not.toHaveBeenCalled();

--- a/app/actions/remote/refresh.ts
+++ b/app/actions/remote/refresh.ts
@@ -5,6 +5,7 @@ import {wipeServerDatabaseWithRetry, wipeServerFiles} from '@actions/local/ephem
 import {cancelSessionNotification, terminateSession} from '@actions/local/session';
 import DatabaseManager from '@database/manager';
 import {getServerCredentials} from '@init/credentials';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import WebsocketManager from '@managers/websocket_manager';
 import {getCurrentChannelId, getCurrentTeamId, getPushVerificationStatus, prepareCommonSystemValues} from '@queries/servers/system';
@@ -35,6 +36,9 @@ export const applyPersistenceModeChange = async (serverUrl: string): Promise<{er
         }
 
         await WebsocketManager.invalidateClient(serverUrl);
+
+        // Stop draft sync before the DB is destroyed so late HTTP callbacks can't touch it.
+        DraftSyncManager.invalidate(serverUrl);
         const {success} = await wipeServerDatabaseWithRetry(serverUrl);
         if (!success) {
             throw new Error('Failed to wipe server database after changing persistence mode');
@@ -57,6 +61,9 @@ export const applyPersistenceModeChange = async (serverUrl: string): Promise<{er
         if (systemModels?.length) {
             await operator.batchRecords(systemModels, 'applyPersistenceModeChange');
         }
+
+        // The DB has been recreated and re-seeded; re-initialize draft sync before WebSocket startup.
+        await DraftSyncManager.initialize(serverUrl);
 
         if (credentials?.token) {
             await WebsocketManager.createClient(serverUrl, credentials.token, credentials.preauthSecret);

--- a/app/init/app.ts
+++ b/app/init/app.ts
@@ -7,6 +7,7 @@ import CallsNative from '@init/calls_native';
 import {getAllServerCredentials} from '@init/credentials';
 import ManagedApp from '@init/managed_app';
 import PushNotifications from '@init/push_notifications';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import GlobalEventHandler from '@managers/global_event_handler';
 import NetworkManager from '@managers/network_manager';
@@ -47,6 +48,11 @@ export async function initialize() {
         // EphemeralModeManager init runs before WS init so any pending wipes
         // complete before WebSocket clients start populating server databases.
         await EphemeralModeManager.init(serverCredentials);
+
+        // Draft sync initializes after any pending ephemeral wipes finish and before
+        // WebSocket startup, so it never races a database that is being destroyed.
+        await Promise.all(serverUrls.map((serverUrl) => DraftSyncManager.initialize(serverUrl)));
+
         await WebsocketManager.init(serverCredentials);
     }
 

--- a/app/managers/draft_sync_manager/index.test.ts
+++ b/app/managers/draft_sync_manager/index.test.ts
@@ -3,7 +3,7 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
-import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, reconcileTeamDrafts, type ReconcileKey} from '@actions/remote/draft';
+import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts, type ReconcileKey} from '@actions/remote/draft';
 import {MM_TABLES} from '@constants/database';
 import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
@@ -23,12 +23,16 @@ jest.mock('@actions/remote/draft', () => ({
     getReconcilableKeys: jest.fn(),
     deleteAbsentCleanDraft: jest.fn(),
     confirmDeleteTombstone: jest.fn(),
+    processOutboxUpsert: jest.fn(),
+    processOutboxDelete: jest.fn(),
 }));
 
 const mockedReconcile = jest.mocked(reconcileTeamDrafts);
 const mockedGetReconcilableKeys = jest.mocked(getReconcilableKeys);
 const mockedDeleteAbsentCleanDraft = jest.mocked(deleteAbsentCleanDraft);
 const mockedConfirmDeleteTombstone = jest.mocked(confirmDeleteTombstone);
+const mockedProcessOutboxUpsert = jest.mocked(processOutboxUpsert);
+const mockedProcessOutboxDelete = jest.mocked(processOutboxDelete);
 
 const {DRAFT_OUTBOX} = MM_TABLES.SERVER;
 const {DraftSyncManagerSingleton} = exportedForTesting;
@@ -42,6 +46,7 @@ const ROOT_ID = '';
 type ManagerInternals = {
     eventBuffers: Record<string, WebSocketMessage[]>;
     lifecycleEpoch: Record<string, number>;
+    inFlightKeys: Record<string, Set<string>>;
 };
 
 const internals = (manager: InstanceType<typeof DraftSyncManagerSingleton>) =>
@@ -113,6 +118,10 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         mockedDeleteAbsentCleanDraft.mockResolvedValue();
         mockedConfirmDeleteTombstone.mockReset();
         mockedConfirmDeleteTombstone.mockResolvedValue();
+        mockedProcessOutboxUpsert.mockReset();
+        mockedProcessOutboxUpsert.mockResolvedValue({outcome: 'done'});
+        mockedProcessOutboxDelete.mockReset();
+        mockedProcessOutboxDelete.mockResolvedValue({outcome: 'done'});
     });
 
     afterEach(async () => {
@@ -505,6 +514,163 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
 
             expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
             expect(candidates().has(DRAFT_KEY)).toBe(false);
+        });
+    });
+
+    describe('drainOutbox (Phase 4.3 outbox workers)', () => {
+        const enableManager = async () => {
+            await setSyncConfig('true');
+            await manager.initialize(SERVER_URL);
+        };
+
+        const setBaseline = (tId = 'team1') => {
+            baselineInternals(manager).baseline[SERVER_URL] = {teamId: tId, at: Date.now()};
+        };
+
+        const createOutboxRow = async (over: {
+            operation?: 'upsert' | 'delete';
+            status?: DraftOutboxStatus;
+            nextAttemptAt?: number;
+            channelId?: string;
+            rootId?: string;
+            teamId?: string;
+        } = {}) => {
+            const channelId = over.channelId ?? CHANNEL_ID;
+            const rootId = over.rootId ?? ROOT_ID;
+            await database.write(async (writer) => {
+                const record = database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).prepareCreate((o) => {
+                    o._raw.id = buildDraftOutboxId(channelId, rootId);
+                    o.channelId = channelId;
+                    o.rootId = rootId;
+                    o.teamId = over.teamId ?? 'team1';
+                    o.operation = over.operation ?? 'upsert';
+                    o.generation = 1;
+                    o.attemptCount = 0;
+                    o.nextAttemptAt = over.nextAttemptAt ?? 0;
+                    o.keepLocal = false;
+                    o.status = over.status ?? DraftOutboxStatus.Pending;
+                    o.lastErrorCode = null;
+                    o.deletedFingerprint = null;
+                });
+                await writer.batch(record);
+            });
+        };
+
+        it('does nothing (no worker call) when there is no baseline', async () => {
+            await enableManager();
+            await createOutboxRow();
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(mockedProcessOutboxUpsert).not.toHaveBeenCalled();
+            expect(mockedProcessOutboxDelete).not.toHaveBeenCalled();
+        });
+
+        it('drains an eligible pending upsert and delete once a baseline exists', async () => {
+            await enableManager();
+            setBaseline();
+            await createOutboxRow({operation: 'upsert', channelId: CHANNEL_ID});
+
+            const deleteChannel = 'deletechanneldeletechannel00';
+            await createOutboxRow({operation: 'delete', channelId: deleteChannel});
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(mockedProcessOutboxUpsert).toHaveBeenCalledTimes(1);
+            expect(mockedProcessOutboxUpsert).toHaveBeenCalledWith(SERVER_URL, CHANNEL_ID, ROOT_ID);
+            expect(mockedProcessOutboxDelete).toHaveBeenCalledTimes(1);
+            expect(mockedProcessOutboxDelete).toHaveBeenCalledWith(SERVER_URL, deleteChannel, ROOT_ID);
+        });
+
+        it('skips a key already marked in-flight', async () => {
+            await enableManager();
+            setBaseline();
+            await createOutboxRow();
+
+            // Pre-mark the key in-flight to simulate an overlapping drain holding it.
+            internals(manager).inFlightKeys[SERVER_URL].add(buildDraftOutboxId(CHANNEL_ID, ROOT_ID));
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(mockedProcessOutboxUpsert).not.toHaveBeenCalled();
+        });
+
+        it('does not drain ConfirmingDelete, Blocked, or WaitingForUpload rows', async () => {
+            await enableManager();
+            setBaseline();
+            await createOutboxRow({operation: 'delete', status: DraftOutboxStatus.ConfirmingDelete, channelId: 'confirmdelchan0confirmdelcha0'});
+            await createOutboxRow({operation: 'upsert', status: DraftOutboxStatus.Blocked, channelId: 'blockedchan00blockedchan0000'});
+            await createOutboxRow({operation: 'upsert', status: DraftOutboxStatus.WaitingForUpload, channelId: 'waitupchan000waitupchan00000'});
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(mockedProcessOutboxUpsert).not.toHaveBeenCalled();
+            expect(mockedProcessOutboxDelete).not.toHaveBeenCalled();
+        });
+
+        it('does not drain a row scheduled for the future (nextAttemptAt > now)', async () => {
+            await enableManager();
+            setBaseline();
+            await createOutboxRow({nextAttemptAt: Date.now() + 60000});
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(mockedProcessOutboxUpsert).not.toHaveBeenCalled();
+        });
+
+        it('disables the server and clears the timer on a suspend outcome', async () => {
+            await enableManager();
+            setBaseline();
+            await createOutboxRow();
+            mockedProcessOutboxUpsert.mockResolvedValue({outcome: 'suspend'});
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(jest.getTimerCount()).toBe(0);
+
+            // The server is now disabled for the session: new events are ignored.
+            manager.enqueueWebSocketEvent(SERVER_URL, fakeEvent());
+            expect(internals(manager).eventBuffers[SERVER_URL].length).toBe(0);
+        });
+
+        it('discards the drain result when the epoch is invalidated mid-drain', async () => {
+            await enableManager();
+            setBaseline();
+            await createOutboxRow({channelId: CHANNEL_ID});
+            await createOutboxRow({channelId: 'secondchannel0secondchannel0'});
+
+            // The first worker invalidates the manager while draining; the loop must then stop and
+            // never process the second eligible row.
+            mockedProcessOutboxUpsert.mockImplementation(async () => {
+                manager.invalidate(SERVER_URL);
+                return {outcome: 'done'};
+            });
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(mockedProcessOutboxUpsert).toHaveBeenCalledTimes(1);
+            expect(jest.getTimerCount()).toBe(0);
+        });
+
+        it('initialize transitions a WaitingForUpload row to BlockedUpload(upload_interrupted)', async () => {
+            await setSyncConfig('true');
+            await createOutbox(DraftOutboxStatus.WaitingForUpload, 0);
+
+            await manager.initialize(SERVER_URL);
+
+            const rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
+                Q.where('channel_id', CHANNEL_ID),
+            ).fetch();
+            expect(rows.length).toBe(1);
+            expect(rows[0].status).toBe(DraftOutboxStatus.BlockedUpload);
+            expect(rows[0].lastErrorCode).toBe('upload_interrupted');
         });
     });
 

--- a/app/managers/draft_sync_manager/index.test.ts
+++ b/app/managers/draft_sync_manager/index.test.ts
@@ -3,6 +3,7 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
+import {reconcileTeamDrafts} from '@actions/remote/draft';
 import {MM_TABLES} from '@constants/database';
 import {DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
@@ -11,10 +12,16 @@ import {buildDraftOutboxId} from '@queries/servers/drafts';
 import {advanceTimers, disableFakeTimers, enableFakeTimers} from '@test/timer_helpers';
 import * as log from '@utils/log';
 
-import {exportedForTesting, default as DraftSyncManagerDefault} from './index';
+import {exportedForTesting, type ManagerBaselineInternals, default as DraftSyncManagerDefault} from './index';
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+
+jest.mock('@actions/remote/draft', () => ({
+    reconcileTeamDrafts: jest.fn(),
+}));
+
+const mockedReconcile = jest.mocked(reconcileTeamDrafts);
 
 const {DRAFT_OUTBOX} = MM_TABLES.SERVER;
 const {DraftSyncManagerSingleton} = exportedForTesting;
@@ -32,6 +39,18 @@ type ManagerInternals = {
 
 const internals = (manager: InstanceType<typeof DraftSyncManagerSingleton>) =>
     manager as unknown as ManagerInternals;
+
+const baselineInternals = (manager: InstanceType<typeof DraftSyncManagerSingleton>) =>
+    manager as unknown as ManagerBaselineInternals;
+
+// flushMicrotasks: drain the promise queue so a fire-and-forget async reconcile (and any coalesced
+// re-run it drains) can settle under fake timers.
+const flushMicrotasks = async () => {
+    for (let i = 0; i < 10; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(process.nextTick);
+    }
+};
 
 const fakeEvent = (): WebSocketMessage => ({
     event: 'draft_created',
@@ -79,6 +98,8 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         database = DatabaseManager.serverDatabases[SERVER_URL]!.database;
         operator = DatabaseManager.serverDatabases[SERVER_URL]!.operator;
         manager = new DraftSyncManagerSingleton();
+        mockedReconcile.mockReset();
+        mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
     });
 
     afterEach(async () => {
@@ -225,6 +246,80 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             Q.where('status', DraftOutboxStatus.Pending),
         ).fetch();
         expect(rows.length).toBe(1);
+    });
+
+    describe('requestReconcile (Phase 4.1 additive reconciliation)', () => {
+        const enableManager = async () => {
+            await setSyncConfig('true');
+            await manager.initialize(SERVER_URL);
+        };
+
+        it('runs reconcileTeamDrafts and records a baseline on success', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 2, drafts: []});
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'test');
+            await flushMicrotasks();
+
+            expect(mockedReconcile).toHaveBeenCalledTimes(1);
+            expect(mockedReconcile).toHaveBeenCalledWith(SERVER_URL, 'team1');
+            expect(baselineInternals(manager).baseline[SERVER_URL]?.teamId).toBe('team1');
+        });
+
+        it('does not record a baseline when reconciliation fails', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({error: new Error('boom')});
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'test');
+            await flushMicrotasks();
+
+            expect(mockedReconcile).toHaveBeenCalledTimes(1);
+            expect(baselineInternals(manager).baseline[SERVER_URL]).toBeUndefined();
+        });
+
+        it('does not record a baseline when the epoch is invalidated mid-flight', async () => {
+            await enableManager();
+
+            let resolveReconcile: (v: {applied?: number}) => void = () => {};
+            mockedReconcile.mockReturnValue(new Promise((resolve) => {
+                resolveReconcile = resolve;
+            }));
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'test');
+
+            // Invalidate while the reconcile await is still outstanding, then let it resolve.
+            manager.invalidate(SERVER_URL);
+            resolveReconcile({applied: 1});
+            await flushMicrotasks();
+
+            expect(baselineInternals(manager).baseline[SERVER_URL]).toBeUndefined();
+        });
+
+        it('coalesces rapid requests: reconciles once, then re-runs once for the coalesced request', async () => {
+            await enableManager();
+
+            let resolveFirst: (v: {applied?: number}) => void = () => {};
+            mockedReconcile.
+                mockReturnValueOnce(new Promise((resolve) => {
+                    resolveFirst = resolve;
+                })).
+                mockResolvedValue({applied: 0, drafts: []});
+
+            // First request starts in-flight; the second coalesces behind it.
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            manager.requestReconcile(SERVER_URL, 'team2', 'second');
+
+            expect(mockedReconcile).toHaveBeenCalledTimes(1);
+
+            // Settle the first pass; the coalesced request drains and runs exactly once more.
+            resolveFirst({applied: 1});
+            await flushMicrotasks();
+
+            expect(mockedReconcile).toHaveBeenCalledTimes(2);
+            expect(mockedReconcile).toHaveBeenNthCalledWith(1, SERVER_URL, 'team1');
+            expect(mockedReconcile).toHaveBeenNthCalledWith(2, SERVER_URL, 'team2');
+            expect(baselineInternals(manager).baseline[SERVER_URL]?.teamId).toBe('team2');
+        });
     });
 
     it('exposes a singleton default instance', () => {

--- a/app/managers/draft_sync_manager/index.test.ts
+++ b/app/managers/draft_sync_manager/index.test.ts
@@ -47,6 +47,7 @@ type ManagerInternals = {
     eventBuffers: Record<string, WebSocketMessage[]>;
     lifecycleEpoch: Record<string, number>;
     inFlightKeys: Record<string, Set<string>>;
+    observationOrdinals: Record<string, Map<string, number>>;
 };
 
 const internals = (manager: InstanceType<typeof DraftSyncManagerSingleton>) =>
@@ -80,6 +81,13 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         await operator.handleConfigs({
             configs: [{id: 'AllowSyncedDrafts', value}],
             configsToDelete: [],
+            prepareRecordsOnly: false,
+        });
+    };
+
+    const seedDmChannel = async (id: string) => {
+        await operator.handleChannel({
+            channels: [{id, team_id: '', type: 'D', display_name: '', total_msg_count: 0} as Channel],
             prepareRecordsOnly: false,
         });
     };
@@ -358,6 +366,38 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             expect(mockedReconcile).toHaveBeenNthCalledWith(2, SERVER_URL, 'team2');
             expect(baselineInternals(manager).baseline[SERVER_URL]?.teamId).toBe('team2');
         });
+
+        it('arms a reconcile retry (real delay) when the snapshot reported missing dependencies (fix #9)', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: [], missingDeps: true});
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'missing');
+            await flushMicrotasks();
+
+            // The additive reconcile still records a baseline, but a reconcile-GET retry is armed so the
+            // snapshot is re-fetched once the missing channels hydrate.
+            expect(baselineInternals(manager).baseline[SERVER_URL]).toBeDefined();
+            expect(jest.getTimerCount()).toBe(1);
+
+            // A real (non-zero) backoff delay — never a busy loop.
+            mockedReconcile.mockClear();
+            await advanceTimers(0);
+            expect(mockedReconcile).not.toHaveBeenCalled();
+        });
+
+        it('bumps the observation ordinal for a returned draft key whose POST is in flight (fix #6)', async () => {
+            await enableManager();
+            const key = buildDraftOutboxId(CHANNEL_ID, ROOT_ID);
+
+            // Simulate an in-flight POST for this key while the reconcile GET observes its content.
+            internals(manager).inFlightKeys[SERVER_URL].add(key);
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: [{channelId: CHANNEL_ID, rootId: ROOT_ID} as NormalizedDraft]});
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'observe');
+            await flushMicrotasks();
+
+            expect(internals(manager).observationOrdinals[SERVER_URL].get(key)).toBe(1);
+        });
     });
 
     describe('runAbsencePass (Phase 4.2 absence quarantine + delete confirmation)', () => {
@@ -410,6 +450,7 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             await enableManager();
             mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
             mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+
             // Simulate production: once deleted, the key leaves the reconcilable universe.
             mockedDeleteAbsentCleanDraft.mockImplementation(async () => {
                 mockedGetReconcilableKeys.mockResolvedValue([]);
@@ -603,9 +644,29 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             await flushMicrotasks();
 
             expect(mockedProcessOutboxUpsert).toHaveBeenCalledTimes(1);
-            expect(mockedProcessOutboxUpsert).toHaveBeenCalledWith(SERVER_URL, CHANNEL_ID, ROOT_ID);
+            expect(mockedProcessOutboxUpsert).toHaveBeenCalledWith(SERVER_URL, CHANNEL_ID, ROOT_ID, expect.objectContaining({shouldAbort: expect.any(Function)}));
             expect(mockedProcessOutboxDelete).toHaveBeenCalledTimes(1);
-            expect(mockedProcessOutboxDelete).toHaveBeenCalledWith(SERVER_URL, deleteChannel, ROOT_ID);
+            expect(mockedProcessOutboxDelete).toHaveBeenCalledWith(SERVER_URL, deleteChannel, ROOT_ID, expect.objectContaining({shouldAbort: expect.any(Function)}));
+        });
+
+        it('drains a teamId="" row only when its channel is DM/GM (or a confirmed member) (fix #9)', async () => {
+            await enableManager();
+            setBaseline('team1');
+
+            // A '' row whose channel IS a DM: valid scope -> drains under the baseline.
+            const dmChannel = 'dmdmdmdmdmdmdmdmdmdmdmdmdm00';
+            await seedDmChannel(dmChannel);
+            await createOutboxRow({operation: 'upsert', teamId: '', channelId: dmChannel});
+
+            // A '' row whose channel is neither DM/GM nor a confirmed membership: mis-stamped, must NOT drain.
+            const orphanChannel = 'orphanorphanorphanorphanor00';
+            await createOutboxRow({operation: 'upsert', teamId: '', channelId: orphanChannel});
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            expect(mockedProcessOutboxUpsert).toHaveBeenCalledTimes(1);
+            expect(mockedProcessOutboxUpsert).toHaveBeenCalledWith(SERVER_URL, dmChannel, ROOT_ID, expect.objectContaining({shouldAbort: expect.any(Function)}));
         });
 
         it('skips a key already marked in-flight', async () => {

--- a/app/managers/draft_sync_manager/index.test.ts
+++ b/app/managers/draft_sync_manager/index.test.ts
@@ -137,13 +137,15 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         expect(getClientSpy).not.toHaveBeenCalled();
     });
 
-    it('initialize reads capability and schedules a retry timer when an eligible outbox row exists and sync is enabled', async () => {
+    it('initialize arms NO timer with a pending row but no baseline and no known team (busy-loop guard)', async () => {
         await setSyncConfig('true');
         await createOutbox(DraftOutboxStatus.Pending, 0);
 
         await manager.initialize(SERVER_URL);
 
-        expect(jest.getTimerCount()).toBe(1);
+        // The drain timer needs a baseline; the reconcile timer needs a known team. On a cold start
+        // there is neither, so nothing is armed — this is what prevents a setTimeout(0) busy loop.
+        expect(jest.getTimerCount()).toBe(0);
     });
 
     it('initialize schedules no timer when sync is disabled even with an eligible outbox row', async () => {
@@ -164,31 +166,33 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         expect(jest.getTimerCount()).toBe(0);
     });
 
-    it('the retry timer firing performs no network call and reschedules itself', async () => {
+    it('a failed reconciliation GET arms a backoff reconcile timer (real delay, never a zero-delay loop)', async () => {
         await setSyncConfig('true');
         await createOutbox(DraftOutboxStatus.Pending, 0);
-
-        const getClientSpy = jest.spyOn(NetworkManager, 'getClient');
-        const querySpy = jest.spyOn(database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX), 'query');
+        mockedReconcile.mockResolvedValue({error: new Error('offline')});
 
         await manager.initialize(SERVER_URL);
+        manager.requestReconcile(SERVER_URL, 'team1', 'trigger');
+        await flushMicrotasks();
+
+        // GET failed -> no baseline, so no drain timer; a reconcile-GET retry is armed with a real
+        // (>= base) backoff delay so a persistently failing GET can never busy-loop.
         expect(jest.getTimerCount()).toBe(1);
 
-        querySpy.mockClear();
-
-        // Fire the heartbeat. It must re-query the outbox and reschedule (row still eligible)
-        // without ever touching the network.
-        await advanceTimers(1);
-
-        expect(getClientSpy).not.toHaveBeenCalled();
-        expect(querySpy).toHaveBeenCalledTimes(1);
-        expect(jest.getTimerCount()).toBe(1);
+        mockedReconcile.mockClear();
+        await advanceTimers(0);
+        expect(mockedReconcile).not.toHaveBeenCalled(); // not a zero-delay timer
     });
 
     it('invalidate synchronously increments the epoch, cancels the timer and clears the event buffer', async () => {
         await setSyncConfig('true');
         await createOutbox(DraftOutboxStatus.Pending, 0);
+        mockedReconcile.mockResolvedValue({error: new Error('offline')});
         await manager.initialize(SERVER_URL);
+
+        // Arm a (reconcile backoff) timer to have something to cancel.
+        manager.requestReconcile(SERVER_URL, 'team1', 'x');
+        await flushMicrotasks();
 
         manager.enqueueWebSocketEvent(SERVER_URL, fakeEvent());
         expect(internals(manager).eventBuffers[SERVER_URL].length).toBe(1);
@@ -206,26 +210,28 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         expect(internals(manager).eventBuffers[SERVER_URL].length).toBe(0);
     });
 
-    it('rejects a retry-timer continuation captured before invalidate as stale and touches nothing', async () => {
+    it('rejects a timer continuation captured before invalidate as stale and touches nothing', async () => {
         await setSyncConfig('true');
         await createOutbox(DraftOutboxStatus.Pending, 0);
+        mockedReconcile.mockResolvedValue({error: new Error('offline')});
 
         const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
         await manager.initialize(SERVER_URL);
+        manager.requestReconcile(SERVER_URL, 'team1', 'x');
+        await flushMicrotasks();
 
-        // Capture the heartbeat callback the manager registered.
+        // Capture the reconcile-timer callback the manager registered.
         const lastCall = setTimeoutSpy.mock.calls[setTimeoutSpy.mock.calls.length - 1];
         const fireCallback = lastCall[0] as () => void;
 
         manager.invalidate(SERVER_URL);
+        mockedReconcile.mockClear();
 
-        const querySpy = jest.spyOn(database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX), 'query');
-
-        // Firing the stale continuation must not re-query the DB nor reschedule a timer.
+        // Firing the stale continuation must not reconcile nor reschedule a timer.
         fireCallback();
         await advanceTimers(0);
 
-        expect(querySpy).not.toHaveBeenCalled();
+        expect(mockedReconcile).not.toHaveBeenCalled();
         expect(jest.getTimerCount()).toBe(0);
     });
 
@@ -248,26 +254,36 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         );
     });
 
-    it('handleCapabilityChange reconstructs the timer on disabled->enabled and cancels it on enabled->disabled without deleting outbox rows', async () => {
-        // Start disabled with an eligible row: initialize leaves capability off and no timer.
-        await createOutbox(DraftOutboxStatus.Pending, 0);
-        await manager.initialize(SERVER_URL);
-        expect(jest.getTimerCount()).toBe(0);
-
-        // disabled -> enabled reconstructs the heartbeat.
+    it('handleCapabilityChange clears the baseline gate on disable and requires a fresh GET on re-enable, keeping durable rows', async () => {
         await setSyncConfig('true');
-        await manager.handleCapabilityChange(SERVER_URL);
-        expect(jest.getTimerCount()).toBe(1);
+        await createOutbox(DraftOutboxStatus.Pending, 0);
+        mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+        await manager.initialize(SERVER_URL);
 
-        // enabled -> disabled cancels the timer but keeps the durable outbox row.
+        // Establish a baseline + a known team.
+        manager.requestReconcile(SERVER_URL, 'team1', 'first');
+        await flushMicrotasks();
+        expect(baselineInternals(manager).baseline[SERVER_URL]).toBeDefined();
+
+        // enabled -> disabled: the baseline gate is reset and timers are cleared (a re-enable must not
+        // drain against a stale snapshot), but the durable outbox row is preserved.
         await setSyncConfig('false');
         await manager.handleCapabilityChange(SERVER_URL);
+        expect(baselineInternals(manager).baseline[SERVER_URL]).toBeUndefined();
         expect(jest.getTimerCount()).toBe(0);
 
         const rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
             Q.where('status', DraftOutboxStatus.Pending),
         ).fetch();
         expect(rows.length).toBe(1);
+
+        // disabled -> enabled with a known team: a fresh reconciliation GET is triggered before any
+        // draining resumes (no draining against the pre-disable baseline).
+        mockedReconcile.mockClear();
+        await setSyncConfig('true');
+        await manager.handleCapabilityChange(SERVER_URL);
+        await flushMicrotasks();
+        expect(mockedReconcile).toHaveBeenCalled();
     });
 
     describe('requestReconcile (Phase 4.1 additive reconciliation)', () => {
@@ -390,17 +406,22 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
         });
 
-        it('deletes a clean key on a second same-scope absence after the delay and clears the candidate', async () => {
+        it('deletes a clean key on the auto-scheduled second same-scope absence after the delay and clears the candidate', async () => {
             await enableManager();
             mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
             mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+            // Simulate production: once deleted, the key leaves the reconcilable universe.
+            mockedDeleteAbsentCleanDraft.mockImplementation(async () => {
+                mockedGetReconcilableKeys.mockResolvedValue([]);
+            });
 
             manager.requestReconcile(SERVER_URL, 'team1', 'first');
             await flushMicrotasks();
 
-            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
+            // First absence only quarantines; the manager auto-schedules the delayed second GET.
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
 
-            manager.requestReconcile(SERVER_URL, 'team1', 'second');
+            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
             await flushMicrotasks();
 
             expect(mockedDeleteAbsentCleanDraft).toHaveBeenCalledTimes(1);
@@ -458,10 +479,13 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             expect(candidates().size).toBe(0);
         });
 
-        it('confirms a delete tombstone via confirmDeleteTombstone after two same-scope absences past the delay', async () => {
+        it('confirms a delete tombstone via confirmDeleteTombstone on the auto-scheduled second same-scope absence past the delay', async () => {
             await enableManager();
             mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
             mockedGetReconcilableKeys.mockResolvedValue([tombstoneKey()]);
+            mockedConfirmDeleteTombstone.mockImplementation(async () => {
+                mockedGetReconcilableKeys.mockResolvedValue([]);
+            });
 
             manager.requestReconcile(SERVER_URL, 'team1', 'first');
             await flushMicrotasks();
@@ -469,7 +493,6 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             expect(candidates().get(DRAFT_KEY)?.teamId).toBe('team1');
 
             await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
-            manager.requestReconcile(SERVER_URL, 'team1', 'second');
             await flushMicrotasks();
 
             expect(mockedConfirmDeleteTombstone).toHaveBeenCalledTimes(1);
@@ -478,22 +501,23 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             expect(candidates().has(DRAFT_KEY)).toBe(false);
         });
 
-        it('does not confirm when the second absence is observed under a different teamId scope', async () => {
+        it('does not confirm when the next observation is under a different teamId scope (window restarts)', async () => {
             await enableManager();
             mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
             mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
 
             manager.requestReconcile(SERVER_URL, 'team1', 'first');
             await flushMicrotasks();
+            expect(candidates().get(DRAFT_KEY)?.teamId).toBe('team1');
 
-            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
+            // A team switch reconciles under team2 (which also clears the team1 auto-timer). The team2
+            // observation sees a team1 candidate, so the window restarts under team2 and nothing is
+            // confirmed — scope, not timing, is the gate here.
             manager.requestReconcile(SERVER_URL, 'team2', 'second-other-scope');
             await flushMicrotasks();
 
-            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
-
-            // The observation window restarted under the new scope.
             expect(candidates().get(DRAFT_KEY)?.teamId).toBe('team2');
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
         });
 
         it('drops an ineligible key candidate (preserve) instead of deleting it', async () => {

--- a/app/managers/draft_sync_manager/index.test.ts
+++ b/app/managers/draft_sync_manager/index.test.ts
@@ -3,9 +3,9 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
-import {reconcileTeamDrafts} from '@actions/remote/draft';
+import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, reconcileTeamDrafts, type ReconcileKey} from '@actions/remote/draft';
 import {MM_TABLES} from '@constants/database';
-import {DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
+import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
 import NetworkManager from '@managers/network_manager';
 import {buildDraftOutboxId} from '@queries/servers/drafts';
@@ -16,12 +16,19 @@ import {exportedForTesting, type ManagerBaselineInternals, default as DraftSyncM
 
 import type ServerDataOperator from '@database/operator/server_data_operator';
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+import type {NormalizedDraft} from '@utils/draft/sync';
 
 jest.mock('@actions/remote/draft', () => ({
     reconcileTeamDrafts: jest.fn(),
+    getReconcilableKeys: jest.fn(),
+    deleteAbsentCleanDraft: jest.fn(),
+    confirmDeleteTombstone: jest.fn(),
 }));
 
 const mockedReconcile = jest.mocked(reconcileTeamDrafts);
+const mockedGetReconcilableKeys = jest.mocked(getReconcilableKeys);
+const mockedDeleteAbsentCleanDraft = jest.mocked(deleteAbsentCleanDraft);
+const mockedConfirmDeleteTombstone = jest.mocked(confirmDeleteTombstone);
 
 const {DRAFT_OUTBOX} = MM_TABLES.SERVER;
 const {DraftSyncManagerSingleton} = exportedForTesting;
@@ -100,6 +107,12 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
         manager = new DraftSyncManagerSingleton();
         mockedReconcile.mockReset();
         mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+        mockedGetReconcilableKeys.mockReset();
+        mockedGetReconcilableKeys.mockResolvedValue([]);
+        mockedDeleteAbsentCleanDraft.mockReset();
+        mockedDeleteAbsentCleanDraft.mockResolvedValue();
+        mockedConfirmDeleteTombstone.mockReset();
+        mockedConfirmDeleteTombstone.mockResolvedValue();
     });
 
     afterEach(async () => {
@@ -319,6 +332,179 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             expect(mockedReconcile).toHaveBeenNthCalledWith(1, SERVER_URL, 'team1');
             expect(mockedReconcile).toHaveBeenNthCalledWith(2, SERVER_URL, 'team2');
             expect(baselineInternals(manager).baseline[SERVER_URL]?.teamId).toBe('team2');
+        });
+    });
+
+    describe('runAbsencePass (Phase 4.2 absence quarantine + delete confirmation)', () => {
+        const DRAFT_KEY = buildDraftOutboxId(CHANNEL_ID, ROOT_ID);
+
+        const enableManager = async () => {
+            await setSyncConfig('true');
+            await manager.initialize(SERVER_URL);
+        };
+
+        const cleanDraftKey = (over: Partial<ReconcileKey> = {}): ReconcileKey => ({
+            channelId: CHANNEL_ID,
+            rootId: ROOT_ID,
+            kind: 'draft',
+            serverUpdateAt: 1000,
+            hasOutbox: false,
+            authoritative: true,
+            ...over,
+        });
+
+        const tombstoneKey = (over: Partial<ReconcileKey> = {}): ReconcileKey => ({
+            channelId: CHANNEL_ID,
+            rootId: ROOT_ID,
+            kind: 'tombstone',
+            serverUpdateAt: 0,
+            hasOutbox: true,
+            outboxOperation: DraftOutboxOperation.Delete,
+            outboxStatus: DraftOutboxStatus.Pending,
+            keepLocal: false,
+            authoritative: true,
+            ...over,
+        });
+
+        const candidates = () => baselineInternals(manager).absenceCandidates[SERVER_URL];
+
+        it('quarantines a clean absent key on first absence without deleting it', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+
+            expect(candidates().get(DRAFT_KEY)?.teamId).toBe('team1');
+            expect(candidates().size).toBe(1);
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
+        });
+
+        it('deletes a clean key on a second same-scope absence after the delay and clears the candidate', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+
+            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'second');
+            await flushMicrotasks();
+
+            expect(mockedDeleteAbsentCleanDraft).toHaveBeenCalledTimes(1);
+            expect(mockedDeleteAbsentCleanDraft).toHaveBeenCalledWith(SERVER_URL, CHANNEL_ID, ROOT_ID);
+            expect(candidates().has(DRAFT_KEY)).toBe(false);
+        });
+
+        it('does not delete when the second absence occurs before the delay elapses', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+
+            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS - 1);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'second');
+            await flushMicrotasks();
+
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
+            expect(candidates().has(DRAFT_KEY)).toBe(true);
+        });
+
+        it('clears the candidate and never deletes when the key reappears in the snapshot', async () => {
+            await enableManager();
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+
+            // First reconcile: key absent from the snapshot -> quarantined.
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+            expect(candidates().has(DRAFT_KEY)).toBe(true);
+
+            // Second reconcile: key present in the snapshot -> candidate cleared, no deletion.
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: [{channelId: CHANNEL_ID, rootId: ROOT_ID} as NormalizedDraft]});
+            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
+            manager.requestReconcile(SERVER_URL, 'team1', 'second');
+            await flushMicrotasks();
+
+            expect(candidates().has(DRAFT_KEY)).toBe(false);
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
+        });
+
+        it('runs no absence pass and deletes nothing when reconciliation fails', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({error: new Error('boom')});
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+
+            expect(mockedGetReconcilableKeys).not.toHaveBeenCalled();
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
+            expect(candidates().size).toBe(0);
+        });
+
+        it('confirms a delete tombstone via confirmDeleteTombstone after two same-scope absences past the delay', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+            mockedGetReconcilableKeys.mockResolvedValue([tombstoneKey()]);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+            expect(mockedConfirmDeleteTombstone).not.toHaveBeenCalled();
+            expect(candidates().get(DRAFT_KEY)?.teamId).toBe('team1');
+
+            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
+            manager.requestReconcile(SERVER_URL, 'team1', 'second');
+            await flushMicrotasks();
+
+            expect(mockedConfirmDeleteTombstone).toHaveBeenCalledTimes(1);
+            expect(mockedConfirmDeleteTombstone).toHaveBeenCalledWith(SERVER_URL, CHANNEL_ID, ROOT_ID);
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
+            expect(candidates().has(DRAFT_KEY)).toBe(false);
+        });
+
+        it('does not confirm when the second absence is observed under a different teamId scope', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+
+            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
+            manager.requestReconcile(SERVER_URL, 'team2', 'second-other-scope');
+            await flushMicrotasks();
+
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
+
+            // The observation window restarted under the new scope.
+            expect(candidates().get(DRAFT_KEY)?.teamId).toBe('team2');
+        });
+
+        it('drops an ineligible key candidate (preserve) instead of deleting it', async () => {
+            await enableManager();
+            mockedReconcile.mockResolvedValue({applied: 0, drafts: []});
+
+            // First pass: eligible clean key -> quarantined.
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey()]);
+            manager.requestReconcile(SERVER_URL, 'team1', 'first');
+            await flushMicrotasks();
+            expect(candidates().has(DRAFT_KEY)).toBe(true);
+
+            // Second pass past the delay, but the key is now non-authoritative (membership lost).
+            mockedGetReconcilableKeys.mockResolvedValue([cleanDraftKey({authoritative: false})]);
+            await advanceTimers(DRAFT_ABSENCE_CONFIRMATION_DELAY_MS);
+            manager.requestReconcile(SERVER_URL, 'team1', 'second');
+            await flushMicrotasks();
+
+            expect(mockedDeleteAbsentCleanDraft).not.toHaveBeenCalled();
+            expect(candidates().has(DRAFT_KEY)).toBe(false);
         });
     });
 

--- a/app/managers/draft_sync_manager/index.test.ts
+++ b/app/managers/draft_sync_manager/index.test.ts
@@ -25,6 +25,9 @@ jest.mock('@actions/remote/draft', () => ({
     confirmDeleteTombstone: jest.fn(),
     processOutboxUpsert: jest.fn(),
     processOutboxDelete: jest.fn(),
+
+    // Deterministic backoff: a real future timestamp so the mis-scoped-row back-off assertion is stable.
+    computeNextAttemptAt: jest.fn((_attemptCount: number, now: number) => now + 1000),
 }));
 
 const mockedReconcile = jest.mocked(reconcileTeamDrafts);
@@ -308,7 +311,10 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             await flushMicrotasks();
 
             expect(mockedReconcile).toHaveBeenCalledTimes(1);
-            expect(mockedReconcile).toHaveBeenCalledWith(SERVER_URL, 'team1');
+            expect(mockedReconcile).toHaveBeenCalledWith(SERVER_URL, 'team1', expect.objectContaining({
+                shouldAbort: expect.any(Function),
+                onSnapshot: expect.any(Function),
+            }));
             expect(baselineInternals(manager).baseline[SERVER_URL]?.teamId).toBe('team1');
         });
 
@@ -362,8 +368,8 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             await flushMicrotasks();
 
             expect(mockedReconcile).toHaveBeenCalledTimes(2);
-            expect(mockedReconcile).toHaveBeenNthCalledWith(1, SERVER_URL, 'team1');
-            expect(mockedReconcile).toHaveBeenNthCalledWith(2, SERVER_URL, 'team2');
+            expect(mockedReconcile).toHaveBeenNthCalledWith(1, SERVER_URL, 'team1', expect.any(Object));
+            expect(mockedReconcile).toHaveBeenNthCalledWith(2, SERVER_URL, 'team2', expect.any(Object));
             expect(baselineInternals(manager).baseline[SERVER_URL]?.teamId).toBe('team2');
         });
 
@@ -389,9 +395,14 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
             await enableManager();
             const key = buildDraftOutboxId(CHANNEL_ID, ROOT_ID);
 
-            // Simulate an in-flight POST for this key while the reconcile GET observes its content.
+            // Simulate an in-flight POST for this key while the reconcile GET observes its content. The
+            // real reconcileTeamDrafts invokes onSnapshot SYNCHRONOUSLY as the GET resolves (before its
+            // apply loop) — reproduce that here so the fence bumps the ordinal for the in-flight key.
             internals(manager).inFlightKeys[SERVER_URL].add(key);
-            mockedReconcile.mockResolvedValue({applied: 0, drafts: [{channelId: CHANNEL_ID, rootId: ROOT_ID} as NormalizedDraft]});
+            mockedReconcile.mockImplementation((_su, _tid, opts) => {
+                opts?.onSnapshot?.([{channelId: CHANNEL_ID, rootId: ROOT_ID}]);
+                return Promise.resolve({applied: 0, drafts: [{channelId: CHANNEL_ID, rootId: ROOT_ID} as NormalizedDraft]});
+            });
 
             manager.requestReconcile(SERVER_URL, 'team1', 'observe');
             await flushMicrotasks();
@@ -667,6 +678,32 @@ describe('DraftSyncManager (Phase 3 shell)', () => {
 
             expect(mockedProcessOutboxUpsert).toHaveBeenCalledTimes(1);
             expect(mockedProcessOutboxUpsert).toHaveBeenCalledWith(SERVER_URL, dmChannel, ROOT_ID, expect.objectContaining({shouldAbort: expect.any(Function)}));
+        });
+
+        it('backs off a mis-scoped teamId="" row rather than leaving it due (fix #2: no zero-delay drain loop)', async () => {
+            await enableManager();
+            setBaseline('team1');
+
+            // A due '' row for a channel that is neither DM/GM nor a confirmed membership. Before the
+            // fix, drainOutbox skipped it without progress while scheduleWork kept counting it as due
+            // Pending work, re-arming a zero-delay drain that skipped it again — a busy loop.
+            const orphanChannel = 'orphanorphanorphanorphanor00';
+            await createOutboxRow({operation: 'upsert', teamId: '', channelId: orphanChannel, nextAttemptAt: 0});
+
+            manager.wake(SERVER_URL);
+            await flushMicrotasks();
+
+            // Not drained (mis-scoped)...
+            expect(mockedProcessOutboxUpsert).not.toHaveBeenCalled();
+
+            // ...but its next_attempt_at is pushed into the future (attempt count bumped), so it leaves
+            // the due set and scheduleWork can only arm a future-delayed drain — never a zero-delay loop.
+            const [row] = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
+                Q.where('id', buildDraftOutboxId(orphanChannel, ROOT_ID)),
+            ).fetch();
+            expect(row.status).toBe(DraftOutboxStatus.Pending);
+            expect(row.attemptCount).toBe(1);
+            expect(row.nextAttemptAt).toBeGreaterThan(Date.now());
         });
 
         it('skips a key already marked in-flight', async () => {

--- a/app/managers/draft_sync_manager/index.ts
+++ b/app/managers/draft_sync_manager/index.ts
@@ -3,14 +3,39 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
-import {reconcileTeamDrafts} from '@actions/remote/draft';
+import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, reconcileTeamDrafts, type ReconcileKey} from '@actions/remote/draft';
 import {MM_TABLES} from '@constants/database';
-import {DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
+import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
-import {getIsDraftSyncEnabled} from '@queries/servers/drafts';
+import {buildDraftOutboxId, getIsDraftSyncEnabled} from '@queries/servers/drafts';
 import {logDebug} from '@utils/log';
 
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
+import type {NormalizedDraft} from '@utils/draft/sync';
+
+// AbsenceCandidate: an in-memory record that a draft key was observed absent from a successful GET
+// snapshot. Deletion is only confirmed on a SECOND same-scope absence >= DRAFT_ABSENCE_CONFIRMATION_
+// DELAY_MS later. Losing these on restart is safe — it merely delays (never mis-triggers) deletion.
+type AbsenceCandidate = {firstAbsentAt: number; teamId: string};
+
+/**
+ * isAbsenceEligible: whether an in-scope key that is ABSENT from the snapshot may (eventually) be
+ * removed. A non-authoritative key (membership lost) is never eligible. A plain Draft is eligible
+ * only when it is clean and server-backed (serverUpdateAt > 0, no outbox). A delete tombstone is
+ * eligible only while it is a Delete in a Pending/ConfirmingDelete status.
+ */
+const isAbsenceEligible = (entry: ReconcileKey): boolean => {
+    if (!entry.authoritative) {
+        return false;
+    }
+
+    if (entry.kind === 'draft') {
+        return entry.serverUpdateAt > 0 && !entry.hasOutbox;
+    }
+
+    return entry.outboxOperation === DraftOutboxOperation.Delete &&
+        (entry.outboxStatus === DraftOutboxStatus.Pending || entry.outboxStatus === DraftOutboxStatus.ConfirmingDelete);
+};
 
 const {DRAFT_OUTBOX} = MM_TABLES.SERVER;
 
@@ -70,6 +95,11 @@ class DraftSyncManagerSingleton {
     // reconcilePending: a coalesced reconcile request that arrived while one was in flight. Drained
     // (run once) after the in-flight reconcile settles.
     private reconcilePending: Record<string, {teamId: string} | undefined> = {};
+
+    // absenceCandidates: per-server map (draftKey -> first-absence observation) for the two-observation
+    // replica-lag guard. A key is only deleted after being observed absent in TWO same-scope reconciles
+    // separated by >= DRAFT_ABSENCE_CONFIRMATION_DELAY_MS. Cleared on invalidate; safe to lose.
+    private absenceCandidates: Record<string, Map<string, AbsenceCandidate>> = {};
 
     /**
      * initialize: idempotent per-server setup. Reads the draft-sync capability into `enabled` and,
@@ -161,11 +191,16 @@ class DraftSyncManagerSingleton {
         }
 
         if (res.error) {
-            // Failure: do NOT set a baseline. The heartbeat will re-request later.
+            // Failure: do NOT set a baseline and run NO absence pass. Without a snapshot nothing may
+            // be deleted. The heartbeat will re-request later.
             logDebug('DraftSyncManager.reconcile: reconciliation failed', serverUrl);
             this.reconstructRetryTimer(serverUrl);
         } else {
             this.baseline[serverUrl] = {teamId, at: Date.now()};
+
+            // Absence pass: a successful snapshot lets us quarantine/confirm keys that are absent
+            // from it. Epoch-guarded internally; it never POSTs/DELETEs over the network.
+            await this.runAbsencePass(serverUrl, teamId, res.drafts ?? [], captured);
         }
 
         this.reconcileInFlight[serverUrl] = false;
@@ -174,6 +209,88 @@ class DraftSyncManagerSingleton {
         if (pending) {
             this.reconcilePending[serverUrl] = undefined;
             this.reconcile(serverUrl, pending.teamId);
+        }
+    };
+
+    /**
+     * runAbsencePass: SAFE absence-based local convergence after a successful snapshot. Every in-scope
+     * key that has a Draft and/or a delete tombstone is classified: keys present in the snapshot clear
+     * their candidate; ineligible keys (legacy/local-only, pending intent, membership lost) are
+     * preserved and clear their candidate; eligible-but-absent keys are QUARANTINED on first absence
+     * and only CONFIRMED (deleted / tombstone-resolved) on a second same-scope absence >= DELAY later.
+     * It performs NO network activity and re-checks epoch staleness before each mutation.
+     */
+    private runAbsencePass = async (serverUrl: string, teamId: string, drafts: NormalizedDraft[], captured: number): Promise<void> => {
+        const database = this.getDatabase(serverUrl);
+        const candidates = this.absenceCandidates[serverUrl];
+        if (!database || !candidates) {
+            return;
+        }
+
+        let universe: ReconcileKey[];
+        try {
+            universe = await getReconcilableKeys(database, teamId);
+        } catch (error) {
+            logDebug('DraftSyncManager.runAbsencePass: universe query failed', serverUrl);
+            return;
+        }
+
+        // A concurrent invalidate/disable during the await discards this pass entirely.
+        if (this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl)) {
+            return;
+        }
+
+        const present = new Set(drafts.map((d) => buildDraftOutboxId(d.channelId, d.rootId)));
+        const universeKeys = new Set(universe.map((e) => buildDraftOutboxId(e.channelId, e.rootId)));
+        const now = Date.now();
+
+        // Drop candidates for keys that vanished from the universe by other means (deleted locally, etc.).
+        for (const key of candidates.keys()) {
+            if (!universeKeys.has(key)) {
+                candidates.delete(key);
+            }
+        }
+
+        const confirmed: ReconcileKey[] = [];
+        for (const entry of universe) {
+            const key = buildDraftOutboxId(entry.channelId, entry.rootId);
+
+            // Reappeared or ineligible (preserve): clear any absence candidate.
+            if (present.has(key) || !isAbsenceEligible(entry)) {
+                candidates.delete(key);
+                continue;
+            }
+
+            const candidate = candidates.get(key);
+            if (!candidate) {
+                // First absence: quarantine, delete nothing yet.
+                candidates.set(key, {firstAbsentAt: now, teamId});
+            } else if (candidate.teamId !== teamId) {
+                // Scope changed since the first observation: restart the window under the new scope.
+                candidates.set(key, {firstAbsentAt: now, teamId});
+            } else if ((now - candidate.firstAbsentAt) >= DRAFT_ABSENCE_CONFIRMATION_DELAY_MS) {
+                // Second same-scope absence past the delay: deletion confirmed.
+                confirmed.push(entry);
+            }
+        }
+
+        for (const entry of confirmed) {
+            if (this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl)) {
+                return;
+            }
+
+            if (entry.kind === 'tombstone') {
+                // eslint-disable-next-line no-await-in-loop
+                await confirmDeleteTombstone(serverUrl, entry.channelId, entry.rootId);
+            } else {
+                // eslint-disable-next-line no-await-in-loop
+                await deleteAbsentCleanDraft(serverUrl, entry.channelId, entry.rootId);
+            }
+            candidates.delete(buildDraftOutboxId(entry.channelId, entry.rootId));
+        }
+
+        if (confirmed.length) {
+            logDebug('DraftSyncManager.runAbsencePass: confirmed absence deletions', serverUrl, confirmed.length);
         }
     };
 
@@ -251,6 +368,7 @@ class DraftSyncManagerSingleton {
         delete this.baseline[serverUrl];
         this.reconcileInFlight[serverUrl] = false;
         this.reconcilePending[serverUrl] = undefined;
+        this.absenceCandidates[serverUrl] = new Map();
         logDebug('DraftSyncManager.invalidate', serverUrl);
     };
 
@@ -373,6 +491,9 @@ class DraftSyncManagerSingleton {
         if (!(serverUrl in this.reconcilePending)) {
             this.reconcilePending[serverUrl] = undefined;
         }
+        if (!(serverUrl in this.absenceCandidates)) {
+            this.absenceCandidates[serverUrl] = new Map();
+        }
     };
 
     // isActive: the server is present, enabled, and not invalidated (invalidate sets enabled=false).
@@ -400,4 +521,5 @@ export type ManagerBaselineInternals = {
     baseline: Record<string, {teamId: string; at: number}>;
     reconcileInFlight: Record<string, boolean>;
     reconcilePending: Record<string, {teamId: string} | undefined>;
+    absenceCandidates: Record<string, Map<string, {firstAbsentAt: number; teamId: string}>>;
 };

--- a/app/managers/draft_sync_manager/index.ts
+++ b/app/managers/draft_sync_manager/index.ts
@@ -3,10 +3,12 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
-import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts, type ReconcileKey, type WorkerOutcome} from '@actions/remote/draft';
+import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts, type OutboxWorkerOpts, type ReconcileKey, type WorkerOutcome} from '@actions/remote/draft';
+import {General} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DRAFT_SYNC_RETRY_BASE_MS, DRAFT_SYNC_RETRY_JITTER, DRAFT_SYNC_RETRY_MAX_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
+import {getChannelById, getMyChannel} from '@queries/servers/channel';
 import {buildDraftOutboxId, getIsDraftSyncEnabled} from '@queries/servers/drafts';
 import {logDebug} from '@utils/log';
 
@@ -82,10 +84,6 @@ class DraftSyncManagerSingleton {
     // disabled OR invalidated so no work is scheduled.
     private enabled: Record<string, boolean> = {};
 
-    // activeCriticalSections: count of in-flight DB writer sections. invalidate() only needs to
-    // wait for these to reach 0 (there is no HTTP in this phase). Tracked here for Phase 4.
-    private activeCriticalSections: Record<string, number> = {};
-
     // lastReconcile: last requested reconciliation intent per server (Phase 3 records only).
     private lastReconcile: Record<string, {teamId: string; reason: string}> = {};
 
@@ -110,6 +108,12 @@ class DraftSyncManagerSingleton {
     // worker. Guarantees per-key serialization across overlapping drains (a wake firing while a timer
     // drain runs) so the same row is never POSTed/DELETEd twice concurrently. Cleared on invalidate.
     private inFlightKeys: Record<string, Set<string>> = {};
+
+    // observationOrdinals: per-server map (draftKey -> monotonically increasing counter). A reconcile
+    // GET that observes newer content for a key whose POST is in flight bumps its ordinal; the worker
+    // captured the ordinal before dispatch and, on ack, refuses to clobber the newer content when it
+    // changed. Init in ensureServer, cleared on invalidate; safe to lose (a re-POST re-captures it).
+    private observationOrdinals: Record<string, Map<string, number>> = {};
 
     /**
      * initialize: idempotent per-server setup. Reads the draft-sync capability into `enabled` and,
@@ -255,6 +259,17 @@ class DraftSyncManagerSingleton {
             this.reconcileAttempt[serverUrl] = 0;
             this.baseline[serverUrl] = {teamId, at: Date.now()};
 
+            // Post-dispatch observation fence: for every returned key whose POST is currently in flight,
+            // bump its observation ordinal. This GET observed the key's content, so the in-flight ack
+            // must not clobber it (the worker captured the ordinal before dispatch). Synchronous, so it
+            // is covered by the epoch check already performed after the await above.
+            const inFlight = this.inFlightKeys[serverUrl];
+            for (const draft of res.drafts ?? []) {
+                if (inFlight?.has(buildDraftOutboxId(draft.channelId, draft.rootId))) {
+                    this.bumpObservation(serverUrl, draft.channelId, draft.rootId);
+                }
+            }
+
             // Absence pass: a successful snapshot lets us quarantine/confirm keys that are absent
             // from it. Epoch-guarded internally; it never POSTs/DELETEs over the network.
             await this.runAbsencePass(serverUrl, teamId, res.drafts ?? [], captured);
@@ -264,6 +279,14 @@ class DraftSyncManagerSingleton {
             // confirming-delete/absence candidates remain).
             if (!this.isEpochStale(serverUrl, captured) && this.isActive(serverUrl)) {
                 await this.drainOutbox(serverUrl);
+            }
+
+            // Missing dependencies: the snapshot referenced channels not yet hydrated, so those keys
+            // were skipped. Record a soft attempt so scheduleWork arms a reconcile-GET retry (a real
+            // backoff delay, never zero) to re-fetch once dependencies may have hydrated. A subsequent
+            // fully-applied reconcile resets the attempt to 0.
+            if (res.missingDeps && !this.isEpochStale(serverUrl, captured) && this.isActive(serverUrl)) {
+                this.reconcileAttempt[serverUrl] = (this.reconcileAttempt[serverUrl] ?? 0) + 1;
             }
         }
 
@@ -450,6 +473,7 @@ class DraftSyncManagerSingleton {
         this.reconcileAttempt[serverUrl] = 0;
         this.absenceCandidates[serverUrl] = new Map();
         this.inFlightKeys[serverUrl] = new Set();
+        this.observationOrdinals[serverUrl] = new Map();
         logDebug('DraftSyncManager.invalidate', serverUrl);
     };
 
@@ -620,6 +644,17 @@ class DraftSyncManagerSingleton {
                 continue;
             }
 
+            // A '' team is a DM/GM scope ONLY. Validate before draining under this arbitrary baseline's
+            // team: a row mis-stamped '' for a since-resolved channel must not drain here. Require the
+            // channel to be a DM/GM or to have confirmed membership; skip otherwise.
+            if (row.teamId === '') {
+                // eslint-disable-next-line no-await-in-loop
+                const validScope = await this.isDmGmOrMember(database, row.channelId);
+                if (!validScope) {
+                    continue;
+                }
+            }
+
             const key = buildDraftOutboxId(row.channelId, row.rootId);
             if (inFlight.has(key)) {
                 continue;
@@ -627,16 +662,21 @@ class DraftSyncManagerSingleton {
 
             inFlight.add(key);
             const captured = this.captureEpoch(serverUrl);
+            const opts: OutboxWorkerOpts = {
+                shouldAbort: () => this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl),
+                captureObservation: () => this.getObservation(serverUrl, row.channelId, row.rootId),
+                observationChanged: (c: number) => this.getObservation(serverUrl, row.channelId, row.rootId) !== c,
+            };
 
             let outcome: WorkerOutcome;
             try {
                 outcome = row.operation === DraftOutboxOperation.Delete ?
 
                     // eslint-disable-next-line no-await-in-loop
-                    await processOutboxDelete(serverUrl, row.channelId, row.rootId) :
+                    await processOutboxDelete(serverUrl, row.channelId, row.rootId, opts) :
 
                     // eslint-disable-next-line no-await-in-loop
-                    await processOutboxUpsert(serverUrl, row.channelId, row.rootId);
+                    await processOutboxUpsert(serverUrl, row.channelId, row.rootId, opts);
             } catch (error) {
                 logDebug('DraftSyncManager.drainOutbox: worker threw', serverUrl);
                 outcome = {outcome: 'retry'};
@@ -692,9 +732,6 @@ class DraftSyncManagerSingleton {
         if (!(serverUrl in this.enabled)) {
             this.enabled[serverUrl] = false;
         }
-        if (!(serverUrl in this.activeCriticalSections)) {
-            this.activeCriticalSections[serverUrl] = 0;
-        }
         if (!(serverUrl in this.reconcileInFlight)) {
             this.reconcileInFlight[serverUrl] = false;
         }
@@ -713,6 +750,9 @@ class DraftSyncManagerSingleton {
         if (!(serverUrl in this.inFlightKeys)) {
             this.inFlightKeys[serverUrl] = new Set();
         }
+        if (!(serverUrl in this.observationOrdinals)) {
+            this.observationOrdinals[serverUrl] = new Map();
+        }
     };
 
     // isActive: the server is present, enabled, and not invalidated (invalidate sets enabled=false).
@@ -723,6 +763,31 @@ class DraftSyncManagerSingleton {
     // getDatabase: the server database or undefined when it is absent/destroyed. Never throws.
     private getDatabase = (serverUrl: string): Database | undefined => {
         return DatabaseManager.serverDatabases[serverUrl]?.database;
+    };
+
+    // isDmGmOrMember: whether a channel is a valid '' (DM/GM) drain scope — a DM/GM channel, or any
+    // channel the current user has a confirmed membership row for.
+    private isDmGmOrMember = async (database: Database, channelId: string): Promise<boolean> => {
+        const channel = await getChannelById(database, channelId);
+        if (channel?.type === General.DM_CHANNEL || channel?.type === General.GM_CHANNEL) {
+            return true;
+        }
+        return Boolean(await getMyChannel(database, channelId));
+    };
+
+    // bumpObservation: increment the per-key observation ordinal (a reconcile GET observed this key).
+    private bumpObservation = (serverUrl: string, channelId: string, rootId: string): void => {
+        const map = this.observationOrdinals[serverUrl];
+        if (!map) {
+            return;
+        }
+        const key = buildDraftOutboxId(channelId, rootId);
+        map.set(key, (map.get(key) ?? 0) + 1);
+    };
+
+    // getObservation: the current per-key observation ordinal (0 when never observed).
+    private getObservation = (serverUrl: string, channelId: string, rootId: string): number => {
+        return this.observationOrdinals[serverUrl]?.get(buildDraftOutboxId(channelId, rootId)) ?? 0;
     };
 }
 

--- a/app/managers/draft_sync_manager/index.ts
+++ b/app/managers/draft_sync_manager/index.ts
@@ -3,13 +3,13 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
-import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts, type OutboxWorkerOpts, type ReconcileKey, type WorkerOutcome} from '@actions/remote/draft';
+import {computeNextAttemptAt, confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts, type OutboxWorkerOpts, type ReconcileKey, type WorkerOutcome} from '@actions/remote/draft';
 import {General} from '@constants';
 import {MM_TABLES} from '@constants/database';
 import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DRAFT_SYNC_RETRY_BASE_MS, DRAFT_SYNC_RETRY_JITTER, DRAFT_SYNC_RETRY_MAX_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
 import {getChannelById, getMyChannel} from '@queries/servers/channel';
-import {buildDraftOutboxId, getIsDraftSyncEnabled} from '@queries/servers/drafts';
+import {buildDraftOutboxId, getIsDraftSyncEnabled, mutateDraftAndOutbox} from '@queries/servers/drafts';
 import {logDebug} from '@utils/log';
 
 import type DraftOutboxModel from '@typings/database/models/servers/draft_outbox';
@@ -238,7 +238,26 @@ class DraftSyncManagerSingleton {
 
         let res: Awaited<ReturnType<typeof reconcileTeamDrafts>>;
         try {
-            res = await reconcileTeamDrafts(serverUrl, teamId);
+            res = await reconcileTeamDrafts(serverUrl, teamId, {
+
+                // Fail closed if the server was torn down while the GET was in flight: no snapshot write.
+                shouldAbort: () => this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl),
+
+                // Post-dispatch observation fence: bump the ordinal for every observed key whose POST is
+                // in flight, SYNCHRONOUSLY as the GET resolves (before the apply loop). A concurrent ack
+                // then sees the change and refuses to clear the outbox / clobber this GET's observation.
+                onSnapshot: (keys) => {
+                    const inFlight = this.inFlightKeys[serverUrl];
+                    if (!inFlight) {
+                        return;
+                    }
+                    for (const {channelId, rootId} of keys) {
+                        if (inFlight.has(buildDraftOutboxId(channelId, rootId))) {
+                            this.bumpObservation(serverUrl, channelId, rootId);
+                        }
+                    }
+                },
+            });
         } catch (error) {
             res = {error};
         }
@@ -259,16 +278,8 @@ class DraftSyncManagerSingleton {
             this.reconcileAttempt[serverUrl] = 0;
             this.baseline[serverUrl] = {teamId, at: Date.now()};
 
-            // Post-dispatch observation fence: for every returned key whose POST is currently in flight,
-            // bump its observation ordinal. This GET observed the key's content, so the in-flight ack
-            // must not clobber it (the worker captured the ordinal before dispatch). Synchronous, so it
-            // is covered by the epoch check already performed after the await above.
-            const inFlight = this.inFlightKeys[serverUrl];
-            for (const draft of res.drafts ?? []) {
-                if (inFlight?.has(buildDraftOutboxId(draft.channelId, draft.rootId))) {
-                    this.bumpObservation(serverUrl, draft.channelId, draft.rootId);
-                }
-            }
+            // (The observation fence for in-flight POSTs is bumped synchronously via onSnapshot above,
+            // the moment the GET resolves — not here, which would be after the whole apply loop.)
 
             // Absence pass: a successful snapshot lets us quarantine/confirm keys that are absent
             // from it. Epoch-guarded internally; it never POSTs/DELETEs over the network.
@@ -651,6 +662,20 @@ class DraftSyncManagerSingleton {
                 // eslint-disable-next-line no-await-in-loop
                 const validScope = await this.isDmGmOrMember(database, row.channelId);
                 if (!validScope) {
+                    // Do NOT bare-continue: the row stays Pending-and-due, so scheduleWork would re-arm a
+                    // zero-delay drain that skips it again — a busy loop. Back its next_attempt_at off so
+                    // it leaves the due set until its channel/membership may have hydrated (a valid drain
+                    // resets the count). The delay caps at DRAFT_SYNC_RETRY_MAX_MS for a truly orphaned row.
+                    // eslint-disable-next-line no-await-in-loop
+                    await mutateDraftAndOutbox(database, row.channelId, row.rootId, ({outbox: o}) => {
+                        if (!o || o.status !== DraftOutboxStatus.Pending) {
+                            return [];
+                        }
+                        return [o.prepareUpdate((x) => {
+                            x.attemptCount += 1;
+                            x.nextAttemptAt = computeNextAttemptAt(x.attemptCount, Date.now());
+                        })];
+                    });
                     continue;
                 }
             }

--- a/app/managers/draft_sync_manager/index.ts
+++ b/app/managers/draft_sync_manager/index.ts
@@ -3,7 +3,7 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
-import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, reconcileTeamDrafts, type ReconcileKey} from '@actions/remote/draft';
+import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts, type ReconcileKey, type WorkerOutcome} from '@actions/remote/draft';
 import {MM_TABLES} from '@constants/database';
 import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
@@ -101,6 +101,11 @@ class DraftSyncManagerSingleton {
     // separated by >= DRAFT_ABSENCE_CONFIRMATION_DELAY_MS. Cleared on invalidate; safe to lose.
     private absenceCandidates: Record<string, Map<string, AbsenceCandidate>> = {};
 
+    // inFlightKeys: per-server set of outbox keys (buildDraftOutboxId) currently being drained by a
+    // worker. Guarantees per-key serialization across overlapping drains (a wake firing while a timer
+    // drain runs) so the same row is never POSTed/DELETEd twice concurrently. Cleared on invalidate.
+    private inFlightKeys: Record<string, Set<string>> = {};
+
     /**
      * initialize: idempotent per-server setup. Reads the draft-sync capability into `enabled` and,
      * when enabled, reconstructs the retry timer from the outbox. Safe to call when the server
@@ -122,8 +127,43 @@ class DraftSyncManagerSingleton {
             return;
         }
 
+        // Interrupted-upload recovery: any WaitingForUpload row survived a process restart with no
+        // live upload behind it, so it can never self-complete. Conservatively transition every such
+        // row to BlockedUpload('upload_interrupted'); a later genuine edit / upload retry re-activates
+        // it. Phase: refine with DraftEditPostUploadManager to only transition rows with no in-progress
+        // upload once that manager is reachable from here.
+        await this.recoverInterruptedUploads(database);
+
         if (this.enabled[serverUrl]) {
             await this.reconstructRetryTimer(serverUrl);
+        }
+    };
+
+    /**
+     * recoverInterruptedUploads: mark every WaitingForUpload outbox row as BlockedUpload with
+     * lastErrorCode 'upload_interrupted'. Called once on initialize because a WaitingForUpload row that
+     * outlived the process has no live upload behind it. Never throws.
+     */
+    private recoverInterruptedUploads = async (database: Database): Promise<void> => {
+        try {
+            const rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
+                Q.where('status', DraftOutboxStatus.WaitingForUpload),
+            ).fetch();
+
+            if (!rows.length) {
+                return;
+            }
+
+            const updates = rows.map((row) => row.prepareUpdate((o) => {
+                o.status = DraftOutboxStatus.BlockedUpload;
+                o.lastErrorCode = 'upload_interrupted';
+            }));
+
+            await database.write(async (writer) => {
+                await writer.batch(...updates);
+            }, 'recoverInterruptedUploads');
+        } catch (error) {
+            logDebug('DraftSyncManager.recoverInterruptedUploads: query/write failed');
         }
     };
 
@@ -136,8 +176,14 @@ class DraftSyncManagerSingleton {
             return;
         }
 
-        // Fire-and-forget: reconstruction is async (DB query) but wake() is synchronous by contract.
-        this.reconstructRetryTimer(serverUrl);
+        // Fire-and-forget: draining is async (DB + HTTP) but wake() is synchronous by contract. With a
+        // baseline established, drain immediately (drainOutbox reschedules the heartbeat when it ends);
+        // without one, only (re)arm the heartbeat so the work drains once a baseline appears.
+        if (this.baseline[serverUrl]) {
+            this.drainOutbox(serverUrl);
+        } else {
+            this.reconstructRetryTimer(serverUrl);
+        }
     };
 
     /**
@@ -369,6 +415,7 @@ class DraftSyncManagerSingleton {
         this.reconcileInFlight[serverUrl] = false;
         this.reconcilePending[serverUrl] = undefined;
         this.absenceCandidates[serverUrl] = new Map();
+        this.inFlightKeys[serverUrl] = new Set();
         logDebug('DraftSyncManager.invalidate', serverUrl);
     };
 
@@ -436,10 +483,95 @@ class DraftSyncManagerSingleton {
                 return;
             }
 
-            // Phase 3: do NOT drain/POST/DELETE. Behave as a self-rescheduling heartbeat.
-            // Phase 4: drain eligible outbox work here.
-            this.reconstructRetryTimer(serverUrl);
+            // Phase 4: drain eligible outbox work. drainOutbox is baseline-gated (no POST/DELETE without
+            // a baseline) and reschedules this heartbeat when it ends, so the timer stays a self-
+            // rescheduling loop even before a baseline exists.
+            this.drainOutbox(serverUrl);
         }, delay);
+    };
+
+    /**
+     * drainOutbox: the write path. Sends eligible Pending outbox rows to the server via the per-key
+     * workers, with per-key serialization (inFlightKeys), epoch guarding around each worker, and a
+     * heartbeat reschedule when it ends. It performs NO network work until a baseline reconciliation
+     * exists for the scope (the exit criterion) — without one it only (re)arms the heartbeat.
+     */
+    private drainOutbox = async (serverUrl: string): Promise<void> => {
+        if (!this.isActive(serverUrl)) {
+            return;
+        }
+
+        const baseline = this.baseline[serverUrl];
+        if (!baseline) {
+            // NO draining without a baseline. Keep the heartbeat alive so queued work drains once a
+            // baseline is established (re-querying the outbox is not a network send).
+            await this.reconstructRetryTimer(serverUrl);
+            return;
+        }
+
+        const database = this.getDatabase(serverUrl);
+        const inFlight = this.inFlightKeys[serverUrl];
+        if (!database || !inFlight) {
+            return;
+        }
+
+        let rows: DraftOutboxModel[];
+        try {
+            rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
+                Q.where('status', DraftOutboxStatus.Pending),
+                Q.where('operation', Q.oneOf([DraftOutboxOperation.Upsert, DraftOutboxOperation.Delete])),
+                Q.where('next_attempt_at', Q.lte(Date.now())),
+            ).fetch();
+        } catch (error) {
+            logDebug('DraftSyncManager.drainOutbox: outbox query failed', serverUrl);
+            return;
+        }
+
+        for (const row of rows) {
+            // Scope gate: only this baseline's team, or DM/GM ('' team) rows.
+            if (row.teamId !== baseline.teamId && row.teamId !== '') {
+                continue;
+            }
+
+            const key = buildDraftOutboxId(row.channelId, row.rootId);
+            if (inFlight.has(key)) {
+                continue;
+            }
+
+            inFlight.add(key);
+            const captured = this.captureEpoch(serverUrl);
+
+            let outcome: WorkerOutcome;
+            try {
+                outcome = row.operation === DraftOutboxOperation.Delete ?
+
+                    // eslint-disable-next-line no-await-in-loop
+                    await processOutboxDelete(serverUrl, row.channelId, row.rootId) :
+
+                    // eslint-disable-next-line no-await-in-loop
+                    await processOutboxUpsert(serverUrl, row.channelId, row.rootId);
+            } catch (error) {
+                logDebug('DraftSyncManager.drainOutbox: worker threw', serverUrl);
+                outcome = {outcome: 'retry'};
+            } finally {
+                inFlight.delete(key);
+            }
+
+            // A concurrent invalidate/disable during the worker discards its result entirely.
+            if (this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl)) {
+                return;
+            }
+
+            if (outcome.outcome === 'suspend') {
+                // Server-wide failure: stop scheduling for this session and drop the heartbeat.
+                this.enabled[serverUrl] = false;
+                this.clearRetryTimer(serverUrl);
+                return;
+            }
+        }
+
+        // Schedule the next wake for the earliest remaining nextAttemptAt.
+        await this.reconstructRetryTimer(serverUrl);
     };
 
     // getEarliestNextAttemptAt: earliest nextAttemptAt across retry-eligible outbox rows, or
@@ -493,6 +625,9 @@ class DraftSyncManagerSingleton {
         }
         if (!(serverUrl in this.absenceCandidates)) {
             this.absenceCandidates[serverUrl] = new Map();
+        }
+        if (!(serverUrl in this.inFlightKeys)) {
+            this.inFlightKeys[serverUrl] = new Set();
         }
     };
 

--- a/app/managers/draft_sync_manager/index.ts
+++ b/app/managers/draft_sync_manager/index.ts
@@ -3,6 +3,7 @@
 
 import {Q, type Database} from '@nozbe/watermelondb';
 
+import {reconcileTeamDrafts} from '@actions/remote/draft';
 import {MM_TABLES} from '@constants/database';
 import {DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
@@ -58,6 +59,18 @@ class DraftSyncManagerSingleton {
     // lastReconcile: last requested reconciliation intent per server (Phase 3 records only).
     private lastReconcile: Record<string, {teamId: string; reason: string}> = {};
 
+    // baseline: the last successful reconciliation snapshot marker per server (teamId + timestamp).
+    // Set only after a reconcile whose epoch stayed valid succeeds. A later sub-step uses it to gate
+    // absence-based decisions; this sub-step only records it.
+    private baseline: Record<string, {teamId: string; at: number}> = {};
+
+    // reconcileInFlight: true while a reconcile await is outstanding for the server (single-flight).
+    private reconcileInFlight: Record<string, boolean> = {};
+
+    // reconcilePending: a coalesced reconcile request that arrived while one was in flight. Drained
+    // (run once) after the in-flight reconcile settles.
+    private reconcilePending: Record<string, {teamId: string} | undefined> = {};
+
     /**
      * initialize: idempotent per-server setup. Reads the draft-sync capability into `enabled` and,
      * when enabled, reconstructs the retry timer from the outbox. Safe to call when the server
@@ -98,8 +111,8 @@ class DraftSyncManagerSingleton {
     };
 
     /**
-     * requestReconcile: Phase 3 records the request (last teamId/reason) and ensures a retry timer
-     * exists. It does NOT perform a GET — baseline reconciliation is Phase 4.
+     * requestReconcile: records the request and fires the additive baseline reconciliation
+     * (fire-and-forget; synchronous by contract). Draining/absence-detection stay in later sub-steps.
      */
     public requestReconcile = (serverUrl: string, teamId: string, reason: string): void => {
         if (!this.isActive(serverUrl)) {
@@ -109,8 +122,59 @@ class DraftSyncManagerSingleton {
         this.lastReconcile[serverUrl] = {teamId, reason};
         logDebug('DraftSyncManager.requestReconcile', serverUrl, reason);
 
-        // Phase 4: trigger baseline reconciliation here (GET drafts for the team, diff, reconcile).
-        this.reconstructRetryTimer(serverUrl);
+        // Phase 4.1: additive baseline reconciliation (GET drafts for the team, apply the snapshot).
+        // Absence-based deletion and POST/DELETE draining are deliberately NOT done here.
+        this.reconcile(serverUrl, teamId);
+    };
+
+    /**
+     * reconcile: single-flight, epoch-guarded additive baseline reconciliation for a team. It applies
+     * the server snapshot via reconcileTeamDrafts (which never deletes for absence) and, on success,
+     * records the baseline. It never drains/POSTs/DELETEs. Concurrent requests coalesce: the latest
+     * teamId is remembered and run once after the in-flight pass settles.
+     */
+    private reconcile = async (serverUrl: string, teamId: string): Promise<void> => {
+        if (!this.isActive(serverUrl)) {
+            return;
+        }
+
+        if (this.reconcileInFlight[serverUrl]) {
+            // Coalesce: remember the latest request and let the in-flight pass drain it when it ends.
+            this.reconcilePending[serverUrl] = {teamId};
+            return;
+        }
+
+        this.reconcileInFlight[serverUrl] = true;
+        const captured = this.captureEpoch(serverUrl);
+
+        let res: Awaited<ReturnType<typeof reconcileTeamDrafts>>;
+        try {
+            res = await reconcileTeamDrafts(serverUrl, teamId);
+        } catch (error) {
+            res = {error};
+        }
+
+        // A concurrent invalidate/disable during the await discards this continuation entirely.
+        if (this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl)) {
+            this.reconcileInFlight[serverUrl] = false;
+            return;
+        }
+
+        if (res.error) {
+            // Failure: do NOT set a baseline. The heartbeat will re-request later.
+            logDebug('DraftSyncManager.reconcile: reconciliation failed', serverUrl);
+            this.reconstructRetryTimer(serverUrl);
+        } else {
+            this.baseline[serverUrl] = {teamId, at: Date.now()};
+        }
+
+        this.reconcileInFlight[serverUrl] = false;
+
+        const pending = this.reconcilePending[serverUrl];
+        if (pending) {
+            this.reconcilePending[serverUrl] = undefined;
+            this.reconcile(serverUrl, pending.teamId);
+        }
     };
 
     /**
@@ -184,6 +248,9 @@ class DraftSyncManagerSingleton {
         this.eventBuffers[serverUrl] = [];
         this.enabled[serverUrl] = false;
         this.lastReconcile[serverUrl] = {teamId: '', reason: ''};
+        delete this.baseline[serverUrl];
+        this.reconcileInFlight[serverUrl] = false;
+        this.reconcilePending[serverUrl] = undefined;
         logDebug('DraftSyncManager.invalidate', serverUrl);
     };
 
@@ -300,6 +367,12 @@ class DraftSyncManagerSingleton {
         if (!(serverUrl in this.activeCriticalSections)) {
             this.activeCriticalSections[serverUrl] = 0;
         }
+        if (!(serverUrl in this.reconcileInFlight)) {
+            this.reconcileInFlight[serverUrl] = false;
+        }
+        if (!(serverUrl in this.reconcilePending)) {
+            this.reconcilePending[serverUrl] = undefined;
+        }
     };
 
     // isActive: the server is present, enabled, and not invalidated (invalidate sets enabled=false).
@@ -319,4 +392,12 @@ export default DraftSyncManager;
 export const exportedForTesting = {
     DraftSyncManagerSingleton,
     RETRY_ELIGIBLE_STATUSES,
+};
+
+// ManagerBaselineInternals: narrow view onto the private baseline/single-flight state so tests can
+// assert reconciliation bookkeeping without adding production-only accessors.
+export type ManagerBaselineInternals = {
+    baseline: Record<string, {teamId: string; at: number}>;
+    reconcileInFlight: Record<string, boolean>;
+    reconcilePending: Record<string, {teamId: string} | undefined>;
 };

--- a/app/managers/draft_sync_manager/index.ts
+++ b/app/managers/draft_sync_manager/index.ts
@@ -5,7 +5,7 @@ import {Q, type Database} from '@nozbe/watermelondb';
 
 import {confirmDeleteTombstone, deleteAbsentCleanDraft, getReconcilableKeys, processOutboxDelete, processOutboxUpsert, reconcileTeamDrafts, type ReconcileKey, type WorkerOutcome} from '@actions/remote/draft';
 import {MM_TABLES} from '@constants/database';
-import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
+import {DRAFT_ABSENCE_CONFIRMATION_DELAY_MS, DRAFT_SYNC_RETRY_BASE_MS, DRAFT_SYNC_RETRY_JITTER, DRAFT_SYNC_RETRY_MAX_MS, DraftOutboxOperation, DraftOutboxStatus, MAX_DRAFT_SYNC_EVENT_BUFFER} from '@constants/draft';
 import DatabaseManager from '@database/manager';
 import {buildDraftOutboxId, getIsDraftSyncEnabled} from '@queries/servers/drafts';
 import {logDebug} from '@utils/log';
@@ -39,23 +39,16 @@ const isAbsenceEligible = (entry: ReconcileKey): boolean => {
 
 const {DRAFT_OUTBOX} = MM_TABLES.SERVER;
 
-// RETRY_ELIGIBLE_STATUSES: outbox statuses that represent outstanding work the retry timer must
-// wake up for. Blocked/BlockedUpload/WaitingForUpload rows are intentionally excluded — they are
-// parked awaiting an external signal (unblock, upload completion) and are NOT time-driven.
-const RETRY_ELIGIBLE_STATUSES: DraftOutboxStatus[] = [
-    DraftOutboxStatus.Pending,
-    DraftOutboxStatus.ConfirmingDelete,
-];
-
 /**
- * DraftSyncManager (Phase 3 shell): the per-server coordinator for synchronized drafts.
+ * DraftSyncManager: the per-server coordinator for synchronized drafts.
  *
- * CRITICAL: this phase performs NO network activity. It owns per-server lifecycle state, a
- * lifecycle epoch used to reject stale async continuations, a bounded inbound WebSocket event
- * buffer, and a single durable retry timer per server that reconstructs itself from the
- * DraftOutbox. The retry timer's fire callback does NOT send anything — it merely re-queries the
- * outbox and reschedules itself (a self-rescheduling heartbeat). Phase 4 will add draining/POST/
- * DELETE/GET at the marked call sites.
+ * It owns per-server lifecycle state, a lifecycle epoch that rejects stale async continuations, a
+ * bounded inbound WebSocket event buffer, the baseline gate, in-memory absence candidates, and two
+ * timers scheduled by scheduleWork: a DRAIN timer (POST/DELETE the outbox, only with a baseline) and
+ * a RECONCILE timer (GET the team snapshot to establish/refresh the baseline or run a delayed
+ * absence/confirmation observation, only with a known team). Neither timer can form a zero-delay
+ * loop: the drain timer requires due Pending work under a baseline, and the reconcile timer always
+ * uses a real backoff/confirmation delay.
  *
  * Per-server state is keyed by serverUrl. A server entry is "present" once initialize() (or any
  * scheduling path) has created it. A missing entry is treated as invalidated: no new work is
@@ -66,8 +59,20 @@ class DraftSyncManagerSingleton {
     // epoch that no longer matches (or whose server entry is gone) marks a stale continuation.
     private lifecycleEpoch: Record<string, number> = {};
 
-    // retryTimers: at most one active setTimeout per server (the self-rescheduling heartbeat).
+    // retryTimers: the OUTBOX DRAIN timer (at most one per server). Armed only when a baseline exists
+    // and there are due Pending rows in scope; its fire calls drainOutbox. Never armed without a
+    // baseline (draining without a baseline would no-op), so it can never form a zero-delay loop.
     private retryTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+    // reconcileTimers: the RECONCILE (GET) timer (at most one per server). Armed with a real delay
+    // (never 0) to (a) establish a baseline before draining, (b) retry a failed GET with backoff, or
+    // (c) run the delayed second observation for confirming-delete tombstones / absence candidates.
+    // Requires a known team (baseline.teamId or the last requested team); without one, nothing is armed.
+    private reconcileTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+    // reconcileAttempt: consecutive failed-GET count per server, driving the reconcile backoff. Reset
+    // to 0 on a successful reconcile.
+    private reconcileAttempt: Record<string, number> = {};
 
     // eventBuffers: inbound WebSocket events awaiting Phase 4 draining, bounded by
     // MAX_DRAFT_SYNC_EVENT_BUFFER. Overflowing events are dropped (oldest kept) with a debug log.
@@ -134,8 +139,11 @@ class DraftSyncManagerSingleton {
         // upload once that manager is reachable from here.
         await this.recoverInterruptedUploads(database);
 
+        // Do NOT arm a drain timer here: there is no baseline yet (draining needs one) and no known
+        // team to reconcile until a trigger (requestReconcile) supplies one. scheduleWork therefore
+        // arms nothing on a cold start with no team/baseline, which is what prevents a busy loop.
         if (this.enabled[serverUrl]) {
-            await this.reconstructRetryTimer(serverUrl);
+            await this.scheduleWork(serverUrl);
         }
     };
 
@@ -177,12 +185,13 @@ class DraftSyncManagerSingleton {
         }
 
         // Fire-and-forget: draining is async (DB + HTTP) but wake() is synchronous by contract. With a
-        // baseline established, drain immediately (drainOutbox reschedules the heartbeat when it ends);
-        // without one, only (re)arm the heartbeat so the work drains once a baseline appears.
+        // baseline established, drain immediately (drainOutbox reschedules via scheduleWork when it
+        // ends); without one, let scheduleWork arm a reconcile (only if a team is known) so the work
+        // drains once a baseline appears.
         if (this.baseline[serverUrl]) {
             this.drainOutbox(serverUrl);
         } else {
-            this.reconstructRetryTimer(serverUrl);
+            this.scheduleWork(serverUrl);
         }
     };
 
@@ -237,19 +246,31 @@ class DraftSyncManagerSingleton {
         }
 
         if (res.error) {
-            // Failure: do NOT set a baseline and run NO absence pass. Without a snapshot nothing may
-            // be deleted. The heartbeat will re-request later.
+            // Failure: do NOT set a baseline and run NO absence pass (without a snapshot nothing may be
+            // deleted). Increment the backoff count; scheduleWork arms a reconcile-GET retry with a real
+            // delay (never 0) so a persistently failing GET can never form a busy loop.
             logDebug('DraftSyncManager.reconcile: reconciliation failed', serverUrl);
-            this.reconstructRetryTimer(serverUrl);
+            this.reconcileAttempt[serverUrl] = (this.reconcileAttempt[serverUrl] ?? 0) + 1;
         } else {
+            this.reconcileAttempt[serverUrl] = 0;
             this.baseline[serverUrl] = {teamId, at: Date.now()};
 
             // Absence pass: a successful snapshot lets us quarantine/confirm keys that are absent
             // from it. Epoch-guarded internally; it never POSTs/DELETEs over the network.
             await this.runAbsencePass(serverUrl, teamId, res.drafts ?? [], captured);
+
+            // A fresh baseline means queued outbox work can now drain. drainOutbox re-checks epoch and
+            // calls scheduleWork when it ends (which re-arms the delayed confirmation reconcile if any
+            // confirming-delete/absence candidates remain).
+            if (!this.isEpochStale(serverUrl, captured) && this.isActive(serverUrl)) {
+                await this.drainOutbox(serverUrl);
+            }
         }
 
         this.reconcileInFlight[serverUrl] = false;
+
+        // Re-evaluate timers (reconcile backoff on failure; delayed confirmation on success).
+        await this.scheduleWork(serverUrl);
 
         const pending = this.reconcilePending[serverUrl];
         if (pending) {
@@ -386,17 +407,28 @@ class DraftSyncManagerSingleton {
 
         if (wasEnabled && !nowEnabled) {
             // enabled -> disabled: stop scheduling and drop transient state, but keep durable rows.
+            // CRITICAL: clear the baseline and absence candidates so re-enabling cannot drain/POST
+            // against a stale snapshot — a fresh successful GET is required before draining resumes.
             this.clearRetryTimer(serverUrl);
+            this.clearReconcileTimer(serverUrl);
             this.eventBuffers[serverUrl] = [];
+            delete this.baseline[serverUrl];
+            this.absenceCandidates[serverUrl] = new Map();
+            this.reconcileAttempt[serverUrl] = 0;
             logDebug('DraftSyncManager.handleCapabilityChange: disabled', serverUrl);
             return;
         }
 
         if (!wasEnabled && nowEnabled) {
-            // disabled -> enabled: resume the heartbeat.
+            // disabled -> enabled: require a fresh baseline before any draining. If a team is known,
+            // reconcile now (which will drain on success); otherwise scheduleWork waits for a trigger.
             logDebug('DraftSyncManager.handleCapabilityChange: enabled', serverUrl);
-            await this.reconstructRetryTimer(serverUrl);
-            this.wake(serverUrl);
+            const teamId = this.lastReconcile[serverUrl]?.teamId;
+            if (teamId) {
+                this.reconcile(serverUrl, teamId);
+            } else {
+                await this.scheduleWork(serverUrl);
+            }
         }
     };
 
@@ -408,12 +440,14 @@ class DraftSyncManagerSingleton {
     public invalidate = (serverUrl: string): void => {
         this.lifecycleEpoch[serverUrl] = (this.lifecycleEpoch[serverUrl] ?? 0) + 1;
         this.clearRetryTimer(serverUrl);
+        this.clearReconcileTimer(serverUrl);
         this.eventBuffers[serverUrl] = [];
         this.enabled[serverUrl] = false;
         this.lastReconcile[serverUrl] = {teamId: '', reason: ''};
         delete this.baseline[serverUrl];
         this.reconcileInFlight[serverUrl] = false;
         this.reconcilePending[serverUrl] = undefined;
+        this.reconcileAttempt[serverUrl] = 0;
         this.absenceCandidates[serverUrl] = new Map();
         this.inFlightKeys[serverUrl] = new Set();
         logDebug('DraftSyncManager.invalidate', serverUrl);
@@ -434,60 +468,113 @@ class DraftSyncManagerSingleton {
     };
 
     /**
-     * reconstructRetryTimer: rebuilds the single per-server heartbeat from the outbox.
+     * scheduleWork: the single decider for which timers to arm. Called after initialize, wake,
+     * reconcile, and drainOutbox. It arms at most two timers, and never a zero-delay busy loop:
      *
-     * - When disabled/invalidated or the DB is absent, clears any existing timer and returns.
-     * - Queries retry-eligible rows (Pending / ConfirmingDelete) and finds the earliest
-     *   nextAttemptAt (0 meaning "eligible now").
-     * - With none pending, clears the timer.
-     * - Otherwise schedules ONE setTimeout for max(0, earliest - now). When it fires it guards on
-     *   epoch staleness, then re-runs reconstruction (self-rescheduling). It sends NOTHING.
+     * - DRAIN timer (retryTimers): only when a baseline exists AND there is a due Pending upsert/delete
+     *   row in scope. Its fire drains those rows. A due row fires once, is consumed (removed or backed
+     *   off to a future nextAttemptAt), so it cannot re-arm at zero.
+     * - RECONCILE timer (reconcileTimers): armed only when a team is known, with a real delay:
+     *     (a) failed GET  -> reconcile backoff (>= base);
+     *     (b) no baseline but Pending work exists -> base delay, to establish a baseline first;
+     *     (c) confirming-delete rows or absence candidates -> DELAY, for the second observation GET.
+     *
+     * With no baseline and no known team (a cold start before any reconcile trigger), NOTHING is armed.
      */
-    private reconstructRetryTimer = async (serverUrl: string): Promise<void> => {
+    private scheduleWork = async (serverUrl: string): Promise<void> => {
         if (!this.isActive(serverUrl)) {
             this.clearRetryTimer(serverUrl);
+            this.clearReconcileTimer(serverUrl);
             return;
         }
 
         const database = this.getDatabase(serverUrl);
         if (!database) {
             this.clearRetryTimer(serverUrl);
+            this.clearReconcileTimer(serverUrl);
             return;
         }
 
         const captured = this.captureEpoch(serverUrl);
 
-        let earliest: number | undefined;
+        let rows: DraftOutboxModel[];
         try {
-            earliest = await this.getEarliestNextAttemptAt(database);
+            rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query().fetch();
         } catch (error) {
-            logDebug('DraftSyncManager.reconstructRetryTimer: outbox query failed', serverUrl);
+            logDebug('DraftSyncManager.scheduleWork: outbox query failed', serverUrl);
             return;
         }
 
-        // A concurrent invalidate/disable during the await must not resurrect a timer.
         if (this.isEpochStale(serverUrl, captured) || !this.isActive(serverUrl)) {
             return;
         }
 
-        // Always clear the prior timer before deciding — guarantees one timer per server.
-        this.clearRetryTimer(serverUrl);
+        const baseline = this.baseline[serverUrl];
+        const teamId = baseline?.teamId || this.lastReconcile[serverUrl]?.teamId || '';
+        const inScope = (row: DraftOutboxModel) => row.teamId === teamId || row.teamId === '';
+        const isPendingWork = (row: DraftOutboxModel) => row.status === DraftOutboxStatus.Pending &&
+            (row.operation === DraftOutboxOperation.Upsert || row.operation === DraftOutboxOperation.Delete);
+        const now = Date.now();
 
-        if (earliest === undefined) {
-            return;
+        // --- Drain timer ---
+        this.clearRetryTimer(serverUrl);
+        if (baseline) {
+            const pendingDue = rows.filter((r) => inScope(r) && isPendingWork(r));
+            if (pendingDue.length) {
+                const earliest = Math.min(...pendingDue.map((r) => r.nextAttemptAt));
+                this.armDrainTimer(serverUrl, Math.max(0, earliest - now), captured);
+            }
         }
 
-        const delay = Math.max(0, earliest - Date.now());
+        // --- Reconcile timer ---
+        this.clearReconcileTimer(serverUrl);
+        if (teamId) {
+            const attempt = this.reconcileAttempt[serverUrl] ?? 0;
+            const hasPendingInScope = rows.some((r) => inScope(r) && isPendingWork(r));
+            const hasConfirmingInScope = rows.some((r) => inScope(r) && r.status === DraftOutboxStatus.ConfirmingDelete);
+            const hasCandidates = (this.absenceCandidates[serverUrl]?.size ?? 0) > 0;
+
+            let delay: number | undefined;
+            if (attempt > 0) {
+                delay = this.reconcileBackoffMs(attempt);
+            } else if (!baseline && hasPendingInScope) {
+                delay = DRAFT_SYNC_RETRY_BASE_MS;
+            } else if (hasConfirmingInScope || hasCandidates) {
+                delay = DRAFT_ABSENCE_CONFIRMATION_DELAY_MS;
+            }
+
+            if (delay !== undefined) {
+                this.armReconcileTimer(serverUrl, teamId, delay, captured);
+            }
+        }
+    };
+
+    // armDrainTimer: schedule ONE drain timer; the fire re-checks epoch then drains.
+    private armDrainTimer = (serverUrl: string, delay: number, captured: number): void => {
         this.retryTimers[serverUrl] = setTimeout(() => {
             if (this.isEpochStale(serverUrl, captured)) {
                 return;
             }
-
-            // Phase 4: drain eligible outbox work. drainOutbox is baseline-gated (no POST/DELETE without
-            // a baseline) and reschedules this heartbeat when it ends, so the timer stays a self-
-            // rescheduling loop even before a baseline exists.
             this.drainOutbox(serverUrl);
         }, delay);
+    };
+
+    // armReconcileTimer: schedule ONE reconcile-GET timer; the fire re-checks epoch then reconciles.
+    private armReconcileTimer = (serverUrl: string, teamId: string, delay: number, captured: number): void => {
+        this.reconcileTimers[serverUrl] = setTimeout(() => {
+            if (this.isEpochStale(serverUrl, captured)) {
+                return;
+            }
+            this.reconcile(serverUrl, teamId);
+        }, delay);
+    };
+
+    // reconcileBackoffMs: capped exponential backoff (attempt 1 -> base) with +/- jitter, for retrying
+    // a failed reconciliation GET.
+    private reconcileBackoffMs = (attempt: number): number => {
+        const capped = Math.min(DRAFT_SYNC_RETRY_BASE_MS * (2 ** (attempt - 1)), DRAFT_SYNC_RETRY_MAX_MS);
+        const jitter = 1 + ((Math.random() * 2 * DRAFT_SYNC_RETRY_JITTER) - DRAFT_SYNC_RETRY_JITTER);
+        return Math.max(0, Math.round(capped * jitter));
     };
 
     /**
@@ -503,9 +590,9 @@ class DraftSyncManagerSingleton {
 
         const baseline = this.baseline[serverUrl];
         if (!baseline) {
-            // NO draining without a baseline. Keep the heartbeat alive so queued work drains once a
-            // baseline is established (re-querying the outbox is not a network send).
-            await this.reconstructRetryTimer(serverUrl);
+            // NO draining without a baseline. Defer to scheduleWork, which arms a reconcile-GET (only
+            // if a team is known) to establish one; it never arms a zero-delay drain loop.
+            await this.scheduleWork(serverUrl);
             return;
         }
 
@@ -563,43 +650,34 @@ class DraftSyncManagerSingleton {
             }
 
             if (outcome.outcome === 'suspend') {
-                // Server-wide failure: stop scheduling for this session and drop the heartbeat.
+                // Server-wide failure: stop scheduling for this session and drop both timers.
                 this.enabled[serverUrl] = false;
                 this.clearRetryTimer(serverUrl);
+                this.clearReconcileTimer(serverUrl);
                 return;
             }
         }
 
-        // Schedule the next wake for the earliest remaining nextAttemptAt.
-        await this.reconstructRetryTimer(serverUrl);
+        // Re-evaluate timers: arm the drain timer for the earliest remaining Pending row and, if any
+        // confirming-delete/absence work remains, the delayed reconcile GET.
+        await this.scheduleWork(serverUrl);
     };
 
-    // getEarliestNextAttemptAt: earliest nextAttemptAt across retry-eligible outbox rows, or
-    // undefined when there is no outstanding work.
-    private getEarliestNextAttemptAt = async (database: Database): Promise<number | undefined> => {
-        const rows = await database.collections.get<DraftOutboxModel>(DRAFT_OUTBOX).query(
-            Q.where('status', Q.oneOf(RETRY_ELIGIBLE_STATUSES)),
-        ).fetch();
-
-        if (!rows.length) {
-            return undefined;
-        }
-
-        let earliest = rows[0].nextAttemptAt;
-        for (const row of rows) {
-            if (row.nextAttemptAt < earliest) {
-                earliest = row.nextAttemptAt;
-            }
-        }
-        return earliest;
-    };
-
-    // clearRetryTimer: cancels and forgets the per-server timer if present.
+    // clearRetryTimer: cancels and forgets the per-server drain timer if present.
     private clearRetryTimer = (serverUrl: string): void => {
         const timer = this.retryTimers[serverUrl];
         if (timer) {
             clearTimeout(timer);
             delete this.retryTimers[serverUrl];
+        }
+    };
+
+    // clearReconcileTimer: cancels and forgets the per-server reconcile-GET timer if present.
+    private clearReconcileTimer = (serverUrl: string): void => {
+        const timer = this.reconcileTimers[serverUrl];
+        if (timer) {
+            clearTimeout(timer);
+            delete this.reconcileTimers[serverUrl];
         }
     };
 
@@ -619,6 +697,12 @@ class DraftSyncManagerSingleton {
         }
         if (!(serverUrl in this.reconcileInFlight)) {
             this.reconcileInFlight[serverUrl] = false;
+        }
+        if (!(serverUrl in this.reconcileAttempt)) {
+            this.reconcileAttempt[serverUrl] = 0;
+        }
+        if (!(serverUrl in this.lastReconcile)) {
+            this.lastReconcile[serverUrl] = {teamId: '', reason: ''};
         }
         if (!(serverUrl in this.reconcilePending)) {
             this.reconcilePending[serverUrl] = undefined;
@@ -647,7 +731,6 @@ export default DraftSyncManager;
 
 export const exportedForTesting = {
     DraftSyncManagerSingleton,
-    RETRY_ELIGIBLE_STATUSES,
 };
 
 // ManagerBaselineInternals: narrow view onto the private baseline/single-flight state so tests can

--- a/app/managers/ephemeral_mode_manager/index.ts
+++ b/app/managers/ephemeral_mode_manager/index.ts
@@ -10,6 +10,7 @@ import {clearEphemeralModeState, setDisconnectedSince, setLastSeenTime, setOffli
 import {Screens} from '@constants';
 import DatabaseManager from '@database/manager';
 import PushNotifications from '@init/push_notifications';
+import DraftSyncManager from '@managers/draft_sync_manager';
 import WebsocketManager from '@managers/websocket_manager';
 import {getServer, getServerDisplayName} from '@queries/app/servers';
 import {getDisconnectedSince, getLastSeenTime, getOfflineSince, observeConfigValue} from '@queries/servers/system';
@@ -408,6 +409,9 @@ class EphemeralModeManagerSingleton {
     };
 
     private wipeServerArtifacts = (serverUrl: string) => {
+        // Stop draft sync before the database is wiped so a late HTTP completion cannot touch a
+        // destroyed database. A wiped/zero-persistence database intentionally loses its outbox.
+        DraftSyncManager.invalidate(serverUrl);
         PushNotifications.removeServerNotifications(serverUrl);
         return Promise.all([
             wipeServerDatabaseWithRetry(serverUrl),
@@ -437,6 +441,9 @@ class EphemeralModeManagerSingleton {
                 logError('EphemeralModeManager.runWipe: wipe failed after retries, server re-added with stale data', serverUrl);
             }
             await this.addServer(serverUrl);
+
+            // Re-initialize draft sync against the freshly re-added (recreated) database.
+            await DraftSyncManager.initialize(serverUrl);
         } catch (error) {
             logError('EphemeralModeManager.runWipe', error);
         } finally {

--- a/app/utils/draft/sync.ts
+++ b/app/utils/draft/sync.ts
@@ -20,7 +20,7 @@ type DraftLike = {
 // It uses the DraftModel property names so a later phase can assign the values
 // directly onto a prepared record. It intentionally never carries a record id or
 // a local update_at; the caller stamps update_at when content actually changes.
-type NormalizedDraft = {
+export type NormalizedDraft = {
     channelId: string;
     rootId: string;
     message: string;


### PR DESCRIPTION
## Summary

Phase 4 — **the first phase that turns on network activity.** Drafts now actually synchronize: the manager pulls the server snapshot, converges local state safely, and drains the durable outbox to the server. Stacked on the Phase 3 branch (#9967).

Delivered in four verified sub-steps.

**4.1 — Additive snapshot reconciliation (read path)** (`edad5c9`)
`fetchDraftsForTeam` + `reconcileTeamDrafts`: adopt legacy drafts first, GET the active-team snapshot, restrict to confirmed-membership + DM/GM channels, and apply the incoming matrix per key via `mutateDraftAndOutbox` — create server-only, update clean, preserve pending (props-merge, local-wins), preserve uploads' local files, fingerprint-abandon a pending DELETE when new content arrives. GET failure applies/deletes nothing; missing channel skips one key, missing root never blocks a reply draft. Manager gains a single-flight, epoch-guarded, coalescing `reconcile` that records a baseline only on epoch-valid success.

**4.2 — Absence quarantine + delete-tombstone confirmation** (`cb15717`)
Replica-lag-safe convergence: a clean server-backed draft (or a delete tombstone) absent from a successful snapshot is only acted on after **two** same-scope reconciliations ≥ `DRAFT_ABSENCE_CONFIRMATION_DELAY_MS` apart. In-memory candidates in the manager; scope change restarts the window; reappearance/ineligibility/lost-membership preserves. `keepLocal` parks `unsyncable_empty`; ordinary tombstone is removed.

**4.3 — Gated outbox POST/DELETE workers (write path)** (`0d714e8`)
`processOutboxUpsert`/`processOutboxDelete` + backoff/error classifier. Draining is **gated on a baseline**, serialized per key, and guarded by generation (no stale-ack clobber) + lifecycle epoch. Empty→keepLocal-DELETE/park; missing-draft→blocked; DELETE 2xx→`confirming_delete`; **DELETE 404 ≠ success** (unsupported route→suspend); full error table (401 logout / 403·400 blocked / 429 Retry-After / 501 suspend / 5xx·network·malformed backoff). Connection-Id on POST/DELETE. Interrupted-upload recovery on init.

**4.4 — Lifecycle teardown wiring** (`6b0618d`)
`invalidate` on logout (before client/DB teardown) and before ephemeral wipe (re-init after re-add); initialize in `app/init/app.ts` after pending wipes and before WebSocket startup.

### Checks
- `npm run tsc` clean; `eslint --quiet` clean on all changed files.
- Jest — every touched + adjacent suite green (remote/local draft actions, drafts queries, manager, sync, session, ephemeral). Largest combined runs: 144 / 125 / 117 / 87 pass.

### Exit criteria met
Manual reconciliation and explicit manager `wake` safely converge drafts; **no mutation drains without a successful current-scope baseline.**

### Deferred to Phase 5 (WebSocket + lifecycle integration)
- **Reconcile/wake triggers** aren't wired to app events yet, so the manager is inert in production until Phase 5 (initial/reconnect reconcile, team switch, foreground/connectivity forwarding, capability-change hooks, Global Drafts stale-on-open, `wake` after local mutations).
- **WS-ordinal "remote-observation-after-dispatch requeue"** (the generation check already prevents stale-ack clobber; WS handlers land in Phase 5).
- **BoR-guard-on-remote-type** refinement (carried from Phase 3) and **mobile-MCP** verification (Phase 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)