### PR TITLE
[MM-70694] Drop fake-webapp-dir workaround from i18n precommit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "e2e:android": "cd detox && npm run e2e:android-build && npm run e2e:android-test && cd ..",
     "e2e:ios": "cd detox && npm run e2e:ios-test && cd ..",
     "fix": "npm run lint -- --fix",
-    "i18n-clean-empty": "npm run mmjstool -- i18n clean-empty --mobile-dir .",
+    "i18n-clean-empty": "npm run mmjstool -- i18n clean-empty-mobile --mobile-dir .",
     "i18n-extract": "npm run mmjstool -- i18n extract-mobile",
     "ios": "react-native run-ios",
     "ios-gems": "bundle install",

--- a/scripts/precommit/i18n.sh
+++ b/scripts/precommit/i18n.sh
@@ -3,13 +3,11 @@ set -e
 
 mkdir -p tmp
 cp assets/base/i18n/en.json tmp/en.json
-mkdir -p tmp/fake-webapp-dir/i18n/
-echo '{}' > tmp/fake-webapp-dir/i18n/en.json
 
-npm run mmjstool -- i18n extract-mobile --webapp-dir tmp/fake-webapp-dir --mobile-dir .
+npm run mmjstool -- i18n extract-mobile --mobile-dir .
 diff tmp/en.json assets/base/i18n/en.json
 # Address weblate behavior which does not remove whole translation item when translation string is set to empty
-npm run mmjstool -- i18n clean-empty --webapp-dir tmp/fake-webapp-dir --mobile-dir . --check
+npm run mmjstool -- i18n clean-empty-mobile --mobile-dir . --check
 
 rm -rf tmp
 


### PR DESCRIPTION
#### Summary


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-70694

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Release Note

```release-note
NONE
```
