### PR TITLE
[MM-56573] Render authenticated Markdown file images

### DIFF
--- a/app/components/expo_image/index.test.ts
+++ b/app/components/expo_image/index.test.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {testExports} from './index';
+
+describe('shouldAttachServerAuthHeaders', () => {
+    const {shouldAttachServerAuthHeaders} = testExports;
+
+    it.each([
+        ['https://mattermost.example.com', 'https://mattermost.example.com/api/v4/files/file-id'],
+        ['https://mattermost.example.com/', 'https://mattermost.example.com/api/v4/files/file-id/preview'],
+        ['https://mattermost.example.com/mattermost', 'https://mattermost.example.com/mattermost/api/v4/files/file-id'],
+        ['https://mattermost.example.com/mattermost/', 'https://mattermost.example.com/mattermost/api/v4/files/file-id/preview'],
+    ])('should accept API paths under server URL %s', (serverUrl, uri) => {
+        expect(shouldAttachServerAuthHeaders(uri, serverUrl)).toBe(true);
+    });
+
+    it.each([
+        ['https://mattermost.example.com/api/v4/files/file-id', 'https://mattermost.example.com/mattermost'],
+        ['https://mattermost.example.com/other/api/v4/files/file-id', 'https://mattermost.example.com/mattermost'],
+        ['https://external.example.com/mattermost/api/v4/files/file-id', 'https://mattermost.example.com/mattermost'],
+    ])('should reject URI %s outside server URL %s', (uri, serverUrl) => {
+        expect(shouldAttachServerAuthHeaders(uri, serverUrl)).toBe(false);
+    });
+});

--- a/app/components/expo_image/index.tsx
+++ b/app/components/expo_image/index.tsx
@@ -30,7 +30,8 @@ function shouldAttachServerAuthHeaders(uri: string | undefined, serverUrl: strin
             return false;
         }
 
