### PR TITLE
perf: start WebSocket TCP before notification routing

### DIFF
--- a/app/client/websocket/index.test.ts
+++ b/app/client/websocket/index.test.ts
@@ -94,6 +94,39 @@ describe('WebSocketClient', () => {
         expect(logInfo).toHaveBeenCalledWith('websocket connecting to wss://example.com/api/v4/websocket');
     });
 
+    it('should skip waiting for config and not force reliable websockets when skipConfigWait is set', async () => {
+        mockedHasReliableWebsocket.mockReturnValue(false);
+
+        await client.initialize({skipConfigWait: true}, true);
+
+        expect(mockedGetConfigValue).not.toHaveBeenCalled();
+        expect(mockedHasReliableWebsocket).toHaveBeenCalledWith(undefined, undefined);
+        expect(mockedGetOrCreateWebSocketClient).toHaveBeenCalledWith(
+            'wss://example.com/api/v4/websocket',
+            {headers: {origin: 'https://example.com'}, timeoutInterval: 30000},
+        );
+    });
+
+    it('should read DB config on retry after a skipConfigWait connect', async () => {
+        DatabaseManager.serverDatabases[serverUrl] = {database: {} as any, operator: {} as any};
+
+        await client.initialize({skipConfigWait: true}, true);
+        expect(mockedGetConfigValue).not.toHaveBeenCalled();
+
+        mockedGetConfigValue.mockResolvedValueOnce('wss://ws.example.com');
+        mockedGetConfigValue.mockResolvedValueOnce('5.0.0');
+        mockedGetConfigValue.mockResolvedValueOnce('false');
+
+        mockConn.close();
+        await advanceTimers(6000);
+
+        expect(mockedGetConfigValue).toHaveBeenCalled();
+        expect(mockedGetOrCreateWebSocketClient).toHaveBeenLastCalledWith(
+            'wss://ws.example.com/api/v4/websocket',
+            {headers: {origin: 'wss://ws.example.com'}, timeoutInterval: 30000},
+        );
+    });
+
     it('should handle WebSocket open event - skip sync', async () => {
         const firstConnectCallback = jest.fn();
         client.setFirstConnectCallback(firstConnectCallback);

--- a/app/client/websocket/index.ts
+++ b/app/client/websocket/index.ts
@@ -20,8 +20,14 @@ const PING_INTERVAL = toMilliseconds({seconds: 30});
 const WAIT_FOR_CLOSE_TIMEOUT = 500;
 const DEFAULT_OPTIONS = {
     forceConnection: true,
+    skipConfigWait: false,
 };
 const TLS_HANDSHARE_ERROR = 1015;
+
+type WebSocketInitializeOpts = {
+    forceConnection?: boolean;
+    skipConfigWait?: boolean;
+};
 
 export default class WebSocketClient {
     private conn?: WebSocketClientInterface;
@@ -68,8 +74,8 @@ export default class WebSocketClient {
         this.preauthSecret = preauthSecret;
     }
 
-    public async initialize(opts = {}, shouldSkipSync = false) {
-        const {forceConnection} = Object.assign({}, DEFAULT_OPTIONS, opts);
+    public async initialize(opts: WebSocketInitializeOpts = {}, shouldSkipSync = false) {
+        const {forceConnection, skipConfigWait} = Object.assign({}, DEFAULT_OPTIONS, opts);
 
         if (forceConnection) {
             this.stop = false;
@@ -79,20 +85,28 @@ export default class WebSocketClient {
             return;
         }
 
-        const database = DatabaseManager.serverDatabases[this.serverUrl]?.database;
-        if (!database) {
-            return;
-        }
+        let websocketUrl: string | undefined;
+        let version: string | undefined;
+        let reliableWebsocketConfig: string | undefined;
 
-        const [websocketUrl, version, reliableWebsocketConfig] = await Promise.all([
-            getConfigValue(database, 'WebsocketURL'),
-            getConfigValue(database, 'Version'),
-            getConfigValue(database, 'EnableReliableWebSockets'),
-        ]);
+        if (skipConfigWait) {
+            websocketUrl = this.serverUrl;
+        } else {
+            const database = DatabaseManager.serverDatabases[this.serverUrl]?.database;
+            if (!database) {
+                return;
+            }
 
-        // Bail if teardown started while we were awaiting config values
-        if (this.stop) {
-            return;
+            [websocketUrl, version, reliableWebsocketConfig] = await Promise.all([
+                getConfigValue(database, 'WebsocketURL'),
+                getConfigValue(database, 'Version'),
+                getConfigValue(database, 'EnableReliableWebSockets'),
+            ]);
+
+            // Bail if teardown started while we were awaiting config values
+            if (this.stop) {
+                return;
+            }
         }
 
         const connectionUrl = (websocketUrl || this.serverUrl) + '/api/v4/websocket';
@@ -289,7 +303,7 @@ export default class WebSocketClient {
                         clearTimeout(this.connectionTimeout);
                         return;
                     }
-                    this.initialize(opts);
+                    this.initialize({...opts, skipConfigWait: false});
                 },
                 retryTime,
             );

--- a/app/init/launch.test.ts
+++ b/app/init/launch.test.ts
@@ -20,6 +20,48 @@ jest.mock('@queries/app/servers');
 jest.mock('@queries/servers/preference');
 jest.mock('@queries/servers/team');
 jest.mock('@store/ephemeral_store');
+jest.mock('@actions/remote/entry', () => ({
+    appEntry: jest.fn(),
+    pushNotificationEntry: jest.fn(),
+}));
+jest.mock('@managers/websocket_manager', () => ({
+    __esModule: true,
+    default: {
+        initializeClient: jest.fn(),
+    },
+}));
+
+describe('startColdStartEntry', () => {
+    it('should kick off websocket and appEntry without waiting for initializeClient', async () => {
+        await jest.isolateModulesAsync(async () => {
+            const {startColdStartEntry: start} = require('./launch') as typeof import('./launch');
+            const {appEntry: entry} = require('@actions/remote/entry') as {appEntry: jest.Mock};
+            const WebsocketManager = require('@managers/websocket_manager').default as {initializeClient: jest.Mock};
+
+            const order: string[] = [];
+            WebsocketManager.initializeClient.mockImplementation(() => {
+                order.push('ws');
+                return Promise.resolve();
+            });
+            entry.mockImplementation(() => {
+                order.push('entry');
+            });
+
+            start('https://hub.example.com');
+            start('https://hub.example.com');
+
+            expect(WebsocketManager.initializeClient).toHaveBeenCalledTimes(2);
+            expect(WebsocketManager.initializeClient).toHaveBeenCalledWith(
+                'https://hub.example.com',
+                'Cold Start',
+                {skipConfigWait: true},
+            );
+            expect(entry).toHaveBeenCalledTimes(2);
+            expect(entry).toHaveBeenCalledWith('https://hub.example.com');
+            expect(order).toEqual(['ws', 'entry', 'ws', 'entry']);
+        });
+    });
+});
 
 describe('determineRouteFromLaunchProps', () => {
     const serverUrl = 'https://server-1.com';

--- a/app/init/launch.ts
+++ b/app/init/launch.ts
@@ -13,8 +13,11 @@ import {DeepLink, Events, Launch, PushNotification, Screens} from '@constants';
 import {PostTypes} from '@constants/post';
 import {getDefaultThemeByAppearance} from '@context/theme';
 import DatabaseManager from '@database/manager';
-import {getActiveServerUrl, getServerCredentials} from '@init/credentials';
+import {getActiveServerUrl, getServerCredentials, hasCachedCredentials} from '@init/credentials';
+import {launchMark} from '@init/launch_profiler';
+import {getCachedActiveServer} from '@init/session_cache';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
+import WebsocketManager from '@managers/websocket_manager';
 import {getLastViewedChannelIdAndServer, getLastViewedTeamIdAndServer, getLastViewedThreadIdAndServer, getOnboardingViewed} from '@queries/app/global';
 import {getActiveServer, getAllServers, getServer} from '@queries/app/servers';
 import {queryPostsByType} from '@queries/servers/post';
@@ -23,7 +26,7 @@ import {queryMyTeams} from '@queries/servers/team';
 import {getExpoRouterPath} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
 import {handleDeepLink, getLaunchPropsFromDeepLink} from '@utils/deep_link';
-import {logInfo} from '@utils/log';
+import {logDebug, logInfo} from '@utils/log';
 import {convertToNotificationData} from '@utils/notification';
 import {removeProtocol} from '@utils/url';
 
@@ -39,12 +42,30 @@ export type ExpoRouterLaunchResult = {
 };
 
 const initialNotificationTypes = [PushNotification.NOTIFICATION_TYPE.MESSAGE, PushNotification.NOTIFICATION_TYPE.SESSION];
+const AFTER_FIRST_PAINT_MS = 500;
+
+function deferAfterFirstPaint(task: () => void) {
+    setTimeout(task, AFTER_FIRST_PAINT_MS);
+}
+
+/**
+ * Start websocket/sync as soon as we know the active server, without waiting
+ * on notification/deeplink routing. Safe to call more than once per launch.
+ */
+export function startColdStartEntry(serverUrl: string) {
+    launchMark('cold_start_entry');
+    WebsocketManager.initializeClient(serverUrl, 'Cold Start', {skipConfigWait: true}).catch((error) => {
+        logDebug('startColdStartEntry', error);
+    });
+    appEntry(serverUrl);
+}
 
 /**
  * Determine initial route for Expo Router based on app launch conditions
  */
 export async function determineInitialExpoRoute(): Promise<ExpoRouterLaunchResult> {
-    const activeServer = await getActiveServer();
+    const startedAt = Date.now();
+    const activeServer = getCachedActiveServer() ?? await getActiveServer();
     if (activeServer && activeServer.persistenceFlag === 'wiped') {
         return {
             route: getExpoRouterPath(Screens.DATA_ERASED)!,
@@ -52,14 +73,20 @@ export async function determineInitialExpoRoute(): Promise<ExpoRouterLaunchResul
         };
     }
 
-    // Check for deep link launch
-    const deepLinkUrl = await Linking.getInitialURL();
+    if (activeServer && hasCachedCredentials()) {
+        startColdStartEntry(activeServer.url);
+    }
+
+    launchMark('route_start');
+    const [deepLinkUrl, notification] = await Promise.all([
+        Linking.getInitialURL(),
+        Notifications.getInitialNotification(),
+    ]);
+    launchMark('link_ms');
+    launchMark('notif_ms');
     if (deepLinkUrl) {
         return determineRouteFromDeeplink(deepLinkUrl);
     }
-
-    // Check for notification launch
-    const notification = await Notifications.getInitialNotification();
     let tapped = Platform.select({android: true, ios: false})!;
     if (Platform.OS === 'ios' && notification) {
         // when a notification is received on iOS, getInitialNotification, will return the notification
@@ -78,7 +105,10 @@ export async function determineInitialExpoRoute(): Promise<ExpoRouterLaunchResul
 
     // Normal launch
     const coldStart = notification ? (tapped || AppState.currentState === 'active') : true;
-    return determineRoute({launchType: Launch.Normal, coldStart});
+    const result = await determineRoute({launchType: Launch.Normal, coldStart});
+    logDebug('determineInitialExpoRoute completed', `${Date.now() - startedAt}ms`);
+    launchMark('route_done');
+    return result;
 }
 
 async function determineRouteFromDeeplink(deepLinkUrl: string): Promise<ExpoRouterLaunchResult> {
@@ -174,7 +204,9 @@ const determineRoute = async (props: LaunchProps): Promise<ExpoRouterLaunchResul
         serverUrl = await getActiveServerUrl();
     }
 
-    cleanupEphemeralPosts();
+    deferAfterFirstPaint(() => {
+        cleanupEphemeralPosts();
+    });
 
     return determineRouteFromLaunchProps({...props, serverUrl});
 };
@@ -227,7 +259,7 @@ async function determineAuthenticatedRoute(props: LaunchProps): Promise<ExpoRout
     switch (props.launchType) {
         case Launch.DeepLink: {
             if (props.extra?.type !== DeepLink.MagicLink) {
-                appEntry(props.serverUrl!);
+                startColdStartEntry(props.serverUrl!);
             }
             break;
         }
@@ -239,25 +271,31 @@ async function determineAuthenticatedRoute(props: LaunchProps): Promise<ExpoRout
                 break;
             }
 
-            appEntry(props.serverUrl!);
+            startColdStartEntry(props.serverUrl!);
             break;
         }
         case Launch.Normal:
             if (props.coldStart) {
-                const lastViewedChannel = await getLastViewedChannelIdAndServer();
-                const lastViewedThread = await getLastViewedThreadIdAndServer();
+                startColdStartEntry(props.serverUrl!);
+
+                const [lastViewedChannel, lastViewedThread] = await Promise.all([
+                    getLastViewedChannelIdAndServer(),
+                    getLastViewedThreadIdAndServer(),
+                ]);
 
                 if (lastViewedThread && lastViewedThread.server_url === props.serverUrl && lastViewedThread.thread_id) {
                     PerformanceMetricsManager.setLoadTarget('THREAD');
-                    fetchAndSwitchToThread(props.serverUrl!, lastViewedThread.thread_id);
+                    deferAfterFirstPaint(() => {
+                        fetchAndSwitchToThread(props.serverUrl!, lastViewedThread.thread_id);
+                    });
                 } else if (lastViewedChannel && lastViewedChannel.server_url === props.serverUrl && lastViewedChannel.channel_id) {
                     PerformanceMetricsManager.setLoadTarget('CHANNEL');
-                    switchToChannelById(props.serverUrl!, lastViewedChannel.channel_id);
+                    deferAfterFirstPaint(() => {
+                        switchToChannelById(props.serverUrl!, lastViewedChannel.channel_id);
+                    });
                 } else {
                     PerformanceMetricsManager.setLoadTarget('HOME');
                 }
-
-                appEntry(props.serverUrl!);
             }
             break;
     }

--- a/app/managers/websocket_manager.test.ts
+++ b/app/managers/websocket_manager.test.ts
@@ -10,6 +10,7 @@ import {handleFirstConnect, handleReconnect} from '@actions/websocket';
 import {hasActiveNativeCall} from '@calls/native_call_mappings';
 import WebSocketClient from '@client/websocket';
 import DatabaseManager from '@database/manager';
+import {launchMark} from '@init/launch_profiler';
 import {getCurrentUserId} from '@queries/servers/system';
 import {queryAllUsers} from '@queries/servers/user';
 import TestHelper from '@test/test_helper';
@@ -30,6 +31,9 @@ jest.mock('@calls/native_call_mappings', () => ({
 }));
 jest.mock('@client/websocket');
 jest.mock('@database/manager');
+jest.mock('@init/launch_profiler', () => ({
+    launchMark: jest.fn(),
+}));
 jest.mock('@queries/servers/system');
 jest.mock('@queries/servers/user');
 jest.mock('@utils/log');
@@ -172,6 +176,7 @@ describe('WebsocketManager', () => {
     describe('connection handling', () => {
         beforeEach(async () => {
             await manager.init(mockCredentials);
+            jest.mocked(handleFirstConnect).mockResolvedValue(undefined);
         });
 
         it('should handle first connect correctly', async () => {
@@ -179,12 +184,66 @@ describe('WebsocketManager', () => {
 
             await manager.initializeClient(mockServerUrl);
 
-            expect(mockWebSocketClient.initialize).toHaveBeenCalledWith({}, true);
+            expect(mockWebSocketClient.initialize).toHaveBeenCalledWith({skipConfigWait: false}, true);
             expect(handleFirstConnect).toHaveBeenCalledWith(mockServerUrl, 'WebSocket Reconnect');
 
             if (mockCallbacks.firstConnect) {
                 mockCallbacks.firstConnect();
             }
+        });
+
+        it('should pass skipConfigWait on first connect and mark ws_connecting', async () => {
+            mockWebSocketClient.isConnected.mockReturnValue(false);
+
+            await manager.initializeClient(mockServerUrl, 'Cold Start', {skipConfigWait: true});
+
+            expect(mockWebSocketClient.initialize).toHaveBeenCalledWith({skipConfigWait: true}, true);
+            expect(handleFirstConnect).toHaveBeenCalledWith(mockServerUrl, 'Cold Start');
+            expect(launchMark).toHaveBeenCalledWith('ws_connecting');
+        });
+
+        it('should still run handleFirstConnect when already connected but not yet synced', async () => {
+            mockWebSocketClient.isConnected.mockReturnValue(true);
+
+            await manager.initializeClient(mockServerUrl, 'Cold Start');
+
+            expect(mockWebSocketClient.initialize).not.toHaveBeenCalled();
+            expect(handleFirstConnect).toHaveBeenCalledWith(mockServerUrl, 'Cold Start');
+        });
+
+        it('should return the same in-flight promise for concurrent initializeClient calls', async () => {
+            mockWebSocketClient.isConnected.mockReturnValue(false);
+            let release = () => {};
+            jest.mocked(handleFirstConnect).mockImplementation(() => new Promise((resolve) => {
+                release = () => resolve(undefined);
+            }));
+
+            const first = manager.initializeClient(mockServerUrl, 'Cold Start');
+            const second = manager.initializeClient(mockServerUrl, 'Login');
+
+            expect(second).toBe(first);
+            expect(handleFirstConnect).toHaveBeenCalledTimes(1);
+            expect(handleFirstConnect).toHaveBeenCalledWith(mockServerUrl, 'Cold Start');
+            expect(mockWebSocketClient.initialize).toHaveBeenCalledTimes(1);
+
+            release();
+            await Promise.all([first, second]);
+
+            expect(handleFirstConnect).toHaveBeenCalledTimes(1);
+        });
+
+        it('should allow initializeClient to sync again after invalidateClient', async () => {
+            mockWebSocketClient.isConnected.mockReturnValue(false);
+
+            await manager.initializeClient(mockServerUrl);
+            expect(handleFirstConnect).toHaveBeenCalledTimes(1);
+
+            await manager.invalidateClient(mockServerUrl);
+            await manager.createClient(mockServerUrl, mockToken);
+            mockWebSocketClient.isConnected.mockReturnValue(false);
+
+            await manager.initializeClient(mockServerUrl);
+            expect(handleFirstConnect).toHaveBeenCalledTimes(2);
         });
 
         it('should handle reconnect correctly', async () => {

--- a/app/managers/websocket_manager.ts
+++ b/app/managers/websocket_manager.ts
@@ -15,6 +15,7 @@ import {hasActiveNativeCall} from '@calls/native_call_mappings';
 import WebSocketClient from '@client/websocket';
 import {General} from '@constants';
 import DatabaseManager from '@database/manager';
+import {launchMark} from '@init/launch_profiler';
 import {getCurrentUserId} from '@queries/servers/system';
 import {queryAllUsers} from '@queries/servers/user';
 import {toMilliseconds} from '@utils/datetime';
@@ -36,6 +37,7 @@ class WebsocketManagerSingleton {
     private statusUpdatesIntervalIDs: Record<string, NodeJS.Timeout> = {};
     private backgroundTimerId: ReturnType<typeof BackgroundTimer.setTimeout> | undefined;
     private firstConnectionSynced: Record<string, boolean> = {};
+    private initializingClients = new Map<string, Promise<void>>();
 
     private appStateSubscription: NativeEventSubscription | undefined;
     private netStateSubscription: NetInfoSubscription | undefined;
@@ -77,6 +79,7 @@ class WebsocketManagerSingleton {
         delete this.connectionTimerIDs[serverUrl];
         delete this.clients[serverUrl];
         delete this.firstConnectionSynced[serverUrl];
+        this.initializingClients.delete(serverUrl);
         this.stopPeriodicStatusUpdates(serverUrl);
 
         if (client) {
@@ -135,7 +138,9 @@ class WebsocketManagerSingleton {
             } else {
                 queued += 1;
                 this.getConnectedSubject(clientUrl).next('connecting');
-                this.connectionTimerIDs[clientUrl] = setTimeout(() => this.initializeClient(clientUrl, groupLabel), WAIT_UNTIL_NEXT * queued);
+                this.connectionTimerIDs[clientUrl] = setTimeout(() => {
+                    this.initializeClient(clientUrl, groupLabel);
+                }, WAIT_UNTIL_NEXT * queued);
             }
         }
     };
@@ -165,28 +170,63 @@ class WebsocketManagerSingleton {
         }
     };
 
-    public initializeClient = async (serverUrl: string, groupLabel: BaseRequestGroupLabel = 'WebSocket Reconnect') => {
+    public initializeClient = (
+        serverUrl: string,
+        groupLabel: BaseRequestGroupLabel = 'WebSocket Reconnect',
+        opts?: {skipConfigWait?: boolean},
+    ): Promise<void> => {
+        const existing = this.initializingClients.get(serverUrl);
+        if (existing) {
+            return existing;
+        }
+
+        const promise = this.runInitializeClient(serverUrl, groupLabel, opts);
+        this.initializingClients.set(serverUrl, promise);
+        promise.finally(() => {
+            if (this.initializingClients.get(serverUrl) === promise) {
+                this.initializingClients.delete(serverUrl);
+            }
+        }).then(undefined, (error) => {
+            logDebug('WebsocketManager.initializeClient', error);
+        });
+        return promise;
+    };
+
+    private runInitializeClient = async (
+        serverUrl: string,
+        groupLabel: BaseRequestGroupLabel,
+        opts?: {skipConfigWait?: boolean},
+    ) => {
         const client = this.clients[serverUrl];
         clearTimeout(this.connectionTimerIDs[serverUrl]);
         delete this.connectionTimerIDs[serverUrl];
         if (!client) {
             return;
         }
-        if (!client.isConnected()) {
-            const hasSynced = this.firstConnectionSynced[serverUrl];
-            client.initialize({}, !hasSynced);
-            if (!hasSynced) {
-                const error = await handleFirstConnect(serverUrl, groupLabel);
-                if (error) {
-                    // This will try to reconnect and try to sync again
-                    client.close(false);
-                }
 
-                // Makes sure a client still exist, and therefore we haven't been logged out
-                if (this.clients[serverUrl]) {
-                    this.firstConnectionSynced[serverUrl] = true;
+        if (!this.firstConnectionSynced[serverUrl]) {
+            if (!client.isConnected()) {
+                client.initialize({skipConfigWait: Boolean(opts?.skipConfigWait)}, true);
+                if (opts?.skipConfigWait) {
+                    launchMark('ws_connecting');
                 }
             }
+
+            const error = await handleFirstConnect(serverUrl, groupLabel);
+            if (error) {
+                // This will try to reconnect and try to sync again
+                client.close(false);
+            }
+
+            // Makes sure a client still exist, and therefore we haven't been logged out
+            if (this.clients[serverUrl]) {
+                this.firstConnectionSynced[serverUrl] = true;
+            }
+            return;
+        }
+
+        if (!client.isConnected()) {
+            client.initialize({}, false);
         }
     };
 


### PR DESCRIPTION
#### Summary
Kick WebSocket TCP from cold-start entry without waiting on SQLite `WebsocketURL` or `getInitialURL` / `getInitialNotification`. Icon launches connect immediately; notification/deeplink handling is a late route correction.

`initializeClient` is the single connection entry point (in-flight promise map). `skipConfigWait` only skips the first config read and does not force reliable-WS or leak into retries.

On a Galaxy S25 Ultra debug build (Metro connected, force-stop cold start until Home channel rows): **14.6s → 14.4s (~0s to first paint)**. Time-to-live socket is earlier; Home rows were already unblocked by the keystore layer below this PR.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W (Galaxy S25 Ultra), Android 16

#### Release Note
```release-note
Started the WebSocket connection earlier on Android cold start so the client is live sooner after launch.
```

Made with [Cursor](https://cursor.com)