### PR TITLE
fix(ci): keep release Fastlane install path; opt-in gem cache for E2E

### DIFF
--- a/.github/actions/prepare-android-build/action.yaml
+++ b/.github/actions/prepare-android-build/action.yaml
@@ -5,12 +5,18 @@ inputs:
   sign:
     description: Flag to enable android package signing
     default: "true"
+  bundler-cache:
+    description: 'Enable Fastlane gem bundler-cache (E2E only; leave false for release/beta builds)'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
   steps:
     - name: ci/prepare-mobile-build
       uses: ./.github/actions/prepare-mobile-build
+      with:
+        bundler-cache: ${{ inputs.bundler-cache }}
 
     - name: ci/setup-java
       uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -9,6 +9,10 @@ inputs:
   intune-ssh-private-key:
     description: 'SSH private key for Intune submodule repository access (required if intune-enabled is true)'
     required: false
+  bundler-cache:
+    description: 'Enable Fastlane gem bundler-cache (E2E only; leave false for release/beta builds)'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -117,6 +121,8 @@ runs:
 
     - name: ci/prepare-mobile-build
       uses: ./.github/actions/prepare-mobile-build
+      with:
+        bundler-cache: ${{ inputs.bundler-cache }}
 
     - name: ci/setup-intune
       if: inputs.intune-enabled == 'true'

--- a/.github/actions/prepare-mobile-build/action.yaml
+++ b/.github/actions/prepare-mobile-build/action.yaml
@@ -1,20 +1,73 @@
 name: prepare-mobile-build
 description: Action to prepare environment for mobile build
 
+inputs:
+  bundler-cache:
+    description: >
+      Use setup-ruby bundler-cache (deployment mode). Enable for E2E builds only.
+      Release/beta/PR production builds should leave this false to keep the
+      historical plain bundle install path.
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
-    # bundler-cache restores/installs fastlane/Gemfile.lock gems before the job
-    # continues. The previous manual cache targeted repo-root vendor/bundle while
-    # bundle install ran in fastlane/, so the cache never hit or saved.
-    # ruby-version must be set explicitly: working-directory makes setup-ruby look
-    # for .ruby-version under fastlane/, but the file lives at the repo root.
+    # --- Release / production path (default) ---
+    # Plain bundle install without deployment mode. Do not change this path
+    # for E2E caching concerns.
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
+      if: inputs.bundler-cache != 'true'
+
+    - name: ci/setup-fastlane-dependencies
+      if: inputs.bundler-cache != 'true'
+      shell: bash
+      run: |
+        echo "::group::setup-fastlane-dependencies"
+        bundle install
+        echo "::endgroup::"
+      working-directory: ./fastlane
+
+    - name: Cache Ruby gems
+      if: inputs.bundler-cache != 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    # --- E2E path ---
+    # bundler-cache restores/installs fastlane/Gemfile.lock gems correctly under
+    # fastlane/vendor/bundle. Requires the runner platform to be in Gemfile.lock
+    # because setup-ruby enables Bundler deployment mode.
     - name: Read Ruby version
+      if: inputs.bundler-cache == 'true'
       id: ruby-version
       shell: bash
       run: echo "version=$(tr -d '[:space:]' < .ruby-version)" >> "$GITHUB_OUTPUT"
 
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
+      if: inputs.bundler-cache == 'true'
+      with:
+        ruby-version: ${{ steps.ruby-version.outputs.version }}
+        working-directory: fastlane
+
+    - name: Ensure Bundler platform is locked
+      if: inputs.bundler-cache == 'true'
+      shell: bash
+      working-directory: fastlane
+      run: |
+        platform="$(ruby -e 'require "bundler"; print Bundler.local_platform')"
+        if grep -qE "^[[:space:]]+${platform}$" Gemfile.lock; then
+          echo "Platform ${platform} already present in Gemfile.lock"
+        else
+          echo "Adding missing platform ${platform} to Gemfile.lock"
+          bundle lock --add-platform "${platform}"
+        fi
+
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
+      if: inputs.bundler-cache == 'true'
       with:
         ruby-version: ${{ steps.ruby-version.outputs.version }}
         bundler-cache: true

