### PR TITLE
MM-26917 update channel header message format

### DIFF
--- a/app/components/post_list/post/system_message/__snapshots__/system_message_helpers.test.js.snap
+++ b/app/components/post_list/post/system_message/__snapshots__/system_message_helpers.test.js.snap
@@ -119,7 +119,95 @@ exports[`renderSystemMessage uses renderer for Channel Header update 1`] = `
         }
         testID="markdown_text"
       >
-         updated the channel header from: old header to: new header
+         updated the channel header
+      </Text>
+      <Text
+        testID="markdown_break"
+      >
+        
+
+      </Text>
+      <Text
+        selectable={false}
+        style={
+          [
+            {
+              "color": "rgba(63,67,80,0.6)",
+              "fontFamily": "OpenSans",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "lineHeight": 24,
+            },
+            [
+              {
+                "fontFamily": "OpenSans-SemiBold",
+                "fontWeight": "600",
+              },
+            ],
+          ]
+        }
+        testID="markdown_text"
+      >
+        From:
+      </Text>
+      <Text
+        selectable={false}
+        style={
+          {
+            "color": "rgba(63,67,80,0.6)",
+            "fontFamily": "OpenSans",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          }
+        }
+        testID="markdown_text"
+      >
+         old header
+      </Text>
+      <Text
+        testID="markdown_break"
+      >
+        
+
+      </Text>
+      <Text
+        selectable={false}
+        style={
+          [
+            {
+              "color": "rgba(63,67,80,0.6)",
+              "fontFamily": "OpenSans",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "lineHeight": 24,
+            },
+            [
+              {
+                "fontFamily": "OpenSans-SemiBold",
+                "fontWeight": "600",
+              },
+            ],
+          ]
+        }
+        testID="markdown_text"
+      >
+        To:
+      </Text>
+      <Text
+        selectable={false}
+        style={
+          {
+            "color": "rgba(63,67,80,0.6)",
+            "fontFamily": "OpenSans",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          }
+        }
+        testID="markdown_text"
+      >
+         new header
       </Text>
     </Text>
   </View>

--- a/app/components/post_list/post/system_message/system_message.tsx
+++ b/app/components/post_list/post/system_message/system_message.tsx
@@ -91,7 +91,7 @@ const renderMessage = ({location, post, styles, intl, localeHolder, theme, value
 const headerMessages = defineMessages({
     updatedFrom: {
         id: 'mobile.system_message.update_channel_header_message_and_forget.updated_from',
-        defaultMessage: '{username} updated the channel header from: {oldHeader} to: {newHeader}',
+        defaultMessage: '{username} updated the channel header\n**From:** {oldHeader}\n**To:** {newHeader}',
     },
     updatedTo: {
         id: 'mobile.system_message.update_channel_header_message_and_forget.updated_to',

--- a/app/components/post_list/post/system_message/system_message_helpers.test.js
+++ b/app/components/post_list/post/system_message/system_message_helpers.test.js
@@ -44,7 +44,13 @@ describe('renderSystemMessage', () => {
         );
         expect(toJSON()).toMatchSnapshot();
         expect(getByText('@username')).toBeTruthy();
-        expect(getByText('updated the channel header from: old header to: new header')).toBeTruthy();
+        expect(getByText('updated the channel header')).toBeTruthy();
+
+        expect(getByText('From:')).toBeTruthy();
+        expect(getByText('old header')).toBeTruthy();
+
+        expect(getByText('To:')).toBeTruthy();
+        expect(getByText('new header')).toBeTruthy();
     });
 
     test('uses renderer for Channel Display Name update', () => {

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -1067,7 +1067,7 @@
   "mobile.system_message.channel_unarchived_message": "{username} unarchived the channel",
   "mobile.system_message.update_channel_displayname_message_and_forget.updated_from": "{username} updated the channel display name from: {oldDisplayName} to: {newDisplayName}",
   "mobile.system_message.update_channel_header_message_and_forget.removed": "{username} removed the channel header (was: {oldHeader})",
-  "mobile.system_message.update_channel_header_message_and_forget.updated_from": "{username} updated the channel header from: {oldHeader} to: {newHeader}",
+  "mobile.system_message.update_channel_header_message_and_forget.updated_from": "{username} updated the channel header\n**From:** {oldHeader}\n**To:** {newHeader}",
   "mobile.system_message.update_channel_header_message_and_forget.updated_to": "{username} updated the channel header to: {newHeader}",
   "mobile.system_message.update_channel_purpose_message.removed": "{username} removed the channel purpose (was: {oldPurpose})",
   "mobile.system_message.update_channel_purpose_message.updated_from": "{username} updated the channel purpose from: {oldPurpose} to: {newPurpose}",


### PR DESCRIPTION
#### Summary
Updated the channel header system message format to show the changes in a clearer From/To format.

#### Changes
- Updated the channel header system message translation format in `assets/base/i18n/en.json`.
- Updated the system message renderer unit test and snapshot for the new From/To format.
- Added separate lines for **From** and **To** values to improve readability.

#### Ticket
MM-26917

#### Testing
Run:
npx jest app/components/post_list/post/system_message/system_message_helpers.test.js -u

Result:
9 tests passed.

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information

This PR was tested on: Not tested

#### Screenshots

N/A

#### Release Note

```release-note
Updated channel header system message format to display changes with From and To fields.
```
