### PR TITLE
[MM-70111] fix(report-problem): always open the Report a Problem screen instead of skipping it

### DIFF
--- a/app/screens/report_a_problem/copy_metadata.tsx
+++ b/app/screens/report_a_problem/copy_metadata.tsx
@@ -69,6 +69,7 @@ const CopyMetadata = ({
                     iconName='content-copy'
                     theme={theme}
                     text={intl.formatMessage({id: 'report_a_problem.metadata.copy', defaultMessage: 'Copy'})}
+                    testID='report_problem.metadata.copy.button'
                 />
             </View>
         </View>

--- a/app/screens/settings/report_problem/index.test.tsx
+++ b/app/screens/settings/report_problem/index.test.tsx
@@ -5,15 +5,12 @@ import {Database} from '@nozbe/watermelondb';
 import React, {type ComponentProps} from 'react';
 import {View, Text} from 'react-native';
 
-import {SYSTEM_IDENTIFIERS} from '@constants/database';
 import DatabaseManager from '@database/manager';
 import {renderWithEverything} from '@test/intl-test-helper';
 
 import ReportProblem from './report_problem';
 
 import enhanced from './index';
-
-import type {ReportAProblemMetadata} from '@typings/screens/report_a_problem';
 
 jest.mock('./report_problem', () => ({
     __esModule: true,
@@ -22,23 +19,12 @@ jest.mock('./report_problem', () => ({
 jest.mocked(ReportProblem).mockImplementation((props) => {
     return (
         <View>
-            {Object.keys(props).map((key) => {
-                if (key === 'metadata') {
-                    return Object.keys(props[key]).map((metadataKey) => (
-                        <Text
-                            key={metadataKey}
-                            testID={metadataKey}
-                        >{`${props.metadata[metadataKey as keyof ReportAProblemMetadata]}`}</Text>
-                    ));
-                }
-
-                return (
-                    <Text
-                        key={key}
-                        testID={key}
-                    >{`${props[key as keyof ComponentProps<typeof ReportProblem>]}`}</Text>
-                );
-            })}
+            {Object.keys(props).map((key) => (
+                <Text
+                    key={key}
+                    testID={key}
+                >{`${props[key as keyof ComponentProps<typeof ReportProblem>]}`}</Text>
+            ))}
         </View>
     );
 });
@@ -64,82 +50,19 @@ describe('screens/settings/report_problem/index', () => {
             {database},
         );
 
-        expect(getByTestId('currentUserId')).toHaveTextContent('');
-        expect(getByTestId('currentTeamId')).toHaveTextContent('');
-        expect(getByTestId('serverVersion')).toHaveTextContent('Unknown (Build Unknown)');
-        expect(getByTestId('appVersion')).toHaveTextContent('0.0.0 (Build 0)');
-        expect(getByTestId('appPlatform')).toHaveTextContent('ios');
-        expect(getByTestId('deviceModel')).toHaveTextContent('Unknown');
         expect(getByTestId('reportAProblemType')).toHaveTextContent('undefined');
-        expect(getByTestId('reportAProblemMail')).toHaveTextContent('undefined');
-        expect(getByTestId('siteName')).toHaveTextContent('undefined');
         expect(getByTestId('allowDownloadLogs')).toHaveTextContent('true');
-        expect(getByTestId('isFreeEdition')).toHaveTextContent('true');
     });
 
     it('should enhance ReportProblem with correct observables', async () => {
         const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
         await operator.handleConfigs({
             configs: [
-                {id: 'ReportAProblemType', value: 'email'},
-                {id: 'ReportAProblemMail', value: 'test@example.com'},
-                {id: 'SiteName', value: 'Test Site'},
-                {id: 'AllowDownloadLogs', value: 'true'},
-                {id: 'Version', value: '7.8.0'},
-                {id: 'BuildNumber', value: '123'},
-            ],
-            prepareRecordsOnly: false,
-            configsToDelete: [],
-        });
-
-        await operator.handleSystem({
-            systems: [
-                {id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: 'user1'},
-                {id: SYSTEM_IDENTIFIERS.CURRENT_TEAM_ID, value: 'team1'},
-            ],
-            prepareRecordsOnly: false,
-        });
-
-        const Component = enhanced;
-        const {getByTestId} = renderWithEverything(
-            <Component/>,
-            {database},
-        );
-
-        expect(getByTestId('currentUserId')).toHaveTextContent('user1');
-        expect(getByTestId('currentTeamId')).toHaveTextContent('team1');
-        expect(getByTestId('serverVersion')).toHaveTextContent('7.8.0 (Build 123)');
-        expect(getByTestId('appVersion')).toHaveTextContent('0.0.0 (Build 0)');
-        expect(getByTestId('appPlatform')).toHaveTextContent('ios');
-        expect(getByTestId('deviceModel')).toHaveTextContent('Unknown');
-        expect(getByTestId('reportAProblemType')).toHaveTextContent('email');
-        expect(getByTestId('reportAProblemMail')).toHaveTextContent('test@example.com');
-        expect(getByTestId('siteName')).toHaveTextContent('Test Site');
-        expect(getByTestId('allowDownloadLogs')).toHaveTextContent('true');
-        expect(getByTestId('isFreeEdition')).toHaveTextContent('true');
-    });
-
-    it('different data should show different values', async () => {
-        const {operator} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
-        await operator.handleConfigs({
-            configs: [
                 {id: 'ReportAProblemType', value: 'link'},
-                {id: 'ReportAProblemMail', value: 'test2@example.com'},
-                {id: 'SiteName', value: 'Test Site2'},
                 {id: 'AllowDownloadLogs', value: 'false'},
-                {id: 'Version', value: '7.8.1'},
-                {id: 'BuildNumber', value: '124'},
             ],
             prepareRecordsOnly: false,
             configsToDelete: [],
-        });
-
-        await operator.handleSystem({
-            systems: [
-                {id: SYSTEM_IDENTIFIERS.CURRENT_USER_ID, value: 'user2'},
-                {id: SYSTEM_IDENTIFIERS.CURRENT_TEAM_ID, value: 'team2'},
-            ],
-            prepareRecordsOnly: false,
         });
 
         const Component = enhanced;
@@ -148,16 +71,7 @@ describe('screens/settings/report_problem/index', () => {
             {database},
         );
 
-        expect(getByTestId('currentUserId')).toHaveTextContent('user2');
-        expect(getByTestId('currentTeamId')).toHaveTextContent('team2');
-        expect(getByTestId('serverVersion')).toHaveTextContent('7.8.1 (Build 124)');
-        expect(getByTestId('appVersion')).toHaveTextContent('0.0.0 (Build 0)');
-        expect(getByTestId('appPlatform')).toHaveTextContent('ios');
-        expect(getByTestId('deviceModel')).toHaveTextContent('Unknown');
         expect(getByTestId('reportAProblemType')).toHaveTextContent('link');
-        expect(getByTestId('reportAProblemMail')).toHaveTextContent('test2@example.com');
-        expect(getByTestId('siteName')).toHaveTextContent('Test Site2');
         expect(getByTestId('allowDownloadLogs')).toHaveTextContent('false');
-        expect(getByTestId('isFreeEdition')).toHaveTextContent('true');
     });
 });

--- a/app/screens/settings/report_problem/index.test.tsx
+++ b/app/screens/settings/report_problem/index.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Database} from '@nozbe/watermelondb';
-import React, {type ComponentProps} from 'react';
+import React from 'react';
 import {View, Text} from 'react-native';
 
 import DatabaseManager from '@database/manager';
@@ -16,15 +16,11 @@ jest.mock('./report_problem', () => ({
     __esModule: true,
     default: jest.fn(),
 }));
-jest.mocked(ReportProblem).mockImplementation((props) => {
+jest.mocked(ReportProblem).mockImplementation(({allowDownloadLogs, reportAProblemType}) => {
     return (
         <View>
-            {Object.keys(props).map((key) => (
-                <Text
-                    key={key}
-                    testID={key}
-                >{`${props[key as keyof ComponentProps<typeof ReportProblem>]}`}</Text>
-            ))}
+            <Text testID='allowDownloadLogs'>{`${allowDownloadLogs}`}</Text>
+            <Text testID='reportAProblemType'>{`${reportAProblemType}`}</Text>
         </View>
     );
 });

--- a/app/screens/settings/report_problem/index.ts
+++ b/app/screens/settings/report_problem/index.ts
@@ -3,17 +3,13 @@
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
 
-import {observeConfigBooleanValue, observeConfigValue, observeIsFreeEdition, observeReportAProblemMetadata} from '@queries/servers/system';
+import {observeConfigBooleanValue, observeConfigValue} from '@queries/servers/system';
 
 import ReportProblem from './report_problem';
 
 const enhanced = withObservables([], ({database}) => ({
     allowDownloadLogs: observeConfigBooleanValue(database, 'AllowDownloadLogs', true),
-    isFreeEdition: observeIsFreeEdition(database),
-    reportAProblemMail: observeConfigValue(database, 'ReportAProblemMail'),
     reportAProblemType: observeConfigValue(database, 'ReportAProblemType'),
-    siteName: observeConfigValue(database, 'SiteName'),
-    metadata: observeReportAProblemMetadata(database),
 }));
 
 export default withDatabase(enhanced(ReportProblem));

--- a/app/screens/settings/report_problem/report_problem.test.tsx
+++ b/app/screens/settings/report_problem/report_problem.test.tsx
@@ -129,9 +129,32 @@ describe('screens/settings/report_problem/report_problem', () => {
         });
     });
 
-    it('should open forum link directly when type is default and free edition', async () => {
+    it('should navigate to report problem screen when type is default and free edition', async () => {
         const props = {
             ...baseProps,
+            reportAProblemType: 'default',
+            isFreeEdition: true,
+        };
+
+        const {getByTestId} = renderWithIntl(
+            <ReportProblem {...props}/>,
+        );
+
+        await act(async () => {
+            fireEvent.press(getByTestId('settings.report_problem.option'));
+            expect(navigateToSettingsScreen).toHaveBeenCalledWith(
+                Screens.REPORT_PROBLEM,
+                {title: 'Report a problem'},
+            );
+            expect(tryOpenURL).not.toHaveBeenCalled();
+            expect(emailLogs).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should open forum link directly when type is default, free edition, and logs not allowed', async () => {
+        const props = {
+            ...baseProps,
+            allowDownloadLogs: false,
             reportAProblemType: 'default',
             isFreeEdition: true,
         };

--- a/app/screens/settings/report_problem/report_problem.test.tsx
+++ b/app/screens/settings/report_problem/report_problem.test.tsx
@@ -5,38 +5,16 @@ import {act, fireEvent} from '@testing-library/react-native';
 import React from 'react';
 
 import {Screens} from '@constants';
-import {DEFAULT_REPORT_A_PROBLEM_EMAIL} from '@constants/report_a_problem';
 import {navigateToSettingsScreen} from '@screens/navigation';
 import {renderWithIntl} from '@test/intl-test-helper';
-import {emailLogs, getDefaultReportAProblemLink} from '@utils/share_logs';
-import {tryOpenURL} from '@utils/url';
 
 import ReportProblem from './report_problem';
 
 jest.mock('@screens/navigation');
 
-jest.mock('@utils/share_logs', () => ({
-    emailLogs: jest.fn(),
-    getDefaultReportAProblemLink: jest.fn().mockReturnValue('default-forum-link'),
-}));
-
-jest.mock('@utils/url', () => ({
-    tryOpenURL: jest.fn(),
-}));
-
 describe('screens/settings/report_problem/report_problem', () => {
     const baseProps = {
         allowDownloadLogs: true,
-        attachLogsEnabled: false,
-        isFreeEdition: false,
-        metadata: {
-            currentUserId: 'user1',
-            currentTeamId: 'team1',
-            serverVersion: '7.8.0',
-            appVersion: '2.0.0',
-            appPlatform: 'ios',
-            deviceModel: 'iPhone 14',
-        },
     };
 
     beforeEach(() => {
@@ -51,9 +29,9 @@ describe('screens/settings/report_problem/report_problem', () => {
         expect(getByTestId('settings.report_problem.option')).toBeTruthy();
     });
 
-    it('should not render when type is hidden', () => {
+    it('should not render when type is hidden and logs are not allowed', () => {
         const props = {
-            ...baseProps,
+            allowDownloadLogs: false,
             reportAProblemType: 'hidden',
         };
 
@@ -62,13 +40,13 @@ describe('screens/settings/report_problem/report_problem', () => {
         );
 
         expect(queryByTestId('settings.report_problem.option')).toBeNull();
+        expect(queryByTestId('settings.download_logs.option')).toBeNull();
     });
 
-    it('should navigate to report problem screen when logs are allowed', async () => {
+    it('should render the download logs option when type is hidden and logs are allowed', async () => {
         const props = {
-            ...baseProps,
             allowDownloadLogs: true,
-            reportAProblemType: 'email',
+            reportAProblemType: 'hidden',
         };
 
         const {getByTestId} = renderWithIntl(
@@ -76,172 +54,37 @@ describe('screens/settings/report_problem/report_problem', () => {
         );
 
         await act(async () => {
-            fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(navigateToSettingsScreen).toHaveBeenCalledWith(
-                Screens.REPORT_PROBLEM,
-                {title: 'Report a problem'},
-            );
+            fireEvent.press(getByTestId('settings.download_logs.option'));
         });
+
+        expect(navigateToSettingsScreen).toHaveBeenCalledWith(
+            Screens.REPORT_PROBLEM,
+            {title: 'Download app logs'},
+        );
     });
 
-    it('should navigate to report problem screen when type is not email', async () => {
-        const props = {
-            ...baseProps,
-            allowDownloadLogs: false,
-            reportAProblemType: 'link',
-        };
-
+    // The screen is where the troubleshooting metadata, the app logs and the attach logs toggle
+    // live, so every configuration must be able to reach it. Which report action runs is decided
+    // by the screen, so the license tier no longer takes part in this decision (MM-70111).
+    it.each([
+        ['email type', {allowDownloadLogs: true, reportAProblemType: 'email'}],
+        ['email type without downloadable logs', {allowDownloadLogs: false, reportAProblemType: 'email'}],
+        ['link type', {allowDownloadLogs: true, reportAProblemType: 'link'}],
+        ['default type', {allowDownloadLogs: true, reportAProblemType: 'default'}],
+        ['default type without downloadable logs', {allowDownloadLogs: false, reportAProblemType: 'default'}],
+        ['old servers where the type is not defined', {allowDownloadLogs: true}],
+    ])('should navigate to the report problem screen for %s', async (_, props) => {
         const {getByTestId} = renderWithIntl(
             <ReportProblem {...props}/>,
         );
 
         await act(async () => {
             fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(navigateToSettingsScreen).toHaveBeenCalledWith(
-                Screens.REPORT_PROBLEM,
-                {title: 'Report a problem'},
-            );
         });
-    });
 
-    it('should share logs directly when logs are not allowed and type is email', async () => {
-        const props = {
-            ...baseProps,
-            allowDownloadLogs: false,
-            reportAProblemType: 'email',
-            reportAProblemMail: 'test@example.com',
-            siteName: 'Test Site',
-        };
-
-        const {getByTestId} = renderWithIntl(
-            <ReportProblem {...props}/>,
+        expect(navigateToSettingsScreen).toHaveBeenCalledWith(
+            Screens.REPORT_PROBLEM,
+            {title: 'Report a problem'},
         );
-
-        await act(async () => {
-            fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(emailLogs).toHaveBeenCalledWith(
-                props.metadata,
-                props.siteName,
-                props.reportAProblemMail,
-                true,
-            );
-            expect(navigateToSettingsScreen).not.toHaveBeenCalled();
-        });
-    });
-
-    it('should navigate to report problem screen when type is default and free edition', async () => {
-        const props = {
-            ...baseProps,
-            reportAProblemType: 'default',
-            isFreeEdition: true,
-        };
-
-        const {getByTestId} = renderWithIntl(
-            <ReportProblem {...props}/>,
-        );
-
-        await act(async () => {
-            fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(navigateToSettingsScreen).toHaveBeenCalledWith(
-                Screens.REPORT_PROBLEM,
-                {title: 'Report a problem'},
-            );
-            expect(tryOpenURL).not.toHaveBeenCalled();
-            expect(emailLogs).not.toHaveBeenCalled();
-        });
-    });
-
-    it('should open forum link directly when type is default, free edition, and logs not allowed', async () => {
-        const props = {
-            ...baseProps,
-            allowDownloadLogs: false,
-            reportAProblemType: 'default',
-            isFreeEdition: true,
-        };
-
-        const {getByTestId} = renderWithIntl(
-            <ReportProblem {...props}/>,
-        );
-
-        await act(async () => {
-            fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(getDefaultReportAProblemLink).toHaveBeenCalledWith(false);
-            expect(tryOpenURL).toHaveBeenCalledWith('default-forum-link');
-            expect(navigateToSettingsScreen).not.toHaveBeenCalled();
-        });
-    });
-
-    it('should email directly when type is default, paid edition, and logs not allowed', async () => {
-        const props = {
-            ...baseProps,
-            allowDownloadLogs: false,
-            reportAProblemType: 'default',
-            isFreeEdition: false,
-            siteName: 'Test Site',
-        };
-
-        const {getByTestId} = renderWithIntl(
-            <ReportProblem {...props}/>,
-        );
-
-        await act(async () => {
-            fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(emailLogs).toHaveBeenCalledWith(
-                props.metadata,
-                props.siteName,
-                DEFAULT_REPORT_A_PROBLEM_EMAIL,
-                true,
-            );
-            expect(navigateToSettingsScreen).not.toHaveBeenCalled();
-        });
-    });
-
-    it('should navigate to screen when type is default, paid edition, logs allowed, and attach preference is set', async () => {
-        const props = {
-            ...baseProps,
-            allowDownloadLogs: true,
-            attachLogsEnabled: true,
-            reportAProblemType: 'default',
-            isFreeEdition: false,
-            siteName: 'Test Site',
-        };
-
-        const {getByTestId} = renderWithIntl(
-            <ReportProblem {...props}/>,
-        );
-
-        await act(async () => {
-            fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(navigateToSettingsScreen).toHaveBeenCalledWith(
-                Screens.REPORT_PROBLEM,
-                {title: 'Report a problem'},
-            );
-            expect(emailLogs).not.toHaveBeenCalled();
-            expect(tryOpenURL).not.toHaveBeenCalled();
-        });
-    });
-
-    it('should navigate to screen when type is default, paid edition, logs allowed, and not auto-attached', async () => {
-        const props = {
-            ...baseProps,
-            allowDownloadLogs: true,
-            attachLogsEnabled: false,
-            reportAProblemType: 'default',
-            isFreeEdition: false,
-        };
-
-        const {getByTestId} = renderWithIntl(
-            <ReportProblem {...props}/>,
-        );
-
-        await act(async () => {
-            fireEvent.press(getByTestId('settings.report_problem.option'));
-            expect(navigateToSettingsScreen).toHaveBeenCalledWith(
-                Screens.REPORT_PROBLEM,
-                {title: 'Report a problem'},
-            );
-            expect(emailLogs).not.toHaveBeenCalled();
-            expect(tryOpenURL).not.toHaveBeenCalled();
-        });
     });
 });

--- a/app/screens/settings/report_problem/report_problem.tsx
+++ b/app/screens/settings/report_problem/report_problem.tsx
@@ -37,10 +37,12 @@ const ReportProblem = ({
 }: ReportProblemProps) => {
     const intl = useIntl();
     const onlyAllowLogs = allowDownloadLogs && reportAProblemType === 'hidden';
-    const skipReportAProblemScreen =
-        (reportAProblemType === 'email' && !allowDownloadLogs) ||
-        (reportAProblemType === 'default' && isFreeEdition === true) ||
-        (reportAProblemType === 'default' && isFreeEdition === false && !allowDownloadLogs);
+
+    // The screen exists to show the troubleshooting details and the app logs, so it is only
+    // skipped when there are no logs to download. Free edition servers still get the screen,
+    // where the report action points to the forums instead of a support ticket.
+    const skipReportAProblemScreen = !allowDownloadLogs &&
+        (reportAProblemType === 'email' || reportAProblemType === 'default');
 
     const onPress = useCallback(() => {
         if (skipReportAProblemScreen) {

--- a/app/screens/settings/report_problem/report_problem.tsx
+++ b/app/screens/settings/report_problem/report_problem.tsx
@@ -6,20 +6,11 @@ import {defineMessages, useIntl} from 'react-intl';
 
 import SettingItem from '@components/settings/item';
 import {Screens} from '@constants';
-import {DEFAULT_REPORT_A_PROBLEM_EMAIL} from '@constants/report_a_problem';
 import {navigateToSettingsScreen} from '@screens/navigation';
-import {emailLogs, getDefaultReportAProblemLink} from '@utils/share_logs';
-import {tryOpenURL} from '@utils/url';
-
-import type {ReportAProblemMetadata} from '@typings/screens/report_a_problem';
 
 type ReportProblemProps = {
     allowDownloadLogs?: boolean;
-    isFreeEdition?: boolean;
-    reportAProblemMail?: string;
     reportAProblemType?: string;
-    siteName?: string;
-    metadata: ReportAProblemMetadata;
 }
 
 const messages = defineMessages({
@@ -29,35 +20,19 @@ const messages = defineMessages({
 
 const ReportProblem = ({
     allowDownloadLogs,
-    isFreeEdition,
-    reportAProblemMail,
     reportAProblemType,
-    siteName,
-    metadata,
 }: ReportProblemProps) => {
     const intl = useIntl();
+
+    // When the admin hides the report action there is nothing to report to, but the screen is
+    // still useful to get to the app logs.
     const onlyAllowLogs = allowDownloadLogs && reportAProblemType === 'hidden';
 
-    // The screen exists to show the troubleshooting details and the app logs, so it is only
-    // skipped when there are no logs to download. Free edition servers still get the screen,
-    // where the report action points to the forums instead of a support ticket.
-    const skipReportAProblemScreen = !allowDownloadLogs &&
-        (reportAProblemType === 'email' || reportAProblemType === 'default');
-
     const onPress = useCallback(() => {
-        if (skipReportAProblemScreen) {
-            if (reportAProblemType === 'default' && isFreeEdition) {
-                tryOpenURL(getDefaultReportAProblemLink(false));
-            } else {
-                const mail = reportAProblemType === 'default' ? DEFAULT_REPORT_A_PROBLEM_EMAIL : reportAProblemMail;
-                emailLogs(metadata, siteName, mail, !allowDownloadLogs);
-            }
-            return;
-        }
         const message = onlyAllowLogs ? messages.downloadLogs : messages.reportProblem;
         const title = intl.formatMessage(message);
         navigateToSettingsScreen(Screens.REPORT_PROBLEM, {title});
-    }, [allowDownloadLogs, intl, isFreeEdition, metadata, onlyAllowLogs, reportAProblemMail, reportAProblemType, siteName, skipReportAProblemScreen]);
+    }, [intl, onlyAllowLogs]);
 
     if (onlyAllowLogs) {
         return (

--- a/detox/e2e/support/ui/screen/report_problem.ts
+++ b/detox/e2e/support/ui/screen/report_problem.ts
@@ -33,25 +33,13 @@ class ReportProblemScreen {
     /**
      * Opens the Report a Problem screen from Settings.
      *
-     * On servers where the in-app screen is not available (unlicensed, or config
-     * not yet synced), tapping "Report a Problem" opens an external browser
-     * instead. This method detects that case, dismisses the browser, and returns
-     * false so callers can skip in-app assertions.
-     *
-     * @returns true if the in-app screen opened, false if an external browser opened
+     * Every license tier reaches this screen — the license only decides whether the
+     * button at the bottom opens a mail composer or the forums.
      */
-    open = async (): Promise<boolean> => {
+    open = async () => {
         await SettingsScreen.reportProblemOption.tap();
 
-        try {
-            await this.toBeVisible();
-            return true;
-        } catch {
-            // In-app screen didn't appear — external browser/email opened instead.
-            // Dismiss it so the app returns to Settings.
-            await tapNativeBackButton();
-            return false;
-        }
+        return this.toBeVisible();
     };
 
     back = async () => {

--- a/detox/e2e/test/products/channels/account/settings.e2e.ts
+++ b/detox/e2e/test/products/channels/account/settings.e2e.ts
@@ -20,6 +20,7 @@ import {
     HomeScreen,
     NotificationSettingsScreen,
     LoginScreen,
+    ReportProblemScreen,
     ServerScreen,
     SettingsScreen,
 } from '@support/ui/screen';
@@ -103,5 +104,14 @@ describe('Account - Settings', () => {
 
         // # Go back to settings screen
         await AboutScreen.back();
+    });
+
+    it('MM-T4991_6 - should be able to go to report a problem screen', async () => {
+        // # Tap on report a problem option
+        // * Verify on report a problem screen, on any license tier
+        await ReportProblemScreen.open();
+
+        // # Go back to settings screen
+        await ReportProblemScreen.back();
     });
 });

--- a/detox/maestro/flows/account/attach_logs.yml
+++ b/detox/maestro/flows/account/attach_logs.yml
@@ -1,27 +1,28 @@
-# MM-T67856: Tapping Report a Problem leaves Settings and opens the report form.
+# MM-T67856: Tapping Report a Problem opens the report screen and you can get back to Settings.
 #
 # PRE-CONDITIONS:
 #   - Logged-in test user (via subflows/auth/login.yml)
-#   - Unlicensed / free-edition server (default Matterwick provisioning)
+#   - Any license tier, including unlicensed / Entry (default Matterwick provisioning)
+#   - AllowDownloadLogs enabled (default Matterwick provisioning)
 #
 # REQUIRED ENV VARS:
 #   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD
 #
 # ASSERTIONS:
-#   - Tapping Report a Problem navigates away from the Settings list
-#   - User can return to Settings and see Report a Problem again
-#   - iOS: external browser sheet OR in-app report screen is shown, then dismissed
-#   - Android: external browser tab opens, Back returns to Settings
+#   - Tapping Report a Problem opens the report screen, on every license tier
+#   - The app logs download is reachable from it
+#   - User can leave the screen and see Report a Problem in Settings again
 #
 # testIDs:
 #   - tab_bar.account.tab
 #   - account.screen
 #   - account.settings.option
 #   - settings.report_problem.option
-#   - breadcrumb
 #   - report_problem.screen
+#   - app_logs_download_button
+#   - tab_bar.home.tab
 #
-# Related flows (in-app report screen path):
+# Related flows:
 #   - MM-T67856_1 attach_logs_toggle_visible.yml
 #   - MM-T67856_2 attach_logs_toggle_on_surfaces_option.yml
 #   - MM-T67856_4 attach_logs_disabled_when_download_logs_off.yml
@@ -58,64 +59,56 @@ appId: ${MAESTRO_APP_ID}
 - tapOn:
     id: "settings.report_problem.option"
 
-# * Verify the report form opened, then dismiss it and return to Settings.
-# iOS: free-edition servers open an external browser; licensed servers show in-app screen.
+# * Verify the report screen opened rather than an external browser or mail composer.
+- extendedWaitUntil:
+    visible:
+      id: "report_problem.screen"
+    timeout: 30000
+- takeScreenshot: report-problem-opened
+
+# * Verify the app logs are reachable from the screen.
+# The logs section sits below the troubleshooting details, so scrolling is required.
+- scrollUntilVisible:
+    element:
+      id: "app_logs_download_button"
+    direction: DOWN
+    timeout: 10000
+
+# # Leave the report screen and return to Settings.
+# On iOS 26.3 Maestro's `back` does not dismiss modal-presented screens; relaunching
+# (stopApp + clearState:false) restarts the app without wiping data, so the user stays
+# logged in and lands on the Home tab.
 - runFlow:
     when:
       platform: iOS
     commands:
-      - runFlow:
-          when:
-            visible:
-              id: "breadcrumb"
-          commands:
-            - takeScreenshot: report-problem-opened
-            - tapOn:
-                id: "breadcrumb"
-            - tapOn:
-                text: "Done"
-                optional: true
-      - runFlow:
-          when:
-            visible:
-              id: "report_problem.screen"
-          commands:
-            - takeScreenshot: report-problem-in-app
-            # # iOS 26+: modal Report a Problem ignores Maestro `back`; relaunch keeps session.
-            - launchApp:
-                stopApp: true
-                clearState: false
-            - waitForAnimationToEnd:
-                timeout: 30000
-            - extendedWaitUntil:
-                visible:
-                  id: "tab_bar.home.tab"
-                timeout: 15000
-            - tapOn:
-                id: "tab_bar.account.tab"
-            - extendedWaitUntil:
-                visible:
-                  id: "account.settings.option"
-                timeout: 10000
-            - tapOn:
-                id: "account.settings.option"
-
-# * Verify the browser tab opened on Android, then Back returns to Settings.
-# Android: Chrome Custom Tab opens; Settings option leaves the tree until Back is pressed.
+      - launchApp:
+          stopApp: true
+          clearState: false
+      - waitForAnimationToEnd:
+          timeout: 30000
+      - extendedWaitUntil:
+          visible:
+            id: "tab_bar.home.tab"
+          timeout: 30000
+      - tapOn:
+          id: "tab_bar.account.tab"
+      - extendedWaitUntil:
+          visible:
+            id: "account.settings.option"
+          timeout: 10000
+      - tapOn:
+          id: "account.settings.option"
 - runFlow:
     when:
       platform: Android
     commands:
-      - extendedWaitUntil:
-          notVisible:
-            id: "settings.report_problem.option"
-          timeout: 8000
-      - takeScreenshot: report-problem-opened
       - pressKey: Back
 
 # * Verify Settings is visible again with Report a Problem listed
-- extendedWaitUntil:
-    visible:
+- scrollUntilVisible:
+    element:
       id: "settings.report_problem.option"
-    timeout: 10000
+    direction: DOWN
+    timeout: 15000
 - takeScreenshot: report-problem-dismissed

--- a/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
+++ b/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
@@ -58,8 +58,16 @@ appId: ${MAESTRO_APP_ID}
     timeout: 30000
 - takeScreenshot: report-problem-without-logs
 
+# # Scroll to the end of the details first. assertNotVisible also passes for a
+# control that is merely below the fold, so reach the bottom before asserting.
+# Copy is the last control on the screen when the app logs are unavailable.
+- scrollUntilVisible:
+    element:
+      text: "Copy"
+    direction: DOWN
+    timeout: 10000
+
 # * Verify neither the attach-app-logs toggle nor the logs download is offered.
-# Only the troubleshooting details are listed here, so nothing is below the fold.
 - assertNotVisible:
     id: "report_problem.enable_log_attachments"
 - assertNotVisible:

--- a/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
+++ b/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
@@ -1,17 +1,18 @@
-# MM-T67856_4: With AllowDownloadLogs disabled, Report a Problem skips the in-app screen.
+# MM-T67856_4: With AllowDownloadLogs disabled, Report a Problem still opens the in-app
+# screen, but without the app logs or the attach-app-logs toggle.
 #
 # PRE-CONDITIONS:
 #   - Server SupportSettings.AllowDownloadLogs=false (patched in CI before this flow runs)
-#   - Logged-in test user on a licensed server
+#   - Logged-in test user
 #   - CI restores AllowDownloadLogs=true after this flow (exclude-tag + dedicated step)
 #
 # REQUIRED ENV VARS:
 #   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD, SITE_1_URL, ADMIN_TOKEN
 #
 # ASSERTIONS:
-#   - Tapping Report a Problem does not open the in-app report screen
-#   - Attach-app-logs toggle is never shown (screen is bypassed)
-#   - Mail composer or share sheet may appear and is dismissed via Back
+#   - Tapping Report a Problem opens the in-app report screen
+#   - Attach-app-logs toggle is not offered
+#   - App logs download is not offered
 #
 # testIDs:
 #   - tab_bar.account.tab
@@ -19,6 +20,7 @@
 #   - settings.report_problem.option
 #   - report_problem.screen
 #   - report_problem.enable_log_attachments
+#   - app_logs_download_button
 tags:
   - MM-T67856_4
 appId: ${MAESTRO_APP_ID}
@@ -48,19 +50,44 @@ appId: ${MAESTRO_APP_ID}
 - tapOn:
     id: "settings.report_problem.option"
 
-# # Give the email composer / share sheet time to appear before asserting the
-# in-app screen did not render. waitForAnimationToEnd settles any modal that
-# the mail-client invocation may animate in.
-- waitForAnimationToEnd:
-    timeout: 5000
+# * Verify the report screen opens even when logs cannot be downloaded.
+# The logs setting arrives with the server config, which can lag on first login.
+- extendedWaitUntil:
+    visible:
+      id: "report_problem.screen"
+    timeout: 30000
+- takeScreenshot: report-problem-without-logs
 
-# * Verify the in-app Report a Problem screen is not present, which means
-# the toggle is unreachable (the test's "hidden" condition).
-- assertNotVisible:
-    id: "report_problem.screen"
+# * Verify neither the attach-app-logs toggle nor the logs download is offered.
+# Only the troubleshooting details are listed here, so nothing is below the fold.
 - assertNotVisible:
     id: "report_problem.enable_log_attachments"
+- assertNotVisible:
+    id: "app_logs_download_button"
 
-# # Defensive cleanup: dismiss any modal/share-sheet/mail composer that may
-# have appeared so the next test starts on a clean screen.
-- back
+# # Leave the report screen so the next flow starts on a clean screen.
+# On iOS 26.3 Maestro's `back` does not dismiss modal-presented screens; relaunching
+# (stopApp + clearState:false) restarts the app without wiping data, so the user stays
+# logged in and lands on the Home tab.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - launchApp:
+          stopApp: true
+          clearState: false
+      - waitForAnimationToEnd:
+          timeout: 30000
+      - extendedWaitUntil:
+          visible:
+            id: "tab_bar.home.tab"
+          timeout: 30000
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - pressKey: Back
+      - extendedWaitUntil:
+          visible:
+            id: "settings.report_problem.option"
+          timeout: 10000

--- a/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
+++ b/detox/maestro/flows/account/attach_logs_disabled_when_download_logs_off.yml
@@ -19,8 +19,10 @@
 #   - account.settings.option
 #   - settings.report_problem.option
 #   - report_problem.screen
+#   - report_problem.metadata.copy.button
 #   - report_problem.enable_log_attachments
 #   - app_logs_download_button
+#   - tab_bar.home.tab
 tags:
   - MM-T67856_4
 appId: ${MAESTRO_APP_ID}
@@ -60,10 +62,10 @@ appId: ${MAESTRO_APP_ID}
 
 # # Scroll to the end of the details first. assertNotVisible also passes for a
 # control that is merely below the fold, so reach the bottom before asserting.
-# Copy is the last control on the screen when the app logs are unavailable.
+# Copy metadata is the last control on the screen when the app logs are unavailable.
 - scrollUntilVisible:
     element:
-      text: "Copy"
+      id: "report_problem.metadata.copy.button"
     direction: DOWN
     timeout: 10000
 
@@ -99,3 +101,6 @@ appId: ${MAESTRO_APP_ID}
           visible:
             id: "settings.report_problem.option"
           timeout: 10000
+
+# # Capture the final state
+- takeScreenshot: report-problem-logs-disabled-end

--- a/detox/maestro/flows/account/attach_logs_toggle_on_surfaces_option.yml
+++ b/detox/maestro/flows/account/attach_logs_toggle_on_surfaces_option.yml
@@ -1,7 +1,8 @@
 # MM-T67856_2: Enabling the attach-app-logs toggle surfaces the option in the post attachment menu.
 #
 # PRE-CONDITIONS:
-#   - Same server config as MM-T67856_1 (in-app Report a Problem path)
+#   - Same server config as MM-T67856_1 (AllowDownloadLogs enabled)
+#   - Any license tier: the report screen opens on unlicensed and Entry servers too
 #   - Toggle may start on or off — flow enables it idempotently
 #
 # REQUIRED ENV VARS:
@@ -15,6 +16,8 @@
 #   - tab_bar.account.tab
 #   - account.settings.option
 #   - settings.report_problem.option
+#   - report_problem.screen
+#   - report_problem.enable_log_attachments
 #   - report_problem.enable_log_attachments.toggled.false.button
 #   - report_problem.enable_log_attachments.toggled.true.button
 #   - tab_bar.home.tab
@@ -50,97 +53,70 @@ appId: ${MAESTRO_APP_ID}
 - tapOn:
     id: "settings.report_problem.option"
 
-# # Let the transition settle before branching on which screen opened.
-# On unlicensed servers, tapping "Report a Problem" opens an external browser
-# or email composer instead of the in-app screen. The conditional blocks below
-# handle both paths: run toggle + menu assertions on licensed servers, dismiss
-# the external browser on unlicensed servers.
+# * Verify the report screen opened.
+# The logs setting arrives with the server config, which can lag on first login.
+- extendedWaitUntil:
+    visible:
+      id: "report_problem.screen"
+    timeout: 30000
+
+# # Bring the toggle into view. It is below the fold and assertVisible does not auto-scroll.
+- scrollUntilVisible:
+    element:
+      id: "report_problem.enable_log_attachments"
+    direction: DOWN
+    timeout: 10000
+
+# # Tap the toggle switch to turn it ON. Use optional:true so if the toggle is
+# already ON (from a prior run's saved preference), the tap is skipped.
+- tapOn:
+    id: "report_problem.enable_log_attachments.toggled.false.button"
+    optional: true
+
+# * Verify the toggle confirms "on" state. This also gives the async savePreference
+# call time to complete (API + local DB write) before the app is killed.
+- extendedWaitUntil:
+    visible:
+      id: "report_problem.enable_log_attachments.toggled.true.button"
+    timeout: 10000
+
+# # Give the async DB write a moment to flush.
 - waitForAnimationToEnd:
     timeout: 3000
 
-# # Path A: In-app Report a Problem screen (licensed server)
-- runFlow:
-    when:
-      visible:
-        id: "report_problem.enable_log_attachments"
-    commands:
-      # # Tap the toggle switch to turn it ON. Use optional:true so if toggle
-      # is already ON (from a prior run's saved preference), the tap is skipped.
-      - tapOn:
-          id: "report_problem.enable_log_attachments.toggled.false.button"
-          optional: true
+# # Navigate back to the Home tab, then into the test channel.
+# On iOS 26.3, Maestro's `back` doesn't dismiss modal-presented screens.
+# Re-launching the app (stopApp + clearState:false) kills and restarts the
+# app without wiping data — user stays logged in, app lands on Home tab.
+- launchApp:
+    stopApp: true
+    clearState: false
 
-      # * Verify the toggle confirms "on" state. This also gives the async
-      # savePreference call time to complete (API + local DB write) before the
-      # app is killed.
-      - extendedWaitUntil:
-          visible:
-            id: "report_problem.enable_log_attachments.toggled.true.button"
-          timeout: 10000
+# # Wait for the app to relaunch and JS bundle to load.
+- waitForAnimationToEnd:
+    timeout: 30000
 
-      # # Give the async DB write a moment to flush.
-      - waitForAnimationToEnd:
-          timeout: 3000
+# * Verify we're on the Home tab with tab bar visible.
+- extendedWaitUntil:
+    visible:
+      id: "tab_bar.home.tab"
+    timeout: 30000
 
-      # # Navigate back to the Home tab, then into the test channel.
-      # On iOS 26.3, Maestro's `back` doesn't dismiss modal-presented screens.
-      # Re-launching the app (stopApp + clearState:false) kills and restarts the
-      # app without wiping data — user stays logged in, app lands on Home tab.
-      - launchApp:
-          stopApp: true
-          clearState: false
+# # Wait for the channel list to render before navigating into the test channel.
+- extendedWaitUntil:
+    visible:
+      id: "channel_list.category.channels.channel_item.${TEST_CHANNEL_NAME}"
+    timeout: 30000
 
-      # # Wait for the app to relaunch and JS bundle to load.
-      - waitForAnimationToEnd:
-          timeout: 30000
+- runFlow: ../../subflows/navigation/navigate_to_channel.yml
 
-      # * Verify we're on the Home tab with tab bar visible.
-      - extendedWaitUntil:
-          visible:
-            id: "tab_bar.home.tab"
-          timeout: 30000
+# # Open the post-draft attachment menu. Adjust the id if `inspect_screen`
+# shows a different prefix on your build.
+- tapOn:
+    id: "channel.post_draft.quick_actions.attachment_action"
 
-      # # Wait for the channel list to render before navigating into the test channel.
-      - extendedWaitUntil:
-          visible:
-            id: "channel_list.category.channels.channel_item.${TEST_CHANNEL_NAME}"
-          timeout: 30000
-
-      - runFlow: ../../subflows/navigation/navigate_to_channel.yml
-
-      # # Open the post-draft attachment menu. Adjust the id if `inspect_screen`
-      # shows a different prefix on your build.
-      - tapOn:
-          id: "channel.post_draft.quick_actions.attachment_action"
-
-      # * Verify the Attach app logs option is now offered.
-      - extendedWaitUntil:
-          visible:
-            id: "file_attachment.attach_logs"
-          timeout: 10000
-
-# # Path B: External browser / email composer (unlicensed server) — dismiss
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - runFlow:
-          when:
-            visible:
-              id: "breadcrumb"
-          commands:
-            - tapOn:
-                id: "breadcrumb"
-            - tapOn:
-                text: "Done"
-                optional: true
-- runFlow:
-    when:
-      platform: Android
-    commands:
-      - runFlow:
-          when:
-            notVisible:
-              id: "settings.report_problem.option"
-          commands:
-            - pressKey: Back
+# * Verify the Attach app logs option is now offered.
+- extendedWaitUntil:
+    visible:
+      id: "file_attachment.attach_logs"
+    timeout: 10000

--- a/detox/maestro/flows/account/attach_logs_toggle_on_surfaces_option.yml
+++ b/detox/maestro/flows/account/attach_logs_toggle_on_surfaces_option.yml
@@ -120,3 +120,6 @@ appId: ${MAESTRO_APP_ID}
     visible:
       id: "file_attachment.attach_logs"
     timeout: 10000
+
+# # Capture the final state
+- takeScreenshot: attach-app-logs-option-offered

--- a/detox/maestro/flows/account/attach_logs_toggle_visible.yml
+++ b/detox/maestro/flows/account/attach_logs_toggle_visible.yml
@@ -89,3 +89,6 @@ appId: ${MAESTRO_APP_ID}
           visible:
             id: "settings.report_problem.option"
           timeout: 10000
+
+# # Capture the final state
+- takeScreenshot: report-problem-toggle-visible-end

--- a/detox/maestro/flows/account/attach_logs_toggle_visible.yml
+++ b/detox/maestro/flows/account/attach_logs_toggle_visible.yml
@@ -1,15 +1,15 @@
-# MM-T67856_1: The attach-app-logs toggle is visible on the in-app Report a Problem screen.
+# MM-T67856_1: The attach-app-logs toggle is visible on the Report a Problem screen.
 #
 # PRE-CONDITIONS:
-#   - Logged-in test user on a licensed server with default Report a Problem settings
+#   - Logged-in test user with default Report a Problem settings
 #   - AllowDownloadLogs enabled (default Matterwick provisioning)
-#   - Tapping Report a Problem opens the in-app screen (not email-only shortcut)
+#   - Any license tier: the report screen opens on unlicensed and Entry servers too
 #
 # REQUIRED ENV VARS:
 #   - MAESTRO_APP_ID, TEST_USER_EMAIL, TEST_USER_PASSWORD
 #
 # ASSERTIONS:
-#   - In-app Report a Problem screen appears after tapping the settings entry
+#   - The Report a Problem screen appears after tapping the settings entry
 #   - "Show an option to attach app logs" toggle row is visible
 #
 # testIDs:
@@ -47,46 +47,45 @@ appId: ${MAESTRO_APP_ID}
 - tapOn:
     id: "settings.report_problem.option"
 
-# # Let the transition settle.
-# Unlicensed servers open external browser/email — conditional blocks handle both paths.
-- waitForAnimationToEnd:
-    timeout: 3000
+# * Verify the report screen opened.
+# The logs setting arrives with the server config, which can lag on first login.
+- extendedWaitUntil:
+    visible:
+      id: "report_problem.screen"
+    timeout: 30000
 
-# * Verify the attach-app-logs toggle is visible on the in-app screen (licensed server).
-# Path A. Toggle is below the fold — use scrollUntilVisible (assertVisible does not auto-scroll).
-- runFlow:
-    when:
-      visible:
-        id: "report_problem.screen"
-    commands:
-      - scrollUntilVisible:
-          element:
-            id: "report_problem.enable_log_attachments"
-          direction: DOWN
-          timeout: 10000
+# * Verify the attach-app-logs toggle is offered.
+# The toggle is below the fold — scrollUntilVisible is required because
+# assertVisible does not auto-scroll.
+- scrollUntilVisible:
+    element:
+      id: "report_problem.enable_log_attachments"
+    direction: DOWN
+    timeout: 10000
+- takeScreenshot: report-problem-attach-logs-toggle
 
-# # Path B: External browser / email composer (unlicensed server) — dismiss
+# # Leave the report screen so the next flow starts on a clean screen.
+# On iOS 26.3 Maestro's `back` does not dismiss modal-presented screens; relaunching
+# (stopApp + clearState:false) restarts the app without wiping data.
 - runFlow:
     when:
       platform: iOS
     commands:
-      - runFlow:
-          when:
-            visible:
-              id: "breadcrumb"
-          commands:
-            - tapOn:
-                id: "breadcrumb"
-            - tapOn:
-                text: "Done"
-                optional: true
+      - launchApp:
+          stopApp: true
+          clearState: false
+      - waitForAnimationToEnd:
+          timeout: 30000
+      - extendedWaitUntil:
+          visible:
+            id: "tab_bar.home.tab"
+          timeout: 30000
 - runFlow:
     when:
       platform: Android
     commands:
-      - runFlow:
-          when:
-            notVisible:
-              id: "settings.report_problem.option"
-          commands:
-            - pressKey: Back
+      - pressKey: Back
+      - extendedWaitUntil:
+          visible:
+            id: "settings.report_problem.option"
+          timeout: 10000


### PR DESCRIPTION
#### Summary

`Settings → Report a Problem` had accumulated conditions under which it fired the report action immediately and never opened the Report a Problem screen. One of those conditions was *any Entry or unlicensed server*:

```ts
// app/screens/settings/report_problem/report_problem.tsx (before)
const skipReportAProblemScreen =
    (reportAProblemType === 'email' && !allowDownloadLogs) ||
    (reportAProblemType === 'default' && isFreeEdition === true) ||          // <-- MM-70111
    (reportAProblemType === 'default' && isFreeEdition === false && !allowDownloadLogs);
```

Skipping the screen also skips everything on it: the troubleshooting metadata, the app logs download, and the "Enable app log attachments" toggle. Entry users were sent straight to `mattermost.com/pl/report_a_problem_unlicensed` with no way to get the logs they were being asked to bring along. (`observeIsFreeEdition` is `!IsLicensed || SkuShortName === 'Entry'`, so this hit unlicensed and Entry alike.)

The entry point now always navigates to the screen. Deciding *where* the report goes is the screen's job, so the menu item no longer observes the license, the mail address, the site name or the metadata — it is down to `AllowDownloadLogs` and `ReportAProblemType`.

#### What actually changes for users

Only the four previously-skipping combinations change. In every one of them the destination of the report is the same as before — the user just gets the screen first.

| `ReportAProblemType` | `AllowDownloadLogs` | License | Before | After |
|---|---|---|---|---|
| `default` | `true` | Entry / unlicensed | Opened `/pl/report_a_problem_unlicensed` at once; **logs unreachable** | Screen with metadata, logs and toggle → button opens the same link |
| `default` | `false` | Entry / unlicensed | Opened `/pl/report_a_problem_unlicensed` at once | Screen with metadata → button opens the same link |
| `default` | `false` | Licensed | Emailed `reportaproblem@mattermost.com` at once | Screen with metadata → button emails the same address |
| `email` | `false` | any | Emailed `ReportAProblemMail` at once | Screen with metadata → button emails the same address |

Unchanged: `email` with logs allowed, `link`, `default` on a licensed server with logs allowed, servers that do not send `ReportAProblemType`, and `hidden`.

#### Why the screen itself needed no change

`handleReport` in `app/screens/report_a_problem/report_problem.tsx` already resolves email-vs-forums for every type, which is what the ticket asks the bottom button to do:

| `ReportAProblemType` | Bottom button |
|---|---|
| `email` | Emails `ReportAProblemMail` (logs attached only when `AllowDownloadLogs`) |
| `link` | Opens `ReportAProblemLink`; if unset, the licensed or unlicensed default link based on the license |
| `default` | Entry/unlicensed → opens `/pl/report_a_problem_unlicensed`; licensed → emails `reportaproblem@mattermost.com` |
| `hidden` | No button rendered; the screen is reached as "Download app logs" |
| unset (old servers) | Opens `ReportAProblemLink` if set, otherwise the legacy share sheet with logs attached |

Permissions still apply throughout: the logs list and the attach-logs toggle remain gated on `AllowDownloadLogs`, and `hidden` + `AllowDownloadLogs=false` still renders no menu item at all, because the screen would then have neither logs nor a button.

#### Diff notes

* `report_problem.tsx` (settings item): `skipReportAProblemScreen` and its action branch deleted; props reduced to `allowDownloadLogs` and `reportAProblemType`.
* `index.ts`: dropped the `isFreeEdition`, `ReportAProblemMail`, `SiteName` and metadata observables. `observeIsFreeEdition` is still used by the screen's own container, so nothing is orphaned.
* Tests: the skip-branch cases are replaced by a table asserting that every configuration reaches the screen, plus the two `hidden` cases. No new user-facing strings, so no `en.json` change.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-70111

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes — a screen becomes reachable where it previously was not. No new components, styles or strings were added, so there is nothing new to check against the core themes.

#### Device Information
This PR was tested on: ios Sim iphone 17

#### Screenshots
| no license | access | action | action when there is license|
|---|---|---|---|
| <img width="784" height="1472" alt="CleanShot 2026-08-05 at 14 30 16@2x" src="https://github.com/user-attachments/assets/b26723c9-3e27-4068-b821-ac77d000241f" /> | <img width="800" height="1588" alt="CleanShot 2026-08-05 at 14 30 24@2x" src="https://github.com/user-attachments/assets/de25b7de-6a04-4e1f-9e41-4ffb29683d2b" /> | <img width="758" height="1680" alt="CleanShot 2026-08-05 at 14 30 34@2x" src="https://github.com/user-attachments/assets/7dd9d78b-c78c-48eb-958a-7c3a359a6f8e" /> | <img width="790" height="1574" alt="CleanShot 2026-08-05 at 14 35 29@2x" src="https://github.com/user-attachments/assets/26588c9d-0157-403b-956a-9ef8d8f7f796" /> |

```release-note
Fixed an issue where the "Report a Problem" screen was skipped on Entry and unlicensed servers, preventing users from viewing troubleshooting details, downloading app logs or enabling app log attachments.
```