### PR TITLE
Fix iOS crash when attaching photos (SIGABRT)

### DIFF
--- a/patches/react-native-image-picker+8.2.1.patch
+++ b/patches/react-native-image-picker+8.2.1.patch
@@ -1,0 +1,126 @@
+diff --git a/node_modules/react-native-image-picker/ios/ImagePickerManager.mm b/node_modules/react-native-image-picker/ios/ImagePickerManager.mm
+index 93e99be..94082ec 100644
+--- a/node_modules/react-native-image-picker/ios/ImagePickerManager.mm
++++ b/node_modules/react-native-image-picker/ios/ImagePickerManager.mm
+@@ -68,7 +68,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
+     self.callback = callback;
+ 
+     if (target == camera && [ImagePickerUtils isSimulator]) {
+-        self.callback(@[@{@"errorCode": errCameraUnavailable}]);
++        [self invokeCallback:@[@{@"errorCode": errCameraUnavailable}]];
+         return;
+     }
+ 
+@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
+ 
+                 [self checkPhotosPermissions:^(BOOL granted) {
+                     if (!granted) {
+-                        self.callback(@[@{@"errorCode": errPermission}]);
++                        [self invokeCallback:@[@{@"errorCode": errPermission}]];
+                         return;
+                     }
+                     [self showPickerViewController:picker];
+@@ -108,7 +108,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
+     if([self.options[@"includeExtra"] boolValue]) {
+         [self checkPhotosPermissions:^(BOOL granted) {
+             if (!granted) {
+-                self.callback(@[@{@"errorCode": errPermission}]);
++                [self invokeCallback:@[@{@"errorCode": errPermission}]];
+                 return;
+             }
+             [self showPickerViewController:picker];
+@@ -126,6 +126,22 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
+     });
+ }
+ 
++// The bridge callback aborts the app if invoked more than once. Delegate
++// callbacks can double-fire (e.g. presentationControllerDidDismiss followed by
++// picker:didFinishPicking:), so consume the callback exactly once, serialized
++// on the main queue.
++- (void)invokeCallback:(NSArray *)response
++{
++    dispatch_async(dispatch_get_main_queue(), ^{
++        RCTResponseSenderBlock callback = self.callback;
++        if (callback == nil) {
++            return;
++        }
++        self.callback = nil;
++        callback(response);
++    });
++}
++
+ #pragma mark - Helpers
+ 
+ NSData* extractImageData(UIImage* image){
+@@ -465,7 +481,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
+             if (videoAsset == nil) {
+                 NSString *errorMessage = error.localizedFailureReason;
+                 if (errorMessage == nil) errorMessage = @"Video asset not found";
+-                self.callback(@[@{@"errorCode": errOthers, @"errorMessage": errorMessage}]);
++                [self invokeCallback:@[@{@"errorCode": errOthers, @"errorMessage": errorMessage}]];
+                 return;
+             }
+             [assets addObject:videoAsset];
+@@ -473,7 +489,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
+ 
+         NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
+         response[@"assets"] = assets;
+-        self.callback(@[response]);
++        [self invokeCallback:@[response]];
+     };
+ 
+     dispatch_async(dispatch_get_main_queue(), ^{
+@@ -485,7 +501,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
+ {
+     dispatch_async(dispatch_get_main_queue(), ^{
+         [picker dismissViewControllerAnimated:YES completion:^{
+-            self.callback(@[@{@"didCancel": @YES}]);
++            [self invokeCallback:@[@{@"didCancel": @YES}]];
+         }];
+     });
+ }
+@@ -496,7 +512,14 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
+ 
+ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+ {
+-    self.callback(@[@{@"didCancel": @YES}]);
++    // A selection already being processed must win over the interactive
++    // dismissal, otherwise the picked assets would later hit a consumed
++    // callback (or be reported as a cancel).
++    if (photoSelected == YES) {
++        return;
++    }
++    photoSelected = YES;
++    [self invokeCallback:@[@{@"didCancel": @YES}]];
+ }
+ 
+ @end
+@@ -514,9 +537,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
+     photoSelected = YES;
+ 
+     if (results.count == 0) {
+-        dispatch_async(dispatch_get_main_queue(), ^{
+-            self.callback(@[@{@"didCancel": @YES}]);
+-        });
++        [self invokeCallback:@[@{@"didCancel": @YES}]];
+         return;
+     }
+ 
+@@ -571,7 +592,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
+         //  mapVideoToAsset can fail and return nil, leaving asset NSNull.
+         for (NSDictionary *asset in assets) {
+             if ([asset isEqual:[NSNull null]]) {
+-                self.callback(@[@{@"errorCode": errOthers}]);
++                [self invokeCallback:@[@{@"errorCode": errOthers}]];
+                 return;
+             }
+         }
+@@ -579,7 +600,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
+         NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
+         [response setObject:assets forKey:@"assets"];
+ 
+-        self.callback(@[response]);
++        [self invokeCallback:@[response]];
+     });
+ }
+ 


### PR DESCRIPTION
#### Summary
Patches react-native-image-picker 8.2.1 to stop the picker callback from
being invoked twice, which hard-crashes the app on iOS.

On the New Architecture RN wraps the callback in a single-shot block that
aborts the process if called again. ImagePickerManager has two paths to
self.callback and only one is guarded: presentationControllerDidDismiss
fires didCancel unguarded, while picker:didFinishPicking invokes from a
dispatch_group_notify block after all assets load. If a dismissal overlaps
an in-flight load, both fire and the app dies with:

  Callback arg cannot be called more than once
  RCTTurboModule.mm:158 / ImagePickerManager.mm:582

Worst with multi-select and iCloud or video assets, where loading takes
seconds. The abort happens before JS runs, so there's nothing we can do
from the app side - it has to be fixed natively.

This ports upstream PR https://github.com/react-native-image-picker/react-native-image-picker/pull/2406: adds an invokeCallback: helper that consumes
the callback exactly once on the main queue, routes all 10 call sites
through it, and guards presentationControllerDidDismiss with photoSelected.

Patching instead of upgrading because 8.2.1 is still the latest release
(May 2025) and #2406, #2413 and #2410 are all open and unreviewed. Related:
#2415, #2391, #2414.

Testing: Attach a single photo, several photos and
a video from the gallery, take a photo with the camera, and swipe the picker
down while assets are still loading. The race is timing-dependent so this
confirms the flow still works rather than proving the race is gone.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70577

#### Release Note
```release-note
Fixed iOS crash when attaching photos (SIGABRT)
```
