### PR TITLE
perf: drop the reconnect loading gate before deferred fetches

### DIFF
--- a/app/actions/websocket/index.test.ts
+++ b/app/actions/websocket/index.test.ts
@@ -22,6 +22,7 @@ import {getIsCRTEnabled} from '@queries/servers/thread';
 import {getCurrentUser} from '@queries/servers/user';
 import EphemeralStore from '@store/ephemeral_store';
 import {NavigationStore} from '@store/navigation_store';
+import {setTeamLoading} from '@store/team_load_store';
 import TestHelper from '@test/test_helper';
 
 import {handleFirstConnect, handleReconnect} from './index';
@@ -163,6 +164,33 @@ describe('WebSocket Index Actions', () => {
             expect(expiredBoRPostCleanup).toHaveBeenCalled();
             expect(AppsManager.refreshAppBindings).toHaveBeenCalled();
             expect(handlePlaybookReconnect).toHaveBeenCalledWith(serverUrl);
+        });
+
+        it('should release team loading before deferred entry actions', async () => {
+            jest.mocked(entry).mockResolvedValue({
+                models: [],
+                initialTeamId: currentTeamId,
+                initialChannelId: currentChannelId,
+                prefData: {preferences: []},
+                teamData: {memberships: [], teams: []},
+                chData: {memberships: [], channels: []},
+                gmConverted: false,
+            });
+            jest.mocked(getCurrentUser).mockResolvedValue(TestHelper.fakeUserModel({
+                id: currentUserId,
+                locale: 'en',
+            }));
+            jest.mocked(getConfig).mockResolvedValue({Version: '9.0.0'} as ClientConfig);
+
+            await handleReconnect(serverUrl);
+
+            const loadEndOrder = jest.mocked(setTeamLoading).mock.calls.findIndex((call) => call[1] === false);
+            expect(loadEndOrder).toBeGreaterThan(-1);
+            expect(jest.mocked(setTeamLoading).mock.invocationCallOrder[loadEndOrder]).toBeLessThan(
+                jest.mocked(deferredAppEntryActions).mock.invocationCallOrder[0],
+            );
+            const releaseCalls = jest.mocked(setTeamLoading).mock.calls.filter((call) => call[1] === false);
+            expect(releaseCalls).toHaveLength(1);
         });
 
         it('should fetch posts for channel screen', async () => {

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -9,6 +9,7 @@ import {
     entry,
     handleEntryAfterLoadNavigation,
     setExtraSessionProps,
+    type EntryResponse,
 } from '@actions/remote/entry/common';
 import {deferredAppEntryActions} from '@actions/remote/entry/deferred';
 import {fetchPostsForChannel, fetchPostThread} from '@actions/remote/post';
@@ -63,20 +64,23 @@ async function doReconnect(serverUrl: string, groupLabel?: BaseRequestGroupLabel
 
     const {database} = operator;
 
+    const lastFullSync = await getLastFullSync(database);
+    const now = Date.now();
+
+    const currentTeamId = await getCurrentTeamId(database);
+    const currentChannelId = await getCurrentChannelId(database);
+
+    let entrySuccess: Exclude<EntryResponse, {error: unknown}>;
+
+    setTeamLoading(serverUrl, true);
     try {
-        const lastFullSync = await getLastFullSync(database);
-        const now = Date.now();
-
-        const currentTeamId = await getCurrentTeamId(database);
-        const currentChannelId = await getCurrentChannelId(database);
-
-        setTeamLoading(serverUrl, true);
         const entryData = await entry(serverUrl, currentTeamId, currentChannelId, lastFullSync, groupLabel);
         if ('error' in entryData) {
             return entryData.error;
         }
 
-        const {models, initialTeamId, initialChannelId, prefData, teamData, chData, meData, gmConverted} = entryData;
+        entrySuccess = entryData;
+        const {models, initialTeamId, initialChannelId, teamData, chData, gmConverted} = entryData;
 
         await handleEntryAfterLoadNavigation(serverUrl, teamData.memberships || [], chData?.memberships || [], currentTeamId || '', currentChannelId || '', initialTeamId, initialChannelId, gmConverted);
 
@@ -86,37 +90,40 @@ async function doReconnect(serverUrl: string, groupLabel?: BaseRequestGroupLabel
         }
 
         logInfo('WEBSOCKET RECONNECT MODELS BATCHING TOOK', `${Date.now() - dt}ms`);
-        await fetchPostDataIfNeeded(serverUrl, groupLabel);
-
-        const {id: currentUserId, locale: currentUserLocale} = (await getCurrentUser(database))!;
-        const license = await getLicense(database);
-        const config = await getConfig(database);
-
-        handlePlaybookReconnect(serverUrl);
-        handleAgentsReconnect(serverUrl);
-
-        if (isSupportedServerCalls(config?.Version)) {
-            loadConfigAndCalls(serverUrl, currentUserId, groupLabel);
-        }
-
-        checkIsAgentsPluginEnabled(serverUrl);
-        fetchClassificationBanner(serverUrl, true);
-
-        await deferredAppEntryActions(serverUrl, lastFullSync, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, meData, initialTeamId, undefined, groupLabel);
-
-        await setLastFullSync(operator, now);
-
-        openAllUnreadChannels(serverUrl, groupLabel);
-
-        dataRetentionCleanup(serverUrl);
-
-        expiredBoRPostCleanup(serverUrl);
-
-        AppsManager.refreshAppBindings(serverUrl, groupLabel);
-        return undefined;
     } finally {
         setTeamLoading(serverUrl, false);
     }
+
+    const {prefData, teamData, chData, meData, initialTeamId} = entrySuccess;
+
+    await fetchPostDataIfNeeded(serverUrl, groupLabel);
+
+    const {id: currentUserId, locale: currentUserLocale} = (await getCurrentUser(database))!;
+    const license = await getLicense(database);
+    const config = await getConfig(database);
+
+    handlePlaybookReconnect(serverUrl);
+    handleAgentsReconnect(serverUrl);
+
+    if (isSupportedServerCalls(config?.Version)) {
+        loadConfigAndCalls(serverUrl, currentUserId, groupLabel);
+    }
+
+    checkIsAgentsPluginEnabled(serverUrl);
+    fetchClassificationBanner(serverUrl, true);
+
+    await deferredAppEntryActions(serverUrl, lastFullSync, currentUserId, currentUserLocale, prefData.preferences, config, license, teamData, chData, meData, initialTeamId, undefined, groupLabel);
+
+    await setLastFullSync(operator, now);
+
+    openAllUnreadChannels(serverUrl, groupLabel);
+
+    dataRetentionCleanup(serverUrl);
+
+    expiredBoRPostCleanup(serverUrl);
+
+    AppsManager.refreshAppBindings(serverUrl, groupLabel);
+    return undefined;
 }
 
 async function fetchPostDataIfNeeded(serverUrl: string, groupLabel?: RequestGroupLabel) {


### PR DESCRIPTION
#### Summary
Release `setTeamLoading` as soon as reconnect models are batched, instead of holding the channel-list loading gate through `fetchPostDataIfNeeded` and `deferredAppEntryActions`. Scope the increment/decrement `try/finally` to that window so the loading counter cannot underflow if sync IDs fail before the increment.

Stacked on #10065.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **14.6s → 14.2s** (~0.4s). This mainly helps reconnect/paint-while-deferred, not the first force-stop launch.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```