### PR TITLE
[MM-70319] fix: don't mark a channel as read when the posts fetch failed

### DIFF
--- a/app/actions/remote/channel.test.ts
+++ b/app/actions/remote/channel.test.ts
@@ -150,12 +150,12 @@ const mockClient = {
     convertChannelToPrivate: jest.fn(),
     getGroupMessageMembersCommonTeams: jest.fn(() => ({id: teamId, name: 'teamname'})),
     convertGroupMessageToPrivateChannel: jest.fn((channelId: string) => ({id: channelId, name: 'channel1', creatorId: user.id, type: 'P'})),
-    getPosts: jest.fn(() => ({
+    getPosts: jest.fn(async () => ({
         order: [],
         posts: [],
         previousPostId: '',
     })),
-    getPostsSince: jest.fn(() => ({
+    getPostsSince: jest.fn(async () => ({
         order: [],
         posts: [],
         previousPostId: '',
@@ -483,19 +483,33 @@ describe('app/actions/remote/channel', () => {
                 expect(result).toHaveProperty('error');
             });
 
+            // The context has to change while the posts request is in flight, not before it starts,
+            // so that these cover the revalidation done after the fetch resolves. Leaving from inside
+            // the client mock is what makes the ordering deterministic.
+            const leaveDuringFetch = (viewedChannelId: string, activeServerUrl = serverUrl) => {
+                mockClient.getPosts.mockImplementationOnce(async () => {
+                    await setViewing(viewedChannelId, activeServerUrl);
+                    return {order: [], posts: [], previousPostId: ''};
+                });
+            };
+
             it('should not mark the channel as read when the user left the channel while fetching', async () => {
-                await setViewing('another-channel-id');
+                await setViewing(channelId);
+                leaveDuringFetch('another-channel-id');
 
                 await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
 
+                expect(mockClient.getPosts).toHaveBeenCalled();
                 expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
             });
 
             it('should not mark the channel as read when the user left the server while fetching', async () => {
-                await setViewing(channelId, 'https://another.server.com');
+                await setViewing(channelId);
+                leaveDuringFetch(channelId, 'https://another.server.com');
 
                 await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
 
+                expect(mockClient.getPosts).toHaveBeenCalled();
                 expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
             });
         });

--- a/app/actions/remote/channel.test.ts
+++ b/app/actions/remote/channel.test.ts
@@ -88,12 +88,15 @@ jest.mock('@utils/helpers', () => {
 });
 
 let mockGetActiveServer: jest.Mock;
+let mockGetActiveServerUrl: jest.Mock;
 jest.mock('@queries/app/servers', () => {
     const original = jest.requireActual('@queries/app/servers');
     mockGetActiveServer = jest.fn(() => false);
+    mockGetActiveServerUrl = jest.fn(() => '');
     return {
         ...original,
         getActiveServer: mockGetActiveServer,
+        getActiveServerUrl: mockGetActiveServerUrl,
     };
 });
 
@@ -449,7 +452,14 @@ describe('app/actions/remote/channel', () => {
         });
 
         describe('markChannelAsReadOnceFetched', () => {
+            const setViewing = async (viewedChannelId: string, activeServerUrl = serverUrl) => {
+                mockGetActiveServerUrl.mockImplementation(() => activeServerUrl);
+                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: viewedChannelId}], prepareRecordsOnly: false});
+            };
+
             it('should mark the channel as read when the posts were fetched', async () => {
+                await setViewing(channelId);
+
                 const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
 
                 expect(mockClient.viewMyChannel).toHaveBeenCalledWith(channelId, undefined, undefined);
@@ -457,12 +467,29 @@ describe('app/actions/remote/channel', () => {
             });
 
             it('should not mark the channel as read when the posts fetch failed', async () => {
+                await setViewing(channelId);
                 const fetchError = new Error('Too many requests');
 
                 const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({error: fetchError}));
 
                 expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
                 expect(result).toEqual({error: fetchError});
+            });
+
+            it('should not mark the channel as read when the user left the channel while fetching', async () => {
+                await setViewing('another-channel-id');
+
+                await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+
+                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
+            });
+
+            it('should not mark the channel as read when the user left the server while fetching', async () => {
+                await setViewing(channelId, 'https://another.server.com');
+
+                await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+
+                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
             });
         });
 

--- a/app/actions/remote/channel.test.ts
+++ b/app/actions/remote/channel.test.ts
@@ -29,7 +29,7 @@ import {
     joinChannel,
     joinChannelIfNeeded,
     markChannelAsRead,
-    markChannelAsReadOnceFetched,
+    fetchPostsAndMarkChannelAsRead,
     unsetActiveChannelOnServer,
     joinIfNeededAndSwitchToChannel,
     fetchMissingDirectChannelsInfo,
@@ -151,6 +151,11 @@ const mockClient = {
     getGroupMessageMembersCommonTeams: jest.fn(() => ({id: teamId, name: 'teamname'})),
     convertGroupMessageToPrivateChannel: jest.fn((channelId: string) => ({id: channelId, name: 'channel1', creatorId: user.id, type: 'P'})),
     getPosts: jest.fn(() => ({
+        order: [],
+        posts: [],
+        previousPostId: '',
+    })),
+    getPostsSince: jest.fn(() => ({
         order: [],
         posts: [],
         previousPostId: '',
@@ -451,7 +456,7 @@ describe('app/actions/remote/channel', () => {
             expect(result).not.toHaveProperty('error');
         });
 
-        describe('markChannelAsReadOnceFetched', () => {
+        describe('fetchPostsAndMarkChannelAsRead', () => {
             const setViewing = async (viewedChannelId: string, activeServerUrl = serverUrl) => {
                 mockGetActiveServerUrl.mockImplementation(() => activeServerUrl);
                 await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: viewedChannelId}], prepareRecordsOnly: false});
@@ -460,7 +465,7 @@ describe('app/actions/remote/channel', () => {
             it('should mark the channel as read when the posts were fetched', async () => {
                 await setViewing(channelId);
 
-                const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+                const result = await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
 
                 expect(mockClient.viewMyChannel).toHaveBeenCalledWith(channelId, undefined, undefined);
                 expect(result).not.toHaveProperty('error');
@@ -468,18 +473,20 @@ describe('app/actions/remote/channel', () => {
 
             it('should not mark the channel as read when the posts fetch failed', async () => {
                 await setViewing(channelId);
-                const fetchError = new Error('Too many requests');
+                mockClient.getPosts.mockImplementationOnce(() => {
+                    throw new Error('Too many requests');
+                });
 
-                const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({error: fetchError}));
+                const result = await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
 
                 expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
-                expect(result).toEqual({error: fetchError});
+                expect(result).toHaveProperty('error');
             });
 
             it('should not mark the channel as read when the user left the channel while fetching', async () => {
                 await setViewing('another-channel-id');
 
-                await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+                await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
 
                 expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
             });
@@ -487,7 +494,7 @@ describe('app/actions/remote/channel', () => {
             it('should not mark the channel as read when the user left the server while fetching', async () => {
                 await setViewing(channelId, 'https://another.server.com');
 
-                await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+                await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
 
                 expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
             });

--- a/app/actions/remote/channel.test.ts
+++ b/app/actions/remote/channel.test.ts
@@ -448,28 +448,33 @@ describe('app/actions/remote/channel', () => {
             expect(result).not.toHaveProperty('error');
         });
 
-        it('markChannelAsReadOnceFetched - marks the channel as read when the posts were fetched', async () => {
-            await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
+        describe('markChannelAsReadOnceFetched', () => {
+            it('should mark the channel as read when the posts were fetched', async () => {
+                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
 
-            await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+                const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
 
-            expect(mockClient.viewMyChannel).toHaveBeenCalledWith(channelId, undefined, undefined);
-        });
+                expect(mockClient.viewMyChannel).toHaveBeenCalledWith(channelId, undefined, undefined);
+                expect(result).not.toHaveProperty('error');
+            });
 
-        it('markChannelAsReadOnceFetched - does not mark the channel as read when the posts fetch failed', async () => {
-            await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
+            it('should not mark the channel as read when the posts fetch failed', async () => {
+                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
+                const fetchError = new Error('Too many requests');
 
-            await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({error: new Error('Too many requests')}));
+                const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({error: fetchError}));
 
-            expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
-        });
+                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
+                expect(result).toEqual({error: fetchError});
+            });
 
-        it('markChannelAsReadOnceFetched - does not mark the channel as read when the user already left the channel', async () => {
-            await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: 'another-channel-id'}], prepareRecordsOnly: false});
+            it('should not mark the channel as read when the user already left the channel', async () => {
+                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: 'another-channel-id'}], prepareRecordsOnly: false});
 
-            await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+                await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
 
-            expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
+                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
+            });
         });
 
         it('unsetActiveChannelOnServer - base case', async () => {

--- a/app/actions/remote/channel.test.ts
+++ b/app/actions/remote/channel.test.ts
@@ -29,7 +29,6 @@ import {
     joinChannel,
     joinChannelIfNeeded,
     markChannelAsRead,
-    fetchPostsAndMarkChannelAsRead,
     unsetActiveChannelOnServer,
     joinIfNeededAndSwitchToChannel,
     fetchMissingDirectChannelsInfo,
@@ -88,15 +87,12 @@ jest.mock('@utils/helpers', () => {
 });
 
 let mockGetActiveServer: jest.Mock;
-let mockGetActiveServerUrl: jest.Mock;
 jest.mock('@queries/app/servers', () => {
     const original = jest.requireActual('@queries/app/servers');
     mockGetActiveServer = jest.fn(() => false);
-    mockGetActiveServerUrl = jest.fn(() => '');
     return {
         ...original,
         getActiveServer: mockGetActiveServer,
-        getActiveServerUrl: mockGetActiveServerUrl,
     };
 });
 
@@ -150,12 +146,7 @@ const mockClient = {
     convertChannelToPrivate: jest.fn(),
     getGroupMessageMembersCommonTeams: jest.fn(() => ({id: teamId, name: 'teamname'})),
     convertGroupMessageToPrivateChannel: jest.fn((channelId: string) => ({id: channelId, name: 'channel1', creatorId: user.id, type: 'P'})),
-    getPosts: jest.fn(async () => ({
-        order: [],
-        posts: [],
-        previousPostId: '',
-    })),
-    getPostsSince: jest.fn(async () => ({
+    getPosts: jest.fn(() => ({
         order: [],
         posts: [],
         previousPostId: '',
@@ -454,64 +445,6 @@ describe('app/actions/remote/channel', () => {
             const result = await markChannelAsRead(serverUrl, channelId, true);
             expect(result).toBeDefined();
             expect(result).not.toHaveProperty('error');
-        });
-
-        describe('fetchPostsAndMarkChannelAsRead', () => {
-            const setViewing = async (viewedChannelId: string, activeServerUrl = serverUrl) => {
-                mockGetActiveServerUrl.mockImplementation(() => activeServerUrl);
-                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: viewedChannelId}], prepareRecordsOnly: false});
-            };
-
-            it('should mark the channel as read when the posts were fetched', async () => {
-                await setViewing(channelId);
-
-                const result = await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
-
-                expect(mockClient.viewMyChannel).toHaveBeenCalledWith(channelId, undefined, undefined);
-                expect(result).not.toHaveProperty('error');
-            });
-
-            it('should not mark the channel as read when the posts fetch failed', async () => {
-                await setViewing(channelId);
-                mockClient.getPosts.mockImplementationOnce(() => {
-                    throw new Error('Too many requests');
-                });
-
-                const result = await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
-
-                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
-                expect(result).toHaveProperty('error');
-            });
-
-            // The context has to change while the posts request is in flight, not before it starts,
-            // so that these cover the revalidation done after the fetch resolves. Leaving from inside
-            // the client mock is what makes the ordering deterministic.
-            const leaveDuringFetch = (viewedChannelId: string, activeServerUrl = serverUrl) => {
-                mockClient.getPosts.mockImplementationOnce(async () => {
-                    await setViewing(viewedChannelId, activeServerUrl);
-                    return {order: [], posts: [], previousPostId: ''};
-                });
-            };
-
-            it('should not mark the channel as read when the user left the channel while fetching', async () => {
-                await setViewing(channelId);
-                leaveDuringFetch('another-channel-id');
-
-                await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
-
-                expect(mockClient.getPosts).toHaveBeenCalled();
-                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
-            });
-
-            it('should not mark the channel as read when the user left the server while fetching', async () => {
-                await setViewing(channelId);
-                leaveDuringFetch(channelId, 'https://another.server.com');
-
-                await fetchPostsAndMarkChannelAsRead(serverUrl, channelId);
-
-                expect(mockClient.getPosts).toHaveBeenCalled();
-                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
-            });
         });
 
         it('unsetActiveChannelOnServer - base case', async () => {

--- a/app/actions/remote/channel.test.ts
+++ b/app/actions/remote/channel.test.ts
@@ -29,6 +29,7 @@ import {
     joinChannel,
     joinChannelIfNeeded,
     markChannelAsRead,
+    markChannelAsReadOnceFetched,
     unsetActiveChannelOnServer,
     joinIfNeededAndSwitchToChannel,
     fetchMissingDirectChannelsInfo,
@@ -445,6 +446,30 @@ describe('app/actions/remote/channel', () => {
             const result = await markChannelAsRead(serverUrl, channelId, true);
             expect(result).toBeDefined();
             expect(result).not.toHaveProperty('error');
+        });
+
+        it('markChannelAsReadOnceFetched - marks the channel as read when the posts were fetched', async () => {
+            await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
+
+            await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+
+            expect(mockClient.viewMyChannel).toHaveBeenCalledWith(channelId, undefined, undefined);
+        });
+
+        it('markChannelAsReadOnceFetched - does not mark the channel as read when the posts fetch failed', async () => {
+            await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
+
+            await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({error: new Error('Too many requests')}));
+
+            expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
+        });
+
+        it('markChannelAsReadOnceFetched - does not mark the channel as read when the user already left the channel', async () => {
+            await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: 'another-channel-id'}], prepareRecordsOnly: false});
+
+            await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
+
+            expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
         });
 
         it('unsetActiveChannelOnServer - base case', async () => {

--- a/app/actions/remote/channel.test.ts
+++ b/app/actions/remote/channel.test.ts
@@ -450,8 +450,6 @@ describe('app/actions/remote/channel', () => {
 
         describe('markChannelAsReadOnceFetched', () => {
             it('should mark the channel as read when the posts were fetched', async () => {
-                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
-
                 const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
 
                 expect(mockClient.viewMyChannel).toHaveBeenCalledWith(channelId, undefined, undefined);
@@ -459,21 +457,12 @@ describe('app/actions/remote/channel', () => {
             });
 
             it('should not mark the channel as read when the posts fetch failed', async () => {
-                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: channelId}], prepareRecordsOnly: false});
                 const fetchError = new Error('Too many requests');
 
                 const result = await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({error: fetchError}));
 
                 expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
                 expect(result).toEqual({error: fetchError});
-            });
-
-            it('should not mark the channel as read when the user already left the channel', async () => {
-                await operator.handleSystem({systems: [{id: SYSTEM_IDENTIFIERS.CURRENT_CHANNEL_ID, value: 'another-channel-id'}], prepareRecordsOnly: false});
-
-                await markChannelAsReadOnceFetched(serverUrl, channelId, Promise.resolve({posts: [], order: []}));
-
-                expect(mockClient.viewMyChannel).not.toHaveBeenCalled();
             });
         });
 

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -15,7 +15,7 @@ import {privateChannelJoinPrompt} from '@helpers/api/channel';
 import {getTeammateNameDisplaySetting} from '@helpers/api/preference';
 import AppsManager from '@managers/apps_manager';
 import NetworkManager from '@managers/network_manager';
-import {getActiveServer, getActiveServerUrl} from '@queries/app/servers';
+import {getActiveServer} from '@queries/app/servers';
 import {prepareMyChannelsForTeam, getChannelById, getChannelByName, getMyChannel, getChannelInfo, queryMyChannelSettingsByIds, getMembersCountByChannelsId, deleteChannelMembership, queryChannelsById} from '@queries/servers/channel';
 import {queryDisplayNamePreferences} from '@queries/servers/preference';
 import {canViewArchivedChannels, getCommonSystemValues, getConfig, getCurrentChannelId, getCurrentTeamId, getCurrentUserId, getLicense, setCurrentChannelId, setCurrentTeamAndChannelId} from '@queries/servers/system';
@@ -756,59 +756,6 @@ export async function markChannelAsRead(serverUrl: string, channelId: string, up
     }
 }
 
-/**
- * Fetches the posts for a channel and, only if that request succeeded, tells the server the channel
- * was read.
- *
- * The read itself is server only. markChannelAsRead is called with updateLocal false, so nothing
- * here touches the local unread state or viewedAt, and the new messages line is unaffected.
- *
- * Why the read is worth withholding: viewMyChannel resets the membership msg_count and
- * mention_count, and that is not recoverable. The unread state and the mention badge are cleared on
- * every device even though the user never got to see the messages. So when the fetch fails (a 429
- * from a rate limited server, a dropped connection, ...) we leave the server state alone. The
- * channel still looks read locally, because switchToChannel cleared it optimistically before we got
- * here, but the next membership sync recomputes is_unread from the server counters and restores it.
- *
- * The read is dropped as well when the user is no longer on this channel and server by the time the
- * posts arrive. The fetch is not cancelled on switch, so a slow channel can resolve after a channel
- * the user moved on to and become the last read sent. What that costs is not the posts we fetched
- * but the ones we did not: viewMyChannel marks everything read as of when it lands, so any message
- * that reached the channel after the user left it would be marked read unseen. And while this call
- * itself stays server side, the effect does not: the server broadcasts multiple_channels_viewed
- * back, and since the channel is no longer the current one,
- * handleMultipleChannelsViewedEvent is the one that clears its local unread flag and mention badge.
- */
-export async function fetchPostsAndMarkChannelAsRead(serverUrl: string, channelId: string, groupLabel?: RequestGroupLabel) {
-    const {error: fetchError} = await fetchPostsForChannel(serverUrl, channelId, false, false, groupLabel);
-    if (fetchError) {
-        logDebug('skipping markChannelAsRead, the posts fetch failed for channel', channelId);
-        return {error: fetchError};
-    }
-
-    try {
-        const database = DatabaseManager.serverDatabases[serverUrl]?.database;
-        if (!database) {
-            return {};
-        }
-
-        const [activeServerUrl, currentChannelId] = await Promise.all([
-            getActiveServerUrl(),
-            getCurrentChannelId(database),
-        ]);
-
-        if (activeServerUrl !== serverUrl || currentChannelId !== channelId) {
-            logDebug('skipping markChannelAsRead, the user left channel', channelId);
-            return {};
-        }
-    } catch (error) {
-        logDebug('error on fetchPostsAndMarkChannelAsRead', getFullErrorMessage(error));
-        return {error};
-    }
-
-    return markChannelAsRead(serverUrl, channelId, false, groupLabel);
-}
-
 export async function unsetActiveChannelOnServer(serverUrl: string) {
     try {
         const client = NetworkManager.getClient(serverUrl);
@@ -1240,7 +1187,7 @@ export async function switchToChannelById(serverUrl: string, channelId: string, 
     DeviceEventEmitter.emit(Events.BLUR_AND_DISMISS_KEYBOARD);
     DeviceEventEmitter.emit(Events.CHANNEL_SWITCH, true);
 
-    fetchPostsAndMarkChannelAsRead(serverUrl, channelId, groupLabel);
+    fetchPostsForChannel(serverUrl, channelId, false, false, groupLabel);
     fetchChannelBookmarks(serverUrl, channelId, false, groupLabel);
     await switchToChannel(serverUrl, channelId, teamId, skipLastUnread);
     openChannelIfNeeded(serverUrl, channelId, groupLabel);

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -35,7 +35,7 @@ import {displayGroupMessageName, displayUsername} from '@utils/user';
 import {addChannelToManagedCategoryIfNeeded, fetchCategories} from './category';
 import {fetchChannelBookmarks} from './channel_bookmark';
 import {fetchGroupsForChannelIfConstrained} from './groups';
-import {fetchPostsForChannel, type PostsForChannel} from './post';
+import {fetchPostsForChannel} from './post';
 import {openChannelIfNeeded, savePreference} from './preference';
 import {fetchRolesIfNeeded} from './role';
 import {forceLogoutIfNecessary} from './session';
@@ -757,25 +757,30 @@ export async function markChannelAsRead(serverUrl: string, channelId: string, up
 }
 
 /**
- * Marks the channel as read on the server, but only once the posts request that should have
- * brought in the new messages actually succeeded.
+ * Fetches the posts for a channel and, only if that request succeeded, tells the server the channel
+ * was read.
  *
- * Telling the server the channel was read resets the membership msg_count and mention_count, and
- * that is not recoverable: the unread state and the mention badge are cleared on every device even
- * though the user never got to see the messages. So when the fetch fails (a 429 from a rate limited
- * server, a dropped connection, ...) we leave the server state alone. The local optimistic clear
- * done by markChannelAsViewed is then repaired by the next membership sync, which recomputes
- * is_unread from the server counters, and the read is retried once the posts do arrive.
+ * The read itself is server only. markChannelAsRead is called with updateLocal false, so nothing
+ * here touches the local unread state or viewedAt, and the new messages line is unaffected.
  *
- * The read is also dropped when the user is no longer on this channel and server by the time the
- * posts arrive. Fetches are not cancelled on switch, so a slow channel can resolve after a channel
- * the user moved on to and become the last read sent, marking messages that arrived in the meantime
- * as read. That is not confined to the server either: the server broadcasts multiple_channels_viewed
- * back, and since the channel is no longer the current one handleMultipleChannelsViewedEvent clears
- * its local unread flag and mention badge as well.
+ * Why the read is worth withholding: viewMyChannel resets the membership msg_count and
+ * mention_count, and that is not recoverable. The unread state and the mention badge are cleared on
+ * every device even though the user never got to see the messages. So when the fetch fails (a 429
+ * from a rate limited server, a dropped connection, ...) we leave the server state alone. The
+ * channel still looks read locally, because switchToChannel cleared it optimistically before we got
+ * here, but the next membership sync recomputes is_unread from the server counters and restores it.
+ *
+ * The read is dropped as well when the user is no longer on this channel and server by the time the
+ * posts arrive. The fetch is not cancelled on switch, so a slow channel can resolve after a channel
+ * the user moved on to and become the last read sent. What that costs is not the posts we fetched
+ * but the ones we did not: viewMyChannel marks everything read as of when it lands, so any message
+ * that reached the channel after the user left it would be marked read unseen. And while this call
+ * itself stays server side, the effect does not: the server broadcasts multiple_channels_viewed
+ * back, and since the channel is no longer the current one,
+ * handleMultipleChannelsViewedEvent is the one that clears its local unread flag and mention badge.
  */
-export async function markChannelAsReadOnceFetched(serverUrl: string, channelId: string, postsRequest: Promise<PostsForChannel>, groupLabel?: RequestGroupLabel) {
-    const {error: fetchError} = await postsRequest;
+export async function fetchPostsAndMarkChannelAsRead(serverUrl: string, channelId: string, groupLabel?: RequestGroupLabel) {
+    const {error: fetchError} = await fetchPostsForChannel(serverUrl, channelId, false, false, groupLabel);
     if (fetchError) {
         logDebug('skipping markChannelAsRead, the posts fetch failed for channel', channelId);
         return {error: fetchError};
@@ -797,7 +802,7 @@ export async function markChannelAsReadOnceFetched(serverUrl: string, channelId:
             return {};
         }
     } catch (error) {
-        logDebug('error on markChannelAsReadOnceFetched', getFullErrorMessage(error));
+        logDebug('error on fetchPostsAndMarkChannelAsRead', getFullErrorMessage(error));
         return {error};
     }
 
@@ -1235,11 +1240,10 @@ export async function switchToChannelById(serverUrl: string, channelId: string, 
     DeviceEventEmitter.emit(Events.BLUR_AND_DISMISS_KEYBOARD);
     DeviceEventEmitter.emit(Events.CHANNEL_SWITCH, true);
 
-    const postsRequest = fetchPostsForChannel(serverUrl, channelId, false, false, groupLabel);
+    fetchPostsAndMarkChannelAsRead(serverUrl, channelId, groupLabel);
     fetchChannelBookmarks(serverUrl, channelId, false, groupLabel);
     await switchToChannel(serverUrl, channelId, teamId, skipLastUnread);
     openChannelIfNeeded(serverUrl, channelId, groupLabel);
-    markChannelAsReadOnceFetched(serverUrl, channelId, postsRequest, groupLabel);
     fetchChannelStats(serverUrl, channelId, false, groupLabel);
     fetchGroupsForChannelIfConstrained(serverUrl, channelId, false, groupLabel);
 

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -15,7 +15,7 @@ import {privateChannelJoinPrompt} from '@helpers/api/channel';
 import {getTeammateNameDisplaySetting} from '@helpers/api/preference';
 import AppsManager from '@managers/apps_manager';
 import NetworkManager from '@managers/network_manager';
-import {getActiveServer} from '@queries/app/servers';
+import {getActiveServer, getActiveServerUrl} from '@queries/app/servers';
 import {prepareMyChannelsForTeam, getChannelById, getChannelByName, getMyChannel, getChannelInfo, queryMyChannelSettingsByIds, getMembersCountByChannelsId, deleteChannelMembership, queryChannelsById} from '@queries/servers/channel';
 import {queryDisplayNamePreferences} from '@queries/servers/preference';
 import {canViewArchivedChannels, getCommonSystemValues, getConfig, getCurrentChannelId, getCurrentTeamId, getCurrentUserId, getLicense, setCurrentChannelId, setCurrentTeamAndChannelId} from '@queries/servers/system';
@@ -767,17 +767,38 @@ export async function markChannelAsRead(serverUrl: string, channelId: string, up
  * done by markChannelAsViewed is then repaired by the next membership sync, which recomputes
  * is_unread from the server counters, and the read is retried once the posts do arrive.
  *
- * Once the posts are in we send the read even if the user has already left the channel. This call
- * does not touch local state, and a stale active channel on the server is corrected by the next
- * channel view or by unsetActiveChannelOnServer; skipping the read instead would leave the channel
- * unread on the server after the local state was already cleared, so it would come back as unread
- * on the next sync.
+ * The read is also dropped when the user is no longer on this channel and server by the time the
+ * posts arrive. Fetches are not cancelled on switch, so a slow channel can resolve after a channel
+ * the user moved on to and become the last read sent, marking messages that arrived in the meantime
+ * as read. That is not confined to the server either: the server broadcasts multiple_channels_viewed
+ * back, and since the channel is no longer the current one handleMultipleChannelsViewedEvent clears
+ * its local unread flag and mention badge as well.
  */
 export async function markChannelAsReadOnceFetched(serverUrl: string, channelId: string, postsRequest: Promise<PostsForChannel>, groupLabel?: RequestGroupLabel) {
     const {error: fetchError} = await postsRequest;
     if (fetchError) {
         logDebug('skipping markChannelAsRead, the posts fetch failed for channel', channelId);
         return {error: fetchError};
+    }
+
+    try {
+        const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+        if (!database) {
+            return {};
+        }
+
+        const [activeServerUrl, currentChannelId] = await Promise.all([
+            getActiveServerUrl(),
+            getCurrentChannelId(database),
+        ]);
+
+        if (activeServerUrl !== serverUrl || currentChannelId !== channelId) {
+            logDebug('skipping markChannelAsRead, the user left channel', channelId);
+            return {};
+        }
+    } catch (error) {
+        logDebug('error on markChannelAsReadOnceFetched', getFullErrorMessage(error));
+        return {error};
     }
 
     return markChannelAsRead(serverUrl, channelId, false, groupLabel);

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -35,7 +35,7 @@ import {displayGroupMessageName, displayUsername} from '@utils/user';
 import {addChannelToManagedCategoryIfNeeded, fetchCategories} from './category';
 import {fetchChannelBookmarks} from './channel_bookmark';
 import {fetchGroupsForChannelIfConstrained} from './groups';
-import {fetchPostsForChannel} from './post';
+import {fetchPostsForChannel, type PostsForChannel} from './post';
 import {openChannelIfNeeded, savePreference} from './preference';
 import {fetchRolesIfNeeded} from './role';
 import {forceLogoutIfNecessary} from './session';
@@ -756,13 +756,47 @@ export async function markChannelAsRead(serverUrl: string, channelId: string, up
     }
 }
 
+/**
+ * Marks the channel as read on the server, but only once the posts request that should have
+ * brought in the new messages actually succeeded.
+ *
+ * Telling the server the channel was read resets the membership msg_count and mention_count, and
+ * that is not recoverable: the unread state and the mention badge are cleared on every device even
+ * though the user never got to see the messages. So when the fetch fails (a 429 from a rate limited
+ * server, a dropped connection, ...) we leave the server state alone. The local optimistic clear
+ * done by markChannelAsViewed is then repaired by the next membership sync, which recomputes
+ * is_unread from the server counters, and the read is retried once the posts do arrive.
+ */
+export async function markChannelAsReadOnceFetched(serverUrl: string, channelId: string, postsRequest: Promise<PostsForChannel>, groupLabel?: RequestGroupLabel) {
+    const {error: fetchError} = await postsRequest;
+    if (fetchError) {
+        logDebug('skipping markChannelAsRead, the posts fetch failed for channel', channelId);
+        return;
+    }
+
+    try {
+        // The fetch may have outlived the channel the user is looking at. Viewing a channel also sets
+        // it as the active one on the server, so marking a channel the user already left would
+        // suppress its push notifications.
+        const database = DatabaseManager.serverDatabases[serverUrl]?.database;
+        if (!database || (await getCurrentChannelId(database)) !== channelId) {
+            return;
+        }
+    } catch (error) {
+        logDebug('error on markChannelAsReadOnceFetched', getFullErrorMessage(error));
+        return;
+    }
+
+    markChannelAsRead(serverUrl, channelId, false, groupLabel);
+}
+
 export async function unsetActiveChannelOnServer(serverUrl: string) {
     try {
         const client = NetworkManager.getClient(serverUrl);
         await client.viewMyChannel('');
         return {};
     } catch (error) {
-        logDebug('error on markChannelAsRead', getFullErrorMessage(error));
+        logDebug('error on unsetActiveChannelOnServer', getFullErrorMessage(error));
         return {error};
     }
 }
@@ -1187,11 +1221,11 @@ export async function switchToChannelById(serverUrl: string, channelId: string, 
     DeviceEventEmitter.emit(Events.BLUR_AND_DISMISS_KEYBOARD);
     DeviceEventEmitter.emit(Events.CHANNEL_SWITCH, true);
 
-    fetchPostsForChannel(serverUrl, channelId, false, false, groupLabel);
+    const postsRequest = fetchPostsForChannel(serverUrl, channelId, false, false, groupLabel);
     fetchChannelBookmarks(serverUrl, channelId, false, groupLabel);
     await switchToChannel(serverUrl, channelId, teamId, skipLastUnread);
     openChannelIfNeeded(serverUrl, channelId, groupLabel);
-    markChannelAsRead(serverUrl, channelId, false, groupLabel);
+    markChannelAsReadOnceFetched(serverUrl, channelId, postsRequest, groupLabel);
     fetchChannelStats(serverUrl, channelId, false, groupLabel);
     fetchGroupsForChannelIfConstrained(serverUrl, channelId, false, groupLabel);
 

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -771,7 +771,7 @@ export async function markChannelAsReadOnceFetched(serverUrl: string, channelId:
     const {error: fetchError} = await postsRequest;
     if (fetchError) {
         logDebug('skipping markChannelAsRead, the posts fetch failed for channel', channelId);
-        return;
+        return {error: fetchError};
     }
 
     try {
@@ -780,14 +780,14 @@ export async function markChannelAsReadOnceFetched(serverUrl: string, channelId:
         // suppress its push notifications.
         const database = DatabaseManager.serverDatabases[serverUrl]?.database;
         if (!database || (await getCurrentChannelId(database)) !== channelId) {
-            return;
+            return {};
         }
     } catch (error) {
         logDebug('error on markChannelAsReadOnceFetched', getFullErrorMessage(error));
-        return;
+        return {error};
     }
 
-    markChannelAsRead(serverUrl, channelId, false, groupLabel);
+    return markChannelAsRead(serverUrl, channelId, false, groupLabel);
 }
 
 export async function unsetActiveChannelOnServer(serverUrl: string) {

--- a/app/actions/remote/channel.ts
+++ b/app/actions/remote/channel.ts
@@ -766,25 +766,18 @@ export async function markChannelAsRead(serverUrl: string, channelId: string, up
  * server, a dropped connection, ...) we leave the server state alone. The local optimistic clear
  * done by markChannelAsViewed is then repaired by the next membership sync, which recomputes
  * is_unread from the server counters, and the read is retried once the posts do arrive.
+ *
+ * Once the posts are in we send the read even if the user has already left the channel. This call
+ * does not touch local state, and a stale active channel on the server is corrected by the next
+ * channel view or by unsetActiveChannelOnServer; skipping the read instead would leave the channel
+ * unread on the server after the local state was already cleared, so it would come back as unread
+ * on the next sync.
  */
 export async function markChannelAsReadOnceFetched(serverUrl: string, channelId: string, postsRequest: Promise<PostsForChannel>, groupLabel?: RequestGroupLabel) {
     const {error: fetchError} = await postsRequest;
     if (fetchError) {
         logDebug('skipping markChannelAsRead, the posts fetch failed for channel', channelId);
         return {error: fetchError};
-    }
-
-    try {
-        // The fetch may have outlived the channel the user is looking at. Viewing a channel also sets
-        // it as the active one on the server, so marking a channel the user already left would
-        // suppress its push notifications.
-        const database = DatabaseManager.serverDatabases[serverUrl]?.database;
-        if (!database || (await getCurrentChannelId(database)) !== channelId) {
-            return {};
-        }
-    } catch (error) {
-        logDebug('error on markChannelAsReadOnceFetched', getFullErrorMessage(error));
-        return {error};
     }
 
     return markChannelAsRead(serverUrl, channelId, false, groupLabel);

--- a/app/actions/websocket/index.test.ts
+++ b/app/actions/websocket/index.test.ts
@@ -187,6 +187,23 @@ describe('WebSocket Index Actions', () => {
             expect(EphemeralStore.setNotificationTapped).toHaveBeenCalledWith(false);
         });
 
+        it('should not mark the channel as read when the user switched servers during the fetch', async () => {
+            jest.mocked(NavigationStore.getScreensInStack).mockReturnValue(['channel']);
+
+            // The user moves to another server while the posts are still being fetched. The current
+            // channel of this server does not change, so only the active server reveals the switch.
+            jest.mocked(fetchPostsForChannel).mockImplementation(async () => {
+                jest.mocked(getActiveServerUrl).mockResolvedValue('https://another.server.com');
+                return {};
+            });
+
+            await handleReconnect(serverUrl);
+
+            expect(fetchPostsForChannel).toHaveBeenCalledWith(serverUrl, currentChannelId, false, false, 'WebSocket Reconnect');
+            expect(markChannelAsRead).not.toHaveBeenCalled();
+            expect(markChannelAsViewed).not.toHaveBeenCalled();
+        });
+
         it('should not mark the channel as read when the user switched channels during the fetch', async () => {
             jest.mocked(NavigationStore.getScreensInStack).mockReturnValue(['channel']);
 

--- a/app/actions/websocket/index.test.ts
+++ b/app/actions/websocket/index.test.ts
@@ -187,6 +187,22 @@ describe('WebSocket Index Actions', () => {
             expect(EphemeralStore.setNotificationTapped).toHaveBeenCalledWith(false);
         });
 
+        it('should not mark the channel as read when the user switched channels during the fetch', async () => {
+            jest.mocked(NavigationStore.getScreensInStack).mockReturnValue(['channel']);
+
+            // The user leaves the channel while the posts are still being fetched.
+            jest.mocked(fetchPostsForChannel).mockImplementation(async () => {
+                jest.mocked(getCurrentChannelId).mockResolvedValue('another-channel-id');
+                return {};
+            });
+
+            await handleReconnect(serverUrl);
+
+            expect(fetchPostsForChannel).toHaveBeenCalledWith(serverUrl, currentChannelId, false, false, 'WebSocket Reconnect');
+            expect(markChannelAsRead).not.toHaveBeenCalled();
+            expect(markChannelAsViewed).not.toHaveBeenCalled();
+        });
+
         it('should fetch thread posts when CRT enabled', async () => {
             const threadId = 'thread-id';
             const lastPost = TestHelper.fakePostModel({id: 'post-id', createAt: 123});

--- a/app/actions/websocket/index.test.ts
+++ b/app/actions/websocket/index.test.ts
@@ -128,6 +128,7 @@ describe('WebSocket Index Actions', () => {
             jest.mocked(getIsCRTEnabled).mockResolvedValue(false);
             jest.mocked(EphemeralStore.getCurrentThreadId).mockReturnValue('');
             jest.mocked(EphemeralStore.wasNotificationTapped).mockReturnValue(false);
+            jest.mocked(fetchPostsForChannel).mockResolvedValue({});
         });
 
         it('should handle reconnection successfully', async () => {
@@ -172,6 +173,18 @@ describe('WebSocket Index Actions', () => {
             expect(fetchPostsForChannel).toHaveBeenCalledWith(serverUrl, currentChannelId, false, false, 'WebSocket Reconnect');
             expect(markChannelAsRead).toHaveBeenCalledWith(serverUrl, currentChannelId, false, 'WebSocket Reconnect');
             expect(markChannelAsViewed).toHaveBeenCalledWith(serverUrl, currentChannelId, true);
+        });
+
+        it('should not mark the channel as read when fetching the posts failed', async () => {
+            jest.mocked(NavigationStore.getScreensInStack).mockReturnValue(['channel']);
+            jest.mocked(fetchPostsForChannel).mockResolvedValue({error: new Error('Too many requests')});
+
+            await handleReconnect(serverUrl);
+
+            expect(fetchPostsForChannel).toHaveBeenCalledWith(serverUrl, currentChannelId, false, false, 'WebSocket Reconnect');
+            expect(markChannelAsRead).not.toHaveBeenCalled();
+            expect(markChannelAsViewed).not.toHaveBeenCalled();
+            expect(EphemeralStore.setNotificationTapped).toHaveBeenCalledWith(false);
         });
 
         it('should fetch thread posts when CRT enabled', async () => {

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -160,15 +160,16 @@ async function fetchPostDataIfNeeded(serverUrl: string, groupLabel?: RequestGrou
             // unread state and the mention badge for messages the user never received.
             if (error) {
                 logDebug('skipped marking channel as read after reconnect, the posts fetch failed for channel', currentChannelId);
-            } else if ((await getCurrentChannelId(database)) === currentChannelId) {
+            } else if ((await getActiveServerUrl()) === serverUrl && (await getCurrentChannelId(database)) === currentChannelId) {
                 markChannelAsRead(serverUrl, currentChannelId, false, groupLabel);
                 if (!EphemeralStore.wasNotificationTapped()) {
                     markChannelAsViewed(serverUrl, currentChannelId, true);
                 }
             } else {
-                // The user switched channels while the posts were being fetched. Unlike the channel
-                // switch flow, this clears the local unread state too, so going ahead would wipe the
-                // unread flag and the mention badge of a channel the user is no longer looking at.
+                // The user moved to another channel or server while the posts were being fetched.
+                // Both are rechecked because the current channel of this server does not change when
+                // the user switches servers. Going ahead would wipe the unread flag and the mention
+                // badge of a channel the user is no longer looking at.
                 logDebug('skipped marking channel as read after reconnect, the user left channel', currentChannelId);
             }
             EphemeralStore.setNotificationTapped(false);

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -160,11 +160,16 @@ async function fetchPostDataIfNeeded(serverUrl: string, groupLabel?: RequestGrou
             // unread state and the mention badge for messages the user never received.
             if (error) {
                 logDebug('skipped marking channel as read after reconnect, the posts fetch failed for channel', currentChannelId);
-            } else {
+            } else if ((await getCurrentChannelId(database)) === currentChannelId) {
                 markChannelAsRead(serverUrl, currentChannelId, false, groupLabel);
                 if (!EphemeralStore.wasNotificationTapped()) {
                     markChannelAsViewed(serverUrl, currentChannelId, true);
                 }
+            } else {
+                // The user switched channels while the posts were being fetched. Viewing a channel
+                // also sets it as the active one on the server, so marking the one they left would
+                // suppress its push notifications.
+                logDebug('skipped marking channel as read after reconnect, the user left channel', currentChannelId);
             }
             EphemeralStore.setNotificationTapped(false);
         }

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -166,9 +166,9 @@ async function fetchPostDataIfNeeded(serverUrl: string, groupLabel?: RequestGrou
                     markChannelAsViewed(serverUrl, currentChannelId, true);
                 }
             } else {
-                // The user switched channels while the posts were being fetched. Viewing a channel
-                // also sets it as the active one on the server, so marking the one they left would
-                // suppress its push notifications.
+                // The user switched channels while the posts were being fetched. Unlike the channel
+                // switch flow, this clears the local unread state too, so going ahead would wipe the
+                // unread flag and the mention badge of a channel the user is no longer looking at.
                 logDebug('skipped marking channel as read after reconnect, the user left channel', currentChannelId);
             }
             EphemeralStore.setNotificationTapped(false);

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -153,10 +153,18 @@ async function fetchPostDataIfNeeded(serverUrl: string, groupLabel?: RequestGrou
         }
 
         if (currentChannelId && (isChannelScreenMounted || tabletDevice)) {
-            await fetchPostsForChannel(serverUrl, currentChannelId, false, false, groupLabel);
-            markChannelAsRead(serverUrl, currentChannelId, false, groupLabel);
-            if (!EphemeralStore.wasNotificationTapped()) {
-                markChannelAsViewed(serverUrl, currentChannelId, true);
+            const {error} = await fetchPostsForChannel(serverUrl, currentChannelId, false, false, groupLabel);
+
+            // Only clear the unread state once we have the posts. Marking the channel as read resets
+            // the membership counters on the server, so doing it after a failed fetch loses the
+            // unread state and the mention badge for messages the user never received.
+            if (error) {
+                logDebug('skipped marking channel as read after reconnect, the posts fetch failed for channel', currentChannelId);
+            } else {
+                markChannelAsRead(serverUrl, currentChannelId, false, groupLabel);
+                if (!EphemeralStore.wasNotificationTapped()) {
+                    markChannelAsViewed(serverUrl, currentChannelId, true);
+                }
             }
             EphemeralStore.setNotificationTapped(false);
         }

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -121,6 +121,80 @@ describe('components/post_list/PostList', () => {
         expect(getByTestId('post_list.new_messages_line')).toBeTruthy();
     });
 
+    describe('onNewMessageLineViewed', () => {
+        const unreadProps = {
+            ...baseProps,
+            showNewMessageLine: true,
+            lastViewedAt: 1234567000, // Before mockPost's create_at
+            posts: [mockPostModel({createAt: 1234567890})],
+        };
+
+        const viewable = (index: number, item: unknown) => ({viewableItems: [{index, item, isViewable: true}]});
+
+        const findSeparatorIndex = (data: Array<{type: string}>) => data.findIndex((i) => i.type === 'start-of-new-messages');
+
+        it('should notify once when the new messages line becomes viewable', () => {
+            const onNewMessageLineViewed = jest.fn();
+            const {getByTestId} = renderWithEverything(
+                <PostList
+                    {...unreadProps}
+                    onNewMessageLineViewed={onNewMessageLineViewed}
+                />,
+                {database, serverUrl},
+            );
+            const flatList = getByTestId('post_list.flat_list');
+            const index = findSeparatorIndex(flatList.props.data);
+            expect(index).toBeGreaterThanOrEqual(0);
+
+            act(() => {
+                flatList.props.onViewableItemsChanged(viewable(index, flatList.props.data[index]));
+                flatList.props.onViewableItemsChanged(viewable(index, flatList.props.data[index]));
+            });
+
+            expect(onNewMessageLineViewed).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not notify while the new messages line is out of view', () => {
+            const onNewMessageLineViewed = jest.fn();
+            const {getByTestId} = renderWithEverything(
+                <PostList
+                    {...unreadProps}
+                    onNewMessageLineViewed={onNewMessageLineViewed}
+                />,
+                {database, serverUrl},
+            );
+            const flatList = getByTestId('post_list.flat_list');
+            const separatorIndex = findSeparatorIndex(flatList.props.data);
+            const otherIndex = flatList.props.data.findIndex((i: {type: string}) => i.type === 'post');
+            expect(otherIndex).not.toBe(separatorIndex);
+
+            act(() => {
+                flatList.props.onViewableItemsChanged(viewable(otherIndex, flatList.props.data[otherIndex]));
+            });
+
+            expect(onNewMessageLineViewed).not.toHaveBeenCalled();
+        });
+
+        it('should not notify when there is no new messages line', () => {
+            const onNewMessageLineViewed = jest.fn();
+            const {getByTestId} = renderWithEverything(
+                <PostList
+                    {...baseProps}
+                    onNewMessageLineViewed={onNewMessageLineViewed}
+                />,
+                {database, serverUrl},
+            );
+            const flatList = getByTestId('post_list.flat_list');
+            expect(findSeparatorIndex(flatList.props.data)).toBe(-1);
+
+            act(() => {
+                flatList.props.onViewableItemsChanged(viewable(0, flatList.props.data[0]));
+            });
+
+            expect(onNewMessageLineViewed).not.toHaveBeenCalled();
+        });
+    });
+
     it('handles refresh in channel', async () => {
         const {getByTestId} = renderWithEverything(<PostList {...baseProps}/>, {database, serverUrl});
         const flatList = getByTestId('post_list.flat_list');

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -129,11 +129,19 @@ describe('components/post_list/PostList', () => {
             posts: [mockPostModel({createAt: 1234567890})],
         };
 
-        const viewable = (index: number, item: unknown) => ({viewableItems: [{index, item, isViewable: true}]});
-
         const findSeparatorIndex = (data: Array<{type: string}>) => data.findIndex((i) => i.type === 'start-of-new-messages');
 
-        it('should notify once when the new messages line becomes viewable', () => {
+        // VirtualizedList keeps the onViewableItemsChanged it was constructed with, so the callback
+        // production runs is the one from the first render. Tests have to hold on to that same
+        // reference; reading the prop again after a re-render would exercise a function the list
+        // never calls.
+        const fireOn = (callback: (info: unknown) => void, index: number, item: unknown) => {
+            act(() => {
+                callback({viewableItems: [{index, item, isViewable: true}]});
+            });
+        };
+
+        it('should report the separator coming into view', () => {
             const onNewMessageLineViewed = jest.fn();
             const {getByTestId} = renderWithEverything(
                 <PostList
@@ -146,50 +154,12 @@ describe('components/post_list/PostList', () => {
             const index = findSeparatorIndex(flatList.props.data);
             expect(index).toBeGreaterThanOrEqual(0);
 
-            act(() => {
-                flatList.props.onViewableItemsChanged(viewable(index, flatList.props.data[index]));
-                flatList.props.onViewableItemsChanged(viewable(index, flatList.props.data[index]));
-            });
+            fireOn(flatList.props.onViewableItemsChanged, index, flatList.props.data[index]);
 
             expect(onNewMessageLineViewed).toHaveBeenCalledTimes(1);
         });
 
-        it('should notify again when a later message moves the unread boundary', () => {
-            const onNewMessageLineViewed = jest.fn();
-            const {getByTestId, rerender} = renderWithEverything(
-                <PostList
-                    {...unreadProps}
-                    onNewMessageLineViewed={onNewMessageLineViewed}
-                />,
-                {database, serverUrl},
-            );
-            const fireOnSeparator = () => {
-                const flatList = getByTestId('post_list.flat_list');
-                const index = findSeparatorIndex(flatList.props.data);
-                expect(index).toBeGreaterThanOrEqual(0);
-                act(() => {
-                    flatList.props.onViewableItemsChanged(viewable(index, flatList.props.data[index]));
-                });
-            };
-
-            fireOnSeparator();
-            expect(onNewMessageLineViewed).toHaveBeenCalledTimes(1);
-
-            // A message arrives while the user stays in the channel, so the boundary moves.
-            rerender(
-                <PostList
-                    {...unreadProps}
-                    lastViewedAt={1234567900}
-                    onNewMessageLineViewed={onNewMessageLineViewed}
-                    posts={[mockPostModel({id: 'newer-post', createAt: 1234568000}), ...unreadProps.posts]}
-                />,
-            );
-
-            fireOnSeparator();
-            expect(onNewMessageLineViewed).toHaveBeenCalledTimes(2);
-        });
-
-        it('should not notify while the new messages line is out of view', () => {
+        it('should not report while the separator is out of view', () => {
             const onNewMessageLineViewed = jest.fn();
             const {getByTestId} = renderWithEverything(
                 <PostList
@@ -203,14 +173,12 @@ describe('components/post_list/PostList', () => {
             const otherIndex = flatList.props.data.findIndex((i: {type: string}) => i.type === 'post');
             expect(otherIndex).not.toBe(separatorIndex);
 
-            act(() => {
-                flatList.props.onViewableItemsChanged(viewable(otherIndex, flatList.props.data[otherIndex]));
-            });
+            fireOn(flatList.props.onViewableItemsChanged, otherIndex, flatList.props.data[otherIndex]);
 
             expect(onNewMessageLineViewed).not.toHaveBeenCalled();
         });
 
-        it('should not notify when there is no new messages line', () => {
+        it('should not report when there is no separator', () => {
             const onNewMessageLineViewed = jest.fn();
             const {getByTestId} = renderWithEverything(
                 <PostList
@@ -222,11 +190,46 @@ describe('components/post_list/PostList', () => {
             const flatList = getByTestId('post_list.flat_list');
             expect(findSeparatorIndex(flatList.props.data)).toBe(-1);
 
-            act(() => {
-                flatList.props.onViewableItemsChanged(viewable(0, flatList.props.data[0]));
-            });
+            fireOn(flatList.props.onViewableItemsChanged, 0, flatList.props.data[0]);
 
             expect(onNewMessageLineViewed).not.toHaveBeenCalled();
+        });
+
+        it('should report later boundaries through the callback the list captured', () => {
+            const onNewMessageLineViewed = jest.fn();
+            const {getByTestId, rerender} = renderWithEverything(
+                <PostList
+                    {...unreadProps}
+                    onNewMessageLineViewed={onNewMessageLineViewed}
+                />,
+                {database, serverUrl},
+            );
+            const initialFlatList = getByTestId('post_list.flat_list');
+            const initialSeparatorIndex = findSeparatorIndex(initialFlatList.props.data);
+            const captured = initialFlatList.props.onViewableItemsChanged;
+
+            // A message arrives while the user stays in the channel, so the boundary moves.
+            rerender(
+                <PostList
+                    {...unreadProps}
+                    lastViewedAt={1234567900}
+                    onNewMessageLineViewed={onNewMessageLineViewed}
+                    posts={[
+                        mockPostModel({id: 'newest-post', createAt: 1234568100}),
+                        mockPostModel({id: 'newer-post', createAt: 1234568000}),
+                        ...unreadProps.posts,
+                    ]}
+                />,
+            );
+
+            const flatList = getByTestId('post_list.flat_list');
+            const movedIndex = findSeparatorIndex(flatList.props.data);
+            expect(movedIndex).toBeGreaterThanOrEqual(0);
+            expect(movedIndex).not.toBe(initialSeparatorIndex);
+
+            fireOn(captured, movedIndex, flatList.props.data[movedIndex]);
+
+            expect(onNewMessageLineViewed).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/app/components/post_list/post_list.test.tsx
+++ b/app/components/post_list/post_list.test.tsx
@@ -154,6 +154,41 @@ describe('components/post_list/PostList', () => {
             expect(onNewMessageLineViewed).toHaveBeenCalledTimes(1);
         });
 
+        it('should notify again when a later message moves the unread boundary', () => {
+            const onNewMessageLineViewed = jest.fn();
+            const {getByTestId, rerender} = renderWithEverything(
+                <PostList
+                    {...unreadProps}
+                    onNewMessageLineViewed={onNewMessageLineViewed}
+                />,
+                {database, serverUrl},
+            );
+            const fireOnSeparator = () => {
+                const flatList = getByTestId('post_list.flat_list');
+                const index = findSeparatorIndex(flatList.props.data);
+                expect(index).toBeGreaterThanOrEqual(0);
+                act(() => {
+                    flatList.props.onViewableItemsChanged(viewable(index, flatList.props.data[index]));
+                });
+            };
+
+            fireOnSeparator();
+            expect(onNewMessageLineViewed).toHaveBeenCalledTimes(1);
+
+            // A message arrives while the user stays in the channel, so the boundary moves.
+            rerender(
+                <PostList
+                    {...unreadProps}
+                    lastViewedAt={1234567900}
+                    onNewMessageLineViewed={onNewMessageLineViewed}
+                    posts={[mockPostModel({id: 'newer-post', createAt: 1234568000}), ...unreadProps.posts]}
+                />,
+            );
+
+            fireOnSeparator();
+            expect(onNewMessageLineViewed).toHaveBeenCalledTimes(2);
+        });
+
         it('should not notify while the new messages line is out of view', () => {
             const onNewMessageLineViewed = jest.fn();
             const {getByTestId} = renderWithEverything(

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -54,6 +54,7 @@ type Props = {
     lastViewedAt: number;
     location: AvailableScreens;
     onEndReached?: () => void;
+    onNewMessageLineViewed?: () => void;
     posts: PostModel[];
     rootId?: string;
     shouldRenderReplyButton?: boolean;
@@ -105,6 +106,7 @@ const PostList = ({
     lastViewedAt,
     location,
     onEndReached,
+    onNewMessageLineViewed,
     posts,
     rootId,
     shouldRenderReplyButton = true,
@@ -167,6 +169,7 @@ const PostList = ({
 
     const onScrollEndIndexListener = useRef<onScrollEndIndexListenerEvent | undefined>(undefined);
     const onViewableItemsChangedListener = useRef<ViewableItemsChangedListenerEvent | undefined>(undefined);
+    const newMessageLineViewedFor = useRef<string | undefined>(undefined);
     const scrolledToHighlighted = useRef(false);
     const initialRenderTracked = useRef(false);
     const viewableItemsDebounceTimer = useRef<NodeJS.Timeout | null>(null);
@@ -385,10 +388,19 @@ const PostList = ({
             DeviceEventEmitter.emit(Events.ITEM_IN_VIEWPORT, viewableItemsMap);
         });
 
+        // The new messages separator being on screen is what tells us the user has reached the
+        // unread boundary. Callers use it to decide the channel has actually been read, so it must
+        // not be inferred from the posts merely having been fetched.
+        if (onNewMessageLineViewed && initialIndex >= 0 && newMessageLineViewedFor.current !== channelId &&
+            viewableItems.some(({index, isViewable}) => isViewable && index === initialIndex)) {
+            newMessageLineViewedFor.current = channelId;
+            onNewMessageLineViewed();
+        }
+
         if (onViewableItemsChangedListener.current) {
             onViewableItemsChangedListener.current(viewableItems);
         }
-    }, [location, trackInitialRenderMetrics]);
+    }, [location, trackInitialRenderMetrics, onNewMessageLineViewed, initialIndex, channelId]);
 
     const registerScrollEndIndexListener = useCallback((listener: onScrollEndIndexListenerEvent) => {
         onScrollEndIndexListener.current = listener;

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -169,7 +169,7 @@ const PostList = ({
 
     const onScrollEndIndexListener = useRef<onScrollEndIndexListenerEvent | undefined>(undefined);
     const onViewableItemsChangedListener = useRef<ViewableItemsChangedListenerEvent | undefined>(undefined);
-    const newMessageLineViewedFor = useRef<string | undefined>(undefined);
+    const newMessageLine = useRef({channelId, initialIndex: -1, onNewMessageLineViewed});
     const scrolledToHighlighted = useRef(false);
     const initialRenderTracked = useRef(false);
     const viewableItemsDebounceTimer = useRef<NodeJS.Timeout | null>(null);
@@ -219,6 +219,8 @@ const PostList = ({
             initialIndex: unreadIndex,
         };
     }, [posts, lastViewedAt, showNewMessageLine, currentUserId, currentUsername, shouldShowJoinLeaveMessages, currentTimezone, location, savedPostIds, showAllPosts]);
+
+    newMessageLine.current = {channelId, initialIndex, onNewMessageLineViewed};
 
     const isNewMessage = lastPostId ? firstIdInPosts !== lastPostId : false;
 
@@ -388,24 +390,23 @@ const PostList = ({
             DeviceEventEmitter.emit(Events.ITEM_IN_VIEWPORT, viewableItemsMap);
         });
 
-        // The new messages separator being on screen is what tells us the user has reached the
-        // unread boundary. Callers use it to decide the channel has actually been read, so it must
-        // not be inferred from the posts merely having been fetched.
-        // Keyed on lastViewedAt as well as the channel because the separator moves every time the
-        // boundary does. Posts arriving while the user sits in the channel push it down, and each of
-        // those is a new boundary that has to be reported once seen; keying on the channel alone
-        // would report the first one and then stay silent for the rest of the visit.
-        const newMessageLineKey = `${channelId}-${lastViewedAt}`;
-        if (onNewMessageLineViewed && initialIndex >= 0 && newMessageLineViewedFor.current !== newMessageLineKey &&
-            viewableItems.some(({index, isViewable}) => isViewable && index === initialIndex)) {
-            newMessageLineViewedFor.current = newMessageLineKey;
-            onNewMessageLineViewed();
+        // The separator being on screen is what tells us the user reached the unread boundary; it must
+        // not be inferred from the posts merely having been fetched. Report the fact and let the
+        // caller decide what it means. Values come
+        // from a ref rather than this closure: VirtualizedList captures onViewableItemsChanged in its
+        // constructor, so the callback it calls is the one from the first render no matter how many
+        // times this is recreated. Reading props directly here would pin us to the first render's
+        // channel and unread boundary forever.
+        const current = newMessageLine.current;
+        if (current.onNewMessageLineViewed && current.initialIndex >= 0 &&
+            viewableItems.some(({index, isViewable}) => isViewable && index === current.initialIndex)) {
+            current.onNewMessageLineViewed();
         }
 
         if (onViewableItemsChangedListener.current) {
             onViewableItemsChangedListener.current(viewableItems);
         }
-    }, [location, trackInitialRenderMetrics, onNewMessageLineViewed, initialIndex, channelId, lastViewedAt]);
+    }, [location, trackInitialRenderMetrics]);
 
     const registerScrollEndIndexListener = useCallback((listener: onScrollEndIndexListenerEvent) => {
         onScrollEndIndexListener.current = listener;

--- a/app/components/post_list/post_list.tsx
+++ b/app/components/post_list/post_list.tsx
@@ -391,16 +391,21 @@ const PostList = ({
         // The new messages separator being on screen is what tells us the user has reached the
         // unread boundary. Callers use it to decide the channel has actually been read, so it must
         // not be inferred from the posts merely having been fetched.
-        if (onNewMessageLineViewed && initialIndex >= 0 && newMessageLineViewedFor.current !== channelId &&
+        // Keyed on lastViewedAt as well as the channel because the separator moves every time the
+        // boundary does. Posts arriving while the user sits in the channel push it down, and each of
+        // those is a new boundary that has to be reported once seen; keying on the channel alone
+        // would report the first one and then stay silent for the rest of the visit.
+        const newMessageLineKey = `${channelId}-${lastViewedAt}`;
+        if (onNewMessageLineViewed && initialIndex >= 0 && newMessageLineViewedFor.current !== newMessageLineKey &&
             viewableItems.some(({index, isViewable}) => isViewable && index === initialIndex)) {
-            newMessageLineViewedFor.current = channelId;
+            newMessageLineViewedFor.current = newMessageLineKey;
             onNewMessageLineViewed();
         }
 
         if (onViewableItemsChangedListener.current) {
             onViewableItemsChangedListener.current(viewableItems);
         }
-    }, [location, trackInitialRenderMetrics, onNewMessageLineViewed, initialIndex, channelId]);
+    }, [location, trackInitialRenderMetrics, onNewMessageLineViewed, initialIndex, channelId, lastViewedAt]);
 
     const registerScrollEndIndexListener = useCallback((listener: onScrollEndIndexListenerEvent) => {
         onScrollEndIndexListener.current = listener;

--- a/app/screens/channel/channel_post_list/channel_post_list.test.tsx
+++ b/app/screens/channel/channel_post_list/channel_post_list.test.tsx
@@ -1,0 +1,157 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {cleanup} from '@testing-library/react-native';
+import React from 'react';
+
+import {markChannelAsViewed} from '@actions/local/channel';
+import {markChannelAsRead} from '@actions/remote/channel';
+import {Screens} from '@constants';
+import {getMyChannel} from '@queries/servers/channel';
+import {NavigationStore} from '@store/navigation_store';
+import {renderWithEverything, act, waitFor} from '@test/intl-test-helper';
+import TestHelper from '@test/test_helper';
+
+import ChannelPostList from './index';
+
+import type Database from '@nozbe/watermelondb/Database';
+
+type PostListProps = {onNewMessageLineViewed?: () => void};
+let mockPostListProps: PostListProps;
+
+jest.mock('@actions/remote/channel');
+jest.mock('@hooks/device', () => ({
+    useAppState: () => 'active',
+    useIsTablet: () => false,
+}));
+jest.mock('@components/post_list', () => {
+    const react = require('react');
+    const {Text} = require('react-native');
+    return function MockPostList(props: PostListProps) {
+        mockPostListProps = props;
+        return react.createElement(Text, {testID: 'mock-post-list'}, 'posts');
+    };
+});
+
+describe('screens/channel/channel_post_list', () => {
+    const serverUrl = 'https://appv1.mattermost.com';
+    let database: Database;
+    let channelId: string;
+
+    // The screen is rendered through its container so the observables read the same database the
+    // real actions wrote to. Passing props by hand would hide the bugs that live in what other code
+    // does to that state before this screen mounts.
+    // lastPostAt is what the server said about the channel and viewedAt is the boundary the
+    // separator is drawn from. Written directly so the precondition is exact, then the real action
+    // runs on top of it.
+    const seedChannel = async (lastPostAt: number, lastViewedAt: number) => {
+        const myChannel = await getMyChannel(database, channelId);
+        await database.write(async () => {
+            await myChannel!.update((m) => {
+                m.lastPostAt = lastPostAt;
+                m.lastViewedAt = lastViewedAt;
+                m.viewedAt = 0;
+                m.isUnread = true;
+                m.messageCount = 2;
+            });
+        });
+
+        // What switchToChannel does on every open: clears the unread flag and the mention count
+        // locally and moves viewedAt to the previous view, all before this screen mounts.
+        await markChannelAsViewed(serverUrl, channelId);
+    };
+
+    const renderList = () => renderWithEverything(
+        <ChannelPostList channelId={channelId}/>,
+        {database, serverUrl},
+    );
+
+    beforeAll(async () => {
+        const server = await TestHelper.setupServerDatabase(serverUrl);
+        database = server.database;
+        channelId = TestHelper.basicChannel!.id;
+    });
+
+    beforeEach(() => {
+        jest.mocked(markChannelAsRead).mockResolvedValue({});
+        jest.spyOn(NavigationStore, 'getVisibleScreen').mockReturnValue(Screens.CHANNEL);
+    });
+
+    afterEach(async () => {
+        cleanup();
+        jest.restoreAllMocks();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    afterAll(async () => {
+        await TestHelper.tearDown();
+    });
+
+    it('should not mark the channel as read when the server has posts the user has not seen', async () => {
+        await seedChannel(3000, 1000);
+
+        renderList();
+
+        await waitFor(() => {
+            expect(mockPostListProps).toBeDefined();
+        });
+        expect(markChannelAsRead).not.toHaveBeenCalled();
+    });
+
+    it('should mark the channel as read when there is nothing left to see', async () => {
+        await seedChannel(500, 1000);
+
+        renderList();
+
+        await waitFor(() => {
+            expect(markChannelAsRead).toHaveBeenCalledWith(serverUrl, channelId, true);
+        });
+    });
+
+    it('should mark the channel as read once the separator is reported', async () => {
+        await seedChannel(3000, 1000);
+        renderList();
+        await waitFor(() => {
+            expect(mockPostListProps).toBeDefined();
+        });
+
+        await act(async () => {
+            await mockPostListProps.onNewMessageLineViewed?.();
+        });
+
+        expect(markChannelAsRead).toHaveBeenCalledWith(serverUrl, channelId, true);
+    });
+
+    it('should ignore a reported separator while another screen is on top', async () => {
+        await seedChannel(3000, 1000);
+        jest.spyOn(NavigationStore, 'getVisibleScreen').mockReturnValue(Screens.THREAD);
+        renderList();
+        await waitFor(() => {
+            expect(mockPostListProps).toBeDefined();
+        });
+
+        await act(async () => {
+            await mockPostListProps.onNewMessageLineViewed?.();
+        });
+
+        expect(markChannelAsRead).not.toHaveBeenCalled();
+    });
+
+    it('should retry the same separator when the read failed', async () => {
+        await seedChannel(3000, 1000);
+        jest.mocked(markChannelAsRead).mockResolvedValueOnce({error: new Error('Too many requests')});
+        renderList();
+        await waitFor(() => {
+            expect(mockPostListProps).toBeDefined();
+        });
+
+        await act(async () => {
+            await mockPostListProps.onNewMessageLineViewed?.();
+        });
+        await act(async () => {
+            await mockPostListProps.onNewMessageLineViewed?.();
+        });
+
+        expect(markChannelAsRead).toHaveBeenCalledTimes(2);
+    });
+});

--- a/app/screens/channel/channel_post_list/channel_post_list.tsx
+++ b/app/screens/channel/channel_post_list/channel_post_list.tsx
@@ -29,6 +29,7 @@ type Props = {
     lastViewedAt: number;
     posts: PostModel[];
     shouldShowJoinLeaveMessages: boolean;
+    unreadCount: number;
 }
 
 const edges: Edge[] = [];
@@ -39,7 +40,7 @@ const styles = StyleSheet.create({
 
 const ChannelPostList = ({
     channelId, contentContainerStyle, isCRTEnabled,
-    lastViewedAt, posts, shouldShowJoinLeaveMessages,
+    lastViewedAt, posts, shouldShowJoinLeaveMessages, unreadCount,
 }: Props) => {
     const appState = useAppState();
     const isTablet = useIsTablet();
@@ -47,7 +48,6 @@ const ChannelPostList = ({
     const canLoadPostsBefore = useRef(true);
     const canLoadPost = useRef(true);
     const [fetchingPosts, setFetchingPosts] = useState(EphemeralStore.isLoadingMessagesForChannel(serverUrl, channelId));
-    const oldPostsCount = useRef<number>(posts.length);
 
     const handleEndReached = useCallback(async () => {
         if (!fetchingPosts && canLoadPostsBefore.current && posts.length) {
@@ -89,12 +89,24 @@ const ChannelPostList = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fetchingPosts, posts]);
 
-    useDidUpdate(() => {
-        if (oldPostsCount.current < posts.length && appState === 'active') {
-            oldPostsCount.current = posts.length;
+    // Marking the channel read is driven by what the user has actually seen, not by the posts having
+    // been fetched. Telling the server resets the membership counters irreversibly, so a fetch that
+    // silently failed must not be able to clear unreads for messages that never made it to the
+    // client. The new messages separator coming into view is that signal.
+    const onNewMessageLineViewed = useCallback(() => {
+        if (appState === 'active') {
             markChannelAsRead(serverUrl, channelId, true);
         }
-    }, [posts.length]);
+    }, [appState, channelId, serverUrl]);
+
+    // With nothing unread there is no separator to wait for and nothing to lose, so view the channel
+    // right away. That keeps it registered as the active channel on the server, which is what
+    // suppresses its push notifications while the user is looking at it.
+    useEffect(() => {
+        if (!unreadCount && appState === 'active') {
+            markChannelAsRead(serverUrl, channelId, true);
+        }
+    }, [unreadCount, appState, channelId, serverUrl]);
 
     useDidUpdate(() => {
         if (appState === 'active') {
@@ -122,6 +134,7 @@ const ChannelPostList = ({
             lastViewedAt={lastViewedAt}
             location={Screens.CHANNEL}
             onEndReached={onEndReached}
+            onNewMessageLineViewed={onNewMessageLineViewed}
             posts={posts}
             shouldShowJoinLeaveMessages={shouldShowJoinLeaveMessages}
             showMoreMessages={true}

--- a/app/screens/channel/channel_post_list/channel_post_list.tsx
+++ b/app/screens/channel/channel_post_list/channel_post_list.tsx
@@ -30,7 +30,7 @@ type Props = {
     lastViewedAt: number;
     posts: PostModel[];
     shouldShowJoinLeaveMessages: boolean;
-    isUnread: boolean;
+    lastPostAt: number;
 }
 
 const edges: Edge[] = [];
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
 
 const ChannelPostList = ({
     channelId, contentContainerStyle, isCRTEnabled,
-    isUnread, lastViewedAt, posts, shouldShowJoinLeaveMessages,
+    lastPostAt, lastViewedAt, posts, shouldShowJoinLeaveMessages,
 }: Props) => {
     const appState = useAppState();
     const isTablet = useIsTablet();
@@ -130,16 +130,23 @@ const ChannelPostList = ({
         markAsRead(boundaryKey);
     }, [appState, boundaryKey, isChannelVisible, markAsRead]);
 
-    // With nothing unread there is no separator to wait for and nothing to lose, so view the channel
-    // right away. That keeps it registered as the active channel on the server, which is what
-    // suppresses its push notifications while the user is looking at it. This reads isUnread rather
-    // than the message count because resetMessageCount zeroes that count locally when the more
-    // messages button is dismissed, which says nothing about the channel having been read.
+    // With nothing newer than what the user has already seen there is no separator to wait for and
+    // nothing to lose, so view the channel right away. That keeps it registered as the active channel
+    // on the server, which is what suppresses its push notifications while the user is reading.
+    //
+    // This compares timestamps rather than asking whether the channel is unread, because the unread
+    // flag and the message count are both cleared locally and optimistically before this screen
+    // mounts: switchToChannel calls markChannelAsViewed on every open, and resetMessageCount zeroes
+    // the count when the more messages button is dismissed. Either would make every channel look
+    // already read and send the read unconditionally. lastPostAt comes from the server's channel
+    // record, so it still describes messages we failed to fetch, and viewedAt is the boundary the
+    // separator is drawn from; together they say whether anything is left to see.
+    const hasUnseenPosts = lastPostAt > lastViewedAt;
     useEffect(() => {
-        if (!isUnread && appState === 'active') {
+        if (!hasUnseenPosts && appState === 'active') {
             markChannelAsRead(serverUrl, channelId, true);
         }
-    }, [isUnread, appState, channelId, serverUrl]);
+    }, [hasUnseenPosts, appState, channelId, serverUrl]);
 
     useDidUpdate(() => {
         if (appState !== 'active') {

--- a/app/screens/channel/channel_post_list/channel_post_list.tsx
+++ b/app/screens/channel/channel_post_list/channel_post_list.tsx
@@ -16,6 +16,7 @@ import useDidMount from '@hooks/did_mount';
 import useDidUpdate from '@hooks/did_update';
 import {useDebounce} from '@hooks/utils';
 import EphemeralStore from '@store/ephemeral_store';
+import {NavigationStore} from '@store/navigation_store';
 
 import Intro from './intro';
 
@@ -29,7 +30,7 @@ type Props = {
     lastViewedAt: number;
     posts: PostModel[];
     shouldShowJoinLeaveMessages: boolean;
-    unreadCount: number;
+    isUnread: boolean;
 }
 
 const edges: Edge[] = [];
@@ -40,7 +41,7 @@ const styles = StyleSheet.create({
 
 const ChannelPostList = ({
     channelId, contentContainerStyle, isCRTEnabled,
-    lastViewedAt, posts, shouldShowJoinLeaveMessages, unreadCount,
+    isUnread, lastViewedAt, posts, shouldShowJoinLeaveMessages,
 }: Props) => {
     const appState = useAppState();
     const isTablet = useIsTablet();
@@ -92,28 +93,67 @@ const ChannelPostList = ({
     // Marking the channel read is driven by what the user has actually seen, not by the posts having
     // been fetched. Telling the server resets the membership counters irreversibly, so a fetch that
     // silently failed must not be able to clear unreads for messages that never made it to the
-    // client. The new messages separator coming into view is that signal.
-    const onNewMessageLineViewed = useCallback(() => {
-        if (appState === 'active') {
-            markChannelAsRead(serverUrl, channelId, true);
+    // client. The new messages separator coming into view is that signal, and the boundary it refers
+    // to is identified by lastViewedAt so that later ones are reported too.
+    const boundaryKey = `${channelId}-${lastViewedAt}`;
+    const markedBoundary = useRef<string | undefined>(undefined);
+    const markingBoundary = useRef<string | undefined>(undefined);
+
+    // Viewability is layout based and the channel stays mounted underneath threads and modals, so a
+    // separator can be reported while the user is looking at something else. On a tablet the channel
+    // lives inside the home screen rather than being the visible one.
+    const isChannelVisible = useCallback(() => {
+        const visibleScreen = NavigationStore.getVisibleScreen();
+        return visibleScreen === Screens.CHANNEL || (isTablet && visibleScreen === Screens.HOME);
+    }, [isTablet]);
+
+    const markAsRead = useCallback(async (key: string) => {
+        if (markedBoundary.current === key || markingBoundary.current === key) {
+            return;
         }
-    }, [appState, channelId, serverUrl]);
+
+        // Only remember the boundary once the server accepted it, otherwise a failed request would
+        // never be retried for a separator that is still on screen.
+        markingBoundary.current = key;
+        const {error} = await markChannelAsRead(serverUrl, channelId, true);
+        markingBoundary.current = undefined;
+        if (!error) {
+            markedBoundary.current = key;
+        }
+    }, [channelId, serverUrl]);
+
+    const onNewMessageLineViewed = useCallback(() => {
+        if (appState !== 'active' || !isChannelVisible()) {
+            return;
+        }
+
+        markAsRead(boundaryKey);
+    }, [appState, boundaryKey, isChannelVisible, markAsRead]);
 
     // With nothing unread there is no separator to wait for and nothing to lose, so view the channel
     // right away. That keeps it registered as the active channel on the server, which is what
-    // suppresses its push notifications while the user is looking at it.
+    // suppresses its push notifications while the user is looking at it. This reads isUnread rather
+    // than the message count because resetMessageCount zeroes that count locally when the more
+    // messages button is dismissed, which says nothing about the channel having been read.
     useEffect(() => {
-        if (!unreadCount && appState === 'active') {
+        if (!isUnread && appState === 'active') {
             markChannelAsRead(serverUrl, channelId, true);
         }
-    }, [unreadCount, appState, channelId, serverUrl]);
+    }, [isUnread, appState, channelId, serverUrl]);
 
     useDidUpdate(() => {
-        if (appState === 'active') {
-            markChannelAsRead(serverUrl, channelId, true);
-        }
         if (appState !== 'active') {
             unsetActiveChannelOnServer(serverUrl);
+            return;
+        }
+
+        // Coming back from background is not evidence the channel was read. If the user had already
+        // reached this boundary, view it again so the channel is registered as active on the server;
+        // otherwise re-arm and wait for the separator to be reported once more.
+        if (markedBoundary.current === boundaryKey) {
+            markChannelAsRead(serverUrl, channelId, true);
+        } else {
+            markedBoundary.current = undefined;
         }
     }, [appState === 'active']);
 

--- a/app/screens/channel/channel_post_list/index.ts
+++ b/app/screens/channel/channel_post_list/index.ts
@@ -38,8 +38,8 @@ const enhanced = withObservables(['channelId'], ({database, channelId}: {channel
                 return queryPostsBetween(database, earliest, latest, Q.desc, '', channelId, isCRTEnabled ? '' : undefined).observe();
             }),
         ),
-        unreadCount: observeMyChannel(database, channelId).pipe(
-            switchMap((myChannel) => of$(myChannel?.messageCount ?? 0)),
+        isUnread: observeMyChannel(database, channelId).pipe(
+            switchMap((myChannel) => of$(Boolean(myChannel?.isUnread))),
             distinctUntilChanged(),
         ),
         shouldShowJoinLeaveMessages: queryAdvanceSettingsPreferences(database, Preferences.ADVANCED_FILTER_JOIN_LEAVE).

--- a/app/screens/channel/channel_post_list/index.ts
+++ b/app/screens/channel/channel_post_list/index.ts
@@ -38,8 +38,8 @@ const enhanced = withObservables(['channelId'], ({database, channelId}: {channel
                 return queryPostsBetween(database, earliest, latest, Q.desc, '', channelId, isCRTEnabled ? '' : undefined).observe();
             }),
         ),
-        isUnread: observeMyChannel(database, channelId).pipe(
-            switchMap((myChannel) => of$(Boolean(myChannel?.isUnread))),
+        lastPostAt: observeMyChannel(database, channelId).pipe(
+            switchMap((myChannel) => of$(myChannel?.lastPostAt ?? 0)),
             distinctUntilChanged(),
         ),
         shouldShowJoinLeaveMessages: queryAdvanceSettingsPreferences(database, Preferences.ADVANCED_FILTER_JOIN_LEAVE).

--- a/app/screens/channel/channel_post_list/index.ts
+++ b/app/screens/channel/channel_post_list/index.ts
@@ -38,6 +38,10 @@ const enhanced = withObservables(['channelId'], ({database, channelId}: {channel
                 return queryPostsBetween(database, earliest, latest, Q.desc, '', channelId, isCRTEnabled ? '' : undefined).observe();
             }),
         ),
+        unreadCount: observeMyChannel(database, channelId).pipe(
+            switchMap((myChannel) => of$(myChannel?.messageCount ?? 0)),
+            distinctUntilChanged(),
+        ),
         shouldShowJoinLeaveMessages: queryAdvanceSettingsPreferences(database, Preferences.ADVANCED_FILTER_JOIN_LEAVE).
             observeWithColumns(['value']).pipe(
                 switchMap((preferences) => of$(getAdvanceSettingPreferenceAsBool(preferences, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true))),


### PR DESCRIPTION
Context: https://hub.mattermost.com/private-core/pl/b1bog3gr3jf1pgj5surd9eztce

Marking a channel as read resets the membership `msg_count` and `mention_count`, which is not recoverable. Both the channel switch and the websocket reconnect flows called `markChannelAsRead` regardless of whether the request that should have brought in the new messages succeeded:

- `switchToChannelById` fired `fetchPostsForChannel` without awaiting it, then marked the channel read a few lines later.
- `fetchPostDataIfNeeded` awaited it but discarded the result — and since that action returns `{error}` instead of throwing, the surrounding `try/catch` never saw the failure either.

So a 429 or any dropped posts request cleared the unread state **and the mention badge, on every device**, for messages the user never received. The posts themselves return on the next successful since-fetch (`lastFetchedAt` only advances when they're stored), but with no unread treatment, so the user gets no signal anything was missed.

**Fix:** only send the read once the posts request has succeeded.

The local optimistic clear is kept, so switching channels still feels instant; it self-repairs via `handleMyChannel` recomputing `is_unread` from the server counters on the next membership sync. Only the irreversible server-side counter reset is gated.

Both flows also revalidate the **current channel and the active server** before sending the deferred read. Fetches aren't cancelled on switch, so a slow channel can resolve after the user has moved on and become the last read sent. That isn't confined to the server: `multiple_channels_viewed` is broadcast back, and since the channel is no longer current, `handleMultipleChannelsViewedEvent` clears its local unread flag and mention badge too. The active server needs its own check because a server's current channel doesn't change when the user switches servers.

Also fixed a copy-paste log label: `unsetActiveChannelOnServer` was logging `'error on markChannelAsRead'`.

#### Ticket Link
[MM-70319](https://mattermost.atlassian.net/browse/MM-70319)

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information

Tested on iOS simulator. Verified the asymmetric case the fix targets — failing only the posts endpoint for one channel while the view endpoint stayed reachable.

Forced situation when ios was failing for a specific channel (with a code change forcing the issue), channel is marked as viewed up until the point where the messages were received while the server still keeps the unread for the non-read ones.
<img width="1598" height="1954" alt="CleanShot 2026-08-19 at 12 54 05@2x" src="https://github.com/user-attachments/assets/19435e25-d87a-468d-8733-5e7fab17688a" />

```release-note
Fixed a bug where a channel could be marked as read when fetching its new messages failed.
```

[MM-70319]: https://mattermost.atlassian.net/browse/MM-70319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