### PR TITLE
MM-70688 Autolink phone numbers in posts as tel: links

### DIFF
--- a/app/components/markdown/markdown.test.tsx
+++ b/app/components/markdown/markdown.test.tsx
@@ -251,4 +251,35 @@ describe('Markdown', () => {
             });
         });
     });
+
+    describe('phone number autolinking', () => {
+        it('should autolink phone numbers when links are enabled', () => {
+            const spy = jest.spyOn(Transforms, 'autolinkPhoneNumbers');
+
+            renderWithIntl(
+                <Markdown
+                    {...baseProps}
+                    value='This is a test'
+                />,
+            );
+
+            expect(spy).toHaveBeenCalled();
+            spy.mockRestore();
+        });
+
+        it('should not autolink phone numbers when links are disabled', () => {
+            const spy = jest.spyOn(Transforms, 'autolinkPhoneNumbers');
+
+            renderWithIntl(
+                <Markdown
+                    {...baseProps}
+                    disableLinks={true}
+                    value='This is a test'
+                />,
+            );
+
+            expect(spy).not.toHaveBeenCalled();
+            spy.mockRestore();
+        });
+    });
 });

--- a/app/components/markdown/markdown.test.tsx
+++ b/app/components/markdown/markdown.test.tsx
@@ -21,6 +21,18 @@ jest.mock('@screens/navigation', () => ({
     navigateToRoot: jest.fn(),
 }));
 
