### PR TITLE
Mm 68296 audit ephemeral mode events

### DIFF
--- a/app/actions/app/global.ts
+++ b/app/actions/app/global.ts
@@ -7,6 +7,7 @@ import DatabaseManager from '@database/manager';
 import {getActiveServerUrl} from '@init/credentials';
 import {logError} from '@utils/log';
 
+import type {EphemeralModeAuditEvent} from '@constants/ephemeral_mode';
 import type GlobalModel from '@typings/database/models/app/global';
 
 const {APP: {GLOBAL}} = MM_TABLES;
@@ -134,4 +135,8 @@ export const removePushSigningKey = async (serverUrl: string) => {
         // no cached signing key to remove
     }
     return {};
+};
+
+export const replaceEphemeralModeAuditEvents = async (serverUrl: string, events: EphemeralModeAuditEvent[]) => {
+    return storeGlobal(`${GLOBAL_IDENTIFIERS.EPHEMERAL_MODE_AUDIT_QUEUE}${serverUrl}`, events.length ? events : null, false);
 };

--- a/app/actions/local/ephemeral_mode/audit_queue.test.ts
+++ b/app/actions/local/ephemeral_mode/audit_queue.test.ts
@@ -140,7 +140,7 @@ describe('pruneAuditQueueOnSessionEnd', () => {
         });
         await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.SessionWipe,
-            userId: 'user1',
+            signature: 'sig1',
             occurredAt: 3000,
         });
     });

--- a/app/actions/local/ephemeral_mode/audit_queue.test.ts
+++ b/app/actions/local/ephemeral_mode/audit_queue.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {replaceEphemeralModeAuditEvents} from '@actions/app/global';
 import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import DatabaseManager from '@database/manager';
 import {getEphemeralModeAuditEvents} from '@queries/app/global';
@@ -15,6 +16,7 @@ describe('enqueueAuditEvent', () => {
     });
 
     afterEach(async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, []);
         await DatabaseManager.destroyServerDatabase(serverUrl);
     });
 
@@ -22,11 +24,13 @@ describe('enqueueAuditEvent', () => {
         await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 1000,
         });
         await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 2,
+            playbookRunsDeleted: 0,
             occurredAt: 2000,
         });
 
@@ -40,11 +44,13 @@ describe('enqueueAuditEvent', () => {
         const first = enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 1000,
         });
         const second = enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 2,
+            playbookRunsDeleted: 0,
             occurredAt: 2000,
         });
 
@@ -59,6 +65,7 @@ describe('enqueueAuditEvent', () => {
         const id = await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 1000,
         });
 
@@ -74,6 +81,7 @@ describe('attachAuditEventErrorReason', () => {
     });
 
     afterEach(async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, []);
         await DatabaseManager.destroyServerDatabase(serverUrl);
     });
 
@@ -86,6 +94,7 @@ describe('attachAuditEventErrorReason', () => {
         await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 2000,
         });
 
@@ -103,6 +112,7 @@ describe('attachAuditEventErrorReason', () => {
         await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 1000,
         });
 
@@ -125,6 +135,7 @@ describe('pruneAuditQueueOnSessionEnd', () => {
         await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 2000,
         });
         await enqueueAuditEvent(serverUrl, {
@@ -135,6 +146,7 @@ describe('pruneAuditQueueOnSessionEnd', () => {
     });
 
     afterEach(async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, []);
         await DatabaseManager.destroyServerDatabase(serverUrl);
     });
 

--- a/app/actions/local/ephemeral_mode/audit_queue.test.ts
+++ b/app/actions/local/ephemeral_mode/audit_queue.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
+import DatabaseManager from '@database/manager';
+import {getEphemeralModeAuditEvents} from '@queries/app/global';
+
+import {attachAuditEventErrorReason, enqueueAuditEvent, pruneAuditQueueOnSessionEnd} from './audit_queue';
+
+const serverUrl = 'audit-queue.test.com';
+
+describe('enqueueAuditEvent', () => {
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('should append to an existing queue rather than overwriting it', async () => {
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 1000,
+        });
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 2,
+            occurredAt: 2000,
+        });
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+
+        expect(events).toHaveLength(2);
+        expect(events.map((e) => e.occurredAt)).toEqual([1000, 2000]);
+    });
+
+    it('should land both events when two enqueues for the same server race', async () => {
+        const first = enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 1000,
+        });
+        const second = enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 2,
+            occurredAt: 2000,
+        });
+
+        await Promise.all([first, second]);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+
+        expect(events).toHaveLength(2);
+    });
+
+    it('should resolve with the id assigned to the enqueued event', async () => {
+        const id = await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 1000,
+        });
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+
+        expect(events[0].id).toBe(id);
+    });
+});
+
+describe('attachAuditEventErrorReason', () => {
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('should set errorReason on the event matching the given id, leaving every other queued event untouched', async () => {
+        const targetId = await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.OfflinePurge,
+            offlineTimeMinutes: 30,
+            occurredAt: 1000,
+        });
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 2000,
+        });
+
+        await attachAuditEventErrorReason(serverUrl, targetId, 'database wipe failed after retries');
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        const target = events.find((event) => event.id === targetId);
+        const other = events.find((event) => event.id !== targetId);
+
+        expect(target?.errorReason).toBe('database wipe failed after retries');
+        expect(other?.errorReason).toBeUndefined();
+    });
+
+    it('should leave the queue unchanged when the id no longer matches any queued event', async () => {
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 1000,
+        });
+
+        await attachAuditEventErrorReason(serverUrl, 'already-flushed-id', 'database wipe failed after retries');
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+
+        expect(events[0].errorReason).toBeUndefined();
+    });
+});
+
+describe('pruneAuditQueueOnSessionEnd', () => {
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.OfflinePurge,
+            offlineTimeMinutes: 30,
+            occurredAt: 1000,
+        });
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 2000,
+        });
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.SessionWipe,
+            userId: 'user1',
+            occurredAt: 3000,
+        });
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+    });
+
+    it('should remove offlinePurge and cleanup events while keeping sessionWipe', async () => {
+        await pruneAuditQueueOnSessionEnd(serverUrl, false);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+
+        expect(events).toHaveLength(1);
+        expect(events[0].kind).toBe(EphemeralModeAuditEventKind.SessionWipe);
+    });
+
+    it('should remove every event including sessionWipe when the server was removed', async () => {
+        await pruneAuditQueueOnSessionEnd(serverUrl, true);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+
+        expect(events).toHaveLength(0);
+    });
+});

--- a/app/actions/local/ephemeral_mode/audit_queue.ts
+++ b/app/actions/local/ephemeral_mode/audit_queue.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {replaceEphemeralModeAuditEvents} from '@actions/app/global';
+import {EphemeralModeAuditEventKind, type EphemeralModeAuditEvent, type EphemeralModeAuditEventInput} from '@constants/ephemeral_mode';
+import {getEphemeralModeAuditEvents} from '@queries/app/global';
+import {generateId} from '@utils/general';
+import {logDebug} from '@utils/log';
+
+let auditQueueChain: Promise<unknown> = Promise.resolve();
+
+// Serializes read-modify-write on the Global row; `update` is synchronous so nothing holds the queue across a request.
+const updateAuditQueue = (serverUrl: string, update: (events: EphemeralModeAuditEvent[]) => EphemeralModeAuditEvent[]) => {
+    const next = auditQueueChain.then(async () => {
+        const existing = await getEphemeralModeAuditEvents(serverUrl);
+        return replaceEphemeralModeAuditEvents(serverUrl, update(existing));
+    });
+    auditQueueChain = next.catch(() => undefined);
+    return next;
+};
+
+export const enqueueAuditEvent = (serverUrl: string, event: EphemeralModeAuditEventInput): Promise<string> => {
+    const id = generateId();
+    return updateAuditQueue(serverUrl, (events) => [...events, {...event, id, attempts: 0} as EphemeralModeAuditEvent]).
+        then(() => id);
+};
+
+// A no-op if the event was already sent and removed from the queue by a concurrent flush.
+export const attachAuditEventErrorReason = (serverUrl: string, id: string, errorReason: string) => {
+    return updateAuditQueue(serverUrl, (events) => events.map((event) => (event.id === id ? {...event, errorReason} : event)));
+};
+
+// Drops what the flush finished with, and charges an attempt to whatever failed.
+export const settleAuditEvents = (serverUrl: string, consumed: Set<string>, failed: Set<string>) => {
+    return updateAuditQueue(serverUrl, (events) => events.
+        filter(({id}) => !consumed.has(id)).
+        map((event) => (failed.has(event.id) ? {...event, attempts: event.attempts + 1} : event)));
+};
+
+// /purge and /cleanup are attributed to the sending session, so keep only /wipe (has its own user_id); drop everything if the server itself is removed.
+export const pruneAuditQueueOnSessionEnd = (serverUrl: string, serverRemoved: boolean) => {
+    return updateAuditQueue(serverUrl, (events) => {
+        const keep = serverRemoved ? [] : events.filter(({kind}) => kind === EphemeralModeAuditEventKind.SessionWipe);
+        if (keep.length !== events.length) {
+            logDebug('pruneAuditQueueOnSessionEnd', serverUrl, events.length - keep.length);
+        }
+        return keep;
+    });
+};

--- a/app/actions/local/ephemeral_mode/audit_queue.ts
+++ b/app/actions/local/ephemeral_mode/audit_queue.ts
@@ -37,7 +37,7 @@ export const settleAuditEvents = (serverUrl: string, consumed: Set<string>, fail
         map((event) => (failed.has(event.id) ? {...event, attempts: event.attempts + 1} : event)));
 };
 
-// /purge and /cleanup are attributed to the sending session, so keep only /wipe (has its own user_id); drop everything if the server itself is removed.
+// /purge and /cleanup are attributed to the sending session, so keep only /wipe (uses signature as a proof of ownership); drop everything if the server itself is removed.
 export const pruneAuditQueueOnSessionEnd = (serverUrl: string, serverRemoved: boolean) => {
     return updateAuditQueue(serverUrl, (events) => {
         const keep = serverRemoved ? [] : events.filter(({kind}) => kind === EphemeralModeAuditEventKind.SessionWipe);

--- a/app/actions/local/ephemeral_mode/cleanup.test.ts
+++ b/app/actions/local/ephemeral_mode/cleanup.test.ts
@@ -490,33 +490,57 @@ describe('autoCacheCleanup', () => {
         expect(flushAuditQueue).toHaveBeenCalledWith(SERVER_URL);
     });
 
-    it('should log the error when the viewed-channel delete call returns an error', async () => {
+    it('reports the postsDeleted count already collected from the unprotected-channels block when the viewed-channel delete call fails afterward', async () => {
         const viewedChannelId = 'ch-viewed-err';
+        const unprotectedChannelId = 'ch-unprotected-viewed-err';
         jest.spyOn(DatabaseManager, 'getActiveServerUrl').mockResolvedValue(SERVER_URL);
         jest.mocked(NavigationStore.getScreensInStack).mockReturnValue([Screens.CHANNEL]);
         jest.mocked(getCurrentChannelId).mockResolvedValue(viewedChannelId);
 
+        await writePiC(unprotectedChannelId);
         await writePiC(viewedChannelId);
-        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('viewed channel delete failed'), deletedCount: 0});
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).
+            mockResolvedValueOnce({error: undefined, deletedCount: 3}).
+            mockResolvedValueOnce({error: new Error('viewed channel delete failed'), deletedCount: 0});
 
-        await autoCacheCleanup(SERVER_URL);
+        const result = await autoCacheCleanup(SERVER_URL);
 
         expect(logError).toHaveBeenCalledWith('autoCacheCleanup', 'viewed channel delete failed');
+        expect(result).toEqual({error: new Error('viewed channel delete failed')});
+        expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 3,
+            playbookRunsDeleted: 0,
+            occurredAt: NOW,
+            errorReason: 'cleanup failed before completion',
+        });
     });
 
-    it('should log the error when the thread-parent-channel delete call returns an error', async () => {
+    it('reports the postsDeleted count already collected from the unprotected-channels block when the thread-parent-channel delete call fails afterward', async () => {
         const rootId = 'root-err';
         const threadParentChannelId = 'ch-thread-parent-err';
+        const unprotectedChannelId = 'ch-unprotected-thread-err';
         jest.spyOn(DatabaseManager, 'getActiveServerUrl').mockResolvedValue(SERVER_URL);
         jest.mocked(EphemeralStore.getCurrentThreadId).mockReturnValue(rootId);
         await writePost(rootId, threadParentChannelId, OLD);
 
+        await writePiC(unprotectedChannelId);
         await writePiC(threadParentChannelId);
-        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('thread parent channel delete failed'), deletedCount: 0});
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).
+            mockResolvedValueOnce({error: undefined, deletedCount: 2}).
+            mockResolvedValueOnce({error: new Error('thread parent channel delete failed'), deletedCount: 0});
 
-        await autoCacheCleanup(SERVER_URL);
+        const result = await autoCacheCleanup(SERVER_URL);
 
         expect(logError).toHaveBeenCalledWith('autoCacheCleanup', 'thread parent channel delete failed');
+        expect(result).toEqual({error: new Error('thread parent channel delete failed')});
+        expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 2,
+            playbookRunsDeleted: 0,
+            occurredAt: NOW,
+            errorReason: 'cleanup failed before completion',
+        });
     });
 
     it('should delete AI threads older than the cutoff and keeps newer ones', async () => {

--- a/app/actions/local/ephemeral_mode/cleanup.test.ts
+++ b/app/actions/local/ephemeral_mode/cleanup.test.ts
@@ -1,10 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {enqueueAuditEvent} from '@actions/local/ephemeral_mode/audit_queue';
 import * as LocalPost from '@actions/local/post';
+import {flushAuditQueue} from '@actions/remote/ephemeral_mode';
 import {AGENTS_TABLES} from '@agents/constants/database';
 import {Screens} from '@constants';
 import {MM_TABLES, SYSTEM_IDENTIFIERS} from '@constants/database';
+import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import {AUTO_CACHE_CLEANUP_PROTECTION_BUFFER} from '@constants/post';
 import DatabaseManager from '@database/manager';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
@@ -52,6 +55,14 @@ jest.mock('@queries/servers/system', () => ({
 
 jest.mock('@actions/local/post', () => ({
     deletePostsInChannelsByCutoff: jest.fn(),
+}));
+
+jest.mock('@actions/local/ephemeral_mode/audit_queue', () => ({
+    enqueueAuditEvent: jest.fn(),
+}));
+
+jest.mock('@actions/remote/ephemeral_mode', () => ({
+    flushAuditQueue: jest.fn(),
 }));
 
 const SERVER_URL = 'cleanup.test.com';
@@ -115,7 +126,7 @@ describe('autoCacheCleanup', () => {
         jest.mocked(EphemeralStore.getCurrentFileViewerPostId).mockReturnValue('');
         jest.mocked(EphemeralStore.getCurrentPlaybookRunId).mockReturnValue('');
         jest.mocked(getCurrentChannelId).mockResolvedValue('');
-        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValue({error: undefined});
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValue({error: undefined, deletedCount: 0});
     });
 
     afterEach(async () => {
@@ -154,6 +165,21 @@ describe('autoCacheCleanup', () => {
 
         expect(LocalPost.deletePostsInChannelsByCutoff).toHaveBeenCalledTimes(1);
         expect(second).toEqual({error: undefined, skipped: true});
+        expect(enqueueAuditEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not run cleanup or enqueue an audit event when it already ran today', async () => {
+        // shouldRun compares against `new Date()` (no args), which isn't affected by the
+        // Date.now mock — seed with the real wall-clock time so both fall on today.
+        await operator.handleSystem({
+            systems: [{id: SYSTEM_IDENTIFIERS.LAST_AUTO_CACHE_CLEANUP_RUN, value: new Date().getTime()}],
+            prepareRecordsOnly: false,
+        });
+
+        await autoCacheCleanup(SERVER_URL);
+
+        expect(LocalPost.deletePostsInChannelsByCutoff).not.toHaveBeenCalled();
+        expect(enqueueAuditEvent).not.toHaveBeenCalled();
     });
 
     it('should skip the run without deleting anything when the cleanup already ran earlier today', async () => {
@@ -367,8 +393,49 @@ describe('autoCacheCleanup', () => {
         expect(result).toEqual({error: undefined});
     });
 
+    it('enqueues one cleanup event with the summed postsDeleted and flushes the queue, on a run that deletes posts across more than one channel', async () => {
+        const viewedChannelId = 'ch-viewed-audit';
+        const unprotectedChannelId = 'ch-unprotected-audit';
+        jest.spyOn(DatabaseManager, 'getActiveServerUrl').mockResolvedValue(SERVER_URL);
+        jest.mocked(NavigationStore.getScreensInStack).mockReturnValue([Screens.CHANNEL]);
+        jest.mocked(getCurrentChannelId).mockResolvedValue(viewedChannelId);
+        await writePiC(viewedChannelId, OLD, RECENT);
+        await writePiC(unprotectedChannelId, OLD, RECENT);
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).
+            mockResolvedValueOnce({error: undefined, deletedCount: 3}).
+            mockResolvedValueOnce({error: undefined, deletedCount: 2});
+
+        await autoCacheCleanup(SERVER_URL);
+
+        expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 5,
+            occurredAt: NOW,
+        });
+        expect(flushAuditQueue).toHaveBeenCalledWith(SERVER_URL);
+    });
+
+    it('enqueues a cleanup event with postsDeleted: 0 on a run that deletes nothing', async () => {
+        await autoCacheCleanup(SERVER_URL);
+
+        expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 0,
+            occurredAt: NOW,
+        });
+    });
+
+    it('logs the error and does not flush when enqueueAuditEvent rejects', async () => {
+        jest.mocked(enqueueAuditEvent).mockRejectedValueOnce(new Error('queue write failed'));
+
+        await autoCacheCleanup(SERVER_URL);
+
+        expect(logError).toHaveBeenCalledWith('autoCacheCleanup enqueueAndFlushCleanupAuditEvent', 'queue write failed');
+        expect(flushAuditQueue).not.toHaveBeenCalled();
+    });
+
     it('should report the error when the unprotected-channels delete call returns an error', async () => {
-        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('cleanup failed')});
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('cleanup failed'), deletedCount: 0});
 
         await writePiC('ch-err');
 
@@ -376,6 +443,13 @@ describe('autoCacheCleanup', () => {
 
         expect(logError).toHaveBeenCalledWith('autoCacheCleanup', 'cleanup failed');
         expect(result).toEqual({error: new Error('cleanup failed')});
+        expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 0,
+            occurredAt: NOW,
+            errorReason: 'cleanup failed before completion',
+        });
+        expect(flushAuditQueue).toHaveBeenCalledWith(SERVER_URL);
     });
 
     it('should log the error when the viewed-channel delete call returns an error', async () => {
@@ -385,7 +459,7 @@ describe('autoCacheCleanup', () => {
         jest.mocked(getCurrentChannelId).mockResolvedValue(viewedChannelId);
 
         await writePiC(viewedChannelId);
-        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('viewed channel delete failed')});
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('viewed channel delete failed'), deletedCount: 0});
 
         await autoCacheCleanup(SERVER_URL);
 
@@ -400,7 +474,7 @@ describe('autoCacheCleanup', () => {
         await writePost(rootId, threadParentChannelId, OLD);
 
         await writePiC(threadParentChannelId);
-        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('thread parent channel delete failed')});
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: new Error('thread parent channel delete failed'), deletedCount: 0});
 
         await autoCacheCleanup(SERVER_URL);
 