-        return requestUrl.pathname.startsWith('/api/v4/');
+        const serverBasePath = serverBaseUrl.pathname.replace(/\/+$/, '');
+        return requestUrl.pathname.startsWith(`${serverBasePath}/api/v4/`);
     } catch {
         // On any parsing error, do not attach auth headers
         return false;
@@ -178,6 +179,10 @@ const ExpoImageAnimated = Animated.createAnimatedComponent(ExpoImage);
 export {
     ExpoImageAnimated,
     ExpoImageBackground,
+};
+
+export const testExports = {
+    shouldAttachServerAuthHeaders,
 };
 
 export default ExpoImage;

--- a/app/components/markdown/markdown.test.tsx
+++ b/app/components/markdown/markdown.test.tsx
@@ -5,9 +5,10 @@ import {screen} from '@testing-library/react-native';
 import * as CommonMark from 'commonmark';
 const {Node} = CommonMark;
 import React from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
 
 import {Preferences, Screens} from '@constants';
+import ServerUrlProvider from '@context/server';
 import {renderWithIntl} from '@test/intl-test-helper';
 import {getMarkdownTextStyles} from '@utils/markdown';
 import {typography} from '@utils/typography';
@@ -16,10 +17,18 @@ import Markdown, {testExports} from './markdown';
 import * as Transforms from './transform';
 
 const Parser = jest.requireActual('commonmark').Parser;
+const SERVER_URL = 'https://mattermost.example.com/mattermost';
+const FILE_ID = 'abcdefghijklmnopqrstuvwxyz';
+
+function MockMarkdownImage({source}: {source: string}) {
+    return <Text testID='markdown_image'>{source}</Text>;
+}
 
 jest.mock('@screens/navigation', () => ({
     navigateToRoot: jest.fn(),
 }));
+
+jest.mock('./markdown_image', () => MockMarkdownImage);
 
 describe('Markdown', () => {
     const baseProps: React.ComponentProps<typeof Markdown> = {
@@ -142,6 +151,143 @@ describe('Markdown', () => {
 
             expect(screen.queryByText('This is a text')).not.toBeVisible();
             expect(screen.getByText('An error occurred while rendering this text')).toBeVisible();
+        });
+    });
+
+    describe('image render gate', () => {
+        const {getCurrentServerFileSource} = testExports;
+
+        beforeEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it.each([
+            `${SERVER_URL}/api/v4/files/${FILE_ID}`,
+            `${SERVER_URL}/api/v4/files/${FILE_ID}/preview?width=120#image`,
+            `/api/v4/files/${FILE_ID}`,
+            `/api/v4/files/${FILE_ID}/preview`,
+        ])('should accept a current-server file endpoint: %s', (source) => {
+            expect(getCurrentServerFileSource(source, SERVER_URL)).toBeDefined();
+        });
+
+        it.each([
+            `https://external.example.com/mattermost/api/v4/files/${FILE_ID}`,
+            `https://mattermost.example.com.evil.test/mattermost/api/v4/files/${FILE_ID}`,
+            `https://mattermost.example.com:8443/mattermost/api/v4/files/${FILE_ID}`,
+            `http://mattermost.example.com/mattermost/api/v4/files/${FILE_ID}`,
+            `https://mattermost.example.com/mattermost/api/v4/users/${FILE_ID}`,
+            `https://mattermost.example.com/mattermost/api/v4/files/${FILE_ID}/preview/extra`,
+            `https://user@mattermost.example.com/mattermost/api/v4/files/${FILE_ID}`,
+            `//mattermost.example.com/mattermost/api/v4/files/${FILE_ID}`,
+            `https://mattermost.example.com/api/v4/files/${FILE_ID}`,
+            `https://mattermost.example.com/mattermost/api/v4/files%2F${FILE_ID}`,
+            `/api/v4/files/${FILE_ID.toUpperCase()}`,
+        ])('should reject a non-file or malformed endpoint: %s', (source) => {
+            expect(getCurrentServerFileSource(source, SERVER_URL)).toBeUndefined();
+        });
+
+        it.each([
+            [
+                `${SERVER_URL}/api/v4/files/${FILE_ID}`,
+                `${SERVER_URL}/api/v4/files/${FILE_ID}/preview`,
+            ],
+            [
+                `${SERVER_URL}/api/v4/files/${FILE_ID}?width=120#image`,
+                `${SERVER_URL}/api/v4/files/${FILE_ID}/preview?width=120#image`,
+            ],
+            [
+                `${SERVER_URL}/api/v4/files/${FILE_ID}/preview?width=120#image`,
+                `${SERVER_URL}/api/v4/files/${FILE_ID}/preview?width=120#image`,
+            ],
+        ])('should render metadata-less current-server file source %s as a preview', (source, expectedSource) => {
+            renderWithIntl(
+                <ServerUrlProvider server={{displayName: 'Mattermost', url: SERVER_URL}}>
+                    <Markdown
+                        {...baseProps}
+                        postId='post-id'
+                        value={`![](${source})`}
+                    />
+                </ServerUrlProvider>,
+            );
+
+            expect(screen.getByTestId('markdown_image').props.children).toBe(expectedSource);
+        });
+
+        it('should suppress an external image without image metadata', () => {
+            renderWithIntl(
+                <ServerUrlProvider server={{displayName: 'Mattermost', url: SERVER_URL}}>
+                    <Markdown
+                        {...baseProps}
+                        postId='post-id'
+                        value='![](https://external.example.com/image.png)'
+                    />
+                </ServerUrlProvider>,
+            );
+
+            expect(screen.queryByTestId('markdown_image')).not.toBeVisible();
+        });
+
+        it('should preserve external image rendering when image metadata is present', () => {
+            renderWithIntl(
+                <ServerUrlProvider server={{displayName: 'Mattermost', url: SERVER_URL}}>
+                    <Markdown
+                        {...baseProps}
+                        imagesMetadata={{}}
+                        postId='post-id'
+                        value='![](https://external.example.com/image.png)'
+                    />
+                </ServerUrlProvider>,
+            );
+
+            expect(screen.getByTestId('markdown_image')).toBeVisible();
+        });
+
+        it('should suppress a metadata-less file image inside a table', () => {
+            const value = `| image |\n| --- |\n| ![](${SERVER_URL}/api/v4/files/${FILE_ID}) |`;
+            renderWithIntl(
+                <ServerUrlProvider server={{displayName: 'Mattermost', url: SERVER_URL}}>
+                    <Markdown
+                        {...baseProps}
+                        postId='post-id'
+                        value={value}
+                    />
+                </ServerUrlProvider>,
+            );
+
+            expect(screen.queryByTestId('markdown_image')).not.toBeVisible();
+            expect(screen.queryByTestId('markdown_table_image')).not.toBeVisible();
+        });
+
+        it('should preserve metadata-backed image rendering inside a table', () => {
+            const value = '| image |\n| --- |\n| ![](https://external.example.com/image.png) |';
+            renderWithIntl(
+                <ServerUrlProvider server={{displayName: 'Mattermost', url: SERVER_URL}}>
+                    <Markdown
+                        {...baseProps}
+                        imagesMetadata={{}}
+                        postId='post-id'
+                        value={value}
+                    />
+                </ServerUrlProvider>,
+            );
+
+            expect(screen.getByTestId('markdown_table_image')).toBeVisible();
+        });
+
+        it('should suppress a current-server file URL in an unsafe-links post', () => {
+            renderWithIntl(
+                <ServerUrlProvider server={{displayName: 'Mattermost', url: SERVER_URL}}>
+                    <Markdown
+                        {...baseProps}
+                        imagesMetadata={{}}
+                        isUnsafeLinksPost={true}
+                        postId='post-id'
+                        value={`![](${SERVER_URL}/api/v4/files/${FILE_ID})`}
+                    />
+                </ServerUrlProvider>,
+            );
+
+            expect(screen.queryByTestId('markdown_image')).not.toBeVisible();
         });
     });
 

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -8,6 +8,7 @@ import Renderer from 'commonmark-react-renderer';
 import React, {type ReactElement, useCallback, useMemo, useRef} from 'react';
 import {Dimensions, type StyleProp, StyleSheet, Text, type TextStyle, View, type ViewStyle} from 'react-native';
 import performance from 'react-native-performance';
+import urlParse from 'url-parse';
 
 import CompassIcon from '@components/compass_icon';
 import EditedIndicator from '@components/edited_indicator';
@@ -19,7 +20,7 @@ import {computeTextStyle, getMarkdownBlockStyles, getMarkdownTextStyles} from '@
 import PostListPerformance from '@utils/performance/post_list_performance';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
-import {getScheme} from '@utils/url';
+import {getScheme, isValidUrl} from '@utils/url';
 
 import AtMention from './at_mention';
 import ChannelMention from './channel_mention';
@@ -113,6 +114,65 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
     };
 });
