### PR TITLE
[MM-70525] Fix CallKit call disconnect on lock-screen answer

### DIFF
--- a/app/init/calls_native.test.ts
+++ b/app/init/calls_native.test.ts
@@ -17,7 +17,7 @@ import {
     getNativeCallMapping,
     setNativeCallMapping,
 } from '@calls/native_call';
-import {getCurrentCall, setMicPermissionsGranted} from '@calls/state';
+import {getCurrentCall, getCallsState, setMicPermissionsGranted} from '@calls/state';
 import {Device} from '@constants';
 import DatabaseManager from '@database/manager';
 import {getServerByIdentifier} from '@queries/app/servers';
@@ -53,6 +53,7 @@ jest.mock('@managers/websocket_manager', () => ({
 }));
 jest.mock('@calls/state', () => ({
     getCurrentCall: jest.fn(),
+    getCallsState: jest.fn(() => ({calls: {}})),
     setMicPermissionsGranted: jest.fn(),
 }));
 jest.mock('@queries/app/servers', () => ({
@@ -205,8 +206,45 @@ describe('onIncomingCall', () => {
             channelId: 'ch1',
             postId: 'p1',
             threadId: 't1',
+            callId: '',
         });
         expect(CallsNative.reportEnded).not.toHaveBeenCalled();
+    });
+
+    it('seeds callId from state when call_started arrived before the VoIP push', async () => {
+        (getServerByIdentifier as jest.Mock).mockResolvedValueOnce({url: SERVER_URL});
+        jest.mocked(getCallsState).mockReturnValueOnce({calls: {'ch1': {id: 'call-1'}}} as any);
+        const {onIncomingCall} = loadAndInit();
+
+        await onIncomingCall({
+            uuid: 'u1',
+            serverId: 's1',
+            channelId: 'ch1',
+            postId: '',
+            threadId: '',
+            callerId: '',
+            callerName: '',
+        });
+
+        expect(setNativeCallMapping).toHaveBeenCalledWith('u1', expect.objectContaining({callId: 'call-1'}));
+    });
+
+    it('sets empty callId when call_started has not yet arrived', async () => {
+        (getServerByIdentifier as jest.Mock).mockResolvedValueOnce({url: SERVER_URL});
+        jest.mocked(getCallsState).mockReturnValueOnce({calls: {}} as any);
+        const {onIncomingCall} = loadAndInit();
+
+        await onIncomingCall({
+            uuid: 'u1',
+            serverId: 's1',
+            channelId: 'ch1',
+            postId: '',
+            threadId: '',
+            callerId: '',
+            callerName: '',
+        });
+
+        expect(setNativeCallMapping).toHaveBeenCalledWith('u1', expect.objectContaining({callId: ''}));
     });
 
     it('opens the WS to the call server so live events arrive while ringing', async () => {

--- a/app/init/calls_native.ts
+++ b/app/init/calls_native.ts
@@ -27,6 +27,7 @@ import {
 } from '@calls/native_call';
 import {
     getCurrentCall,
+    getCallsState,
     setMicPermissionsGranted,
 } from '@calls/state';
 import {Device} from '@constants';
@@ -107,6 +108,7 @@ class CallsNativeSingleton {
             channelId,
             postId,
             threadId,
+            callId: getCallsState(server.url).calls[channelId]?.id ?? '',
         });
 
         // Open WS to the call's server so user_dismissed_notification /

--- a/app/products/calls/connection/websocket_event_handlers.test.ts
+++ b/app/products/calls/connection/websocket_event_handlers.test.ts
@@ -7,7 +7,7 @@ import {fetchUsersByIds} from '@actions/remote/user';
 import {leaveCall, muteMyself, unraiseHand} from '@calls/actions';
 import {createCallAndAddToIds} from '@calls/actions/calls';
 import {hostRemovedErr} from '@calls/errors';
-import {endNativeCall, getNativeCallUUIDForCall} from '@calls/native_call';
+import {endNativeCall, getNativeCallMapping, getNativeCallUUIDForCall, setNativeCallMapping} from '@calls/native_call';
 import {
     callEnded,
     callStarted,
@@ -82,7 +82,9 @@ jest.mock('@actions/remote/user');
 jest.mock('@calls/actions/calls');
 jest.mock('@calls/native_call', () => ({
     endNativeCall: jest.fn(),
+    getNativeCallMapping: jest.fn(),
     getNativeCallUUIDForCall: jest.fn(),
+    setNativeCallMapping: jest.fn(),
 }));
 jest.mock('@calls/state');
 jest.mock('@database/manager');
@@ -241,6 +243,55 @@ describe('websocket event handlers', () => {
             });
         });
 
+        it('should backfill callId into an existing native call mapping on call_started', () => {
+            jest.mocked(getNativeCallUUIDForCall).mockReturnValue('uuid-1');
+            jest.mocked(getNativeCallMapping).mockReturnValue({
+                serverUrl,
+                channelId,
+                postId: 'post-id',
+                threadId: 'thread-id',
+                callId: '',
+            });
+
+            handleCallStarted(serverUrl, {
+                broadcast: {channel_id: channelId},
+                data: {
+                    id: 'call-b',
+                    channelID: channelId,
+                    start_at: Date.now(),
+                    thread_id: 'thread-id',
+                    owner_id: 'owner-id',
+                    host_id: 'host-id',
+                },
+            } as WebSocketMessage<CallStartData>);
+
+            expect(setNativeCallMapping).toHaveBeenCalledWith('uuid-1', {
+                serverUrl,
+                channelId,
+                postId: 'post-id',
+                threadId: 'thread-id',
+                callId: 'call-b',
+            });
+        });
+
+        it('should not backfill callId when no native mapping exists for the channel', () => {
+            jest.mocked(getNativeCallUUIDForCall).mockReturnValue(undefined);
+
+            handleCallStarted(serverUrl, {
+                broadcast: {channel_id: channelId},
+                data: {
+                    id: 'call-b',
+                    channelID: channelId,
+                    start_at: Date.now(),
+                    thread_id: 'thread-id',
+                    owner_id: 'owner-id',
+                    host_id: 'host-id',
+                },
+            } as WebSocketMessage<CallStartData>);
+
+            expect(setNativeCallMapping).not.toHaveBeenCalled();
+        });
+
         it('should handle call ended', () => {
             jest.spyOn(DeviceEventEmitter, 'emit');
             handleCallEnded(serverUrl, {
@@ -249,6 +300,45 @@ describe('websocket event handlers', () => {
             } as WebSocketMessage<EmptyData>);
             expect(DeviceEventEmitter.emit).toHaveBeenCalledWith('custom_com.mattermost.calls_call_end', {channelId});
             expect(callEnded).toHaveBeenCalledWith(serverUrl, channelId);
+            expect(endNativeCall).toHaveBeenCalledWith(serverUrl, channelId, 'remoteEnded', undefined);
+        });
+
+        it('should pass callId from state to endNativeCall before state is cleared', () => {
+            jest.mocked(getCallsState).mockReturnValue({
+                ...DefaultCallsState,
+                myUserId: userId,
+                calls: {
+                    [channelId]: {
+                        ...DefaultCall,
+                        id: 'call-b',
+                        channelId,
+                    },
+                },
+            });
+
+            handleCallEnded(serverUrl, {
+                broadcast: {channel_id: channelId},
+                data: {},
+            } as WebSocketMessage<EmptyData>);
+
+            expect(callEnded).toHaveBeenCalledWith(serverUrl, channelId);
+            expect(endNativeCall).toHaveBeenCalledWith(serverUrl, channelId, 'remoteEnded', 'call-b');
+        });
+
+        it('should pass undefined callId to endNativeCall when no call is active (stale replay)', () => {
+            // No call in state simulates a stale call_end from a prior call arriving
+            // after the channel's call state was already cleared. endNativeCall receives
+            // undefined, which is rejected by the mapping guard as an unidentified event.
+            jest.mocked(getCallsState).mockReturnValue({
+                ...DefaultCallsState,
+                myUserId: userId,
+            });
+
+            handleCallEnded(serverUrl, {
+                broadcast: {channel_id: channelId},
+                data: {},
+            } as WebSocketMessage<EmptyData>);
+
             expect(endNativeCall).toHaveBeenCalledWith(serverUrl, channelId, 'remoteEnded', undefined);
         });
     });

--- a/app/products/calls/connection/websocket_event_handlers.test.ts
+++ b/app/products/calls/connection/websocket_event_handlers.test.ts
@@ -249,7 +249,7 @@ describe('websocket event handlers', () => {
             } as WebSocketMessage<EmptyData>);
             expect(DeviceEventEmitter.emit).toHaveBeenCalledWith('custom_com.mattermost.calls_call_end', {channelId});
             expect(callEnded).toHaveBeenCalledWith(serverUrl, channelId);
-            expect(endNativeCall).toHaveBeenCalledWith(serverUrl, channelId, 'remoteEnded');
+            expect(endNativeCall).toHaveBeenCalledWith(serverUrl, channelId, 'remoteEnded', undefined);
         });
     });
 

