### PR TITLE
Fix time-of-day flake in apps_form initValues datetime tests

### DIFF
--- a/app/screens/apps_form/apps_form_component.test.ts
+++ b/app/screens/apps_form/apps_form_component.test.ts
@@ -68,12 +68,15 @@ describe('initValues', () => {
             const parsed = moment(values.dt as string);
             expect(parsed.isValid()).toBe(true);
 
-            // Default interval is 60 min. Result should be between `before` (rounded up to next hour)
-            // and slightly after `after`, and always at minute=0 / second=0.
+            // Default interval is 60 min. Result is always at minute=0 / second=0.
+            // When `before` falls exactly on an interval boundary (e.g. 13:00:26),
+            // the implementation keeps the boundary minute and only truncates
+            // seconds (matching the webapp), so compare against the start of
+            // `before`'s minute.
             expect(parsed.second()).toBe(0);
             expect(parsed.millisecond()).toBe(0);
             expect(parsed.minute()).toBe(0);
-            expect(parsed.isSameOrAfter(before)).toBe(true);
+            expect(parsed.isSameOrAfter(before.clone().startOf('minute'))).toBe(true);
 
             // Upper bound: within one full interval after `after`
             expect(parsed.diff(after, 'minutes')).toBeLessThanOrEqual(60);
@@ -105,6 +108,31 @@ describe('initValues', () => {
             ]);
             const parsed = moment(values.dt as string);
             expect([0, 15, 30, 45]).toContain(parsed.minute());
+        });
+
+        describe('time exactly on an interval boundary', () => {
+            afterEach(() => {
+                jest.useRealTimers();
+            });
+
+            it('should keep the boundary minute and truncate seconds (no rounding up)', () => {
+                // Matches the webapp: when minutes % interval === 0 the current
+                // time is kept and only seconds/milliseconds are cleared, so
+                // 13:00:26 yields 13:00:00 rather than 14:00:00.
+                jest.useFakeTimers({doNotFake: ['nextTick']});
+                jest.setSystemTime(new Date(2026, 0, 15, 13, 0, 26));
+
+                const values = initValues([
+                    {
+                        name: 'dt',
+                        type: AppFieldTypes.DATETIME,
+                        is_required: true,
+                    } as AppField,
+                ]);
+
+                const parsed = moment(values.dt as string);
+                expect(parsed.isSame(moment(new Date(2026, 0, 15, 13, 0, 0, 0)))).toBe(true);
+            });
         });
 
         it('does NOT auto-populate a non-required datetime field', () => {
@@ -195,7 +223,9 @@ describe('initValues', () => {
                 const parsed = moment(values.dt as string);
                 const after = moment();
 
-                expect(parsed.isSameOrAfter(before)).toBe(true);
+                // startOf('minute') tolerates `before` falling exactly on an
+                // interval boundary, where only seconds are truncated
+                expect(parsed.isSameOrAfter(before.clone().startOf('minute'))).toBe(true);
                 expect(parsed.diff(after, 'minutes')).toBeLessThanOrEqual(60);
             });
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
`app/screens/apps_form/apps_form_component.test.ts` failed intermittently whenever the test file ran during minute 0 of any hour (~1-2% of CI runs). Two tests asserted `parsed.isSameOrAfter(before)` where `before = moment()` was captured just before calling `initValues()`.

`initValues()` auto-populates required datetime fields by rounding the current time up to the next `time_interval` boundary — but when the current minute is already exactly on the boundary (`minutesMod === 0`, e.g. 13:00:26 with a 60-minute interval), it keeps the current minute and only truncates seconds, producing 13:00:00. That is earlier than `before` (13:00:26), so the assertion failed.

This behavior intentionally matches the webapp (`initFormValues` in `webapp/channels/src/components/apps_form/apps_form_component.tsx` in the mattermost/mattermost monorepo uses identical `minutesMod === 0` logic), so the implementation is correct and only the tests are changed:

- Both flaky assertions now compare against `before.clone().startOf('minute')`, which tolerates the boundary case while keeping the existing upper-bound assertions intact.
- Added a deterministic regression test for the boundary case using `jest.useFakeTimers` + `jest.setSystemTime` pinned to 13:00:26, asserting the documented webapp-matching behavior (13:00:26 yields 13:00:00, not 14:00:00). Real timers are restored in `afterEach`.

Verification:
- Reproduced the flake by temporarily pinning the suite's system time to 13:00:26: the two diagnosed tests failed, all others passed.
- With the fix, the suite passes both at real time and pinned to 13:00:26 (18/18).
- `npm run fix` and `npm run tsc` pass cleanly.

#### Ticket Link
None — fixes a CI test flake introduced with the tests in #9521.

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-715744e3-b06f-443e-9cea-1a5529841aa9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-715744e3-b06f-443e-9cea-1a5529841aa9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

