### PR TITLE
Avoid decrypting absent Android pre-auth secrets during startup

### DIFF
--- a/app/init/credentials.test.ts
+++ b/app/init/credentials.test.ts
@@ -6,6 +6,7 @@ import * as KeyChain from 'react-native-keychain';
 
 import {
     getAllServerCredentials,
+    getPreauthSecret,
     getServerCredentials,
     setServerCredentials,
     removeServerCredentials,
@@ -27,6 +28,7 @@ jest.mock('react-native-keychain', () => ({
     resetInternetCredentials: jest.fn(),
     setGenericPassword: jest.fn(),
     getGenericPassword: jest.fn(),
+    hasGenericPassword: jest.fn(),
     resetGenericPassword: jest.fn(),
     getAllInternetPasswordServers: jest.fn(),
     getAllGenericPasswordServices: jest.fn(),
@@ -59,6 +61,7 @@ describe('credentials', () => {
             service: mockServerUrl,
             storage: 'keychain',
         } as any);
+        jest.mocked(KeyChain.hasGenericPassword).mockResolvedValue(true);
         jest.mocked(KeyChain.resetGenericPassword).mockResolvedValue(true);
     });
 
@@ -260,6 +263,51 @@ describe('credentials', () => {
             const result = await getServerCredentials(mockServerUrl);
 
             expect(result).toBeNull();
+        });
+    });
+
+    describe('getPreauthSecret', () => {
+        beforeEach(() => {
+            Platform.OS = 'android';
+        });
+
+        it('should skip decryption when Android metadata proves the secret is absent', async () => {
+            jest.mocked(KeyChain.hasGenericPassword).mockResolvedValue(false);
+
+            const result = await getPreauthSecret(mockServerUrl);
+
+            expect(result).toBeUndefined();
+            expect(KeyChain.getGenericPassword).not.toHaveBeenCalled();
+        });
+
+        it('should decrypt the secret when Android metadata reports it is present', async () => {
+            jest.mocked(KeyChain.hasGenericPassword).mockResolvedValue(true);
+            jest.mocked(KeyChain.getGenericPassword).mockResolvedValue({
+                username: 'preshared_secret',
+                password: mockPreauthSecret,
+                service: mockServerUrl,
+                storage: 'keychain' as any,
+            });
+
+            const result = await getPreauthSecret(mockServerUrl);
+
+            expect(result).toBe(mockPreauthSecret);
+            expect(KeyChain.getGenericPassword).toHaveBeenCalledWith({server: mockServerUrl});
+        });
+
+        it('should securely fall back to decryption when Android metadata fails', async () => {
+            jest.mocked(KeyChain.hasGenericPassword).mockRejectedValue(new Error('Metadata error'));
+            jest.mocked(KeyChain.getGenericPassword).mockResolvedValue({
+                username: 'preshared_secret',
+                password: mockPreauthSecret,
+                service: mockServerUrl,
+                storage: 'keychain' as any,
+            });
+
+            const result = await getPreauthSecret(mockServerUrl);
+
+            expect(result).toBe(mockPreauthSecret);
+            expect(KeyChain.getGenericPassword).toHaveBeenCalledWith({server: mockServerUrl});
         });
     });
 

--- a/app/init/credentials.ts
+++ b/app/init/credentials.ts
@@ -129,6 +129,17 @@ export const removePreauthSecret = async (serverUrl: string) => {
 };
 
 export const getPreauthSecret = async (serverUrl: string): Promise<string | undefined> => {
+    if (Platform.OS === 'android') {
+        try {
+            const hasPreauthSecret = await KeyChain.hasGenericPassword({server: serverUrl});
+            if (!hasPreauthSecret) {
+                return undefined;
+            }
+        } catch {
+            // Fall back to the secure read when metadata cannot prove the secret is absent.
+        }
+    }
+
     try {
         const preauthCredentials = await KeyChain.getGenericPassword({
             server: serverUrl,
@@ -173,16 +184,7 @@ export const getServerCredentials = async (serverUrl: string): Promise<ServerCre
         }
 
         // Get preauth secret separately
-        let preauthSecret: string | undefined;
-        try {
-            const preauthCredentials = await KeyChain.getGenericPassword({
-                server: serverUrl,
-            });
-            preauthSecret = preauthCredentials ? preauthCredentials.password : undefined;
-        } catch (e) {
-            // Preauth secret is optional, so ignore errors
-            preauthSecret = undefined;
-        }
+        const preauthSecret = await getPreauthSecret(serverUrl);
 
         return {
             serverUrl,


### PR DESCRIPTION
#### Status

This PR is not ready for merge. Physical-device testing invalidated the earlier performance conclusion, so it is being kept as a draft while the behavior is isolated with a same-base Samsung A/B.

#### Summary

The source-level overlap with #10056 is real, but it does not establish a physical fix:

- Build 799 contained the earlier #10076 implementation and reproduced the original severe startup problem on a Samsung SM-F966B running Android 16.
- Build 800 combined that implementation with the DB-first active-server lookup, Android service-listing skip, and concurrent known-credential reads from #10056, without #10056's long-lived credential cache. It also reproduced the problem on the same device.
- The previously successful build 798 used a different release-2.43 base plus a larger instrumented source state. The build-798 and build-800 bases already differed across 278 paths, so that result cannot be assigned to one credential change.

The current reduced two-file patch is also not yet justified as a performance optimization. In react-native-keychain 10.0.0 on Android, `getGenericPassword` checks the encrypted entry first and returns `false` before `decryptCredentials` when the entry is absent. An added `hasGenericPassword` preflight repeats that metadata lookup. Any benefit from avoiding bridge, coroutine, or mutex work is unmeasured and must be benchmarked rather than assumed.

Current `main` does cache positive credentials from initialization, which avoids later layout reads and positive route hits. A route URL missing from an initialized cache can still fall through to a native Keychain read. Existing tests do not cover that negative startup lookup.

Next step: a retained-state, same-base physical A/B on the affected Samsung. Until that identifies a stable production delta, this PR should not be reviewed or merged as a performance fix.

No UI or text changed.

#### Ticket Link

Related to:

- https://github.com/mattermost/mattermost-mobile/issues/7202
- https://github.com/mattermost/mattermost-mobile/issues/7660
- https://github.com/mattermost/mattermost-mobile/pull/10056

#### Test Results

The current reduced patch has focused unit and static coverage, but those checks do not prove physical-device performance. Builds 799 and 800 also passed their unit, TypeScript, lint, packaging, and emulator launch checks before failing physical validation.

#### Device Information

Affected device: Samsung SM-F966B, Android 16 / API 36.

Physical result:

- Earlier #10076 build: failed, original problem reproduced.
- #10076 plus the main #10056 startup mechanisms: failed, original problem reproduced.
- Same-base A/B for the reduced patch: not yet performed.

#### Release Note

```release-note
N/A - draft investigation, not ready for merge.
```
