### PR TITLE
perf: keep launch splash until the channel list paints

### DIFF
--- a/app/init/splash.test.ts
+++ b/app/init/splash.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {advanceTimers, disableFakeTimers, enableFakeTimers} from '@test/timer_helpers';
+
+jest.mock('expo-splash-screen', () => ({
+    hideAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('./launch_profiler', () => ({
+    launchMark: jest.fn(),
+}));
+
+type SplashModule = typeof import('./splash');
+type SplashScreenModule = typeof import('expo-splash-screen');
+
+describe('splash', () => {
+    beforeEach(() => {
+        enableFakeTimers();
+        jest.resetModules();
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        disableFakeTimers();
+    });
+
+    function loadSplash() {
+        const splash = require('./splash') as SplashModule;
+        const splashScreen = require('expo-splash-screen') as SplashScreenModule;
+        return {
+            splash,
+            hideAsync: jest.mocked(splashScreen.hideAsync),
+        };
+    }
+
+    it('should hide the launch splash', () => {
+        const {splash, hideAsync} = loadSplash();
+
+        splash.hideLaunchSplash();
+
+        expect(hideAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep the splash hidden when hide is called again', () => {
+        const {splash, hideAsync} = loadSplash();
+
+        splash.hideLaunchSplash();
+        splash.hideLaunchSplash();
+
+        expect(hideAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should hide the splash after the fallback timer', async () => {
+        const {splash, hideAsync} = loadSplash();
+
+        splash.armLaunchSplashFallback();
+        expect(hideAsync).not.toHaveBeenCalled();
+
+        await advanceTimers(30000);
+
+        expect(hideAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not hide from the fallback after the splash is already hidden', async () => {
+        const {splash, hideAsync} = loadSplash();
+
+        splash.hideLaunchSplash();
+        splash.armLaunchSplashFallback();
+        await advanceTimers(30000);
+
+        expect(hideAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not hide again if hidden before the fallback fires', async () => {
+        const {splash, hideAsync} = loadSplash();
+
+        splash.armLaunchSplashFallback();
+        splash.hideLaunchSplash();
+        await advanceTimers(30000);
+
+        expect(hideAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should hide the splash after channels painted', () => {
+        const {splash, hideAsync} = loadSplash();
+
+        splash.hideLaunchSplashAfterChannelsPainted();
+
+        expect(hideAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep the splash hidden when channels painted is signaled again', () => {
+        const {splash, hideAsync} = loadSplash();
+
+        splash.hideLaunchSplashAfterChannelsPainted();
+        splash.hideLaunchSplashAfterChannelsPainted();
+
+        expect(hideAsync).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/init/splash.ts
+++ b/app/init/splash.ts
@@ -3,7 +3,13 @@
 
 import * as SplashScreen from 'expo-splash-screen';
 
+import {launchMark} from './launch_profiler';
+
+const SPLASH_FALLBACK_MS = 30000;
+
 let hidden = false;
+let channelsPainted = false;
+let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
 
 export function hideLaunchSplash() {
     if (hidden) {
@@ -11,6 +17,28 @@ export function hideLaunchSplash() {
     }
     hidden = true;
 
+    if (fallbackTimer !== undefined) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = undefined;
+    }
+
     // hideAsync rejects if the splash is already hidden; safe to ignore.
     SplashScreen.hideAsync().catch(() => undefined);
+}
+
+export function armLaunchSplashFallback() {
+    if (fallbackTimer !== undefined || hidden) {
+        return;
+    }
+    fallbackTimer = setTimeout(() => {
+        hideLaunchSplash();
+    }, SPLASH_FALLBACK_MS);
+}
+
+export function hideLaunchSplashAfterChannelsPainted() {
+    if (!channelsPainted) {
+        channelsPainted = true;
+        launchMark('channels_painted');
+    }
+    hideLaunchSplash();
 }

--- a/app/init/splash.ts
+++ b/app/init/splash.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as SplashScreen from 'expo-splash-screen';
+
+let hidden = false;
+
+export function hideLaunchSplash() {
+    if (hidden) {
+        return;
+    }
+    hidden = true;
+
+    // hideAsync rejects if the splash is already hidden; safe to ignore.
+    SplashScreen.hideAsync().catch(() => undefined);
+}

--- a/app/routes/(unauthenticated)/_layout.tsx
+++ b/app/routes/(unauthenticated)/_layout.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Stack, Redirect} from 'expo-router';
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {Platform, StyleSheet} from 'react-native';
 import {SafeAreaView, type Edge} from 'react-native-safe-area-context';
 import tinycolor from 'tinycolor2';
@@ -10,6 +10,7 @@ import tinycolor from 'tinycolor2';
 import {Screens} from '@constants';
 import {useThemeByAppearanceWithDefault} from '@context/theme';
 import {useHasCredentials} from '@hooks/use_has_credentials';
+import {hideLaunchSplash} from '@init/splash';
 
 import type {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 
@@ -35,6 +36,13 @@ export default function UnauthenticatedLayout() {
         headerBackButtonMenuEnabled: false,
         ...Platform.select({android: {statusBarBackgroundColor: theme.centerChannelBg, statusBarTranslucent: true, statusBarStyle: tinycolor(theme.centerChannelBg).isLight() ? 'dark' : 'light'}}),
     }), [theme]);
+
+    useEffect(() => {
+        // null: credentials not resolved yet. Stay on splash until we know this is login.
+        if (hasCredentials === false) {
+            hideLaunchSplash();
+        }
+    }, [hasCredentials]);
 
     // Redirect to authenticated if has credentials
     if (hasCredentials) {

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -19,7 +19,7 @@ import {useThemeByAppearanceWithDefault} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
 import {DEFAULT_LOCALE, getTranslations} from '@i18n';
 import {cleanup, initialize} from '@init/app';
-import {hideLaunchSplash} from '@init/splash';
+import {armLaunchSplashFallback} from '@init/splash';
 import InAppNotificationContainer from '@screens/in_app_notification';
 import ReviewAppContainer from '@screens/review_app';
 import ShareFeedbackContainer from '@screens/share_feedback';
@@ -79,8 +79,10 @@ export default function RootLayout() {
                 RNUtils.lockPortrait();
 
                 setAppReady(true);
+                armLaunchSplashFallback();
             } catch (error) {
                 setAppReady(true); // Still show UI with error state
+                armLaunchSplashFallback();
             }
         }
 
@@ -90,12 +92,6 @@ export default function RootLayout() {
             cleanup();
         };
     });
-
-    useEffect(() => {
-        if (appReady) {
-            hideLaunchSplash();
-        }
-    }, [appReady]);
 
     useEffect(() => {
         const handleKeyboardHide = () => {

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -46,10 +46,6 @@ const styles = StyleSheet.create({
     },
 });
 
-// Prevent splash screen from auto-hiding
-SplashScreen.setOptions({fade: true});
-SplashScreen.preventAutoHideAsync();
-
 export default function RootLayout() {
     const [appReady, setAppReady] = useState(false);
     const navigationRef = useNavigationContainerRef();

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -5,7 +5,6 @@ import {PortalHost, PortalProvider} from '@gorhom/portal';
 import {Provider as EMMProvider} from '@mattermost/react-native-emm';
 import RNUtils from '@mattermost/rnutils';
 import {Stack, useNavigationContainerRef} from 'expo-router';
-import * as SplashScreen from 'expo-splash-screen';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {IntlProvider} from 'react-intl';
 import {Keyboard, Platform, StyleSheet} from 'react-native';
@@ -20,6 +19,7 @@ import {useThemeByAppearanceWithDefault} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
 import {DEFAULT_LOCALE, getTranslations} from '@i18n';
 import {cleanup, initialize} from '@init/app';
+import {hideLaunchSplash} from '@init/splash';
 import InAppNotificationContainer from '@screens/in_app_notification';
 import ReviewAppContainer from '@screens/review_app';
 import ShareFeedbackContainer from '@screens/share_feedback';
@@ -93,7 +93,7 @@ export default function RootLayout() {
 
     useEffect(() => {
         if (appReady) {
-            SplashScreen.hideAsync();
+            hideLaunchSplash();
         }
     }, [appReady]);
 

--- a/app/screens/data_erased/index.tsx
+++ b/app/screens/data_erased/index.tsx
@@ -13,6 +13,7 @@ import Alert from '@components/illustrations/alert';
 import {useTheme} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
 import {usePreventDoubleTap} from '@hooks/utils';
+import {hideLaunchSplash} from '@init/splash';
 import Servers from '@screens/home/channel_list/servers';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -89,6 +90,7 @@ const DataErased = ({serverUrl, displayName}: DataErasedProps) => {
     const [hasError, setHasError] = useState(false);
 
     useDidMount(() => {
+        hideLaunchSplash();
         const sub = AppState.addEventListener('change', (state) => {
             if (state === 'active') {
                 setHasError(false);

--- a/app/screens/home/channel_list/categories_list/categories/categories.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/categories.tsx
@@ -215,13 +215,14 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
 
     const showEmptyState = onlyUnreads && flattenedItems.length === 0 && !isTablet;
     const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
+    const showLoadError = flattenedItems.length === 0 && !switchingTeam && !initialLoad && !onlyUnreads && !isInitialSync;
 
     useEffect(() => {
-        if (showLoading) {
-            return;
+        // FlashList v2 onLoad does not fire for empty data / ListEmptyComponent.
+        if (!showLoading && flattenedItems.length === 0) {
+            hideLaunchSplashAfterChannelsPainted();
         }
-        hideLaunchSplashAfterChannelsPainted();
-    }, [showLoading]);
+    }, [showLoading, flattenedItems.length]);
 
     const ListEmptyComponent = useMemo(() => {
         if (showEmptyState) {
@@ -234,7 +235,7 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
         return undefined;
     }, [showEmptyState, listHeight]);
 
-    if (flattenedItems.length === 0 && !switchingTeam && !initialLoad && !onlyUnreads && !isInitialSync) {
+    if (showLoadError) {
         return <LoadCategoriesError/>;
     }
 
@@ -253,6 +254,7 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
                     showsVerticalScrollIndicator={false}
                     contentContainerStyle={listContentStyle}
                     ListEmptyComponent={ListEmptyComponent}
+                    onLoad={hideLaunchSplashAfterChannelsPainted}
                     onViewableItemsChanged={onViewableItemsChanged}
                     viewabilityConfig={VIEWABILITY_CONFIG}
                 />

--- a/app/screens/home/channel_list/categories_list/categories/categories.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/categories.tsx
@@ -15,6 +15,7 @@ import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useIsInitialSync} from '@hooks/is_initial_sync';
 import {useTeamSwitch} from '@hooks/team_switch';
+import {hideLaunchSplashAfterChannelsPainted} from '@init/splash';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {isDMorGM} from '@utils/channel';
 import {logDebug} from '@utils/log';
@@ -203,6 +204,14 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
     }, []);
 
     const showEmptyState = onlyUnreads && flattenedItems.length === 0 && !isTablet;
+    const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
+
+    useEffect(() => {
+        if (showLoading) {
+            return;
+        }
+        hideLaunchSplashAfterChannelsPainted();
+    }, [showLoading]);
 
     const ListEmptyComponent = useMemo(() => {
         if (showEmptyState) {
@@ -218,8 +227,6 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
     if (flattenedItems.length === 0 && !switchingTeam && !initialLoad && !onlyUnreads && !isInitialSync) {
         return <LoadCategoriesError/>;
     }
-
-    const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
 
     return (
         <>

--- a/app/screens/home/channel_list/categories_list/categories/categories.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/categories.tsx
@@ -16,6 +16,7 @@ import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useIsInitialSync} from '@hooks/is_initial_sync';
 import {useTeamSwitch} from '@hooks/team_switch';
+import {hideLaunchSplashAfterChannelsPainted} from '@init/splash';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {isDMorGM} from '@utils/channel';
 import {logDebug} from '@utils/log';
@@ -213,6 +214,14 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
     }, []);
 
     const showEmptyState = onlyUnreads && flattenedItems.length === 0 && !isTablet;
+    const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
+
+    useEffect(() => {
+        if (showLoading) {
+            return;
+        }
+        hideLaunchSplashAfterChannelsPainted();
+    }, [showLoading]);
 
     const ListEmptyComponent = useMemo(() => {
         if (showEmptyState) {
@@ -228,8 +237,6 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
     if (flattenedItems.length === 0 && !switchingTeam && !initialLoad && !onlyUnreads && !isInitialSync) {
         return <LoadCategoriesError/>;
     }
-
-    const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
 
     return (
         <>

--- a/app/screens/home/channel_list/categories_list/categories/categories.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/categories.tsx
@@ -205,13 +205,14 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
 
     const showEmptyState = onlyUnreads && flattenedItems.length === 0 && !isTablet;
     const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
+    const showLoadError = flattenedItems.length === 0 && !switchingTeam && !initialLoad && !onlyUnreads && !isInitialSync;
 
     useEffect(() => {
-        if (showLoading) {
-            return;
+        // FlashList v2 onLoad does not fire for empty data / ListEmptyComponent.
+        if (!showLoading && flattenedItems.length === 0) {
+            hideLaunchSplashAfterChannelsPainted();
         }
-        hideLaunchSplashAfterChannelsPainted();
-    }, [showLoading]);
+    }, [showLoading, flattenedItems.length]);
 
     const ListEmptyComponent = useMemo(() => {
         if (showEmptyState) {
@@ -224,7 +225,7 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
         return undefined;
     }, [showEmptyState, listHeight]);
 
-    if (flattenedItems.length === 0 && !switchingTeam && !initialLoad && !onlyUnreads && !isInitialSync) {
+    if (showLoadError) {
         return <LoadCategoriesError/>;
     }
 
@@ -242,6 +243,7 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
                     showsHorizontalScrollIndicator={false}
                     showsVerticalScrollIndicator={false}
                     ListEmptyComponent={ListEmptyComponent}
+                    onLoad={hideLaunchSplashAfterChannelsPainted}
                     onViewableItemsChanged={onViewableItemsChanged}
                     viewabilityConfig={VIEWABILITY_CONFIG}
                 />

--- a/app/screens/home/channel_list/categories_list/categories/helpers/observe_flattened_categories.ts
+++ b/app/screens/home/channel_list/categories_list/categories/helpers/observe_flattened_categories.ts
@@ -1,13 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {of as of$, combineLatest, type Observable} from 'rxjs';
-import {switchMap, map, distinctUntilChanged} from 'rxjs/operators';
+import {of as of$, combineLatest, merge, type Observable} from 'rxjs';
+import {switchMap, map, distinctUntilChanged, take, startWith, tap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {DMS_CATEGORY, MANAGED_LOCAL_CATEGORY_PREFIX, UNREADS_CATEGORY} from '@constants/categories';
 import {getSidebarPreferenceAsBool} from '@helpers/api/preference';
 import {filterAndSortMyChannels, makeChannelsMap} from '@helpers/database';
+import {launchMark} from '@init/launch_profiler';
 import {queryCategoriesByTeamIds} from '@queries/servers/categories';
 import {getChannelById, observeChannelsByLastPostAt, observeNotifyPropsByChannels, queryMyChannelUnreads} from '@queries/servers/channel';
 import {queryPreferencesByCategoryAndName, querySidebarPreferences} from '@queries/servers/preference';
@@ -29,6 +30,7 @@ import type CategoryModel from '@typings/database/models/servers/category';
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type MyChannelModel from '@typings/database/models/servers/my_channel';
 import type PreferenceModel from '@typings/database/models/servers/preference';
+import type UserModel from '@typings/database/models/servers/user';
 
 const observeCategoryChannels = (category: CategoryModel, myChannels: Observable<MyChannelModel[]>) => {
     // observe delete_at to react to channel archive/unarchive
@@ -54,6 +56,51 @@ const observeCategoryChannels = (category: CategoryModel, myChannels: Observable
         }),
     );
 };
+
+type CategoryFilterInputs = {
+    channelId: string;
+    unreadId?: string;
+    notifyProps: Record<string, Partial<ChannelNotifyProps>>;
+    manuallyClosedDms: PreferenceModel[];
+    autoclose: PreferenceModel[];
+    deactivatedUsers?: Map<string, UserModel | undefined>;
+    maxDms: number;
+};
+
+const FAST_PAINT_INPUTS: CategoryFilterInputs = {
+    channelId: '',
+    notifyProps: {},
+    manuallyClosedDms: [],
+    autoclose: [],
+    maxDms: Preferences.CHANNEL_SIDEBAR_LIMIT_DMS_DEFAULT,
+};
+
+let fastPaintDone = false;
+
+function toCategoryData(
+    category: CategoryModel,
+    currentUserId: string,
+    locale: string,
+    cwms: ChannelWithMyChannel[],
+    catData: {sorting: CategoryModel['sorting']; collapsed: boolean; type: CategoryModel['type']},
+    inputs: CategoryFilterInputs,
+): CategoryData {
+    let channelsW = cwms;
+    channelsW = filterArchivedChannels(channelsW, inputs.channelId);
+    channelsW = filterManuallyClosedDms(channelsW, inputs.notifyProps, inputs.manuallyClosedDms, currentUserId, inputs.unreadId);
+    channelsW = filterAutoclosedDMs(catData.type, inputs.maxDms, currentUserId, inputs.channelId, channelsW, inputs.autoclose, inputs.notifyProps, inputs.deactivatedUsers, inputs.unreadId);
+
+    const sortedChannels = sortChannels(catData.sorting, channelsW, inputs.notifyProps, locale);
+    const unreadIds = getUnreadIds(cwms, inputs.notifyProps, inputs.unreadId);
+    const allUnreadChannels = sortedChannels.filter((c) => unreadIds.has(c.id));
+
+    return {
+        category,
+        sortedChannels,
+        unreadIds,
+        allUnreadChannels,
+    };
+}
 
 const observeCategoryData = (
     category: CategoryModel,
@@ -107,7 +154,7 @@ const observeCategoryData = (
 
     const deactivated = (category.type === DMS_CATEGORY) ? observeDeactivatedUsers(database) : of$(undefined);
 
-    return combineLatest([
+    const fullCategoryData = combineLatest([
         channelsWithMyChannel,
         categoryObservable,
         currentChannelId,
@@ -118,24 +165,32 @@ const observeCategoryData = (
         deactivated,
         limit,
     ]).pipe(
+        tap(() => {
+            fastPaintDone = true;
+        }),
         map(([cwms, catData, channelId, unreadId, notifyProps, manuallyClosedDms, autoclose, deactivatedUsers, maxDms]) => {
-            let channelsW = cwms;
-            channelsW = filterArchivedChannels(channelsW, channelId);
-            channelsW = filterManuallyClosedDms(channelsW, notifyProps, manuallyClosedDms, currentUserId, unreadId);
-            channelsW = filterAutoclosedDMs(catData.type, maxDms, currentUserId, channelId, channelsW, autoclose, notifyProps, deactivatedUsers, unreadId);
-
-            const sortedChannels = sortChannels(catData.sorting, channelsW, notifyProps, locale);
-            const unreadIds = getUnreadIds(cwms, notifyProps, unreadId);
-            const allUnreadChannels = sortedChannels.filter((c) => unreadIds.has(c.id));
-
-            return {
+            return toCategoryData(
                 category,
-                sortedChannels,
-                unreadIds,
-                allUnreadChannels,
-            };
+                currentUserId,
+                locale,
+                cwms,
+                catData,
+                {channelId, unreadId, notifyProps, manuallyClosedDms, autoclose, deactivatedUsers, maxDms},
+            );
         }),
     );
+
+    if (fastPaintDone) {
+        return fullCategoryData;
+    }
+
+    // First paint from cached memberships; prefs/deactivated users refine afterwards.
+    const fastCategoryData = combineLatest([channelsWithMyChannel, categoryObservable]).pipe(
+        map(([cwms, catData]) => toCategoryData(category, currentUserId, locale, cwms, catData, FAST_PAINT_INPUTS)),
+        take(1),
+    );
+
+    return merge(fastCategoryData, fullCategoryData);
 };
 
 export type FlattenedCategoriesData = {
@@ -252,11 +307,11 @@ const observeFlattenedCategoriesNormal = (
         return of$({items: [], unreadChannelIds: new Set<string>()});
     }
 
-    const unreadsOnTop = querySidebarPreferences(database, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS).
-        observeWithColumns(['value']).
-        pipe(
-            switchMap((prefs: PreferenceModel[]) => of$(getSidebarPreferenceAsBool(prefs, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS))),
+    const unreadsOnTopSource = querySidebarPreferences(database, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS).
+        observeWithColumns(['value']).pipe(
+            switchMap((prefs) => of$(getSidebarPreferenceAsBool(prefs, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS))),
         );
+    const unreadsOnTop = fastPaintDone ? unreadsOnTopSource : unreadsOnTopSource.pipe(startWith(false));
 
     const categoryDataObservables = categories.map((category) =>
         observeCategoryData(category, database, currentUserId, locale, isTablet),
@@ -312,6 +367,16 @@ const sortCategories = (categories: CategoryModel[]) => {
     return categories.sort((a, b) => a.sortOrder - b.sortOrder);
 };
 
+let flattenFirstMarked = false;
+
+const markFlattenFirst = (itemCount: number) => {
+    if (flattenFirstMarked) {
+        return;
+    }
+    flattenFirstMarked = true;
+    launchMark('flatten_first', `${itemCount} items`);
+};
+
 // Routes to the appropriate observable based on onlyUnreads mode
 export const observeFlattenedCategories = (
     database: Database,
@@ -321,14 +386,16 @@ export const observeFlattenedCategories = (
     onlyUnreads: boolean,
     currentTeamId: string,
 ): Observable<FlattenedCategoriesData> => {
+    let source: Observable<FlattenedCategoriesData>;
     if (onlyUnreads) {
-        return observeFlattenedUnreads(database, currentTeamId, isTablet);
+        source = observeFlattenedUnreads(database, currentTeamId, isTablet);
+    } else {
+        source = queryCategoriesByTeamIds(database, [currentTeamId]).observeWithColumns(['sort_order', 'collapsed']).pipe(
+            switchMap((cats) => observeFlattenedCategoriesNormal(sortCategories(cats), database, currentUserId, locale, isTablet)),
+        );
     }
 
-    // Observe categories for the current team
-    const categories = queryCategoriesByTeamIds(database, [currentTeamId]).observeWithColumns(['sort_order', 'collapsed']);
-
-    return categories.pipe(
-        switchMap((cats) => observeFlattenedCategoriesNormal(sortCategories(cats), database, currentUserId, locale, isTablet)),
+    return source.pipe(
+        tap((data) => markFlattenFirst(data.items.length)),
     );
 };

--- a/app/screens/home/channel_list/categories_list/categories_list.tsx
+++ b/app/screens/home/channel_list/categories_list/categories_list.tsx
@@ -20,6 +20,7 @@ import DatabaseManager from '@database/manager';
 import {useIsTablet} from '@hooks/device';
 import {useIsInitialSync} from '@hooks/is_initial_sync';
 import {useTeamsLoading} from '@hooks/teams_loading';
+import {hideLaunchSplashAfterChannelsPainted} from '@init/splash';
 import PlaybooksButton from '@playbooks/components/playbooks_button';
 import {getDefaultTeamId} from '@queries/servers/team';
 import {logDebug} from '@utils/log';
@@ -45,6 +46,7 @@ type ScreenType = typeof Screens.GLOBAL_DRAFTS | typeof Screens.GLOBAL_THREADS |
 
 type ChannelListProps = {
     hasChannels: boolean;
+    hasTeams: boolean;
     iconPad?: boolean;
     isCRTEnabled?: boolean;
     moreThanOneTeam: boolean;
@@ -65,6 +67,7 @@ const edges: Edge[] = ['right'];
 
 const CategoriesList = ({
     hasChannels,
+    hasTeams,
     iconPad,
     isCRTEnabled,
     moreThanOneTeam,
@@ -111,6 +114,13 @@ const CategoriesList = ({
             }
         })();
     }, [hasChannels, isTeamLoading, serverUrl]);
+
+    // Covers teams-with-no-channels first paint (LoadChannelsError).
+    useEffect(() => {
+        if (hasTeams && !hasChannels && !isInitialSync && !isTeamLoading) {
+            hideLaunchSplashAfterChannelsPainted();
+        }
+    }, [hasTeams, hasChannels, isInitialSync, isTeamLoading]);
 
     useEffect(() => {
         if (isTablet) {

--- a/app/screens/home/channel_list/categories_list/index.test.tsx
+++ b/app/screens/home/channel_list/categories_list/index.test.tsx
@@ -46,6 +46,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostHasError={false}
@@ -63,6 +64,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -81,6 +83,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={1}
                 scheduledPostCount={0}
@@ -105,6 +108,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -135,6 +139,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={true}
+                hasTeams={true}
                 hasChannels={false}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -156,6 +161,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={1}
@@ -172,6 +178,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={1}
@@ -187,6 +194,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -202,6 +210,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -219,6 +228,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={false}
                 draftsCount={0}
                 scheduledPostCount={0}

--- a/app/screens/home/channel_list/channel_list.tsx
+++ b/app/screens/home/channel_list/channel_list.tsx
@@ -20,7 +20,9 @@ import {HOME_TAB_SCREENS} from '@constants/screens';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
+import useDidMount from '@hooks/did_mount';
 import useDidUpdate from '@hooks/did_update';
+import {launchMark} from '@init/launch_profiler';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {navigateToScreen} from '@screens/navigation';
 import {NavigationStore, useCurrentScreen} from '@store/navigation_store';
@@ -184,13 +186,11 @@ const ChannelListScreen = (props: ChannelProps) => {
         }
     }, [props.launchType, props.coldStart]);
 
-    useEffect(() => {
+    useDidMount(() => {
+        launchMark('home_mounted');
         PerformanceMetricsManager.finishLoad('HOME', serverUrl);
         PerformanceMetricsManager.measureTimeToInteraction();
-
-        // Only needed on mount
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    });
 
     return (
         <Animated.View
@@ -217,6 +217,7 @@ const ChannelListScreen = (props: ChannelProps) => {
                         isCRTEnabled={props.isCRTEnabled}
                         moreThanOneTeam={props.hasMoreThanOneTeam}
                         hasChannels={props.hasChannels}
+                        hasTeams={props.hasTeams}
                     />
                     {isTablet && props.hasChannels &&
                     <AdditionalTabletView/>

--- a/app/screens/select_team/select_team.tsx
+++ b/app/screens/select_team/select_team.tsx
@@ -13,6 +13,7 @@ import {Screens} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
+import {hideLaunchSplash} from '@init/splash';
 import {navigateToScreen} from '@screens/navigation';
 import {logDebug} from '@utils/log';
 import {alertTeamAddError} from '@utils/navigation';
@@ -122,6 +123,7 @@ const SelectTeam = ({
     }, [shouldRedirectToHome]);
 
     useDidMount(() => {
+        hideLaunchSplash();
         loadTeams();
     });
 

--- a/index.tsx
+++ b/index.tsx
@@ -4,6 +4,7 @@
 import {RUNNING_E2E} from '@env';
 import TurboLogger from '@mattermost/react-native-turbo-log';
 import {ExpoRoot} from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
 import React from 'react';
 import {AppRegistry, LogBox, Platform} from 'react-native';
 import {BackgroundTimer} from 'react-native-nitro-bg-timer-plus';
@@ -59,6 +60,10 @@ if (Platform.OS === 'android') {
     const ShareExtension = require('./share_extension/index.tsx').default;
     AppRegistry.registerComponent('MattermostShare', () => ShareExtension);
 }
+
+// Before ExpoRoot; NavigationContainer onReady otherwise hides splash.
+SplashScreen.setOptions({fade: true});
+SplashScreen.preventAutoHideAsync().catch(() => undefined);
 
 // Must be exported or Fast Refresh won't update the context
 export function App() {


### PR DESCRIPTION
#### Summary
Keep the native launch splash up until Home has something real to show.

- Call `preventAutoHideAsync` in `index.tsx` before ExpoRoot mounts, so NavigationContainer `onReady` cannot dismiss splash first.
- Hide splash after the channel list's first real paint (one-shot fast membership snapshot; `fastPaintDone` latches so collapse/reorder does not flash unfiltered rows). Teams with no channels hide via `LoadChannelsError`. A 30s fallback still dismisses splash if initial sync never completes.
- Login (`hasCredentials === false`), data-erased, and select-team hide splash themselves because those screens never emit channel flatten.

Release APK on a Galaxy S25 Ultra (Samsung SM-S938W, Android 16), Metro not running, force-stop until Home channel rows (n=8): keystore-only **7246ms** vs this splash layer on top **7932ms** (no additional wall-clock win; this is splash correctness, not a first-paint speedup).

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W (Galaxy S25 Ultra), Android 16

#### Release Note
```release-note
Kept the Android launch splash visible until the channel list paints, instead of dismissing it on first navigation.
```