### PR TITLE
perf: hide splash after the channel list paints

### DIFF
--- a/app/init/splash.ts
+++ b/app/init/splash.ts
@@ -3,7 +3,13 @@
 
 import * as SplashScreen from 'expo-splash-screen';
 
+import {launchMark} from './launch_profiler';
+
+const SPLASH_FALLBACK_MS = 30000;
+
 let hidden = false;
+let channelsPainted = false;
+let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
 
 export function hideLaunchSplash() {
     if (hidden) {
@@ -11,6 +17,28 @@ export function hideLaunchSplash() {
     }
     hidden = true;
 
+    if (fallbackTimer !== undefined) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = undefined;
+    }
+
     // hideAsync rejects if the splash is already hidden; safe to ignore.
     SplashScreen.hideAsync().catch(() => undefined);
+}
+
+export function armLaunchSplashFallback() {
+    if (fallbackTimer !== undefined || hidden) {
+        return;
+    }
+    fallbackTimer = setTimeout(() => {
+        hideLaunchSplash();
+    }, SPLASH_FALLBACK_MS);
+}
+
+export function hideLaunchSplashAfterChannelsPainted() {
+    if (!channelsPainted) {
+        channelsPainted = true;
+        launchMark('channels_painted');
+    }
+    hideLaunchSplash();
 }

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -19,7 +19,7 @@ import {useThemeByAppearanceWithDefault} from '@context/theme';
 import useDidMount from '@hooks/did_mount';
 import {DEFAULT_LOCALE, getTranslations} from '@i18n';
 import {cleanup, initialize} from '@init/app';
-import {hideLaunchSplash} from '@init/splash';
+import {armLaunchSplashFallback} from '@init/splash';
 import InAppNotificationContainer from '@screens/in_app_notification';
 import ReviewAppContainer from '@screens/review_app';
 import ShareFeedbackContainer from '@screens/share_feedback';
@@ -79,8 +79,10 @@ export default function RootLayout() {
                 RNUtils.lockPortrait();
 
                 setAppReady(true);
+                armLaunchSplashFallback();
             } catch (error) {
                 setAppReady(true); // Still show UI with error state
+                armLaunchSplashFallback();
             }
         }
 
@@ -90,12 +92,6 @@ export default function RootLayout() {
             cleanup();
         };
     });
-
-    useEffect(() => {
-        if (appReady) {
-            hideLaunchSplash();
-        }
-    }, [appReady]);
 
     useEffect(() => {
         const handleKeyboardHide = () => {

--- a/app/screens/home/channel_list/categories_list/categories/categories.tsx
+++ b/app/screens/home/channel_list/categories_list/categories/categories.tsx
@@ -15,6 +15,7 @@ import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useIsInitialSync} from '@hooks/is_initial_sync';
 import {useTeamSwitch} from '@hooks/team_switch';
+import {hideLaunchSplashAfterChannelsPainted} from '@init/splash';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {isDMorGM} from '@utils/channel';
 import {logDebug} from '@utils/log';
@@ -203,6 +204,14 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
     }, []);
 
     const showEmptyState = onlyUnreads && flattenedItems.length === 0 && !isTablet;
