### PR TITLE
Guard long-running DB chains against RUNNINGBOARD 0xdead10cc on iOS

### DIFF
--- a/app/actions/remote/entry/deferred.test.ts
+++ b/app/actions/remote/entry/deferred.test.ts
@@ -3,6 +3,7 @@
 
 /* eslint-disable max-lines */
 
+import RNUtils from '@mattermost/rnutils';
 import {act} from '@testing-library/react-native';
 
 import {fetchMyChannelsForTeam, fetchMissingDirectChannelsInfo, type MyChannelsRequest} from '@actions/remote/channel';
@@ -147,6 +148,7 @@ describe('actions/remote/entry/deferred', () => {
                 initialTeamId,
                 initialChannelId,
             );
+            await new Promise(process.nextTick);
 
             expect(fetchMissingDirectChannelsInfo).toHaveBeenCalled();
             expect(updateAllUsersSince).toHaveBeenCalledWith(serverUrl, since, false, undefined);
@@ -156,6 +158,53 @@ describe('actions/remote/entry/deferred', () => {
             expect(fetchGroupsForMember).toHaveBeenCalledWith(serverUrl, currentUserId, false, undefined);
             expect(fetchScheduledPosts).toHaveBeenCalledWith(serverUrl, initialTeamId, true, undefined);
             expect(fetchRoles).toHaveBeenCalledWith(serverUrl, defaultTeamData.memberships, defaultChData.memberships, defaultMeData.user, false, true, undefined);
+            expect(RNUtils.beginDatabaseActivity).toHaveBeenCalledWith(serverUrl, 'restDeferredAppEntryActions');
+            expect(RNUtils.endDatabaseActivity).toHaveBeenCalledWith('token-1');
+        });
+
+        it('should still end the database activity when processing teams fails', async () => {
+            jest.mocked(fetchMyChannelsForTeam).mockRejectedValueOnce(new Error('test'));
+
+            await restDeferredAppEntryActions(
+                serverUrl,
+                since,
+                currentUserId,
+                currentUserLocale,
+                [],
+                defaultConfig,
+                license,
+                defaultTeamData,
+                defaultChData,
+                defaultMeData,
+                initialTeamId,
+                initialChannelId,
+            );
+            await new Promise(process.nextTick);
+
+            expect(RNUtils.beginDatabaseActivity).toHaveBeenCalledWith(serverUrl, 'restDeferredAppEntryActions');
+            expect(RNUtils.endDatabaseActivity).toHaveBeenCalledWith('token-1');
+        });
+
+        it('should not end the database activity when no token was granted', async () => {
+            jest.mocked(RNUtils.beginDatabaseActivity).mockResolvedValueOnce(null);
+
+            await restDeferredAppEntryActions(
+                serverUrl,
+                since,
+                currentUserId,
+                currentUserLocale,
+                [],
+                defaultConfig,
+                license,
+                defaultTeamData,
+                defaultChData,
+                defaultMeData,
+                initialTeamId,
+                initialChannelId,
+            );
+            await new Promise(process.nextTick);
+
+            expect(RNUtils.endDatabaseActivity).not.toHaveBeenCalled();
         });
 
         it('should handle missing data gracefully', async () => {

--- a/app/actions/remote/entry/deferred.ts
+++ b/app/actions/remote/entry/deferred.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import RNUtils from '@mattermost/rnutils';
+
 import {fetchMissingDirectChannelsInfo, fetchMyChannelsForTeam, type MyChannelsRequest} from '@actions/remote/channel';
 import {fetchGroupsForMember} from '@actions/remote/groups';
 import {fetchPostsForUnreadChannels} from '@actions/remote/post';
@@ -160,7 +162,13 @@ export async function restDeferredAppEntryActions(
             teamQueue = [...myOtherSortedTeams];
         }
 
-        processTeams();
+        // Guards against RUNNINGBOARD 0xdead10cc; released once processTeams (fire-and-forget) settles.
+        const activityToken = await RNUtils.beginDatabaseActivity(serverUrl, 'restDeferredAppEntryActions');
+        processTeams().finally(() => {
+            if (activityToken) {
+                RNUtils.endDatabaseActivity(activityToken);
+            }
+        });
     });
 }
 

--- a/app/actions/websocket/index.test.ts
+++ b/app/actions/websocket/index.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import RNUtils from '@mattermost/rnutils';
 import {DeviceEventEmitter} from 'react-native';
 
 import {markChannelAsViewed} from '@actions/local/channel';
