### PR TITLE
Fix Android crashes caused by animated custom emoji

### DIFF
--- a/patches/expo-image+55.0.10.patch
+++ b/patches/expo-image+55.0.10.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/expo-image/android/build.gradle b/node_modules/expo-image/android/build.gradle
-index 2668d8d..4f097c2 100644
+index 2668d8d..fc387fe 100644
 --- a/node_modules/expo-image/android/build.gradle
 +++ b/node_modules/expo-image/android/build.gradle
 @@ -1,17 +1,9 @@
@@ -20,7 +20,7 @@ index 2668d8d..4f097c2 100644
  group = 'expo.modules.image'
  version = '55.0.10'
  
-@@ -42,7 +34,7 @@ dependencies {
+@@ -42,6 +34,6 @@ dependencies {
    implementation 'com.facebook.react:react-android'
  
    api "com.github.bumptech.glide:glide:${GLIDE_VERSION}"
@@ -28,12 +28,29 @@ index 2668d8d..4f097c2 100644
 +  kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
    api 'com.caverock:androidsvg-aar:1.4'
  
-   implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.5"
 diff --git a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
-index 5735515..dbbb924 100644
 --- a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
 +++ b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
-@@ -22,5 +22,19 @@ class ExpoImageAppGlideModule : AppGlideModule() {
+@@ -2,9 +2,16 @@ package expo.modules.image
+-
++
+ import android.content.Context
+ import android.util.Log
++import com.bumptech.glide.Glide
+ import com.bumptech.glide.GlideBuilder
++import com.bumptech.glide.Registry
+ import com.bumptech.glide.annotation.GlideModule
++import com.bumptech.glide.load.resource.gif.ByteBufferGifDecoder
++import com.bumptech.glide.load.resource.gif.GifDrawable
++import com.bumptech.glide.load.resource.gif.StreamGifDecoder
+ import com.bumptech.glide.module.AppGlideModule
++import java.io.InputStream
++import java.nio.ByteBuffer
+-
++
+ /**
+  * We need to include an [AppGlideModule] for [GlideModule] annotations
+@@ -22,5 +29,32 @@ class ExpoImageAppGlideModule : AppGlideModule() {
          Log.ERROR
        }
      )
@@ -48,16 +65,29 @@ index 5735515..dbbb924 100644
 +    diskCacheInstance = diskCache
 +  }
 +
++  override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
++    super.registerComponents(context, glide, registry)
++
++    // APNG4Android's GIF decoder can write beyond its output buffer. Prepending
++    // Glide's decoders keeps GIFs animated without routing them through that decoder.
++    val parsers = registry.imageHeaderParsers
++    val byteBufferDecoder = ByteBufferGifDecoder(context, parsers, glide.bitmapPool, glide.arrayPool)
++    val streamDecoder = StreamGifDecoder(parsers, byteBufferDecoder, glide.arrayPool)
++
++    registry.prepend(InputStream::class.java, GifDrawable::class.java, streamDecoder)
++    registry.prepend(ByteBuffer::class.java, GifDrawable::class.java, byteBufferDecoder)
++  }
++
 +  companion object {
 +    // Store reference to access clearPath method from ExpoImageModule
 +    internal var diskCacheInstance: PerServerDiskCache? = null
    }
  }
 diff --git a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
-index 2579cb3..1ef3a8f 100644
+index 2579cb3..18a742a 100644
 --- a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
 +++ b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
-@@ -184,13 +184,17 @@ class ExpoImageModule : Module() {
+@@ -184,13 +175,17 @@ class ExpoImageModule : Module() {
        return@AsyncFunction true
      }.runOnQueue(Queues.MAIN)
  

--- a/patches/expo-image+55.0.10.patch
+++ b/patches/expo-image+55.0.10.patch
@@ -544,6 +544,39 @@ index 4d23e20..5e6d392 100644
    var pixelCount: Double {
      return width * height * scale * scale
    }
+diff --git a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+--- a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
++++ b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+@@ -448,6 +448,15 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(c
+     requestManager.clear(secondTarget)
+   }
+ 
++  fun onTargetCleared(target: ImageViewWrapperTarget) {
++    if (firstView.currentTarget === target) {
++      firstView.recycleView()
++    }
++    if (secondView.currentTarget === target) {
++      secondView.recycleView()
++    }
++  }
++
+   private fun cleanIfNeeded(
+     newBestSource: Source?,
+     newBestSourceModel: GlideModelProvider?,
+diff --git a/node_modules/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt b/node_modules/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
+--- a/node_modules/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
++++ b/node_modules/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
+@@ -128,7 +128,9 @@ class ImageViewWrapperTarget(
+     endLoadingNewImageTraceBlock()
+   }
+ 
+-  override fun onLoadCleared(placeholder: Drawable?) = Unit
++  override fun onLoadCleared(placeholder: Drawable?) {
++    imageViewHolder.get()?.onTargetCleared(this)
++  }
+ 
+   override fun getSize(cb: SizeReadyCallback) {
+     // If we can't resolve the image, we just return unknown size.
 diff --git a/node_modules/expo-image/ios/ImageView.swift b/node_modules/expo-image/ios/ImageView.swift
 index 034b662..efec047 100644
 --- a/node_modules/expo-image/ios/ImageView.swift


### PR DESCRIPTION
#### Summary

Fixes native Android crashes caused by APNG4Android decoding some animated GIFs.

APNG4Android's interlaced GIF decoder can calculate an output position beyond its allocated frame buffer. The resulting heap corruption may surface later in unrelated native code, which makes the crash appear in Android rendering, Hermes, Worklets, or other threads rather than at the original invalid write.

This prepends Glide's built-in GIF decoders for both `InputStream` and `ByteBuffer` sources. GIFs remain animated but no longer pass through APNG4Android's GIF decoder. APNG4Android remains registered for APNG, animated WebP, and animated AVIF support.

#### Crash Evidence

The issue was reproduced reliably with the Play Store build of Mattermost 2.42.3 on a Pixel 9 Pro by opening the reaction picker and scrolling through the full custom server emoji list.

Android recorded two consecutive native crashes. The tombstone showed:

- `SIGSEGV` in `com.mattermost.rn`
- The crashing thread named `FrameDecoderExe`
- `com.github.penfeizhou.animation.FrameAnimationDrawable.onRender`
- `android.graphics.Bitmap.copyPixelsFromBuffer`
- Three concurrent decoder threads executing `com.github.penfeizhou.animation.gif.decode.GifDecoder.renderFrame`

The corrupted pointer closely matches a recurring pointer signature reported in #9726. Reports on #8252 also identify specific custom GIF emoji as the trigger for persistent picker, message, and reaction crashes.

#### Testing

Manual A/B verification on the same device, server, message, and custom emoji list:

- Play Store Mattermost 2.42.3 reliably crashed after opening the reaction picker and scrolling through the custom server emoji list.
- The patched release build completed the same flow without crashing.

Decoder routing was also verified from a cold cache:

| Format | Decoder after this change |
| --- | --- |
| GIF | Glide `GifDrawable` |
| APNG | APNG4Android |
| Animated WebP | APNG4Android |
| Animated AVIF | APNG4Android |

Additional verification:

- A valid interlaced GIF reproduced the APNG4Android out-of-bounds destination calculation.
- Expo Image display, prefetch, and `loadAsync` paths were checked for GIF handling.
- Patch application and reverse-application checks passed.
- TypeScript check passed.
- ESLint passed.
- Expo Image Android Kotlin compilation passed.
- Android debug and release builds passed.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-mobile/issues/8252

Related to https://github.com/mattermost/mattermost-mobile/issues/9726

Internal ticket: MM-61196

#### Device Information

This PR was tested on: Pixel 9 Pro, Android 17/API 37

#### Screenshots

N/A, no UI changes.

#### Release Note

```release-note
Fixed Android crashes caused by rendering some animated custom emoji.
```