### PR TITLE
perf: hide splash on login, wiped, and select-team screens

### DIFF
--- a/app/routes/(unauthenticated)/_layout.tsx
+++ b/app/routes/(unauthenticated)/_layout.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Stack, Redirect} from 'expo-router';
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {Platform, StyleSheet} from 'react-native';
 import {SafeAreaView, type Edge} from 'react-native-safe-area-context';
 import tinycolor from 'tinycolor2';
@@ -10,6 +10,7 @@ import tinycolor from 'tinycolor2';
 import {Screens} from '@constants';
 import {useThemeByAppearanceWithDefault} from '@context/theme';
 import {useHasCredentials} from '@hooks/use_has_credentials';
+import {hideLaunchSplash} from '@init/splash';
 
 import type {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 
@@ -35,6 +36,13 @@ export default function UnauthenticatedLayout() {
         headerBackButtonMenuEnabled: false,
         ...Platform.select({android: {statusBarBackgroundColor: theme.centerChannelBg, statusBarTranslucent: true, statusBarStyle: tinycolor(theme.centerChannelBg).isLight() ? 'dark' : 'light'}}),
     }), [theme]);
+
+    useEffect(() => {
+        // null: credentials not resolved yet. Stay on splash until we know this is login.
+        if (hasCredentials === false) {
+            hideLaunchSplash();
+        }
+    }, [hasCredentials]);
 
     // Redirect to authenticated if has credentials
     if (hasCredentials) {

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -5,7 +5,6 @@ import {PortalHost, PortalProvider} from '@gorhom/portal';
 import {Provider as EMMProvider} from '@mattermost/react-native-emm';
 import RNUtils from '@mattermost/rnutils';
 import {Stack, useNavigationContainerRef} from 'expo-router';
-import * as SplashScreen from 'expo-splash-screen';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {IntlProvider} from 'react-intl';
 import {Keyboard, Platform, StyleSheet} from 'react-native';
@@ -20,6 +19,7 @@ import {useThemeByAppearanceWithDefault} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
 import {DEFAULT_LOCALE, getTranslations} from '@i18n';
 import {cleanup, initialize} from '@init/app';
+import {hideLaunchSplash} from '@init/splash';
 import InAppNotificationContainer from '@screens/in_app_notification';
 import ReviewAppContainer from '@screens/review_app';
 import ShareFeedbackContainer from '@screens/share_feedback';
@@ -93,7 +93,7 @@ export default function RootLayout() {
 
     useEffect(() => {
         if (appReady) {
-            SplashScreen.hideAsync();
+            hideLaunchSplash();
         }
     }, [appReady]);
 

--- a/app/screens/data_erased/index.tsx
+++ b/app/screens/data_erased/index.tsx
@@ -13,6 +13,7 @@ import Alert from '@components/illustrations/alert';
 import {useTheme} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
 import {usePreventDoubleTap} from '@hooks/utils';
+import {hideLaunchSplash} from '@init/splash';
 import Servers from '@screens/home/channel_list/servers';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -89,6 +90,7 @@ const DataErased = ({serverUrl, displayName}: DataErasedProps) => {
     const [hasError, setHasError] = useState(false);
 
     useDidMount(() => {
+        hideLaunchSplash();
         const sub = AppState.addEventListener('change', (state) => {
             if (state === 'active') {
                 setHasError(false);

--- a/app/screens/select_team/select_team.tsx
+++ b/app/screens/select_team/select_team.tsx
@@ -13,6 +13,7 @@ import {Screens} from '@constants';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
+import {hideLaunchSplash} from '@init/splash';
 import {navigateToScreen} from '@screens/navigation';
 import {logDebug} from '@utils/log';
 import {alertTeamAddError} from '@utils/navigation';
@@ -122,6 +123,7 @@ const SelectTeam = ({
     }, [shouldRedirectToHome]);
 
     useDidMount(() => {
+        hideLaunchSplash();
         loadTeams();
     });
 


### PR DESCRIPTION
#### Summary
Hide the native splash on login (`hasCredentials === false`), data-erased, and select-team so those screens do not hang after Home switches to hide-on-paint. Route the root `appReady` hide through `hideLaunchSplash` so a child hide cannot leave a raw `hideAsync()` rejection.

Stacked on #10067.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **13.8s → 14.1s** (~0s). This is a correctness layer for the next splash-on-paint PR, not a first-paint win on the logged-in Home path.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
NONE
```