@@ -172,6 +173,26 @@ describe('WebSocket Index Actions', () => {
             expect(AppsManager.refreshAppBindings).toHaveBeenCalled();
             expect(handlePlaybookReconnect).toHaveBeenCalledWith(serverUrl);
             expect(SessionAttributesManager.refreshManifest).toHaveBeenCalledWith(serverUrl);
+            expect(RNUtils.beginDatabaseActivity).toHaveBeenCalledWith(serverUrl, 'doReconnect');
+            expect(RNUtils.endDatabaseActivity).toHaveBeenCalledWith('token-1');
+        });
+
+        it('should still end the database activity when reconnect fails', async () => {
+            jest.mocked(entry).mockResolvedValueOnce({error: new Error('entry failed')});
+
+            await handleReconnect(serverUrl);
+
+            expect(RNUtils.beginDatabaseActivity).toHaveBeenCalledWith(serverUrl, 'doReconnect');
+            expect(RNUtils.endDatabaseActivity).toHaveBeenCalledWith('token-1');
+        });
+
+        it('should not end the database activity when no token was granted', async () => {
+            jest.mocked(RNUtils.beginDatabaseActivity).mockResolvedValueOnce(null);
+            jest.mocked(entry).mockResolvedValueOnce({error: new Error('entry failed')});
+
+            await handleReconnect(serverUrl);
+
+            expect(RNUtils.endDatabaseActivity).not.toHaveBeenCalled();
         });
 
         it('should fetch posts for channel screen', async () => {

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import RNUtils from '@mattermost/rnutils';
+
 import {markChannelAsViewed} from '@actions/local/channel';
 import {dataRetentionCleanup, expiredBoRPostCleanup} from '@actions/local/systems';
 import {markChannelAsRead} from '@actions/remote/channel';
@@ -64,6 +66,9 @@ async function doReconnect(serverUrl: string, groupLabel?: BaseRequestGroupLabel
 
     const {database} = operator;
 
+    // Guards against RUNNINGBOARD 0xdead10cc if the app backgrounds mid-sync.
+    const activityToken = await RNUtils.beginDatabaseActivity(serverUrl, 'doReconnect');
+
     try {
         await SessionAttributesManager.refreshManifest(serverUrl);
 
@@ -119,6 +124,9 @@ async function doReconnect(serverUrl: string, groupLabel?: BaseRequestGroupLabel
         return undefined;
     } finally {
         setTeamLoading(serverUrl, false);
+        if (activityToken) {
+            RNUtils.endDatabaseActivity(activityToken);
+        }
     }
 }
 

--- a/ios/Mattermost/AppDelegate.swift
+++ b/ios/Mattermost/AppDelegate.swift
@@ -35,13 +35,7 @@ class AppDelegate: ExpoAppDelegate, OrientationLockable {
     var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
     var reactNativeFactory: RCTReactNativeFactory?
 
-    // Background-task assertion held across the background transition so any
-    // in-flight WatermelonDB operation (read or write) can finish and release
-    // the shared App Group SQLite lock before the OS suspends the app. Without
-    // it, iOS terminates the app with RUNNINGBOARD 0xdead10cc when it suspends
-    // while a SQLite statement still holds the lock. Only touched from main-
-    // thread lifecycle callbacks and the (also main-thread) expiration handler.
-    private var databaseLockBackgroundTask: UIBackgroundTaskIdentifier = .invalid
+    private var databaseLockProtectionToken: String?
 
     override func application(
         _ application: UIApplication,
@@ -294,22 +288,17 @@ class AppDelegate: ExpoAppDelegate, OrientationLockable {
 
     // MARK: - Database lock protection (prevents RUNNINGBOARD 0xdead10cc)
 
-    // Keeps the app from being suspended while a WatermelonDB statement still
-    // holds the shared App Group SQLite lock. Begun when entering the
-    // background; released when returning to the foreground or when the OS
-    // background-execution time expires (whichever comes first), by which point
-    // any in-flight DB read/write has finished and released the lock.
+    // Baseline safety net for the background transition; specific long-running
+    // chains hold their own independent job via DatabaseLockProtectionManager.
     private func beginDatabaseLockProtection() {
-        guard databaseLockBackgroundTask == .invalid else { return }
-        databaseLockBackgroundTask = UIApplication.shared.beginBackgroundTask(withName: "MMDatabaseLockProtection") { [weak self] in
-            self?.endDatabaseLockProtection()
-        }
+        guard databaseLockProtectionToken == nil else { return }
+        databaseLockProtectionToken = DatabaseLockProtectionManager.shared.begin("lifecycle", task: "MMDatabaseLockProtection")
     }
 
     private func endDatabaseLockProtection() {
-        guard databaseLockBackgroundTask != .invalid else { return }
-        UIApplication.shared.endBackgroundTask(databaseLockBackgroundTask)
-        databaseLockBackgroundTask = .invalid
+        guard let token = databaseLockProtectionToken else { return }
+        DatabaseLockProtectionManager.shared.end(token)
+        databaseLockProtectionToken = nil
     }
 
     // MARK: - Orientation

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -263,6 +263,7 @@ PODS:
     - DoubleConversion
     - fast_float
     - fmt
+    - Gekidou
     - glog
     - hermes-engine
     - RCT-Folly
@@ -4463,7 +4464,7 @@ SPEC CHECKSUMS:
   fmt: 530618a01105dae0fa3a2f27c81ae11fa8f67eac
   Gekidou: 94199ed8d31b900f2caeb9d5739c19bed9defc4a
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: f9aed8041a90723c1e15c5d973e57e1f1137f94e
+  hermes-engine: 28814c9c9296d16aef26cb514de5378d18885e44
   JitsiWebRTC: b47805ab5668be38e7ee60e2258f49badfe8e1d0
   KituraContracts: e845e60dc8627ad0a76fa55ef20a45451d8f830b
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4472,7 +4473,7 @@ SPEC CHECKSUMS:
   mattermost-calls-native: 51d049f98b8c356184b8c0f273ccc8d725db990e
   mattermost-hardware-keyboard: 95eb9c1e3d32b9e9921abcbb8765c516beaba9fd
   mattermost-react-native-turbo-log: 4aa8e7add21cd5df616cdbcdd70dd24cc541deba
-  mattermost-rnutils: 4e564bc3e775c80e653adeff4225ec7f0f807583
+  mattermost-rnutils: f5818ce6823a1f469f118ff7a923096b36185da0
   NitroBackgroundTimer: ca9c6ce4aace694da8dc082dbe202e14ae8b311c
   NitroModules: d2038959f7d0a9bf7b6f87e9a7c18da8b13311ff
   OpenGraph: 596722bb7f112d2dabcdb284cb817f01341a7540

--- a/libraries/@mattermost/rnutils/android/src/main/java/com/mattermost/rnutils/RNUtilsModuleImpl.kt
+++ b/libraries/@mattermost/rnutils/android/src/main/java/com/mattermost/rnutils/RNUtilsModuleImpl.kt
@@ -219,6 +219,14 @@ class RNUtilsModuleImpl(private val reactContext: ReactApplicationContext): Life
         serverUrl?.let { Notifications.removeServerNotifications(it) }
     }
 
+    fun beginDatabaseActivity(serverUrl: String?, task: String?, promise: Promise?) {
+        promise?.resolve(null)
+    }
+
+    fun endDatabaseActivity(token: String?, promise: Promise?) {
+        promise?.resolve(null)
+    }
+
     fun setSoftKeyboardToAdjustNothing() {
         val currentActivity: Activity = reactContext.currentActivity ?: return
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {

--- a/libraries/@mattermost/rnutils/android/src/newarch/RNUtilsModule.kt
+++ b/libraries/@mattermost/rnutils/android/src/newarch/RNUtilsModule.kt
@@ -69,6 +69,14 @@ class RNUtilsModule(val reactContext: ReactApplicationContext) : NativeRNUtilsSp
         implementation.removeServerNotifications(serverUrl)
     }
 
+    override fun beginDatabaseActivity(serverUrl: String?, task: String?, promise: Promise?) {
+        implementation.beginDatabaseActivity(serverUrl, task, promise)
+    }
+
+    override fun endDatabaseActivity(token: String?, promise: Promise?) {
+        implementation.endDatabaseActivity(token, promise)
+    }
+
     override fun setSoftKeyboardToAdjustResize() {
         implementation.setSoftKeyboardToAdjustResize()
     }

--- a/libraries/@mattermost/rnutils/android/src/oldarch/RNUtilsModule.kt
+++ b/libraries/@mattermost/rnutils/android/src/oldarch/RNUtilsModule.kt
@@ -102,6 +102,16 @@ class RNUtilsModule(context: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun beginDatabaseActivity(serverUrl: String?, task: String?, promise: Promise?) {
+        implementation.beginDatabaseActivity(serverUrl, task, promise)
+    }
+
+    @ReactMethod
+    fun endDatabaseActivity(token: String?, promise: Promise?) {
+        implementation.endDatabaseActivity(token, promise)
+    }
+
+    @ReactMethod
     fun setSoftKeyboardToAdjustResize() {
         implementation.setSoftKeyboardToAdjustResize()
     }

--- a/libraries/@mattermost/rnutils/ios/Managers/DatabaseActivityAssertion.swift
+++ b/libraries/@mattermost/rnutils/ios/Managers/DatabaseActivityAssertion.swift
@@ -1,0 +1,60 @@
+import Foundation
+import UIKit
+import Gekidou
+
+/// Prevents suspension via a `UIApplication` background task assertion. Ported from
+/// Quinn "The Eskimo!"'s `QRunInBackgroundAssertion` (https://developer.apple.com/forums/thread/729335).
+class DatabaseActivityAssertion {
+    let name: String
+
+    /// Called on the main thread if the system releases the assertion itself.
+    var systemDidReleaseAssertion: (() -> Void)? {
+        willSet { dispatchPrecondition(condition: .onQueue(.main)) }
+    }
+
+    private(set) var isGranted: Bool
+
+    private var taskID: UIBackgroundTaskIdentifier
+
+    init(name: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        self.name = name
+        self.systemDidReleaseAssertion = nil
+        self.taskID = .invalid
+        self.isGranted = false
+        let t = UIApplication.shared.beginBackgroundTask(withName: name) {
+            self.taskDidExpire()
+        }
+        self.taskID = t
+        self.isGranted = t != .invalid
+        if !isGranted {
+            GekidouLogger.shared.log(.error, "DatabaseActivityAssertion: OS declined background task %{public}@", name)
+        }
+    }
+
+    /// Safe to call redundantly. Must be called on the main thread.
+    func release() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        consumeValidTaskID {}
+    }
+
+    deinit {
+        consumeValidTaskID {}
+    }
+
+    private func consumeValidTaskID(_ body: () -> Void) {
+        guard taskID != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(taskID)
+        taskID = .invalid
+        body()
+        systemDidReleaseAssertion = nil
+    }
+
+    private func taskDidExpire() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        GekidouLogger.shared.log(.error, "DatabaseActivityAssertion: OS expired background task %{public}@", name)
+        consumeValidTaskID {
+            self.systemDidReleaseAssertion?()
+        }
+    }
+}

--- a/libraries/@mattermost/rnutils/ios/Managers/DatabaseLockProtectionManager.swift
+++ b/libraries/@mattermost/rnutils/ios/Managers/DatabaseLockProtectionManager.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Owns one `DatabaseActivityAssertion` per caller, keyed by a generated token, so each
+/// job's assertion is released independently. Used by both `AppDelegate`'s lifecycle
+/// transitions and JS (via RNUtils) around specific long-running DB chains.
+public class DatabaseLockProtectionManager: NSObject {
+    @objc public static let shared = DatabaseLockProtectionManager()
+
+    private var assertions: [String: DatabaseActivityAssertion] = [:]
+
+    private override init() {}
+
+    /// Returns `nil` if the OS declined to grant a background task. Must be called on the main thread.
+    @objc public func begin(_ serverUrl: String, task: String) -> String? {
+        dispatchPrecondition(condition: .onQueue(.main))
+
+        let encodedServerUrl = Data(serverUrl.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let timestampMs = Int(Date().timeIntervalSince1970 * 1000)
+        let token = "\(encodedServerUrl)-\(task)-\(timestampMs)"
+
+        let assertion = DatabaseActivityAssertion(name: task)
+        guard assertion.isGranted else { return nil }
+
+        assertion.systemDidReleaseAssertion = { [weak self] in
+            self?.assertions.removeValue(forKey: token)
+        }
+        assertions[token] = assertion
+        return token
+    }
+
+    /// Safe to call with an unknown/already-ended token (no-op). Must be called on the main thread.
+    @objc public func end(_ token: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
+
+        guard let assertion = assertions.removeValue(forKey: token) else { return }
+        assertion.release()
+    }
+}

--- a/libraries/@mattermost/rnutils/ios/RNUtils.mm
+++ b/libraries/@mattermost/rnutils/ios/RNUtils.mm
@@ -107,6 +107,19 @@ RCT_REMAP_METHOD(removeThreadNotifications, server:(NSString *)serverUrl
     [self removeThreadNotifications:serverUrl threadId:threadId];
 }
 
+RCT_EXPORT_METHOD(beginDatabaseActivity:(NSString *)serverUrl
+                  task:(NSString *)task
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject) {
+    [self beginDatabaseActivity:serverUrl task:task resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(endDatabaseActivity:(NSString *)token
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject) {
+    [self endDatabaseActivity:token resolve:resolve reject:reject];
+}
+
 RCT_REMAP_METHOD(removeServerNotifications, serverUrl:(NSString *)serverUrl) {
     [self removeServerNotifications:serverUrl];
 }
@@ -220,6 +233,20 @@ RCT_EXPORT_METHOD(createZipFile:(NSArray<NSString *> *)paths
 
 - (void)removeServerNotifications:(NSString *)serverUrl {
     [[NotificationManager shared] removeServerNotificationsWithServerUrl:serverUrl];
+}
+
+- (void)beginDatabaseActivity:(NSString *)serverUrl task:(NSString *)task resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSString *token = [[DatabaseLockProtectionManager shared] begin:serverUrl task:task];
+        resolve(token);
+    });
+}
+
+- (void)endDatabaseActivity:(NSString *)token resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[DatabaseLockProtectionManager shared] end:token];
+        resolve(nil);
+    });
 }
 
 - (void)getRealFilePath:(NSString *)filePath resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {

--- a/libraries/@mattermost/rnutils/mattermost-rnutils.podspec
+++ b/libraries/@mattermost/rnutils/mattermost-rnutils.podspec
@@ -15,6 +15,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
+  s.dependency 'Gekidou'
+
   fabric_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
   other_cpp_flags = fabric_enabled ? "-DRCT_NEW_ARCH_ENABLED=1" : ""
 

--- a/libraries/@mattermost/rnutils/src/NativeRNUtils.ts
+++ b/libraries/@mattermost/rnutils/src/NativeRNUtils.ts
@@ -71,6 +71,10 @@ export interface Spec extends TurboModule {
     removeThreadNotifications(serverUrl: string, threadId: string): void;
     removeServerNotifications(serverUrl: string): void;
 
+    // iOS only - guards against RUNNINGBOARD 0xdead10cc; null on Android or if declined.
+    beginDatabaseActivity(serverUrl: string, task: string): Promise<string | null>;
+    endDatabaseActivity(token: string): Promise<void>;
+
     setSoftKeyboardToAdjustResize(): void;
     setSoftKeyboardToAdjustNothing(): void;
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -320,6 +320,9 @@ jest.doMock('react-native', () => {
             getWindowDimensions: jest.fn().mockReturnValue({width: 426, height: 952}),
 
             deleteDatabaseDirectory: jest.fn(),
+
+            beginDatabaseActivity: jest.fn().mockResolvedValue('token-1'),
+            endDatabaseActivity: jest.fn(),
         },
         APIClient: {
             getConstants: () => ({


### PR DESCRIPTION
#### Summary

iOS can terminate the app if it's suspended while a SQLite statement still holds the shared App Group database lock. AppDelegate already held a single background-task assertion across the background transition, but it was a blind, fixed-duration timer: it never tracked whether a DB operation was actually still running, and a chain that started after the timer had already begun (or ran long enough to outlast it) got no protection.

Add DatabaseActivityAssertion (a Swift port of Quinn "The Eskimo!"'s QRunInBackgroundAssertion) and DatabaseLockProtectionManager, which lets any caller - the app lifecycle transition, or a specific long-running chain - acquire its own independent background-task job and release it exactly when its own work finishes. Wire this into the websocket reconnect sync (doReconnect) and the deferred per-team entry sync (restDeferredAppEntryActions), the two longest sequential local-DB chains in the app, via a new pair of RNUtils methods (iOS only; Android is a no-op, since 0xdead10cc has no Android equivalent).

#### Ticket Link
TDB

#### Release Note
```release-note
NONE
```
