### PR TITLE
fix(ci): stop Fastlane gem cache from breaking on new macOS runners

### DIFF
--- a/.github/actions/prepare-android-build/action.yaml
+++ b/.github/actions/prepare-android-build/action.yaml
@@ -5,18 +5,12 @@ inputs:
   sign:
     description: Flag to enable android package signing
     default: "true"
-  bundler-cache:
-    description: 'Enable Fastlane gem bundler-cache (E2E only; leave false for release/beta builds)'
-    required: false
-    default: 'false'
 
 runs:
   using: composite
   steps:
     - name: ci/prepare-mobile-build
       uses: ./.github/actions/prepare-mobile-build
-      with:
-        bundler-cache: ${{ inputs.bundler-cache }}
 
     - name: ci/setup-java
       uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0

--- a/.github/actions/prepare-ios-build/action.yaml
+++ b/.github/actions/prepare-ios-build/action.yaml
@@ -9,10 +9,6 @@ inputs:
   intune-ssh-private-key:
     description: 'SSH private key for Intune submodule repository access (required if intune-enabled is true)'
     required: false
-  bundler-cache:
-    description: 'Enable Fastlane gem bundler-cache (E2E only; leave false for release/beta builds)'
-    required: false
-    default: 'false'
 
 runs:
   using: composite
@@ -121,8 +117,6 @@ runs:
 
     - name: ci/prepare-mobile-build
       uses: ./.github/actions/prepare-mobile-build
-      with:
-        bundler-cache: ${{ inputs.bundler-cache }}
 
     - name: ci/setup-intune
       if: inputs.intune-enabled == 'true'
@@ -152,13 +146,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pods-v4-intune-${{ inputs.intune-enabled }}-${{ steps.intune-hash.outputs.hash }}-
 
+    # Arch-scoped for the same reason as the gem cache in prepare-mobile-build:
+    # native extensions under vendor/bundle are not portable across arm64/x86_64.
     - name: Cache CocoaPods Ruby gems
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-cocoapods-gems-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-cocoapods-gems-${{ hashFiles('Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cocoapods-gems-
+          ${{ runner.os }}-${{ runner.arch }}-cocoapods-gems-
 
     - name: ci/install-pods-dependencies
       shell: bash

--- a/.github/actions/prepare-mobile-build/action.yaml
+++ b/.github/actions/prepare-mobile-build/action.yaml
@@ -1,58 +1,32 @@
 name: prepare-mobile-build
 description: Action to prepare environment for mobile build
 
-inputs:
-  bundler-cache:
-    description: >
-      Use setup-ruby bundler-cache (deployment mode). Enable for E2E builds only.
-      Release/beta/PR production builds should leave this false to keep the
-      historical plain bundle install path.
-    required: false
-    default: 'false'
-
 runs:
   using: composite
   steps:
-    # --- Release / production path (default) ---
-    # Plain bundle install without deployment mode. Do not change this path
-    # for E2E caching concerns.
+    # Do not use setup-ruby bundler-cache. It enables Bundler deployment mode,
+    # which fails when a GitHub runner platform is missing from Gemfile.lock
+    # (e.g. darwin-24 → darwin-25 image bumps). Plain bundle install does not.
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
-      if: inputs.bundler-cache != 'true'
+
+    # Arch-scoped: vendor/bundle holds compiled native extensions that are not
+    # portable across arm64/x86_64. runner.os alone is just "macOS" and spans both.
+    - name: Cache Fastlane Ruby gems
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: fastlane/vendor/bundle
+        key: ${{ runner.os }}-${{ runner.arch }}-fastlane-gems-${{ hashFiles('fastlane/Gemfile.lock', '.ruby-version') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-fastlane-gems-
 
     - name: ci/setup-fastlane-dependencies
-      if: inputs.bundler-cache != 'true'
       shell: bash
       run: |
         echo "::group::setup-fastlane-dependencies"
+        bundle config set --local path 'vendor/bundle'
         bundle install
         echo "::endgroup::"
       working-directory: ./fastlane
-
-    - name: Cache Ruby gems
-      if: inputs.bundler-cache != 'true'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-
-    # --- E2E path ---
-    # bundler-cache restores/installs fastlane/Gemfile.lock gems under
-    # fastlane/vendor/bundle. Runner platforms must be listed in Gemfile.lock
-    # (deployment mode); add new ones via PR when GitHub runner images change.
-    - name: Read Ruby version
-      if: inputs.bundler-cache == 'true'
-      id: ruby-version
-      shell: bash
-      run: echo "version=$(tr -d '[:space:]' < .ruby-version)" >> "$GITHUB_OUTPUT"
-
-    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
-      if: inputs.bundler-cache == 'true'
-      with:
-        ruby-version: ${{ steps.ruby-version.outputs.version }}
-        bundler-cache: true
-        working-directory: fastlane
 
     - name: ci/prepare-node-deps
       uses: ./.github/actions/prepare-node-deps

--- a/.github/workflows/e2e-detox-pr.yml
+++ b/.github/workflows/e2e-detox-pr.yml
@@ -479,7 +479,6 @@ jobs:
         with:
           intune-enabled: ${{ env.INTUNE_ENABLED }}
           intune-ssh-private-key: ${{ secrets.MM_MOBILE_INTUNE_DEPLOY_KEY }}
-          bundler-cache: true
 
       - name: Set .env with RUNNING_E2E=true
         if: env.SKIP_BUILD != 'true'
@@ -565,8 +564,6 @@ jobs:
       - name: Prepare Android Build
         if: env.SKIP_BUILD != 'true'
         uses: ./.github/actions/prepare-android-build
-        with:
-          bundler-cache: true
         env:
           STORE_FILE: ${{ secrets.MM_MOBILE_STORE_FILE }}
           STORE_ALIAS: ${{ secrets.MM_MOBILE_STORE_ALIAS }}
@@ -663,8 +660,6 @@ jobs:
       - name: Prepare Android Build
         if: env.SKIP_BUILD != 'true'
         uses: ./.github/actions/prepare-android-build
-        with:
-          bundler-cache: true
         env:
           STORE_FILE: ${{ secrets.MM_MOBILE_STORE_FILE }}
           STORE_ALIAS: ${{ secrets.MM_MOBILE_STORE_ALIAS }}


### PR DESCRIPTION
### Summary
A while back we turned on gem caching for E2E to speed up builds. That used `bundler-cache: true`, which puts Bundler into deployment mode. Deployment mode is strict: if the GitHub macOS runner’s platform isn’t already listed in `Gemfile.lock`, the install fails.

That’s what broke beta/release when runners moved to `x86_64-darwin-24`, and it hit open PRs again when runners moved to `arm64-darwin-25`. We unblocked release by adding the missing platform to the lockfile and keeping release on the old plain `bundle install` path (#10015). Open PRs had to do the same kind of one-off patch (e.g. #9926 adding `arm64-darwin-25` and arch-scoping cache keys).

BUT for every new darwin version means another lockfile bump or another broken CI run.

This follow-up removes that trap. E2E and release now share one path: plain `bundle install` plus a normal `actions/cache`, keyed by OS and arch. We still cache gems, we just don’t use setup-ruby’s deployment mode anymore. New runner platforms shouldn’t take down builds, and we shouldn’t need to keep updating `Gemfile.lock` just to keep CI green.

```release-note
NONE
```
