### PR TITLE
[MM-69761][MM-70133][MM-70179] Auto-open full-screen call view on initiation and hide "People" button in 1:1 DM Call

### DIFF
--- a/app/products/calls/components/current_call_bar/index.test.tsx
+++ b/app/products/calls/components/current_call_bar/index.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {setCurrentCall} from '@calls/state';
+import {DefaultCurrentCall} from '@calls/types/calls';
+import {General} from '@constants';
+import DatabaseManager from '@database/manager';
+import {act, renderWithEverything} from '@test/intl-test-helper';
+import TestHelper from '@test/test_helper';
+
+import CurrentCallBar from './current_call_bar';
+
+import CurrentCallBarIndex from './index';
+
+import type {Database} from '@nozbe/watermelondb';
+
+jest.mock('./current_call_bar');
+jest.mocked(CurrentCallBar).mockImplementation((props) => {
+    return React.createElement('CurrentCallBar', {
+        testID: 'current-call-bar',
+        ...props,
+    });
+});
+
+// withObservables emits each prop on its own database tick; give them all a chance to land inside act().
+const flushObservables = async () => {
+    await act(async () => {
+        await new Promise(process.nextTick);
+    });
+};
+
+const activeServerUrl = 'active-server';
+const callServerUrl = 'call-server';
+const channelId = 'channel-id';
+const myUserId = 'my-user-id';
+
+describe('CurrentCallBar Index', () => {
+    let activeDatabase: Database;
+
+    beforeEach(async () => {
+        await DatabaseManager.init([activeServerUrl, callServerUrl]);
+        const active = DatabaseManager.getServerDatabaseAndOperator(activeServerUrl);
+        const call = DatabaseManager.getServerDatabaseAndOperator(callServerUrl);
+        activeDatabase = active.database;
+
+        // The same channel id, and the name display setting, exist on both servers with different values, so that
+        // reading them from the active server's database (instead of the call server's) is observable in the props.
+        await active.operator.handleChannel({
+            channels: [TestHelper.fakeChannel({id: channelId, display_name: 'Wrong Active Channel'})],
+            prepareRecordsOnly: false,
+        });
+        await active.operator.handleConfigs({
+            configs: [{id: 'TeammateNameDisplay', value: General.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME}],
+            configsToDelete: [],
+            prepareRecordsOnly: false,
+        });
+
+        await call.operator.handleChannel({
+            channels: [TestHelper.fakeChannel({id: channelId, display_name: 'Correct Call Channel'})],
+            prepareRecordsOnly: false,
+        });
+        await call.operator.handleConfigs({
+            configs: [{id: 'TeammateNameDisplay', value: General.TEAMMATE_NAME_DISPLAY.SHOW_FULLNAME}],
+            configsToDelete: [],
+            prepareRecordsOnly: false,
+        });
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            setCurrentCall(null);
+        });
+        await DatabaseManager.destroyServerDatabase(activeServerUrl);
+        await DatabaseManager.destroyServerDatabase(callServerUrl);
+    });
+
+    it('should derive the props from the call server database, not the active server database', async () => {
+        setCurrentCall({
+            ...DefaultCurrentCall,
+            id: 'call-id',
+            channelId,
+            serverUrl: callServerUrl,
+            myUserId,
+        });
+
+        // The provider is given the active server's database on purpose: the call bar is rendered while another
+        // server is active.
+        const {getByTestId} = renderWithEverything(
+            <CurrentCallBarIndex/>,
+            {database: activeDatabase, serverUrl: activeServerUrl},
+        );
+        await flushObservables();
+
+        const component = getByTestId('current-call-bar');
+        expect(component.props.displayName).toBe('Correct Call Channel');
+        expect(component.props.teammateNameDisplay).toBe(General.TEAMMATE_NAME_DISPLAY.SHOW_FULLNAME);
+    });
+});

--- a/app/products/calls/components/current_call_bar/index.ts
+++ b/app/products/calls/components/current_call_bar/index.ts
@@ -2,36 +2,22 @@
 // See LICENSE.txt for license information.
 
 import {withObservables} from '@nozbe/watermelondb/react';
-import {combineLatest, of as of$} from 'rxjs';
+import {of as of$} from 'rxjs';
 import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
-import {observeCurrentSessionsDict, observeEndCallDetails} from '@calls/observers';
+import {observeCallChannel, observeCallDatabase, observeCurrentSessionsDict, observeEndCallDetails} from '@calls/observers';
 import {observeCurrentCall, observeGlobalCallsState} from '@calls/state';