--- a/.github/actions/prepare-mobile-build/action.yaml
+++ b/.github/actions/prepare-mobile-build/action.yaml
@@ -38,33 +38,14 @@ runs:
           ${{ runner.os }}-gems-
 
     # --- E2E path ---
-    # bundler-cache restores/installs fastlane/Gemfile.lock gems correctly under
-    # fastlane/vendor/bundle. Requires the runner platform to be in Gemfile.lock
-    # because setup-ruby enables Bundler deployment mode.
+    # bundler-cache restores/installs fastlane/Gemfile.lock gems under
+    # fastlane/vendor/bundle. Runner platforms must be listed in Gemfile.lock
+    # (deployment mode); add new ones via PR when GitHub runner images change.
     - name: Read Ruby version
       if: inputs.bundler-cache == 'true'
       id: ruby-version
       shell: bash
       run: echo "version=$(tr -d '[:space:]' < .ruby-version)" >> "$GITHUB_OUTPUT"
-
-    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
-      if: inputs.bundler-cache == 'true'
-      with:
-        ruby-version: ${{ steps.ruby-version.outputs.version }}
-        working-directory: fastlane
-
-    - name: Ensure Bundler platform is locked
-      if: inputs.bundler-cache == 'true'
-      shell: bash
-      working-directory: fastlane
-      run: |
-        platform="$(ruby -e 'require "bundler"; print Bundler.local_platform')"
-        if grep -qE "^[[:space:]]+${platform}$" Gemfile.lock; then
-          echo "Platform ${platform} already present in Gemfile.lock"
-        else
-          echo "Adding missing platform ${platform} to Gemfile.lock"
-          bundle lock --add-platform "${platform}"
-        fi
 
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
       if: inputs.bundler-cache == 'true'

--- a/.github/workflows/e2e-detox-pr.yml
+++ b/.github/workflows/e2e-detox-pr.yml
@@ -479,6 +479,7 @@ jobs:
         with:
           intune-enabled: ${{ env.INTUNE_ENABLED }}
           intune-ssh-private-key: ${{ secrets.MM_MOBILE_INTUNE_DEPLOY_KEY }}
+          bundler-cache: true
 
       - name: Set .env with RUNNING_E2E=true
         if: env.SKIP_BUILD != 'true'
@@ -564,6 +565,8 @@ jobs:
       - name: Prepare Android Build
         if: env.SKIP_BUILD != 'true'
         uses: ./.github/actions/prepare-android-build
+        with:
+          bundler-cache: true
         env:
           STORE_FILE: ${{ secrets.MM_MOBILE_STORE_FILE }}
           STORE_ALIAS: ${{ secrets.MM_MOBILE_STORE_ALIAS }}
@@ -660,6 +663,8 @@ jobs:
       - name: Prepare Android Build
         if: env.SKIP_BUILD != 'true'
         uses: ./.github/actions/prepare-android-build
+        with:
+          bundler-cache: true
         env:
           STORE_FILE: ${{ secrets.MM_MOBILE_STORE_FILE }}
           STORE_ALIAS: ${{ secrets.MM_MOBILE_STORE_ALIAS }}

--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -251,6 +251,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## Summary
- Beta/release/PR builds keep the historical plain `bundle install` path (no Bundler deployment mode).
- E2E (`e2e-detox-pr`) opts into `bundler-cache: true` via a new input.
- Adds `x86_64-darwin-24` to `fastlane/Gemfile.lock` so the E2E cache path works on current runners; future platforms should be added via PR.

This unblocks `build-beta-797` iOS jobs that failed in `ci/prepare-ios-build` ([run](https://github.com/mattermost/mattermost-mobile/actions/runs/31074300830)).

```release-note
NONE
```


Made with [Cursor](https://cursor.com)