### PR TITLE
perf: drop withServerDatabase from the snackbar overlay

### DIFF
--- a/app/screens/snack_bar/index.tsx
+++ b/app/screens/snack_bar/index.tsx
@@ -8,20 +8,31 @@ import {DeviceEventEmitter} from 'react-native';
 import {FullWindowOverlay} from 'react-native-screens';
 
 import {Navigation} from '@constants';
-import {withServerDatabase} from '@database/components';
+import DeviceInfoProvider from '@context/device';
+import {CustomThemeProvider} from '@context/theme';
+import UserLocaleProvider from '@context/user_locale';
+import DatabaseManager from '@database/manager';
 import useDidMount from '@hooks/did_mount';
+import {getCachedActiveServer} from '@init/session_cache';
+import EphemeralStore from '@store/ephemeral_store';
 import SnackBarStore from '@store/snackbar_store';
+import {secureGetFromRecord} from '@utils/types';
 
 import SnackBar from './snack_bar';
 
 function SnackBarContainer() {
-    const [state, setState] = useState(SnackBarStore.getState());
+    const [state, setState] = useState(() => SnackBarStore.getState());
+    const [theme, setTheme] = useState(() => EphemeralStore.getTheme());
     const pathname = usePathname();
 
     // Subscribe to store changes
     useDidMount(() => {
         const sub = SnackBarStore.observe().subscribe(setState);
-        return () => sub.unsubscribe();
+        const themeSub = EphemeralStore.observeTheme().subscribe(setTheme);
+        return () => {
+            sub.unsubscribe();
+            themeSub.unsubscribe();
+        };
     });
 
     // Auto-dismiss on navigation changes
@@ -55,16 +66,29 @@ function SnackBarContainer() {
         return null;
     }
 
+    const cached = getCachedActiveServer();
+    const database = cached ? secureGetFromRecord(DatabaseManager.serverDatabases, cached.url)?.database : undefined;
+
+    let tree = (
+        <CustomThemeProvider theme={theme}>
+            <Portal hostName='snack_bar'>
+                <FullWindowOverlay>
+                    <SnackBar
+                        {...state.config}
+                        onDismiss={SnackBarStore.dismiss}
+                    />
+                </FullWindowOverlay>
+            </Portal>
+        </CustomThemeProvider>
+    );
+    if (database) {
+        tree = <UserLocaleProvider database={database}>{tree}</UserLocaleProvider>;
+    }
     return (
-        <Portal hostName='snack_bar'>
-            <FullWindowOverlay>
-                <SnackBar
-                    {...state.config}
-                    onDismiss={SnackBarStore.dismiss}
-                />
-            </FullWindowOverlay>
-        </Portal>
+        <DeviceInfoProvider>
+            {tree}
+        </DeviceInfoProvider>
     );
 }
 
-export default withServerDatabase(SnackBarContainer);
+export default SnackBarContainer;


### PR DESCRIPTION
#### Summary
Stop wrapping the root snackbar overlay in `withServerDatabase`, which after the session-cache seed was mounting a second Device/Locale/Server/Theme tree on every launch even when no snackbar is shown. Theme comes from `EphemeralStore`. When a snackbar is visible, wrap with `DeviceInfoProvider` and `UserLocaleProvider` from the cached server database so tablet split-view and non-English copy still work.

Stacked on #10063.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **14.2s → 14.3s** (~0s, within noise). The win is removing a duplicate provider tree on the launch path, not first-paint wall clock.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```