### PR TITLE
test(e2e): backport CMT harness fixes to release-2.44

### DIFF
--- a/.github/actions/provision-e2e-servers/action.yml
+++ b/.github/actions/provision-e2e-servers/action.yml
@@ -1,0 +1,98 @@
+# Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+# See LICENSE.txt for license information.
+name: Provision E2E test servers
+description: >-
+  Validate Matterwick server URLs, cache the demo-plugin fixture, and run
+  detox provision (license + plugins) on each unique URL. PR E2E and CMT share
+  this so dialog/plugin specs do not assume a pre-provisioned server.
+
+inputs:
+  server-urls:
+    description: Newline-separated HTTPS Mattermost test server URLs
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate server URLs
+      env:
+        SERVER_URLS: ${{ inputs.server-urls }}
+      run: |
+        set -euo pipefail
+        validate_url() {
+          local url="$1" label="$2"
+          if [ -z "$url" ]; then return 0; fi
+
+          if [[ "$url" =~ [[:space:]] ]]; then
+            echo "::error::$label contains whitespace: $url"
+            exit 1
+          fi
+
+          if [[ ! "$url" =~ ^https:// ]]; then
+            echo "::error::$label must use HTTPS: $url"
+            exit 1
+          fi
+
+          hostname=$(python3 -c 'import sys; from urllib.parse import urlparse; print(urlparse(sys.argv[1]).hostname or "")' "$url" | tr '[:upper:]' '[:lower:]')
+
+          if echo "$hostname" | grep -qE '^(127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|0\.|localhost|::1$|::ffff:|fe80:)'; then
+            echo "::error::$label points to a private/internal address: $hostname"
+            exit 1
+          fi
+
+          if ! echo "$hostname" | grep -qE '\.(cloud\.mattermost\.com|test\.mattermost\.cloud|mattermost\.com|mattermost\.cloud)$'; then
+            echo "::error::$label domain not in allowlist: $hostname"
+            exit 1
+          fi
+
+          echo "✓ $label validated: $hostname"
+        }
+
+        index=0
+        while IFS= read -r url; do
+          [ -z "$url" ] && continue
+          index=$((index + 1))
+          validate_url "$url" "SERVER_URL[$index]"
+        done <<< "$SERVER_URLS"
+
+        if [ "$index" -eq 0 ]; then
+          echo "::error::No server URLs provided to provision-e2e-servers"
+          exit 1
+        fi
+      shell: bash
+
+    # Runner (not the Mattermost origin) fetches the tarball. install_from_url
+    # through Cloudflare 524s and wedges config/patch + uploads for the shard.
+    - name: Cache demo plugin fixture
+      id: demo-plugin-cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: detox/e2e/support/fixtures/mattermost-plugin-demo-v0.11.1-linux-amd64.tar.gz
+        key: mattermost-plugin-demo-linux-amd64-v0.11.1
+
+    - name: Download demo plugin fixture
+      if: steps.demo-plugin-cache.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p detox/e2e/support/fixtures
+        curl -fsSL -o detox/e2e/support/fixtures/mattermost-plugin-demo-v0.11.1-linux-amd64.tar.gz \
+          "https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.11.1/mattermost-plugin-demo-v0.11.1-linux-amd64.tar.gz"
+        ls -lh detox/e2e/support/fixtures/mattermost-plugin-demo-v0.11.1-linux-amd64.tar.gz
+      shell: bash
+
+    - name: Provision servers (license + plugins)
+      env:
+        SERVER_URLS: ${{ inputs.server-urls }}
+      run: |
+        set -euo pipefail
+        cd detox
+        npm ci --prefer-offline --no-audit --no-fund
+        declare -A provisioned=()
+        while IFS= read -r url; do
+          [ -z "$url" ] && continue
+          if [ -z "${provisioned[$url]+x}" ]; then
+            echo "--- Provisioning $url ---"
+            npm run provision -- "$url"
+            provisioned["$url"]=1
+          fi
+        done <<< "$SERVER_URLS"
+      shell: bash

--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -150,6 +150,50 @@ jobs:
           fi
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
+  # PR E2E runs detox provision (demo plugin, license, config) before tests.
+  # CMT previously skipped that and only used Matterwick-booted servers, so
+  # interactive_dialog_plugin failed 24× with "Demo plugin is not active".
+  provision-cmt-servers:
+    name: Provision CMT test servers
+    runs-on: ubuntu-24.04
+    needs:
+      - calculate-commit-hash
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.MOBILE_VERSION }}
+          persist-credentials: false
+
+      - name: Collect unique matrix server URLs
+        id: urls
+        env:
+          CMT_MATRIX: ${{ inputs.CMT_MATRIX }}
+        run: |
+          URLS=$(echo "$CMT_MATRIX" | jq -r '
+            .server[]
+            | .android_site_1_url, .android_site_2_url, .ios_site_1_url, .ios_site_2_url, .site_3_url
+            | select(. != null and . != "")
+          ' | awk 'NF && !seen[$0]++')
+          if [ -z "$URLS" ]; then
+            echo "::error::CMT_MATRIX contained no server URLs to provision"
+            exit 1
+          fi
+          echo "Provisioning $(echo "$URLS" | wc -l | tr -d ' ') unique server(s)"
+          {
+            echo "list<<EOF"
+            printf '%s\n' "$URLS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Provision test servers
+        uses: ./.github/actions/provision-e2e-servers
+        env:
+          ADMIN_USERNAME: ${{ secrets.MM_MOBILE_E2E_ADMIN_USERNAME }}
+          ADMIN_PASSWORD: ${{ secrets.MM_MOBILE_E2E_ADMIN_PASSWORD }}
+        with:
+          server-urls: ${{ steps.urls.outputs.list }}
+
   # Input follows the below schema
   # {
   #   "server": [
@@ -299,6 +343,7 @@ jobs:
     needs:
       - build-ios-simulator
       - cmt-identity
+      - provision-cmt-servers
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.CMT_MATRIX) }}
@@ -341,6 +386,7 @@ jobs:
     needs:
       - build-ios-simulator
       - cmt-identity
