### PR TITLE
fix: read GLOBAL record value, not row existence, in tutorial/push-ack observers

### DIFF
--- a/app/queries/app/global.ts
+++ b/app/queries/app/global.ts
@@ -76,8 +76,11 @@ export const observePushDisabledInServerAcknowledged = (serverDomainString: stri
         return of$(false);
     }
     return query.observe().pipe(
-        switchMap((result) => (result.length ? result[0].observe() : of$(false))),
-        switchMap((v) => of$(Boolean(v))),
+
+        // Map the record's value, not the record. Boolean(model) is always true, so a row
+        // written with a null value (how the remove/reset paths clear these keys) read as set.
+        switchMap((result) => (result.length ? result[0].observe() : of$(undefined))),
+        switchMap((v) => of$(Boolean(v?.value))),
     );
 };
 
@@ -111,7 +114,10 @@ export const observeTutorialWatched = (tutorial: string) => {
         return of$(false);
     }
     return query.observe().pipe(
-        switchMap((result) => (result.length ? result[0].observe() : of$(false))),
-        switchMap((v) => of$(Boolean(v))),
+
+        // Map the record's value, not the record. Boolean(model) is always true, so a row
+        // written with a null value (how the remove/reset paths clear these keys) read as set.
+        switchMap((result) => (result.length ? result[0].observe() : of$(undefined))),
+        switchMap((v) => of$(Boolean(v?.value))),
     );
 };


### PR DESCRIPTION
## Summary

`main` CI has been red since `f3af9dbe9` on a single **unit** test:

```
● SendButton › should return true if the scheduled post tutorial is watched
  expect(received).toBe(expected)
  Expected: false
  Received: true
  at app/components/post_draft/send_button/index.test.tsx:69
```

This PR fixes it in one file, `app/queries/app/global.ts`: the same two-line correction applied at each of its two affected observables (+10/-4 including comments).

**Scope:** this is a Jest unit test in the `ci` workflow's `test` job. It is unrelated to the Detox/Maestro E2E suites, which run in separate workflows and are unaffected either way.

## Root cause: a pre-existing bug, surfaced by two unrelated changes meeting on main

```js
switchMap((result) => (result.length ? result[0].observe() : of$(false))),
switchMap((v) => of$(Boolean(v))),
```

`result[0].observe()` emits the `GlobalModel`, not its value. `Boolean(model)` is always `true`, so **any existing row read as set regardless of its contents**.

The test clears via `storeGlobal(Tutorial.SCHEDULED_POST, null)` in `afterEach`, and `storeGlobal` writes a row with a null value rather than deleting it.

Three ingredients had to line up, and no single PR is at fault:

1. **The buggy observable** — already on `main` at the last green commit `f663d0f52`:
   ```
   $ git show f663d0f52:app/queries/app/global.ts | grep -n "Boolean(v)"
   80:        switchMap((v) => of$(Boolean(v))),
   115:        switchMap((v) => of$(Boolean(v))),
   ```
   It is present in the oldest commit available in a shallow clone (`05f7875d2`, 2024-10-21), so it is **at least** that old. I can't date its true origin or name an author — `git blame` attributes it to the shallow graft boundary, not to whoever wrote it, and `git log -S` finds nothing. Not claiming more than that.

2. **#10023** added the assertion that reads the initial state, rewriting the case from "write `'true'` → render → assert `true`" to "render → assert initial `false` → write `'true'` → assert `true`". That new first assertion is strictly stronger and correct; the old ordering was structurally incapable of catching this. #10023 **did not touch the observable**:
   ```
   $ git diff f663d0f52 f3af9dbe9 -- app/queries/app/global.ts | wc -l
   0
   ```

3. **#10056** changed the DatabaseManager **test mock** so the app database is reused between tests instead of being recreated on every `init()`:
   ```diff
   -    public init = async (serverUrls: string[]): Promise<void> => {
   -        await this.createAppDatabase();          // always recreated -> row wiped
   +    public initAppDatabase = async (): Promise<void> => {
   +        if (!this.appDatabase) {                 // reused -> row survives
   +            await this.createAppDatabase();
   +        }
   +    };
   ```
   Before this, every `beforeEach` got a fresh app database, so the null-valued row written by `afterEach` was wiped and the second test saw no row at all — masking the bug.

**#10023's own CI was green** (`run 33015753746`: 680 suites, 9008 passed, 0 failed) precisely because its branch predates #10056. The red appeared only once the two landed together on `main`.

### 2x2 confirming the interaction

Run locally on this branch, toggling only the observable and the mock:

| observable | DatabaseManager mock | result |
|---|---|---|
| buggy | current (post-#10056) | **1 failed, 1 passed** |
| buggy | pre-#10056 (`fac096837`) | 2 passed |
| fixed | pre-#10056 | 2 passed |
| fixed | current | 2 passed |

Only the combination fails, and the fix here passes under both mock versions.

## The second call site is a live defect, not just a test artifact

`observePushDisabledInServerAcknowledged` had the identical bug. `removePushDisabledInServerAcknowledged` (`app/actions/app/global.ts:118`) also clears by writing `null`, so the row persists and the observer kept reporting *acknowledged* after removal — leaving the push-disabled warning suppressed. Fixed here too; reviewers may want to judge whether that deserves its own note.

## The fix

```js
switchMap((result) => (result.length ? result[0].observe() : of$(undefined))),
switchMap((v) => of$(Boolean(v?.value))),
```

This matches `getPushDisabledInServerAcknowledged` immediately above, which already did `Boolean(records?.[0]?.value)` — the observables were the inconsistent ones.

**No production behaviour change for the tutorial keys.** Every writer stores only `'true'` (`app/actions/app/global.ts:40-60`, `:115`) and nothing writes `'false'`, so a row exists only when the value is `'true'` and old/new agree. The change only affects rows whose value is null or empty — exactly the clear-by-null case.

## Verification

- `send_button` suite: **2/2 pass** with the fix; **fails 4/4 runs** on this same branch without it
- All 9 `observeTutorialWatched` consumers plus `push_proxy`: **21 suites, 151 tests pass**
- `tsc --noEmit` clean, `eslint` clean
- CI on this PR: `test` and `lint-typecheck` both green

## Notes

- The same fix is also on #10050, where it was found; that PR's `test` job is green again with it.
- Scoped deliberately to the observable. #10050 additionally carries a Detox `server_list` visibility fix, which is not applicable to `main` (`ServerListScreen.toBeVisible` there uses `toExist` only).

```release-note
NONE
```

