### PR TITLE
[MM-69129] Prevent crash on nameless attachment

### DIFF
--- a/app/components/post_draft/uploads/upload_item/upload_item_wrapper.test.tsx
+++ b/app/components/post_draft/uploads/upload_item/upload_item_wrapper.test.tsx
@@ -36,11 +36,6 @@ jest.mock('@context/edit_post', () => ({
     useEditPost: jest.fn(() => ({isEditMode: false, updateFileCallback: undefined, onFileRemove: undefined})),
 }));
 
-jest.mock('@utils/file', () => ({
-    isImage: jest.fn(),
-    getFormattedFileSize: jest.fn((size) => `${size} KB`),
-}));
-
 jest.mock('@components/files/image_file', () => ({
     __esModule: true,
     default: jest.fn(),
@@ -52,8 +47,6 @@ jest.mock('@components/files/file_icon', () => ({
     default: jest.fn(),
 }));
 jest.mocked(FileIcon).mockImplementation((props) => React.createElement('FileIcon', {...props}));
-
-const {isImage} = require('@utils/file');
 
 describe('UploadItem', () => {
     const serverUrl = 'serverUrl';
@@ -90,10 +83,6 @@ describe('UploadItem', () => {
     };
 
     describe('Image Files', () => {
-        beforeEach(() => {
-            isImage.mockReturnValue(true);
-        });
-
         it('should display thumbnail for image files', () => {
             const imageFile = {
                 ...baseProps.file,
@@ -145,10 +134,6 @@ describe('UploadItem', () => {
     });
 
     describe('Non-Image Files', () => {
-        beforeEach(() => {
-            isImage.mockReturnValue(false);
-        });
-
         it('should display file name, extension, and size for non-image files', () => {
             const documentFile = {
                 ...baseProps.file,
@@ -170,7 +155,7 @@ describe('UploadItem', () => {
 
             expect(getByTestId('id')).toBeTruthy();
             expect(getByText('document.pdf')).toBeTruthy();
-            expect(getByText('PDF 5120 KB')).toBeTruthy();
+            expect(getByText('PDF 5 KB')).toBeTruthy();
         });
 
         it('should display file info for different file types', () => {
@@ -193,7 +178,7 @@ describe('UploadItem', () => {
             );
 
             expect(getByText('spreadsheet.xlsx')).toBeTruthy();
-            expect(getByText('XLSX 3072 KB')).toBeTruthy();
+            expect(getByText('XLSX 3 KB')).toBeTruthy();
         });
 
         it('should handle files without extension gracefully', () => {
@@ -216,7 +201,7 @@ describe('UploadItem', () => {
             );
 
             expect(getByText('document')).toBeTruthy();
-            expect(getByText('DOCUMENT 1024 KB')).toBeTruthy();
+            expect(getByText('DOCUMENT 1024 B')).toBeTruthy();
         });
 
         it('should extract extension from file name when extension field is missing', () => {
@@ -239,7 +224,7 @@ describe('UploadItem', () => {
             );
 
             expect(getByText('report.docx')).toBeTruthy();
-            expect(getByText('DOCX 2048 KB')).toBeTruthy();
+            expect(getByText('DOCX 2 KB')).toBeTruthy();
         });
     });
 

--- a/app/components/upload_item_shared/index.test.tsx
+++ b/app/components/upload_item_shared/index.test.tsx
@@ -15,12 +15,6 @@ import type {Database} from '@nozbe/watermelondb';
 jest.mock('@components/files/file_icon', () => 'FileIcon');
 jest.mock('@components/files/image_file', () => 'ImageFile');
 jest.mock('@components/progress_bar', () => 'ProgressBar');
-jest.mock('@utils/file', () => ({
-    isImage: jest.fn(),
-    getFormattedFileSize: jest.fn(),
-}));
-
-const {isImage, getFormattedFileSize} = require('@utils/file');
 
 describe('UploadItemShared', () => {
     const serverUrl = 'serverUrl';
@@ -29,7 +23,6 @@ describe('UploadItemShared', () => {
     beforeEach(async () => {
         jest.clearAllMocks();
         database = (await TestHelper.setupServerDatabase(serverUrl)).database;
-        getFormattedFileSize.mockReturnValue('1024 KB');
     });
 
     afterAll(async () => {
@@ -41,7 +34,7 @@ describe('UploadItemShared', () => {
         clientId: 'test-client-id',
         name: 'test-file.jpg',
         extension: 'jpg',
-        size: 1024,
+        size: 1024 * 1024,
         uri: 'file://test-uri',
         failed: false,
         width: 800,
@@ -50,9 +43,15 @@ describe('UploadItemShared', () => {
         ...overrides,
     });
 
+    const createMockDocumentFile = (overrides: Partial<UploadItemFile> = {}): UploadItemFile => createMockFile({
+        name: 'report.pdf',
+        extension: 'pdf',
+        mime_type: 'application/pdf',
+        ...overrides,
+    });
+
     describe('File Type Display Behavior', () => {
         it('should display image thumbnail for image files', () => {
-            isImage.mockReturnValue(true);
             const imageFile = createMockFile({
                 name: 'vacation.jpg',
                 mime_type: 'image/jpeg',
@@ -75,12 +74,7 @@ describe('UploadItemShared', () => {
         });
 
         it('should display file info for document files', () => {
-            isImage.mockReturnValue(false);
-            const docFile = createMockFile({
-                name: 'report.pdf',
-                extension: 'pdf',
-                mime_type: 'application/pdf',
-            });
+            const docFile = createMockDocumentFile();
 
             const {getByText} = renderWithEverything(
                 <UploadItemShared
@@ -96,7 +90,6 @@ describe('UploadItemShared', () => {
         });
 
         it('should handle files without extension gracefully', () => {
-            isImage.mockReturnValue(false);
             const fileWithoutExt = createMockFile({
                 name: 'document_no_extension',
                 extension: undefined,
@@ -116,7 +109,6 @@ describe('UploadItemShared', () => {
         });
 
         it('should extract extension from filename when extension field is missing', () => {
-            isImage.mockReturnValue(false);
             const fileWithNameExt = createMockFile({
                 name: 'document.docx',
                 extension: '',
@@ -138,12 +130,11 @@ describe('UploadItemShared', () => {
 
     describe('User Interactions', () => {
         it('should call onPress when user taps the file', () => {
-            isImage.mockReturnValue(false);
             const onPress = jest.fn();
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     onPress={onPress}
                     testID='test-upload'
                 />,
@@ -155,9 +146,8 @@ describe('UploadItemShared', () => {
         });
 
         it('should call onRetry when user taps retry button on failed upload', () => {
-            isImage.mockReturnValue(false);
             const onRetry = jest.fn();
-            const failedFile = createMockFile({
+            const failedFile = createMockDocumentFile({
                 failed: true,
             });
 
@@ -182,11 +172,10 @@ describe('UploadItemShared', () => {
         });
 
         it('should not crash when tapped without onPress handler', () => {
-            isImage.mockReturnValue(false);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     testID='test-upload'
                 />,
                 {database},
@@ -201,11 +190,10 @@ describe('UploadItemShared', () => {
 
     describe('Upload Progress and States', () => {
         it('should show progress bar during active upload', () => {
-            isImage.mockReturnValue(false);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     loading={true}
                     progress={0.5}
                     testID='test-upload'
@@ -218,11 +206,10 @@ describe('UploadItemShared', () => {
         });
 
         it('should not show progress bar for completed uploads', () => {
-            isImage.mockReturnValue(false);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     loading={false}
                     testID='test-upload'
                 />,
@@ -234,8 +221,7 @@ describe('UploadItemShared', () => {
         });
 
         it('should not show progress bar for failed uploads', () => {
-            isImage.mockReturnValue(false);
-            const failedFile = createMockFile({
+            const failedFile = createMockDocumentFile({
                 failed: true,
             });
 
@@ -253,8 +239,7 @@ describe('UploadItemShared', () => {
         });
 
         it('should show retry button only when file is failed and showRetryButton is true', () => {
-            isImage.mockReturnValue(false);
-            const failedFile = createMockFile({
+            const failedFile = createMockDocumentFile({
                 failed: true,
             });
 
@@ -272,11 +257,10 @@ describe('UploadItemShared', () => {
         });
 
         it('should not show retry button for successful uploads', () => {
-            isImage.mockReturnValue(false);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     showRetryButton={true}
                     testID='test-upload'
                 />,
@@ -289,7 +273,6 @@ describe('UploadItemShared', () => {
 
     describe('Share Extension vs Main App Context', () => {
         it('should handle share extension context for images', () => {
-            isImage.mockReturnValue(true);
             const imageFile = createMockFile({
                 name: 'shared-photo.jpg',
                 uri: 'file://local-path/photo.jpg',
@@ -309,7 +292,6 @@ describe('UploadItemShared', () => {
         });
 
         it('should handle main app context for images', () => {
-            isImage.mockReturnValue(true);
             const imageFile = createMockFile({
                 name: 'main-app-photo.jpg',
             });
@@ -332,11 +314,10 @@ describe('UploadItemShared', () => {
 
     describe('Layout Modes', () => {
         it('should use full width layout for non-image files when specified', () => {
-            isImage.mockReturnValue(false);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     fullWidth={true}
                     testID='test-upload'
                 />,
@@ -347,7 +328,6 @@ describe('UploadItemShared', () => {
         });
 
         it('should not apply full width to image files even when specified', () => {
-            isImage.mockReturnValue(true);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
@@ -365,11 +345,10 @@ describe('UploadItemShared', () => {
 
     describe('Error States and Visual Feedback', () => {
         it('should apply error styling when hasError is true', () => {
-            isImage.mockReturnValue(false);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     hasError={true}
                     testID='test-upload'
                 />,
@@ -381,11 +360,10 @@ describe('UploadItemShared', () => {
         });
 
         it('should not apply error styling when hasError is false', () => {
-            isImage.mockReturnValue(false);
 
             const {getByTestId} = renderWithEverything(
                 <UploadItemShared
-                    file={createMockFile()}
+                    file={createMockDocumentFile()}
                     hasError={false}
                     testID='test-upload'
                 />,
@@ -398,10 +376,7 @@ describe('UploadItemShared', () => {
     });
 
     describe('Data Resilience', () => {
-        // A draft persisted without file metadata reaches this component with no name
-        // and no extension, so the real isImage has to tolerate that rather than throw.
         it('should handle files with missing name and extension gracefully', () => {
-            isImage.mockImplementation(jest.requireActual('@utils/file').isImage);
             const fileWithoutName = createMockFile({
                 name: undefined,
                 extension: undefined,
@@ -420,9 +395,7 @@ describe('UploadItemShared', () => {
         });
 
         it('should handle files with zero size', () => {
-            isImage.mockReturnValue(false);
-            getFormattedFileSize.mockReturnValue('0 KB');
-            const emptyFile = createMockFile({
+            const emptyFile = createMockDocumentFile({
                 size: 0,
             });
 
@@ -434,12 +407,11 @@ describe('UploadItemShared', () => {
                 {database},
             );
 
-            expect(getByText('JPG 0 KB')).toBeTruthy(); // Extension + size format
+            expect(getByText('PDF 0 B')).toBeTruthy(); // Extension + size format
         });
 
         it('should handle files with no URI', () => {
-            isImage.mockReturnValue(false);
-            const fileWithoutUri = createMockFile({
+            const fileWithoutUri = createMockDocumentFile({
                 uri: undefined,
             });
 
@@ -456,8 +428,7 @@ describe('UploadItemShared', () => {
         });
 
         it('should handle files with no mime type', () => {
-            isImage.mockReturnValue(false);
-            const fileWithoutMimeType = createMockFile({
+            const fileWithoutMimeType = createMockDocumentFile({
                 mime_type: undefined,
             });
 
@@ -475,12 +446,10 @@ describe('UploadItemShared', () => {
 
     describe('Complex Interaction Scenarios', () => {
         it('should handle retry flow for failed uploads', () => {
-            isImage.mockReturnValue(false);
             const onRetry = jest.fn();
-            const failedFile = createMockFile({
+            const failedFile = createMockDocumentFile({
                 failed: true,
                 name: 'failed-upload.pdf',
-                extension: 'pdf',
             });
 
             const {getByText} = renderWithEverything(
@@ -499,7 +468,6 @@ describe('UploadItemShared', () => {
         });
 
         it('should handle image files in error state', () => {
-            isImage.mockReturnValue(true);
             const errorImageFile = createMockFile({
                 name: 'corrupted.jpg',
                 failed: true,
@@ -524,8 +492,7 @@ describe('UploadItemShared', () => {
         });
 
         it('should handle simultaneous loading and error states correctly', () => {
-            isImage.mockReturnValue(false);
-            const conflictedFile = createMockFile({
+            const conflictedFile = createMockDocumentFile({
                 failed: true,
             });
 

--- a/app/components/upload_item_shared/index.test.tsx
+++ b/app/components/upload_item_shared/index.test.tsx
@@ -398,10 +398,13 @@ describe('UploadItemShared', () => {
     });
 
     describe('Data Resilience', () => {
-        it('should handle files with missing name gracefully', () => {
-            isImage.mockReturnValue(false);
+        // A draft persisted without file metadata reaches this component with no name
+        // and no extension, so the real isImage has to tolerate that rather than throw.
+        it('should handle files with missing name and extension gracefully', () => {
+            isImage.mockImplementation(jest.requireActual('@utils/file').isImage);
             const fileWithoutName = createMockFile({
                 name: undefined,
+                extension: undefined,
             });
 
             const {getByText} = renderWithEverything(

--- a/app/utils/file/index.test.ts
+++ b/app/utils/file/index.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Directory} from 'expo-file-system';
+import {Directory, File} from 'expo-file-system';
 import Permissions from 'react-native-permissions';
 
 import {getIntlShape} from '@utils/general';
@@ -33,6 +33,8 @@ import {
     pathWithPrefix,
     uploadDisabledWarning,
 } from './index';
+
+import type {Asset} from 'react-native-image-picker';
 
 jest.mock('react-native', () => {
     const RN = jest.requireActual('react-native');
@@ -172,6 +174,11 @@ describe('Image utils', () => {
             expect(isImage({name: 'file.jpg', mimeType: 'image/jpeg'} as unknown as FileInfo)).toBe(true);
             expect(isImage({name: 'file.png', mimeType: 'text/plain'} as unknown as FileInfo)).toBe(false);
             expect(isImage({name: 'file.png', extension: '.png'} as unknown as FileInfo)).toBe(true);
+            expect(isImage({name: 'file.png'} as unknown as FileInfo)).toBe(true);
+        });
+
+        it('should return false for a file with no name and no extension', () => {
+            expect(isImage({mime_type: 'image/jpg', localPath: 'file:///draft.jpg'} as unknown as FileInfo)).toBe(false);
         });
     });
 
@@ -235,6 +242,17 @@ describe('Image utils', () => {
             expect(result).toEqual(expect.any(Array));
             result = await extractFileInfo([{uri: 'file://somefile', size: 12345, fileName: 'file.png', type: 'image/png'}]);
             expect(result).toEqual(expect.any(Array));
+        });
+
+        it('should read the size from the local file when the asset has no file size', async () => {
+            jest.mocked(File).mockImplementationOnce(() => ({info: () => ({exists: true, size: 999})}) as unknown as File);
+
+            const result = await extractFileInfo([{uri: 'file:///tmp/A1B2C3.jpg', fileName: 'A1B2C3.jpg', type: 'image/jpg'}] as unknown as Asset[]);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('A1B2C3.jpg');
+            expect(result[0].size).toBe(999);
+            expect(logError).not.toHaveBeenCalled();
         });
     });
 

--- a/app/utils/file/index.ts
+++ b/app/utils/file/index.ts
@@ -255,6 +255,11 @@ export const isImage = (file?: FileInfo | FileModel) => {
         return true;
     }
 
+    // A draft persisted before its file metadata resolved has neither, despite the types.
+    if (!file.extension && !file.name) {
+        return false;
+    }
+
     const fileExt = extractExtension(file.extension || file.name);
 
     if (!SUPPORTED_IMAGE_FORMAT.includes(fileExt)) {
@@ -263,7 +268,7 @@ export const isImage = (file?: FileInfo | FileModel) => {
 
     let mimeType = 'mime_type' in file ? file.mime_type : file.mimeType;
     if (!mimeType) {
-        mimeType = lookupMimeType(file.extension) || lookupMimeType(file.name);
+        mimeType = lookupMimeType(fileExt);
     }
 
     return Boolean(mimeType?.startsWith('image/'));


### PR DESCRIPTION
#### Summary

Prevent a crash when an attachment lacks both a name and an extension, which is how the iOS photo picker leaves a draft when the app is backgrounded mid-selection.

* **Prevent crash on nameless attachment** — `isImage` called `extractExtension(undefined)` on every render of the channel and of the global Drafts screen, throwing `Cannot read property 'split' of undefined` into the error boundary. It now returns `false` for such a record, so the draft renders as a plain file card that the user can remove.
* **Exercise the upload item tests against the real file utils** — both suites stubbed `isImage` and `getFormattedFileSize`, which are pure functions, so neither could have caught this crash. Dropping the mocks lets each fixture decide which branch renders.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69129

#### Checklist

- [x] Added or updated unit tests (required for all new features)

#### Device Information

This PR was tested on: iPhone 17 Pro simulator, iOS 26.5

Attaching a photo from the library and sending it still works. The crash itself needs the picker backgrounded mid-selection, so it is covered at the unit level: against the unpatched `app/utils/file/index.ts`, the two `isImage` tests and the `upload_item_shared` render test fail with the ticket's exact `TypeError`.

```release-note
Fixed a crash on the channel and Drafts screens when a draft held an attachment that was persisted without its file metadata.
```