+      - provision-cmt-servers
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.CMT_MATRIX) }}
@@ -388,6 +434,7 @@ jobs:
       - build-ios-simulator
       - prepare-maestro-matrix
       - cmt-identity
+      - provision-cmt-servers
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-maestro-matrix.outputs.matrix) }}
@@ -425,6 +472,7 @@ jobs:
     needs:
       - build-android-apk
       - cmt-identity
+      - provision-cmt-servers
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.CMT_MATRIX) }}
@@ -470,6 +518,7 @@ jobs:
       - build-android-apk-maestro
       - prepare-maestro-matrix
       - cmt-identity
+      - provision-cmt-servers
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-maestro-matrix.outputs.matrix) }}
@@ -504,6 +553,7 @@ jobs:
     needs:
       - cmt-identity
       - calculate-commit-hash
+      - provision-cmt-servers
       - detox-e2e
       - detox-android-e2e
       - detox-ipad-e2e
@@ -519,7 +569,7 @@ jobs:
         id: upstream
         run: |
           UPSTREAM="true"
-          for r in "${{ needs.detox-e2e.result }}" "${{ needs.detox-android-e2e.result }}" "${{ needs.detox-ipad-e2e.result }}" "${{ needs.maestro-ios-e2e.result }}" "${{ needs.maestro-android-e2e.result }}"; do
+          for r in "${{ needs.provision-cmt-servers.result }}" "${{ needs.detox-e2e.result }}" "${{ needs.detox-android-e2e.result }}" "${{ needs.detox-ipad-e2e.result }}" "${{ needs.maestro-ios-e2e.result }}" "${{ needs.maestro-android-e2e.result }}"; do
             case "$r" in
               success|skipped) ;;
               *) UPSTREAM="false" ;;

--- a/detox/e2e/test/products/channels/messaging/markdown_image.e2e.ts
+++ b/detox/e2e/test/products/channels/messaging/markdown_image.e2e.ts
@@ -24,6 +24,12 @@ import {
 } from '@support/ui/screen';
 import {timeouts} from '@support/utils';
 