@@ -509,5 +583,28 @@ describe('autoCacheCleanup', () => {
         const items = await database.get(PLAYBOOK_CHECKLIST_ITEM).query().fetch();
         expect(checklists.length).toBe(0);
         expect(items.length).toBe(0);
+    });
+
+    it('reports the postsDeleted count already collected when playbook-run cleanup fails afterward', async () => {
+        const unprotectedChannelId = 'ch-unprotected-partial';
+        await writePiC(unprotectedChannelId, OLD, RECENT);
+        jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: undefined, deletedCount: 4});
+        await writePlaybookRun('run-partial-fail', OLD);
+
+        jest.spyOn(operator, 'batchRecords').mockImplementation(async (_records, description) => {
+            if (description === 'cleanupPlaybookRuns') {
+                throw new Error('playbook batch failed');
+            }
+        });
+
+        await autoCacheCleanup(SERVER_URL);
+
+        expect(logError).toHaveBeenCalledWith('autoCacheCleanup', 'playbook batch failed');
+        expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 4,
+            occurredAt: NOW,
+            errorReason: 'cleanup failed before completion',
+        });
     });
 });

--- a/app/actions/local/ephemeral_mode/cleanup.test.ts
+++ b/app/actions/local/ephemeral_mode/cleanup.test.ts
@@ -112,6 +112,21 @@ async function writePost(id: string, channelId: string, createAt: number): Promi
     });
 }
 
