### PR TITLE
perf: seed withServerDatabase from the session cache

### DIFF
--- a/app/database/components/index.tsx
+++ b/app/database/components/index.tsx
@@ -10,22 +10,25 @@ import ThemeProvider from '@context/theme';
 import UserLocaleProvider from '@context/user_locale';
 import DatabaseManager from '@database/manager';
 import {subscribeActiveServers} from '@database/subscription/servers';
+import {getCachedActiveServer, setCachedActiveServer, type CachedActiveServer} from '@init/session_cache';
 import {secureGetFromRecord} from '@utils/types';
 
 import type {Database} from '@nozbe/watermelondb';
-import type {PersistenceFlag} from '@typings/database/models/app/servers';
 import type ServersModel from '@typings/database/models/app/servers';
 
-type State = {
-    database: Database;
-    serverUrl: string;
-    serverDisplayName: string;
-    persistenceFlag: PersistenceFlag;
-};
+type State = { database: Database; server: CachedActiveServer };
+
+function toState(server: CachedActiveServer): State | undefined {
+    const database = secureGetFromRecord(DatabaseManager.serverDatabases, server.url)?.database;
+    return database ? {database, server} : undefined;
+}
 
 export function withServerDatabase<T extends React.JSX.IntrinsicAttributes>(Component: ComponentType<T>): ComponentType<T> {
     return function ServerDatabaseComponent(props: T) {
-        const [state, setState] = useState<State | undefined>();
+        const [state, setState] = useState<State | undefined>(() => {
+            const cached = getCachedActiveServer();
+            return cached && toState(cached);
+        });
 
         const observer = (servers: ServersModel[]) => {
             const server = servers?.length ? servers.reduce((a, b) =>
@@ -33,18 +36,18 @@ export function withServerDatabase<T extends React.JSX.IntrinsicAttributes>(Comp
             ) : undefined;
 
             if (server) {
-                const database =
-                    secureGetFromRecord(DatabaseManager.serverDatabases, server.url)?.database;
-
-                if (database) {
-                    setState({
-                        database,
-                        serverUrl: server.url,
-                        serverDisplayName: server.displayName,
-                        persistenceFlag: server.persistenceFlag,
-                    });
+                const active: CachedActiveServer = {
+                    url: server.url,
+                    displayName: server.displayName,
+                    persistenceFlag: server.persistenceFlag,
+                };
+                setCachedActiveServer(active);
+                const next = toState(active);
+                if (next) {
+                    setState(next);
                 }
             } else {
+                setCachedActiveServer(undefined);
                 setState(undefined);
             }
         };
@@ -64,7 +67,7 @@ export function withServerDatabase<T extends React.JSX.IntrinsicAttributes>(Comp
         // Flip the key when the adapter changes (on-disk ↔ in-memory) so React unmounts and
         // remounts the subtree; withObservables uses empty triggerProps and only binds to the
         // database at mount, so without a remount it would stay subscribed to the dropped instance.
-        const dbKey = state.persistenceFlag === 'zero-persistence' ? `${state.serverUrl}.mem` : state.serverUrl;
+        const dbKey = state.server.persistenceFlag === 'zero-persistence' ? `${state.server.url}.mem` : state.server.url;
 
         return (
             <DatabaseProvider
@@ -73,7 +76,7 @@ export function withServerDatabase<T extends React.JSX.IntrinsicAttributes>(Comp
             >
                 <DeviceInfoProvider>
                     <UserLocaleProvider database={state.database}>
-                        <ServerProvider server={{displayName: state.serverDisplayName, url: state.serverUrl}}>
+                        <ServerProvider server={{displayName: state.server.displayName, url: state.server.url}}>
                             <ThemeProvider database={state.database}>
                                 <Component {...props}/>
                             </ThemeProvider>


### PR DESCRIPTION
#### Summary
Seed `withServerDatabase` from the in-memory active-server cache set during `initialize()`, so Home can mount before `subscribeActiveServers` emits. Seed and observer share a `toState` helper that looks up the WatermelonDB instance from `CachedActiveServer`. The observer still writes the cache; moving that to the subscription layer is a follow-up.

Stacked on #10061.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **15.1s → 15.7s** (~0s, within Metro noise). This unblocks later layers that assume the server database is already available on first paint.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```