+
+const FILE_ENDPOINT_PATTERN = /^\/api\/v4\/files\/[a-z0-9]{26}(?:\/preview)?$/;
+const UNSAFE_URL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F\\]/;
+
+const getCurrentServerFileSource = (source: string, serverUrl: string) => {
+    if (!source || !serverUrl || UNSAFE_URL_CHARACTER_PATTERN.test(source)) {
+        return undefined;
+    }
+
+    const parsedServerUrl = urlParse(serverUrl);
+    if (!['http:', 'https:'].includes(parsedServerUrl.protocol) || !parsedServerUrl.hostname) {
+        return undefined;
+    }
+
+    let fileEndpointPath: string;
+    if (source.startsWith('/')) {
+        if (source.startsWith('//')) {
+            return undefined;
+        }
+
+        fileEndpointPath = urlParse(source).pathname;
+    } else {
+        if (!isValidUrl(source)) {
+            return undefined;
+        }
+
+        const parsedSource = urlParse(source);
+        if (
+            parsedSource.username ||
+            parsedSource.password ||
+            parsedSource.protocol !== parsedServerUrl.protocol ||
+            parsedSource.hostname.toLowerCase() !== parsedServerUrl.hostname.toLowerCase() ||
+            parsedSource.port !== parsedServerUrl.port
+        ) {
+            return undefined;
+        }
+
+        const serverBasePath = parsedServerUrl.pathname.replace(/\/+$/, '');
+        if (!parsedSource.pathname.startsWith(`${serverBasePath}/`)) {
+            return undefined;
+        }
+        fileEndpointPath = parsedSource.pathname.slice(serverBasePath.length);
+    }
+
+    if (!FILE_ENDPOINT_PATTERN.test(fileEndpointPath)) {
+        return undefined;
+    }
+
+    if (fileEndpointPath.endsWith('/preview')) {
+        return source;
+    }
+
+    const suffixStart = source.search(/[?#]/);
+    if (suffixStart === -1) {
+        return `${source}/preview`;
+    }
+
+    return `${source.slice(0, suffixStart)}/preview${source.slice(suffixStart)}`;
+};
 
 const getExtraPropsForNode = (node: any) => {
     const extraProps: Record<string, any> = {
@@ -444,7 +504,12 @@ const Markdown = ({
     }, [renderText, style.block]);
 
     const renderImage = useCallback(({linkDestination, context, src, size}: MarkdownImageRenderer) => {
-        if (!imagesMetadata || isUnsafeLinksPost) {
+        if (isUnsafeLinksPost) {
+            return null;
+        }
+
+        const imageSource = imagesMetadata ? src : getCurrentServerFileSource(src, serverUrl);
+        if (!imageSource) {
             return null;
         }
 
@@ -453,6 +518,10 @@ const Markdown = ({
         const disableInteraction = (disableGallery ?? Boolean(!location)) || isInsideLink;
 
         if (context.indexOf('table') !== -1) {
+            if (!imagesMetadata) {
+                return null;
+            }
+
             // We have enough problems rendering images as is, so just render a link inside of a table
             return (
                 <MarkdownTableImage
@@ -477,12 +546,12 @@ const Markdown = ({
                 isReplyPost={isReplyPost}
                 location={location}
                 postId={postId!}
-                source={src}
+                source={imageSource}
                 sourceSize={size}
                 theme={theme}
             />
         );
-    }, [baseTextStyle, disableGallery, imagesMetadata, isReplyPost, isUnsafeLinksPost, layoutHeight, layoutWidth, location, postId, textStyles, theme]);
+    }, [baseTextStyle, disableGallery, imagesMetadata, isReplyPost, isUnsafeLinksPost, layoutHeight, layoutWidth, location, postId, serverUrl, textStyles, theme]);
 
     const renderLatexInline = useCallback(({context, latexCode}: MarkdownLatexRenderer) => {
         if (!enableInlineLatex || isUnsafeLinksPost) {
@@ -797,6 +866,7 @@ const Markdown = ({
 };
 
 export const testExports = {
+    getCurrentServerFileSource,
     renderHashtagWithStyles,
 };
 

--- a/app/components/markdown/markdown_image/index.tsx
+++ b/app/components/markdown/markdown_image/index.tsx
@@ -36,7 +36,7 @@ import type {GalleryItemType} from '@typings/screens/gallery';
 type MarkdownImageProps = {
     disabled?: boolean;
     errorTextStyle: StyleProp<TextStyle>;
-    imagesMetadata: Record<string, PostImage | undefined>;
+    imagesMetadata?: Record<string, PostImage | undefined>;
     isReplyPost?: boolean;
     linkDestination?: string;
     layoutHeight?: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixes inline Markdown images that use authenticated same-server Mattermost file URLs. Metadata-less file URLs are limited to exact file endpoints, raw URLs use bounded previews, and image authentication respects server subpaths.

Validated with:
- Focused Jest suites (41 tests)
- `npm run tsc`
- `npm run fix`
- Live iOS and Android simulator verification

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56573

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on:
- iPhone 17 Pro simulator, iOS 26.5
- Pixel API 35 emulator, Android 15

#### Screenshots
##### iOS
Before:
[Before on iOS](https://cursor.com/agents/bc-42deabe6-882e-4f0b-80a6-43b46d52d346/artifacts?path=%2Ftmp%2Fmm-56573%2Fbefore-ios.png)

After:
[After on iOS](https://cursor.com/agents/bc-42deabe6-882e-4f0b-80a6-43b46d52d346/artifacts?path=%2Ftmp%2Fmm-56573%2Fafter-ios.png)

##### Android
Before:
[Before on Android](https://cursor.com/agents/bc-42deabe6-882e-4f0b-80a6-43b46d52d346/artifacts?path=%2Ftmp%2Fmm-56573%2Fbefore-android.png)

After:
[After on Android](https://cursor.com/agents/bc-42deabe6-882e-4f0b-80a6-43b46d52d346/artifacts?path=%2Ftmp%2Fmm-56573%2Fafter-android.png)

#### Release Note
```release-note
Fixed inline Markdown images that use authenticated Mattermost file URLs.
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42deabe6-882e-4f0b-80a6-43b46d52d346?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42deabe6-882e-4f0b-80a6-43b46d52d346&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