+async function writePlaybookRun(id: string, createAt: number): Promise<void> {
+    await database.write(async () => {
+        const run = await database.get(PLAYBOOK_RUN).create((r: any) => {
+            r._raw.id = id;
+            r.createAt = createAt;
+        });
+        const checklist = await database.get(PLAYBOOK_CHECKLIST).create((r: any) => {
+            r.runId = run.id;
+        });
+        await database.get(PLAYBOOK_CHECKLIST_ITEM).create((r: any) => {
+            r.checklistId = checklist.id;
+        });
+    });
+}
+
 describe('autoCacheCleanup', () => {
     beforeEach(async () => {
         jest.clearAllMocks();
@@ -399,8 +414,8 @@ describe('autoCacheCleanup', () => {
         jest.spyOn(DatabaseManager, 'getActiveServerUrl').mockResolvedValue(SERVER_URL);
         jest.mocked(NavigationStore.getScreensInStack).mockReturnValue([Screens.CHANNEL]);
         jest.mocked(getCurrentChannelId).mockResolvedValue(viewedChannelId);
-        await writePiC(viewedChannelId, OLD, RECENT);
-        await writePiC(unprotectedChannelId, OLD, RECENT);
+        await writePiC(viewedChannelId);
+        await writePiC(unprotectedChannelId);
         jest.mocked(LocalPost.deletePostsInChannelsByCutoff).
             mockResolvedValueOnce({error: undefined, deletedCount: 3}).
             mockResolvedValueOnce({error: undefined, deletedCount: 2});
@@ -410,6 +425,7 @@ describe('autoCacheCleanup', () => {
         expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 5,
+            playbookRunsDeleted: 0,
             occurredAt: NOW,
         });
         expect(flushAuditQueue).toHaveBeenCalledWith(SERVER_URL);
@@ -421,6 +437,27 @@ describe('autoCacheCleanup', () => {
         expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 0,
+            playbookRunsDeleted: 0,
+            occurredAt: NOW,
+        });
+    });
+
+    it('enqueues a cleanup event with the playbookRunsDeleted count of runs removed, not their cascaded checklist rows', async () => {
+        await operator.handlePlaybookRun({
+            runs: [
+                TestHelper.fakePlaybookRun({id: 'run-old-1', create_at: OLD, checklists: [TestHelper.fakePlaybookChecklist('run-old-1', {})]}),
+                TestHelper.fakePlaybookRun({id: 'run-old-2', create_at: OLD, checklists: [TestHelper.fakePlaybookChecklist('run-old-2', {})]}),
+                TestHelper.fakePlaybookRun({id: 'run-recent', create_at: RECENT, checklists: [TestHelper.fakePlaybookChecklist('run-recent', {})]}),
+            ],
+            ...PLAYBOOK_SEED,
+        });
+
+        await autoCacheCleanup(SERVER_URL);
+
+        expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 0,
+            playbookRunsDeleted: 2,
             occurredAt: NOW,
         });
     });
@@ -446,6 +483,7 @@ describe('autoCacheCleanup', () => {
         expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 0,
+            playbookRunsDeleted: 0,
             occurredAt: NOW,
             errorReason: 'cleanup failed before completion',
         });
@@ -585,9 +623,9 @@ describe('autoCacheCleanup', () => {
         expect(items.length).toBe(0);
     });
 
-    it('reports the postsDeleted count already collected when playbook-run cleanup fails afterward', async () => {
+    it('reports the postsDeleted count already collected, and playbookRunsDeleted: 0, when playbook-run cleanup fails afterward', async () => {
         const unprotectedChannelId = 'ch-unprotected-partial';
-        await writePiC(unprotectedChannelId, OLD, RECENT);
+        await writePiC(unprotectedChannelId);
         jest.mocked(LocalPost.deletePostsInChannelsByCutoff).mockResolvedValueOnce({error: undefined, deletedCount: 4});
         await writePlaybookRun('run-partial-fail', OLD);
 
@@ -597,12 +635,14 @@ describe('autoCacheCleanup', () => {
             }
         });
 
-        await autoCacheCleanup(SERVER_URL);
+        const result = await autoCacheCleanup(SERVER_URL);
 
         expect(logError).toHaveBeenCalledWith('autoCacheCleanup', 'playbook batch failed');
+        expect(result).toEqual({error: new Error('playbook batch failed')});
         expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 4,
+            playbookRunsDeleted: 0,
             occurredAt: NOW,
             errorReason: 'cleanup failed before completion',
         });

--- a/app/actions/local/ephemeral_mode/cleanup.ts
+++ b/app/actions/local/ephemeral_mode/cleanup.ts
@@ -217,28 +217,31 @@ async function cleanupPlaybookRuns(
     operator: {batchRecords: (models: Model[], description: string) => Promise<void>},
     cutoff: number,
     viewedPlaybookRunId: string | undefined,
-) {
+): Promise<number> {
     const staleRuns = await queryPlaybookRunsBefore(database, cutoff).fetch();
+    const runsToDelete = staleRuns.filter((run) => run.id !== viewedPlaybookRunId);
     const prepared = (await Promise.all(
-        staleRuns.
-            filter((run) => run.id !== viewedPlaybookRunId).
-            map((run) => run.prepareDestroyWithRelations()),
+        runsToDelete.map((run) => run.prepareDestroyWithRelations()),
     )).flat();
 
     if (prepared.length > 0) {
         await operator.batchRecords(prepared, 'cleanupPlaybookRuns');
     }
+
+    return runsToDelete.length;
 }
 
 async function enqueueAndFlushCleanupAuditEvent(
     serverUrl: string,
     postsDeleted: number,
+    playbookRunsDeleted: number,
     errorReason?: string,
 ): Promise<void> {
     try {
         await enqueueAuditEvent(serverUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted,
+            playbookRunsDeleted,
             occurredAt: Date.now(),
             errorReason,
         });
@@ -281,6 +284,7 @@ export async function autoCacheCleanup(serverUrl: string): Promise<{error?: unkn
         }
 
         let postsDeleted = 0;
+        let playbookRunsDeleted = 0;
         try {
             const cutoff = Date.now() - toMilliseconds({days: cleanupDays});
             const activeUrl = await DatabaseManager.getActiveServerUrl();
@@ -308,16 +312,20 @@ export async function autoCacheCleanup(serverUrl: string): Promise<{error?: unkn
 
             postsDeleted = await cleanupPosts(serverUrl, cutoff, limits);
             await cleanupAiThreads(database, operator, cutoff, limits.viewedThreadId);
-            await cleanupPlaybookRuns(database, operator, cutoff, limits.viewedPlaybookRunId);
+            playbookRunsDeleted = await cleanupPlaybookRuns(database, operator, cutoff, limits.viewedPlaybookRunId);
 
             await setLastAutoCacheCleanupRun(serverUrl);
 
-            logDebug('autoCacheCleanup: completed successfully for', serverUrl, '— postsDeleted:', postsDeleted);
-            await enqueueAndFlushCleanupAuditEvent(serverUrl, postsDeleted);
+            logDebug(
+                'autoCacheCleanup: completed successfully for', serverUrl,
+                '— postsDeleted:', postsDeleted,
+                '— playbookRunsDeleted:', playbookRunsDeleted,
+            );
+            await enqueueAndFlushCleanupAuditEvent(serverUrl, postsDeleted, playbookRunsDeleted);
             return {error: undefined};
         } catch (error) {
             logError('autoCacheCleanup', getFullErrorMessage(error));
-            await enqueueAndFlushCleanupAuditEvent(serverUrl, postsDeleted, 'cleanup failed before completion');
+            await enqueueAndFlushCleanupAuditEvent(serverUrl, postsDeleted, playbookRunsDeleted, 'cleanup failed before completion');
             return {error};
         }
     } finally {

--- a/app/actions/local/ephemeral_mode/cleanup.ts
+++ b/app/actions/local/ephemeral_mode/cleanup.ts
@@ -140,7 +140,7 @@ async function cleanupPosts(
     serverUrl: string,
     cutoff: number,
     protections: CleanupProtections,
-): Promise<number> {
+): Promise<{postsDeleted: number; error?: unknown}> {
     const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
     const postsInChannelItems = await database.get<PostInChannelModel>(POSTS_IN_CHANNEL).query().fetch();
     const channelsWithPostRanges = new Set(postsInChannelItems.map((row) => row.channelId));
@@ -161,9 +161,9 @@ async function cleanupPosts(
     // delete posts in channels not currently being viewed using a single query.
     // PostsInChannel/PostsInThread/MyChannel bookkeeping is applied atomically inside this call.
     if (unprotectedChannels.size > 0) {
-        const {error: deleteError, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, Array.from(unprotectedChannels), cutoff, excludedPostIds);
-        if (deleteError) {
-            throw deleteError;
+        const {error, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, Array.from(unprotectedChannels), cutoff, excludedPostIds);
+        if (error) {
+            return {postsDeleted, error};
         }
         postsDeleted += deletedCount;
     }
@@ -171,9 +171,9 @@ async function cleanupPosts(
     // delete posts in viewed channel if any
     if (protections.viewedChannelId && channelsWithPostRanges.has(protections.viewedChannelId)) {
         const computedChannelCutoff = Math.min(cutoff, channelProtectionLimit(protections.viewedChannelId, protections));
-        const {error: deleteError, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, [protections.viewedChannelId], computedChannelCutoff, excludedPostIds);
-        if (deleteError) {
-            throw deleteError;
+        const {error, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, [protections.viewedChannelId], computedChannelCutoff, excludedPostIds);
+        if (error) {
+            return {postsDeleted, error};
         }
         postsDeleted += deletedCount;
     }
@@ -181,14 +181,14 @@ async function cleanupPosts(
     // delete posts in thread parent channel if any
     if (protections.threadParentChannelId && protections.threadParentChannelId !== protections.viewedChannelId && channelsWithPostRanges.has(protections.threadParentChannelId)) {
         const computedChannelCutoff = Math.min(cutoff, channelProtectionLimit(protections.threadParentChannelId, protections));
-        const {error: deleteError, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, [protections.threadParentChannelId], computedChannelCutoff, excludedPostIds);
-        if (deleteError) {
-            throw deleteError;
+        const {error, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, [protections.threadParentChannelId], computedChannelCutoff, excludedPostIds);
+        if (error) {
+            return {postsDeleted, error};
         }
         postsDeleted += deletedCount;
     }
 
-    return postsDeleted;
+    return {postsDeleted};
 }
 
 // AI threads self-heal on next open (re-fetched from the server), so the only
@@ -310,7 +310,12 @@ export async function autoCacheCleanup(serverUrl: string): Promise<{error?: unkn
                 '— currentPlaybookRunId:', limits.viewedPlaybookRunId,
             );
 
-            postsDeleted = await cleanupPosts(serverUrl, cutoff, limits);
+            const postsResult = await cleanupPosts(serverUrl, cutoff, limits);
+            postsDeleted = postsResult.postsDeleted;
+            if (postsResult.error) {
+                throw postsResult.error;
+            }
+
             await cleanupAiThreads(database, operator, cutoff, limits.viewedThreadId);
             playbookRunsDeleted = await cleanupPlaybookRuns(database, operator, cutoff, limits.viewedPlaybookRunId);
 

--- a/app/actions/local/ephemeral_mode/cleanup.ts
+++ b/app/actions/local/ephemeral_mode/cleanup.ts
@@ -1,10 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {enqueueAuditEvent} from '@actions/local/ephemeral_mode/audit_queue';
 import {deletePostsInChannelsByCutoff} from '@actions/local/post';
+import {flushAuditQueue} from '@actions/remote/ephemeral_mode';
 import {queryAIThreadsBefore} from '@agents/database/queries/thread';
 import {Screens} from '@constants';
 import {MM_TABLES, SYSTEM_IDENTIFIERS} from '@constants/database';
+import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import {AUTO_CACHE_CLEANUP_PROTECTION_BUFFER} from '@constants/post';
 import DatabaseManager from '@database/manager';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
@@ -137,7 +140,7 @@ async function cleanupPosts(
     serverUrl: string,
     cutoff: number,
     protections: CleanupProtections,
-): Promise<void> {
+): Promise<number> {
     const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
     const postsInChannelItems = await database.get<PostInChannelModel>(POSTS_IN_CHANNEL).query().fetch();
     const channelsWithPostRanges = new Set(postsInChannelItems.map((row) => row.channelId));
@@ -153,32 +156,39 @@ async function cleanupPosts(
         ...(protections.fileViewerPostId ? [protections.fileViewerPostId] : []),
     ]);
 
+    let postsDeleted = 0;
+
     // delete posts in channels not currently being viewed using a single query.
     // PostsInChannel/PostsInThread/MyChannel bookkeeping is applied atomically inside this call.
     if (unprotectedChannels.size > 0) {
-        const {error: deleteError} = await deletePostsInChannelsByCutoff(serverUrl, Array.from(unprotectedChannels), cutoff, excludedPostIds);
+        const {error: deleteError, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, Array.from(unprotectedChannels), cutoff, excludedPostIds);
         if (deleteError) {
             throw deleteError;
         }
+        postsDeleted += deletedCount;
     }
 
     // delete posts in viewed channel if any
     if (protections.viewedChannelId && channelsWithPostRanges.has(protections.viewedChannelId)) {
         const computedChannelCutoff = Math.min(cutoff, channelProtectionLimit(protections.viewedChannelId, protections));
-        const {error: deleteError} = await deletePostsInChannelsByCutoff(serverUrl, [protections.viewedChannelId], computedChannelCutoff, excludedPostIds);
+        const {error: deleteError, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, [protections.viewedChannelId], computedChannelCutoff, excludedPostIds);
         if (deleteError) {
             throw deleteError;
         }
+        postsDeleted += deletedCount;
     }
 
     // delete posts in thread parent channel if any
     if (protections.threadParentChannelId && protections.threadParentChannelId !== protections.viewedChannelId && channelsWithPostRanges.has(protections.threadParentChannelId)) {
         const computedChannelCutoff = Math.min(cutoff, channelProtectionLimit(protections.threadParentChannelId, protections));
-        const {error: deleteError} = await deletePostsInChannelsByCutoff(serverUrl, [protections.threadParentChannelId], computedChannelCutoff, excludedPostIds);
+        const {error: deleteError, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, [protections.threadParentChannelId], computedChannelCutoff, excludedPostIds);
         if (deleteError) {
             throw deleteError;
         }
+        postsDeleted += deletedCount;
     }
+
+    return postsDeleted;
 }
 
 // AI threads self-heal on next open (re-fetched from the server), so the only
@@ -220,6 +230,25 @@ async function cleanupPlaybookRuns(
     }
 }
 
+async function enqueueAndFlushCleanupAuditEvent(
+    serverUrl: string,
+    postsDeleted: number,
+    errorReason?: string,
+): Promise<void> {
+    try {
+        await enqueueAuditEvent(serverUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted,
+            occurredAt: Date.now(),
+            errorReason,
+        });
+    } catch (error) {
+        logError('autoCacheCleanup enqueueAndFlushCleanupAuditEvent', getFullErrorMessage(error));
+        return;
+    }
+    flushAuditQueue(serverUrl);
+}
+
 export async function autoCacheCleanup(serverUrl: string): Promise<{error?: unknown; skipped?: boolean}> {
     const cleanupDays = EphemeralModeManager.getAutoCacheCleanupDays(serverUrl);
     if (cleanupDays <= 0) {
@@ -251,6 +280,7 @@ export async function autoCacheCleanup(serverUrl: string): Promise<{error?: unkn
             return {error: undefined, skipped: true};
         }
 
+        let postsDeleted = 0;
         try {
             const cutoff = Date.now() - toMilliseconds({days: cleanupDays});
             const activeUrl = await DatabaseManager.getActiveServerUrl();
@@ -276,16 +306,18 @@ export async function autoCacheCleanup(serverUrl: string): Promise<{error?: unkn
                 '— currentPlaybookRunId:', limits.viewedPlaybookRunId,
             );
 
-            await cleanupPosts(serverUrl, cutoff, limits);
+            postsDeleted = await cleanupPosts(serverUrl, cutoff, limits);
             await cleanupAiThreads(database, operator, cutoff, limits.viewedThreadId);
             await cleanupPlaybookRuns(database, operator, cutoff, limits.viewedPlaybookRunId);
 
             await setLastAutoCacheCleanupRun(serverUrl);
 
-            logDebug('autoCacheCleanup: completed successfully for', serverUrl);
+            logDebug('autoCacheCleanup: completed successfully for', serverUrl, '— postsDeleted:', postsDeleted);
+            await enqueueAndFlushCleanupAuditEvent(serverUrl, postsDeleted);
             return {error: undefined};
         } catch (error) {
             logError('autoCacheCleanup', getFullErrorMessage(error));
+            await enqueueAndFlushCleanupAuditEvent(serverUrl, postsDeleted, 'cleanup failed before completion');
             return {error};
         }
     } finally {

--- a/app/actions/local/post.test.ts
+++ b/app/actions/local/post.test.ts
@@ -505,6 +505,27 @@ describe('deletePostsInChannelsByCutoff', () => {
         expect(error).toBeTruthy();
     });
 
+    it('returns the number of posts matched by the cutoff', async () => {
+        jest.spyOn(operator.database.adapter, 'unsafeExecute').mockResolvedValue();
+        const oldPosts = [
+            TestHelper.fakePost({channel_id: channelId, create_at: OLD}),
+            TestHelper.fakePost({channel_id: channelId, create_at: OLD}),
+        ];
+        const recentPost = TestHelper.fakePost({channel_id: channelId, create_at: RECENT});
+
+        await operator.handlePosts({
+            actionType: ActionType.POSTS.RECEIVED_IN_CHANNEL,
+            order: [oldPosts[0].id, oldPosts[1].id, recentPost.id],
+            posts: [...oldPosts, recentPost],
+            prepareRecordsOnly: false,
+        });
+
+        const {error, deletedCount} = await deletePostsInChannelsByCutoff(serverUrl, [channelId], CUTOFF);
+
+        expect(error).toBeUndefined();
+        expect(deletedCount).toBe(2);
+    });
+
     // A cached model whose earliest advances has to go through the model layer (fires observers)
     it('advances the cached PostsInChannel earliest through the model layer', async () => {
         jest.spyOn(operator.database.adapter, 'unsafeExecute').mockResolvedValue();

--- a/app/actions/local/post.ts
+++ b/app/actions/local/post.ts
@@ -424,9 +424,9 @@ export async function deletePostsInChannelsByCutoff(
     channelIds: string[],
     cutoff: number,
     excludedPostIds: Set<string> = new Set(),
-): Promise<{error: unknown}> {
+): Promise<{error: unknown; deletedCount: number}> {
     if (channelIds.length === 0) {
-        return {error: undefined};
+        return {error: undefined, deletedCount: 0};
     }
 
     try {
@@ -446,6 +446,13 @@ export async function deletePostsInChannelsByCutoff(
         const postCondition = `channel_id IN (${channelPlaceholders}) AND create_at < ${cutoff} AND NOT ${hasActiveReply} AND NOT ${hasDraft}${exclusionClause}`;
         const postConditionArgs = [...channelIds, ...excludedIds];
         const postSubquery = `SELECT id FROM ${POST} WHERE ${postCondition}`;
+
+        // Upper-bound count: unlike the delete below, it doesn't exclude thread roots an active reply keeps alive.
+        const deletedCount = await database.get<PostModel>(POST).query(
+            Q.where('channel_id', Q.oneOf(channelIds)),
+            Q.where('create_at', Q.lt(cutoff)),
+            ...(excludedPostIds.size > 0 ? [Q.where('id', Q.notIn([...excludedPostIds]))] : []),
+        ).fetchCount();
 
         // Scopes PostsInThread trimming to roots in these channels.
         const rootInChannelsExists = `EXISTS (SELECT 1 FROM ${POST} WHERE ${POST}.id = ${POSTS_IN_THREAD}.root_id AND ${POST}.channel_id IN (${channelPlaceholders}))`;
@@ -504,9 +511,9 @@ export async function deletePostsInChannelsByCutoff(
             await operator.batchRecords(prepared, 'deletePostsInChannelsByCutoff.reconcile');
         }
 
-        return {error: undefined};
+        return {error: undefined, deletedCount};
     } catch (error) {
-        return {error};
+        return {error, deletedCount: 0};
     }
 }
 

--- a/app/actions/local/session/index.test.ts
+++ b/app/actions/local/session/index.test.ts
@@ -5,6 +5,7 @@ import NetInfo, {type NetInfoState} from '@react-native-community/netinfo';
 import {Platform} from 'react-native';
 
 import {removePushDisabledInServerAcknowledged, removePushSigningKey} from '@actions/app/global';
+import {pruneAuditQueueOnSessionEnd} from '@actions/local/ephemeral_mode/audit_queue';
 import DatabaseManager from '@database/manager';
 import {resetMomentLocale} from '@i18n';
 import {getAllServerCredentials, removeServerCredentials} from '@init/credentials';
@@ -32,6 +33,7 @@ jest.mock('expo-image', () => ({
     },
 }));
 jest.mock('@actions/app/global');
+jest.mock('@actions/local/ephemeral_mode/audit_queue');
 jest.mock('@database/manager', () => ({
     getServerDatabaseAndOperator: jest.fn(),
     getActiveServerDatabase: jest.fn(),
@@ -302,6 +304,12 @@ describe('session actions', () => {
             await terminateSession(mockServerUrl, true);
 
             expect(clearCookiesForServer).toHaveBeenCalledWith(mockServerUrl);
+        });
+
+        it('should prune session-bound audit events on a session expiry without removing the server', async () => {
+            await terminateSession(mockServerUrl, false);
+
+            expect(pruneAuditQueueOnSessionEnd).toHaveBeenCalledWith(mockServerUrl, false);
         });
 
         it('should clear image cache with URL-safe encoded server URL', async () => {

--- a/app/actions/local/session/index.ts
+++ b/app/actions/local/session/index.ts
@@ -5,6 +5,7 @@ import NetInfo from '@react-native-community/netinfo';
 import {Platform} from 'react-native';
 
 import {removePushDisabledInServerAcknowledged, removePushSigningKey} from '@actions/app/global';
+import {pruneAuditQueueOnSessionEnd} from '@actions/local/ephemeral_mode/audit_queue';
 import {clearConversationCacheForServer} from '@agents/actions/remote/conversation';
 import loopInStore from '@agents/store/loop_in_store';
 import streamingStore from '@agents/store/streaming_store';
@@ -138,6 +139,11 @@ export const terminateSession = async (serverUrl: string, removeServer: boolean)
     await safeExecute('removeServerCredentials', async () => {
         await removeServerCredentials(serverUrl);
     });
+
+    // Prune the audit queue (non-critical): session-attributed events can no longer be reported truthfully
+    await safeExecute('auditQueue', async () => {
+        await pruneAuditQueueOnSessionEnd(serverUrl, removeServer);
+    }, false);
 
     // Remove push notifications (synchronous, no error handling needed)
     PushNotifications.removeServerNotifications(serverUrl);

--- a/app/actions/remote/ephemeral_mode.test.ts
+++ b/app/actions/remote/ephemeral_mode.test.ts
@@ -58,7 +58,7 @@ describe('flushAuditQueue', () => {
     it('should send one event of each kind to its matching client method, oldest-first, then clear the queue', async () => {
         await seed({kind: EphemeralModeAuditEventKind.OfflinePurge, offlineTimeMinutes: 30, occurredAt: 1000});
         await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 2, playbookRunsDeleted: 0, occurredAt: 2000});
-        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 3000});
+        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, signature: 'sig1', occurredAt: 3000});
 
         const client = makeClient();
         jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
@@ -67,7 +67,7 @@ describe('flushAuditQueue', () => {
 
         expect(client.logOfflinePurge).toHaveBeenCalledWith(30, 1000, undefined);
         expect(client.logCleanup).toHaveBeenCalledWith(2, 0, 2000, undefined);
-        expect(client.logSessionWipe).toHaveBeenCalledWith('user1', 3000, undefined);
+        expect(client.logSessionWipe).toHaveBeenCalledWith('sig1', 3000, undefined);
 
         const purgeOrder = client.logOfflinePurge.mock.invocationCallOrder[0];
         const cleanupOrder = client.logCleanup.mock.invocationCallOrder[0];
@@ -151,7 +151,7 @@ describe('flushAuditQueue', () => {
 
     it('should forward a queued sessionWipe event\'s errorReason to logSessionWipe as its third argument', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
-            {id: 'evt1', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 1000, attempts: 0, errorReason: 'terminateSession failed: databaseOperation'},
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.SessionWipe, signature: 'sig1', occurredAt: 1000, attempts: 0, errorReason: 'terminateSession failed: databaseOperation'},
         ]);
 
         const client = makeClient();
@@ -159,7 +159,7 @@ describe('flushAuditQueue', () => {
 
         await flushAuditQueue(serverUrl);
 
-        expect(client.logSessionWipe).toHaveBeenCalledWith('user1', 1000, 'terminateSession failed: databaseOperation');
+        expect(client.logSessionWipe).toHaveBeenCalledWith('sig1', 1000, 'terminateSession failed: databaseOperation');
     });
 
     it('should send nothing and leave the queue unchanged when the device is offline', async () => {
@@ -208,7 +208,7 @@ describe('flushAuditQueue', () => {
     it('should keep session events queued when getClient throws, while still sending a queued sessionWipe', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
             {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 0},
-            {id: 'evt2', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 2000, attempts: 0},
+            {id: 'evt2', kind: EphemeralModeAuditEventKind.SessionWipe, signature: 'sig1', occurredAt: 2000, attempts: 0},
         ]);
 
         jest.mocked(NetworkManager.getClient).mockImplementation(() => {
@@ -220,7 +220,7 @@ describe('flushAuditQueue', () => {
 
         await flushAuditQueue(serverUrl);
 
-        expect(tokenlessClient.logSessionWipe).toHaveBeenCalledWith('user1', 2000, undefined);
+        expect(tokenlessClient.logSessionWipe).toHaveBeenCalledWith('sig1', 2000, undefined);
 
         const events = await getEphemeralModeAuditEvents(serverUrl);
         expect(events).toHaveLength(1);
@@ -236,7 +236,7 @@ describe('flushAuditQueue', () => {
         client.logCleanup.mockImplementation(async () => {
             await enqueueAuditEvent(serverUrl, {
                 kind: EphemeralModeAuditEventKind.SessionWipe,
-                userId: 'user2',
+                signature: 'sig2',
                 occurredAt: 5000,
             });
             return {status: 'OK'};
@@ -258,7 +258,7 @@ describe('flushAuditQueue', () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
             {id: 'evtA', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 0},
             {id: 'evtB', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 2000, attempts: 0},
-            {id: 'evtC', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 3000, attempts: 0},
+            {id: 'evtC', kind: EphemeralModeAuditEventKind.SessionWipe, signature: 'sig1', occurredAt: 3000, attempts: 0},
         ]);
 
         const client = makeClient();
@@ -294,7 +294,7 @@ describe('flushAuditQueue', () => {
     });
 
     it('should create and then invalidate a tokenless client for a sessionWipe when getClient throws', async () => {
-        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 1000});
+        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, signature: 'sig1', occurredAt: 1000});
 
         jest.mocked(NetworkManager.getClient).mockImplementation(() => {
             throw new Error(`${serverUrl} client not found`);
@@ -306,12 +306,12 @@ describe('flushAuditQueue', () => {
         await flushAuditQueue(serverUrl);
 
         expect(NetworkManager.createClient).toHaveBeenCalledWith(serverUrl, undefined, 'preauth-secret');
-        expect(tokenlessClient.logSessionWipe).toHaveBeenCalledWith('user1', 1000, undefined);
+        expect(tokenlessClient.logSessionWipe).toHaveBeenCalledWith('sig1', 1000, undefined);
         expect(NetworkManager.invalidateClient).toHaveBeenCalledWith(serverUrl);
     });
 
     it('should reuse the existing client for a sessionWipe without invalidating it', async () => {
-        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 1000});
+        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, signature: 'sig1', occurredAt: 1000});
 
         const client = makeClient();
         jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
@@ -319,7 +319,7 @@ describe('flushAuditQueue', () => {
         await flushAuditQueue(serverUrl);
 
         expect(NetworkManager.createClient).not.toHaveBeenCalled();
-        expect(client.logSessionWipe).toHaveBeenCalledWith('user1', 1000, undefined);
+        expect(client.logSessionWipe).toHaveBeenCalledWith('sig1', 1000, undefined);
         expect(NetworkManager.invalidateClient).not.toHaveBeenCalled();
     });
 

--- a/app/actions/remote/ephemeral_mode.test.ts
+++ b/app/actions/remote/ephemeral_mode.test.ts
@@ -1,0 +1,377 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import NetInfo, {type NetInfoState} from '@react-native-community/netinfo';
+
+import {replaceEphemeralModeAuditEvents} from '@actions/app/global';
+import {enqueueAuditEvent, pruneAuditQueueOnSessionEnd} from '@actions/local/ephemeral_mode/audit_queue';
+import {EphemeralModeAuditEventKind, MAX_AUDIT_SEND_ATTEMPTS, type EphemeralModeAuditEventInput} from '@constants/ephemeral_mode';
+import DatabaseManager from '@database/manager';
+import {getPreauthSecret} from '@init/credentials';
+import NetworkManager from '@managers/network_manager';
+import {getEphemeralModeAuditEvents} from '@queries/app/global';
+
+import {flushAuditQueue, flushOrphanedAuditQueues} from './ephemeral_mode';
+
+jest.mock('@react-native-community/netinfo');
+jest.mock('@init/credentials', () => ({
+    getPreauthSecret: jest.fn(),
+}));
+jest.mock('@managers/network_manager', () => ({
+    getClient: jest.fn(),
+    createClient: jest.fn(),
+    invalidateClient: jest.fn(),
+}));
+
+const serverUrl = 'flush.test.com';
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+const makeClient = () => ({
+    logOfflinePurge: jest.fn().mockResolvedValue({status: 'OK'}),
+    logCleanup: jest.fn().mockResolvedValue({status: 'OK'}),
+    logSessionWipe: jest.fn().mockResolvedValue({status: 'OK'}),
+});
+
+const seed = async (event: EphemeralModeAuditEventInput) => {
+    await enqueueAuditEvent(serverUrl, event);
+};
+
+describe('flushAuditQueue', () => {
+    beforeEach(async () => {
+        await DatabaseManager.init([serverUrl]);
+        jest.mocked(NetInfo.fetch).mockResolvedValue({isConnected: true} as NetInfoState);
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(serverUrl);
+        jest.clearAllMocks();
+    });
+
+    it('should not call the client when the queue is empty', async () => {
+        await flushAuditQueue(serverUrl);
+
+        expect(NetworkManager.getClient).not.toHaveBeenCalled();
+    });
+
+    it('should send one event of each kind to its matching client method, oldest-first, then clear the queue', async () => {
+        await seed({kind: EphemeralModeAuditEventKind.OfflinePurge, offlineTimeMinutes: 30, occurredAt: 1000});
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 2, occurredAt: 2000});
+        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 3000});
+
+        const client = makeClient();
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(client.logOfflinePurge).toHaveBeenCalledWith(30, 1000, undefined);
+        expect(client.logCleanup).toHaveBeenCalledWith(2, 2000, undefined);
+        expect(client.logSessionWipe).toHaveBeenCalledWith('user1', 3000, undefined);
+
+        const purgeOrder = client.logOfflinePurge.mock.invocationCallOrder[0];
+        const cleanupOrder = client.logCleanup.mock.invocationCallOrder[0];
+        const wipeOrder = client.logSessionWipe.mock.invocationCallOrder[0];
+        expect(purgeOrder).toBeLessThan(cleanupOrder);
+        expect(cleanupOrder).toBeLessThan(wipeOrder);
+
+        expect(await getEphemeralModeAuditEvents(serverUrl)).toHaveLength(0);
+    });
+
+    it('should requeue an event whose request failed without a status code', async () => {
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+
+        const client = makeClient();
+        client.logCleanup.mockRejectedValue(new Error('network down'));
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(1);
+    });
+
+    it.each([408, 429, 500, 502, 503, 504])(
+        'should requeue an event rejected with status code %d',
+        async (statusCode) => {
+            await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+
+            const client = makeClient();
+            client.logCleanup.mockRejectedValue(Object.assign(new Error('rejected'), {status_code: statusCode}));
+            jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+            await flushAuditQueue(serverUrl);
+
+            const events = await getEphemeralModeAuditEvents(serverUrl);
+            expect(events).toHaveLength(1);
+        },
+    );
+
+    it.each([400, 401, 403, 404, 501, 409])(
+        'should drop an event rejected with unlisted status code %d',
+        async (statusCode) => {
+            await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+
+            const client = makeClient();
+            client.logCleanup.mockRejectedValue(Object.assign(new Error('rejected'), {status_code: statusCode}));
+            jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+            await flushAuditQueue(serverUrl);
+
+            const events = await getEphemeralModeAuditEvents(serverUrl);
+            expect(events).toHaveLength(0);
+        },
+    );
+
+    it('should forward a queued offlinePurge event\'s errorReason to logOfflinePurge as its third argument', async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.OfflinePurge, offlineTimeMinutes: 30, occurredAt: 1000, attempts: 0, errorReason: 'database wipe failed after retries'},
+        ]);
+
+        const client = makeClient();
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(client.logOfflinePurge).toHaveBeenCalledWith(30, 1000, 'database wipe failed after retries');
+    });
+
+    it('should forward a queued cleanup event\'s errorReason to logCleanup as its third argument', async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0, errorReason: 'cleanup failed before completion'},
+        ]);
+
+        const client = makeClient();
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(client.logCleanup).toHaveBeenCalledWith(1, 1000, 'cleanup failed before completion');
+    });
+
+    it('should forward a queued sessionWipe event\'s errorReason to logSessionWipe as its third argument', async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 1000, attempts: 0, errorReason: 'terminateSession failed: databaseOperation'},
+        ]);
+
+        const client = makeClient();
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(client.logSessionWipe).toHaveBeenCalledWith('user1', 1000, 'terminateSession failed: databaseOperation');
+    });
+
+    it('should send nothing and leave the queue unchanged when the device is offline', async () => {
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+        jest.mocked(NetInfo.fetch).mockResolvedValue({isConnected: false} as NetInfoState);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(NetworkManager.getClient).not.toHaveBeenCalled();
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(1);
+        expect(events[0].attempts).toBe(0);
+    });
+
+    it('should increment attempts on an event whose request failed', async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 3},
+        ]);
+
+        const client = makeClient();
+        client.logCleanup.mockRejectedValue(new Error('still failing'));
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(1);
+        expect(events[0].attempts).toBe(4);
+    });
+
+    it('should discard an event on its final allowed attempt', async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: MAX_AUDIT_SEND_ATTEMPTS - 1},
+        ]);
+
+        const client = makeClient();
+        client.logCleanup.mockRejectedValue(new Error('still failing'));
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(0);
+    });
+
+    it('should keep session events queued when getClient throws, while still sending a queued sessionWipe', async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0},
+            {id: 'evt2', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 2000, attempts: 0},
+        ]);
+
+        jest.mocked(NetworkManager.getClient).mockImplementation(() => {
+            throw new Error(`${serverUrl} client not found`);
+        });
+        jest.mocked(getPreauthSecret).mockResolvedValue('preauth-secret');
+        const tokenlessClient = makeClient();
+        jest.mocked(NetworkManager.createClient).mockResolvedValue(tokenlessClient as any);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(tokenlessClient.logSessionWipe).toHaveBeenCalledWith('user1', 2000, undefined);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(1);
+        expect(events[0].kind).toBe(EphemeralModeAuditEventKind.Cleanup);
+    });
+
+    it('should keep an event enqueued while the requests were in flight', async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0},
+        ]);
+
+        const client = makeClient();
+        client.logCleanup.mockImplementation(async () => {
+            await enqueueAuditEvent(serverUrl, {
+                kind: EphemeralModeAuditEventKind.SessionWipe,
+                userId: 'user2',
+                occurredAt: 5000,
+            });
+            return {status: 'OK'};
+        });
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(1);
+        expect(events[0].kind).toBe(EphemeralModeAuditEventKind.SessionWipe);
+    });
+
+    it('should not restore events pruned by a concurrent session end mid-flight', async () => {
+        // evtA fails (would normally be kept with attempts+1), evtB's send triggers a
+        // concurrent session end that prunes both session-bound events from storage,
+        // and evtC (session-less) succeeds. A write-back computed from the stale
+        // pre-flush snapshot would resurrect evtA; one that re-reads storage must not.
+        await replaceEphemeralModeAuditEvents(serverUrl, [
+            {id: 'evtA', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0},
+            {id: 'evtB', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 2000, attempts: 0},
+            {id: 'evtC', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 3000, attempts: 0},
+        ]);
+
+        const client = makeClient();
+        client.logCleanup.mockImplementation(async (_postsDeleted, occurredAt) => {
+            if (occurredAt === 1000) {
+                throw new Error('still failing');
+            }
+
+            // A session ends mid-flush and removes both session-bound events from
+            // storage before this pass gets a chance to write evtA's outcome back.
+            await pruneAuditQueueOnSessionEnd(serverUrl, false);
+            return {status: 'OK'};
+        });
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(0);
+    });
+
+    it('should not send anything on a second flush for a server already flushing', async () => {
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+
+        const client = makeClient();
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        const first = flushAuditQueue(serverUrl);
+        const second = flushAuditQueue(serverUrl);
+        await Promise.all([first, second]);
+
+        expect(NetworkManager.getClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create and then invalidate a tokenless client for a sessionWipe when getClient throws', async () => {
+        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 1000});
+
+        jest.mocked(NetworkManager.getClient).mockImplementation(() => {
+            throw new Error(`${serverUrl} client not found`);
+        });
+        jest.mocked(getPreauthSecret).mockResolvedValue('preauth-secret');
+        const tokenlessClient = makeClient();
+        jest.mocked(NetworkManager.createClient).mockResolvedValue(tokenlessClient as any);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(NetworkManager.createClient).toHaveBeenCalledWith(serverUrl, undefined, 'preauth-secret');
+        expect(tokenlessClient.logSessionWipe).toHaveBeenCalledWith('user1', 1000, undefined);
+        expect(NetworkManager.invalidateClient).toHaveBeenCalledWith(serverUrl);
+    });
+
+    it('should reuse the existing client for a sessionWipe without invalidating it', async () => {
+        await seed({kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 1000});
+
+        const client = makeClient();
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushAuditQueue(serverUrl);
+
+        expect(NetworkManager.createClient).not.toHaveBeenCalled();
+        expect(client.logSessionWipe).toHaveBeenCalledWith('user1', 1000, undefined);
+        expect(NetworkManager.invalidateClient).not.toHaveBeenCalled();
+    });
+
+    it('should create no client and not touch the Global key when getClient throws and nothing queued is a sessionWipe', async () => {
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+
+        jest.mocked(NetworkManager.getClient).mockImplementation(() => {
+            throw new Error(`${serverUrl} client not found`);
+        });
+
+        await flushAuditQueue(serverUrl);
+
+        expect(NetworkManager.createClient).not.toHaveBeenCalled();
+        const events = await getEphemeralModeAuditEvents(serverUrl);
+        expect(events).toHaveLength(1);
+        expect(events[0].attempts).toBe(0);
+    });
+});
+
+describe('flushOrphanedAuditQueues', () => {
+    const credentialedUrl = 'flush-credentialed.test.com';
+    const orphanedUrl = 'flush-orphaned.test.com';
+
+    beforeEach(async () => {
+        await DatabaseManager.init([credentialedUrl, orphanedUrl]);
+        jest.mocked(NetInfo.fetch).mockResolvedValue({isConnected: true} as NetInfoState);
+
+        await enqueueAuditEvent(credentialedUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 1000,
+        });
+        await enqueueAuditEvent(orphanedUrl, {
+            kind: EphemeralModeAuditEventKind.Cleanup,
+            postsDeleted: 1,
+            occurredAt: 1000,
+        });
+    });
+
+    afterEach(async () => {
+        await DatabaseManager.destroyServerDatabase(credentialedUrl);
+        await DatabaseManager.destroyServerDatabase(orphanedUrl);
+        jest.clearAllMocks();
+    });
+
+    it('should flush only the servers absent from the supplied credentials', async () => {
+        const client = makeClient();
+        jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
+
+        await flushOrphanedAuditQueues([{serverUrl: credentialedUrl, userId: 'user1', token: 'token'}]);
+        await flushPromises();
+
+        expect(await getEphemeralModeAuditEvents(orphanedUrl)).toHaveLength(0);
+        expect(await getEphemeralModeAuditEvents(credentialedUrl)).toHaveLength(1);
+    });
+});

