### PR TITLE
fix(calls): force device unlock before answering when mic permission not granted

### DIFF
--- a/libraries/@mattermost/calls-native/ios/Source/Managers/CallKitProvider.swift
+++ b/libraries/@mattermost/calls-native/ios/Source/Managers/CallKitProvider.swift
@@ -47,10 +47,12 @@ private struct CallInfo {
         self.bridge = bridge
 
         let configuration = CXProviderConfiguration()
-        // Calls today is audio + screen share — no front-camera video. Screen
-        // share doesn't surface through CallKit (it's handled in-app), so
-        // CallKit's video affordance stays off.
-        configuration.supportsVideo = false
+        // supportsVideo must be true even though Mattermost Calls is audio-only.
+        // When the user has not yet granted microphone permission we report
+        // incoming calls with hasVideo = true so that iOS requires the device
+        // to be unlocked before answering (see reportIncomingCall). That flag
+        // is only respected by CallKit when the provider declares video support.
+        configuration.supportsVideo = true
         configuration.maximumCallGroups = 2
         configuration.maximumCallsPerCallGroup = 1
         configuration.supportedHandleTypes = [.generic]
@@ -100,7 +102,14 @@ private struct CallInfo {
         // configs the ack-receipt round-trip refreshes it via
         // updateCallerName(uuid:name:).
         update.localizedCallerName = Self.bestInitialDisplayName(request)
-        update.hasVideo = false
+        // AVAudioSession cannot present system permission dialogs from a locked
+        // or backgrounded context (TCC.framework restriction). If mic permission
+        // is not yet granted, mark this call as video so iOS requires the device
+        // to be unlocked before answering — that foregrounds the app and lets the
+        // JS permission request show its system dialog normally. Once permission
+        // has been granted once, all subsequent calls are reported as audio-only.
+        let micPermission = AVAudioSession.sharedInstance().recordPermission
+        update.hasVideo = micPermission != .granted
         update.supportsHolding = false
         update.supportsGrouping = false
         update.supportsUngrouping = false


### PR DESCRIPTION
## Summary

Fixes a bug where answering an incoming call from the iOS lock screen — without having previously granted microphone permission — results in a silent/broken call: the answering side shows "Connected" in CallKit but no audio flows, and the caller's outbound ring continues.

- Set `CXProviderConfiguration.supportsVideo = true` so per-call `hasVideo` overrides are honored by CallKit
- In `reportIncomingCall()`, check `AVAudioSession.recordPermission` at report time; if not `.granted`, set `CXCallUpdate.hasVideo = true` to force device unlock before answering

Fixes [MM-70323](https://mattermost.atlassian.net/browse/MM-70323)

## Root cause

iOS's `TCC.framework` cannot present `AVAudioSession` permission dialogs from a backgrounded or locked context. With `hasVideo = false` (audio-only), a user can slide to answer from the lock screen without unlocking the device. The app stays backgrounded, `hasMicrophonePermission()` silently returns `false`, `joinCall` is called with `hasMic: false`, no voice track is ever created, and `unmuteMyself()` becomes a no-op. The WebRTC peer connects at the transport level (so CallKit flips to "Connected") but carries no audio.

## Fix

At `reportIncomingCall` time, check `AVAudioSession.sharedInstance().recordPermission`. If not `.granted`, set `CXCallUpdate.hasVideo = true`. This tells iOS to treat the incoming call as a video call on the lock screen, which **requires device unlock before answering**. Unlocking foregrounds the app, so the JS `hasMicrophonePermission()` call in `onCallAnswered` can show the system permission dialog normally.

Once the user grants mic permission, all subsequent calls report `hasVideo = false` (audio-only) as before. The `supportsVideo = true` configuration change has no other visible effect since individual calls with `hasVideo = false` show no video affordances in the active-call CallKit UI.

## Test results

Verified on a physical iPhone SE (3rd gen), iOS 26.6, app build 2.43.0 (790). Incoming DM ring from a browser client, phone locked.

> **A physical device is required to verify this.** The iOS Simulator has no PushKit/APNs VoIP delivery — `xcrun simctl push` only injects UserNotifications payloads, not `PKPushRegistry` pushes — so `reportIncomingCall` never fires from a real incoming call there.

- [x] **Mic permission never granted** (`.undetermined`) — lock screen required unlock before answering; after unlocking, the mic permission dialog appeared; granting it connected the call with audio in both directions
- [x] **Mic permission previously granted** (`.granted`) — slide to answer from the lock screen without unlocking, no permission prompt, audio both directions; answered entirely from the CallKit UI without foregrounding the app
- [x] **Mic permission denied** (`.denied`) — unlock required; no permission dialog after unlocking (correct — iOS will not re-prompt a blocked permission); call connected with inbound audio only, mic muted with a prompt to open Settings
- [x] **Active (unlocked) device** — normal answer flow verified in all three permission states: audio-only with no prompt and no video affordance (`.granted`), joins muted with the settings banner (`.denied`), and permission dialogs presented inline with no unlock step (`.undetermined`)
- [ ] **Authentication failure while device is locked** — with permission ungranted (so `hasVideo = true`), attempt to answer without authenticating: decline Touch ID, fail it repeatedly, or use a passcode-only device with biometrics disabled. Verify the call does **not** become active while the device remains locked. Apple forum material ([thread/798090](https://developer.apple.com/forums/thread/798090)) suggests iOS may answer and stay in the lock-screen UI when it cannot authenticate, which would make the forced unlock best-effort rather than guaranteed and leave the original bug reachable.

While permission is ungranted the incoming call is labelled "… Video" in the CallKit UI, a direct consequence of `hasVideo = true`. It reverts to audio-only once permission has been granted.

[MM-70323]: https://mattermost.atlassian.net/browse/MM-70323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



