### PR TITLE
perf: seed Home chrome observables without gating first paint

### DIFF
--- a/app/components/global_classification_banner/index.ts
+++ b/app/components/global_classification_banner/index.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 import {observeClassificationBannerState} from '@queries/servers/properties';
 import {observeConfigBooleanValue} from '@queries/servers/system';
@@ -12,12 +12,14 @@ import GlobalClassificationBannerContainer, {GLOBAL_BANNER_PORTAL_HOST} from './
 import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
-    const state$ = observeClassificationBannerState(database);
+    const state$ = observeClassificationBannerState(database).pipe(
+        startWith({visible: false, levelName: '', color: ''}),
+    );
     return {
         visible: state$.pipe(map((s) => s.visible)),
         levelName: state$.pipe(map((s) => s.levelName)),
         color: state$.pipe(map((s) => s.color)),
-        classificationEnabled: observeConfigBooleanValue(database, 'FeatureFlagClassificationMarkings'),
+        classificationEnabled: observeConfigBooleanValue(database, 'FeatureFlagClassificationMarkings').pipe(startWith(false)),
     };
 });
 

--- a/app/context/theme/index.tsx
+++ b/app/context/theme/index.tsx
@@ -4,6 +4,7 @@
 import {withObservables} from '@nozbe/watermelondb/react';
 import React, {type ComponentType, createContext, useEffect, useState} from 'react';
 import {Appearance} from 'react-native';
+import {startWith} from 'rxjs';
 
 import {Preferences} from '@constants';
 import useDidUpdate from '@hooks/did_update';
@@ -145,8 +146,8 @@ export function useThemeByAppearanceWithDefault(themeProp?: Theme): Theme {
 }
 
 const enhancedThemeProvider = withObservables([], ({database}: {database: Database}) => ({
-    currentTeamId: observeCurrentTeamId(database),
-    themes: queryThemePreferences(database).observeWithColumns(['value']),
+    currentTeamId: observeCurrentTeamId(database).pipe(startWith<string | undefined>(undefined)),
+    themes: queryThemePreferences(database).observeWithColumns(['value']).pipe(startWith<PreferenceModel[]>([])),
 }));
 
 export default enhancedThemeProvider(ThemeProvider);

