### PR TITLE
E2E/Test: Re-enable full Detox iOS tests

### DIFF
--- a/.github/workflows/e2e-detox.yml
+++ b/.github/workflows/e2e-detox.yml
@@ -84,7 +84,7 @@ jobs:
       # Phone legs exclude @ipad_only (tag filter — not directory).
       search_path: detox/e2e/test
       # Avoid `cond && '' || tag` — empty string is falsy in GHA expressions.
-      detox-include-tags: ${{ (inputs.run_type != 'MAIN' && inputs.run_type != 'MASTER' && inputs.run_type != 'RELEASE' && inputs.run_type != 'RELEASE_CUT') && '@ios_pr,@ios_only' || '' }}
+      detox-include-tags: ''
       detox-exclude-tags: '@ipad_only'
       parallelism: ${{ (inputs.run_type == 'MAIN' || inputs.run_type == 'MASTER' || inputs.run_type == 'RELEASE' || inputs.run_type == 'RELEASE_CUT') && '20' || '10' }}
       record_tests_in_zephyr: ${{ inputs.run_type == 'RELEASE' || inputs.run_type == 'RELEASE_CUT' || inputs.run_type == 'MAIN' || inputs.run_type == 'MASTER' }}

--- a/detox/maestro/config/exclude_tags.json
+++ b/detox/maestro/config/exclude_tags.json
@@ -5,21 +5,15 @@
   "_UNEXCLUDED_2026_08_11": "MM-T1325, MM-T3260 (iOS only), MM-T5611, MM-T67856_1, MM-T67856_2 were un-excluded on 2026-08-11 after each was run locally on a freshly provisioned+seeded server (iOS 26.2, iPhone 17 Pro, RUNNING_E2E build). MM-T1325 clock_display: PASSED — it had never been probed, and was carried on the _DIAGNOSIS_CORRECTION TLS rationale it was never tested against; it reached the timezone screen through connect+login with no TLS involvement at all. MM-T3260 help_url: PASSED — was excluded on BOTH platforms, i.e. zero coverage anywhere; the browser hand-off opened and dismissed via the breadcrumb with the reopen recovery unused. MM-T67856_1/_2: PASSED locally, and previously PASSED on the CI probe run 31324371751. MM-T5611: see _MM-T5611_VACUOUS. Caveat: the QUIC flake in _ROOT_CAUSE_QUIC is real and unfixed, so these can still fail intermittently at connect/login. That is a transport defect with a named owner, not a reason to keep the flows dark. If a tag proves genuinely unstable in CI, re-exclude it WITH the failing run ID.",
   "_MM-T5611_VACUOUS": "MM-T5611 was not merely failing on iOS — it was PASSING WITHOUT TESTING ANYTHING. The iOS branch tapped text 'mattermost.com' then text 'Mattermost', both optional:true. Maestro's text matcher is a FULL-STRING regex, so neither matched the OG-autofilled title 'Mattermost | Collaboration Platform...'; both no-opped silently (logged WARNED) and the flow then re-asserted channel_header.bookmarks.list, which was already true. Fixed 2026-08-11: match the title as a regex, non-optional so a miss fails loudly, and assert the hand-off actually happened via notVisible:channel.post_draft.post.input. Note the hand-off is an inter-app switch to Safari (status-bar 'back to app' breadcrumb), not an in-app SFSafariViewController — the assertion holds because the app is backgrounded. Verified twice locally with the browser screenshot showing mattermost.com in Safari.",
   "_MM-T5603": "Skip iOS: channel_bookmark_file.yml is genuinely INTERMITTENT — 1 fail / 1 pass locally on 2026-08-11 with identical fixture staging. The failure is a real upload failure the app surfaces as 'Error uploading file. Please try again.' on the Add a bookmark screen, so the flow never reaches channel_bookmark.file.upload_complete. NOT a server or permissions problem: POST /api/v4/files with the same fixture, channel and test user returns 201, and EnableFileAttachments/EnableMobileUpload are true. NOT the fixture staging either: the picker step now passes once the fixture is placed in the AppGroup FileProvider.LocalStorage 'File Provider Storage' dir (the local README omits this step — CI does it), and on the passing run the sandbox extension attached normally. Mechanism UNKNOWN; do not re-enable on a single green run. Likely related to _ROOT_CAUSE_QUIC but unproven.",
-  "_CALLS_IOS": "MM-T1411 / MM-T4832 / MM-T4833 must stay on the ios exclude list for Test System IO. CallKit/WebRTC do not work on the iOS simulator; without these entries CI run 31458940326 leased the three flows and each hit maestro-timeout-ms (540000) as status=interrupted. Coverage stays on maestro-android where the same flows pass (~2–4m).",
-  "_PLATFORM_TAGS": "Plan tags are @snake_case, always @-prefixed, and YAML-quoted in flow files (e.g. - \"@android_only\"). Untagged = all platforms. Restriction tags: @android_only, @ios_only, @multi_device. iOS excludes @android_only + @multi_device; Android excludes @ios_only + @multi_device. Zephyr-specific excludes below still apply for flakes/seeds.",
+  "_DEAD_ENTRIES_REMOVED": "MM-T1411, MM-T4832 and MM-T4833 were removed from the ios list on 2026-08-11. They were dead entries: run_ci_batches.sh already skips every detox/maestro/flows/calls/* flow on iOS unconditionally (CallKit/WebRTC do not work on the simulator), so the tag exclusions never fired. Removing them restores no coverage — it stops this file overstating what is tag-excluded. Getting calls running on an iOS simulator is a separate problem.",
   "_MM-T3260_ANDROID": "Skip Android ONLY: CI run 30331493720 (PR #9893, SHA 9f1496e) — help_url.yml failed with 'Unable to launch app com.mattermost.rnbeta' after ~136s; the Chrome Custom Tab hand-off leaves the driver unable to relaunch the app on API 35. This is a DIFFERENT cause from the iOS exclusion and has NOT been re-tested — the 2026-08-11 verification covered iOS only. Do not un-exclude on the strength of the iOS result.",
   "default": [
     "MM-T67856_4"
   ],
   "ios": [
-    "MM-T5603",
-    "@android_only"
+    "MM-T5603"
   ],
   "android": [
-    "MM-T3260",
-    "@ios_only",
-    "@multi_device"
-  ],
-  "_MM-T3244": "Skip default batch: file_type_preview.yml needs seed_file_preview.ts (IMAGE_FILE_ID etc). Required for Test System IO orchestration discovery.",
-  "_MM-T4829": "Skip default batch: start_call.yml needs calls_seed.ts. Required for Test System IO orchestration discovery."
+    "MM-T3260"
+  ]
 }


### PR DESCRIPTION
#### Summary
Todo

#### Ticket Link
None

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Release Note
```release-note
NONE
```



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>