--- a/app/actions/remote/ephemeral_mode.test.ts
+++ b/app/actions/remote/ephemeral_mode.test.ts
@@ -44,6 +44,7 @@ describe('flushAuditQueue', () => {
     });
 
     afterEach(async () => {
+        await replaceEphemeralModeAuditEvents(serverUrl, []);
         await DatabaseManager.destroyServerDatabase(serverUrl);
         jest.clearAllMocks();
     });
@@ -56,7 +57,7 @@ describe('flushAuditQueue', () => {
 
     it('should send one event of each kind to its matching client method, oldest-first, then clear the queue', async () => {
         await seed({kind: EphemeralModeAuditEventKind.OfflinePurge, offlineTimeMinutes: 30, occurredAt: 1000});
-        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 2, occurredAt: 2000});
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 2, playbookRunsDeleted: 0, occurredAt: 2000});
         await seed({kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 3000});
 
         const client = makeClient();
@@ -65,7 +66,7 @@ describe('flushAuditQueue', () => {
         await flushAuditQueue(serverUrl);
 
         expect(client.logOfflinePurge).toHaveBeenCalledWith(30, 1000, undefined);
-        expect(client.logCleanup).toHaveBeenCalledWith(2, 2000, undefined);
+        expect(client.logCleanup).toHaveBeenCalledWith(2, 0, 2000, undefined);
         expect(client.logSessionWipe).toHaveBeenCalledWith('user1', 3000, undefined);
 
         const purgeOrder = client.logOfflinePurge.mock.invocationCallOrder[0];
@@ -78,7 +79,7 @@ describe('flushAuditQueue', () => {
     });
 
     it('should requeue an event whose request failed without a status code', async () => {
-        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000});
 
         const client = makeClient();
         client.logCleanup.mockRejectedValue(new Error('network down'));
@@ -93,7 +94,7 @@ describe('flushAuditQueue', () => {
     it.each([408, 429, 500, 502, 503, 504])(
         'should requeue an event rejected with status code %d',
         async (statusCode) => {
-            await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+            await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000});
 
             const client = makeClient();
             client.logCleanup.mockRejectedValue(Object.assign(new Error('rejected'), {status_code: statusCode}));
@@ -109,7 +110,7 @@ describe('flushAuditQueue', () => {
     it.each([400, 401, 403, 404, 501, 409])(
         'should drop an event rejected with unlisted status code %d',
         async (statusCode) => {
-            await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+            await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000});
 
             const client = makeClient();
             client.logCleanup.mockRejectedValue(Object.assign(new Error('rejected'), {status_code: statusCode}));
@@ -137,7 +138,7 @@ describe('flushAuditQueue', () => {
 
     it('should forward a queued cleanup event\'s errorReason to logCleanup as its third argument', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
-            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0, errorReason: 'cleanup failed before completion'},
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 0, errorReason: 'cleanup failed before completion'},
         ]);
 
         const client = makeClient();
@@ -145,7 +146,7 @@ describe('flushAuditQueue', () => {
 
         await flushAuditQueue(serverUrl);
 
-        expect(client.logCleanup).toHaveBeenCalledWith(1, 1000, 'cleanup failed before completion');
+        expect(client.logCleanup).toHaveBeenCalledWith(1, 0, 1000, 'cleanup failed before completion');
     });
 
     it('should forward a queued sessionWipe event\'s errorReason to logSessionWipe as its third argument', async () => {
@@ -162,7 +163,7 @@ describe('flushAuditQueue', () => {
     });
 
     it('should send nothing and leave the queue unchanged when the device is offline', async () => {
-        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000});
         jest.mocked(NetInfo.fetch).mockResolvedValue({isConnected: false} as NetInfoState);
 
         await flushAuditQueue(serverUrl);
@@ -175,7 +176,7 @@ describe('flushAuditQueue', () => {
 
     it('should increment attempts on an event whose request failed', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
-            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 3},
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 3},
         ]);
 
         const client = makeClient();
@@ -191,7 +192,7 @@ describe('flushAuditQueue', () => {
 
     it('should discard an event on its final allowed attempt', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
-            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: MAX_AUDIT_SEND_ATTEMPTS - 1},
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: MAX_AUDIT_SEND_ATTEMPTS - 1},
         ]);
 
         const client = makeClient();
@@ -206,7 +207,7 @@ describe('flushAuditQueue', () => {
 
     it('should keep session events queued when getClient throws, while still sending a queued sessionWipe', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
-            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0},
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 0},
             {id: 'evt2', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 2000, attempts: 0},
         ]);
 
@@ -228,7 +229,7 @@ describe('flushAuditQueue', () => {
 
     it('should keep an event enqueued while the requests were in flight', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
-            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0},
+            {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 0},
         ]);
 
         const client = makeClient();
@@ -255,13 +256,13 @@ describe('flushAuditQueue', () => {
         // and evtC (session-less) succeeds. A write-back computed from the stale
         // pre-flush snapshot would resurrect evtA; one that re-reads storage must not.
         await replaceEphemeralModeAuditEvents(serverUrl, [
-            {id: 'evtA', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000, attempts: 0},
-            {id: 'evtB', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 2000, attempts: 0},
+            {id: 'evtA', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 0},
+            {id: 'evtB', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 2000, attempts: 0},
             {id: 'evtC', kind: EphemeralModeAuditEventKind.SessionWipe, userId: 'user1', occurredAt: 3000, attempts: 0},
         ]);
 
         const client = makeClient();
-        client.logCleanup.mockImplementation(async (_postsDeleted, occurredAt) => {
+        client.logCleanup.mockImplementation(async (_postsDeleted, _playbookRunsDeleted, occurredAt) => {
             if (occurredAt === 1000) {
                 throw new Error('still failing');
             }
@@ -280,7 +281,7 @@ describe('flushAuditQueue', () => {
     });
 
     it('should not send anything on a second flush for a server already flushing', async () => {
-        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000});
 
         const client = makeClient();
         jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
@@ -323,7 +324,7 @@ describe('flushAuditQueue', () => {
     });
 
     it('should create no client and not touch the Global key when getClient throws and nothing queued is a sessionWipe', async () => {
-        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, occurredAt: 1000});
+        await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000});
 
         jest.mocked(NetworkManager.getClient).mockImplementation(() => {
             throw new Error(`${serverUrl} client not found`);
@@ -349,11 +350,13 @@ describe('flushOrphanedAuditQueues', () => {
         await enqueueAuditEvent(credentialedUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 1000,
         });
         await enqueueAuditEvent(orphanedUrl, {
             kind: EphemeralModeAuditEventKind.Cleanup,
             postsDeleted: 1,
+            playbookRunsDeleted: 0,
             occurredAt: 1000,
         });
     });

--- a/app/actions/remote/ephemeral_mode.test.ts
+++ b/app/actions/remote/ephemeral_mode.test.ts
@@ -78,7 +78,7 @@ describe('flushAuditQueue', () => {
         expect(await getEphemeralModeAuditEvents(serverUrl)).toHaveLength(0);
     });
 
-    it('should requeue an event whose request failed without a status code', async () => {
+    it('should requeue an event whose request failed without a status code, without charging an attempt', async () => {
         await seed({kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000});
 
         const client = makeClient();
@@ -89,6 +89,7 @@ describe('flushAuditQueue', () => {
 
         const events = await getEphemeralModeAuditEvents(serverUrl);
         expect(events).toHaveLength(1);
+        expect(events[0].attempts).toBe(0);
     });
 
     it.each([408, 429, 500, 502, 503, 504])(
@@ -174,13 +175,13 @@ describe('flushAuditQueue', () => {
         expect(events[0].attempts).toBe(0);
     });
 
-    it('should increment attempts on an event whose request failed', async () => {
+    it('should increment attempts on an event rejected by a reachable server', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
             {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: 3},
         ]);
 
         const client = makeClient();
-        client.logCleanup.mockRejectedValue(new Error('still failing'));
+        client.logCleanup.mockRejectedValue(Object.assign(new Error('still failing'), {status_code: 500}));
         jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
 
         await flushAuditQueue(serverUrl);
@@ -190,13 +191,13 @@ describe('flushAuditQueue', () => {
         expect(events[0].attempts).toBe(4);
     });
 
-    it('should discard an event on its final allowed attempt', async () => {
+    it('should discard an event on its final allowed attempt against a reachable server', async () => {
         await replaceEphemeralModeAuditEvents(serverUrl, [
             {id: 'evt1', kind: EphemeralModeAuditEventKind.Cleanup, postsDeleted: 1, playbookRunsDeleted: 0, occurredAt: 1000, attempts: MAX_AUDIT_SEND_ATTEMPTS - 1},
         ]);
 
         const client = makeClient();
-        client.logCleanup.mockRejectedValue(new Error('still failing'));
+        client.logCleanup.mockRejectedValue(Object.assign(new Error('still failing'), {status_code: 500}));
         jest.mocked(NetworkManager.getClient).mockReturnValue(client as any);
 
         await flushAuditQueue(serverUrl);

--- a/app/actions/remote/ephemeral_mode.ts
+++ b/app/actions/remote/ephemeral_mode.ts
@@ -26,7 +26,7 @@ const sendAuditEvent = (client: Client, event: EphemeralModeAuditEvent) => {
         case EphemeralModeAuditEventKind.OfflinePurge:
             return client.logOfflinePurge(event.offlineTimeMinutes, event.occurredAt, event.errorReason);
         case EphemeralModeAuditEventKind.Cleanup:
-            return client.logCleanup(event.postsDeleted, event.occurredAt, event.errorReason);
+            return client.logCleanup(event.postsDeleted, event.playbookRunsDeleted, event.occurredAt, event.errorReason);
         case EphemeralModeAuditEventKind.SessionWipe:
             return client.logSessionWipe(event.userId, event.occurredAt, event.errorReason);
         default:

--- a/app/actions/remote/ephemeral_mode.ts
+++ b/app/actions/remote/ephemeral_mode.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import NetInfo from '@react-native-community/netinfo';
+
+import {settleAuditEvents} from '@actions/local/ephemeral_mode/audit_queue';
+import {EphemeralModeAuditEventKind, MAX_AUDIT_SEND_ATTEMPTS, type EphemeralModeAuditEvent} from '@constants/ephemeral_mode';
+import {getPreauthSecret} from '@init/credentials';
+import NetworkManager from '@managers/network_manager';
+import {getEphemeralModeAuditEvents} from '@queries/app/global';
+import {getAllServers} from '@queries/app/servers';
+import {getFullErrorMessage, isErrorWithStatusCode} from '@utils/errors';
+import {logDebug, logError, logWarning} from '@utils/log';
+
+import type {Client} from '@client/rest';
+
+// Retry only what can plausibly succeed later; 501 (unlicensed/pre-11.10 server) never will.
+const RETRYABLE_AUDIT_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
+const flushInFlight = new Set<string>();
+
+const isSessionWipe = (event: EphemeralModeAuditEvent) => event.kind === EphemeralModeAuditEventKind.SessionWipe;
+
+const sendAuditEvent = (client: Client, event: EphemeralModeAuditEvent) => {
+    switch (event.kind) {
+        case EphemeralModeAuditEventKind.OfflinePurge:
+            return client.logOfflinePurge(event.offlineTimeMinutes, event.occurredAt, event.errorReason);
+        case EphemeralModeAuditEventKind.Cleanup:
+            return client.logCleanup(event.postsDeleted, event.occurredAt, event.errorReason);
+        case EphemeralModeAuditEventKind.SessionWipe:
+            return client.logSessionWipe(event.userId, event.occurredAt, event.errorReason);
+        default:
+            return undefined;
+    }
+};
+
+export const flushAuditQueue = async (serverUrl: string): Promise<void> => {
+    if (flushInFlight.has(serverUrl)) {
+        logDebug('flushAuditQueue: already running for', serverUrl);
+        return;
+    }
+    flushInFlight.add(serverUrl);
+
+    let tokenless = false;
+    try {
+        // No connectivity is our failure, not the server's: attempt nothing, so no event is charged an attempt.
+        if (!(await NetInfo.fetch()).isConnected) {
+            logDebug('flushAuditQueue: offline, keeping queue for', serverUrl);
+            return;
+        }
+
+        const pending = await getEphemeralModeAuditEvents(serverUrl);
+        if (!pending.length) {
+            logDebug('flushAuditQueue: nothing queued for', serverUrl);
+            return;
+        }
+
+        let client: Client | undefined;
+        try {
+            client = NetworkManager.getClient(serverUrl);
+        } catch {
+            // Logged out: /wipe is the only kind still sendable, and only tokenless.
+            if (pending.some(isSessionWipe)) {
+                client = await NetworkManager.createClient(serverUrl, undefined, await getPreauthSecret(serverUrl));
+                tokenless = true;
+            }
+        }
+
+        if (!client) {
+            logDebug('flushAuditQueue: no usable client, keeping queue for', serverUrl);
+            return;
+        }
+
+        const consumed = new Set<string>();
+        const failed = new Set<string>();
+
+        for (const event of pending) {
+            if (tokenless && !isSessionWipe(event)) {
+                continue;
+            }
+
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await sendAuditEvent(client, event);
+                consumed.add(event.id);
+            } catch (error) {
+                // A definite answer we cannot retry — the request itself is rejected.
+                if (isErrorWithStatusCode(error) && !RETRYABLE_AUDIT_STATUS_CODES.has(error.status_code)) {
+                    logDebug('flushAuditQueue: server rejected event, dropping', serverUrl, event.kind, error.status_code);
+                    consumed.add(event.id);
+                    continue;
+                }
+                logError('flushAuditQueue', serverUrl, event.kind, getFullErrorMessage(error));
+                if (event.attempts + 1 >= MAX_AUDIT_SEND_ATTEMPTS) {
+                    logWarning('flushAuditQueue: giving up on event after repeated failures', serverUrl, event.kind);
+                    consumed.add(event.id);
+                    continue;
+                }
+                failed.add(event.id);
+            }
+        }
+
+        if (consumed.size || failed.size) {
+            // Match on id: the queue may have been appended to or pruned mid-flight.
+            await settleAuditEvents(serverUrl, consumed, failed);
+        }
+    } catch (error) {
+        logError('flushAuditQueue', serverUrl, getFullErrorMessage(error));
+    } finally {
+        if (tokenless) {
+            NetworkManager.invalidateClient(serverUrl);
+        }
+        flushInFlight.delete(serverUrl);
+    }
+};
+
+// Servers the app can no longer log into, so doReconnect will never flush them.
+export const flushOrphanedAuditQueues = async (serverCredentials: ServerCredential[]) => {
+    const credentialed = new Set(serverCredentials.map(({serverUrl}) => serverUrl));
+    const servers = await getAllServers();
+    for (const server of servers.filter(({url}) => !credentialed.has(url))) {
+        flushAuditQueue(server.url);
+    }
+};

--- a/app/actions/remote/ephemeral_mode.ts
+++ b/app/actions/remote/ephemeral_mode.ts
@@ -84,8 +84,14 @@ export const flushAuditQueue = async (serverUrl: string): Promise<void> => {
                 await sendAuditEvent(client, event);
                 consumed.add(event.id);
             } catch (error) {
+                if (!isErrorWithStatusCode(error)) {
+                    // The request never reached a server to be judged, so don't charge an attempt.
+                    logDebug('flushAuditQueue: connectivity error sending event, keeping without charging an attempt', serverUrl, event.kind, getFullErrorMessage(error));
+                    continue;
+                }
+
                 // A definite answer we cannot retry — the request itself is rejected.
-                if (isErrorWithStatusCode(error) && !RETRYABLE_AUDIT_STATUS_CODES.has(error.status_code)) {
+                if (!RETRYABLE_AUDIT_STATUS_CODES.has(error.status_code)) {
                     logDebug('flushAuditQueue: server rejected event, dropping', serverUrl, event.kind, error.status_code);
                     consumed.add(event.id);
                     continue;

--- a/app/actions/remote/ephemeral_mode.ts
+++ b/app/actions/remote/ephemeral_mode.ts
@@ -28,7 +28,7 @@ const sendAuditEvent = (client: Client, event: EphemeralModeAuditEvent) => {
         case EphemeralModeAuditEventKind.Cleanup:
             return client.logCleanup(event.postsDeleted, event.playbookRunsDeleted, event.occurredAt, event.errorReason);
         case EphemeralModeAuditEventKind.SessionWipe:
-            return client.logSessionWipe(event.userId, event.occurredAt, event.errorReason);
+            return client.logSessionWipe(event.signature, event.occurredAt, event.errorReason);
         default:
             return undefined;
     }

--- a/app/actions/websocket/index.test.ts
+++ b/app/actions/websocket/index.test.ts
@@ -10,6 +10,7 @@ import {dataRetentionCleanup, expiredBoRPostCleanup, performVacuum} from '@actio
 import {markChannelAsRead} from '@actions/remote/channel';
 import {entry, handleEntryAfterLoadNavigation} from '@actions/remote/entry/common';
 import {deferredAppEntryActions} from '@actions/remote/entry/deferred';
+import {flushAuditQueue} from '@actions/remote/ephemeral_mode';
 import {fetchPostsForChannel, fetchPostThread} from '@actions/remote/post';
 import {openAllUnreadChannels} from '@actions/remote/preference';
 import {loadConfigAndCalls} from '@calls/actions/calls';
@@ -33,6 +34,7 @@ jest.mock('@actions/local/channel');
 jest.mock('@actions/local/ephemeral_mode/cleanup');
 jest.mock('@actions/local/systems');
 jest.mock('@actions/remote/channel');
+jest.mock('@actions/remote/ephemeral_mode');
 jest.mock('@actions/remote/entry/common');
 jest.mock('@actions/remote/entry/deferred');
 jest.mock('@actions/remote/post');
@@ -175,6 +177,7 @@ describe('WebSocket Index Actions', () => {
             expect(openAllUnreadChannels).toHaveBeenCalled();
             expect(dataRetentionCleanup).toHaveBeenCalled();
             expect(expiredBoRPostCleanup).toHaveBeenCalled();
+            expect(flushAuditQueue).toHaveBeenCalledWith(serverUrl);
             expect(AppsManager.refreshAppBindings).toHaveBeenCalled();
             expect(handlePlaybookReconnect).toHaveBeenCalledWith(serverUrl);
             expect(SessionAttributesManager.refreshManifest).toHaveBeenCalledWith(serverUrl);

--- a/app/actions/websocket/index.ts
+++ b/app/actions/websocket/index.ts
@@ -14,6 +14,7 @@ import {
     setExtraSessionProps,
 } from '@actions/remote/entry/common';
 import {deferredAppEntryActions} from '@actions/remote/entry/deferred';
+import {flushAuditQueue} from '@actions/remote/ephemeral_mode';
 import {fetchPostsForChannel, fetchPostThread} from '@actions/remote/post';
 import {openAllUnreadChannels} from '@actions/remote/preference';
 import {autoUpdateTimezone} from '@actions/remote/user';
@@ -118,6 +119,8 @@ async function doReconnect(serverUrl: string, groupLabel?: BaseRequestGroupLabel
         openAllUnreadChannels(serverUrl, groupLabel);
 
         doCleanup(serverUrl);
+
+        flushAuditQueue(serverUrl);
 
         AppsManager.refreshAppBindings(serverUrl, groupLabel);
         return undefined;

--- a/app/client/rest/ephemeral_mode.test.ts
+++ b/app/client/rest/ephemeral_mode.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import TestHelper from '@test/test_helper';
+
+import type ClientBase from './base';
+import type {ClientEphemeralModeMix} from './ephemeral_mode';
+
+describe('ClientEphemeralMode', () => {
+    let client: ClientEphemeralModeMix & ClientBase;
+
+    beforeAll(() => {
+        client = TestHelper.createClient();
+        client.doFetch = jest.fn();
+    });
+
+    it('should POST offline_time_minutes and purge_at to the purge route', async () => {
+        const expectedUrl = `${client.urlVersion}/ephemeral_mode/purge`;
+        const expectedOptions = {
+            method: 'post',
+            body: {offline_time_minutes: 42, purge_at: 1000},
+        };
+
+        await client.logOfflinePurge(42, 1000);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    it('should include error_reason in the purge body when a reason is passed', async () => {
+        const expectedUrl = `${client.urlVersion}/ephemeral_mode/purge`;
+        const expectedOptions = {
+            method: 'post',
+            body: {offline_time_minutes: 42, purge_at: 1000, error_reason: 'database wipe failed after retries'},
+        };
+
+        await client.logOfflinePurge(42, 1000, 'database wipe failed after retries');
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    it('should POST posts_deleted and cleanup_at to the cleanup route', async () => {
+        const expectedUrl = `${client.urlVersion}/ephemeral_mode/cleanup`;
+        const expectedOptions = {
+            method: 'post',
+            body: {posts_deleted: 3, cleanup_at: 2000},
+        };
+
+        await client.logCleanup(3, 2000);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    it('should include error_reason in the cleanup body when a reason is passed', async () => {
+        const expectedUrl = `${client.urlVersion}/ephemeral_mode/cleanup`;
+        const expectedOptions = {
+            method: 'post',
+            body: {posts_deleted: 3, cleanup_at: 2000, error_reason: 'cleanup failed before completion'},
+        };
+
+        await client.logCleanup(3, 2000, 'cleanup failed before completion');
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    it('should POST user_id and wipe_at to the wipe route', async () => {
+        const expectedUrl = `${client.urlVersion}/ephemeral_mode/wipe`;
+        const expectedOptions = {
+            method: 'post',
+            body: {user_id: 'user123', wipe_at: 3000},
+        };
+
+        await client.logSessionWipe('user123', 3000);
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+
+    it('should include error_reason in the wipe body when a reason is passed', async () => {
+        const expectedUrl = `${client.urlVersion}/ephemeral_mode/wipe`;
+        const expectedOptions = {
+            method: 'post',
+            body: {user_id: 'user123', wipe_at: 3000, error_reason: 'terminateSession failed: databaseOperation'},
+        };
+
+        await client.logSessionWipe('user123', 3000, 'terminateSession failed: databaseOperation');
+
+        expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    });
+});

--- a/app/client/rest/ephemeral_mode.test.ts
+++ b/app/client/rest/ephemeral_mode.test.ts
@@ -62,14 +62,14 @@ describe('ClientEphemeralMode', () => {
         expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
     });
 
-    it('should POST user_id and wipe_at to the wipe route', async () => {
+    it('should POST signature and wipe_at to the wipe route', async () => {
         const expectedUrl = `${client.urlVersion}/ephemeral_mode/wipe`;
         const expectedOptions = {
             method: 'post',
-            body: {user_id: 'user123', wipe_at: 3000},
+            body: {signature: 'signature123', wipe_at: 3000},
         };
 
-        await client.logSessionWipe('user123', 3000);
+        await client.logSessionWipe('signature123', 3000);
 
         expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
     });
@@ -78,10 +78,10 @@ describe('ClientEphemeralMode', () => {
         const expectedUrl = `${client.urlVersion}/ephemeral_mode/wipe`;
         const expectedOptions = {
             method: 'post',
-            body: {user_id: 'user123', wipe_at: 3000, error_reason: 'terminateSession failed: databaseOperation'},
+            body: {signature: 'signature123', wipe_at: 3000, error_reason: 'terminateSession failed: databaseOperation'},
         };
 
-        await client.logSessionWipe('user123', 3000, 'terminateSession failed: databaseOperation');
+        await client.logSessionWipe('signature123', 3000, 'terminateSession failed: databaseOperation');
 
         expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
     });

--- a/app/client/rest/ephemeral_mode.test.ts
+++ b/app/client/rest/ephemeral_mode.test.ts
@@ -38,14 +38,14 @@ describe('ClientEphemeralMode', () => {
         expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
     });
 
-    it('should POST posts_deleted and cleanup_at to the cleanup route', async () => {
+    it('should POST posts_deleted, playbook_runs_deleted, and cleanup_at to the cleanup route', async () => {
         const expectedUrl = `${client.urlVersion}/ephemeral_mode/cleanup`;
         const expectedOptions = {
             method: 'post',
-            body: {posts_deleted: 3, cleanup_at: 2000},
+            body: {posts_deleted: 3, playbook_runs_deleted: 1, cleanup_at: 2000},
         };
 
-        await client.logCleanup(3, 2000);
+        await client.logCleanup(3, 1, 2000);
 
         expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
     });
@@ -54,10 +54,10 @@ describe('ClientEphemeralMode', () => {
         const expectedUrl = `${client.urlVersion}/ephemeral_mode/cleanup`;
         const expectedOptions = {
             method: 'post',
-            body: {posts_deleted: 3, cleanup_at: 2000, error_reason: 'cleanup failed before completion'},
+            body: {posts_deleted: 3, playbook_runs_deleted: 1, cleanup_at: 2000, error_reason: 'cleanup failed before completion'},
         };
 
-        await client.logCleanup(3, 2000, 'cleanup failed before completion');
+        await client.logCleanup(3, 1, 2000, 'cleanup failed before completion');
 
         expect(client.doFetch).toHaveBeenCalledWith(expectedUrl, expectedOptions);
     });

--- a/app/client/rest/ephemeral_mode.ts
+++ b/app/client/rest/ephemeral_mode.ts
@@ -6,7 +6,7 @@ import type ClientBase from './base';
 export interface ClientEphemeralModeMix {
     logOfflinePurge: (offlineTimeMinutes: number, purgeAt: number, errorReason?: string) => Promise<{status: string}>;
     logCleanup: (postsDeleted: number, playbookRunsDeleted: number, cleanupAt: number, errorReason?: string) => Promise<{status: string}>;
-    logSessionWipe: (userId: string, wipeAt: number, errorReason?: string) => Promise<{status: string}>;
+    logSessionWipe: (signature: string, wipeAt: number, errorReason?: string) => Promise<{status: string}>;
 }
 
 const ClientEphemeralMode = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
@@ -24,10 +24,10 @@ const ClientEphemeralMode = <TBase extends Constructor<ClientBase>>(superclass: 
         );
     };
 
-    logSessionWipe = async (userId: string, wipeAt: number, errorReason?: string) => {
+    logSessionWipe = async (signature: string, wipeAt: number, errorReason?: string) => {
         return this.doFetch(
             `${this.urlVersion}/ephemeral_mode/wipe`,
-            {method: 'post', body: {user_id: userId, wipe_at: wipeAt, error_reason: errorReason}},
+            {method: 'post', body: {signature, wipe_at: wipeAt, error_reason: errorReason}},
         );
     };
 };

--- a/app/client/rest/ephemeral_mode.ts
+++ b/app/client/rest/ephemeral_mode.ts
@@ -5,7 +5,7 @@ import type ClientBase from './base';
 
 export interface ClientEphemeralModeMix {
     logOfflinePurge: (offlineTimeMinutes: number, purgeAt: number, errorReason?: string) => Promise<{status: string}>;
-    logCleanup: (postsDeleted: number, cleanupAt: number, errorReason?: string) => Promise<{status: string}>;
+    logCleanup: (postsDeleted: number, playbookRunsDeleted: number, cleanupAt: number, errorReason?: string) => Promise<{status: string}>;
     logSessionWipe: (userId: string, wipeAt: number, errorReason?: string) => Promise<{status: string}>;
 }
 
@@ -17,10 +17,10 @@ const ClientEphemeralMode = <TBase extends Constructor<ClientBase>>(superclass: 
         );
     };
 
-    logCleanup = async (postsDeleted: number, cleanupAt: number, errorReason?: string) => {
+    logCleanup = async (postsDeleted: number, playbookRunsDeleted: number, cleanupAt: number, errorReason?: string) => {
         return this.doFetch(
             `${this.urlVersion}/ephemeral_mode/cleanup`,
-            {method: 'post', body: {posts_deleted: postsDeleted, cleanup_at: cleanupAt, error_reason: errorReason}},
+            {method: 'post', body: {posts_deleted: postsDeleted, playbook_runs_deleted: playbookRunsDeleted, cleanup_at: cleanupAt, error_reason: errorReason}},
         );
     };
 

--- a/app/client/rest/ephemeral_mode.ts
+++ b/app/client/rest/ephemeral_mode.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type ClientBase from './base';
+
+export interface ClientEphemeralModeMix {
+    logOfflinePurge: (offlineTimeMinutes: number, purgeAt: number, errorReason?: string) => Promise<{status: string}>;
+    logCleanup: (postsDeleted: number, cleanupAt: number, errorReason?: string) => Promise<{status: string}>;
+    logSessionWipe: (userId: string, wipeAt: number, errorReason?: string) => Promise<{status: string}>;
+}
+
+const ClientEphemeralMode = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
+    logOfflinePurge = async (offlineTimeMinutes: number, purgeAt: number, errorReason?: string) => {
+        return this.doFetch(
+            `${this.urlVersion}/ephemeral_mode/purge`,
+            {method: 'post', body: {offline_time_minutes: offlineTimeMinutes, purge_at: purgeAt, error_reason: errorReason}},
+        );
+    };
+
+    logCleanup = async (postsDeleted: number, cleanupAt: number, errorReason?: string) => {
+        return this.doFetch(
+            `${this.urlVersion}/ephemeral_mode/cleanup`,
+            {method: 'post', body: {posts_deleted: postsDeleted, cleanup_at: cleanupAt, error_reason: errorReason}},
+        );
+    };
+
+    logSessionWipe = async (userId: string, wipeAt: number, errorReason?: string) => {
+        return this.doFetch(
+            `${this.urlVersion}/ephemeral_mode/wipe`,
+            {method: 'post', body: {user_id: userId, wipe_at: wipeAt, error_reason: errorReason}},
+        );
+    };
+};
+
+export default ClientEphemeralMode;

--- a/app/client/rest/index.ts
+++ b/app/client/rest/index.ts
@@ -15,6 +15,7 @@ import ClientChannels, {type ClientChannelsMix} from './channels';
 import {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID} from './constants';
 import ClientCustomAttributes, {type ClientCustomAttributesMix} from './custom_profile_attributes';
 import ClientEmojis, {type ClientEmojisMix} from './emojis';
+import ClientEphemeralMode, {type ClientEphemeralModeMix} from './ephemeral_mode';
 import ClientFiles, {type ClientFilesMix} from './files';
 import ClientGeneral, {type ClientGeneralMix} from './general';
 import ClientGroups, {type ClientGroupsMix} from './groups';
@@ -38,6 +39,7 @@ interface Client extends ClientBase,
     ClientChannelsMix,
     ClientChannelBookmarksMix,
     ClientEmojisMix,
+    ClientEphemeralModeMix,
     ClientFilesMix,
     ClientGeneralMix,
     ClientGroupsMix,
@@ -67,6 +69,7 @@ class Client extends mix(ClientBase).with(
     ClientChannels,
     ClientChannelBookmarks,
     ClientEmojis,
+    ClientEphemeralMode,
     ClientFiles,
     ClientGeneral,
     ClientGroups,

--- a/app/constants/database.ts
+++ b/app/constants/database.ts
@@ -100,6 +100,7 @@ export const GLOBAL_IDENTIFIERS = {
     PUSH_DISABLED_ACK: 'pushDisabledAck',
     CACHE_MIGRATION: 'cacheMigration',
     PUSH_SIGNING_KEY: 'pushSigningKey',
+    EPHEMERAL_MODE_AUDIT_QUEUE: 'ephemeralModeAuditQueue',
 };
 
 export enum OperationType {

--- a/app/constants/ephemeral_mode.ts
+++ b/app/constants/ephemeral_mode.ts
@@ -29,6 +29,7 @@ export type EphemeralModeOfflinePurgeAuditEvent = EphemeralModeAuditEventBase & 
 export type EphemeralModeCleanupAuditEvent = EphemeralModeAuditEventBase & {
     kind: typeof EphemeralModeAuditEventKind.Cleanup;
     postsDeleted: number;
+    playbookRunsDeleted: number;
 };
 
 export type EphemeralModeSessionWipeAuditEvent = EphemeralModeAuditEventBase & {

--- a/app/constants/ephemeral_mode.ts
+++ b/app/constants/ephemeral_mode.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const EphemeralModeAuditEventKind = {
+    OfflinePurge: 'offlinePurge',
+    Cleanup: 'cleanup',
+    SessionWipe: 'sessionWipe',
+} as const;
+
+// Consecutive failures against a reachable network before an event is given up on.
+export const MAX_AUDIT_SEND_ATTEMPTS = 20;
+
+type EphemeralModeAuditEventBase = {
+    id: string;
+    occurredAt: number;
+
+    // Only incremented when a send actually reached the network.
+    attempts: number;
+
+    // Set once the operation's outcome is known, which can be after enqueue. Omitted means it succeeded.
+    errorReason?: string;
+};
+
+export type EphemeralModeOfflinePurgeAuditEvent = EphemeralModeAuditEventBase & {
+    kind: typeof EphemeralModeAuditEventKind.OfflinePurge;
+    offlineTimeMinutes: number;
+};
+
+export type EphemeralModeCleanupAuditEvent = EphemeralModeAuditEventBase & {
+    kind: typeof EphemeralModeAuditEventKind.Cleanup;
+    postsDeleted: number;
+};
+
+export type EphemeralModeSessionWipeAuditEvent = EphemeralModeAuditEventBase & {
+    kind: typeof EphemeralModeAuditEventKind.SessionWipe;
+    userId: string;
+};
+
+export type EphemeralModeAuditEvent =
+    | EphemeralModeOfflinePurgeAuditEvent
+    | EphemeralModeCleanupAuditEvent
+    | EphemeralModeSessionWipeAuditEvent;
+
+// Distributed over the union so each variant keeps its own fields — a plain Omit would collapse to the common ones.
+export type EphemeralModeAuditEventInput =
+    | Omit<EphemeralModeOfflinePurgeAuditEvent, 'id' | 'attempts'>
+    | Omit<EphemeralModeCleanupAuditEvent, 'id' | 'attempts'>
+    | Omit<EphemeralModeSessionWipeAuditEvent, 'id' | 'attempts'>;

--- a/app/constants/ephemeral_mode.ts
+++ b/app/constants/ephemeral_mode.ts
@@ -34,7 +34,7 @@ export type EphemeralModeCleanupAuditEvent = EphemeralModeAuditEventBase & {
 
 export type EphemeralModeSessionWipeAuditEvent = EphemeralModeAuditEventBase & {
     kind: typeof EphemeralModeAuditEventKind.SessionWipe;
-    userId: string;
+    signature: string;
 };
 
 export type EphemeralModeAuditEvent =

--- a/app/init/app.ts
+++ b/app/init/app.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {flushOrphanedAuditQueues} from '@actions/remote/ephemeral_mode';
 import {CallsManager} from '@calls/calls_manager';
 import DatabaseManager from '@database/manager';
 import CallsNative from '@init/calls_native';
@@ -49,6 +50,8 @@ export async function initialize() {
 
             await DatabaseManager.initServerDatabases(serverCredentials.map((c) => c.serverUrl));
             await NetworkManager.init(serverCredentials);
+
+            flushOrphanedAuditQueues(serverCredentials);
 
             // EphemeralModeManager init runs before WS init so any pending wipes
             // complete before WebSocket clients start populating server databases.

--- a/app/init/push_notifications.test.ts
+++ b/app/init/push_notifications.test.ts
@@ -11,7 +11,6 @@ import {openNotification} from '@actions/remote/notifications';
 import {Device, Events, PushNotification, Screens} from '@constants';
 import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import DatabaseManager from '@database/manager';
-import {getServerCredentials} from '@init/credentials';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import {getCurrentChannelId} from '@queries/servers/system';
 import {getIsCRTEnabled, getThreadById} from '@queries/servers/thread';
@@ -97,10 +96,6 @@ jest.mock('@managers/ephemeral_mode_manager', () => ({
 jest.mock('@actions/local/ephemeral_mode/audit_queue', () => ({
     enqueueAuditEvent: jest.fn(),
 }));
-jest.mock('@init/credentials', () => ({
-    getServerCredentials: jest.fn(),
-}));
-
 describe('PushNotifications', () => {
     let pushNotifications: typeof PushNotifications;
 
@@ -496,7 +491,6 @@ describe('PushNotifications', () => {
             jest.spyOn(DeviceEventEmitter, 'emit');
             jest.spyOn(Date, 'now').mockReturnValue(NOW);
             jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(false);
-            jest.mocked(getServerCredentials).mockResolvedValue(null);
             jest.mocked(enqueueAuditEvent).mockResolvedValue('audit-evt-1');
         });
 
@@ -506,10 +500,10 @@ describe('PushNotifications', () => {
 
         it('should emit session expired event on user interaction without enqueueing an audit event', async () => {
             jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
-            jest.mocked(getServerCredentials).mockResolvedValue({serverUrl: SERVER_URL, userId: 'user1', token: 'token'});
             const notification = {
                 payload: {
                     server_url: SERVER_URL,
+                    signature: 'sig1',
                 },
                 userInteraction: true,
             };
@@ -522,10 +516,10 @@ describe('PushNotifications', () => {
 
         it('should enqueue a sessionWipe audit event and emit server logout event on an ephemeral-mode server without user interaction', async () => {
             jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
-            jest.mocked(getServerCredentials).mockResolvedValue({serverUrl: SERVER_URL, userId: 'user1', token: 'token'});
             const notification = {
                 payload: {
                     server_url: SERVER_URL,
+                    signature: 'sig1',
                 },
                 userInteraction: false,
             };
@@ -534,7 +528,7 @@ describe('PushNotifications', () => {
 
             expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
                 kind: EphemeralModeAuditEventKind.SessionWipe,
-                userId: 'user1',
+                signature: 'sig1',
                 occurredAt: NOW,
             });
             expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SERVER_LOGOUT, {serverUrl: SERVER_URL, auditEventId: 'audit-evt-1'});
@@ -545,6 +539,7 @@ describe('PushNotifications', () => {
             const notification = {
                 payload: {
                     server_url: SERVER_URL,
+                    signature: 'sig1',
                 },
                 userInteraction: false,
             };
@@ -555,9 +550,8 @@ describe('PushNotifications', () => {
             expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SERVER_LOGOUT, {serverUrl: SERVER_URL, auditEventId: undefined});
         });
 
-        it('should emit server logout event without enqueueing when there are no keychain credentials', async () => {
+        it('should emit server logout event without enqueueing when the notification payload has no signature', async () => {
             jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
-            jest.mocked(getServerCredentials).mockResolvedValue(null);
             const notification = {
                 payload: {
                     server_url: SERVER_URL,
@@ -573,11 +567,11 @@ describe('PushNotifications', () => {
 
         it('should still emit server logout event when enqueueing the audit event rejects', async () => {
             jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
-            jest.mocked(getServerCredentials).mockResolvedValue({serverUrl: SERVER_URL, userId: 'user1', token: 'token'});
             jest.mocked(enqueueAuditEvent).mockRejectedValue(new Error('queue write failed'));
             const notification = {
                 payload: {
                     server_url: SERVER_URL,
+                    signature: 'sig1',
                 },
                 userInteraction: false,
             };

--- a/app/init/push_notifications.test.ts
+++ b/app/init/push_notifications.test.ts
@@ -5,10 +5,14 @@ import {AppState, DeviceEventEmitter, Platform} from 'react-native';
 
 import {storeDeviceToken} from '@actions/app/global';
 import {markChannelAsViewed} from '@actions/local/channel';
+import {enqueueAuditEvent} from '@actions/local/ephemeral_mode/audit_queue';
 import {updateThread} from '@actions/local/thread';
 import {openNotification} from '@actions/remote/notifications';
 import {Device, Events, PushNotification, Screens} from '@constants';
+import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import DatabaseManager from '@database/manager';
+import {getServerCredentials} from '@init/credentials';
+import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import {getCurrentChannelId} from '@queries/servers/system';
 import {getIsCRTEnabled, getThreadById} from '@queries/servers/thread';
 import EphemeralStore from '@store/ephemeral_store';
@@ -85,6 +89,16 @@ jest.mock('@queries/servers/system', () => ({
 jest.mock('@queries/servers/thread', () => ({
     getIsCRTEnabled: jest.fn(),
     getThreadById: jest.fn(),
+}));
+jest.mock('@managers/ephemeral_mode_manager', () => ({
+    __esModule: true,
+    default: {isEphemeralModeEnabled: jest.fn()},
+}));
+jest.mock('@actions/local/ephemeral_mode/audit_queue', () => ({
+    enqueueAuditEvent: jest.fn(),
+}));
+jest.mock('@init/credentials', () => ({
+    getServerCredentials: jest.fn(),
 }));
 
 describe('PushNotifications', () => {
@@ -475,34 +489,102 @@ describe('PushNotifications', () => {
     });
 
     describe('handleSessionNotification', () => {
+        const SERVER_URL = 'http://test.com';
+        const NOW = 5_000;
+
         beforeEach(() => {
             jest.spyOn(DeviceEventEmitter, 'emit');
+            jest.spyOn(Date, 'now').mockReturnValue(NOW);
+            jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(false);
+            jest.mocked(getServerCredentials).mockResolvedValue(null);
+            jest.mocked(enqueueAuditEvent).mockResolvedValue('audit-evt-1');
         });
 
-        it('should emit session expired event on user interaction', async () => {
+        afterEach(() => {
+            jest.mocked(Date.now).mockRestore();
+        });
+
+        it('should emit session expired event on user interaction without enqueueing an audit event', async () => {
+            jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
+            jest.mocked(getServerCredentials).mockResolvedValue({serverUrl: SERVER_URL, userId: 'user1', token: 'token'});
             const notification = {
                 payload: {
-                    server_url: 'http://test.com',
+                    server_url: SERVER_URL,
                 },
                 userInteraction: true,
             };
 
             await pushNotifications.handleSessionNotification(notification as any);
 
-            expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SESSION_EXPIRED, 'http://test.com');
+            expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SESSION_EXPIRED, SERVER_URL);
+            expect(enqueueAuditEvent).not.toHaveBeenCalled();
         });
 
-        it('should emit server logout event without user interaction', async () => {
+        it('should enqueue a sessionWipe audit event and emit server logout event on an ephemeral-mode server without user interaction', async () => {
+            jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
+            jest.mocked(getServerCredentials).mockResolvedValue({serverUrl: SERVER_URL, userId: 'user1', token: 'token'});
             const notification = {
                 payload: {
-                    server_url: 'http://test.com',
+                    server_url: SERVER_URL,
                 },
                 userInteraction: false,
             };
 
             await pushNotifications.handleSessionNotification(notification as any);
 
-            expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SERVER_LOGOUT, {serverUrl: 'http://test.com'});
+            expect(enqueueAuditEvent).toHaveBeenCalledWith(SERVER_URL, {
+                kind: EphemeralModeAuditEventKind.SessionWipe,
+                userId: 'user1',
+                occurredAt: NOW,
+            });
+            expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SERVER_LOGOUT, {serverUrl: SERVER_URL, auditEventId: 'audit-evt-1'});
+        });
+
+        it('should emit server logout event without enqueueing on a non-ephemeral-mode server', async () => {
+            jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(false);
+            const notification = {
+                payload: {
+                    server_url: SERVER_URL,
+                },
+                userInteraction: false,
+            };
+
+            await pushNotifications.handleSessionNotification(notification as any);
+
+            expect(enqueueAuditEvent).not.toHaveBeenCalled();
+            expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SERVER_LOGOUT, {serverUrl: SERVER_URL, auditEventId: undefined});
+        });
+
+        it('should emit server logout event without enqueueing when there are no keychain credentials', async () => {
+            jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
+            jest.mocked(getServerCredentials).mockResolvedValue(null);
+            const notification = {
+                payload: {
+                    server_url: SERVER_URL,
+                },
+                userInteraction: false,
+            };
+
+            await pushNotifications.handleSessionNotification(notification as any);
+
+            expect(enqueueAuditEvent).not.toHaveBeenCalled();
+            expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SERVER_LOGOUT, {serverUrl: SERVER_URL, auditEventId: undefined});
+        });
+
+        it('should still emit server logout event when enqueueing the audit event rejects', async () => {
+            jest.mocked(EphemeralModeManager.isEphemeralModeEnabled).mockReturnValue(true);
+            jest.mocked(getServerCredentials).mockResolvedValue({serverUrl: SERVER_URL, userId: 'user1', token: 'token'});
+            jest.mocked(enqueueAuditEvent).mockRejectedValue(new Error('queue write failed'));
+            const notification = {
+                payload: {
+                    server_url: SERVER_URL,
+                },
+                userInteraction: false,
+            };
+
+            await pushNotifications.handleSessionNotification(notification as any);
+
+            expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(Events.SERVER_LOGOUT, {serverUrl: SERVER_URL, auditEventId: undefined});
         });
     });
 

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -19,21 +19,26 @@ import {requestNotifications} from 'react-native-permissions';
 
 import {storeDeviceToken} from '@actions/app/global';
 import {markChannelAsViewed} from '@actions/local/channel';
+import {enqueueAuditEvent} from '@actions/local/ephemeral_mode/audit_queue';
 import {updateThread} from '@actions/local/thread';
 import {backgroundNotification, openNotification} from '@actions/remote/notifications';
 import {isCallsStartedMessage} from '@calls/utils';
 import {Device, Events, PushNotification, Screens} from '@constants';
+import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import DatabaseManager from '@database/manager';
 import {DEFAULT_LOCALE, getLocalizedMessage} from '@i18n';
+import {getServerCredentials} from '@init/credentials';
+import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import {getServerDisplayName} from '@queries/app/servers';
 import {getCurrentChannelId} from '@queries/servers/system';
 import {getIsCRTEnabled, getThreadById} from '@queries/servers/thread';
 import EphemeralStore from '@store/ephemeral_store';
 import InAppNotificationStore from '@store/in_app_notification_store';
 import {NavigationStore} from '@store/navigation_store';
+import {getFullErrorMessage} from '@utils/errors';
 import {isBetaApp} from '@utils/general';
 import {isMainActivity, isTablet} from '@utils/helpers';
-import {logDebug, logInfo, logWarning} from '@utils/log';
+import {logDebug, logError, logInfo, logWarning} from '@utils/log';
 import {convertToNotificationData} from '@utils/notification';
 
 const messages = defineMessages({
@@ -210,8 +215,33 @@ class PushNotificationsSingleton {
             if (notification.userInteraction) {
                 DeviceEventEmitter.emit(Events.SESSION_EXPIRED, serverUrl);
             } else {
-                DeviceEventEmitter.emit(Events.SERVER_LOGOUT, {serverUrl});
+                const auditEventId = await this.enqueueSessionWipeAuditEvent(serverUrl);
+                DeviceEventEmitter.emit(Events.SERVER_LOGOUT, {serverUrl, auditEventId});
             }
+        }
+    };
+
+    enqueueSessionWipeAuditEvent = async (serverUrl: string): Promise<string | undefined> => {
+        if (!EphemeralModeManager.isEphemeralModeEnabled(serverUrl)) {
+            logDebug('enqueueSessionWipeAuditEvent: ephemeral mode not enabled for', serverUrl);
+            return undefined;
+        }
+
+        try {
+            const credentials = await getServerCredentials(serverUrl);
+            if (!credentials) {
+                logDebug('enqueueSessionWipeAuditEvent: no credentials for', serverUrl);
+                return undefined;
+            }
+
+            return await enqueueAuditEvent(serverUrl, {
+                kind: EphemeralModeAuditEventKind.SessionWipe,
+                userId: credentials.userId,
+                occurredAt: Date.now(),
+            });
+        } catch (error) {
+            logError('enqueueSessionWipeAuditEvent', getFullErrorMessage(error));
+            return undefined;
         }
     };
 

--- a/app/init/push_notifications.ts
+++ b/app/init/push_notifications.ts
@@ -27,7 +27,6 @@ import {Device, Events, PushNotification, Screens} from '@constants';
 import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import DatabaseManager from '@database/manager';
 import {DEFAULT_LOCALE, getLocalizedMessage} from '@i18n';
-import {getServerCredentials} from '@init/credentials';
 import EphemeralModeManager from '@managers/ephemeral_mode_manager';
 import {getServerDisplayName} from '@queries/app/servers';
 import {getCurrentChannelId} from '@queries/servers/system';
@@ -215,28 +214,27 @@ class PushNotificationsSingleton {
             if (notification.userInteraction) {
                 DeviceEventEmitter.emit(Events.SESSION_EXPIRED, serverUrl);
             } else {
-                const auditEventId = await this.enqueueSessionWipeAuditEvent(serverUrl);
+                const auditEventId = await this.enqueueSessionWipeAuditEvent(serverUrl, notification.payload?.signature);
                 DeviceEventEmitter.emit(Events.SERVER_LOGOUT, {serverUrl, auditEventId});
             }
         }
     };
 
-    enqueueSessionWipeAuditEvent = async (serverUrl: string): Promise<string | undefined> => {
+    enqueueSessionWipeAuditEvent = async (serverUrl: string, signature?: string): Promise<string | undefined> => {
         if (!EphemeralModeManager.isEphemeralModeEnabled(serverUrl)) {
             logDebug('enqueueSessionWipeAuditEvent: ephemeral mode not enabled for', serverUrl);
             return undefined;
         }
 
-        try {
-            const credentials = await getServerCredentials(serverUrl);
-            if (!credentials) {
-                logDebug('enqueueSessionWipeAuditEvent: no credentials for', serverUrl);
-                return undefined;
-            }
+        if (!signature) {
+            logDebug('enqueueSessionWipeAuditEvent: no signature for', serverUrl);
+            return undefined;
+        }
 
+        try {
             return await enqueueAuditEvent(serverUrl, {
                 kind: EphemeralModeAuditEventKind.SessionWipe,
-                userId: credentials.userId,
+                signature,
                 occurredAt: Date.now(),
             });
         } catch (error) {

--- a/app/managers/ephemeral_mode_manager/index.test.ts
+++ b/app/managers/ephemeral_mode_manager/index.test.ts
@@ -14,6 +14,7 @@ import {getServer, getServerDisplayName} from '@queries/app/servers';
 import {navigateToScreen} from '@screens/navigation';
 import {advanceTimers, disableFakeTimers, enableFakeTimers} from '@test/timer_helpers';
 import {deleteFileCache} from '@utils/file';
+import {logError} from '@utils/log';
 
 import EphemeralModeManager from './index';
 
@@ -748,6 +749,17 @@ describe('EphemeralModeManager', () => {
 
             expect(WebsocketManager.observeWebsocketState).toHaveBeenCalledTimes(2);
         });
+
+        it('logs a wipe failure when only the file cache wipe fails', async () => {
+            jest.mocked(wipeServerFiles).mockReturnValueOnce({success: false});
+
+            await triggerWipeForServerA();
+
+            expect(logError).toHaveBeenCalledWith(
+                'EphemeralModeManager.runWipe: wipe failed after retries, server re-added with stale data',
+                serverA,
+            );
+        });
     });
 
     describe('init wipe-resumption', () => {
@@ -774,6 +786,18 @@ describe('EphemeralModeManager', () => {
 
             expect(wipeServerDatabaseWithRetry).not.toHaveBeenCalled();
             expect(wipeServerFiles).not.toHaveBeenCalled();
+        });
+
+        it('logs when a resumed wipe fails again', async () => {
+            jest.mocked(getServer).mockResolvedValue({url: serverA, persistenceFlag: 'wiped'} as ServersModel);
+            jest.mocked(wipeServerDatabaseWithRetry).mockResolvedValueOnce({success: false});
+
+            await EphemeralModeManager.init([credsA]);
+
+            expect(logError).toHaveBeenCalledWith(
+                'EphemeralModeManager.init: resumed wipe failed after retries, server re-added with stale data',
+                serverA,
+            );
         });
     });
 

--- a/app/managers/ephemeral_mode_manager/index.test.ts
+++ b/app/managers/ephemeral_mode_manager/index.test.ts
@@ -4,9 +4,11 @@
 import {AppState, type AppStateStatus} from 'react-native';
 import {BehaviorSubject} from 'rxjs';
 
+import {attachAuditEventErrorReason, enqueueAuditEvent} from '@actions/local/ephemeral_mode/audit_queue';
 import {wipeServerDatabaseWithRetry, wipeServerFiles} from '@actions/local/ephemeral_mode/wipe';
 import {Screens} from '@constants';
 import {SYSTEM_IDENTIFIERS} from '@constants/database';
+import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import DatabaseManager from '@database/manager';
 import PushNotifications from '@init/push_notifications';
 import WebsocketManager from '@managers/websocket_manager';
@@ -20,6 +22,10 @@ import EphemeralModeManager from './index';
 
 import type ServersModel from '@typings/database/models/app/servers';
 
+jest.mock('@actions/local/ephemeral_mode/audit_queue', () => ({
+    enqueueAuditEvent: jest.fn().mockResolvedValue('audit-evt-1'),
+    attachAuditEventErrorReason: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock('@actions/local/ephemeral_mode/wipe', () => ({
     wipeServerDatabaseWithRetry: jest.fn().mockResolvedValue({success: true}),
     wipeServerFiles: jest.fn().mockReturnValue({success: true}),
@@ -750,15 +756,88 @@ describe('EphemeralModeManager', () => {
             expect(WebsocketManager.observeWebsocketState).toHaveBeenCalledTimes(2);
         });
 
-        it('logs a wipe failure when only the file cache wipe fails', async () => {
-            jest.mocked(wipeServerFiles).mockReturnValueOnce({success: false});
+        describe('offline-purge audit event', () => {
+            it('enqueues one offlinePurge event with the full expected shape', async () => {
+                await triggerWipeForServerA();
 
-            await triggerWipeForServerA();
+                expect(enqueueAuditEvent).toHaveBeenCalledWith(serverA, {
+                    kind: EphemeralModeAuditEventKind.OfflinePurge,
+                    occurredAt: expect.any(Number),
+                    offlineTimeMinutes: 60,
+                });
+            });
 
-            expect(logError).toHaveBeenCalledWith(
-                'EphemeralModeManager.runWipe: wipe failed after retries, server re-added with stale data',
-                serverA,
-            );
+            it('enqueues the event before wipeServerDatabaseWithRetry runs, while the server database is still intact', async () => {
+                await triggerWipeForServerA();
+
+                const enqueueOrder = jest.mocked(enqueueAuditEvent).mock.invocationCallOrder[0];
+                const wipeOrder = jest.mocked(wipeServerDatabaseWithRetry).mock.invocationCallOrder[0];
+                expect(enqueueOrder).toBeLessThan(wipeOrder);
+            });
+
+            it('lets the wipe complete when enqueueAuditEvent rejects', async () => {
+                jest.mocked(enqueueAuditEvent).mockRejectedValueOnce(new Error('write failed'));
+
+                await triggerWipeForServerA();
+
+                expect(wipeServerDatabaseWithRetry).toHaveBeenCalledWith(serverA);
+                expect(updatePersistenceFlagSpy).toHaveBeenCalledWith(serverA, 'wiped');
+            });
+        });
+
+        describe('offline-purge audit event failure reason', () => {
+            it('logs and attaches an unexpected-error reason when the wipe artifacts fail after retries', async () => {
+                jest.mocked(wipeServerDatabaseWithRetry).mockResolvedValueOnce({success: false});
+
+                await triggerWipeForServerA();
+
+                expect(logError).toHaveBeenCalledWith('EphemeralModeManager.runWipe', expect.any(Error));
+                expect(attachAuditEventErrorReason).toHaveBeenCalledWith(serverA, 'audit-evt-1', 'unexpected error during wipe');
+            });
+
+            it('never calls attachAuditEventErrorReason when the wipe succeeds', async () => {
+                await triggerWipeForServerA();
+
+                expect(attachAuditEventErrorReason).not.toHaveBeenCalled();
+            });
+
+            it('lets addServer run when attachAuditEventErrorReason rejects', async () => {
+                jest.mocked(wipeServerDatabaseWithRetry).mockResolvedValueOnce({success: false});
+                jest.mocked(attachAuditEventErrorReason).mockRejectedValueOnce(new Error('write failed'));
+
+                await triggerWipeForServerA();
+
+                expect(WebsocketManager.observeWebsocketState).toHaveBeenCalledTimes(2);
+            });
+
+            it('never calls attachAuditEventErrorReason when the initial enqueueAuditEvent also rejected', async () => {
+                jest.mocked(enqueueAuditEvent).mockRejectedValueOnce(new Error('write failed'));
+                jest.mocked(wipeServerDatabaseWithRetry).mockResolvedValueOnce({success: false});
+
+                await triggerWipeForServerA();
+
+                expect(attachAuditEventErrorReason).not.toHaveBeenCalled();
+            });
+
+            it('attaches an unexpected-error reason when an unhandled exception interrupts the wipe after the audit event is created', async () => {
+                updatePersistenceFlagSpy.mockImplementationOnce(() => {
+                    throw new Error('disk full');
+                });
+
+                await triggerWipeForServerA();
+
+                expect(attachAuditEventErrorReason).toHaveBeenCalledWith(serverA, 'audit-evt-1', 'unexpected error during wipe');
+            });
+
+            it('restores tracking for the server when an unhandled exception interrupts the wipe after subscriptions were paused', async () => {
+                jest.mocked(wipeServerFiles).mockImplementationOnce(() => {
+                    throw new Error('fs error');
+                });
+
+                await triggerWipeForServerA();
+
+                expect(WebsocketManager.observeWebsocketState).toHaveBeenCalledTimes(2);
+            });
         });
     });
 
@@ -887,6 +966,30 @@ describe('EphemeralModeManager', () => {
             EphemeralModeManager.removeServer(serverA);
 
             expect(appStateRemoveSpies[0]).toHaveBeenCalled();
+        });
+    });
+
+    describe('isEphemeralModeEnabled', () => {
+        it('returns false for a server never passed to init', () => {
+            expect(EphemeralModeManager.isEphemeralModeEnabled(serverA)).toBe(false);
+        });
+
+        it('returns true for a tracked mem server', async () => {
+            await seedConfigAndRow(serverA, {enabled: true, timeoutSec: 10});
+
+            await EphemeralModeManager.init([credsA]);
+            await advanceTimers(0);
+
+            expect(EphemeralModeManager.isEphemeralModeEnabled(serverA)).toBe(true);
+        });
+
+        it('returns true for a tracked zpm server', async () => {
+            await DatabaseManager.updatePersistenceFlag(serverA, 'zero-persistence');
+
+            await EphemeralModeManager.init([credsA]);
+            await advanceTimers(0);
+
+            expect(EphemeralModeManager.isEphemeralModeEnabled(serverA)).toBe(true);
         });
     });
 });

--- a/app/managers/ephemeral_mode_manager/index.test.ts
+++ b/app/managers/ephemeral_mode_manager/index.test.ts
@@ -791,7 +791,7 @@ describe('EphemeralModeManager', () => {
 
                 await triggerWipeForServerA();
 
-                expect(logError).toHaveBeenCalledWith('EphemeralModeManager.runWipe', expect.any(Error));
+                expect(logError).toHaveBeenCalledWith('EphemeralModeManager.runWipe', 'wipe artifacts failed after retries');
                 expect(attachAuditEventErrorReason).toHaveBeenCalledWith(serverA, 'audit-evt-1', 'unexpected error during wipe');
             });
 
@@ -877,6 +877,39 @@ describe('EphemeralModeManager', () => {
                 'EphemeralModeManager.init: resumed wipe failed after retries, server re-added with stale data',
                 serverA,
             );
+        });
+
+        it('enqueues an offlinePurge audit event with an error reason when a resumed wipe fails again', async () => {
+            jest.mocked(getServer).mockResolvedValue({url: serverA, persistenceFlag: 'wiped'} as ServersModel);
+            jest.mocked(wipeServerDatabaseWithRetry).mockResolvedValueOnce({success: false});
+
+            await EphemeralModeManager.init([credsA]);
+
+            expect(enqueueAuditEvent).toHaveBeenCalledWith(serverA, {
+                kind: EphemeralModeAuditEventKind.OfflinePurge,
+                occurredAt: expect.any(Number),
+                offlineTimeMinutes: 0,
+                errorReason: 'resumed wipe failed after retries, server re-added with stale data',
+            });
+        });
+
+        it('does not enqueue an audit event when a resumed wipe succeeds', async () => {
+            jest.mocked(getServer).mockResolvedValue({url: serverA, persistenceFlag: 'wiped'} as ServersModel);
+
+            await EphemeralModeManager.init([credsA]);
+
+            expect(enqueueAuditEvent).not.toHaveBeenCalled();
+        });
+
+        it('still re-adds the server when enqueueing the resumed-wipe-failure audit event rejects', async () => {
+            await seedConfigAndRow(serverA, {enabled: true, timeoutSec: 10});
+            jest.mocked(getServer).mockResolvedValue({url: serverA, persistenceFlag: 'wiped'} as ServersModel);
+            jest.mocked(wipeServerDatabaseWithRetry).mockResolvedValueOnce({success: false});
+            jest.mocked(enqueueAuditEvent).mockRejectedValueOnce(new Error('write failed'));
+
+            await EphemeralModeManager.init([credsA]);
+
+            expect(WebsocketManager.observeWebsocketState).toHaveBeenCalledWith(serverA);
         });
     });
 

--- a/app/managers/ephemeral_mode_manager/index.ts
+++ b/app/managers/ephemeral_mode_manager/index.ts
@@ -62,7 +62,10 @@ class EphemeralModeManagerSingleton {
                 if (server && server.persistenceFlag === 'wiped') {
                     // Recover from a wipe interrupted by app termination before
                     // the DB + file artifacts were both deleted.
-                    await this.wipeServerArtifacts(serverUrl);
+                    const [databaseResult, filesResult] = await this.wipeServerArtifacts(serverUrl);
+                    if (!databaseResult.success || !filesResult.success) {
+                        logError('EphemeralModeManager.init: resumed wipe failed after retries, server re-added with stale data', serverUrl);
+                    }
                 }
                 await this.addServer(serverUrl);
             } catch (error) {
@@ -454,8 +457,8 @@ class EphemeralModeManagerSingleton {
             await DatabaseManager.updatePersistenceFlag(serverUrl, 'wiped');
 
             this.pauseSubscriptions(serverUrl);
-            const [{success}] = await this.wipeServerArtifacts(serverUrl);
-            if (!success) {
+            const [databaseResult, filesResult] = await this.wipeServerArtifacts(serverUrl);
+            if (!databaseResult.success || !filesResult.success) {
                 logError('EphemeralModeManager.runWipe: wipe failed after retries, server re-added with stale data', serverUrl);
             }
             await this.addServer(serverUrl);

--- a/app/managers/ephemeral_mode_manager/index.ts
+++ b/app/managers/ephemeral_mode_manager/index.ts
@@ -5,15 +5,18 @@ import {AppState, type AppStateStatus, type NativeEventSubscription} from 'react
 import {BehaviorSubject, combineLatest, type Subscription} from 'rxjs';
 import {distinctUntilChanged, skip} from 'rxjs/operators';
 
+import {attachAuditEventErrorReason, enqueueAuditEvent} from '@actions/local/ephemeral_mode/audit_queue';
 import {wipeServerDatabaseWithRetry, wipeServerFiles} from '@actions/local/ephemeral_mode/wipe';
 import {clearEphemeralModeState, setDisconnectedSince, setLastSeenTime, setOfflineSince} from '@actions/local/systems';
 import {Screens} from '@constants';
+import {EphemeralModeAuditEventKind} from '@constants/ephemeral_mode';
 import DatabaseManager from '@database/manager';
 import PushNotifications from '@init/push_notifications';
 import WebsocketManager from '@managers/websocket_manager';
 import {getServer, getServerDisplayName} from '@queries/app/servers';
 import {getDisconnectedSince, getLastSeenTime, getOfflineSince, observeConfigValue} from '@queries/servers/system';
 import {navigateToScreen} from '@screens/navigation';
+import {getFullErrorMessage} from '@utils/errors';
 import {toMilliseconds} from '@utils/datetime';
 import {deleteFileCache} from '@utils/file';
 import {logDebug, logError} from '@utils/log';
@@ -112,6 +115,10 @@ class EphemeralModeManagerSingleton {
 
     public isZeroPersistenceMode = (serverUrl: string): boolean => {
         return this.trackedServers.get(serverUrl)?.kind === 'zpm';
+    };
+
+    public isEphemeralModeEnabled = (serverUrl: string): boolean => {
+        return this.trackedServers.has(serverUrl);
     };
 
     public addServer = async (serverUrl: string, {cleanFileCache = true}: {cleanFileCache?: boolean} = {}) => {
@@ -440,12 +447,33 @@ class EphemeralModeManagerSingleton {
         ]);
     };
 
+    private enqueueOfflinePurgeAuditEvent = async (serverUrl: string): Promise<string | undefined> => {
+        try {
+            const {database} = DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+            const purgeAt = Date.now();
+            const offlineSince = await getOfflineSince(database);
+
+            // Only queried when offlineSince is missing — the expected case never pays for it.
+            const disconnectedSince = offlineSince === undefined ? await getDisconnectedSince(database) : undefined;
+            const since = offlineSince ?? disconnectedSince ?? purgeAt;
+            return await enqueueAuditEvent(serverUrl, {
+                kind: EphemeralModeAuditEventKind.OfflinePurge,
+                offlineTimeMinutes: Math.max(0, Math.round((purgeAt - since) / 60_000)),
+                occurredAt: purgeAt,
+            });
+        } catch (error) {
+            logError('EphemeralModeManager.enqueueOfflinePurgeAuditEvent', getFullErrorMessage(error));
+            return undefined;
+        }
+    };
+
     private runWipe = async (serverUrl: string) => {
         if (this.wipeInProgress.has(serverUrl)) {
             return;
         }
         this.wipeInProgress.add(serverUrl);
 
+        let auditEventId: string | undefined;
         try {
             const activeUrl = await DatabaseManager.getActiveServerUrl();
             const displayName = (await getServerDisplayName(serverUrl)) || serverUrl;
@@ -454,17 +482,31 @@ class EphemeralModeManagerSingleton {
                 navigateToScreen(Screens.DATA_ERASED, {serverUrl, displayName}, true);
             }
 
+            auditEventId = await this.enqueueOfflinePurgeAuditEvent(serverUrl);
+
             await DatabaseManager.updatePersistenceFlag(serverUrl, 'wiped');
 
             this.pauseSubscriptions(serverUrl);
             const [databaseResult, filesResult] = await this.wipeServerArtifacts(serverUrl);
             if (!databaseResult.success || !filesResult.success) {
-                logError('EphemeralModeManager.runWipe: wipe failed after retries, server re-added with stale data', serverUrl);
+                throw new Error('wipe artifacts failed after retries');
             }
-            await this.addServer(serverUrl);
         } catch (error) {
             logError('EphemeralModeManager.runWipe', error);
+            if (auditEventId) {
+                try {
+                    await attachAuditEventErrorReason(serverUrl, auditEventId, 'unexpected error during wipe');
+                } catch (attachError) {
+                    logError('EphemeralModeManager.runWipe: attachAuditEventErrorReason failed', getFullErrorMessage(attachError));
+                }
+            }
         } finally {
+            try {
+                await this.addServer(serverUrl);
+            } catch (error) {
+                logError('EphemeralModeManager.runWipe: addServer failed', error);
+            }
+
             this.wipeInProgress.delete(serverUrl);
         }
     };

--- a/app/managers/ephemeral_mode_manager/index.ts
+++ b/app/managers/ephemeral_mode_manager/index.ts
@@ -16,8 +16,8 @@ import WebsocketManager from '@managers/websocket_manager';
 import {getServer, getServerDisplayName} from '@queries/app/servers';
 import {getDisconnectedSince, getLastSeenTime, getOfflineSince, observeConfigValue} from '@queries/servers/system';
 import {navigateToScreen} from '@screens/navigation';
-import {getFullErrorMessage} from '@utils/errors';
 import {toMilliseconds} from '@utils/datetime';
+import {getFullErrorMessage} from '@utils/errors';
 import {deleteFileCache} from '@utils/file';
 import {logDebug, logError} from '@utils/log';
 
@@ -68,6 +68,17 @@ class EphemeralModeManagerSingleton {
                     const [databaseResult, filesResult] = await this.wipeServerArtifacts(serverUrl);
                     if (!databaseResult.success || !filesResult.success) {
                         logError('EphemeralModeManager.init: resumed wipe failed after retries, server re-added with stale data', serverUrl);
+                        try {
+                            // Add a failure as a new entry in the audit log and keep the original attempt entry untouched.
+                            await enqueueAuditEvent(serverUrl, {
+                                kind: EphemeralModeAuditEventKind.OfflinePurge,
+                                offlineTimeMinutes: 0,
+                                occurredAt: Date.now(),
+                                errorReason: 'resumed wipe failed after retries, server re-added with stale data',
+                            });
+                        } catch (auditError) {
+                            logError('EphemeralModeManager.init: failed to enqueue resumed-wipe-failure audit event', getFullErrorMessage(auditError));
+                        }
                     }
                 }
                 await this.addServer(serverUrl);
@@ -492,7 +503,7 @@ class EphemeralModeManagerSingleton {
                 throw new Error('wipe artifacts failed after retries');
             }
         } catch (error) {
-            logError('EphemeralModeManager.runWipe', error);
+            logError('EphemeralModeManager.runWipe', getFullErrorMessage(error));
             if (auditEventId) {
                 try {
                     await attachAuditEventErrorReason(serverUrl, auditEventId, 'unexpected error during wipe');
@@ -504,7 +515,7 @@ class EphemeralModeManagerSingleton {
             try {
                 await this.addServer(serverUrl);
             } catch (error) {
-                logError('EphemeralModeManager.runWipe: addServer failed', error);
+                logError('EphemeralModeManager.runWipe: addServer failed', getFullErrorMessage(error));
             }
 
             this.wipeInProgress.delete(serverUrl);

--- a/app/managers/session_manager.test.ts
+++ b/app/managers/session_manager.test.ts
@@ -4,7 +4,9 @@
 import CookieManager from '@preeternal/react-native-cookie-manager';
 import {AppState, DeviceEventEmitter, Platform} from 'react-native';
 
+import {attachAuditEventErrorReason} from '@actions/local/ephemeral_mode/audit_queue';
 import {cancelAllSessionNotifications} from '@actions/local/session';
+import {flushAuditQueue} from '@actions/remote/ephemeral_mode';
 import {logout, scheduleSessionNotification} from '@actions/remote/session';
 import {Events} from '@constants';
 import DatabaseManager from '@database/manager';
@@ -51,6 +53,12 @@ jest.mock('@actions/local/session', () => {
         cancelAllSessionNotifications: jest.fn(),
     };
 });
+jest.mock('@actions/local/ephemeral_mode/audit_queue', () => ({
+    attachAuditEventErrorReason: jest.fn(),
+}));
+jest.mock('@actions/remote/ephemeral_mode', () => ({
+    flushAuditQueue: jest.fn(),
+}));
 jest.mock('@init/credentials');
 jest.mock('@init/launch');
 jest.mock('@init/push_notifications');
@@ -201,6 +209,11 @@ describe('SessionManager', () => {
             expect(EphemeralModeManager.removeServer).toHaveBeenCalledWith(mockServerUrl);
             expect(SessionAttributesManager.removeServer).toHaveBeenCalledWith(mockServerUrl);
             expect(IntuneManager.unenrollServer).toHaveBeenCalledWith(mockServerUrl, false);
+
+            // No auditEventId on this event (a non-push-triggered logout) — still
+            // flushes opportunistically, but has nothing to attach a reason to.
+            expect(flushAuditQueue).toHaveBeenCalledWith(mockServerUrl);
+            expect(attachAuditEventErrorReason).not.toHaveBeenCalled();
         });
 
         it('should handle session expiration', async () => {
@@ -214,6 +227,28 @@ describe('SessionManager', () => {
             expect(SessionAttributesManager.removeServer).toHaveBeenCalledWith(mockServerUrl);
             expect(IntuneManager.unenrollServer).toHaveBeenCalledWith(mockServerUrl, true);
             expect(determineRouteFromLaunchProps).toHaveBeenCalled();
+        });
+
+        it('should flush the audit queue without attaching a reason when a push-triggered logout succeeds', async () => {
+            const event = {serverUrl: mockServerUrl, auditEventId: 'audit-evt-1'};
+            DeviceEventEmitter.emit(Events.SERVER_LOGOUT, event);
+
+            await TestHelper.wait(50);
+
+            expect(flushAuditQueue).toHaveBeenCalledWith(mockServerUrl);
+            expect(attachAuditEventErrorReason).not.toHaveBeenCalled();
+        });
+
+        it('should attach a reason naming the failed operation before flushing when a push-triggered logout fails', async () => {
+            jest.mocked(DatabaseManager.deleteServerDatabase).mockRejectedValueOnce(new Error('database is locked'));
+
+            const event = {serverUrl: mockServerUrl, auditEventId: 'audit-evt-1'};
+            DeviceEventEmitter.emit(Events.SERVER_LOGOUT, event);
+
+            await TestHelper.wait(50);
+
+            expect(attachAuditEventErrorReason).toHaveBeenCalledWith(mockServerUrl, 'audit-evt-1', 'terminateSession failed: databaseOperation');
+            expect(flushAuditQueue).toHaveBeenCalledWith(mockServerUrl);
         });
     });
 

--- a/app/managers/session_manager.ts
+++ b/app/managers/session_manager.ts
@@ -5,7 +5,9 @@ import {router} from 'expo-router';
 import {AppState, type AppStateStatus, DeviceEventEmitter, type EventSubscription, type NativeEventSubscription, Platform} from 'react-native';
 
 import {storeGlobal, storeOnboardingViewedValue} from '@actions/app/global';
+import {attachAuditEventErrorReason} from '@actions/local/ephemeral_mode/audit_queue';
 import {cancelAllSessionNotifications, terminateSession} from '@actions/local/session';
+import {flushAuditQueue} from '@actions/remote/ephemeral_mode';
 import {logout, scheduleSessionNotification} from '@actions/remote/session';
 import {Events, Launch} from '@constants';
 import {GLOBAL_IDENTIFIERS} from '@constants/database';
@@ -21,9 +23,10 @@ import {queryGlobalValue} from '@queries/app/global';
 import {getAllServers, getServerDisplayName} from '@queries/app/servers';
 import {propsToParams} from '@screens/navigation';
 import EphemeralStore from '@store/ephemeral_store';
+import {getFullErrorMessage} from '@utils/errors';
 import {deleteFileCacheByDir} from '@utils/file';
 import {isMainActivity} from '@utils/helpers';
-import {logDebug} from '@utils/log';
+import {logDebug, logError} from '@utils/log';
 import {addNewServer} from '@utils/server';
 
 import type {LaunchType} from '@typings/launch';
@@ -31,6 +34,7 @@ import type {LaunchType} from '@typings/launch';
 type LogoutCallbackArg = {
     serverUrl: string;
     removeServer: boolean;
+    auditEventId?: string;
 }
 
 export class SessionManagerSingleton {
@@ -122,7 +126,7 @@ export class SessionManagerSingleton {
         }
     };
 
-    private onLogout = async ({serverUrl, removeServer}: LogoutCallbackArg) => {
+    private onLogout = async ({serverUrl, removeServer, auditEventId}: LogoutCallbackArg) => {
         if (this.terminatingSessionUrl.has(serverUrl)) {
             return;
         }
@@ -134,7 +138,8 @@ export class SessionManagerSingleton {
 
             // We do not unenroll with Wipe as we already removed all the data during terminateSession
             await IntuneManager.unenrollServer(serverUrl, false);
-            await terminateSession(serverUrl, removeServer);
+            const result = await terminateSession(serverUrl, removeServer);
+            await this.recordSessionWipeOutcome(serverUrl, auditEventId, result);
             SecurityManager.removeServer(serverUrl);
             EphemeralModeManager.removeServer(serverUrl);
             SessionAttributesManager.removeServer(serverUrl);
@@ -164,6 +169,24 @@ export class SessionManagerSingleton {
             }
         } finally {
             this.terminatingSessionUrl.delete(serverUrl);
+        }
+    };
+
+    // Runs for every logout; without an auditEventId (non-push triggers) only the opportunistic flush runs.
+    private recordSessionWipeOutcome = async (
+        serverUrl: string,
+        auditEventId: string | undefined,
+        result: Awaited<ReturnType<typeof terminateSession>>,
+    ) => {
+        try {
+            if (auditEventId && result.error) {
+                const reason = result.error.map(({operation}) => operation).join(', ');
+                await attachAuditEventErrorReason(serverUrl, auditEventId, `terminateSession failed: ${reason}`);
+            }
+        } catch (error) {
+            logError('SessionManager.recordSessionWipeOutcome', getFullErrorMessage(error));
+        } finally {
+            flushAuditQueue(serverUrl);
         }
     };
 

--- a/app/queries/app/global.ts
+++ b/app/queries/app/global.ts
@@ -8,6 +8,7 @@ import {switchMap} from 'rxjs/operators';
 import {GLOBAL_IDENTIFIERS, MM_TABLES} from '@constants/database';
 import DatabaseManager from '@database/manager';
 
+import type {EphemeralModeAuditEvent} from '@constants/ephemeral_mode';
 import type GlobalModel from '@typings/database/models/app/global';
 
 const {APP: {GLOBAL}} = MM_TABLES;
@@ -106,6 +107,11 @@ export const getLastViewedChannelIdAndServer = async () => {
 export const getLastViewedThreadIdAndServer = async () => {
     const records = await queryGlobalValue(GLOBAL_IDENTIFIERS.LAST_VIEWED_THREAD)?.fetch();
     return records?.[0]?.value;
+};
+
+export const getEphemeralModeAuditEvents = async (serverUrl: string): Promise<EphemeralModeAuditEvent[]> => {
+    const records = await queryGlobalValue(`${GLOBAL_IDENTIFIERS.EPHEMERAL_MODE_AUDIT_QUEUE}${serverUrl}`)?.fetch();
+    return records?.[0]?.value ?? [];
 };
 
 export const observeTutorialWatched = (tutorial: string) => {

--- a/types/global/push_notifications.d.ts
+++ b/types/global/push_notifications.d.ts
@@ -33,6 +33,7 @@ interface NotificationData {
     sender_id?: string;
     sender_name?: string;
     server_id?: string;
+    signature?: string;
     server_url?: string;
     team_id?: string;
     type: string;


### PR DESCRIPTION
#### Summary
Send audit event logs to server when different Mobile Ephemeral Mode actions happen client side.
The client keeps an audit event queue that is flushed as soon as connectivity is available and server reachable. The events that are send are:

- Offline purge events
- Periodic cleanup events due to auto cache cleanup settings
- wipe events as a result of a session revocation. This is one is unauthenticated and the wipe message signature is provided as a proof the client is the one that received the wipe instruction.

Some events allow duplicate sending on retries. the server will group those.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68296

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: Android 15 emulator and iOS 18 simulator

#### Release Note
```release-note
Sends audit events related to Mobile Ephemeral Mode actions executed on the client app.
```