+    const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
+
+    useEffect(() => {
+        if (showLoading) {
+            return;
+        }
+        hideLaunchSplashAfterChannelsPainted();
+    }, [showLoading]);
 
     const ListEmptyComponent = useMemo(() => {
         if (showEmptyState) {
@@ -218,8 +227,6 @@ const Categories = ({flattenedItems, unreadChannelIds, onlyUnreads, isTablet, li
     if (flattenedItems.length === 0 && !switchingTeam && !initialLoad && !onlyUnreads && !isInitialSync) {
         return <LoadCategoriesError/>;
     }
-
-    const showLoading = switchingTeam || initialLoad || (isInitialSync && flattenedItems.length === 0);
 
     return (
         <>

--- a/app/screens/home/channel_list/categories_list/categories/helpers/observe_flattened_categories.ts
+++ b/app/screens/home/channel_list/categories_list/categories/helpers/observe_flattened_categories.ts
@@ -1,13 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {of as of$, combineLatest, type Observable} from 'rxjs';
-import {switchMap, map, distinctUntilChanged} from 'rxjs/operators';
+import {of as of$, combineLatest, merge, type Observable} from 'rxjs';
+import {switchMap, map, distinctUntilChanged, take, startWith, tap} from 'rxjs/operators';
 
 import {Preferences} from '@constants';
 import {DMS_CATEGORY, MANAGED_LOCAL_CATEGORY_PREFIX, UNREADS_CATEGORY} from '@constants/categories';
 import {getSidebarPreferenceAsBool} from '@helpers/api/preference';
 import {filterAndSortMyChannels, makeChannelsMap} from '@helpers/database';
+import {launchMark} from '@init/launch_profiler';
 import {queryCategoriesByTeamIds} from '@queries/servers/categories';
 import {getChannelById, observeChannelsByLastPostAt, observeNotifyPropsByChannels, queryMyChannelUnreads} from '@queries/servers/channel';
 import {queryPreferencesByCategoryAndName, querySidebarPreferences} from '@queries/servers/preference';
@@ -29,6 +30,7 @@ import type CategoryModel from '@typings/database/models/servers/category';
 import type ChannelModel from '@typings/database/models/servers/channel';
 import type MyChannelModel from '@typings/database/models/servers/my_channel';
 import type PreferenceModel from '@typings/database/models/servers/preference';
+import type UserModel from '@typings/database/models/servers/user';
 
 const observeCategoryChannels = (category: CategoryModel, myChannels: Observable<MyChannelModel[]>) => {
     // observe delete_at to react to channel archive/unarchive
@@ -54,6 +56,51 @@ const observeCategoryChannels = (category: CategoryModel, myChannels: Observable
         }),
     );
 };
+
+type CategoryFilterInputs = {
+    channelId: string;
+    unreadId?: string;
+    notifyProps: Record<string, Partial<ChannelNotifyProps>>;
+    manuallyClosedDms: PreferenceModel[];
+    autoclose: PreferenceModel[];
+    deactivatedUsers?: Map<string, UserModel | undefined>;
+    maxDms: number;
+};
+
+const FAST_PAINT_INPUTS: CategoryFilterInputs = {
+    channelId: '',
+    notifyProps: {},
+    manuallyClosedDms: [],
+    autoclose: [],
+    maxDms: Preferences.CHANNEL_SIDEBAR_LIMIT_DMS_DEFAULT,
+};
+
+let fastPaintDone = false;
+
+function toCategoryData(
+    category: CategoryModel,
+    currentUserId: string,
+    locale: string,
+    cwms: ChannelWithMyChannel[],
+    catData: {sorting: CategoryModel['sorting']; collapsed: boolean; type: CategoryModel['type']},
+    inputs: CategoryFilterInputs,
+): CategoryData {
+    let channelsW = cwms;
+    channelsW = filterArchivedChannels(channelsW, inputs.channelId);
+    channelsW = filterManuallyClosedDms(channelsW, inputs.notifyProps, inputs.manuallyClosedDms, currentUserId, inputs.unreadId);
+    channelsW = filterAutoclosedDMs(catData.type, inputs.maxDms, currentUserId, inputs.channelId, channelsW, inputs.autoclose, inputs.notifyProps, inputs.deactivatedUsers, inputs.unreadId);
+
+    const sortedChannels = sortChannels(catData.sorting, channelsW, inputs.notifyProps, locale);
+    const unreadIds = getUnreadIds(cwms, inputs.notifyProps, inputs.unreadId);
+    const allUnreadChannels = sortedChannels.filter((c) => unreadIds.has(c.id));
+
+    return {
+        category,
+        sortedChannels,
+        unreadIds,
+        allUnreadChannels,
+    };
+}
 
 const observeCategoryData = (
     category: CategoryModel,
@@ -107,7 +154,7 @@ const observeCategoryData = (
 
     const deactivated = (category.type === DMS_CATEGORY) ? observeDeactivatedUsers(database) : of$(undefined);
 
-    return combineLatest([
+    const fullCategoryData = combineLatest([
         channelsWithMyChannel,
         categoryObservable,
         currentChannelId,
@@ -118,24 +165,32 @@ const observeCategoryData = (
         deactivated,
         limit,
     ]).pipe(
+        tap(() => {
+            fastPaintDone = true;
+        }),
         map(([cwms, catData, channelId, unreadId, notifyProps, manuallyClosedDms, autoclose, deactivatedUsers, maxDms]) => {
-            let channelsW = cwms;
-            channelsW = filterArchivedChannels(channelsW, channelId);
-            channelsW = filterManuallyClosedDms(channelsW, notifyProps, manuallyClosedDms, currentUserId, unreadId);
-            channelsW = filterAutoclosedDMs(catData.type, maxDms, currentUserId, channelId, channelsW, autoclose, notifyProps, deactivatedUsers, unreadId);
-
-            const sortedChannels = sortChannels(catData.sorting, channelsW, notifyProps, locale);
-            const unreadIds = getUnreadIds(cwms, notifyProps, unreadId);
-            const allUnreadChannels = sortedChannels.filter((c) => unreadIds.has(c.id));
-
-            return {
+            return toCategoryData(
                 category,
-                sortedChannels,
-                unreadIds,
-                allUnreadChannels,
-            };
+                currentUserId,
+                locale,
+                cwms,
+                catData,
+                {channelId, unreadId, notifyProps, manuallyClosedDms, autoclose, deactivatedUsers, maxDms},
+            );
         }),
     );
+
+    if (fastPaintDone) {
+        return fullCategoryData;
+    }
+
+    // First paint from cached memberships; prefs/deactivated users refine afterwards.
+    const fastCategoryData = combineLatest([channelsWithMyChannel, categoryObservable]).pipe(
+        map(([cwms, catData]) => toCategoryData(category, currentUserId, locale, cwms, catData, FAST_PAINT_INPUTS)),
+        take(1),
+    );
+
+    return merge(fastCategoryData, fullCategoryData);
 };
 
 export type FlattenedCategoriesData = {
@@ -252,11 +307,11 @@ const observeFlattenedCategoriesNormal = (
         return of$({items: [], unreadChannelIds: new Set<string>()});
     }
 
-    const unreadsOnTop = querySidebarPreferences(database, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS).
-        observeWithColumns(['value']).
-        pipe(
-            switchMap((prefs: PreferenceModel[]) => of$(getSidebarPreferenceAsBool(prefs, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS))),
+    const unreadsOnTopSource = querySidebarPreferences(database, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS).
+        observeWithColumns(['value']).pipe(
+            switchMap((prefs) => of$(getSidebarPreferenceAsBool(prefs, Preferences.CHANNEL_SIDEBAR_GROUP_UNREADS))),
         );
+    const unreadsOnTop = fastPaintDone ? unreadsOnTopSource : unreadsOnTopSource.pipe(startWith(false));
 
     const categoryDataObservables = categories.map((category) =>
         observeCategoryData(category, database, currentUserId, locale, isTablet),
@@ -312,6 +367,16 @@ const sortCategories = (categories: CategoryModel[]) => {
     return categories.sort((a, b) => a.sortOrder - b.sortOrder);
 };
 
+let flattenFirstMarked = false;
+
+const markFlattenFirst = (itemCount: number) => {
+    if (flattenFirstMarked) {
+        return;
+    }
+    flattenFirstMarked = true;
+    launchMark('flatten_first', `${itemCount} items`);
+};
+
 // Routes to the appropriate observable based on onlyUnreads mode
 export const observeFlattenedCategories = (
     database: Database,
@@ -321,14 +386,16 @@ export const observeFlattenedCategories = (
     onlyUnreads: boolean,
     currentTeamId: string,
 ): Observable<FlattenedCategoriesData> => {
+    let source: Observable<FlattenedCategoriesData>;
     if (onlyUnreads) {
-        return observeFlattenedUnreads(database, currentTeamId, isTablet);
+        source = observeFlattenedUnreads(database, currentTeamId, isTablet);
+    } else {
+        source = queryCategoriesByTeamIds(database, [currentTeamId]).observeWithColumns(['sort_order', 'collapsed']).pipe(
+            switchMap((cats) => observeFlattenedCategoriesNormal(sortCategories(cats), database, currentUserId, locale, isTablet)),
+        );
     }
 
-    // Observe categories for the current team
-    const categories = queryCategoriesByTeamIds(database, [currentTeamId]).observeWithColumns(['sort_order', 'collapsed']);
-
-    return categories.pipe(
-        switchMap((cats) => observeFlattenedCategoriesNormal(sortCategories(cats), database, currentUserId, locale, isTablet)),
+    return source.pipe(
+        tap((data) => markFlattenFirst(data.items.length)),
     );
 };

--- a/app/screens/home/channel_list/categories_list/categories_list.tsx
+++ b/app/screens/home/channel_list/categories_list/categories_list.tsx
@@ -20,6 +20,7 @@ import DatabaseManager from '@database/manager';
 import {useIsTablet} from '@hooks/device';
 import {useIsInitialSync} from '@hooks/is_initial_sync';
 import {useTeamsLoading} from '@hooks/teams_loading';
+import {hideLaunchSplashAfterChannelsPainted} from '@init/splash';
 import PlaybooksButton from '@playbooks/components/playbooks_button';
 import {getDefaultTeamId} from '@queries/servers/team';
 import {logDebug} from '@utils/log';
@@ -45,6 +46,7 @@ type ScreenType = typeof Screens.GLOBAL_DRAFTS | typeof Screens.GLOBAL_THREADS |
 
 type ChannelListProps = {
     hasChannels: boolean;
+    hasTeams: boolean;
     iconPad?: boolean;
     isCRTEnabled?: boolean;
     moreThanOneTeam: boolean;
@@ -65,6 +67,7 @@ const edges: Edge[] = ['right'];
 
 const CategoriesList = ({
     hasChannels,
+    hasTeams,
     iconPad,
     isCRTEnabled,
     moreThanOneTeam,
@@ -112,6 +115,13 @@ const CategoriesList = ({
             }
         })();
     }, [hasChannels, isTeamLoading, serverUrl]);
+
+    // Covers teams-with-no-channels first paint (LoadChannelsError).
+    useEffect(() => {
+        if (hasTeams && !hasChannels && !isInitialSync && !isTeamLoading) {
+            hideLaunchSplashAfterChannelsPainted();
+        }
+    }, [hasTeams, hasChannels, isInitialSync, isTeamLoading]);
 
     useEffect(() => {
         if (isTablet) {

--- a/app/screens/home/channel_list/categories_list/index.test.tsx
+++ b/app/screens/home/channel_list/categories_list/index.test.tsx
@@ -46,6 +46,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostHasError={false}
@@ -63,6 +64,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -81,6 +83,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={1}
                 scheduledPostCount={0}
@@ -105,6 +108,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -135,6 +139,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={true}
+                hasTeams={true}
                 hasChannels={false}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -156,6 +161,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={1}
@@ -172,6 +178,7 @@ describe('components/categories_list', () => {
             <CategoriesList
                 isCRTEnabled={true}
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={1}
@@ -187,6 +194,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -202,6 +210,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={true}
                 draftsCount={0}
                 scheduledPostCount={0}
@@ -219,6 +228,7 @@ describe('components/categories_list', () => {
         const wrapper = renderWithEverything(
             <CategoriesList
                 moreThanOneTeam={false}
+                hasTeams={true}
                 hasChannels={false}
                 draftsCount={0}
                 scheduledPostCount={0}

--- a/app/screens/home/channel_list/channel_list.tsx
+++ b/app/screens/home/channel_list/channel_list.tsx
@@ -20,7 +20,9 @@ import {HOME_TAB_SCREENS} from '@constants/screens';
 import {useServerUrl} from '@context/server';
 import {useTheme} from '@context/theme';
 import {useIsTablet} from '@hooks/device';
+import useDidMount from '@hooks/did_mount';
 import useDidUpdate from '@hooks/did_update';
+import {launchMark} from '@init/launch_profiler';
 import PerformanceMetricsManager from '@managers/performance_metrics_manager';
 import {navigateToScreen} from '@screens/navigation';
 import {NavigationStore, useCurrentScreen} from '@store/navigation_store';
@@ -181,13 +183,11 @@ const ChannelListScreen = (props: ChannelProps) => {
         }
     }, [props.launchType, props.coldStart]);
 
-    useEffect(() => {
+    useDidMount(() => {
+        launchMark('home_mounted');
         PerformanceMetricsManager.finishLoad('HOME', serverUrl);
         PerformanceMetricsManager.measureTimeToInteraction();
-
-        // Only needed on mount
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    });
 
     return (
         <Animated.View
@@ -214,6 +214,7 @@ const ChannelListScreen = (props: ChannelProps) => {
                         isCRTEnabled={props.isCRTEnabled}
                         moreThanOneTeam={props.hasMoreThanOneTeam}
                         hasChannels={props.hasChannels}
+                        hasTeams={props.hasTeams}
                     />
                     {isTablet && props.hasChannels &&
                     <AdditionalTabletView/>


### PR DESCRIPTION
#### Summary
Hide the native splash after the channel list's first real paint instead of on `appReady`. Flatten emits a one-shot fast snapshot from cached memberships, then the full prefs/filter pipeline; `fastPaintDone` latches so collapse/reorder does not flash unfiltered rows. Teams-with-no-channels hide via `LoadChannelsError`. A 30s fallback still dismisses splash if initial sync never completes.

Stacked on #10068.

Cold-start (Samsung SM-S938W, debug + Metro, force-stop → Home channel rows): **15.4s → 13.5s** (~2s).

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Samsung SM-S938W, Android 16

#### Release Note
```release-note
Improved Android cold start by keeping the launch splash until the channel list paints, and by overlapping Home mount with session cache, locale, and WebSocket setup.
```