--- a/app/screens/home/channel_list/categories_list/categories_list.tsx
+++ b/app/screens/home/channel_list/categories_list/categories_list.tsx
@@ -84,8 +84,9 @@ const CategoriesList = ({
     const isTablet = useIsTablet();
     const isTeamLoading = useTeamsLoading(serverUrl);
     const tabletWidth = useSharedValue(isTablet ? getTabletWidth(moreThanOneTeam) : 0);
-    const [activeScreen, setActiveScreen] = useState<ScreenType>(isTablet && lastChannelId ? lastChannelId : Screens.CHANNEL);
+    const [activeScreen, setActiveScreen] = useState<ScreenType>(Screens.CHANNEL);
     const [listHeight, setListHeight] = useState(0);
+    const restoredRef = useRef(false);
 
     const healedRef = useRef(false);
     useEffect(() => {
@@ -122,7 +123,16 @@ const CategoriesList = ({
     }, [isTablet, moreThanOneTeam]);
 
     useEffect(() => {
+        if (restoredRef.current || !isTablet || !lastChannelId) {
+            return;
+        }
+        restoredRef.current = true;
+        setActiveScreen(lastChannelId);
+    }, [isTablet, lastChannelId]);
+
+    useEffect(() => {
         const listener = DeviceEventEmitter.addListener(Events.ACTIVE_SCREEN, (screen: string) => {
+            restoredRef.current = true;
             if (screen === Screens.GLOBAL_DRAFTS || screen === Screens.GLOBAL_THREADS || screen === Screens.PARTICIPANT_PLAYBOOKS || screen === Screens.AGENT_CHAT) {
                 setActiveScreen(screen);
             } else {

--- a/app/screens/home/channel_list/categories_list/index.tsx
+++ b/app/screens/home/channel_list/categories_list/index.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
-import {combineLatest, of} from 'rxjs';
+import {combineLatest, of, startWith} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {observeIsAgentsEnabled} from '@agents/database/queries/version';
@@ -20,23 +20,32 @@ import type {WithDatabaseArgs} from '@typings/database/database';
 
 const enchanced = withObservables([], ({database}: WithDatabaseArgs) => {
     const currentTeamId = observeCurrentTeamId(database);
-    const draftsCount = currentTeamId.pipe(switchMap((teamId) => observeDraftCount(database, teamId))); // Observe draft count
+    const draftsCount = currentTeamId.pipe(
+        switchMap((teamId) => observeDraftCount(database, teamId)),
+        startWith(0),
+    );
     const allScheduledPost = currentTeamId.pipe(switchMap((teamId) => observeScheduledPostsForTeam(database, teamId, true)));
-    const lastChannelId = currentTeamId.pipe(switchMap((teamId) => observeTeamLastChannelId(database, teamId)));
+    const lastChannelId = currentTeamId.pipe(
+        switchMap((teamId) => observeTeamLastChannelId(database, teamId)),
+        startWith(undefined),
+    );
     const scheduledPostCount = allScheduledPost.pipe(
         switchMap((scheduledPosts) => of(scheduledPosts.length)),
+        startWith(0),
     );
     const scheduledPostHasError = allScheduledPost.pipe(
         switchMap((scheduledPosts) => of(hasScheduledPostError(scheduledPosts))),
+        startWith(false),
     );
-    const scheduledPostsEnabled = observeScheduledPostEnabled(database);
-    const agentsEnabled = observeIsAgentsEnabled(database);
+    const scheduledPostsEnabled = observeScheduledPostEnabled(database).pipe(startWith(false));
+    const agentsEnabled = observeIsAgentsEnabled(database).pipe(startWith(false));
     const showPlaybooksButton = currentTeamId.pipe(
         switchMap((teamId) => combineLatest([
             observeIsPlaybooksEnabled(database),
             observeHasRunningPlaybookRunsInTeam(database, teamId),
         ])),
         switchMap(([enabled, hasRunningRuns]) => of(enabled && hasRunningRuns)),
+        startWith(false),
     );
 
     return {

--- a/app/screens/home/channel_list/channel_list.tsx
+++ b/app/screens/home/channel_list/channel_list.tsx
@@ -45,7 +45,7 @@ type ChannelProps = {
     coldStart?: boolean;
     currentUserId?: string;
     currentTeamId: string;
-    hasCurrentUser: boolean;
+    hasCurrentUser?: boolean;
     showIncomingCalls: boolean;
 };
 
@@ -165,13 +165,10 @@ const ChannelListScreen = (props: ChannelProps) => {
     }, [props.showToS]);
 
     useEffect(() => {
-        if (!props.hasCurrentUser || !props.currentUserId) {
+        if (props.hasCurrentUser === false || (props.hasCurrentUser && !props.currentUserId)) {
             refetchCurrentUser(serverUrl, props.currentUserId);
         }
-
-    // - serverUrl is stable from useServerUrl hook
-    // - We only need to re-run when the current user state changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.currentUserId, props.hasCurrentUser]);
 
     useEffect(() => {

--- a/app/screens/home/channel_list/index.ts
+++ b/app/screens/home/channel_list/index.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {withDatabase, withObservables} from '@nozbe/watermelondb/react';
-import {of as of$} from 'rxjs';
+import {of as of$, startWith} from 'rxjs';
 import {distinctUntilChanged, switchMap} from 'rxjs/operators';
 
 import {observeIncomingCalls} from '@calls/state';
@@ -26,17 +26,16 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
 
     const showIncomingCalls = observeIncomingCalls().pipe(
         switchMap((ics) => of$(ics.incomingCalls.length > 0)),
+        startWith(false),
         distinctUntilChanged(),
     );
 
     return {
-        isCRTEnabled: observeIsCRTEnabled(database),
+        isCRTEnabled: observeIsCRTEnabled(database).pipe(startWith(false)),
+
+        // Real SQLite values; seeding would skip select_team or paint a hollow list
         hasTeams: teamsCount.pipe(
             switchMap((v) => of$(v > 0)),
-            distinctUntilChanged(),
-        ),
-        hasMoreThanOneTeam: teamsCount.pipe(
-            switchMap((v) => of$(v > 1)),
             distinctUntilChanged(),
         ),
         hasChannels: observeCurrentTeamId(database).pipe(
@@ -44,15 +43,27 @@ const enhanced = withObservables([], ({database}: WithDatabaseArgs) => {
             switchMap((v) => of$(v > 0)),
             distinctUntilChanged(),
         ),
-        isLicensed,
-        showToS: observeShowToS(database).pipe(distinctUntilChanged()),
-        currentUserId: observeCurrentUserId(database),
+        hasMoreThanOneTeam: teamsCount.pipe(
+            switchMap((v) => of$(v > 1)),
+            startWith(false),
+            distinctUntilChanged(),
+        ),
+        isLicensed: isLicensed.pipe(startWith(false)),
+        showToS: observeShowToS(database).pipe(
+            startWith(false),
+            distinctUntilChanged(),
+        ),
+        currentUserId: observeCurrentUserId(database).pipe(startWith<string | undefined>(undefined)),
         hasCurrentUser: observeCurrentUser(database).pipe(
             switchMap((u) => of$(Boolean(u))),
+            startWith<boolean | undefined>(undefined),
             distinctUntilChanged(),
         ),
         showIncomingCalls,
-        currentTeamId: observeCurrentTeamId(database).pipe(distinctUntilChanged()),
+        currentTeamId: observeCurrentTeamId(database).pipe(
+            startWith(''),
+            distinctUntilChanged(),
+        ),
     };
 });
 


### PR DESCRIPTION
#### Summary
Seed Home chrome `withObservables` (`ThemeProvider`, classification banner, ChannelList chrome) with `startWith` so the first paint is not gated on those SQLite queries. `hasTeams` and `hasChannels` stay unseeded so select-team routing and the hollow-list guard still wait for real values. `hasCurrentUser` seeds as `undefined` so we do not fire `/users/me` on every cold start, and tablet last-screen restore runs once `lastChannelId` arrives.

Stacked on #10064.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **16.1s → 14.3s** (~2s).

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```