### PR TITLE
fixes server incorrectly flagged as offline during cold start

### DIFF
--- a/app/client/websocket/index.test.ts
+++ b/app/client/websocket/index.test.ts
@@ -173,12 +173,17 @@ describe('WebSocketClient', () => {
     });
 
     it('should handle WebSocket close event - tls handshake error', async () => {
+        const closeCallback = jest.fn();
+        client.setCloseCallback(closeCallback);
+
         await client.initialize();
         const message = {code: 1015, reason: 'tls handshake error'};
 
         mockConn.onClose.mock.calls[0][0]({message});
 
         expect(logDebug).toHaveBeenCalledWith('websocket did not connect', 'wss://example.com/api/v4/websocket', message.reason);
+        expect(closeCallback).toHaveBeenCalledWith(1);
+        expect(client.hasFailedToConnect()).toBe(true);
     });
 
     it('should handle WebSocket error event', async () => {
@@ -310,6 +315,17 @@ describe('WebSocketClient', () => {
         await client.initialize();
 
         expect(client.isConnected()).toBe(true);
+    });
+
+    it('reports a failed connection after a close and clears it once reconnected', async () => {
+        await client.initialize();
+        expect(client.hasFailedToConnect()).toBe(false);
+
+        mockConn.close();
+        expect(client.hasFailedToConnect()).toBe(true);
+
+        await advanceTimers(6000);
+        expect(client.hasFailedToConnect()).toBe(false);
     });
 
     it('should send ping messages on interval and handle pong responses', async () => {

--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -258,6 +258,7 @@ export default class WebSocketClient {
 
             if (ev.message && typeof ev.message === 'object' && 'code' in ev.message && ev.message.code === TLS_HANDSHARE_ERROR) {
                 logDebug('websocket did not connect', this.url, ev.message.reason);
+                this.connectFailCount++;
                 this.closeCallback?.(this.connectFailCount);
                 return;
             }
@@ -467,6 +468,10 @@ export default class WebSocketClient {
 
     public isConnected(): boolean {
         return this.conn?.readyState === WebSocketReadyState.OPEN;
+    }
+
+    public hasFailedToConnect(): boolean {
+        return this.connectFailCount > 0;
     }
 
     public getConnectionId(): string {

--- a/app/managers/ephemeral_mode_manager/index.test.ts
+++ b/app/managers/ephemeral_mode_manager/index.test.ts
@@ -15,7 +15,7 @@ import {navigateToScreen} from '@screens/navigation';
 import {advanceTimers, disableFakeTimers, enableFakeTimers} from '@test/timer_helpers';
 import {deleteFileCache} from '@utils/file';
 
-import EphemeralModeManager from './index';
+import EphemeralModeManager, {OFFLINE_CONNECTION_RECHECK_MAX_WAIT_MS, OFFLINE_CONNECTION_RECHECK_MS} from './index';
 
 import type ServersModel from '@typings/database/models/app/servers';
 
@@ -37,6 +37,7 @@ jest.mock('@managers/websocket_manager', () => ({
     default: {
         observeWebsocketState: jest.fn(),
         isConnected: jest.fn(),
+        hasFailedToConnect: jest.fn(),
     },
 }));
 jest.mock('@queries/app/servers', () => {
@@ -59,6 +60,7 @@ describe('EphemeralModeManager', () => {
     const credsB = {serverUrl: serverB, token: 'token-b'} as ServerCredential;
 
     let wsStates: Record<string, BehaviorSubject<WebsocketConnectedState>>;
+    let wsFailed: Record<string, boolean>;
     let appStateHandlers: Array<(state: AppStateStatus) => void>;
     let appStateRemoveSpies: jest.Mock[];
 
@@ -119,11 +121,21 @@ describe('EphemeralModeManager', () => {
     const getPersistedLastSeen = (url: string) => getPersistedValue<number>(url, SYSTEM_IDENTIFIERS.LAST_SEEN_TIME);
 
     const setWs = (url: string, state: WebsocketConnectedState) => {
+        // Mirror connectFailCount: a live close means an attempt failed; a connect resets it.
+        if (state === 'connected') {
+            wsFailed[url] = false;
+        } else if (state === 'not_connected') {
+            wsFailed[url] = true;
+        }
         if (wsStates[url]) {
             wsStates[url].next(state);
         } else {
             wsStates[url] = new BehaviorSubject<WebsocketConnectedState>(state);
         }
+    };
+
+    const setWsFailed = (url: string, failed: boolean) => {
+        wsFailed[url] = failed;
     };
 
     const setAppState = (state: AppStateStatus) => {
@@ -149,6 +161,7 @@ describe('EphemeralModeManager', () => {
     beforeEach(async () => {
         enableFakeTimers();
         wsStates = {};
+        wsFailed = {};
         appStateHandlers = [];
         appStateRemoveSpies = [];
 
@@ -162,6 +175,9 @@ describe('EphemeralModeManager', () => {
         });
         (WebsocketManager.isConnected as jest.Mock) = jest.fn(
             (url: string) => wsStates[url]?.getValue() === 'connected',
+        );
+        (WebsocketManager.hasFailedToConnect as jest.Mock) = jest.fn(
+            (url: string) => Boolean(wsFailed[url]),
         );
 
         (AppState as {currentState: AppStateStatus}).currentState = 'active';
@@ -263,9 +279,20 @@ describe('EphemeralModeManager', () => {
         expect(await getPersistedSince(serverA)).toBeGreaterThan(0);
     });
 
-    it('resuming after app kill with elapsed time past threshold flags the server offline on init', async () => {
+    it('resuming after app kill with elapsed time past threshold does not flag the server offline until a connection attempt has failed', async () => {
         const now = Date.now();
         await seedConfigAndRow(serverA, {enabled: true, timeoutSec: 10, disconnectedSince: now - 20_000});
+
+        await EphemeralModeManager.init([credsA]);
+        await advanceTimers(0);
+
+        expect(EphemeralModeManager.isOffline(serverA)).toBe(false);
+    });
+
+    it('resuming after app kill with a confirmed failed connection past threshold flags the server offline immediately', async () => {
+        const now = Date.now();
+        await seedConfigAndRow(serverA, {enabled: true, timeoutSec: 10, disconnectedSince: now - 20_000});
+        setWsFailed(serverA, true);
 
         await EphemeralModeManager.init([credsA]);
         await advanceTimers(0);
@@ -273,9 +300,39 @@ describe('EphemeralModeManager', () => {
         expect(EphemeralModeManager.isOffline(serverA)).toBe(true);
     });
 
+    it('resuming after app kill past threshold flags the server offline once a connection attempt fails', async () => {
+        const now = Date.now();
+        await seedConfigAndRow(serverA, {enabled: true, timeoutSec: 10, disconnectedSince: now - 20_000});
+
+        await EphemeralModeManager.init([credsA]);
+        await advanceTimers(0);
+        expect(EphemeralModeManager.isOffline(serverA)).toBe(false);
+
+        setWsFailed(serverA, true);
+        await advanceTimers(OFFLINE_CONNECTION_RECHECK_MS);
+
+        expect(EphemeralModeManager.isOffline(serverA)).toBe(true);
+    });
+
+    it('resuming after app kill past threshold flags the server offline once the recheck cap elapses without a definitive signal', async () => {
+        const now = Date.now();
+        await seedConfigAndRow(serverA, {enabled: true, timeoutSec: 10, disconnectedSince: now - 20_000});
+
+        await EphemeralModeManager.init([credsA]);
+        await advanceTimers(0);
+        expect(EphemeralModeManager.isOffline(serverA)).toBe(false);
+
+        await advanceTimers(OFFLINE_CONNECTION_RECHECK_MAX_WAIT_MS - OFFLINE_CONNECTION_RECHECK_MS);
+        expect(EphemeralModeManager.isOffline(serverA)).toBe(false);
+
+        await advanceTimers(OFFLINE_CONNECTION_RECHECK_MS);
+        expect(EphemeralModeManager.isOffline(serverA)).toBe(true);
+    });
+
     it('resuming after app kill with elapsed time below threshold schedules the remaining time', async () => {
         const now = Date.now();
         await seedConfigAndRow(serverA, {enabled: true, timeoutSec: 10, disconnectedSince: now - 5000});
+        setWsFailed(serverA, true);
 
         await EphemeralModeManager.init([credsA]);
         await advanceTimers(0);
@@ -507,6 +564,7 @@ describe('EphemeralModeManager', () => {
                 lastSeenTime: start - ONE_HOUR_MS,
             });
             wsStates[serverA] = new BehaviorSubject<WebsocketConnectedState>('not_connected');
+            setWsFailed(serverA, true);
 
             await EphemeralModeManager.init([credsA]);
             await advanceTimers(0);

--- a/app/managers/ephemeral_mode_manager/index.ts
+++ b/app/managers/ephemeral_mode_manager/index.ts
@@ -21,9 +21,16 @@ type ServerEntry =
     | {kind: 'zpm'}
     | {kind: 'mem'; thresholdMs: number; purgeThresholdMs: number};
 
+// Poll interval to await a settled connection attempt on cold-start resume.
+export const OFFLINE_CONNECTION_RECHECK_MS = 5000;
+
+// Hard cap on total recheck polling before deciding offline anyway.
+export const OFFLINE_CONNECTION_RECHECK_MAX_WAIT_MS = 60000;
+
 class EphemeralModeManagerSingleton {
     private offlineSubjects: {[serverUrl: string]: BehaviorSubject<boolean>} = {};
     private disconnectionTimers: Record<string, NodeJS.Timeout> = {};
+    private recheckTimers: Record<string, {timeout: NodeJS.Timeout; startedAt: number}> = {};
     private purgeTimers: Record<string, NodeJS.Timeout> = {};
     private wsSubscriptions: Record<string, Subscription> = {};
     private configSubscriptions: Record<string, Subscription> = {};
@@ -185,6 +192,7 @@ class EphemeralModeManagerSingleton {
         this.wsSubscriptions[serverUrl]?.unsubscribe();
         delete this.wsSubscriptions[serverUrl];
         this.clearDisconnectionTimer(serverUrl);
+        this.clearRecheckTimer(serverUrl);
         this.clearPurgeTimer(serverUrl);
         if (!silent) {
             // Server is still alive (feature disabled at runtime); flush offline state.
@@ -242,6 +250,7 @@ class EphemeralModeManagerSingleton {
 
         if (WebsocketManager.isConnected(serverUrl)) {
             this.clearDisconnectionTimer(serverUrl);
+            this.clearRecheckTimer(serverUrl);
             await this.flagOffline(serverUrl, false);
             await setDisconnectedSince(serverUrl, null);
             return;
@@ -272,7 +281,14 @@ class EphemeralModeManagerSingleton {
         const elapsed = Date.now() - currentDisconnectedSince;
         const threshold = entry.thresholdMs;
         if (elapsed >= threshold) {
+            const recheckStartedAt = this.recheckTimers[serverUrl]?.startedAt ?? Date.now();
+            if (!WebsocketManager.hasFailedToConnect(serverUrl) && Date.now() - recheckStartedAt < OFFLINE_CONNECTION_RECHECK_MAX_WAIT_MS) {
+                // Stale persisted timestamp: no attempt has failed yet. Re-check until it settles.
+                this.scheduleRecheck(serverUrl, OFFLINE_CONNECTION_RECHECK_MS);
+                return;
+            }
             this.clearDisconnectionTimer(serverUrl);
+            this.clearRecheckTimer(serverUrl);
             await this.flagOffline(serverUrl, true);
             return;
         }
@@ -283,12 +299,12 @@ class EphemeralModeManagerSingleton {
     private startDisconnectionTimer = (serverUrl: string, remainingMs: number) => {
         this.clearDisconnectionTimer(serverUrl);
         if (remainingMs <= 0) {
-            this.enqueueEval(serverUrl, () => this.flagOffline(serverUrl, true));
+            this.enqueueEval(serverUrl, () => this.evaluateServer(serverUrl));
             return;
         }
         this.disconnectionTimers[serverUrl] = setTimeout(() => {
             delete this.disconnectionTimers[serverUrl];
-            this.enqueueEval(serverUrl, () => this.flagOffline(serverUrl, true));
+            this.enqueueEval(serverUrl, () => this.evaluateServer(serverUrl));
         }, remainingMs);
     };
 
@@ -297,6 +313,24 @@ class EphemeralModeManagerSingleton {
         if (handle) {
             clearTimeout(handle);
             delete this.disconnectionTimers[serverUrl];
+        }
+    };
+
+    private scheduleRecheck = (serverUrl: string, delayMs: number) => {
+        // Preserve the start time across reschedules so the wait cap accumulates.
+        const startedAt = this.recheckTimers[serverUrl]?.startedAt ?? Date.now();
+        this.clearRecheckTimer(serverUrl);
+        const timeout = setTimeout(() => {
+            this.enqueueEval(serverUrl, () => this.evaluateServer(serverUrl));
+        }, delayMs);
+        this.recheckTimers[serverUrl] = {timeout, startedAt};
+    };
+
+    private clearRecheckTimer = (serverUrl: string) => {
+        const entry = this.recheckTimers[serverUrl];
+        if (entry) {
+            clearTimeout(entry.timeout);
+            delete this.recheckTimers[serverUrl];
         }
     };
 

--- a/app/managers/websocket_manager.test.ts
+++ b/app/managers/websocket_manager.test.ts
@@ -69,6 +69,7 @@ describe('WebsocketManager', () => {
             }),
             initialize: jest.fn(),
             isConnected: jest.fn().mockReturnValue(true),
+            hasFailedToConnect: jest.fn().mockReturnValue(false),
             close: jest.fn(),
             invalidate: jest.fn(),
             waitForClose: jest.fn().mockResolvedValue(undefined),
@@ -340,6 +341,26 @@ describe('WebsocketManager', () => {
 
             // Verify that clients are closed when network is disconnected
             expect(manager.getClient(mockServerUrl)?.close).toHaveBeenCalled();
+        });
+    });
+
+    describe('hasFailedToConnect', () => {
+        it('is false when no client exists for the server', () => {
+            expect(manager.hasFailedToConnect('https://nonexistent.com')).toBe(false);
+        });
+
+        it('is false while a client exists but no attempt has failed yet', async () => {
+            await manager.init(mockCredentials);
+            mockWebSocketClient.hasFailedToConnect.mockReturnValue(false);
+
+            expect(manager.hasFailedToConnect(mockServerUrl)).toBe(false);
+        });
+
+        it('is true once a connection attempt has failed', async () => {
+            await manager.init(mockCredentials);
+            mockWebSocketClient.hasFailedToConnect.mockReturnValue(true);
+
+            expect(manager.hasFailedToConnect(mockServerUrl)).toBe(true);
         });
     });
 

--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -144,6 +144,10 @@ class WebsocketManagerSingleton {
         return this.clients[serverUrl]?.isConnected();
     };
 
+    public hasFailedToConnect = (serverUrl: string): boolean => {
+        return this.clients[serverUrl]?.hasFailedToConnect() === true;
+    };
+
     public observeWebsocketState = (serverUrl: string) => {
         return this.getConnectedSubject(serverUrl).asObservable().pipe(
             distinctUntilChanged(),


### PR DESCRIPTION
#### Summary
On cold start, EphemeralModeManager can flag a server "offline" (and begin the ephemeral-mode offline/purge flow) before the websocket has ever attempted to connect — producing a false "offline mode started" immediately after launch even when the server is actually reachable.

This fix changes websocket manager to report failed connection count. This value can then be checked to prevent treating a server as offline before even attempting a connection.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-70105

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Device Information
This PR was tested on: Android and iOS emulator

#### Release Note
```release-note
NONE
```
