### PR TITLE
perf: redirect logged-in launches to Home before route resolution

### DIFF
--- a/app/init/launch.ts
+++ b/app/init/launch.ts
@@ -60,6 +60,13 @@ export function startColdStartEntry(serverUrl: string) {
     appEntry(serverUrl);
 }
 
+function dataErasedResult(server: {url: string; displayName: string}): ExpoRouterLaunchResult {
+    return {
+        route: getExpoRouterPath(Screens.DATA_ERASED)!,
+        params: {serverUrl: server.url, displayName: server.displayName || server.url},
+    };
+}
+
 /**
  * Determine initial route for Expo Router based on app launch conditions
  */
@@ -67,10 +74,7 @@ export async function determineInitialExpoRoute(): Promise<ExpoRouterLaunchResul
     const startedAt = Date.now();
     const activeServer = getCachedActiveServer() ?? await getActiveServer();
     if (activeServer && activeServer.persistenceFlag === 'wiped') {
-        return {
-            route: getExpoRouterPath(Screens.DATA_ERASED)!,
-            params: {serverUrl: activeServer.url, displayName: activeServer.displayName || activeServer.url},
-        };
+        return dataErasedResult(activeServer);
     }
 
     if (activeServer && hasCachedCredentials()) {
@@ -109,6 +113,20 @@ export async function determineInitialExpoRoute(): Promise<ExpoRouterLaunchResul
     logDebug('determineInitialExpoRoute completed', `${Date.now() - startedAt}ms`);
     launchMark('route_done');
     return result;
+}
+
+export function getOptimisticLaunchResult(): ExpoRouterLaunchResult | null {
+    const server = getCachedActiveServer();
+    if (server?.persistenceFlag === 'wiped') {
+        return dataErasedResult(server);
+    }
+    if (hasCachedCredentials()) {
+        return {
+            route: '/(authenticated)/(home)',
+            params: {launchType: Launch.Normal, coldStart: true, serverUrl: server?.url},
+        };
+    }
+    return null;
 }
 
 async function determineRouteFromDeeplink(deepLinkUrl: string): Promise<ExpoRouterLaunchResult> {

--- a/app/init/splash.ts
+++ b/app/init/splash.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as SplashScreen from 'expo-splash-screen';
+
+let hidden = false;
+
+export function hideLaunchSplash() {
+    if (hidden) {
+        return;
+    }
+    hidden = true;
+
+    // hideAsync rejects if the splash is already hidden; safe to ignore.
+    SplashScreen.hideAsync().catch(() => undefined);
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -4,25 +4,50 @@
 import {Redirect, type Href} from 'expo-router';
 import {useEffect, useState} from 'react';
 
-import {determineInitialExpoRoute, type ExpoRouterLaunchResult} from '@init/launch';
+import {determineInitialExpoRoute, getOptimisticLaunchResult, type ExpoRouterLaunchResult} from '@init/launch';
+import {hideLaunchSplash} from '@init/splash';
+import {getFullErrorMessage} from '@utils/errors';
+import {logError} from '@utils/log';
+
+function shouldKeepCurrentLaunch(current: ExpoRouterLaunchResult, next: ExpoRouterLaunchResult) {
+    return current.route === next.route && current.params.serverUrl === next.params.serverUrl;
+}
 
 export default function RootIndex() {
-    const [launchResult, setLaunchResult] = useState<ExpoRouterLaunchResult | null>(null);
+    const [launchResult, setLaunchResult] = useState<ExpoRouterLaunchResult | null>(getOptimisticLaunchResult);
 
     useEffect(() => {
+        let cancelled = false;
         async function initializeLaunch() {
-            const result = await determineInitialExpoRoute();
-            setLaunchResult(result);
+            try {
+                const result = await determineInitialExpoRoute();
+                if (cancelled) {
+                    return;
+                }
+                setLaunchResult((current) => {
+                    if (current && shouldKeepCurrentLaunch(current, result)) {
+                        return current;
+                    }
+                    return result;
+                });
+            } catch (error) {
+                logError('error on initializeLaunch', getFullErrorMessage(error));
+                if (getOptimisticLaunchResult()) {
+                    hideLaunchSplash();
+                }
+            }
         }
 
         initializeLaunch();
+        return () => {
+            cancelled = true;
+        };
     }, []);
 
     if (!launchResult) {
-        return null; // Still determining initial route
+        return null;
     }
 
-    // Redirect to the determined route with params
     const href: Href = {pathname: launchResult.route, params: launchResult.params};
     return <Redirect href={href}/>;
 }


### PR DESCRIPTION
#### Summary
Redirect logged-in launches to Home from the session cache before `determineInitialExpoRoute` finishes deeplink/notification routing. Wipe vs Home policy lives in `launch.ts` (`getOptimisticLaunchResult` + shared `dataErasedResult`). Adds idempotent `hideLaunchSplash` for later splash-on-paint work; this PR does not change when the native splash hides.

Stacked on #10066.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **15.7s → 15.6s** (~0s). The win is overlapping Home mount with route confirmation, not first-paint wall clock until splash hide moves to flatten.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```