-import DatabaseManager from '@database/manager';
-import {observeChannel} from '@queries/servers/channel';
 import {observeTeammateNameDisplay} from '@queries/servers/user';
 
 import CurrentCallBar from './current_call_bar';
 
 const enhanced = withObservables([], () => {
     const currentCall = observeCurrentCall();
-    const ccServerUrl = currentCall.pipe(
-        switchMap((call) => of$(call?.serverUrl || '')),
-        distinctUntilChanged(),
-    );
-    const ccChannelId = currentCall.pipe(
-        switchMap((call) => of$(call?.channelId || '')),
-        distinctUntilChanged(),
-    );
-    const database = ccServerUrl.pipe(
-        switchMap((url) => of$(DatabaseManager.serverDatabases[url]?.database)),
-    );
-    const displayName = combineLatest([database, ccChannelId]).pipe(
-        switchMap(([db, id]) => (db && id ? observeChannel(db, id) : of$(undefined))),
+    const displayName = observeCallChannel().pipe(
         switchMap((c) => of$(c?.displayName || '')),
         distinctUntilChanged(),
     );
-    const teammateNameDisplay = database.pipe(
+    const teammateNameDisplay = observeCallDatabase().pipe(
         switchMap((db) => (db ? observeTeammateNameDisplay(db) : of$(''))),
         distinctUntilChanged(),
     );

--- a/app/products/calls/hooks.test.ts
+++ b/app/products/calls/hooks.test.ts
@@ -351,7 +351,7 @@ describe('Calls Hooks', () => {
             expect(result.current).toBeUndefined();
         });
 
-        it('should join the call on press', async () => {
+        it('should join the call and open the full screen call view on press', async () => {
             const {result} = renderHook(() => useNavigationHeaderCallButtonForDM(channelId, General.DM_CHANNEL));
 
             await act(async () => {
@@ -359,6 +359,19 @@ describe('Calls Hooks', () => {
             });
 
             expect(leaveAndJoinWithAlert).toHaveBeenCalledWith(expect.anything(), 'server1', channelId);
+            expect(navigateToScreen).toHaveBeenCalledWith(Screens.CALL);
+        });
+
+        it('should not open the full screen call view when the user does not join the call due to error', async () => {
+            jest.mocked(leaveAndJoinWithAlert).mockResolvedValue(false);
+
+            const {result} = renderHook(() => useNavigationHeaderCallButtonForDM(channelId, General.DM_CHANNEL));
+
+            await act(async () => {
+                result.current?.onPress();
+            });
+
+            expect(leaveAndJoinWithAlert).toHaveBeenCalled();
             expect(navigateToScreen).not.toHaveBeenCalled();
         });
 
@@ -483,6 +496,7 @@ describe('Calls Hooks', () => {
                 expect(result.current?.isLoading).toBe(false);
             });
             expect(result.current?.disabled).toBe(false);
+            expect(navigateToScreen).not.toHaveBeenCalled();
         });
     });
 });

--- a/app/products/calls/hooks.ts
+++ b/app/products/calls/hooks.ts
@@ -283,7 +283,10 @@ export const useNavigationHeaderCallButtonForDM = (channelId: Channel['id'], cha
 
         setIsJoiningOrStarting(true);
         try {
-            await leaveAndJoinWithAlert(intl, serverUrl, channelId);
+            const joined = await leaveAndJoinWithAlert(intl, serverUrl, channelId);
+            if (joined) {
+                navigateToScreen(Screens.CALL);
+            }
         } catch (error) {
             logError('error on useNavigationHeaderCallButtonForDM.joinOrStart', getFullErrorMessage(error));
         } finally {

--- a/app/products/calls/observers/index.test.ts
+++ b/app/products/calls/observers/index.test.ts
@@ -12,6 +12,7 @@ import {
 import {DefaultCallsState} from '@calls/types/calls';
 import {License} from '@constants';
 import DatabaseManager from '@database/manager';
+import {observeChannel} from '@queries/servers/channel';
 import {observeConfigValue, observeLicense} from '@queries/servers/system';
 import {queryUsersById} from '@queries/servers/user';
 
@@ -19,11 +20,13 @@ import {
     observeIsCallsEnabledInChannel,
     observeIsCallLimitRestricted,
     observeCallStateInChannel,
+    observeCallChannel,
     observeEndCallDetails,
     observeCurrentSessionsDict,
 } from './index';
 
 jest.mock('@calls/state');
+jest.mock('@queries/servers/channel');
 jest.mock('@queries/servers/system');
 jest.mock('@queries/servers/user');
 
@@ -235,6 +238,39 @@ describe('Calls Observers', () => {
                 session1: {...sessions.session1, userModel: userModels[0]},
                 session2: {...sessions.session2, userModel: userModels[1]},
             });
+        });
+    });
+
+    describe('observeCallChannel', () => {
+        it('should resolve the channel from the call server database', async () => {
+            const callServerDatabase = {id: 'call-server-db'} as any;
+            (DatabaseManager as any).serverDatabases = {'test-server': {database: callServerDatabase}};
+            (observeCurrentCall as jest.Mock).mockReturnValue(of$({serverUrl: 'test-server', channelId: 'channel1'}));
+            (observeChannel as jest.Mock).mockReturnValue(of$({id: 'channel1', type: 'D'}));
+
+            const result = await firstValueFrom(observeCallChannel());
+
+            expect(observeChannel).toHaveBeenCalledWith(callServerDatabase, 'channel1');
+            expect(result).toEqual({id: 'channel1', type: 'D'});
+        });
+
+        it('should emit undefined when the call server has no database', async () => {
+            // the call is on a server other than the one whose database is loaded
+            (observeCurrentCall as jest.Mock).mockReturnValue(of$({serverUrl: 'other-server', channelId: 'channel1'}));
+
+            const result = await firstValueFrom(observeCallChannel());
+
+            expect(result).toBeUndefined();
+            expect(observeChannel).not.toHaveBeenCalled();
+        });
+
+        it('should emit undefined when there is no current call', async () => {
+            (observeCurrentCall as jest.Mock).mockReturnValue(of$(null));
+
+            const result = await firstValueFrom(observeCallChannel());
+
+            expect(result).toBeUndefined();
+            expect(observeChannel).not.toHaveBeenCalled();
         });
     });
 

--- a/app/products/calls/observers/index.ts
+++ b/app/products/calls/observers/index.ts
@@ -13,6 +13,7 @@ import {
 import {fillUserModels, userIds} from '@calls/utils';
 import {License} from '@constants';
 import DatabaseManager from '@database/manager';
+import {observeChannel} from '@queries/servers/channel';
 import {observeConfigValue, observeLicense} from '@queries/servers/system';
 import {queryUsersById} from '@queries/servers/user';
 import UserModel from '@typings/database/models/servers/user';
@@ -92,6 +93,19 @@ export const observeCallDatabase = () => {
         switchMap((call) => of$(call ? call.serverUrl : '')),
         distinctUntilChanged(),
         switchMap((url) => of$(DatabaseManager.serverDatabases[url]?.database)),
+    );
+};
+
+// Observes the current call's channel from the call's own server database, which is not necessarily the
+// active server's database (the call screen can be opened from the current call bar while viewing another server).
+export const observeCallChannel = () => {
+    const channelId = observeCurrentCall().pipe(
+        switchMap((call) => of$(call?.channelId || '')),
+        distinctUntilChanged(),
+    );
+
+    return combineLatest([observeCallDatabase(), channelId]).pipe(
+        switchMap(([db, id]) => (db && id ? observeChannel(db, id) : of$(undefined))),
     );
 };
 

--- a/app/products/calls/observers/index.ts
+++ b/app/products/calls/observers/index.ts
@@ -96,8 +96,8 @@ export const observeCallDatabase = () => {
     );
 };
 
