### PR TITLE
perf: emit default locale before user record loads

### DIFF
--- a/app/context/user_locale/index.tsx
+++ b/app/context/user_locale/index.tsx
@@ -4,8 +4,7 @@
 import {withObservables} from '@nozbe/watermelondb/react';
 import React, {type ComponentType, createContext} from 'react';
 import {IntlProvider} from 'react-intl';
-import {of as of$} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {distinctUntilChanged, map, startWith} from 'rxjs';
 
 import {DEFAULT_LOCALE, getTranslations} from '@i18n';
 import {observeCurrentUser} from '@queries/servers/user';
@@ -61,7 +60,9 @@ export function useUserLocale(): string {
 
 const enhancedThemeProvider = withObservables([], ({database}: {database: Database}) => ({
     locale: observeCurrentUser(database).pipe(
-        switchMap((user) => of$(user?.locale || DEFAULT_LOCALE)),
+        map((user) => user?.locale || DEFAULT_LOCALE),
+        startWith(DEFAULT_LOCALE),
+        distinctUntilChanged(),
     ),
 }));
 


### PR DESCRIPTION
#### Summary
Emit `DEFAULT_LOCALE` immediately from the user-locale observable so `IntlProvider` can mount without waiting for `observeCurrentUser`. Skip identical re-emissions with `distinctUntilChanged` so users already on the default locale do not re-render the provider tree when the user record arrives.

Stacked on #10060.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **17.2s → 15.3s** (~2s). Metro variance is high; treat as directional.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```