### PR TITLE
[MM-69381] Add narrow relative-date style and accessibility props to shared components (1/3)

### DIFF
--- a/app/components/friendly_date/friendly_date.test.tsx
+++ b/app/components/friendly_date/friendly_date.test.tsx
@@ -4,8 +4,9 @@
 import React from 'react';
 
 import {renderWithIntl} from '@test/intl-test-helper';
+import {getIntlShape} from '@utils/general';
 
-import FriendlyDate from './index';
+import FriendlyDate, {getFriendlyDate} from './index';
 
 describe('Friendly Date', () => {
     it('should render correctly', () => {
@@ -161,5 +162,38 @@ describe('Friendly Date', () => {
         expect(inYearsText.getByText('in 2 years')).toBeTruthy();
 
         jest.useRealTimers();
+    });
+
+    describe('getFriendlyDate with narrow style', () => {
+        const intl = getIntlShape();
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+            jest.setSystemTime(new Date('2020-05-15T12:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('should render abbreviated relative time', () => {
+            const minutesAgo = new Date();
+            minutesAgo.setMinutes(minutesAgo.getMinutes() - 38);
+            expect(getFriendlyDate(intl, minutesAgo.getTime(), 'narrow')).toBe('38m ago');
+
+            const hoursAgo = new Date();
+            hoursAgo.setHours(hoursAgo.getHours() - 4);
+            expect(getFriendlyDate(intl, hoursAgo.getTime(), 'narrow')).toBe('4h ago');
+
+            const daysAgo = new Date();
+            daysAgo.setDate(daysAgo.getDate() - 3);
+            expect(getFriendlyDate(intl, daysAgo.getTime(), 'narrow')).toBe('3d ago');
+        });
+
+        it('should still render "Now" for the sub-minute branch', () => {
+            const justNow = new Date();
+            justNow.setSeconds(justNow.getSeconds() - 10);
+            expect(getFriendlyDate(intl, justNow.getTime(), 'narrow')).toBe('Now');
+        });
     });
 });

--- a/app/components/friendly_date/index.tsx
+++ b/app/components/friendly_date/index.tsx
@@ -35,12 +35,16 @@ function getDiff(inputDate: number, unit: moment.unitOfTime.Diff) {
     return diff;
 }
 
-export function getFriendlyDate(intl: IntlShape, inputDate: number): string {
+export function getFriendlyDate(intl: IntlShape, inputDate: number, style: 'long' | 'narrow' = 'long'): string {
     const today = new Date();
     const date = new Date(inputDate);
     const difference = (date.getTime() - today.getTime()) / 1000;
     const absoluteDifference = Math.abs(difference);
     const sign = Math.sign(difference);
+
+    // The narrow style yields abbreviated, always-numeric output (e.g. "4h ago", "38m ago", "3d ago").
+    const narrow = style === 'narrow';
+    const formatOptions: Intl.RelativeTimeFormatOptions = narrow ? {numeric: 'always', style: 'narrow'} : {numeric: 'auto'};
 
     // Message: Now
     if (absoluteDifference < SECONDS.MINUTE) {
@@ -52,12 +56,12 @@ export function getFriendlyDate(intl: IntlShape, inputDate: number): string {
 
     // Message: Minutes
     if (absoluteDifference < SECONDS.HOUR) {
-        return intl.formatRelativeTime(getDiff(inputDate, 'minute'), 'minute', {numeric: 'auto', style: 'short'});
+        return intl.formatRelativeTime(getDiff(inputDate, 'minute'), 'minute', narrow ? formatOptions : {numeric: 'auto', style: 'short'});
     }
 
     // Message: Hours
     if (absoluteDifference < SECONDS.DAY) {
-        return intl.formatRelativeTime(getDiff(inputDate, 'hour'), 'hour', {numeric: 'auto'});
+        return intl.formatRelativeTime(getDiff(inputDate, 'hour'), 'hour', formatOptions);
     }
 
     // Message: Days
@@ -65,17 +69,17 @@ export function getFriendlyDate(intl: IntlShape, inputDate: number): string {
         const passedDate = sign === 1 ? today.getDate() <= date.getDate() : today.getDate() >= date.getDate();
         const completedAMonth = today.getMonth() !== date.getMonth() && passedDate;
         if (!completedAMonth) {
-            return intl.formatRelativeTime(getDiff(inputDate, 'day'), 'day', {numeric: 'auto'});
+            return intl.formatRelativeTime(getDiff(inputDate, 'day'), 'day', formatOptions);
         }
     }
 
     // Message: Months
     if (absoluteDifference < SECONDS.DAYS_366) {
-        return intl.formatRelativeTime(getDiff(inputDate, 'month'), 'month', {numeric: 'auto'});
+        return intl.formatRelativeTime(getDiff(inputDate, 'month'), 'month', formatOptions);
     }
 
     // Message: Years
-    return intl.formatRelativeTime(getDiff(inputDate, 'year'), 'year', {numeric: 'auto'});
+    return intl.formatRelativeTime(getDiff(inputDate, 'year'), 'year', formatOptions);
 }
 
 export default FriendlyDate;

--- a/app/components/pressable_opacity/index.tsx
+++ b/app/components/pressable_opacity/index.tsx
@@ -5,16 +5,18 @@ import React, {useCallback} from 'react';
 import {Pressable} from 'react-native-gesture-handler';
 import Animated, {useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 
-import type {StyleProp, ViewStyle} from 'react-native';
+import type {AccessibilityRole, StyleProp, ViewStyle} from 'react-native';
 
 type Props = {
     children: React.ReactNode;
     onPress: () => void;
     style?: StyleProp<ViewStyle>;
     testID?: string;
+    accessibilityLabel?: string;
+    accessibilityRole?: AccessibilityRole;
 }
 
-export default function PressableOpacity({children, onPress, style, testID}: Props) {
+export default function PressableOpacity({children, onPress, style, testID, accessibilityLabel, accessibilityRole}: Props) {
     const cancelOpacity = useSharedValue(1);
 
     const cancelAnimatedStyle = useAnimatedStyle(() => {
@@ -38,6 +40,8 @@ export default function PressableOpacity({children, onPress, style, testID}: Pro
             onPress={onPress}
             style={[style]}
             testID={testID}
+            accessibilityLabel={accessibilityLabel}
+            accessibilityRole={accessibilityRole}
         >
             <Animated.View style={cancelAnimatedStyle}>
                 {children}


### PR DESCRIPTION
#### Summary

**PR 1 of 3** — bottom of a stack that re-slices #9959. No behaviour change on its own; both changes are additive and opt-in.

- `getFriendlyDate` gains a `style` parameter. The default stays `'long'`, so every existing caller renders exactly as before. `'narrow'` switches to always-numeric, abbreviated output (`4h ago`, `38m ago`, `3d ago`) for callers that have to fit a relative time into a chip rather than a sentence.
- `PressableOpacity` forwards `accessibilityLabel` and `accessibilityRole`. Without them a caller has to wrap the pressable in an `accessible` View, which collapses the subtree and hides the interactive element from screen readers. Both props are optional.

The consumer is the playbooks task activity chip in PR 3, but neither change is playbooks-specific.

**The stack**

| | PR |
|---|---|
| 3 | task activity chip |
| 2 | persistence and sync |
| **1** | **shared components (this PR)** |

#### Ticket Link

JIRA - https://mattermost.atlassian.net/browse/MM-69381

#### Checklist

- [x] Added or updated unit tests (required for all new features)

#### Device Information

This PR was tested on: iOS and Android, as part of the combined branch in #9959.

```release-note
NONE
```