+jest.mock('./markdown_link', () => {
+    const MockReact = require('react');
+    const {Text} = require('react-native');
+
+    return {
+        __esModule: true,
+        default: ({href, children}: {href: string; children: React.ReactNode}) => (
+            MockReact.createElement(Text, {testID: 'markdown_link', href}, children)
+        ),
+    };
+});
+
 describe('Markdown', () => {
     const baseProps: React.ComponentProps<typeof Markdown> = {
         baseTextStyle: {},
@@ -253,33 +265,48 @@ describe('Markdown', () => {
     });
 
     describe('phone number autolinking', () => {
-        it('should autolink phone numbers when links are enabled', () => {
-            const spy = jest.spyOn(Transforms, 'autolinkPhoneNumbers');
+        beforeEach(() => {
+            jest.restoreAllMocks();
+        });
 
+        it('should autolink phone numbers when links are enabled', () => {
             renderWithIntl(
                 <Markdown
                     {...baseProps}
-                    value='This is a test'
+                    value='Call 555-123-4567'
                 />,
             );
 
-            expect(spy).toHaveBeenCalled();
-            spy.mockRestore();
+            const links = screen.getAllByTestId('markdown_link');
+            expect(links).toHaveLength(1);
+            expect(links[0].props.href).toBe('tel:5551234567');
+            expect(screen.getByText('555-123-4567')).toBeVisible();
         });
 
         it('should not autolink phone numbers when links are disabled', () => {
-            const spy = jest.spyOn(Transforms, 'autolinkPhoneNumbers');
-
             renderWithIntl(
                 <Markdown
                     {...baseProps}
                     disableLinks={true}
-                    value='This is a test'
+                    value='Call 555-123-4567'
                 />,
             );
 
-            expect(spy).not.toHaveBeenCalled();
-            spy.mockRestore();
+            expect(screen.queryAllByTestId('markdown_link')).toHaveLength(0);
+            expect(screen.getByText('Call 555-123-4567')).toBeVisible();
+        });
+
+        it('should not autolink phone numbers when the post has unsafe links', () => {
+            renderWithIntl(
+                <Markdown
+                    {...baseProps}
+                    isUnsafeLinksPost={true}
+                    value='Call 555-123-4567'
+                />,
+            );
+
+            expect(screen.queryAllByTestId('markdown_link')).toHaveLength(0);
+            expect(screen.getByText('Call 555-123-4567')).toBeVisible();
         });
     });
 });

--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -38,7 +38,7 @@ import MarkdownTable from './markdown_table';
 import MarkdownTableCell, {type MarkdownTableCellProps} from './markdown_table_cell';
 import MarkdownTableImage from './markdown_table_image';
 import MarkdownTableRow, {type MarkdownTableRowProps} from './markdown_table_row';
-import {addListItemIndices, combineTextNodes, highlightMentions, highlightWithoutNotification, highlightSearchPatterns, parseTaskLists, processInlineEntities, pullOutImages} from './transform';
+import {addListItemIndices, autolinkPhoneNumbers, combineTextNodes, highlightMentions, highlightWithoutNotification, highlightSearchPatterns, parseTaskLists, processInlineEntities, pullOutImages} from './transform';
 
 import type {ChannelMentions} from './channel_mention/channel_mention';
 import type {
@@ -728,6 +728,9 @@ const Markdown = ({
             ast = addListItemIndices(ast);
             ast = pullOutImages(ast);
             ast = parseTaskLists(ast);
+            if (!disableLinks && !isUnsafeLinksPost) {
+                ast = autolinkPhoneNumbers(ast);
+            }
             ast = processInlineEntities(ast, serverUrl);
             if (mentionKeys) {
                 ast = highlightMentions(ast, mentionKeys);
@@ -791,7 +794,7 @@ const Markdown = ({
                 />
             );
         }
-    }, [channelId, highlightKeys, isEdited, mentionKeys, parser, postId, renderer, searchPatterns, serverUrl, style.errorMessage, value]);
+    }, [channelId, disableLinks, highlightKeys, isEdited, isUnsafeLinksPost, mentionKeys, parser, postId, renderer, searchPatterns, serverUrl, style.errorMessage, value]);
 
     return output;
 };

--- a/app/components/markdown/markdown_link/markdown_link.test.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.test.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import Clipboard from '@react-native-clipboard/clipboard';
+import {fireEvent} from '@testing-library/react-native';
+import React from 'react';
+import {Text} from 'react-native';
+
+import {bottomSheet} from '@screens/navigation';
+import {renderWithIntl} from '@test/intl-test-helper';
+import {openLink} from '@utils/url/links';
+
+import MarkdownLink from './markdown_link';
+
+jest.mock('@screens/navigation', () => ({
+    bottomSheet: jest.fn(),
+    dismissBottomSheet: jest.fn(),
+}));
+
+jest.mock('@utils/url/links', () => ({
+    openLink: jest.fn(),
+}));
+
+jest.mock('@context/server', () => ({
+    useServerUrl: jest.fn(() => 'https://server.example.com'),
+}));
+
+jest.mock('@react-native-clipboard/clipboard', () => ({
+    setString: jest.fn(),
+}));
+
+describe('MarkdownLink', () => {
+    const siteURL = 'https://site.example.com';
+
+    it('should open a tel: href with openLink', () => {
+        const {getByTestId} = renderWithIntl(
+            <MarkdownLink
+                experimentalNormalizeMarkdownLinks=''
+                href='tel:+15551234567'
+                siteURL={siteURL}
+            >
+                <Text>{'+15551234567'}</Text>
+            </MarkdownLink>,
+        );
+
+        fireEvent.press(getByTestId('markdown_link'));
+
+        expect(openLink).toHaveBeenCalledWith(
+            'tel:+15551234567',
+            'https://server.example.com',
+            siteURL,
+            expect.any(Object),
+        );
+    });
+
+    it('should offer copy phone number on long press of a tel: link', () => {
+        const {getByTestId, getByText} = renderWithIntl(
+            <MarkdownLink
+                experimentalNormalizeMarkdownLinks=''
+                href='tel:5551234567'
+                siteURL={siteURL}
+            >
+                <Text>{'555-123-4567'}</Text>
+            </MarkdownLink>,
+        );
+
+        fireEvent(getByTestId('markdown_link'), 'longPress');
+
+        expect(bottomSheet).toHaveBeenCalledWith(expect.any(Function), expect.any(Array));
+        const renderContent = jest.mocked(bottomSheet).mock.calls[0][0] as () => React.ReactElement;
+        const {getByText: getSheetText} = renderWithIntl(renderContent());
+
+        expect(getSheetText('Copy Phone Number')).toBeVisible();
+
+        fireEvent.press(getSheetText('Copy Phone Number'));
+        expect(Clipboard.setString).toHaveBeenCalledWith('5551234567');
+        expect(getByText('555-123-4567')).toBeVisible();
+    });
+});

--- a/app/components/markdown/markdown_link/markdown_link.tsx
+++ b/app/components/markdown/markdown_link/markdown_link.tsx
@@ -13,6 +13,7 @@ import {useServerUrl} from '@context/server';
 import {usePreventDoubleTap} from '@hooks/utils';
 import {bottomSheet, dismissBottomSheet} from '@screens/navigation';
 import {bottomSheetSnapPoint, isEmail} from '@utils/helpers';
+import {isTelHref} from '@utils/phone_number';
 import {openLink} from '@utils/url/links';
 
 type MarkdownLinkProps = {
@@ -27,6 +28,10 @@ const messages = defineMessages({
     copyEmail: {
         id: 'mobile.markdown.link.copy_email',
         defaultMessage: 'Copy Email Address',
+    },
+    copyPhone: {
+        id: 'mobile.markdown.link.copy_phone',
+        defaultMessage: 'Copy Phone Number',
     },
     copyURL: {
         id: 'mobile.markdown.link.copy_url',
@@ -53,6 +58,18 @@ const parseLinkLiteral = (literal: string) => {
     return parsed.href;
 };
 
+function getCopyLinkMessage(href: string) {
+    if (isTelHref(href)) {
+        return messages.copyPhone;
+    }
+
+    if (isEmail(href.replace(/^(mailto:|tel:)/i, ''))) {
+        return messages.copyEmail;
+    }
+
+    return messages.copyURL;
+}
+
 const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteURL, onLinkLongPress}: MarkdownLinkProps) => {
     const intl = useIntl();
     const managedConfig = useManagedConfig<ManagedConfig>();
@@ -69,8 +86,8 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                 return;
             }
 
-            const cleanHref = href.replace(/^mailto:/, '');
-            const isEmailLink = isEmail(cleanHref);
+            const cleanHref = href.replace(/^(mailto:|tel:)/i, '');
+            const copyMessage = getCopyLinkMessage(href);
 
             const renderContent = () => {
                 return (
@@ -85,7 +102,7 @@ const MarkdownLink = ({children, experimentalNormalizeMarkdownLinks, href, siteU
                                 Clipboard.setString(cleanHref);
                             }}
                             testID='at_mention.bottom_sheet.copy_url'
-                            text={intl.formatMessage(isEmailLink ? messages.copyEmail : messages.copyURL)}
+                            text={intl.formatMessage(copyMessage)}
                         />
                         <SlideUpPanelItem
                             destructive={true}

--- a/app/components/markdown/transform.test.ts
+++ b/app/components/markdown/transform.test.ts
@@ -7,6 +7,7 @@ import {Node, Parser} from 'commonmark';
 
 import {
     addListItemIndices,
+    autolinkPhoneNumbers,
     combineTextNodes,
     getFirstMatch,
     highlightMentions,
@@ -3474,6 +3475,202 @@ describe('Components.Markdown.transform', () => {
                 expect(result).toBeNull();
             });
         });
+    });
+
+    describe('autolinkPhoneNumbers', () => {
+        const tests = [{
+            name: 'grouped national number',
+            input: 'Call me at 555-123-4567',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'Call me at ',
+                    }, {
+                        type: 'link',
+                        destination: 'tel:5551234567',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: '555-123-4567',
+                        }],
+                    }],
+                }],
+            },
+        }, {
+            name: 'E.164 number',
+            input: 'Call +15551234567',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'Call ',
+                    }, {
+                        type: 'link',
+                        destination: 'tel:+15551234567',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: '+15551234567',
+                        }],
+                    }],
+                }],
+            },
+        }, {
+            name: 'tel URI with plus that the parser does not autolink',
+            input: 'Call tel:+15551234567',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'Call ',
+                    }, {
+                        type: 'link',
+                        destination: 'tel:+15551234567',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: 'tel:+15551234567',
+                        }],
+                    }],
+                }],
+            },
+        }, {
+            name: 'multiple numbers',
+            input: '555-123-4567 or 1-800-555-1234',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'link',
+                        destination: 'tel:5551234567',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: '555-123-4567',
+                        }],
+                    }, {
+                        type: 'text',
+                        literal: ' or ',
+                    }, {
+                        type: 'link',
+                        destination: 'tel:18005551234',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: '1-800-555-1234',
+                        }],
+                    }],
+                }],
+            },
+        }, {
+            name: 'does not match inside an existing markdown link',
+            input: '[Call 555-123-4567](https://example.com)',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'link',
+                        destination: 'https://example.com',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: 'Call 555-123-4567',
+                        }],
+                    }],
+                }],
+            },
+        }, {
+            name: 'does not match inside an existing tel markdown link',
+            input: '[Call](tel:+15551234567)',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'link',
+                        destination: 'tel:+15551234567',
+                        title: '',
+                        children: [{
+                            type: 'text',
+                            literal: 'Call',
+                        }],
+                    }],
+                }],
+            },
+        }, {
+            name: 'does not match inside a code span',
+            input: 'Use `555-123-4567`',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'Use ',
+                    }, {
+                        type: 'code',
+                        literal: '555-123-4567',
+                    }],
+                }],
+            },
+        }, {
+            name: 'does not match a bare digit run',
+            input: 'Ticket 1234567890',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'Ticket 1234567890',
+                    }],
+                }],
+            },
+        }, {
+            name: 'links a number inside emphasis',
+            input: 'Call **555-123-4567**',
+            expected: {
+                type: 'document',
+                children: [{
+                    type: 'paragraph',
+                    children: [{
+                        type: 'text',
+                        literal: 'Call ',
+                    }, {
+                        type: 'strong',
+                        children: [{
+                            type: 'link',
+                            destination: 'tel:5551234567',
+                            title: '',
+                            children: [{
+                                type: 'text',
+                                literal: '555-123-4567',
+                            }],
+                        }],
+                    }],
+                }],
+            },
+        }];
+
+        for (const test of tests) {
+            it(test.name, () => {
+                const input = combineTextNodes(parser.parse(test.input));
+                const expected = makeAst(test.expected);
+                const actual = autolinkPhoneNumbers(input);
+
+                assert.ok(verifyAst(actual));
+                assert.deepStrictEqual(stripUnusedFields(actual), stripUnusedFields(expected));
+            });
+        }
     });
 
     describe('processInlineEntities', () => {

--- a/app/components/markdown/transform.test.ts
+++ b/app/components/markdown/transform.test.ts
@@ -3479,7 +3479,7 @@ describe('Components.Markdown.transform', () => {
 
     describe('autolinkPhoneNumbers', () => {
         const tests = [{
-            name: 'grouped national number',
+            name: 'should autolink a grouped national number',
             input: 'Call me at 555-123-4567',
             expected: {
                 type: 'document',
@@ -3500,7 +3500,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'E.164 number',
+            name: 'should autolink an E.164 number',
             input: 'Call +15551234567',
             expected: {
                 type: 'document',
@@ -3521,7 +3521,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'tel URI with plus that the parser does not autolink',
+            name: 'should autolink a tel URI with plus that the parser does not autolink',
             input: 'Call tel:+15551234567',
             expected: {
                 type: 'document',
@@ -3542,7 +3542,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'multiple numbers',
+            name: 'should autolink multiple numbers',
             input: '555-123-4567 or 1-800-555-1234',
             expected: {
                 type: 'document',
@@ -3571,7 +3571,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'does not match inside an existing markdown link',
+            name: 'should not match inside an existing markdown link',
             input: '[Call 555-123-4567](https://example.com)',
             expected: {
                 type: 'document',
@@ -3589,7 +3589,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'does not match inside an existing tel markdown link',
+            name: 'should not match inside an existing tel markdown link',
             input: '[Call](tel:+15551234567)',
             expected: {
                 type: 'document',
@@ -3607,7 +3607,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'does not match inside a code span',
+            name: 'should not match inside a code span',
             input: 'Use `555-123-4567`',
             expected: {
                 type: 'document',
@@ -3623,7 +3623,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'does not match a bare digit run',
+            name: 'should not match a bare digit run',
             input: 'Ticket 1234567890',
             expected: {
                 type: 'document',
@@ -3636,7 +3636,7 @@ describe('Components.Markdown.transform', () => {
                 }],
             },
         }, {
-            name: 'links a number inside emphasis',
+            name: 'should autolink a number inside emphasis',
             input: 'Call **555-123-4567**',
             expected: {
                 type: 'document',

--- a/app/components/markdown/transform.ts
+++ b/app/components/markdown/transform.ts
@@ -7,6 +7,7 @@ import urlParse from 'url-parse';
 import {DeepLink} from '@constants';
 import {parseDeepLink} from '@utils/deep_link';
 import {escapeRegex} from '@utils/markdown';
+import {findPhoneNumbers} from '@utils/phone_number';
 import {safeDecodeURIComponent} from '@utils/url';
 
 import type {HighlightWithoutNotificationKey, SearchPattern, UserMentionKey} from '@typings/global/markdown';
@@ -317,6 +318,53 @@ export function highlightTextNode(node: Node, start: number, end: number, type: 
     }
 
     return highlighted;
+}
+
+const PHONE_AUTOLINK_SKIP_TYPES = new Set(['link', 'image']);
+
+function hasSkippedPhoneAutolinkAncestor(node: Node) {
+    let current = node.parent;
+    while (current) {
+        if (PHONE_AUTOLINK_SKIP_TYPES.has(current.type)) {
+            return true;
+        }
+        current = current.parent;
+    }
+
+    return false;
+}
+
+export function autolinkPhoneNumbers(ast: Node) {
+    const walker = ast.walker();
+
+    let e;
+    while ((e = walker.next())) {
+        if (!e.entering) {
+            continue;
+        }
+
+        const node = e.node;
+        if (node.type !== 'text' || !node.literal) {
+            continue;
+        }
+
+        if (hasSkippedPhoneAutolinkAncestor(node)) {
+            continue;
+        }
+
+        const match = findPhoneNumbers(node.literal)[0];
+        if (!match) {
+            continue;
+        }
+
+        const linkNode = highlightTextNode(node, match.index, match.index + match.length, 'link');
+        linkNode.destination = match.href;
+        linkNode.title = '';
+
+        walker.resumeAt(linkNode, false);
+    }
+
+    return ast;
 }
 
 // Wraps a given node in another node of the given type. The wrapper will take the place of

--- a/app/screens/channel_info/extra/extra.tsx
+++ b/app/screens/channel_info/extra/extra.tsx
@@ -21,6 +21,7 @@ import {ANDROID_33, OS_VERSION} from '@constants/versions';
 import {useTheme} from '@context/theme';
 import {bottomSheet, dismissBottomSheet} from '@screens/navigation';
 import {bottomSheetSnapPoint, isEmail} from '@utils/helpers';
+import {isTelHref} from '@utils/phone_number';
 import {showSnackBar} from '@utils/snack_bar';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
@@ -88,6 +89,10 @@ const messages = defineMessages({
         id: 'mobile.markdown.link.copy_email',
         defaultMessage: 'Copy Email Address',
     },
+    copyPhone: {
+        id: 'mobile.markdown.link.copy_phone',
+        defaultMessage: 'Copy Phone Number',
+    },
     copyURL: {
         id: 'mobile.markdown.link.copy_url',
         defaultMessage: 'Copy URL',
@@ -123,8 +128,13 @@ const Extra = ({channelId, createdAt, createdBy, customStatus, header, isCustomS
     const handleLongPress = useCallback((url?: string) => {
         if (managedConfig?.copyAndPasteProtection !== 'true') {
 
-            const cleanUrl = url?.replace(/^mailto:/, '') || '';
-            const isEmailLink = isEmail(cleanUrl);
+            const cleanUrl = url?.replace(/^(mailto:|tel:)/i, '') || '';
+            let copyMessage = messages.copyURL;
+            if (url && isTelHref(url)) {
+                copyMessage = messages.copyPhone;
+            } else if (isEmail(cleanUrl)) {
+                copyMessage = messages.copyEmail;
+            }
 
             const renderContent = () => (
                 <View
@@ -149,7 +159,7 @@ const Extra = ({channelId, createdAt, createdBy, customStatus, header, isCustomS
                                 onCopy(cleanUrl, true);
                             }}
                             testID={`${headerTestId}.bottom_sheet.copy_url`}
-                            text={intl.formatMessage(isEmailLink ? messages.copyEmail : messages.copyURL)}
+                            text={intl.formatMessage(copyMessage)}
                         />
                     )}
                     <SlideUpPanelItem

--- a/app/utils/phone_number.test.ts
+++ b/app/utils/phone_number.test.ts
@@ -88,7 +88,33 @@ describe('findPhoneNumbers', () => {
     });
 
     it('should not include trailing sentence punctuation', () => {
-        expect(findPhoneNumbers('Call 555-123-4567.')[0].raw).toBe('555-123-4567');
+        const matches = findPhoneNumbers('Call 555-123-4567.');
+        expect(matches).toHaveLength(1);
+        expect(matches[0].raw).toBe('555-123-4567');
+    });
+
+    it('should not match an overlong number continued by a separator', () => {
+        expect(findPhoneNumbers('+123456789012345-6')).toEqual([]);
+        expect(findPhoneNumbers('+1234567890123456')).toEqual([]);
+    });
+
+    it('should not match a grouped number with a numeric prefix', () => {
+        expect(findPhoneNumbers('99-555-123-4567')).toEqual([]);
+        expect(findPhoneNumbers('2-555-123-4567')).toEqual([]);
+    });
+
+    it('should still match a number before a parenthesized second number', () => {
+        const matches = findPhoneNumbers('555-123-4567 (555) 987-6543');
+        expect(matches).toHaveLength(2);
+        expect(matches[0].href).toBe('tel:5551234567');
+        expect(matches[1].href).toBe('tel:5559876543');
+    });
+
+    it('should match two space-separated numbers', () => {
+        const matches = findPhoneNumbers('555-123-4567 555-987-6543');
+        expect(matches).toHaveLength(2);
+        expect(matches[0].href).toBe('tel:5551234567');
+        expect(matches[1].href).toBe('tel:5559876543');
     });
 
     it('should not match a bare digit run', () => {

--- a/app/utils/phone_number.test.ts
+++ b/app/utils/phone_number.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {findPhoneNumbers, isTelHref, toTelHref} from './phone_number';
+
+describe('toTelHref', () => {
+    it('should keep a leading plus and strip separators', () => {
+        expect(toTelHref('+1 (555) 123-4567')).toBe('tel:+15551234567');
+    });
+
+    it('should strip a tel: prefix before normalizing', () => {
+        expect(toTelHref('tel:+15551234567')).toBe('tel:+15551234567');
+    });
+
+    it('should strip separators from a national number', () => {
+        expect(toTelHref('(555) 123-4567')).toBe('tel:5551234567');
+    });
+});
+
+describe('isTelHref', () => {
+    it('should detect tel: hrefs case-insensitively', () => {
+        expect(isTelHref('tel:+15551234567')).toBe(true);
+        expect(isTelHref('TEL:5551234567')).toBe(true);
+        expect(isTelHref('mailto:user@example.com')).toBe(false);
+    });
+});
+
+describe('findPhoneNumbers', () => {
+    it('should match a grouped national number', () => {
+        expect(findPhoneNumbers('Call me at 555-123-4567')).toEqual([{
+            index: 11,
+            length: 12,
+            raw: '555-123-4567',
+            href: 'tel:5551234567',
+        }]);
+    });
+
+    it('should match a parenthesized area code', () => {
+        expect(findPhoneNumbers('Call me at (555) 123-4567')).toEqual([{
+            index: 11,
+            length: 14,
+            raw: '(555) 123-4567',
+            href: 'tel:5551234567',
+        }]);
+    });
+
+    it('should match an E.164 number', () => {
+        expect(findPhoneNumbers('Call me at +15551234567')).toEqual([{
+            index: 11,
+            length: 12,
+            raw: '+15551234567',
+            href: 'tel:+15551234567',
+        }]);
+    });
+
+    it('should match an international number with separators', () => {
+        expect(findPhoneNumbers('Call +44 20 7946 0958')).toEqual([{
+            index: 5,
+            length: 16,
+            raw: '+44 20 7946 0958',
+            href: 'tel:+442079460958',
+        }]);
+    });
+
+    it('should match a tel: URI that includes a plus', () => {
+        expect(findPhoneNumbers('Call me at tel:+15551234567')).toEqual([{
+            index: 11,
+            length: 16,
+            raw: 'tel:+15551234567',
+            href: 'tel:+15551234567',
+        }]);
+    });
+
+    it('should match a toll-free number', () => {
+        expect(findPhoneNumbers('Call 1-800-555-1234')).toEqual([{
+            index: 5,
+            length: 14,
+            raw: '1-800-555-1234',
+            href: 'tel:18005551234',
+        }]);
+    });
+
+    it('should match multiple numbers in one string', () => {
+        const matches = findPhoneNumbers('555-123-4567 or 1-800-555-1234');
+        expect(matches).toHaveLength(2);
+        expect(matches[0].href).toBe('tel:5551234567');
+        expect(matches[1].href).toBe('tel:18005551234');
+    });
+
+    it('should not include trailing sentence punctuation', () => {
+        expect(findPhoneNumbers('Call 555-123-4567.')[0].raw).toBe('555-123-4567');
+    });
+
+    it('should not match a bare digit run', () => {
+        expect(findPhoneNumbers('Call me at 5551234567')).toEqual([]);
+    });
+
+    it('should not match ticket IDs, dates, or version numbers', () => {
+        expect(findPhoneNumbers('Ticket 1234567890')).toEqual([]);
+        expect(findPhoneNumbers('Date 2024-01-15')).toEqual([]);
+        expect(findPhoneNumbers('Version 2.44.0')).toEqual([]);
+        expect(findPhoneNumbers('SSN 123-45-6789')).toEqual([]);
+    });
+
+    it('should not match a number attached to a preceding word', () => {
+        expect(findPhoneNumbers('ext555-123-4567')).toEqual([]);
+    });
+});

--- a/app/utils/phone_number.ts
+++ b/app/utils/phone_number.ts
@@ -14,6 +14,10 @@ const PHONE_NUMBER_PATTERN = /(?:tel:(?:\+[1-9](?:[\s.\-()]*\d){6,14}|[+]?(?:[\s
 const MIN_PHONE_DIGITS = 7;
 const MAX_PHONE_DIGITS = 15;
 
+// Hyphens and dots continue a digit run (`+123456789012345-6`). Spaces and
+// parentheses are left as boundaries so a following number still matches.
+const PHONE_CONTINUATION = /[.\-]/;
+
 export function isTelHref(href: string): boolean {
     return href.toLowerCase().startsWith('tel:');
 }
@@ -25,20 +29,30 @@ export function toTelHref(raw: string): string {
     return `tel:${hasPlus ? '+' : ''}${digits}`;
 }
 
-function isValidBoundary(text: string, index: number): boolean {
-    if (index <= 0) {
-        return true;
-    }
-
-    return !(/[0-9A-Za-z]/).test(text.charAt(index - 1));
+function isDigit(char: string) {
+    return char >= '0' && char <= '9';
 }
 
-function isValidEndBoundary(text: string, end: number): boolean {
-    if (end >= text.length) {
+function isValidPhoneBoundary(text: string, index: number, direction: -1 | 1) {
+    const start = direction === -1 ? index - 1 : index;
+    if (start < 0 || start >= text.length) {
         return true;
     }
 
-    return !(/[0-9A-Za-z]/).test(text.charAt(end));
+    if ((/[0-9A-Za-z]/).test(text.charAt(start))) {
+        return false;
+    }
+
+    let i = start;
+    while (i >= 0 && i < text.length && PHONE_CONTINUATION.test(text.charAt(i))) {
+        i += direction;
+    }
+
+    if (i < 0 || i >= text.length) {
+        return true;
+    }
+
+    return !isDigit(text.charAt(i));
 }
 
 function isValidDigitCount(href: string): boolean {
@@ -59,7 +73,7 @@ export function findPhoneNumbers(text: string): PhoneNumberMatch[] {
         const raw = result[0];
         const index = result.index;
 
-        if (isValidBoundary(text, index) && isValidEndBoundary(text, index + raw.length)) {
+        if (isValidPhoneBoundary(text, index, -1) && isValidPhoneBoundary(text, index + raw.length, 1)) {
             const href = toTelHref(raw);
             if (isValidDigitCount(href)) {
                 matches.push({

--- a/app/utils/phone_number.ts
+++ b/app/utils/phone_number.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type PhoneNumberMatch = {
+    index: number;
+    length: number;
+    raw: string;
+    href: string;
+}
+
+// tel:/E.164 (+ and 7–15 digits) or NANP grouped numbers (separators required).
+const PHONE_NUMBER_PATTERN = /(?:tel:(?:\+[1-9](?:[\s.\-()]*\d){6,14}|[+]?(?:[\s.\-()]*\d){7,15})|\+[1-9](?:[\s.\-()]*\d){6,14}|(?:\+?1[\s.\-]?)?(?:\(\d{3}\)[\s.\-]?|\d{3}[\s.\-])\d{3}[\s.\-]\d{4})/i;
+
+const MIN_PHONE_DIGITS = 7;
+const MAX_PHONE_DIGITS = 15;
+
+export function isTelHref(href: string): boolean {
+    return href.toLowerCase().startsWith('tel:');
+}
+
+export function toTelHref(raw: string): string {
+    const withoutScheme = raw.replace(/^tel:/i, '');
+    const hasPlus = withoutScheme.trimStart().startsWith('+');
+    const digits = withoutScheme.replace(/\D/g, '');
+    return `tel:${hasPlus ? '+' : ''}${digits}`;
+}
+
+function isValidBoundary(text: string, index: number): boolean {
+    if (index <= 0) {
+        return true;
+    }
+
+    return !(/[0-9A-Za-z]/).test(text.charAt(index - 1));
+}
+
+function isValidEndBoundary(text: string, end: number): boolean {
+    if (end >= text.length) {
+        return true;
+    }
+
+    return !(/[0-9A-Za-z]/).test(text.charAt(end));
+}
+
+function isValidDigitCount(href: string): boolean {
+    const digits = href.replace(/^tel:\+?/, '');
+    return digits.length >= MIN_PHONE_DIGITS && digits.length <= MAX_PHONE_DIGITS;
+}
+
+export function findPhoneNumbers(text: string): PhoneNumberMatch[] {
+    if (!text) {
+        return [];
+    }
+
+    const matches: PhoneNumberMatch[] = [];
+    const regex = new RegExp(PHONE_NUMBER_PATTERN.source, 'gi');
+    let result = regex.exec(text);
+
+    while (result) {
+        const raw = result[0];
+        const index = result.index;
+
+        if (isValidBoundary(text, index) && isValidEndBoundary(text, index + raw.length)) {
+            const href = toTelHref(raw);
+            if (isValidDigitCount(href)) {
+                matches.push({
+                    index,
+                    length: raw.length,
+                    raw,
+                    href,
+                });
+            }
+        }
+
+        result = regex.exec(text);
+    }
+
+    return matches;
+}

--- a/app/utils/url/links.test.ts
+++ b/app/utils/url/links.test.ts
@@ -110,4 +110,14 @@ describe('openLink', () => {
         matchDeepLinkMock.mockRestore();
         tryOpenURLMock.mockRestore();
     });
+
+    it('should open tel: links with tryOpenURL', async () => {
+        const tryOpenURLMock = jest.spyOn(UrlUtils, 'tryOpenURL').mockImplementation(() => {});
+
+        await Links.openLink('tel:+15551234567', 'https://server-url.com', 'https://site-url.com', intl);
+
+        expect(tryOpenURLMock).toHaveBeenCalledWith('tel:+15551234567', expect.any(Function));
+
+        tryOpenURLMock.mockRestore();
+    });
 });

--- a/assets/base/i18n/en.json
+++ b/assets/base/i18n/en.json
@@ -948,6 +948,7 @@
   "mobile.markdown.copy_header": "Copy header text",
   "mobile.markdown.image.too_large": "Image exceeds max dimensions of {maxWidth} by {maxHeight}:",
   "mobile.markdown.link.copy_email": "Copy Email Address",
+  "mobile.markdown.link.copy_phone": "Copy Phone Number",
   "mobile.markdown.link.copy_url": "Copy URL",
   "mobile.mention.copy_mention": "Copy Mention",
   "mobile.message_length.message": "Your current message is too long. Current character count: {count}/{max}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Phone numbers in posts (and other Markdown-rendered message surfaces) are now turned into `tel:` links so tapping them opens the device dialer.

Detection covers:
- Grouped national numbers such as `555-123-4567` and `(555) 123-4567`
- E.164 / international numbers such as `+15551234567` and `+44 20 7946 0958`
- Explicit `tel:` URIs, including `tel:+15551234567` which the CommonMark URL autolinker currently misses

It does **not** linkify bare digit runs (`5551234567`, ticket IDs), dates, or version numbers, and it skips numbers inside code, existing links, `disableLinks`, and `unsafe_links` posts.

Long-press on a phone link offers **Copy Phone Number** (same pattern as email links). Tapping uses the existing `openLink` → `Linking.openURL` path, which opens the Phone/dialer app rather than placing a call.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70688

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
- [x] Have tested against the 5 core themes to ensure consistency between them.
- [x] Have run E2E tests by adding label `E2E/Run` (or `E2E/Run-iOS` / `E2E/Run-Android` for platform-specific runs).

#### Device Information
This PR was tested on: unit tests only (Cloud Agent Linux VM; no iOS/Android simulators). Device QA still needed: tap a number in a channel post on iPhone and Android and confirm the dialer opens with the normalized number.

#### Screenshots
N/A — native dialer handoff cannot be exercised in this environment.

#### Release Note
```release-note
Phone numbers in posts are now tappable tel: links that open the device calling app.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b76af0c-e2c2-48bb-a68c-0d4a592ca61b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b76af0c-e2c2-48bb-a68c-0d4a592ca61b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