-// Observes the current call's channel from the call's own server database, which is not necessarily the
-// active server's database (the call screen can be opened from the current call bar while viewing another server).
+// Observes the current call's channel from the call's own server database,
+// which is not necessarily the active server's database.
 export const observeCallChannel = () => {
     const channelId = observeCurrentCall().pipe(
         switchMap((call) => of$(call?.channelId || '')),

--- a/app/products/calls/observers/index.ts
+++ b/app/products/calls/observers/index.ts
@@ -99,13 +99,13 @@ export const observeCallDatabase = () => {
 // Observes the current call's channel from the call's own server database,
 // which is not necessarily the active server's database.
 export const observeCallChannel = () => {
-    const channelId = observeCurrentCall().pipe(
-        switchMap((call) => of$(call?.channelId || '')),
-        distinctUntilChanged(),
-    );
-
-    return combineLatest([observeCallDatabase(), channelId]).pipe(
-        switchMap(([db, id]) => (db && id ? observeChannel(db, id) : of$(undefined))),
+    return observeCurrentCall().pipe(
+        distinctUntilChanged((a, b) => a?.channelId === b?.channelId && a?.serverUrl === b?.serverUrl),
+        switchMap((call) => {
+            const db = call ? DatabaseManager.serverDatabases[call.serverUrl]?.database : undefined;
+            const id = call?.channelId || '';
+            return db && id ? observeChannel(db, id) : of$(undefined);
+        }),
     );
 };
 

--- a/app/products/calls/screens/call_screen/call_screen.test.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.test.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fireEvent} from '@testing-library/react-native';
+import React, {type ComponentProps} from 'react';
+
+import {DefaultCurrentCall, type CallSession, type CurrentCall} from '@calls/types/calls';
+import {Screens} from '@constants';
+import {navigateToScreen} from '@screens/navigation';
+import {renderWithIntlAndTheme} from '@test/intl-test-helper';
+
+import CallScreen from './call_screen';
+
+jest.mock('@screens/navigation', () => ({
+    bottomSheet: jest.fn(),
+    dismissBottomSheet: jest.fn(),
+    navigateBack: jest.fn(),
+    navigateToScreen: jest.fn(),
+}));
+
+const mySession: CallSession = {
+    sessionId: 'session1',
+    userId: 'user1',
+    muted: true,
+    raisedHand: 0,
+};
+
+const currentCall: CurrentCall = {
+    ...DefaultCurrentCall,
+    id: 'call1',
+    channelId: 'channel1',
+    serverUrl: 'server1',
+    myUserId: 'user1',
+    mySessionId: mySession.sessionId,
+    sessions: {[mySession.sessionId]: mySession},
+};
+
+const getBaseProps = (): ComponentProps<typeof CallScreen> => ({
+    currentCall,
+    sessionsDict: {[mySession.sessionId]: mySession},
+    micPermissionsGranted: true,
+    teammateNameDisplay: 'username',
+    displayName: 'channel-display-name',
+    isOwnDirectMessage: false,
+    isDM: false,
+    otherParticipants: false,
+    isAdmin: false,
+    isHost: false,
+});
+
+describe('CallScreen', () => {
+    it('should not show the People button in a DM call, where the only other participant is already on screen', () => {
+        const props = getBaseProps();
+        props.isDM = true;
+
+        const {queryByText} = renderWithIntlAndTheme(<CallScreen {...props}/>);
+
+        expect(queryByText('People')).toBeNull();
+    });
+
+    it('should show the People button and open the participants list when the call is not a DM', () => {
+        const props = getBaseProps();
+        props.isDM = false;
+
+        const {getByText} = renderWithIntlAndTheme(<CallScreen {...props}/>);
+
+        fireEvent.press(getByText('People'));
+
+        expect(navigateToScreen).toHaveBeenCalledWith(Screens.CALL_PARTICIPANTS);
+    });
+});

--- a/app/products/calls/screens/call_screen/call_screen.tsx
+++ b/app/products/calls/screens/call_screen/call_screen.tsx
@@ -73,6 +73,7 @@ export type Props = {
     teammateNameDisplay: string;
     displayName?: string;
     isOwnDirectMessage: boolean;
+    isDM: boolean;
     otherParticipants: boolean;
     isAdmin: boolean;
     isHost: boolean;
@@ -302,6 +303,7 @@ const CallScreen = ({
     teammateNameDisplay,
     displayName,
     isOwnDirectMessage,
+    isDM,
     otherParticipants,
     isAdmin,
     isHost,
@@ -762,21 +764,23 @@ const CallScreen = ({
                                     style={style.buttonText}
                                 />
                             </Pressable>
-                            <Pressable
-                                style={[style.button, isLandscape && style.buttonLandscape]}
-                                onPress={openParticipantsList}
-                            >
-                                <CompassIcon
-                                    name={'account-multiple-outline'}
-                                    size={32}
-                                    style={[style.buttonIcon, isLandscape && style.buttonIconLandscape]}
-                                />
-                                <FormattedText
-                                    id={'mobile.calls_people'}
-                                    defaultMessage={'People'}
-                                    style={style.buttonText}
-                                />
-                            </Pressable>
+                            {!isDM && (
+                                <Pressable
+                                    style={[style.button, isLandscape && style.buttonLandscape]}
+                                    onPress={openParticipantsList}
+                                >
+                                    <CompassIcon
+                                        name={'account-multiple-outline'}
+                                        size={32}
+                                        style={[style.buttonIcon, isLandscape && style.buttonIconLandscape]}
+                                    />
+                                    <FormattedText
+                                        id={'mobile.calls_people'}
+                                        defaultMessage={'People'}
+                                        style={style.buttonText}
+                                    />
+                                </Pressable>
+                            )}
                             {!isLandscape && (isHost || ccAvailable) &&
                                 <Pressable
                                     style={[style.button, isLandscape && style.buttonLandscape]}

--- a/app/products/calls/screens/call_screen/index.test.tsx
+++ b/app/products/calls/screens/call_screen/index.test.tsx
@@ -1,0 +1,107 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {setCurrentCall} from '@calls/state';
+import {DefaultCurrentCall} from '@calls/types/calls';
+import DatabaseManager from '@database/manager';
+import {act, renderWithEverything} from '@test/intl-test-helper';
+import TestHelper from '@test/test_helper';
+
+import CallScreen from './call_screen';
+
+import CallScreenIndex from './index';
+
+import type ServerDataOperator from '@database/operator/server_data_operator';
+import type {Database} from '@nozbe/watermelondb';
+
+jest.mock('./call_screen');
+jest.mocked(CallScreen).mockImplementation((props) => {
+    return React.createElement('CallScreen', {
+        testID: 'call-screen',
+        ...props,
+    });
+});
+
+// withObservables emits each prop on its own database tick; give them all a chance to land inside act().
+const flushObservables = async () => {
+    await act(async () => {
+        await new Promise(process.nextTick);
+    });
+};
+
+const activeServerUrl = 'active-server';
+const callServerUrl = 'call-server';
+const channelId = 'channel-id';
+const myUserId = 'my-user-id';
+const teammateId = 'teammate-id';
+
+describe('CallScreen Index', () => {
+    let activeDatabase: Database;
+    let callOperator: ServerDataOperator;
+
+    beforeEach(async () => {
+        await DatabaseManager.init([activeServerUrl, callServerUrl]);
+        activeDatabase = DatabaseManager.getServerDatabaseAndOperator(activeServerUrl).database;
+        callOperator = DatabaseManager.getServerDatabaseAndOperator(callServerUrl).operator;
+
+        // The same channel id exists on both servers with different values, so that reading it from the
+        // active server's database (instead of the call server's) produces observably wrong props.
+        await DatabaseManager.getServerDatabaseAndOperator(activeServerUrl).operator.handleChannel({
+            channels: [TestHelper.fakeChannel({
+                id: channelId,
+                type: 'O',
+                name: 'wrong-active-channel',
+                display_name: 'Wrong Active Channel',
+            })],
+            prepareRecordsOnly: false,
+        });
+
+        await callOperator.handleChannel({
+            channels: [TestHelper.fakeChannel({
+                id: channelId,
+                type: 'D',
+                name: `${myUserId}__${teammateId}`,
+                display_name: 'Correct Call Channel',
+            })],
+            prepareRecordsOnly: false,
+        });
+
+        await callOperator.handleUsers({
+            users: [TestHelper.fakeUser({id: teammateId})],
+            prepareRecordsOnly: false,
+        });
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            setCurrentCall(null);
+        });
+        await DatabaseManager.destroyServerDatabase(activeServerUrl);
+        await DatabaseManager.destroyServerDatabase(callServerUrl);
+    });
+
+    it('should derive the channel props from the call server database, not the active server database', async () => {
+        setCurrentCall({
+            ...DefaultCurrentCall,
+            id: 'call-id',
+            channelId,
+            serverUrl: callServerUrl,
+            myUserId,
+        });
+
+        // The provider is given the active server's database on purpose: the call screen can be opened from
+        // the current call bar while another server is active.
+        const {getByTestId} = renderWithEverything(
+            <CallScreenIndex/>,
+            {database: activeDatabase, serverUrl: activeServerUrl},
+        );
+        await flushObservables();
+
+        const component = getByTestId('call-screen');
+        expect(component.props.isDM).toBe(true);
+        expect(component.props.displayName).toBe('Correct Call Channel');
+        expect(component.props.isOwnDirectMessage).toBe(false);
+    });
+});

--- a/app/products/calls/screens/call_screen/index.ts
+++ b/app/products/calls/screens/call_screen/index.ts
@@ -1,41 +1,36 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
-import {of as of$, combineLatestWith} from 'rxjs';
+import {withObservables} from '@nozbe/watermelondb/react';
+import {of as of$, combineLatest, combineLatestWith} from 'rxjs';
 import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
-import {observeCallDatabase, observeCurrentSessionsDict, observeEndCallDetails} from '@calls/observers';
+import {observeCallChannel, observeCallDatabase, observeCurrentSessionsDict, observeEndCallDetails} from '@calls/observers';
 import CallScreen from '@calls/screens/call_screen/call_screen';
 import {observeCurrentCall, observeGlobalCallsState} from '@calls/state';
 import {General} from '@constants';
-import {observeChannel} from '@queries/servers/channel';
 import {observeTeammateNameDisplay, observeUser} from '@queries/servers/user';
 import {isDMChannel} from '@utils/channel';
 import {getUserIdFromChannelName} from '@utils/user';
 
-import type {WithDatabaseArgs} from '@typings/database/database';
-
-const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
+const enhanced = withObservables([], () => {
     const micPermissionsGranted = observeGlobalCallsState().pipe(
         switchMap((gs) => of$(gs.micPermissionsGranted)),
         distinctUntilChanged(),
     );
-    const teammateNameDisplay = observeCallDatabase().pipe(
+    const callDatabase = observeCallDatabase();
+    const teammateNameDisplay = callDatabase.pipe(
         switchMap((db) => (db ? observeTeammateNameDisplay(db) : of$(''))),
         distinctUntilChanged(),
     );
 
     const currentCall = observeCurrentCall();
-    const channel = currentCall.pipe(
-        switchMap((cc) => (observeChannel(database, cc?.channelId || ''))),
-    );
-    const dmUser = currentCall.pipe(
-        combineLatestWith(channel),
-        switchMap(([cc, chan]) => {
-            if (chan?.type === General.DM_CHANNEL) {
+    const channel = observeCallChannel();
+    const dmUser = combineLatest([callDatabase, currentCall, channel]).pipe(
+        switchMap(([db, cc, chan]) => {
+            if (db && chan?.type === General.DM_CHANNEL) {
                 const teammateId = getUserIdFromChannelName(cc?.myUserId || '', chan.name);
-                return observeUser(database, teammateId);
+                return observeUser(db, teammateId);
             }
 
             return of$(undefined);
@@ -63,4 +58,4 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
     };
 });
 
-export default withDatabase(enhanced(CallScreen));
+export default enhanced(CallScreen);

--- a/app/products/calls/screens/call_screen/index.ts
+++ b/app/products/calls/screens/call_screen/index.ts
@@ -11,6 +11,7 @@ import {observeCurrentCall, observeGlobalCallsState} from '@calls/state';
 import {General} from '@constants';
 import {observeChannel} from '@queries/servers/channel';
 import {observeTeammateNameDisplay, observeUser} from '@queries/servers/user';
+import {isDMChannel} from '@utils/channel';
 import {getUserIdFromChannelName} from '@utils/user';
 
 import type {WithDatabaseArgs} from '@typings/database/database';
@@ -44,6 +45,10 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
         combineLatestWith(dmUser),
         switchMap(([cc, dm]) => of$(cc?.myUserId === dm?.id)),
     );
+    const isDM = channel.pipe(
+        switchMap((c) => of$(isDMChannel(c?.type))),
+        distinctUntilChanged(),
+    );
     const displayName = channel.pipe(switchMap((c) => of$(c?.displayName)));
 
     return {
@@ -53,6 +58,7 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
         teammateNameDisplay,
         displayName,
         isOwnDirectMessage,
+        isDM,
         ...observeEndCallDetails(),
     };
 });


### PR DESCRIPTION
#### Summary
* `CallScreen` receives an `isDM` prop and uses it to hide the "People" button in 1:1 DM calls
* `useNavigationHeaderCallButtonForDM` opens the full-screen call view when joining succeeds
* **Cross-server fix:** the call screen resolved its channel through `withDatabase` (the *active* server's DB), not the call's server. Opening a call from the current-call bar while viewing another server left `displayName`, `isDM`, `dmUser`, and `isOwnDirectMessage` all resolving against the wrong database — blank channel name in the header, and the "People" button shown in DM calls.
  * Added `observeCallChannel()` to `@calls/observers`, resolving the channel from `currentCall.serverUrl`
  * `call_screen` consumes it and drops `withDatabase` entirely, matching `participants_list` / `host_controls`
  * `current_call_bar` now reuses the shared observer instead of hand-rolling the same lookup (no behavior change)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69761
https://mattermost.atlassian.net/browse/MM-70133
https://mattermost.atlassian.net/browse/MM-70179

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Release Note
```release-note
NONE
```
