### PR TITLE
perf: seed useHasCredentials from the in-memory cache

### DIFF
--- a/app/hooks/use_has_credentials.test.ts
+++ b/app/hooks/use_has_credentials.test.ts
@@ -4,15 +4,17 @@
 import {renderHook, waitFor} from '@testing-library/react-native';
 
 import {useHasCredentials} from '@hooks/use_has_credentials';
-import {getAllServerCredentials} from '@init/credentials';
+import {getAllServerCredentials, hasCachedCredentials} from '@init/credentials';
 
 jest.mock('@init/credentials');
 
 const mockGetAllServerCredentials = jest.mocked(getAllServerCredentials);
+const mockHasCachedCredentials = jest.mocked(hasCachedCredentials);
 
 describe('useHasCredentials', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockHasCachedCredentials.mockReturnValue(null);
     });
 
     it('should return null initially before credentials are loaded', () => {
@@ -97,5 +99,14 @@ describe('useHasCredentials', () => {
 
         // Should still only have called once
         expect(mockGetAllServerCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return cached credentials immediately without waiting on keychain', async () => {
+        mockHasCachedCredentials.mockReturnValue(true);
+        mockGetAllServerCredentials.mockResolvedValue([{serverUrl: 'https://server1.com', userId: 'user1', token: 'token1'}]);
+
+        const {result} = renderHook(() => useHasCredentials());
+
+        expect(result.current).toBe(true);
     });
 });

--- a/app/hooks/use_has_credentials.ts
+++ b/app/hooks/use_has_credentials.ts
@@ -4,11 +4,11 @@
 import {useState} from 'react';
 
 import useDidMount from '@hooks/did_mount';
-import {getAllServerCredentials} from '@init/credentials';
+import {getAllServerCredentials, hasCachedCredentials} from '@init/credentials';
 import {logError} from '@utils/log';
 
 export function useHasCredentials(): boolean | null {
-    const [hasCredentials, setHasCredentials] = useState<boolean | null>(null);
+    const [hasCredentials, setHasCredentials] = useState<boolean | null>(() => hasCachedCredentials());
 
     useDidMount(() => {
         let mounted = true;


### PR DESCRIPTION
#### Summary
Seed `useHasCredentials` from `hasCachedCredentials()` so routing does not wait on a `null` first frame. The mount effect still calls `getAllServerCredentials()` so a cache that fills between first render and mount cannot stick at `null`; a warm cache is a memory hit and React bails out if the boolean is unchanged.

Stacked on #10062.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **18.9s → 14.2s**. The baseline was a noisy outlier (~15s typical on this stack); treat the delta as directional.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```