### PR TITLE
Add E2E coverage for custom terms of service login flow

### DIFF
--- a/app/screens/terms_of_service/terms_of_service.tsx
+++ b/app/screens/terms_of_service/terms_of_service.tsx
@@ -259,6 +259,7 @@ const TermsOfService = ({
                     theme={theme}
                     text={intl.formatMessage({id: 'terms_of_service.acceptButton', defaultMessage: 'Accept'})}
                     size={'lg'}
+                    testID='terms_of_service.accept.button'
                 />
 
                 <Button
@@ -267,6 +268,7 @@ const TermsOfService = ({
                     text={intl.formatMessage({id: 'terms_of_service.decline', defaultMessage: 'Decline'})}
                     size={'lg'}
                     emphasis={'link'}
+                    testID='terms_of_service.decline.button'
                 />
 
             </>
@@ -283,10 +285,18 @@ const TermsOfService = ({
     }, [styles, insets]);
 
     return (
-        <View style={styles.root}>
+        <View
+            style={styles.root}
+            testID='terms_of_service.screen'
+        >
             <View style={containerStyle}>
                 <View style={styles.wrapper}>
-                    <Text style={styles.title}>{intl.formatMessage({id: 'terms_of_service.title', defaultMessage: 'Terms of Service'})}</Text>
+                    <Text
+                        style={styles.title}
+                        testID='terms_of_service.title'
+                    >
+                        {intl.formatMessage({id: 'terms_of_service.title', defaultMessage: 'Terms of Service'})}
+                    </Text>
                     {content}
                 </View>
             </View>

--- a/detox/e2e/support/classification_lock.ts
+++ b/detox/e2e/support/classification_lock.ts
@@ -1,86 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {
-    acquireLock,
-    formatError,
-    releaseLock,
-    type AcquireLockOptions,
-    type LockStore,
-} from '@support/classification_lock_core';
-import Preference, {type UserPreference} from '@support/server_api/preference';
-import User from '@support/server_api/user';
-import {getRandomId} from '@support/utils';
+import {createServerLock} from '@support/server_lock';
 
-const LOCK_CATEGORY = 'e2e_locks';
-const LOCK_NAME = 'classification';
+import type {AcquireLockOptions} from '@support/classification_lock_core';
 
-const loginAsAdmin = async (baseUrl: string) => {
-    const result = await User.apiAdminLogin(baseUrl) as {user?: {id?: string}; error?: unknown};
-    const userId = result.user?.id;
-    if (!userId) {
-        throw new Error(`classification lock: admin login failed: ${formatError(result.error ?? result)}`);
-    }
+const classificationLock = createServerLock('classification');
 
-    return userId;
-};
-
-// The lock cell is an admin user preference on the shared test server.
-const createPreferenceLockStore = (baseUrl: string): LockStore => {
-    let userId: string | undefined;
-
-    const withAdmin = async <T>(operation: (adminId: string) => Promise<T>): Promise<T> => {
-        try {
-            userId = userId ?? await loginAsAdmin(baseUrl);
-            return await operation(userId);
-        } catch (error) {
-            userId = undefined;
-            throw error;
-        }
-    };
-
-    return {
-        read: () => withAdmin(async (adminId) => {
-            const result = await Preference.apiGetUserPreferences(baseUrl, adminId) as {
-                preferences?: UserPreference[];
-                error?: unknown;
-            };
-            if (!result.preferences) {
-                throw new Error(`classification lock: failed to read admin preferences: ${formatError(result.error ?? result)}`);
-            }
-
-            const preference = result.preferences.find(
-                (item) => item.category === LOCK_CATEGORY && item.name === LOCK_NAME,
-            );
-            return preference?.value ?? '';
-        }),
-        write: (value: string) => withAdmin(async (adminId) => {
-            const result = await Preference.apiSaveUserPreferences(baseUrl, adminId, [{
-                user_id: adminId,
-                category: LOCK_CATEGORY,
-                name: LOCK_NAME,
-                value,
-            }]) as {error?: unknown};
-
-            if (result.error) {
-                throw new Error(`classification lock: failed to save admin preference: ${formatError(result.error)}`);
-            }
-        }),
-    };
-};
-
-export const createClassificationLockOwner = () => {
-    return [
-        process.env.GITHUB_RUN_ID || 'local',
-        process.env.GITHUB_JOB || 'job',
-        process.env.DETOX_CONFIGURATION || process.env.DETOX_CONFIG || 'detox',
-        Date.now(),
-
-        // Shards of the same job share every field above and can start in the same
-        // millisecond; without this two owners would compare equal and both hold the lock.
-        process.pid,
-        getRandomId(),
-    ].join('-');
+export const createClassificationLockOwner = (): string => {
+    return classificationLock.createOwner();
 };
 
 export const acquireClassificationLock = async (
@@ -88,9 +16,9 @@ export const acquireClassificationLock = async (
     owner: string,
     options: AcquireLockOptions = {},
 ): Promise<void> => {
-    return acquireLock(createPreferenceLockStore(baseUrl), owner, options);
+    return classificationLock.acquire(baseUrl, owner, options);
 };
 
 export const releaseClassificationLock = async (baseUrl: string, owner: string): Promise<void> => {
-    return releaseLock(createPreferenceLockStore(baseUrl), owner);
+    return classificationLock.release(baseUrl, owner);
 };

--- a/detox/e2e/support/server_api/index.ts
+++ b/detox/e2e/support/server_api/index.ts
@@ -17,6 +17,7 @@ import Setup from './setup';
 import Status from './status';
 import System from './system';
 import Team from './team';
+import TermsOfService from './terms_of_service';
 import User from './user';
 import Webhook from './webhook';
 
@@ -42,6 +43,7 @@ export {
     Status,
     System,
     Team,
+    TermsOfService,
     User,
     Webhook,
 };

--- a/detox/e2e/support/server_api/terms_of_service.ts
+++ b/detox/e2e/support/server_api/terms_of_service.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import client from './client';
+import {getResponseFromError} from './common';
+import System from './system';
+
+// ****************************************************************
+// Terms of Service
+// See https://api.mattermost.com/#tag/terms-of-service
+// ****************************************************************
+
+/**
+ * Create custom terms of service.
+ * See https://api.mattermost.com/#operation/CreateTermsOfService
+ * @param {string} baseUrl - the base server URL
+ * @param {string} text - markdown/plain terms body
+ * @return {Object} returns {terms} on success or {error, status} on error
+ */
+export const apiCreateTermsOfService = async (baseUrl: string, text: string): Promise<any> => {
+    try {
+        const response = await client.post(`${baseUrl}/api/v4/terms_of_service`, {text});
+
+        return {terms: response.data};
+    } catch (err) {
+        return getResponseFromError(err);
+    }
+};
+
+/**
+ * Enable custom terms of service (uses latest created terms from the server).
+ * Requires Enterprise license with CustomTermsOfService.
+ * @param {string} baseUrl - the base server URL
+ * @param {number} reAcceptancePeriodDays - days until re-acceptance is required
+ * @return {Object} returns {config} on success or {error, status} on error
+ */
+export const apiEnableCustomTermsOfService = async (
+    baseUrl: string,
+    reAcceptancePeriodDays = 365,
+): Promise<any> => {
+    return System.apiUpdateConfig(baseUrl, {
+        SupportSettings: {
+            EnableCustomTermsOfService: true,
+            CustomTermsOfServiceReAcceptancePeriod: reAcceptancePeriodDays,
+        },
+    });
+};
+
+/**
+ * Disable custom terms of service so other suites are not forced through ToS.
+ * @param {string} baseUrl - the base server URL
+ * @return {Object} returns {config} on success or {error, status} on error
+ */
+export const apiDisableCustomTermsOfService = async (baseUrl: string): Promise<any> => {
+    return System.apiUpdateConfig(baseUrl, {
+        SupportSettings: {
+            EnableCustomTermsOfService: false,
+        },
+    });
+};
+
+const TermsOfService = {
+    apiCreateTermsOfService,
+    apiEnableCustomTermsOfService,
+    apiDisableCustomTermsOfService,
+};
+
+export default TermsOfService;

--- a/detox/e2e/support/server_api/terms_of_service.ts
+++ b/detox/e2e/support/server_api/terms_of_service.ts
@@ -98,11 +98,30 @@ export const apiAssertCustomTermsOfServiceActive = async (baseUrl: string, terms
     }
 };
 
+/**
+ * Throw unless the client config the app consumes reports custom ToS as off.
+ *
+ * The mirror of apiAssertCustomTermsOfServiceActive, and load-bearing for the same reason:
+ * the config patch returns before the server regenerates client config, so handing the
+ * server to the next suite straight after the disable can do so while it still serves
+ * EnableCustomTermsOfService=true. That suite's app would fetch the stale config and get the
+ * ToS modal in front of its login — the exact interference the disable is meant to end.
+ *
+ * @param {string} baseUrl - the base server URL
+ */
+export const apiAssertCustomTermsOfServiceInactive = async (baseUrl: string): Promise<void> => {
+    const disabled = await System.waitForClientConfigFlag(baseUrl, 'EnableCustomTermsOfService', 'false');
+    if (!disabled) {
+        throw new Error('apiAssertCustomTermsOfServiceInactive: client config EnableCustomTermsOfService never became "false" — the server may still force other suites through ToS');
+    }
+};
+
 const TermsOfService = {
     apiCreateTermsOfService,
     apiEnableCustomTermsOfService,
     apiDisableCustomTermsOfService,
     apiAssertCustomTermsOfServiceActive,
+    apiAssertCustomTermsOfServiceInactive,
 };
 
 export default TermsOfService;

--- a/detox/e2e/support/server_api/terms_of_service.ts
+++ b/detox/e2e/support/server_api/terms_of_service.ts
@@ -28,8 +28,17 @@ export const apiCreateTermsOfService = async (baseUrl: string, text: string): Pr
 };
 
 /**
- * Enable custom terms of service (uses latest created terms from the server).
+ * Enable custom terms of service.
  * Requires Enterprise license with CustomTermsOfService.
+ *
+ * The server field is `SupportSettings.CustomTermsOfServiceEnabled` (server
+ * `model/config.go`). `EnableCustomTermsOfService` is the *client* config key the app reads;
+ * it is derived in `config/client.go` as
+ * `props["EnableCustomTermsOfService"] = FormatBool(*c.SupportSettings.CustomTermsOfServiceEnabled)`.
+ * Patching the client key name instead is silently dropped as an unknown field — the patch
+ * still returns 200 and ToS is never enabled, which is why apiAssertCustomTermsOfServiceActive
+ * below verifies against the client config rather than trusting the patch response.
+ *
  * @param {string} baseUrl - the base server URL
  * @param {number} reAcceptancePeriodDays - days until re-acceptance is required
  * @return {Object} returns {config} on success or {error, status} on error
@@ -40,7 +49,7 @@ export const apiEnableCustomTermsOfService = async (
 ): Promise<any> => {
     return System.apiUpdateConfig(baseUrl, {
         SupportSettings: {
-            EnableCustomTermsOfService: true,
+            CustomTermsOfServiceEnabled: true,
             CustomTermsOfServiceReAcceptancePeriod: reAcceptancePeriodDays,
         },
     });
@@ -54,15 +63,46 @@ export const apiEnableCustomTermsOfService = async (
 export const apiDisableCustomTermsOfService = async (baseUrl: string): Promise<any> => {
     return System.apiUpdateConfig(baseUrl, {
         SupportSettings: {
-            EnableCustomTermsOfService: false,
+            CustomTermsOfServiceEnabled: false,
         },
     });
+};
+
+/**
+ * Throw unless the client config the app actually consumes has custom ToS active for
+ * `termsId`.
+ *
+ * Asserted against `/api/v4/config/client` rather than the admin config because that is what
+ * `observeShowToS` reads, and because the two ToS keys only exist there: the server derives
+ * `EnableCustomTermsOfService` from `CustomTermsOfServiceEnabled`, and sets
+ * `CustomTermsOfServiceId` from `TermsOfService().GetLatest()` — it is not a config field, so
+ * this also catches another suite's terms being the latest row.
+ *
+ * Client config is regenerated asynchronously, hence the poll rather than a single read.
+ *
+ * @param {string} baseUrl - the base server URL
+ * @param {string} termsId - id the suite expects to be active
+ */
+export const apiAssertCustomTermsOfServiceActive = async (baseUrl: string, termsId: string): Promise<void> => {
+    const enabled = await System.waitForClientConfigFlag(baseUrl, 'EnableCustomTermsOfService', 'true');
+    if (!enabled) {
+        throw new Error('apiAssertCustomTermsOfServiceActive: client config EnableCustomTermsOfService never became "true" — check the Enterprise licence covers CustomTermsOfService');
+    }
+
+    const {config, error, status} = await System.apiGetClientConfigOld(baseUrl);
+    if (!config) {
+        throw new Error(`apiAssertCustomTermsOfServiceActive: could not read client config (status ${status ?? 'unknown'}): ${error?.message ?? 'unknown error'}`);
+    }
+    if (config.CustomTermsOfServiceId !== termsId) {
+        throw new Error(`apiAssertCustomTermsOfServiceActive: CustomTermsOfServiceId is "${String(config.CustomTermsOfServiceId)}", expected "${termsId}"`);
+    }
 };
 
 const TermsOfService = {
     apiCreateTermsOfService,
     apiEnableCustomTermsOfService,
     apiDisableCustomTermsOfService,
+    apiAssertCustomTermsOfServiceActive,
 };
 
 export default TermsOfService;

--- a/detox/e2e/support/server_lock.ts
+++ b/detox/e2e/support/server_lock.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Advisory lock for suites that mutate server-wide configuration.
+ *
+ * CI provisions only two Detox servers and rotates them as SITE_1/SITE_2 across every
+ * shard, so a suite that flips a global setting is visible to every other shard sharing
+ * that server. Suites that do so take a named lock first; the lock cell is an admin user
+ * preference on the server being mutated.
+ *
+ * A lock only serialises participants — it does not protect suites that never take it.
+ * It is therefore a complement to, not a substitute for, running such a suite against a
+ * server no one else uses.
+ */
+
+import {
+    acquireLock,
+    formatError,
+    releaseLock,
+    type AcquireLockOptions,
+    type LockStore,
+} from '@support/classification_lock_core';
+import Preference, {type UserPreference} from '@support/server_api/preference';
+import User from '@support/server_api/user';
+import {getRandomId} from '@support/utils';
+
+const LOCK_CATEGORY = 'e2e_locks';
+
+export type ServerLock = {
+    createOwner: () => string;
+    acquire: (baseUrl: string, owner: string, options?: AcquireLockOptions) => Promise<void>;
+    release: (baseUrl: string, owner: string) => Promise<void>;
+};
+
+const loginAsAdmin = async (baseUrl: string, lockName: string) => {
+    const result = await User.apiAdminLogin(baseUrl) as {user?: {id?: string}; error?: unknown};
+    const userId = result.user?.id;
+    if (!userId) {
+        throw new Error(`${lockName} lock: admin login failed: ${formatError(result.error ?? result)}`);
+    }
+
+    return userId;
+};
+
+// The lock cell is an admin user preference on the shared test server.
+const createPreferenceLockStore = (baseUrl: string, lockName: string): LockStore => {
+    let userId: string | undefined;
+
+    const withAdmin = async <T>(operation: (adminId: string) => Promise<T>): Promise<T> => {
+        try {
+            userId = userId ?? await loginAsAdmin(baseUrl, lockName);
+            return await operation(userId);
+        } catch (error) {
+            userId = undefined;
+            throw error;
+        }
+    };
+
+    return {
+        read: () => withAdmin(async (adminId) => {
+            const result = await Preference.apiGetUserPreferences(baseUrl, adminId) as {
+                preferences?: UserPreference[];
+                error?: unknown;
+            };
+            if (!result.preferences) {
+                throw new Error(`${lockName} lock: failed to read admin preferences: ${formatError(result.error ?? result)}`);
+            }
+
+            const preference = result.preferences.find(
+                (item) => item.category === LOCK_CATEGORY && item.name === lockName,
+            );
+            return preference?.value ?? '';
+        }),
+        write: (value: string) => withAdmin(async (adminId) => {
+            const result = await Preference.apiSaveUserPreferences(baseUrl, adminId, [{
+                user_id: adminId,
+                category: LOCK_CATEGORY,
+                name: lockName,
+                value,
+            }]) as {error?: unknown};
+
+            if (result.error) {
+                throw new Error(`${lockName} lock: failed to save admin preference: ${formatError(result.error)}`);
+            }
+        }),
+    };
+};
+
+/**
+ * Build a named advisory lock. `lockName` is the preference key, so two different names
+ * are two independent locks on the same server.
+ */
+export const createServerLock = (lockName: string): ServerLock => {
+    return {
+        createOwner: () => [
+            process.env.GITHUB_RUN_ID || 'local',
+            process.env.GITHUB_JOB || 'job',
+            process.env.DETOX_CONFIGURATION || process.env.DETOX_CONFIG || 'detox',
+            Date.now(),
+
+            // Shards of the same job share every field above and can start in the same
+            // millisecond; without this two owners would compare equal and both hold the lock.
+            process.pid,
+            getRandomId(),
+        ].join('-'),
+
+        acquire: (baseUrl: string, owner: string, options: AcquireLockOptions = {}) =>
+            acquireLock(createPreferenceLockStore(baseUrl, lockName), owner, options),
+
+        release: (baseUrl: string, owner: string) =>
+            releaseLock(createPreferenceLockStore(baseUrl, lockName), owner),
+    };
+};

--- a/detox/e2e/support/site_three_lock.ts
+++ b/detox/e2e/support/site_three_lock.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Exclusive use of the third test site (SITE_3).
+ *
+ * SITE_3 is a single instance shared by the iOS and Android jobs, and the suites that use it
+ * are not independent: `custom_terms_of_service` turns on server-wide custom ToS, which puts
+ * a modal in front of every login on that server — including `server_list`'s login to the
+ * third server. Both suites therefore hold this lock for as long as they are using SITE_3.
+ *
+ * Shared from one module so the two callers cannot drift onto different lock names, which
+ * would silently stop serialising them.
+ */
+
+import {createServerLock} from '@support/server_lock';
+import {timeouts} from '@support/utils';
+
+export const siteThreeLock = createServerLock('site_three');
+
+/**
+ * Long enough for the other platform's job plus the other suite to finish and release, and
+ * comfortably above the 5-minute lease so a live holder is never stolen from.
+ * Callers must give their beforeAll hook a larger timeout than this.
+ */
+export const SITE_THREE_LOCK_TIMEOUT_MS = timeouts.ONE_MIN * 20;

--- a/detox/e2e/support/ui/component/alert.ts
+++ b/detox/e2e/support/ui/component/alert.ts
@@ -36,6 +36,7 @@ class Alert {
         return isAndroid() ? element(by.text(title)) : element(by.label(title)).atIndex(0);
     };
     logoutNotCompleteTitle = isAndroid() ? element(by.text('Logout not complete')) : element(by.label('Logout not complete')).atIndex(0);
+    termsDeclinedTitle = isAndroid() ? element(by.text('You must accept the terms of service')) : element(by.label('You must accept the terms of service')).atIndex(0);
     removedFromTeamTitle = isAndroid() ? element(by.text('Removed from team')) : element(by.label('Removed from team')).atIndex(0);
     unarchivePrivateChannelTitle = isAndroid() ? element(by.text('Unarchive Private Channel')) : element(by.label('Unarchive Private Channel')).atIndex(0);
     unarchivePublicChannelTitle = isAndroid() ? element(by.text('Unarchive Public Channel')) : element(by.label('Unarchive Public Channel')).atIndex(0);

--- a/detox/e2e/support/ui/screen/index.ts
+++ b/detox/e2e/support/ui/screen/index.ts
@@ -58,6 +58,7 @@ import ServerListScreen from './server_list';
 import SettingsScreen from './settings';
 import TableScreen from './table';
 import TeamDropdownMenuScreen from './team_dropdown_menu';
+import TermsOfServiceScreen from './terms_of_service';
 import ThemeDisplaySettingsScreen from './theme_display_settings';
 import ThreadScreen from './thread';
 import ThreadOptionsScreen from './thread_options';
@@ -114,6 +115,7 @@ export {
     SettingsScreen,
     TableScreen,
     TeamDropdownMenuScreen,
+    TermsOfServiceScreen,
     ThemeDisplaySettingsScreen,
     ThreadScreen,
     ThreadOptionsScreen,

--- a/detox/e2e/support/ui/screen/terms_of_service.ts
+++ b/detox/e2e/support/ui/screen/terms_of_service.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Alert} from '@support/ui/component';
+import {ChannelListScreen, HomeScreen, LoginScreen, ServerScreen} from '@support/ui/screen';
+import {isAndroid, isIos, timeouts, wait} from '@support/utils';
+import {expect, waitFor} from 'detox';
+
+class TermsOfServiceScreen {
+    testID = {
+        termsOfServiceScreen: 'terms_of_service.screen',
+        title: 'terms_of_service.title',
+        acceptButton: 'terms_of_service.accept.button',
+        declineButton: 'terms_of_service.decline.button',
+    };
+
+    termsOfServiceScreen = element(by.id(this.testID.termsOfServiceScreen));
+    title = element(by.id(this.testID.title));
+    acceptButton = element(by.id(this.testID.acceptButton));
+    declineButton = element(by.id(this.testID.declineButton));
+
+    toBeVisible = async () => {
+        const timeout = isAndroid() ? timeouts.ONE_MIN : timeouts.HALF_MIN;
+
+        await waitFor(this.termsOfServiceScreen).toExist().withTimeout(timeout);
+        await waitFor(this.acceptButton).toExist().withTimeout(timeout);
+        await waitFor(this.declineButton).toExist().withTimeout(timeout);
+
+        return this.termsOfServiceScreen;
+    };
+
+    /**
+     * Submit login credentials and wait for the custom ToS modal (not the channel list).
+     */
+    loginUntilVisible = async (user: any = {}) => {
+        await LoginScreen.toBeVisible();
+
+        await LoginScreen.usernameInput.tap({x: 150, y: 10});
+        await LoginScreen.usernameInput.replaceText(user.newUser?.email || user.email);
+        await LoginScreen.passwordInput.tap();
+        await LoginScreen.passwordInput.replaceText(user.newUser?.password || user.password);
+        await LoginScreen.loginFormInfoText.tap();
+        await LoginScreen.signinButton.tap();
+
+        // Optional post-login system / push-proxy alerts can cover the ToS modal.
+        if (isIos()) {
+            try {
+                await element(by.label('Not Now')).tap();
+                await wait(timeouts.HALF_SEC);
+            } catch {
+                // not present
+            }
+            try {
+                await element(by.label('Okay')).tap();
+                await wait(timeouts.HALF_SEC);
+            } catch {
+                // not present
+            }
+        } else {
+            try {
+                await waitFor(Alert.okayButton).toExist().withTimeout(timeouts.TWO_SEC);
+                await Alert.okayButton.tap();
+            } catch {
+                // not present
+            }
+        }
+
+        return this.toBeVisible();
+    };
+
+    accept = async () => {
+        await this.acceptButton.tap();
+        await waitFor(this.termsOfServiceScreen).not.toExist().withTimeout(timeouts.HALF_MIN);
+        await ChannelListScreen.toBeVisible();
+        await HomeScreen.toBeVisible();
+    };
+
+    declineAndConfirmLogout = async () => {
+        await this.declineButton.tap();
+
+        // * Decline confirmation alert
+        await waitFor(Alert.termsDeclinedTitle).toExist().withTimeout(timeouts.TEN_SEC);
+        await expect(Alert.termsDeclinedTitle).toBeVisible();
+
+        // # Confirm logout — expected destination is the server address screen
+        await Alert.okButton.tap();
+        await waitFor(ServerScreen.serverScreen).toExist().withTimeout(timeouts.HALF_MIN);
+        await waitFor(ServerScreen.serverUrlInput).toExist().withTimeout(timeouts.TEN_SEC);
+
+        // * No authenticated home chrome after decline
+        await expect(HomeScreen.channelListTab).not.toExist();
+        await expect(ChannelListScreen.channelListScreen).not.toExist();
+    };
+}
+
+const termsOfServiceScreen = new TermsOfServiceScreen();
+export default termsOfServiceScreen;

--- a/detox/e2e/support/ui/screen/terms_of_service.ts
+++ b/detox/e2e/support/ui/screen/terms_of_service.ts
@@ -30,7 +30,12 @@ class TermsOfServiceScreen {
     };
 
     /**
-     * Submit login credentials and wait for the custom ToS modal (not the channel list).
+     * Submit login credentials and wait for the custom ToS modal.
+     *
+     * Custom ToS is NOT a login gate. `channel_list.tsx` navigates to
+     * Screens.TERMS_OF_SERVICE once `observeShowToS` emits true, so the channel list mounts
+     * first and the ToS arrives on top of it as a transparent modal. Waiting for the ToS
+     * "instead of" the channel list therefore describes a flow the app does not implement.
      */
     loginUntilVisible = async (user: any = {}) => {
         await LoginScreen.toBeVisible();
@@ -64,6 +69,12 @@ class TermsOfServiceScreen {
                 // not present
             }
         }
+
+        // Assert the post-login destination first: the channel list exists underneath the
+        // transparent ToS overlay, so this separates "login itself failed" from "login
+        // succeeded but the ToS modal never mounted" instead of reporting both as a ToS
+        // timeout.
+        await waitFor(ChannelListScreen.channelListScreen).toExist().withTimeout(timeouts.ONE_MIN);
 
         return this.toBeVisible();
     };

--- a/detox/e2e/support/ui/screen/terms_of_service.ts
+++ b/detox/e2e/support/ui/screen/terms_of_service.ts
@@ -36,9 +36,9 @@ class TermsOfServiceScreen {
         await LoginScreen.toBeVisible();
 
         await LoginScreen.usernameInput.tap({x: 150, y: 10});
-        await LoginScreen.usernameInput.replaceText(user.newUser?.email || user.email);
+        await LoginScreen.usernameInput.replaceText(user.newUser?.email ?? user.email);
         await LoginScreen.passwordInput.tap();
-        await LoginScreen.passwordInput.replaceText(user.newUser?.password || user.password);
+        await LoginScreen.passwordInput.replaceText(user.newUser?.password ?? user.password);
         await LoginScreen.loginFormInfoText.tap();
         await LoginScreen.signinButton.tap();
 

--- a/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
+++ b/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {
+    Setup,
+    System,
+    TermsOfService,
+    User,
+} from '@support/server_api';
+import {
+    serverOneUrl,
+    siteOneUrl,
+} from '@support/test_config';
+import {
+    ChannelListScreen,
+    HomeScreen,
+    ServerScreen,
+    TermsOfServiceScreen,
+} from '@support/ui/screen';
+import {expect} from 'detox';
+
+describe('Server Login - Custom Terms of Service', () => {
+    const serverOneDisplayName = 'Server 1';
+    const tosText = 'E2E Custom Terms of Service — accept to continue.';
+    let testUser: any;
+
+    beforeAll(async () => {
+        await User.apiAdminLogin(siteOneUrl);
+        await System.apiRequireLicenseForFeature(siteOneUrl, 'CustomTermsOfService');
+
+        const {terms, error: createError} = await TermsOfService.apiCreateTermsOfService(siteOneUrl, tosText);
+        if (createError || !terms?.id) {
+            throw new Error(`Failed to create custom ToS: ${JSON.stringify(createError || terms)}`);
+        }
+
+        const {error: enableError} = await TermsOfService.apiEnableCustomTermsOfService(siteOneUrl);
+        if (enableError) {
+            throw new Error(`Failed to enable custom ToS: ${JSON.stringify(enableError)}`);
+        }
+
+        const {user} = await Setup.apiInit(siteOneUrl);
+        testUser = user;
+    });
+
+    afterAll(async () => {
+        try {
+            await User.apiAdminLogin(siteOneUrl);
+            await TermsOfService.apiDisableCustomTermsOfService(siteOneUrl);
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.warn('[custom_terms_of_service] failed to disable ToS after suite:', error);
+        }
+    });
+
+    it('MM-T1194 - should log in after accepting custom terms of service', async () => {
+        // # Connect and log in until custom ToS is shown
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await TermsOfServiceScreen.loginUntilVisible(testUser);
+
+        // * Verify Accept / Decline are available
+        await expect(TermsOfServiceScreen.acceptButton).toBeVisible();
+        await expect(TermsOfServiceScreen.declineButton).toBeVisible();
+
+        // # Accept terms
+        await TermsOfServiceScreen.accept();
+
+        // * Verify user is logged in
+        await expect(ChannelListScreen.channelListScreen).toExist();
+        await expect(HomeScreen.channelListTab).toExist();
+
+        // # Clean up session for the next case
+        await HomeScreen.logout();
+    });
+
+    it('MM-T1193 - should return to server screen after declining custom terms of service', async () => {
+        // Fresh user so ToS is required again (accepted user would skip the modal)
+        const {user: declineUser} = await Setup.apiInit(siteOneUrl);
+
+        // # Connect and log in until custom ToS is shown
+        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await TermsOfServiceScreen.loginUntilVisible(declineUser);
+
+        // # Decline and confirm the logout alert
+        await TermsOfServiceScreen.declineAndConfirmLogout();
+
+        // * Verify back on server address page with no app home chrome
+        await expect(ServerScreen.serverScreen).toExist();
+        await expect(ServerScreen.serverUrlInput).toExist();
+        await expect(HomeScreen.channelListTab).not.toExist();
+        await expect(ChannelListScreen.channelListScreen).not.toExist();
+    });
+});

--- a/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
+++ b/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
@@ -106,6 +106,11 @@ describeOrSkip('Server Login - Custom Terms of Service', () => {
             if (error) {
                 throw new Error(`Failed to disable custom ToS after suite: ${describeApiError(error, status)}`);
             }
+
+            // Hold the lock until the disable is actually visible in client config. The patch
+            // returns before the server regenerates it, so releasing here would let the next
+            // SITE_3 suite start against a server still advertising ToS as on.
+            await TermsOfService.apiAssertCustomTermsOfServiceInactive(siteThreeUrl);
         } finally {
             // Releasing even when the disable failed is deliberate: holding the lock forever
             // would block every later run, and the next holder disables ToS on acquire.

--- a/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
+++ b/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
@@ -25,6 +25,13 @@ import {
 } from '@support/ui/screen';
 import {expect} from 'detox';
 
+/**
+ * Summarise a server_api error without embedding the raw response payload.
+ */
+const describeApiError = (error: any, status?: number): string => {
+    return `status ${status ?? 'unknown'}: ${error?.message ?? error?.id ?? 'unknown error'}`;
+};
+
 describe('Server Login - Custom Terms of Service', () => {
     const serverOneDisplayName = 'Server 1';
     const tosText = 'E2E Custom Terms of Service — accept to continue.';
@@ -34,14 +41,14 @@ describe('Server Login - Custom Terms of Service', () => {
         await User.apiAdminLogin(siteOneUrl);
         await System.apiRequireLicenseForFeature(siteOneUrl, 'CustomTermsOfService');
 
-        const {terms, error: createError} = await TermsOfService.apiCreateTermsOfService(siteOneUrl, tosText);
+        const {terms, error: createError, status: createStatus} = await TermsOfService.apiCreateTermsOfService(siteOneUrl, tosText);
         if (createError || !terms?.id) {
-            throw new Error(`Failed to create custom ToS: ${JSON.stringify(createError || terms)}`);
+            throw new Error(`Failed to create custom ToS: ${describeApiError(createError, createStatus)}`);
         }
 
-        const {error: enableError} = await TermsOfService.apiEnableCustomTermsOfService(siteOneUrl);
+        const {error: enableError, status: enableStatus} = await TermsOfService.apiEnableCustomTermsOfService(siteOneUrl);
         if (enableError) {
-            throw new Error(`Failed to enable custom ToS: ${JSON.stringify(enableError)}`);
+            throw new Error(`Failed to enable custom ToS: ${describeApiError(enableError, enableStatus)}`);
         }
 
         const {user} = await Setup.apiInit(siteOneUrl);
@@ -49,16 +56,21 @@ describe('Server Login - Custom Terms of Service', () => {
     });
 
     afterAll(async () => {
-        try {
-            await User.apiAdminLogin(siteOneUrl);
-            await TermsOfService.apiDisableCustomTermsOfService(siteOneUrl);
-        } catch (error) {
+        // Leaving custom ToS enabled forces every later suite on this server through
+        // the modal, so a failed cleanup has to be loud rather than swallowed.
+        await User.apiAdminLogin(siteOneUrl);
+
+        const {error, status} = await TermsOfService.apiDisableCustomTermsOfService(siteOneUrl);
+        if (error) {
+            const reason = describeApiError(error, status);
+
             // eslint-disable-next-line no-console
-            console.warn('[custom_terms_of_service] failed to disable ToS after suite:', error);
+            console.warn(`[custom_terms_of_service] failed to disable ToS after suite: ${reason}`);
+            throw new Error(`Failed to disable custom ToS after suite: ${reason}`);
         }
     });
 
-    it('MM-T1194 - should log in after accepting custom terms of service', async () => {
+    it('MM-T1194_1 - should log in after accepting custom terms of service', async () => {
         // # Connect and log in until custom ToS is shown
         await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
         await TermsOfServiceScreen.loginUntilVisible(testUser);
@@ -78,7 +90,7 @@ describe('Server Login - Custom Terms of Service', () => {
         await HomeScreen.logout();
     });
 
-    it('MM-T1193 - should return to server screen after declining custom terms of service', async () => {
+    it('MM-T1193_1 - should return to server screen after declining custom terms of service', async () => {
         // Fresh user so ToS is required again (accepted user would skip the modal)
         const {user: declineUser} = await Setup.apiInit(siteOneUrl);
 

--- a/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
+++ b/detox/e2e/test/products/channels/server_login/custom_terms_of_service.e2e.ts
@@ -13,9 +13,11 @@ import {
     TermsOfService,
     User,
 } from '@support/server_api';
+import {SITE_THREE_LOCK_TIMEOUT_MS, siteThreeLock} from '@support/site_three_lock';
 import {
-    serverOneUrl,
-    siteOneUrl,
+    hasThreeDistinctServers,
+    serverThreeUrl,
+    siteThreeUrl,
 } from '@support/test_config';
 import {
     ChannelListScreen,
@@ -23,7 +25,25 @@ import {
     ServerScreen,
     TermsOfServiceScreen,
 } from '@support/ui/screen';
+import {timeouts} from '@support/utils';
 import {expect} from 'detox';
+
+/**
+ * Enabling custom ToS is server-wide and has no per-user scoping, so every login on the
+ * server is forced through the modal while this suite runs. PR CI provisions only two Detox
+ * servers and rotates them as SITE_1/SITE_2 across all shards, so running this against
+ * SITE_1 would push a ToS modal in front of roughly half the other shards mid-run.
+ *
+ * It therefore runs against the dedicated third site and holds the SITE_3 lock, which
+ * `server_list` also holds while it logs in to the third server — without that, this suite's
+ * ToS modal would land on top of that login. iOS and Android share SITE_3, so the lock also
+ * serialises the two platform jobs.
+ *
+ * The `hasThreeDistinctServers` gate is load-bearing: `siteThreeUrl` silently falls back to
+ * `siteOneUrl` on single-server topologies, so without it a local run would quietly
+ * reintroduce the blast radius this suite exists to avoid.
+ */
+jest.setTimeout(timeouts.ONE_MIN * 25);
 
 /**
  * Summarise a server_api error without embedding the raw response payload.
@@ -32,47 +52,70 @@ const describeApiError = (error: any, status?: number): string => {
     return `status ${status ?? 'unknown'}: ${error?.message ?? error?.id ?? 'unknown error'}`;
 };
 
-describe('Server Login - Custom Terms of Service', () => {
-    const serverOneDisplayName = 'Server 1';
+const describeOrSkip = hasThreeDistinctServers ? describe : describe.skip;
+
+describeOrSkip('Server Login - Custom Terms of Service', () => {
+    const serverDisplayName = 'Server 1';
     const tosText = 'E2E Custom Terms of Service — accept to continue.';
+    let lockOwner = '';
+    let lockAcquired = false;
     let testUser: any;
 
     beforeAll(async () => {
-        await User.apiAdminLogin(siteOneUrl);
-        await System.apiRequireLicenseForFeature(siteOneUrl, 'CustomTermsOfService');
+        lockOwner = siteThreeLock.createOwner();
+        await siteThreeLock.acquire(siteThreeUrl, lockOwner, {timeoutMs: SITE_THREE_LOCK_TIMEOUT_MS});
+        lockAcquired = true;
 
-        const {terms, error: createError, status: createStatus} = await TermsOfService.apiCreateTermsOfService(siteOneUrl, tosText);
+        await User.apiAdminLogin(siteThreeUrl);
+        await System.apiRequireLicenseForFeature(siteThreeUrl, 'CustomTermsOfService');
+
+        // A previous holder that was killed mid-suite (emulator crash, cancelled job) leaves
+        // ToS enabled, and its afterAll never ran. Clearing it on acquire is what makes the
+        // shared server self-heal rather than staying wedged for every later login.
+        await TermsOfService.apiDisableCustomTermsOfService(siteThreeUrl);
+
+        const {terms, error: createError, status: createStatus} = await TermsOfService.apiCreateTermsOfService(siteThreeUrl, tosText);
         if (createError || !terms?.id) {
             throw new Error(`Failed to create custom ToS: ${describeApiError(createError, createStatus)}`);
         }
 
-        const {error: enableError, status: enableStatus} = await TermsOfService.apiEnableCustomTermsOfService(siteOneUrl);
+        const {error: enableError, status: enableStatus} = await TermsOfService.apiEnableCustomTermsOfService(siteThreeUrl);
         if (enableError) {
             throw new Error(`Failed to enable custom ToS: ${describeApiError(enableError, enableStatus)}`);
         }
 
-        const {user} = await Setup.apiInit(siteOneUrl);
+        // Fail here rather than 60s later as an unexplained "modal never appeared".
+        await TermsOfService.apiAssertCustomTermsOfServiceActive(siteThreeUrl, terms.id);
+
+        // Created after ToS is active, so the app fetches a config that already has it on
+        // when it connects below — no reload needed to dodge a stale cached config.
+        const {user} = await Setup.apiInit(siteThreeUrl);
         testUser = user;
-    });
+    }, timeouts.ONE_MIN * 22);
 
     afterAll(async () => {
-        // Leaving custom ToS enabled forces every later suite on this server through
-        // the modal, so a failed cleanup has to be loud rather than swallowed.
-        await User.apiAdminLogin(siteOneUrl);
+        // Never tear down shared server state we do not own.
+        if (!lockAcquired) {
+            return;
+        }
 
-        const {error, status} = await TermsOfService.apiDisableCustomTermsOfService(siteOneUrl);
-        if (error) {
-            const reason = describeApiError(error, status);
+        try {
+            await User.apiAdminLogin(siteThreeUrl);
 
-            // eslint-disable-next-line no-console
-            console.warn(`[custom_terms_of_service] failed to disable ToS after suite: ${reason}`);
-            throw new Error(`Failed to disable custom ToS after suite: ${reason}`);
+            const {error, status} = await TermsOfService.apiDisableCustomTermsOfService(siteThreeUrl);
+            if (error) {
+                throw new Error(`Failed to disable custom ToS after suite: ${describeApiError(error, status)}`);
+            }
+        } finally {
+            // Releasing even when the disable failed is deliberate: holding the lock forever
+            // would block every later run, and the next holder disables ToS on acquire.
+            await siteThreeLock.release(siteThreeUrl, lockOwner);
         }
     });
 
     it('MM-T1194_1 - should log in after accepting custom terms of service', async () => {
         // # Connect and log in until custom ToS is shown
-        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await ServerScreen.connectToServer(serverThreeUrl, serverDisplayName);
         await TermsOfServiceScreen.loginUntilVisible(testUser);
 
         // * Verify Accept / Decline are available
@@ -92,10 +135,10 @@ describe('Server Login - Custom Terms of Service', () => {
 
     it('MM-T1193_1 - should return to server screen after declining custom terms of service', async () => {
         // Fresh user so ToS is required again (accepted user would skip the modal)
-        const {user: declineUser} = await Setup.apiInit(siteOneUrl);
+        const {user: declineUser} = await Setup.apiInit(siteThreeUrl);
 
         // # Connect and log in until custom ToS is shown
-        await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
+        await ServerScreen.connectToServer(serverThreeUrl, serverDisplayName);
         await TermsOfServiceScreen.loginUntilVisible(declineUser);
 
         // # Decline and confirm the logout alert

--- a/detox/e2e/test/products/channels/server_login/server_list.e2e.ts
+++ b/detox/e2e/test/products/channels/server_login/server_list.e2e.ts
@@ -11,6 +11,7 @@ import {
     User,
     Setup,
 } from '@support/server_api';
+import {SITE_THREE_LOCK_TIMEOUT_MS, siteThreeLock} from '@support/site_three_lock';
 import {
     serverOneUrl,
     serverTwoUrl,
@@ -43,14 +44,30 @@ describe('Server Login - Server List', () => {
     let serverOneUser: any;
     let serverTwoUser: any;
     let serverThreeUser: any;
+    let lockOwner = '';
+    let lockAcquired = false;
 
     beforeAll(async () => {
+        // MM-T4691_5 logs in to SITE_3, and custom_terms_of_service turns on server-wide
+        // custom ToS there — that modal would land on top of that login and swallow the taps
+        // that follow. Both suites hold the SITE_3 lock so they never overlap. Held for the
+        // whole suite rather than around the one test: acquiring mid-suite would mean
+        // releasing on paths that have already navigated.
+        if (hasThreeDistinctServers) {
+            lockOwner = siteThreeLock.createOwner();
+            await siteThreeLock.acquire(siteThreeUrl, lockOwner, {timeoutMs: SITE_THREE_LOCK_TIMEOUT_MS});
+            lockAcquired = true;
+        }
+
         // # Log in to the first server
         ({user: serverOneUser} = await Setup.apiInit(siteOneUrl));
         await waitForElementToBeVisible(ServerScreen.headerTitleConnectToServer, timeouts.HALF_MIN);
         await ServerScreen.connectToServer(serverOneUrl, serverOneDisplayName);
         await LoginScreen.login(serverOneUser);
-    });
+
+        // The hook gets its own budget so the lock wait above does not have to fit inside the
+        // default per-test timeout.
+    }, timeouts.ONE_MIN * 22);
 
     beforeEach(async () => {
         // * Verify on channel list screen
@@ -58,8 +75,14 @@ describe('Server Login - Server List', () => {
     });
 
     afterAll(async () => {
-        // # Log out
-        await HomeScreen.logout();
+        try {
+            // # Log out
+            await HomeScreen.logout();
+        } finally {
+            if (lockAcquired) {
+                await siteThreeLock.release(siteThreeUrl, lockOwner);
+            }
+        }
     });
 
     it('MM-T4691_1 - should match elements on server list screen', async () => {


### PR DESCRIPTION
- Add detox test covering accept (MM-T1194) and decline (MM-T1193) paths
- Add TermsOfServiceScreen page object and Alert.termsDeclinedTitle
- Add TermsOfService server API helpers (create/enable/disable)
- Add testIDs to the terms of service screen, title and action buttons

<img width="1313" height="154" alt="image" src="https://github.com/user-attachments/assets/23bddd0f-8499-44a0-b333-2a88dbe2d977" />


```release-note
NONE
```