+// The markdown image must actually load: on a fetch failure MarkdownImage renders a bare
+// broken-image icon and never mounts the `markdown_image` testID. docs.mattermost.com rewrites
+// its `_images/` paths on every docs rebuild (icon-76x76.png now 404s), so use the same
+// mattermost.com asset file_preview_gallery.e2e.ts already relies on.
+const MARKDOWN_IMAGE_URL = 'https://mattermost.com/wp-content/uploads/2022/02/icon_WS.png';
+
 describe('Messaging - Markdown Image', () => {
     const serverOneDisplayName = 'Server 1';
     const channelsCategory = 'channels';
@@ -50,7 +56,7 @@ describe('Messaging - Markdown Image', () => {
 
     it('MM-T4896_1 - should be able to display markdown image', async () => {
         // # Open a channel screen and post a markdown image
-        const markdownImage = '![Mattermost](https://docs.mattermost.com/_images/icon-76x76.png)';
+        const markdownImage = `![Mattermost](${MARKDOWN_IMAGE_URL})`;
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.postMessage(markdownImage);
 
@@ -70,7 +76,7 @@ describe('Messaging - Markdown Image', () => {
 
     it('MM-T4896_2 - should be able to display markdown image with link', async () => {
         // # Open a channel screen and post a markdown image with link
-        const markdownImage = '[![Mattermost](https://docs.mattermost.com/_images/icon-76x76.png)](https://github.com/mattermost/mattermost-server)';
+        const markdownImage = `[![Mattermost](${MARKDOWN_IMAGE_URL})](https://github.com/mattermost/mattermost-server)`;
         await ChannelScreen.open(channelsCategory, testChannel.name);
         await ChannelScreen.postMessage(markdownImage);
 

--- a/detox/maestro/subflows/server/_enter_url_and_connect.yml
+++ b/detox/maestro/subflows/server/_enter_url_and_connect.yml
@@ -17,15 +17,10 @@ appId: ${MAESTRO_APP_ID}
     optional: true
 
 # # Re-enter URL and display name.
-# iOS FloatingTextInput exposes label text to accessibility, not testID.
 - tapOn:
     text: "Enter Server URL"
 - eraseText: 120
 - inputText: ${SITE_1_URL}
-- copyTextFrom:
-    id: "server_form.server_url.input"
-- evalScript: ${output.urlOk = (maestro.copiedText == SITE_1_URL)}
-- assertTrue: ${output.urlOk}
 - tapOn:
     text: "Display Name"
 - eraseText: 120

--- a/detox/maestro/subflows/server/connect_server.yml
+++ b/detox/maestro/subflows/server/connect_server.yml
@@ -37,9 +37,12 @@ appId: ${MAESTRO_APP_ID}
           id: "server_form.server_url.input"
       - eraseText: 50
       - inputText: ${SITE_1_URL}
-      # # Avoid hideKeyboard here — on headless API 35 it can leave the next
-      # TextInput undiscoverable (CI 30216081940). IME next focuses display name
-      # (returnKeyType=next); scroll/wait/tap as fallback.
+      # # Android FloatingTextInput is queryable by testID, not the floated
+      # label. `text: Display Name` fails on API 35 (CI 33915931136, 10/10
+      # flows). Do not hideKeyboard before this field — on headless API 35
+      # that can leave the next TextInput undiscoverable (CI 30216081940).
+      # IME next focuses display name (returnKeyType=next); scroll/wait/tap
+      # by id as fallback.
       - pressKey: Enter
       - scrollUntilVisible:
           element:

--- a/detox/provision/constants.ts
+++ b/detox/provision/constants.ts
@@ -1,7 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {
+    DEMO_PLUGIN_DOWNLOAD_URL,
+    DEMO_PLUGIN_FIXTURE_FILENAME,
+    DEMO_PLUGIN_ID,
+} from '../shared/demo-plugin-fixture';
+
 import type {RequiredPlugin} from './types';
+
+export {DEMO_PLUGIN_DOWNLOAD_URL, DEMO_PLUGIN_FIXTURE_FILENAME, DEMO_PLUGIN_ID};
 
 export const LOG_PREFIX = '[provision]';
 
@@ -15,14 +23,12 @@ export const PLUGIN_STATE_FAILED = 3;
 
 export const CALLS_PLUGIN_URL = 'https://github.com/mattermost/mattermost-plugin-calls/releases/download/v1.11.5/mattermost-plugin-calls-v1.11.5-linux-amd64.tar.gz';
 
-export const DEMO_PLUGIN_ID = 'com.mattermost.demo-plugin';
-export const DEMO_PLUGIN_DOWNLOAD_URL = 'https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.11.1/mattermost-plugin-demo-v0.11.1-linux-amd64.tar.gz';
-export const DEMO_PLUGIN_FIXTURE_FILENAME = 'mattermost-plugin-demo-v0.11.1-linux-amd64.tar.gz';
-
 export const REQUIRED_PLUGINS: RequiredPlugin[] = [
     {id: AGENTS_PLUGIN_ID, url: null, fixture: null},
     {id: 'com.mattermost.calls', url: CALLS_PLUGIN_URL, fixture: null},
-    {id: DEMO_PLUGIN_ID, url: DEMO_PLUGIN_DOWNLOAD_URL, fixture: DEMO_PLUGIN_FIXTURE_FILENAME},
+
+    // url is null on purpose: origin-side install_from_url 524s behind Cloudflare.
+    {id: DEMO_PLUGIN_ID, url: null, fixture: DEMO_PLUGIN_FIXTURE_FILENAME},
 ];
 
 export const ALLOWED_DOMAIN_PATTERNS = [

--- a/detox/provision/log.ts
+++ b/detox/provision/log.ts
@@ -16,3 +16,8 @@ export function logWarn(message: string): void {
 export function logError(message: string): void {
     console.error(`${LOG_PREFIX} ${message}`);
 }
+
+/** Debug-level provision log for non-PII Detox/Maestro diagnostics. */
+export function logDebug(message: string): void {
+    console.debug(`${LOG_PREFIX} ${message}`);
+}

--- a/detox/provision/plugins.ts
+++ b/detox/provision/plugins.ts
@@ -6,6 +6,8 @@
 import https from 'node:https';
 import path from 'node:path';
 
+import {ensureDemoPluginFixture} from '../shared/demo-plugin-fixture';
+
 import {
     AGENTS_PLUGIN_ID,
     AGENTS_PLUGIN_ASSET_NAME,
@@ -410,7 +412,15 @@ export async function installRequiredPlugin(
     }
 
     if (fixtureFilename) {
-        // CI downloads the fixture; local runs fall back to the pinned URL when it is absent.
+        if (pluginId === DEMO_PLUGIN_ID) {
+            try {
+                await ensureDemoPluginFixture();
+            } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err);
+                logWarn(`Could not place demo plugin fixture on the runner: ${detail}`);
+            }
+        }
+
         const fixturePath = path.resolve(__dirname, `../e2e/support/fixtures/${fixtureFilename}`);
         logInfo(`Installing ${pluginId} from fixture: ${fixturePath}`);
         const installResult = await installPluginFromFile(client, token, pluginId, fixturePath, {force: true});
@@ -419,6 +429,11 @@ export async function installRequiredPlugin(
             return;
         }
         logWarn(`Fixture install failed for ${pluginId}: ${installResult.message}`);
+
+        if (pluginId === DEMO_PLUGIN_ID) {
+            logWarn('Not falling back to install_from_url for the demo plugin (Cloudflare 524 while origin fetches GitHub).');
+            return;
+        }
     }
 
     if (pluginUrl) {

--- a/detox/shared/demo-plugin-fixture.test.ts
+++ b/detox/shared/demo-plugin-fixture.test.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {demoPluginInstallPlan} from './demo-plugin-fixture';
+
+describe('demoPluginInstallPlan', () => {
+    it('is a no-op when the plugin is already active (provisioned CI / local)', () => {
+        assert.equal(demoPluginInstallPlan({isActive: true, isInstalled: true}), 'noop');
+    });
+
+    it('enables an installed-but-inactive plugin instead of re-downloading', () => {
+        assert.equal(demoPluginInstallPlan({isActive: false, isInstalled: true}), 'enable');
+    });
+
+    it('uploads the runner fixture when the plugin is missing — never install_from_url', () => {
+        assert.equal(demoPluginInstallPlan({isActive: false, isInstalled: false}), 'upload-fixture');
+        assert.equal(demoPluginInstallPlan({}), 'upload-fixture');
+    });
+});

--- a/detox/shared/demo-plugin-fixture.ts
+++ b/detox/shared/demo-plugin-fixture.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import fs from 'node:fs';
+import https from 'node:https';
+import path from 'node:path';
+
+/**
+ * The Mattermost origin must never download this plugin (install_from_url).
+ * Cloudflare in front of test servers 524s while the origin waits on GitHub,
+ * which then takes down config/patch and file-upload for the rest of the shard.
+ * CI and local fetch the tarball onto the runner, then multipart-upload it.
+ */
+export const DEMO_PLUGIN_ID = 'com.mattermost.demo-plugin';
+export const DEMO_PLUGIN_VERSION = '0.11.1';
+export const DEMO_PLUGIN_FIXTURE_FILENAME = `mattermost-plugin-demo-v${DEMO_PLUGIN_VERSION}-linux-amd64.tar.gz`;
+export const DEMO_PLUGIN_DOWNLOAD_URL =
+    `https://github.com/mattermost/mattermost-plugin-demo/releases/download/v${DEMO_PLUGIN_VERSION}/${DEMO_PLUGIN_FIXTURE_FILENAME}`;
+
+const MIN_FIXTURE_BYTES = 10_000;
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+const DOWNLOAD_ATTEMPTS = 4;
+
+export const demoPluginFixturePath = (): string => {
+    const candidates = [
+        path.resolve(__dirname, '../e2e/support/fixtures'),
+        path.resolve(process.cwd(), 'e2e/support/fixtures'),
+        path.resolve(process.cwd(), 'detox/e2e/support/fixtures'),
+    ];
+    const fallback = path.resolve(__dirname, '../e2e/support/fixtures');
+    const fixturesDir = candidates.find((dir) => fs.existsSync(dir)) ?? fallback;
+    return path.join(fixturesDir, DEMO_PLUGIN_FIXTURE_FILENAME);
+};
+
+export type DemoPluginStatus = {
+    isActive?: boolean;
+    isInstalled?: boolean;
+};
+
+export type DemoPluginPlan = 'noop' | 'enable' | 'upload-fixture';
+
+export const demoPluginInstallPlan = (status: DemoPluginStatus): DemoPluginPlan => {
+    if (status.isActive) {
+        return 'noop';
+    }
+    if (status.isInstalled) {
+        return 'enable';
+    }
+    return 'upload-fixture';
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const downloadToFile = (url: string, dest: string, redirects = 0): Promise<void> =>
+    new Promise((resolve, reject) => {
+        if (redirects > 5) {
+            reject(new Error(`Too many redirects fetching demo plugin from ${url}`));
+            return;
+        }
+
+        const req = https.get(url, {headers: {'User-Agent': 'mattermost-mobile-e2e'}}, (res) => {
+            const location = res.headers.location;
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && location) {
+                res.resume();
+                downloadToFile(location, dest, redirects + 1).then(resolve, reject);
+                return;
+            }
+
+            if (!res.statusCode || res.statusCode >= 400) {
+                res.resume();
+                reject(new Error(`GET ${url} HTTP ${res.statusCode}`));
+                return;
+            }
+
+            const tmp = `${dest}.partial`;
+            const out = fs.createWriteStream(tmp);
+            res.pipe(out);
+            out.on('finish', () => {
+                out.close();
+                fs.renameSync(tmp, dest);
+                resolve();
+            });
+            out.on('error', (err) => {
+                fs.rmSync(tmp, {force: true});
+                reject(err);
+            });
+        });
+
+        req.setTimeout(DOWNLOAD_TIMEOUT_MS, () => {
+            req.destroy();
+            reject(new Error(`Timed out fetching demo plugin from ${url}`));
+        });
+        req.on('error', reject);
+    });
+
+export const ensureDemoPluginFixture = async (): Promise<string> => {
+    const dest = demoPluginFixturePath();
+    fs.mkdirSync(path.dirname(dest), {recursive: true});
+
+    if (fs.existsSync(dest) && fs.statSync(dest).size >= MIN_FIXTURE_BYTES) {
+        return dest;
+    }
+
+    fs.rmSync(dest, {force: true});
+    fs.rmSync(`${dest}.partial`, {force: true});
+
+    let lastError: unknown;
+    /* eslint-disable no-await-in-loop -- runner-side GitHub fetch; sequential retries */
+    for (let attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
+        try {
+            await downloadToFile(DEMO_PLUGIN_DOWNLOAD_URL, dest);
+            if (fs.existsSync(dest) && fs.statSync(dest).size >= MIN_FIXTURE_BYTES) {
+                return dest;
+            }
+            lastError = new Error(`Downloaded demo plugin was too small (${fs.existsSync(dest) ? fs.statSync(dest).size : 0} bytes)`);
+        } catch (err) {
+            lastError = err;
+        }
+
+        fs.rmSync(dest, {force: true});
+        fs.rmSync(`${dest}.partial`, {force: true});
+        if (attempt < DOWNLOAD_ATTEMPTS) {
+            await wait(attempt * 2000);
+        }
+    }
+    /* eslint-enable no-await-in-loop */
+
+    const detail = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(
+        `Could not fetch ${DEMO_PLUGIN_FIXTURE_FILENAME} onto the runner (${detail}). ` +
+        'Do not install_from_url — that path 524s behind Cloudflare. Retry or run detox provision.',
+    );
+};


### PR DESCRIPTION
## Summary

Path-scoped backport of three test-harness fixes from `main`. **No app code changes** (0 files under `app/`). Fixes 29 of the 36 failures in the build-813 Compatibility Matrix run ([34567912246](https://github.com/mattermost/mattermost-mobile/actions/runs/34567912246)).

- **Provision CMT test servers** (from #10023): adds the `provision-cmt-servers` job to `compatibility-matrix-testing.yml`, wired as a dependency of every test job, plus the shared `provision-e2e-servers` composite action and the `detox/provision` / `detox/shared` demo-plugin fixture code it needs. Without it `interactive_dialog_plugin` fails 24× with `Demo plugin (com.mattermost.demo-plugin) is not active`.
- **Maestro iOS server-connect subflow** (from #10023): removes the `copyTextFrom` by id step. iOS never exposes the FloatingTextInput's id to Maestro, so the pre-flight and `attach_logs_disabled_when_download_logs_off` failed with `Element not found: server_form.server_url.input` on every attempt.
- **`markdown_image.e2e.ts`** (mirrors #10122): `docs.mattermost.com/_images/icon-76x76.png` now returns 404, so the image never rendered on either platform (MM-T4896_1/_2). Uses the mattermost.com asset `file_preview_gallery` already relies on; the 813 spec's post helper is kept, only the URL changed.

Whole-commit cherry-picks were not used because #10023 / #10122 / #10125 each carry app-code changes that do not belong on a release branch.

## Why the release branch was affected

CMT is dispatched on the release ref and checks out `MOBILE_VERSION` in every job, so the harness comes from the release branch. These fixes landed on `main` after the 2.44 cut and the automated cherry-pick only moves app commits.

## Verification (against the build-813 iOS simulator artifact)

- Maestro pre-flight on the same 813 app: **red** with the 813 subflow (fails at `Copy text from element with id: server_form.server_url.input`), **green** with this subflow (reaches the login form).
- MM-T4896_1 and MM-T4896_2 pass via Detox with the new URL (77 s / 82 s). Old URL: HTTP 404; new URL: HTTP 200.
- `npm run provision` from this tree against the cloud test server completes with `com.mattermost.demo-plugin` running.
- detox `tsc` clean; `demo-plugin-fixture.test.ts` 3/3.
- Not run here: ESLint (release worktree has no root `node_modules`); the provisioning/fixture files are byte-identical to `main`.

## Test plan

- [ ] Re-run Compatibility Matrix Testing on this head and confirm the Interactive Dialog suite, maestro-ios, and MM-T4896_* are green on Server 11.11.0
- [ ] Remaining known items are unrelated to this PR: MM-T4731_2 (iOS transport drop), 3× Mark-as-Unread beforeAll (one-off login stall), MM-T4929_1 / MM-T4899_2 / MM-T4878_13 (open flakes also present on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


```release-note
NONE
```