### PR TITLE
Fix Android rendering of object replacement characters

### DIFF
--- a/app/components/markdown/markdown.test.tsx
+++ b/app/components/markdown/markdown.test.tsx
@@ -43,6 +43,19 @@ describe('Markdown', () => {
             expect(screen.getByText('This is a test')).toBeVisible();
         });
 
+        it('should remove object replacement characters before rendering Markdown', () => {
+            renderWithIntl(
+                <Markdown
+                    {...baseProps}
+                    value={'before\uFFFCmiddle\n\n\uFFFC\n\nafter'}
+                />,
+            );
+
+            expect(screen.getByText('beforemiddle')).toBeVisible();
+            expect(screen.getByText('after')).toBeVisible();
+            expect(screen.queryByText('\uFFFC')).toBeNull();
+        });
+
         test('should catch errors when parsing Markdown', () => {
             jest.spyOn(CommonMark, 'Parser').mockImplementation(() => {
                 const parser = new Parser();

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -722,7 +722,8 @@ const Markdown = ({
         const startTime = performance.now();
         let ast;
         try {
-            ast = parser.parse(value.toString());
+            const markdownValue = value.toString().replace(/\uFFFC/g, '');
+            ast = parser.parse(markdownValue);
 
             ast = combineTextNodes(ast);
             ast = addListItemIndices(ast);


### PR DESCRIPTION
#### Summary

Prevents an Android `Layout: -2 < 0` render error caused by the Unicode object replacement character (`U+FFFC`) in Markdown input.

The character is removed from the input before parsing. Keeping this at the shared Markdown boundary covers every use of the `Markdown` component without modifying server or database content.

#### Testing

Reproduced the issue without the fix when `U+FFFC` formed its own CommonMark paragraph:

| Markdown input | CommonMark structure |
| --- | --- |
| `U+FFFC` | Standalone paragraph |
| `U+FFFC\n\ntext` | Standalone paragraph before text |
| `text\n\nU+FFFC` | Standalone paragraph after text |

Also confirmed that inline and soft-break occurrences did not trigger the error. The updated implementation removes the character from all positions before parsing.

Verified that the original affected channel renders normally with the fix enabled.

Automated verification:

- Focused Markdown suites: 129 tests passed
- TypeScript check passed
- ESLint passed
- Android release build passed
- Full Jest suite: 8,899 tests passed; two unrelated Korean locale snapshots failed on Windows due to platform-specific AM marker formatting

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-mobile/issues/9960

#### Checklist

- [x] Added or updated unit tests (required for all new features)

#### Device Information

This PR was tested on: Pixel 9 Pro, Android 17/API 37

#### Screenshots

N/A

#### Release Note

```release-note
Fixed an Android rendering error caused by messages containing Unicode object replacement characters.
```