### PR TITLE
fix(android): open every SQLite connection in WAL, not just the JSI one

### DIFF
--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/General.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/General.kt
@@ -89,7 +89,19 @@ fun DatabaseHelper.getDatabaseForServer(context: Context?, serverUrl: String): W
             if (cursor.count == 1) {
                 cursor.moveToFirst()
                 val databasePath = String.format("file://%s", cursor.getString(0))
-                return WMDatabase.buildDatabase(databasePath, context!!, SQLiteDatabase.CREATE_IF_NECESSARY)
+
+                // WAL must match how the JS side opens this same file. WatermelonDB's JSI
+                // connection runs `pragma journal_mode = WAL` (#10109), and journal mode is a
+                // property of the database file, not of a connection -- so opening it here
+                // without ENABLE_WRITE_AHEAD_LOGGING makes Android's SQLiteConnection issue its
+                // own `PRAGMA journal_mode` on open and drag the file back out of WAL underneath
+                // the live JSI connection. Two connections disagreeing about the journal is what
+                // produced "(11) database disk image is malformed" while adding a server.
+                return WMDatabase.buildDatabase(
+                    databasePath,
+                    context!!,
+                    SQLiteDatabase.CREATE_IF_NECESSARY or SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING,
+                )
             }
         }
     } catch (e: Exception) {

--- a/android/app/src/main/java/com/mattermost/helpers/database_extension/General.kt
+++ b/android/app/src/main/java/com/mattermost/helpers/database_extension/General.kt
@@ -89,14 +89,7 @@ fun DatabaseHelper.getDatabaseForServer(context: Context?, serverUrl: String): W
             if (cursor.count == 1) {
                 cursor.moveToFirst()
                 val databasePath = String.format("file://%s", cursor.getString(0))
-
-                // WAL must match how the JS side opens this same file. WatermelonDB's JSI
-                // connection runs `pragma journal_mode = WAL` (#10109), and journal mode is a
-                // property of the database file, not of a connection -- so opening it here
-                // without ENABLE_WRITE_AHEAD_LOGGING makes Android's SQLiteConnection issue its
-                // own `PRAGMA journal_mode` on open and drag the file back out of WAL underneath
-                // the live JSI connection. Two connections disagreeing about the journal is what
-                // produced "(11) database disk image is malformed" while adding a server.
+                // Keep WAL consistent with the JS/JSI connection (#10109).
                 return WMDatabase.buildDatabase(
                     databasePath,
                     context!!,

--- a/patches/@nozbe+watermelondb+0.28.1-0.patch
+++ b/patches/@nozbe+watermelondb+0.28.1-0.patch
@@ -384,7 +384,7 @@ index 055cede..fb7ca33 100755
          new JSIInstaller().installBinding(javaScriptContextHolder);
  
 diff --git a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabase.java b/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabase.java
-index 2f170e0..bd87f92 100644
+index 2f170e0..1aaba0e 100644
 --- a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabase.java
 +++ b/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabase.java
 @@ -11,6 +11,8 @@ import java.util.Arrays;
@@ -396,14 +396,6 @@ index 2f170e0..bd87f92 100644
  public class WMDatabase {
      private final SQLiteDatabase db;
  
-@@ -21,7 +23,7 @@ public class WMDatabase {
-     public static Map<String, WMDatabase> INSTANCES = new HashMap<>();
- 
-     public static WMDatabase getInstance(String name, Context context) {
-         return getInstance(name, context, SQLiteDatabase.CREATE_IF_NECESSARY | SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING);
-     }
- 
-     public static WMDatabase getInstance(String name, Context context, int openFlags) {
 @@ -47,6 +49,22 @@ public class WMDatabase {
          if (name.equals(":memory:") || name.contains("mode=memory")) {
              context.getCacheDir().delete();
@@ -460,22 +452,10 @@ index 4f13512..7fa03f8 100644
      public void getLocal(int tag, String key, Promise promise) {
          withDriver(tag, promise, (driver) -> driver.getLocal(key), "getLocal");
 diff --git a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseDriver.java b/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseDriver.java
-index 1534830..5c5313c 100644
+index 1534830..c8c434b 100644
 --- a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseDriver.java
 +++ b/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseDriver.java
-@@ -55,11 +55,11 @@ public class WMDatabaseDriver {
- 
-     public WMDatabaseDriver(Context context, String dbName, boolean unsafeNativeReuse) {
-         this.database = unsafeNativeReuse ? WMDatabase.getInstance(dbName, context,
-                 SQLiteDatabase.CREATE_IF_NECESSARY |
-                         SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING) :
-                 WMDatabase.buildDatabase(dbName, context,
-                         SQLiteDatabase.CREATE_IF_NECESSARY |
-                                 SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING);
-         if (BuildConfig.DEBUG) {
-             this.log = Logger.getLogger("DB_Driver");
-         } else {
-@@ -230,6 +228,13 @@ public class WMDatabaseDriver {
+@@ -230,6 +230,13 @@ public class WMDatabaseDriver {
          });
      }
  

--- a/patches/@nozbe+watermelondb+0.28.1-0.patch
+++ b/patches/@nozbe+watermelondb+0.28.1-0.patch
@@ -400,8 +400,7 @@ index 2f170e0..bd87f92 100644
      public static Map<String, WMDatabase> INSTANCES = new HashMap<>();
  
      public static WMDatabase getInstance(String name, Context context) {
--        return getInstance(name, context, SQLiteDatabase.CREATE_IF_NECESSARY | SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING);
-+        return getInstance(name, context, SQLiteDatabase.CREATE_IF_NECESSARY);
+         return getInstance(name, context, SQLiteDatabase.CREATE_IF_NECESSARY | SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING);
      }
  
      public static WMDatabase getInstance(String name, Context context, int openFlags) {
@@ -464,17 +463,15 @@ diff --git a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/n
 index 1534830..5c5313c 100644
 --- a/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseDriver.java
 +++ b/node_modules/@nozbe/watermelondb/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseDriver.java
-@@ -55,11 +55,9 @@ public class WMDatabaseDriver {
+@@ -55,11 +55,11 @@ public class WMDatabaseDriver {
  
      public WMDatabaseDriver(Context context, String dbName, boolean unsafeNativeReuse) {
          this.database = unsafeNativeReuse ? WMDatabase.getInstance(dbName, context,
--                SQLiteDatabase.CREATE_IF_NECESSARY |
--                        SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING) :
-+                SQLiteDatabase.CREATE_IF_NECESSARY) :
+                 SQLiteDatabase.CREATE_IF_NECESSARY |
+                         SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING) :
                  WMDatabase.buildDatabase(dbName, context,
--                        SQLiteDatabase.CREATE_IF_NECESSARY |
--                                SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING);
-+                        SQLiteDatabase.CREATE_IF_NECESSARY);
+                         SQLiteDatabase.CREATE_IF_NECESSARY |
+                                 SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING);
          if (BuildConfig.DEBUG) {
              this.log = Logger.getLogger("DB_Driver");
          } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Opens every Android SQLite connection in WAL mode, not only the JSI path. After #10109 re-enabled `pragma journal_mode = WAL` in WatermelonDB's C++ layer, native Kotlin connections (push notification path, `WMDatabase.getInstance`, `getDatabaseForServer`, and `WMDatabaseDriver`) were still opening without `ENABLE_WRITE_AHEAD_LOGGING`. Those non-WAL opens dragged the shared database file out of WAL underneath the live JSI connection, producing `database disk image is malformed` on the first write to `app.db` when adding a server.

This change restores WAL on those native open paths (reverting the patch hunks that stripped upstream's flags) so all connections agree on journal mode.

#### Ticket Link
Related to #10109 / malformed SQLite on Android when adding a server.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Not verified on a device in this cherry-pick; needs an Android build against the WAL-on repro.

#### Screenshots
N/A — native SQLite connection flags only.

```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a76d612-222f-41c2-aa25-5bcd6b0327b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a76d612-222f-41c2-aa25-5bcd6b0327b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