--- a/app/products/calls/connection/websocket_event_handlers.test.ts
+++ b/app/products/calls/connection/websocket_event_handlers.test.ts
@@ -316,6 +316,16 @@ describe('websocket event handlers', () => {
                 },
             });
 
+            // Simulate callEnded() clearing the call from state. If handleCallEnded
+            // reads callId after this runs instead of before, getCallsState returns
+            // no call and endNativeCall receives undefined — failing the assertion below.
+            jest.mocked(callEnded).mockImplementationOnce(() => {
+                jest.mocked(getCallsState).mockReturnValue({
+                    ...DefaultCallsState,
+                    myUserId: userId,
+                });
+            });
+
             handleCallEnded(serverUrl, {
                 broadcast: {channel_id: channelId},
                 data: {},

--- a/app/products/calls/connection/websocket_event_handlers.ts
+++ b/app/products/calls/connection/websocket_event_handlers.ts
@@ -7,7 +7,7 @@ import {fetchUsersByIds} from '@actions/remote/user';
 import {leaveCall, muteMyself, unraiseHand} from '@calls/actions';
 import {createCallAndAddToIds} from '@calls/actions/calls';
 import {hostRemovedErr} from '@calls/errors';
-import {endNativeCall, getNativeCallUUIDForCall} from '@calls/native_call';
+import {endNativeCall, getNativeCallMapping, getNativeCallUUIDForCall, setNativeCallMapping} from '@calls/native_call';
 import {
     callEnded,
     callStarted,
@@ -111,18 +111,31 @@ export const handleCallStarted = (serverUrl: string, msg: WebSocketMessage<CallS
         hostId: msg.data.host_id,
         dismissed: {},
     });
+
+    // Backfill the callId into the native mapping created by the VoIP push.
+    // Until this fires, endNativeCall treats the mapping as unconfirmed and
+    // ignores any call_end events that arrive with a callId.
+    const uuid = getNativeCallUUIDForCall(serverUrl, msg.data.channelID);
+    if (uuid) {
+        const existing = getNativeCallMapping(uuid);
+        if (existing) {
+            setNativeCallMapping(uuid, {...existing, callId: msg.data.id});
+        }
+    }
 };
 
 export const handleCallEnded = (serverUrl: string, msg: WebSocketMessage<EmptyData>) => {
     const channelId = msg.broadcast.channel_id;
     DeviceEventEmitter.emit(WebsocketEvents.CALLS_CALL_END, {channelId});
 
+    // Read callId before callEnded() removes the call from state. Passing it
+    // to endNativeCall lets the stale-replay guard reject events for a prior
+    // call whose call_end was buffered and replayed during a new call's ring.
+    const callId = getCallsState(serverUrl).calls[channelId]?.id;
+
     callEnded(serverUrl, channelId);
 
-    // The call is over on the server. Close any native overlay (ring or
-    // registered call) we still have for it — covers RTC-silent-death and
-    // caller-cancelled-the-ring.
-    endNativeCall(serverUrl, channelId, 'remoteEnded');
+    endNativeCall(serverUrl, channelId, 'remoteEnded', callId);
 };
 
 export const handleCallChannelEnabled = (serverUrl: string, msg: WebSocketMessage<EmptyData>) => {

--- a/app/products/calls/native_call.test.ts
+++ b/app/products/calls/native_call.test.ts
@@ -87,6 +87,16 @@ describe('mapping store', () => {
         expect(getNativeCallUUIDForCall('sA', 'cOther')).toBeUndefined();
         expect(getNativeCallUUIDForCall('sOther', 'cA')).toBeUndefined();
     });
+
+    it('reverse lookup returns undefined when callId provided but mapping.callId is empty (call_started not yet received)', () => {
+        setNativeCallMapping('uuid-a', {serverUrl: 'sA', channelId: 'cA', postId: '', threadId: '', callId: ''});
+        expect(getNativeCallUUIDForCall('sA', 'cA', 'call-1')).toBeUndefined();
+    });
+
+    it('reverse lookup returns uuid when callId matches mapping.callId', () => {
+        setNativeCallMapping('uuid-a', {serverUrl: 'sA', channelId: 'cA', postId: '', threadId: '', callId: 'call-1'});
+        expect(getNativeCallUUIDForCall('sA', 'cA', 'call-1')).toBe('uuid-a');
+    });
 });
 
 describe('clearNativeCallMapping wrapper', () => {
@@ -278,6 +288,32 @@ describe('endNativeCall', () => {
     it('no-op when no mapping matches', () => {
         endNativeCall(serverUrl, 'unknown', 'remoteEnded');
         expect(CallsNative.reportEnded).not.toHaveBeenCalled();
+    });
+
+    it('no-op when callId provided but mapping.callId is empty (stale call_end before call_started)', () => {
+        setNativeCallMapping('uuid-a', {
+            serverUrl,
+            channelId: 'ch1',
+            postId: '',
+            threadId: '',
+            callId: '',
+        });
+        endNativeCall(serverUrl, 'ch1', 'remoteEnded', 'call-1');
+        expect(CallsNative.reportEnded).not.toHaveBeenCalled();
+        expect(getNativeCallMapping('uuid-a')).toBeDefined();
+    });
+
+    it('ends the call when callId matches the mapping', () => {
+        setNativeCallMapping('uuid-a', {
+            serverUrl,
+            channelId: 'ch1',
+            postId: '',
+            threadId: '',
+            callId: 'call-1',
+        });
+        endNativeCall(serverUrl, 'ch1', 'remoteEnded', 'call-1');
+        expect(CallsNative.reportEnded).toHaveBeenCalledWith('uuid-a', 'remoteEnded');
+        expect(getNativeCallMapping('uuid-a')).toBeUndefined();
     });
 
     it('skips when not on iOS', () => {

--- a/app/products/calls/native_call.ts
+++ b/app/products/calls/native_call.ts
@@ -128,11 +128,12 @@ export const endNativeCall = (
     serverUrl: string,
     channelId: string,
     reason: 'unanswered' | 'answeredElsewhere' | 'declinedElsewhere' | 'remoteEnded' | 'failed',
+    callId?: string,
 ) => {
     if (Platform.OS !== 'ios') {
         return;
     }
-    const uuid = getNativeCallUUIDForCall(serverUrl, channelId);
+    const uuid = getNativeCallUUIDForCall(serverUrl, channelId, callId);
     if (!uuid) {
         return;
     }

--- a/app/products/calls/native_call_mappings.ts
+++ b/app/products/calls/native_call_mappings.ts
@@ -10,6 +10,7 @@ export type NativeCallMapping = {
     channelId: string;
     postId: string;
     threadId: string;
+    callId?: string;
 };
 
 const mappings = new Map<string, NativeCallMapping>();
@@ -26,11 +27,19 @@ export const clearNativeCallMapping = (uuid: string): boolean => {
     return mappings.delete(uuid);
 };
 
-export const getNativeCallUUIDForCall = (serverUrl: string, channelId: string): string | undefined => {
+export const getNativeCallUUIDForCall = (serverUrl: string, channelId: string, callId?: string): string | undefined => {
     for (const [uuid, mapping] of mappings) {
-        if (mapping.serverUrl === serverUrl && mapping.channelId === channelId) {
-            return uuid;
+        if (mapping.serverUrl !== serverUrl || mapping.channelId !== channelId) {
+            continue;
         }
+
+        // When a callId is provided, require it to match the mapping — an
+        // unset (empty) mapping.callId means call_started hasn't arrived yet,
+        // so any event carrying a callId is stale and should be ignored.
+        if (callId !== undefined && mapping.callId !== callId) {
+            return undefined;
+        }
+        return uuid;
     }
     return undefined;
 };


### PR DESCRIPTION
## Summary

- Adds `callId` to `NativeCallMapping` so each native CallKit entry is associated with the specific call it represents, not just the channel
- Prevents buffered `call_end` events from a prior call being replayed on WebSocket reconnect from tearing down the active CallKit session for a new incoming call
- Handles both VoIP-push-first and `call_started`-first event orderings correctly

## Root cause

`NativeCallMapping` was keyed only by `(serverUrl, channelId)`. When the phone locks during a call, the WebSocket drops and the server buffers events. When the user receives a VoIP push for a new call and the WebSocket reconnects, the server replays the buffered `call_end` from the previous call. Because there was no call ID check, `endNativeCall` would find the new call's mapping by channel and immediately tear it down — disconnecting the call right after the user answered from the lock screen.

## Changes

- **`native_call_mappings.ts`**: adds optional `callId` field to `NativeCallMapping`; `getNativeCallUUIDForCall` now accepts an optional `callId` and returns `undefined` when the mapping's `callId` is empty (unconfirmed) or mismatched
- **`native_call.ts`**: threads `callId` through `endNativeCall` to the lookup
- **`calls_native.ts`**: `onIncomingCall` seeds `callId` from calls state when creating the mapping — handles the case where `call_started` arrives before the VoIP push
- **`websocket_event_handlers.ts`**: `handleCallStarted` backfills `callId` into the mapping once the WS event confirms the call; `handleCallEnded` reads `callId` from state before `callEnded()` clears it, then passes it to `endNativeCall`

## How the guard works

When a VoIP push arrives, the mapping is created with `callId: ''` (or the call's ID if `call_started` already ran). Until `call_started` backfills it, any `call_end` event carrying a callId will find a mismatch and be a no-op. Once backfilled, legitimate `call_end` events match and dismiss the native UI correctly.

## Test plan

- [ ] New unit tests added with TDD (red → green verified): stale `call_end` before `call_started` is a no-op, legitimate `call_end` after `call_started` succeeds, `call_started`-before-VoIP-push ordering seeds callId correctly
- [ ] All 314 affected tests pass
- [ ] Physical device testing: answer an incoming DM/GM call from the lock screen and verify the call connects and stays connected

Fixes: [MM-70525](https://mattermost.atlassian.net/browse/MM-70525)

```release-note
Fixed an intermittent issue where answering an incoming call from the iOS lock screen would immediately disconnect.
```

[MM-70525]: https://mattermost.atlassian.net/browse/MM-70525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